### PR TITLE
fix(profiling): Fix loading of `Sidekiq::ProfilingMiddleware`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,10 @@ Rails.application.configure do
     Bullet.rails_logger = true
   end
 
+  config.autoload_paths += %W[
+    #{config.root}/dev
+  ]
+
   # Settings specified here will take precedence over those in config/application.rb.
   config.middleware.use(ActionDispatch::Cookies)
   config.middleware.use(ActionDispatch::Session::CookieStore, key: "_lago_dev")

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -83,7 +83,6 @@ Sidekiq.configure_server do |config|
   end
 
   if Rails.env.development? && ENV["SIDEKIQ_PROFILING_ENABLED"] == "true"
-    require "sidekiq/profiling_middleware"
     config.server_middleware do |chain|
       chain.prepend(Sidekiq::ProfilingMiddleware, dir: "tmp/profiling")
     end


### PR DESCRIPTION
## Context

https://github.com/getlago/lago-api/commit/34ba6fd00adc9793034939082eb5d8d6cd8565a9 removed the `dev` folder from the eager load path and the `Sidekiq::ProfilingMiddleware` was not tested after rebasing. It seems that the `require "sidekiq/profiling_middleware"` now fails because `dev` folder is no longer part of the load paths.

## Description

This fixes it by adding `dev` folder as part of the `autoload_paths` in development env.