### PR TITLE
perf(webhook): Skip webhook job if no webhook endpoint defined

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -75,13 +75,18 @@ class SendWebhookJob < ApplicationJob
     "wallet_transaction.payment_failure" => Webhooks::PaymentProviders::WalletTransactionPaymentFailureService
   }.freeze
 
+  # This is a placeholder object to know which arguments were provided.
+  UNDEFINED = Object.new.freeze
+  private_constant :UNDEFINED
+
   # Override the default perform_later to avoid creating webhooks if no webhook endpoints are present.
   #
   # This will prevent enqueueing jobs only to return early from the jobs.
-  def self.perform_later(webhook_type, object, options = {}, webhook_id = nil)
-    return if webhook_id.nil? && object.organization.webhook_endpoints.none?
+  def self.perform_later(webhook_type, object, options = UNDEFINED, webhook_id = UNDEFINED)
+    return if (webhook_id.nil? || webhook_id == UNDEFINED) && object.organization.webhook_endpoints.none?
 
-    super
+    args = [webhook_type, object, options, webhook_id].filter { |arg| arg != UNDEFINED }
+    super(*args)
   end
 
   def perform(webhook_type, object, options = {}, webhook_id = nil)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -235,6 +235,11 @@ class Organization < ApplicationRecord
     !clickhouse_events_store?
   end
 
+  # This is added to have a common interface for all organization-related models to access the organization.
+  def organization
+    self
+  end
+
   private
 
   # NOTE: After creating an organization, default document_number_prefix needs to be generated.

--- a/spec/jobs/plans/destroy_job_spec.rb
+++ b/spec/jobs/plans/destroy_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Plans::DestroyJob do
       expect do
         described_class.perform_later(plan)
         described_class.perform_later(plan)
-      end.to change(enqueued_jobs, :count).by(1)
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
     end
   end
 

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe SendWebhookJob do
           described_class.perform_later("invoice.created", invoice)
         end.not_to have_enqueued_job(described_class)
       end
+
+      context "when webhook_id is nil" do
+        it "does not enqueue a job" do
+          expect do
+            described_class.perform_later("invoice.created", invoice, {}, nil)
+          end.not_to have_enqueued_job(described_class)
+        end
+      end
     end
 
     context "when webhook_id is present" do
@@ -37,8 +45,8 @@ RSpec.describe SendWebhookJob do
     context "when webhook endpoint is present and no webhook_id is present" do
       it "enqueues a job to send the webhook" do
         expect do
-          described_class.perform_later("invoice.created", invoice)
-        end.to have_enqueued_job(described_class).with("invoice.created", invoice, {}, nil)
+          described_class.perform_later("invoice.created", invoice, {key: "value"})
+        end.to have_enqueued_job(described_class).with("invoice.created", invoice, {key: "value"})
       end
     end
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -513,4 +513,10 @@ RSpec.describe Organization do
       end
     end
   end
+
+  describe "#organization" do
+    it "returns the organization" do
+      expect(organization.organization).to eq(organization)
+    end
+  end
 end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::WalletsController do
-  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:, currency: "EUR") }
   let(:subscription) { create(:subscription, customer:) }
   let(:expiration_at) { (Time.current + 1.year).iso8601 }
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::WalletsController do
 
       expect(SendWebhookJob).to have_been_enqueued.with("wallet.created", Wallet)
 
-      perform_all_enqueued_jobs
+      perform_all_enqueued_jobs(except: [SendWebhookJob])
 
       expect(response).to have_http_status(:success)
 

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, type: :request do
-  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:organization) { create(:organization) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:, amount_cents: 1000, pay_in_advance: true) }
@@ -44,7 +44,10 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
   let(:original_fee) { original_invoice.fees.first }
 
   describe "#call" do
-    before { original_invoice }
+    before do
+      stub_request(:post, organization.webhook_endpoints.first.webhook_url).to_return(status: 200, body: "")
+      original_invoice
+    end
 
     it "regenerates invoice with adjusted display name, units and unit amount" do
       result = regenerate_result

--- a/spec/services/payment_receipts/create_service_spec.rb
+++ b/spec/services/payment_receipts/create_service_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe PaymentReceipts::CreateService do
 
             context "when payment is succeeded" do
               let(:payable_payment_status) { "succeeded" }
-              let(:payment_receipt) { build(:payment_receipt) }
+              let(:payment_receipt) { build(:payment_receipt, organization:) }
 
               before do
                 allow(PaymentReceipt).to receive(:new).and_return(payment_receipt)

--- a/spec/support/queues_helper.rb
+++ b/spec/support/queues_helper.rb
@@ -15,10 +15,22 @@ module QueuesHelper
   #
   # ⚠️ Notice that `have_been_enqueued` might not work with perform_all_enqueued_jobs
   # because it's only aware of the last run of the loop.
-  def perform_all_enqueued_jobs
-    until enqueued_jobs.empty?
-      perform_enqueued_jobs
+  def perform_all_enqueued_jobs(only: nil, except: nil)
+    until enqueued_jobs(only:, except:).empty?
+      perform_enqueued_jobs(only:, except:)
       Sidekiq::Worker.drain_all
+    end
+  end
+
+  def enqueued_jobs(only: nil, except: nil)
+    super().filter do |job|
+      if only && !only.include?(job[:job])
+        next false
+      end
+      if except&.include?(job[:job])
+        next false
+      end
+      true
     end
   end
 end


### PR DESCRIPTION
## Context

When delivering webhooks, we only check whether there's any webhook endpoint defined for the organization once we're processing the `SendWebhookJob` job itself.

This means that when we're generating a lot of invoices (on billing day for instance), we're scheduling thousands of `SendWebhookJob` only to return early. This adds unnecessary pressure on Redis, Sidekiq and DB and might actually delay delivery for organization which have webhook endpoints defined.

## Description

This overrides the `SendWebhookJob.perform_later` method to skip the job scheduling if there's not webhook endpoint defined for the organization. This allows for an easy fix without impacting all the services depending on this job.

Given that I relied on `object.organization`, I added a `Organization#organization` method to have a consistent interface between all organization models.

This also broke a lot of tests that I had to update by adding the `options` and `webhook_id` default values to the job expectations :

```diff
-    expect(SendWebhookJob).to have_been_enqueued.with("wallet.terminated", Wallet)
+    expect(SendWebhookJob).to have_been_enqueued.with("wallet.terminated", Wallet, {}, nil)
```

I also need to update the `perform_all_enqueued_jobs` helper with an `except` option in order to fix the `spec/requests/api/v1/wallets_controller_spec.rb` spec.