### PR TITLE
fix(wallet): Fix wallet top-up rounding

### DIFF
--- a/app/services/wallets/balance/increase_service.rb
+++ b/app/services/wallets/balance/increase_service.rb
@@ -14,18 +14,19 @@ module Wallets
       end
 
       def call
-        credits_amount = wallet_transaction.credit_amount
+        transaction_credits_amount = wallet_transaction.credit_amount
+        transaction_amount_cents = wallet_transaction.amount_cents
 
         currency = wallet.currency_for_balance
         update_params = {
-          balance_cents: ((wallet.credits_balance + credits_amount) * wallet.rate_amount * currency.subunit_to_unit).floor,
-          credits_balance: wallet.credits_balance + credits_amount,
+          balance_cents: wallet.balance_cents + transaction_amount_cents,
+          credits_balance: wallet.credits_balance + transaction_credits_amount,
           last_balance_sync_at: Time.current
         }
 
         if reset_consumed_credits
-          update_params[:consumed_credits] = [0.0, wallet.consumed_credits - credits_amount].max
-          update_params[:consumed_amount_cents] = [0, ((wallet.consumed_credits - credits_amount) * wallet.rate_amount * currency.subunit_to_unit).floor].max
+          update_params[:consumed_credits] = [0.0, wallet.consumed_credits - transaction_credits_amount].max
+          update_params[:consumed_amount_cents] = [0, ((wallet.consumed_credits - transaction_credits_amount) * wallet.rate_amount * currency.subunit_to_unit).floor].max
         end
 
         wallet.update!(update_params)

--- a/spec/scenarios/wallets/topup_with_rounding_spec.rb
+++ b/spec/scenarios/wallets/topup_with_rounding_spec.rb
@@ -56,6 +56,7 @@ describe "Wallet Transaction with rounding" do
 
     wallet.reload
     expect(wallet.credits_balance).to eq 17.97
+    expect(wallet.balance_cents).to eq 1797
   end
 
   it "does not apply rounding handling granted_credits" do
@@ -85,5 +86,6 @@ describe "Wallet Transaction with rounding" do
 
     wallet.reload
     expect(wallet.credits_balance).to eq 17.96999
+    expect(wallet.balance.to_d).to eq 17.97
   end
 end

--- a/spec/services/wallets/balance/increase_service_spec.rb
+++ b/spec/services/wallets/balance/increase_service_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe Wallets::Balance::IncreaseService do
     create(
       :wallet,
       balance_cents: 1000,
-      ongoing_balance_cents: 800,
       credits_balance: 10.0,
-      credits_ongoing_balance: 8.0
+      ongoing_balance_cents: 800,
+      credits_ongoing_balance: 8.0,
+      consumed_credits: 1.0,
+      consumed_amount_cents: 100
     )
   end
 
@@ -23,22 +25,67 @@ RSpec.describe Wallets::Balance::IncreaseService do
 
   before { wallet }
 
+  def call_and_reload_wallet
+    create_service.call
+    wallet.reload
+  end
+
   describe ".call" do
     it "updates wallet balance" do
-      expect { create_service.call }
-        .to change(wallet.reload, :balance_cents).from(1000).to(1450)
-        .and change(wallet, :credits_balance).from(10.0).to(14.5)
+      call_and_reload_wallet
+
+      expect(wallet.balance_cents).to eq(1450)
+      expect(wallet.credits_balance).to eq(14.5)
     end
 
     it "refreshes wallet ongoing balance" do
-      expect { create_service.call }
-        .to change(wallet.reload, :ongoing_balance_cents).from(800).to(1450)
-        .and change(wallet, :credits_ongoing_balance).from(8.0).to(14.5)
+      call_and_reload_wallet
+
+      expect(wallet.ongoing_balance_cents).to eq(1450)
+      expect(wallet.credits_ongoing_balance).to eq(14.5)
     end
 
     it "sends a `wallet.updated` webhook" do
       expect { create_service.call }
         .to have_enqueued_job(SendWebhookJob).with("wallet.updated", Wallet)
