### PR TITLE
misc: Clock::ApiKeys::TrackUsageJob should inherit from ClockJob

### DIFF
--- a/app/jobs/clock/api_keys/track_usage_job.rb
+++ b/app/jobs/clock/api_keys/track_usage_job.rb
@@ -2,17 +2,7 @@
 
 module Clock
   module ApiKeys
-    class TrackUsageJob < ApplicationJob
-      include SentryCronConcern
-
-      queue_as do
-        if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-          :clock_worker
-        else
-          :clock
-        end
-      end
-
+    class TrackUsageJob < ClockJob
       def perform
         ::ApiKeys::TrackUsageService.call
       end


### PR DESCRIPTION
## Description
This PR removes code duplication for the `Clock::ApiKeys::TrackUsageJob` making sure it inherits from `ClockJob`