### PR TITLE
misc(datadog): Add service middleware

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -174,6 +174,7 @@ class BaseService
   end
 
   use(Middlewares::LogTracerMiddleware)
+  use(Middlewares::DatadogMiddleware) if ENV["DD_AGENT_HOST"].present?
 
   def self.call(*, **, &)
     new(*, **).call_with_middlewares(&)

--- a/app/services/middlewares/datadog_middleware.rb
+++ b/app/services/middlewares/datadog_middleware.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Middlewares
+  class DatadogMiddleware < BaseMiddleware
+    def before_call
+      @span = Datadog::Tracing.trace("service.call", service: service_name, resource: service_instance.class.name)
+    end
+
+    def after_call(result)
+      return if @span.nil?
+
+      if result.success?
+        @span.set_tag("result.status", "success")
+      else
+        @span.set_tag("result.status", "failure")
+        @span.record_exception(result.error)
+      end
+
+      @span.finish
+    end
+
+    def handle_error(error)
+      return if @span.nil?
+
+      @span.set_tag("result.status", "failure")
+      @span.record_exception(error)
+      @span.finish
+    end
+
+    private
+
+    def service_name
+      @service_name ||= ENV["DD_SERVICE_NAME"] || "lago-api"
+    end
+  end
+end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 if ENV["DD_AGENT_HOST"]
+  require "lago_utils"
   require "datadog/auto_instrument"
 
   Datadog.configure do |c|
@@ -11,7 +12,7 @@ if ENV["DD_AGENT_HOST"]
     c.tracing.instrument :pg
     c.tracing.instrument :redis
 
-    c.env ENV["DD_ENV"] || Rails.env
+    c.env = ENV["DD_ENV"] || Rails.env
     c.service = ENV["DD_SERVICE_NAME"] || "lago-api"
     c.version = LagoUtils::Version.call(default: Rails.env).number
 

--- a/spec/services/middlewares/datadog_middleware_spec.rb
+++ b/spec/services/middlewares/datadog_middleware_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "datadog/auto_instrument"
+
+RSpec.describe Middlewares::DatadogMiddleware do
+  let(:service_class) do
+    Class.new(BaseService) do
+      use Middlewares::DatadogMiddleware
+
+      def self.name
+        "CustomeService"
+      end
+
+      def call
+        result
+      end
+    end
+  end
+
+  let(:span) { instance_double(Datadog::Tracing::SpanOperation) }
+
+  before do
+    allow(Datadog::Tracing).to receive(:trace)
+      .with("service.call", service: "lago-api", resource: "CustomeService")
+      .and_return(span)
+  end
+
+  describe "Tracking" do
+    it "tracks the service call" do
+      allow(span).to receive(:set_tag).with("result.status", "success")
+      allow(span).to receive(:finish)
+
+      service_class.call
+
+      expect(Datadog::Tracing).to have_received(:trace).with("service.call", service: "lago-api", resource: "CustomeService")
+      expect(span).to have_received(:set_tag).with("result.status", "success")
+      expect(span).to have_received(:finish)
+    end
+
+    context "when result is a failure" do
+      let(:service_class) do
+        Class.new(BaseService) do
+          use Middlewares::DatadogMiddleware
+
+          def self.name
+            "CustomeService"
+          end
+
+          def call
+            result.not_found_failure!(resource: "fake")
+          end
+        end
+      end
+
+      it "tracks the service call" do
+        allow(span).to receive(:set_tag).with("result.status", "failure")
+        allow(span).to receive(:record_exception).with(BaseService::NotFoundFailure)
+        allow(span).to receive(:finish)
+
+        service_class.call
+
+        expect(Datadog::Tracing).to have_received(:trace).with("service.call", service: "lago-api", resource: "CustomeService")
+        expect(span).to have_received(:set_tag).with("result.status", "failure")
+        expect(span).to have_received(:record_exception).with(BaseService::NotFoundFailure)
+        expect(span).to have_received(:finish)
+      end
+    end
+
+    context "when service raises an error" do
+      let(:service_class) do
+        Class.new(BaseService) do
+          use Middlewares::DatadogMiddleware
+
+          def self.name
+            "CustomeService"
+          end
+
+          def call
+            raise StandardError, "Service error"
+          end
+        end
+      end
+
+      it "tracks the service call" do
+        allow(span).to receive(:set_tag).with("result.status", "failure")
+        allow(span).to receive(:record_exception).with(StandardError)
+        allow(span).to receive(:finish)
+
+        expect { service_class.call }.to raise_error(StandardError)
+
+        expect(Datadog::Tracing).to have_received(:trace).with("service.call", service: "lago-api", resource: "CustomeService")
+        expect(span).to have_received(:set_tag).with("result.status", "failure")
+        expect(span).to have_received(:record_exception).with(StandardError)
+        expect(span).to have_received(:finish)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR follows https://github.com/getlago/lago-api/pull/4621 that was adding an optional config to enable datadog monitoring.

This part is adding a new service middleware name `DatadogMiddleware` to monitor the service execution.

