### PR TITLE
feat(multiple-payment-methods): expose payment method in subscription GQL type

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -40,6 +40,9 @@ module Types
 
       field :lifetime_usage, Types::Subscriptions::LifetimeUsageObject, null: true
 
+      field :payment_method, Types::PaymentMethods::Object
+      field :payment_method_type, Types::PaymentMethods::MethodTypeEnum
+
       def next_plan
         object.next_subscription&.plan
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -9826,6 +9826,8 @@ type Subscription {
   nextSubscriptionType: NextSubscriptionTypeEnum
   onTerminationCreditNote: OnTerminationCreditNoteEnum
   onTerminationInvoice: OnTerminationInvoiceEnum!
+  paymentMethod: PaymentMethod
+  paymentMethodType: PaymentMethodTypeEnum
   periodEndDate: ISO8601Date
   plan: Plan!
   startedAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -53144,6 +53144,30 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentMethod",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PaymentMethod",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentMethodType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "PaymentMethodTypeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "periodEndDate",
               "description": null,
               "args": [],

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -40,5 +40,8 @@ RSpec.describe Types::Subscriptions::Object do
     expect(subject).to have_field(:fees).of_type("[Fee!]")
 
     expect(subject).to have_field(:lifetime_usage).of_type("SubscriptionLifetimeUsage")
+
+    expect(subject).to have_field(:payment_method).of_type("PaymentMethod")
+    expect(subject).to have_field(:payment_method_type).of_type("PaymentMethodTypeEnum")
   end
 end


### PR DESCRIPTION
## Context

Currently in Lago, there can only be one payment provider customer, with only one attached payment method.

## Description

With this feature, it will be possible to add multiple payment methods per provider customer.

This PR attaches payment method to subscription in GQL context