### PR TITLE
feat(subscription): Return entitlements for `show` and `create`

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -75,7 +75,7 @@ module Api
 
         if result.success?
           response[:subscription] = ::V1::SubscriptionSerializer.new(
-            result.subscription, includes: %i[plan]
+            result.subscription, includes: %i[plan entitlements]
           ).serialize
 
           render(json: response)
@@ -139,7 +139,7 @@ module Api
           )
         return not_found_error(resource: "subscription") unless subscription
 
-        render_subscription(subscription)
+        render_subscription(subscription, includes: %i[plan entitlements])
       end
 
       def index
@@ -224,12 +224,12 @@ module Api
         ]
       end
 
-      def render_subscription(subscription)
+      def render_subscription(subscription, includes: %i[plan])
         render(
           json: ::V1::SubscriptionSerializer.new(
             subscription,
             root_name: "subscription",
-            includes: %i[plan]
+            includes:
           )
         )
       end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Api::V1::SubscriptionsController do
 
     it "returns a success", :aggregate_failures do
       create(:plan, code: plan.code, parent_id: plan.id, organization:, description: "foo")
+      create(:entitlement, organization:, plan:)
 
       freeze_time do
         subject
@@ -73,6 +74,13 @@ RSpec.describe Api::V1::SubscriptionsController do
           next_plan_code: nil,
           downgrade_plan_date: nil
         )
+        expect(json[:subscription][:entitlements]).to contain_exactly({
+          code: "feature_1",
+          name: "Feature Name",
+          description: "Feature Description",
+          privileges: [],
+          overrides: {}
+        })
         expect(json[:subscription][:plan]).to include(
           amount_cents: 100,
           name: "overridden name",
@@ -1117,6 +1125,7 @@ RSpec.describe Api::V1::SubscriptionsController do
     include_examples "requires API permission", "subscription", "read"
 
     it "returns a subscription" do
+      create(:entitlement, :subscription, organization:, subscription:)
       subject
 
       expect(response).to have_http_status(:success)
@@ -1124,6 +1133,13 @@ RSpec.describe Api::V1::SubscriptionsController do
         lago_id: subscription.id,
         external_id: subscription.external_id
       )
+      expect(json[:subscription][:entitlements]).to contain_exactly({
+        code: "feature_1",
+        name: "Feature Name",
+        description: "Feature Description",
+        privileges: [],
+        overrides: {}
+      })
     end
 
     context "when subscription does not exist" do


### PR DESCRIPTION
Creating and retrieving a subscription will now return the subscription entitlements.

```
GET   /v1/subscriptions
POST  /v1/subscriptions
```

> [!WARNING]
> We can't add `entitlements` to the list endpoint because there is no easy way to eagerload the relationship for now.