### PR TITLE
fix(wallet): Fix wallet balance rounding on outbound transactions

### DIFF
--- a/app/services/wallets/balance/decrease_service.rb
+++ b/app/services/wallets/balance/decrease_service.rb
@@ -11,15 +11,15 @@ module Wallets
       end
 
       def call
-        credits_amount = wallet_transaction.credit_amount
+        transaction_credits_amount = wallet_transaction.credit_amount
         currency = wallet.currency_for_balance
 
         wallet.update!(
-          balance_cents: ((wallet.credits_balance - credits_amount) * wallet.rate_amount * currency.subunit_to_unit).floor,
-          credits_balance: wallet.credits_balance - credits_amount,
+          balance_cents: wallet.balance_cents - wallet_transaction.amount_cents,
+          credits_balance: wallet.credits_balance - transaction_credits_amount,
           last_balance_sync_at: Time.zone.now,
-          consumed_credits: wallet.consumed_credits + credits_amount,
-          consumed_amount_cents: ((wallet.consumed_credits + credits_amount) * wallet.rate_amount * currency.subunit_to_unit).floor,
+          consumed_credits: wallet.consumed_credits + transaction_credits_amount,
+          consumed_amount_cents: ((wallet.consumed_credits + transaction_credits_amount) * wallet.rate_amount * currency.subunit_to_unit).floor,
           last_consumed_credit_at: Time.current
         )
 

--- a/spec/scenarios/wallets/voiding_wallet_credits_spec.rb
+++ b/spec/scenarios/wallets/voiding_wallet_credits_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Voiding wallet credits", :premium do
+  let(:organization) { create(:organization, :with_static_values, webhook_url: nil) }
+  let(:customer) { create(:customer, :with_static_values, organization:) }
+
+  around do |test|
+    # Set the time to have a fixed issue date in invoice
+    travel_to Time.zone.local(2025, 1, 1, 0, 0, 0), &test
+  end
+
+  it "voids a wallet credit" do
+    wallet = create_wallet({
+      external_customer_id: customer.external_id,
+      rate_amount: "1",
+      name: "Wallet1",
+      currency: "EUR",
+      granted_credits: "100",
+      invoice_requires_successful_payment: false
+    }, as: :model)
+
+    transactions = create_wallet_transaction({
+      wallet_id: wallet.id,
+      voided_credits: "14.28444999"
+    }, as: :model)
+
+    expect(transactions.count).to eq(1)
+    transaction = transactions.first
+    expect(transaction.status).to eq("settled")
+    expect(transaction.transaction_status).to eq("voided")
+    expect(transaction.amount).to eq(14.28)
+    expect(transaction.credit_amount).to eq(14.28444)
+
+    wallet.reload
+    expect(wallet.credits_balance).to eq(85.71556)
+    # FIXME
+    expect(wallet.balance.to_d).to eq(85.72)
+  end
+end

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
       expect(Utils::ActivityLog).to have_received(:produce).thrice.with(an_instance_of(WalletTransaction), "wallet_transaction.created")
     end
 
+    context "when rounding is applied" do
+      let(:paid_credits) { "0" }
+      let(:granted_credits) { "10.000000" }
+      let(:voided_credits) { "4.28444999" }
+
+      it "creates wallet transactions with rounded values" do
+        transaction = subject.wallet_transactions.find(&:voided?)
+
+        expect(transaction.credit_amount).to eq(4.28444)
+        expect(transaction.amount).to eq(4.28)
+
+        wallet.reload
+
+        expect(wallet.credits_balance).to eq(15.71556)
+        expect(wallet.balance.to_d).to eq(15.72)
+      end
+    end
+
     context "with metadata parameter" do
       let(:metadata) { [{"key" => "valid_value", "value" => "also_valid"}] }
       let(:params) do


### PR DESCRIPTION
## Context

When creating an outbound wallet transaction, we will convert the new wallet credit balance into amount and floor the value. This can cause a discrepancy between wallet and the sum of wallet transaction as we round the amount on the wallet transaction.

**Steps to reproduce:**

1. Create a customer
2. Create a wallet with `100` granted credits
3. Void `14.28444999` credits

Wallet transaction amount is 14.28 BUT wallet balance is 85.71
**Expected behaviour:**

1. Wallet transaction amount is 14.28
3. Wallet balance is 85.72

**Actual behaviour:**

1. Wallet transaction amount is 14.28
2. Wallet balance is 85.71

## Description

I added tests to reproduce this behavior and fixed the behaviour:

```sh
Voiding wallet credits
  voids a wallet credit (FAILED - 1)

WalletTransactions::CreateFromParamsService
  #call
    when rounding is applied
      creates wallet transactions with rounded values (FAILED - 2)

Failures:

  1) Voiding wallet credits voids a wallet credit
     Failure/Error: expect(wallet.balance.to_d).to eq(85.72)
       Expected 0.8571e2 to eq 85.72.
     # ./spec/scenarios/wallets/voiding_wallet_credits_spec.rb:39:in 'block (2 levels) in <top (required)>'
     # ./spec/scenarios/wallets/voiding_wallet_credits_spec.rb:11:in 'block (2 levels) in <top (required)>'
     # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
     # ./spec/spec_helper.rb:218:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'

  2) WalletTransactions::CreateFromParamsService#call when rounding is applied creates wallet transactions with rounded values
     Failure/Error: expect(wallet.balance.to_d).to eq(15.72)
       Expected 0.1571e2 to eq 15.72.
     # ./spec/services/wallet_transactions/create_from_params_service_spec.rb:109:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:220:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'

Finished in 3.2 seconds (files took 12.36 seconds to load)
31 examples, 2 failures

Failed examples:

rspec ./spec/scenarios/wallets/voiding_wallet_credits_spec.rb:14 # Voiding wallet credits voids a wallet credit
rspec ./spec/services/wallet_transactions/create_from_params_service_spec.rb:100 # WalletTransactions::CreateFromParamsService#call when rounding is applied creates wallet transactions with rounded values
```
