### PR TITLE
fix(wallet): Fix prepaid credit when limitation applies

### DIFF
--- a/app/services/credits/applied_prepaid_credits_service.rb
+++ b/app/services/credits/applied_prepaid_credits_service.rb
@@ -28,6 +28,7 @@ module Credits
       ApplicationRecord.transaction do
         wallet_transaction = create_wallet_transaction(amount_cents)
         result.wallet_transaction = wallet_transaction
+        amount_cents = wallet_transaction.amount_cents
 
         with_optimistic_lock_retry(wallet) do
           Wallets::Balance::DecreaseService.call(wallet:, wallet_transaction:)

--- a/spec/scenarios/invoices/invoicing_with_prepaid_credits_spec.rb
+++ b/spec/scenarios/invoices/invoicing_with_prepaid_credits_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Invoicing with prepaid credits", :premium do
+  let(:organization) { create(:organization, :with_static_values, webhook_url: nil) }
+  let(:customer) { create(:customer, :with_static_values, organization:) }
+  let(:billable_metric_1) { create(:billable_metric, organization:, code: "count_1") }
+  let(:billable_metric_2) { create(:billable_metric, organization:, code: "count_2") }
+  let(:other_billable_metric) { create(:sum_billable_metric, organization:) }
+  let(:plan) { create(:plan, organization:, amount_cents: 0) }
+  let(:tax) { create(:tax, rate: 24, organization:) }
+  let(:external_subscription_id) { SecureRandom.uuid }
+
+  before do
+    charge_1 = create(:standard_charge, plan:, billable_metric: billable_metric_1, pay_in_advance: true, properties: {amount: "14.29"})
+    create(:charge_applied_tax, charge: charge_1, tax:)
+
+    charge_2 = create(:standard_charge, plan:, billable_metric: billable_metric_2, pay_in_advance: true, properties: {amount: "14.27"})
+    create(:charge_applied_tax, charge: charge_2, tax:)
+
+    create(:standard_charge, plan:, billable_metric: other_billable_metric, pay_in_advance: true, properties: {amount: "10"})
+
+    create_subscription({
+      external_customer_id: customer.external_id,
+      external_id: external_subscription_id,
+      plan_code: plan.code
+    })
+  end
+
+  context "with limitations" do
+    it "invoices a customer with prepaid credits" do
+      wallet = setup_wallet
+
+      expect(customer.invoices.count).to eq(0)
+
+      test_invoice_with_non_applicable_billable_metric(wallet)
+      test_invoice_with_applicable_billable_metric(wallet)
+    end
+
+    private
+
+    def setup_wallet
+      create_wallet({
+        external_customer_id: customer.external_id,
+        rate_amount: "1",
+        currency: "EUR",
+        granted_credits: "39.00",
+        invoice_requires_successful_payment: false,
+        applies_to: {billable_metric_codes: [billable_metric_1.code, billable_metric_2.code]}
+      }, as: :model)
+    end
+
+    def test_invoice_with_non_applicable_billable_metric(wallet)
+      expect do
+        create_event({
+          code: other_billable_metric.code,
+          external_customer_id: customer.external_id,
+          external_subscription_id: external_subscription_id,
+          properties: {item_id: "1"}
+        })
+      end.to change { customer.invoices.count }.by(1)
+
+      invoice = customer.invoices.last
+      expect(invoice.prepaid_credit_amount_cents).to eq(0)
+    end
+
+    def test_invoice_with_applicable_billable_metric(wallet)
+      expect do
+        create_event({
+          code: billable_metric_1.code,
+          external_customer_id: customer.external_id,
+          external_subscription_id: external_subscription_id,
+          properties: {}
+        })
+      end.to change { customer.invoices.count }.by(1)
+
+      invoice = customer.invoices.order(:created_at).last
+
+      expect(invoice.total_amount_cents).to eq(0)
+      expect(invoice.sub_total_including_taxes_amount.to_d).to eq(17.72)
+      expect(invoice.prepaid_credit_amount.to_d).to eq(17.72)
+
+      wallet.reload
+
+      expect(wallet.credits_balance).to eq(21.28)
+      expect(wallet.balance.to_d).to eq(21.28)
+
+      expect do
+        create_event({
+          code: billable_metric_2.code,
+          external_customer_id: customer.external_id,
+          external_subscription_id: external_subscription_id,
+          properties: {}
+        })
+      end.to change { customer.invoices.count }.by(1)
+
+      invoice = customer.invoices.order(:created_at).last
+
+      expect(invoice.total_amount.to_d).to eq(0)
+      expect(invoice.sub_total_including_taxes_amount.to_d).to eq(17.69)
+      expect(invoice.prepaid_credit_amount.to_d).to eq(17.69)
+
+      wallet.reload
+
+      expect(wallet.credits_balance).to eq(3.59)
+      expect(wallet.balance.to_d).to eq(3.59)
+    end
+  end
+end

