### PR TITLE
fix(clickhouse): Fix cloud migration for events dead letter

### DIFF
--- a/db/clickhouse_migrate/cloud/09_events_dead_letter_queue.sql
+++ b/db/clickhouse_migrate/cloud/09_events_dead_letter_queue.sql
@@ -7,5 +7,5 @@ CREATE TABLE default.events_dead_letter_queue
     `error_message` String
 )
 ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
-ORDER BY (failed_at, event, initial_error_message, error_code, error_message)
+ORDER BY (failed_at, initial_error_message, error_code, error_message)
 SETTINGS index_granularity = 8192

--- a/db/clickhouse_migrate/cloud/10_events_dead_letter_mv.sql
+++ b/db/clickhouse_migrate/cloud/10_events_dead_letter_mv.sql
@@ -13,13 +13,13 @@ CREATE MATERIALIZED VIEW events_dead_letter_mv TO events_dead_letter
     `error_message` String
 )
 AS SELECT
-  JSONExtractString(event, 'organization_id') AS organization_id,
-  JSONExtractString(event, 'external_subscription_id') AS external_subscription_id,
-  JSONExtractString(event, 'code') AS code,
-  JSONExtractString(event, 'transaction_id') AS transaction_id,
-  toDateTime64(JSONExtractString(event, 'timestamp'), 3) AS timestamp,
-  toDateTime64(JSONExtractString(event, 'ingested_at'), 3) AS ingested_at,
-  toDateTime64(parseDateTime64BestEffort(failed_at), 3) as failed_at,
+  event.organization_id AS organization_id,
+  event.external_subscription_id AS external_subscription_id,
+  event.code AS code,
+  event.transaction_id AS transaction_id,
+  toDateTime64OrNull(toString(event.timestamp), 3) AS timestamp,
+  toDateTime64(event.ingested_at, 3) AS ingested_at,
+  failed_at,
   event,
   error_code,
   error_message,


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/4602

## Description

The goal here is to fix the migration scripts used to setup the events_dead_letter pipeline in Clickhouse production instances

NOTE: These scripts are not run automatically, they are only here to keep track of the setup and allow us to setup a new instance if required