### PR TITLE
fix(forecasted-usage): Add a condition for charges with pricing group keys

### DIFF
--- a/app/services/charges/calculate_price_service.rb
+++ b/app/services/charges/calculate_price_service.rb
@@ -3,7 +3,7 @@
 module Charges
   class CalculatePriceService < BaseService
     Result = BaseResult[:charge_amount_cents, :subscription_amount_cents, :total_amount_cents]
-    AggregationResult = Struct.new(:aggregation, :total_aggregated_units, :current_usage_units, :full_units_number, :precise_total_amount_cents, :custom_aggregation, :options)
+    AggregationResult = Struct.new(:aggregations, :aggregation, :total_aggregated_units, :current_usage_units, :full_units_number, :precise_total_amount_cents, :custom_aggregation, :options)
 
     def initialize(units:, charge:, charge_filter: nil)
       @units = BigDecimal(units || 0)
@@ -48,7 +48,7 @@ module Charges
     end
 
     def aggregation_result
-      AggregationResult.new(units, units, units, units, 0, nil, running_total: [])
+      AggregationResult.new(nil, units, units, units, units, 0, nil, running_total: [])
     end
   end
 end

--- a/spec/services/charges/calculate_price_service_spec.rb
+++ b/spec/services/charges/calculate_price_service_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe Charges::CalculatePriceService do
       end
     end
 
+    context "when charge has pricing_group_keys but no grouped data" do
+      let(:charge) do
+        create(
+          :standard_charge,
+          plan:,
+          billable_metric:,
+          properties: {
+            pricing_group_keys: ["region"],
+            amount: "10"
+          }
+        )
+      end
+
+      it "calculates using base pricing without grouped service" do
+        result = calculate_price_service.call
+
+        expect(result.charge_amount_cents).to eq(50)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1050)
+      end
+    end
+
     context "when there is a graduated charge" do
       let(:charge) do
         create(


### PR DESCRIPTION
## Context

Some records failed to update when the charges have pricing group keys configured.

## Description

Added the missing initialize parameter to bypass this calculation with the base value.