### PR TITLE
fix(stripe): Fix Stripe customer creation when customer is deleted

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -11,6 +11,8 @@ module PaymentProviderCustomers
     end
 
     def create
+      return result unless customer
+
       result.stripe_customer = stripe_customer
       return result if stripe_customer.provider_customer_id? || !stripe_payment_provider
 

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe PaymentProviderCustomers::StripeService do
   end
 
   describe "#create" do
+    context "when customer is deleted" do
+      before do
+        customer.discard!
+        stripe_customer.reload
+      end
+
+      it "returns a deleted_customer failure" do
+        result = stripe_service.create
+
+        expect(result).to be_success
+        expect(result.stripe_customer).to be_nil
+      end
+    end
+
     context "when customer name is present" do
       let(:customer_name) { "Big inc" }
 


### PR DESCRIPTION
## Context

It can happen that a customer is deleted before we try to synchronize with Stripe.

## Description

This skips the user creation on Stripe if customer is deleted.
