### PR TITLE
test: Add `super_diff`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,7 @@ group :development, :test do
   gem "rubocop-thread_safety", require: false
 
   gem "vernier", "~> 1.0", require: false
+  gem "super_diff", "~> 0.16.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
     anyway_config (2.7.2)
       ruby-next-core (~> 1.0)
     ast (2.4.3)
+    attr_extras (7.1.0)
     awesome_print (1.9.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.967.0)
@@ -720,6 +721,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
+    optimist (3.2.1)
     os (1.1.4)
     ostruct (0.6.1)
     paper_trail (16.0.0)
@@ -731,6 +733,8 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     pg (1.5.9)
     pp (0.6.3)
       prettyprint
@@ -989,6 +993,10 @@ GEM
     stripe (6.5.0)
     strong_migrations (2.0.2)
       activerecord (>= 6.1)
+    super_diff (0.16.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     temple (0.8.2)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
@@ -1154,6 +1162,7 @@ DEPENDENCIES
   standard
   stripe
   strong_migrations
+  super_diff (~> 0.16.0)
   throttling
   timecop
   tzinfo-data

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ require "simplecov"
 require "money-rails/test_helpers"
 require "active_storage_validations/matchers"
 require "karafka/testing/rspec/helpers"
+require "super_diff/rspec-rails"
 
 DatabaseCleaner.allow_remote_database_url = true
 


### PR DESCRIPTION
## Context

It is sometimes a bit hard to understand what's wrong with our test assertions. Let's take the following example:

```ruby
expected = [
  {
    "model" => %w[llama-2],
    :metadata => {
      option: {
        "size" => %w[512],
        "steps" => %w[25]
      }
    },
    "available_sizes" => %w[256 512 1024],
    "available_steps" => %w[50 75 100]
  }
]
actual = [
  {
    "model" => %w[llama-2],
    :metadata => {
      option: {
        "size" => %w[511],
        "steps" => %w[25]
      }
    },
    "available_sizes" => %w[256 512 1021],
    "available_steps" => %w[50 75 100]
  }
]
expect(actual).to eq(expected)
```

RSpec would output the following diff:

```ruby
Diff:

@@ -1,5 +1,5 @@
-[{"available_sizes" => ["256", "512", "1024"],
+[{"available_sizes" => ["256", "512", "1021"],
   "available_steps" => ["50", "75", "100"],
-  :metadata => {:option => {"size" => ["512"], "steps" => ["25"]}},
+  :metadata => {:option => {"size" => ["511"], "steps" => ["25"]}},
   "model" => ["llama-2"]}]
```

The main issue here is that it displays good and invalid diff on the same line (the `steps` are the same) making it hard to when dealing with nested structures.

## Description

This adds [`super_difff`](https://github.com/splitwise/super_diff) to improve the readability of diffs. With the example above, we get:

```ruby
       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         [
           {
             "model" => [
               "llama-2"
             ],
             :metadata => {
               "size" => [
       -         "512"
       +         "511"
               ],
               "steps" => [
                 "25"
               ]
             },
             "sizes" => [
               "256",
               "512",
       -       "1024"
       +       "1021"
             ],
             "steps" => [
               "50",
               "75",
               "100"
             ]
           }
         ]
```

This diff allows us to fix the issue much faster.

Note that you can also use `super_diff` in development environment using:

```rb
lago-api(dev)> require "super_diff"
lago-api(dev)> puts SuperDiff.diff({a: 1},{a: 2, b: 1 })
  {
-   a: 1
+   a: 2,
+   b: 1
  }
=> nil
```
