### PR TITLE
fix(okta-graphql): Add host to Okta Graphql object

### DIFF
--- a/app/graphql/types/integrations/okta.rb
+++ b/app/graphql/types/integrations/okta.rb
@@ -9,6 +9,7 @@ module Types
       field :client_secret, ObfuscatedStringType, null: true
       field :code, String, null: false
       field :domain, String, null: false
+      field :host, String, null: true
       field :id, ID, null: false
       field :name, String, null: false
       field :organization_name, String, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -7959,6 +7959,7 @@ type OktaIntegration {
   clientSecret: ObfuscatedString
   code: String!
   domain: String!
+  host: String
   id: ID!
   name: String!
   organizationName: String!

--- a/schema.json
+++ b/schema.json
@@ -38216,6 +38216,18 @@
               "deprecationReason": null
             },
             {
+              "name": "host",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [],

--- a/spec/graphql/types/integrations/okta_spec.rb
+++ b/spec/graphql/types/integrations/okta_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Integrations::Okta do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
+
+    expect(subject).to have_field(:client_id).of_type("String")
+    expect(subject).to have_field(:client_secret).of_type("ObfuscatedString")
+    expect(subject).to have_field(:code).of_type("String!")
+    expect(subject).to have_field(:domain).of_type("String!")
+    expect(subject).to have_field(:name).of_type("String!")
+    expect(subject).to have_field(:organization_name).of_type("String!")
+    expect(subject).to have_field(:host).of_type("String")
+  end
+
+  it "ensure all fields are tested" do
+    expect(subject.fields.values.map(&:original_name) -
+      %i[id client_id client_secret code domain name organization_name host]).to be_empty
+  end
+end


### PR DESCRIPTION
This PR adds the `host` field to `Types::Integrations::Okta`.

It also adds a test class that didn't existed for this GraphQL object.