### PR TITLE
fix(stripe): last_payment_error might not have code field

### DIFF
--- a/app/services/payment_providers/stripe/webhooks/base_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/base_service.rb
@@ -67,7 +67,7 @@ module PaymentProviders
               id: event.data.object.id,
               status: event.data.object.status,
               metadata:,
-              error_code: event.data.object["last_payment_error"]&.code
+              error_code: event.data.object.to_hash.dig(:last_payment_error, :code)
             )
           ).raise_if_error!
         end


### PR DESCRIPTION
Stripe objects are a little annoying because you cannot use `dig` and you get `no method error` so `&` does not help.

Some last_payment_error don't have a `code`, so I'm turning the object to a hash to use dig.
