### PR TITLE
deps: make sure we use correct version of pg in workflow

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         ports:
           - "5432:5432"
         env:


### PR DESCRIPTION
We recently bumped pg to v15. This should be reflected in the workflow jobs.