--- a/spec/services/credits/applied_prepaid_credits_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credits_service_spec.rb
@@ -195,6 +195,17 @@ RSpec.describe Credits::AppliedPrepaidCreditsService do
         expect(wallet.credits_balance).to eq(9.56)
       end
 
+      context "when precise fees have decimals" do
+        let(:amount_cents) { 110.1 }
+
+        let(:fee2) { create(:charge_fee, invoice:, subscription:, precise_amount_cents: 40.1, taxes_precise_amount_cents: 4, charge:) }
+
+        it "rounds the decimals" do
+          expect(result).to be_success
+          expect(result.prepaid_credit_amount_cents).to eq(44)
+        end
+      end
+
       context "when wallet credits are less than invoice amount" do
         let(:amount_cents) { 10_000 }
         let(:fee1) { create(:fee, invoice:, subscription:, precise_amount_cents: 6_000, taxes_precise_amount_cents: 600) }

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1749,15 +1749,18 @@ RSpec.describe Invoices::CalculateFeesService do
       it "updates the invoice accordingly" do
         result = invoice_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.fees_amount_cents).to eq(20_000)
-          expect(result.invoice.taxes_amount_cents).to eq(1_550)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(15_500)
-          expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(17_050)
-          expect(result.invoice.progressive_billing_credit_amount_cents).to eq(3_000)
-          expect(result.invoice.total_amount_cents).to eq(9_727) # 17_050 - 1_000 (credit note) - 6_323 (wallet)
-        end
+        expect(result).to be_success
+
+        invoice = result.invoice
+        expect(invoice.fees_amount_cents).to eq(20_000)
+        expect(invoice.progressive_billing_credit_amount_cents).to eq(3_000)
+        expect(invoice.coupons_amount_cents).to eq(1_500)
+        expect(invoice.sub_total_excluding_taxes_amount_cents).to eq(15_500) # 20_000 - 1_500 - 3_000
+        expect(invoice.taxes_amount_cents).to eq(1_550)
+        expect(invoice.sub_total_including_taxes_amount_cents).to eq(17_050) # 15_500 + 1_550
+        expect(invoice.prepaid_credit_amount_cents).to eq(6_323)
+        expect(invoice.credit_notes_amount_cents).to eq(1_000)
+        expect(invoice.total_amount_cents).to eq(9_727) # 17_050 - 1_000 - 6_323
       end
     end
   end


### PR DESCRIPTION
## Context

When generating an invoice, if the customer has a wallet with fee limitations, we can end up with two rounding issues:

1. 1 cent discrepancy on invoice's `prepaid_credit_amount` compared to the wallet/wallet transaction value
2. A negative value on invoice's `total_amount_cents`

This occurs because the wallet/wallet transaction value is rounded while the invoice `prepaid_credit_amount` is not.

### 1 cent discrepancy on invoice's `prepaid_credit_amount`

**Steps to reproduce:**

1. Create a customer
2. Create two count billable metrics
3. Create a wallet with `100` granted credits
4. Create a plan with:
  a. Charge 1: `14.29 EUR` pay-in-advance charge with `24%` tax on billable metric 1
  b. Charge 2: `14.27 EUR` pay-in-advance charge with `24%` tax on billable metric 2
5. Assign the plan to the customer
6. Sent an event for billable metric 1

