### PR TITLE
perf(sidekiq): Make Sidekiq scheduler interval configurable

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -38,6 +38,7 @@ Sidekiq.configure_server do |config|
   config.super_fetch! if Sidekiq.pro?
   config.redis = redis_config
   config.logger = nil
+  config.average_scheduled_poll_interval = ENV.fetch("LAGO_SIDEKIQ_AVERAGE_SCHEDULED_POLL_INTERVAL", 5).to_f
   config[:max_retries] = 0
   config[:dead_max_jobs] = ENV.fetch("LAGO_SIDEKIQ_MAX_DEAD_JOBS", 100_000).to_i
   config.on(:startup) do


### PR DESCRIPTION
## Context

By default, Sidekiq will enqueue scheduled jobs on average every 5 seconds (see https://github.com/sidekiq/sidekiq/blob/d09147898edcc64879432764a6bd355666eeb8ba/lib/sidekiq/scheduled.rb#L129). This can be cumbersome in cases where multiples jobs are retried due to high concurrency and DB locks. The failed jobs will usually be retried with a polynomially longer retry and some jitter but, due to the way Sidekiq scheduler works, every 5 seconds we’ll retry a whole set of scheduled jobs at the same time, causing some jobs to fail again.

Example:

```
t = 0s
  • Job 1, Job 2, Job 3 start together.
  • Job 1 acquires the lock, and succeeds.
  • Job 2 and Job 3 hit the DB lock, and fail.
  • Job 2 and Job 3 are pushed to the retry set to run at 2.5 s and 3.5 s (3 s backoff + 0.5 s jitter).

t = 5s
  • Scheduler wakes.
  • Workers picks up Job 2 and Job 3.
  • Job 2 acquires the lock, and succeeds.
  • Job 3 hits the DB lock, and fails.
  • Job 3 is pushed to the retry set to run at 6.5 s (6 s backoff + 0.5 s jitter).

t = 10s
  • Scheduler wakes again.
  • No job is picked up.

t = 15s
  • Scheduler wakes again.
  • Job 3 is picked up.
  • Job 3 acquires the lock, and succeeds.
```

In this example, Job 2 and Job 3 could have been processed at different times without hitting DB lock if we had a smaller scheduler interval (1 second for instance):

```
t = 0s
  • Job 1, Job 2, Job 3 start together.
  • Job 1 acquires the lock, and succeeds.
  • Job 2 and Job 3 hit the DB lock, and fail.
  • Job 2 and Job 3 are pushed to the retry set to run at 2.5 s and 3.5 s (3 s backoff + 0.5 s jitter).

t = 1s
  • Scheduler wakes.
  • No job is picked up.

t = 2s
  • Scheduler wakes.
  • No job is picked up.

t = 3s
  • Scheduler wakes.
  • Workers picks up Job 2.
  • Job 2 acquires the lock, and succeeds.

t = 4s
  • Scheduler wakes.
  • Workers picks up Job 3.
  • Job 3 acquires the lock, and succeeds.  
```

Note that, based on my tests, I noticed that the scheduler actual average interval is half of the config value i.e. 2.5 seconds for a config set to `5`. I've reported this bug [on Sidekiq repository.](https://github.com/sidekiq/sidekiq/issues/6866)

## Description

This change allows us to configure the Sidekiq `average_scheduled_poll_interval` to be able to reduce the scheduled poll interval. We'll experiment with different values and monitor Redis to see the impact.