+    end
+
+    context "with rounding" do
+      let(:wallet_credit) { WalletCredit.new(wallet:, credit_amount: credits_amount, invoiceable: false) }
+      let(:credits_amount) { BigDecimal("17.96999") }
+      let(:wallet_transaction) { create(:wallet_transaction, wallet:, credit_amount: wallet_credit.credit_amount, amount: wallet_credit.amount) }
+
+      it "updates wallet balance" do
+        expect(wallet_credit.amount).to eq(17.97)
+
+        call_and_reload_wallet
+
+        expect(wallet.balance.to_d).to eq(27.97)
+        expect(wallet.credits_balance).to eq(0.2796999e2)
+      end
+    end
+
+    context "when reset_consumed_credits is true" do
+      subject(:create_service) { described_class.new(wallet:, wallet_transaction:, reset_consumed_credits: true) }
+
+      let!(:wallet_transaction) { create(:wallet_transaction, wallet:, amount: 0.5, credit_amount: 0.5) }
+
+      it "resets consumed credits" do
+        call_and_reload_wallet
+        expect(wallet.consumed_credits).to eq(0.5)
+        expect(wallet.consumed_amount_cents).to eq(50)
+      end
+
+      context "when the consumed credits are greater than the credits amount" do
+        let(:wallet_transaction) { create(:wallet_transaction, wallet:, amount: 2.0, credit_amount: 2.0) }
+
+        it "resets consumed credits" do
+          call_and_reload_wallet
+
+          expect(wallet.consumed_credits).to eq(0)
+          expect(wallet.consumed_amount_cents).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

When topping-up a wallet, we will convert the new wallet credit balance into amount and floor the value. This can cause a discrepancy between wallet and the sum of wallet transaction as we round the amount on the wallet transaction.

**Steps to reproduce:**

1. Create a customer
2. Assign a wallet with "17.9699999999999988631316" granted credits

**Expected behaviour:**

1. Wallet transaction amount is 17.97
2. Wallet balance is 17.97   

**Actual behaviour:**

1. Wallet transaction amount is 17.97
2. Wallet balance is 17.96

## Description

I added tests to reproduce this behavior and fixed the behaviour:

```sh
Wallet Transaction with rounding
  does not apply rounding handling granted_credits (FAILED - 1)

Wallets::Balance::IncreaseService
  .call
    with rounding
      updates wallet balance (FAILED - 2)

Failures:

  1) Wallet Transaction with rounding does not apply rounding handling granted_credits
     Failure/Error: expect(wallet.balance.to_d).to eq 17.97
       Expected 0.1796e2 to eq 17.97.
     # ./spec/scenarios/wallets/topup_with_rounding_spec.rb:89:in 'block (2 levels) in <top (required)>'
     # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
     # ./spec/scenarios/wallets/topup_with_rounding_spec.rb:12:in 'block (3 levels) in <top (required)>'
     # ./spec/scenarios/wallets/topup_with_rounding_spec.rb:11:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:220:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'

  2) Wallets::Balance::IncreaseService.call with rounding updates wallet balance
     Failure/Error: expect(wallet.balance.to_d).to eq(27.97)
       Expected 0.2796e2 to eq 27.97.
     # ./spec/services/wallets/balance/increase_service_spec.rb:65:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:220:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'

Finished in 1.18 seconds (files took 18.98 seconds to load)
2 examples, 2 failures

Failed examples:

rspec ./spec/scenarios/wallets/topup_with_rounding_spec.rb:62 # Wallet Transaction with rounding does not apply rounding handling granted_credits
rspec ./spec/services/wallets/balance/increase_service_spec.rb:59 # Wallets::Balance::IncreaseService.call with rounding updates wallet balance
```