**Expected behaviour:**

1. Invoice prepaid credits is `17.72 EUR`
2. Invoice total is `0 EUR`
3. Wallet balance is `82.28 EUR`

**Actual behaviour:**

1. Invoice prepaid credits is `17.71 EUR`
2. Invoice total is `0 EUR`
3. Wallet balance is `82.28 EUR`

### A negative value on invoice's `total_amount_cents`

**Steps to reproduce:**

1. Create a customer
2. Create two count billable metrics
3. Create a wallet with `100` granted credits
4. Create a plan with:
  a. Charge 1: `14.29 EUR` pay-in-advance charge with `24%` tax on billable metric 1
  b. Charge 2: `14.27 EUR` pay-in-advance charge with `24%` tax on billable metric 2
5. Assign the plan to the customer
6. Sent an event for billable metric 2

**Expected behaviour:**

1. Invoice prepaid credits is `17.69 EUR`
2. Invoice total is `0 EUR`
3. Wallet balance is `82.28 EUR`

**Actual behaviour:**

The invoice failed to generate with a `{"total_amount_cents":["value_is_out_of_range"]}` error.

## Description

I added tests to reproduce this behavior and fixed the behaviour:

```ruby
Invoicing with prepaid credits
  with limitations
    invoices a customer with prepaid credits (FAILED - 1)

Credits::AppliedPrepaidCreditsService
  #call
    with billable metric limitations
      when precise fees have decimals
        rounds the decimals (FAILED - 2)

Invoices::CalculateFeesService
  #call
    with all types of credits
      updates the invoice accordingly (FAILED - 3)

Failures:

  1) Invoicing with prepaid credits with limitations invoices a customer with prepaid credits
     Got 1 failure and 1 other error:

     1.1) Failure/Error: expect(invoice.prepaid_credit_amount.to_d).to eq(17.72)
            Expected 0.1771e2 to eq 17.72.
          # ./spec/scenarios/invoices/invoicing_with_prepaid_credits_spec.rb:82:in 'RSpec::ExampleGroups::InvoicingWithPrepaidCredits::WithLimitations#test_invoice_with_applicable_billable_metric'
          # ./spec/scenarios/invoices/invoicing_with_prepaid_credits_spec.rb:38:in 'block (3 levels) in <top (required)>'
          # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
          # ./spec/spec_helper.rb:218:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/null_strategy.rb:17:in 'DatabaseCleaner::NullStrategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
          # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'
          # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

     1.2) Failure/Error: raise(error)

          BaseService::ValidationFailure:
            Validation errors: {"total_amount_cents":["value_is_out_of_range"]}
          # ./app/services/result.rb:78:in 'Result#raise_if_error!'
          # ./app/services/base_service.rb:190:in 'BaseService.call!'
          # ./app/services/invoices/transition_to_final_status_service.rb:14:in 'Invoices::TransitionToFinalStatusService#call'
          # ./app/services/base_service.rb:213:in 'block in BaseService#call_with_middlewares'
          # ./app/services/base_service.rb:237:in 'block in BaseService#init_middlewares'
          # ./app/services/middlewares/base_middleware.rb:31:in 'Middlewares::BaseMiddleware#call_next'
          # ./app/services/middlewares/log_tracer_middleware.rb:7:in 'block in Middlewares::LogTracerMiddleware#call'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/context.rb:87:in 'OpenTelemetry::Context.with_value'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
          # ./app/services/middlewares/log_tracer_middleware.rb:6:in 'Middlewares::LogTracerMiddleware#call'
          # ./app/services/base_service.rb:245:in 'block (2 levels) in BaseService#init_middlewares'
          # ./app/services/base_service.rb:213:in 'BaseService#call_with_middlewares'
          # ./app/services/base_service.rb:180:in 'BaseService.call'
          # ./app/services/invoices/create_pay_in_advance_charge_service.rb:45:in 'block in Invoices::CreatePayInAdvanceChargeService#call'
          # ./app/services/invoices/create_pay_in_advance_charge_service.rb:20:in 'Invoices::CreatePayInAdvanceChargeService#call'
          # ./app/services/base_service.rb:213:in 'block in BaseService#call_with_middlewares'
          # ./app/services/base_service.rb:237:in 'block in BaseService#init_middlewares'
          # ./app/services/middlewares/base_middleware.rb:31:in 'Middlewares::BaseMiddleware#call_next'
          # ./app/services/middlewares/log_tracer_middleware.rb:7:in 'block in Middlewares::LogTracerMiddleware#call'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/context.rb:87:in 'OpenTelemetry::Context.with_value'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
          # /usr/local/bundle/gems/opentelemetry-api-1.3.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
          # ./app/services/middlewares/log_tracer_middleware.rb:6:in 'Middlewares::LogTracerMiddleware#call'
          # ./app/services/base_service.rb:245:in 'block (2 levels) in BaseService#init_middlewares'
          # ./app/services/base_service.rb:213:in 'BaseService#call_with_middlewares'
          # ./app/services/base_service.rb:180:in 'BaseService.call'
          # ./app/jobs/invoices/create_pay_in_advance_charge_job.rb:21:in 'Invoices::CreatePayInAdvanceChargeJob#perform'
          # /usr/local/bundle/gems/i18n-1.14.7/lib/i18n.rb:353:in 'I18n::Base#with_locale'
          # /usr/local/bundle/gems/sentry-rails-5.18.2/lib/sentry/rails/active_job.rb:6:in 'Sentry::Rails::ActiveJobExtensions#perform_now'
          # ./spec/support/queues_helper.rb:20:in 'QueuesHelper#perform_all_enqueued_jobs'
          # ./spec/support/scenarios_helper.rb:19:in 'ScenariosHelper#api_call'
          # ./spec/support/scenarios_helper.rb:260:in 'ScenariosHelper#create_event'
          # ./spec/scenarios/invoices/invoicing_with_prepaid_credits_spec.rb:90:in 'block in RSpec::ExampleGroups::InvoicingWithPrepaidCredits::WithLimitations#test_invoice_with_applicable_billable_metric'
          # ./spec/scenarios/invoices/invoicing_with_prepaid_credits_spec.rb:96:in 'RSpec::ExampleGroups::InvoicingWithPrepaidCredits::WithLimitations#test_invoice_with_applicable_billable_metric'
          # ./spec/scenarios/invoices/invoicing_with_prepaid_credits_spec.rb:38:in 'block (3 levels) in <top (required)>'
          # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
          # ./spec/spec_helper.rb:218:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/null_strategy.rb:17:in 'DatabaseCleaner::NullStrategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
          # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'
          # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

  2) Credits::AppliedPrepaidCreditsService#call with billable metric limitations when precise fees have decimals rounds the decimals
     Failure/Error: expect(result.prepaid_credit_amount_cents).to eq(44)
       Expected 0.441e2 to eq 44.
     # ./spec/services/credits/applied_prepaid_credits_service_spec.rb:205:in 'block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:220:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/null_strategy.rb:17:in 'DatabaseCleaner::NullStrategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
     # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

  3) Invoices::CalculateFeesService#call with all types of credits updates the invoice accordingly
     Failure/Error: expect(invoice.prepaid_credit_amount_cents).to eq(6_323)
       Expected 6322 to eq 6323.
     # ./spec/services/invoices/calculate_fees_service_spec.rb:1761:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:220:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/null_strategy.rb:17:in 'DatabaseCleaner::NullStrategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
     # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

Finished in 15.96 seconds (files took 3.09 seconds to load)
145 examples, 3 failures

Failed examples:

rspec ./spec/scenarios/invoices/invoicing_with_prepaid_credits_spec.rb:32 # Invoicing with prepaid credits with limitations invoices a customer with prepaid credits
rspec ./spec/services/credits/applied_prepaid_credits_service_spec.rb:203 # Credits::AppliedPrepaidCreditsService#call with billable metric limitations when precise fees have decimals rounds the decimals
rspec ./spec/services/invoices/calculate_fees_service_spec.rb:1749 # Invoices::CalculateFeesService#call with all types of credits updates the invoice accordingly
```
