### PR TITLE
feat(event): Add new filter service for billing period

### DIFF
--- a/app/services/billable_metrics/aggregation_factory.rb
+++ b/app/services/billable_metrics/aggregation_factory.rb
@@ -4,7 +4,7 @@ module BillableMetrics
   class AggregationFactory
     def self.new_instance(charge:, current_usage: false, **attributes)
       aggregator_class(charge, current_usage).new(
-        event_store_class: Events::Stores::StoreFactory.store_class(organization: charge.billable_metric.organization, current_usage:),
+        event_store_class: Events::Stores::StoreFactory.store_class(organization: charge.billable_metric.organization),
         charge:,
         **attributes
       )

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Events
+  class BillingPeriodFilterService < BaseService
+    Result = BaseResult[:charge_ids]
+
+    def initialize(subscription:, boundaries:)
+      @subscription = subscription
+      @boundaries = boundaries
+      super
+    end
+
+    def call
+      values = plan.charges.joins(:billable_metric)
+        .where(billable_metrics: {code: distinct_event_codes})
+        .or(plan.charges.joins(:billable_metric).where(billable_metrics: {recurring: true}))
+        .pluck("DISTINCT(charges.id)")
+
+      result.charge_ids = values
+
+      result
+    end
+
+    private
+
+    attr_reader :subscription, :boundaries
+
+    delegate :plan, to: :subscription
+
+    def distinct_event_codes
+      Events::Stores::StoreFactory.new_instance(
+        organization: subscription.organization,
+        subscription:,
+        boundaries: {
+          from_datetime: boundaries.charges_from_datetime,
+          to_datetime: boundaries.charges_to_datetime
+        }
+      ).distinct_codes
+    end
+  end
+end

--- a/app/services/events/stores/store_factory.rb
+++ b/app/services/events/stores/store_factory.rb
@@ -9,7 +9,7 @@ module Events
         end
       end
 
-      def self.store_class(organization:, current_usage: false)
+      def self.store_class(organization:)
         event_store = Events::Stores::PostgresStore
 
         if supports_clickhouse? && organization.clickhouse_events_store?
@@ -19,8 +19,8 @@ module Events
         event_store
       end
 
-      def self.new_instance(organization:, current_usage: false, **kwargs)
-        store_class(organization: organization, current_usage: current_usage).new(**kwargs)
+      def self.new_instance(organization:, **kwargs)
+        store_class(organization: organization).new(**kwargs)
       end
     end
   end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -103,7 +103,7 @@ module Invoices
     def create_charges_fees(subscription, boundaries)
       return unless charge_boundaries_valid?(boundaries)
 
-      received_event_codes = distinct_event_codes(subscription, boundaries)
+      filters = event_filters(subscription, boundaries)
 
       subscription
         .plan
@@ -116,7 +116,7 @@ module Invoices
         .find_each do |charge|
           next if should_not_create_charge_fee?(charge, subscription)
 
-          bypass_aggregation = !received_event_codes.include?(charge.billable_metric.code)
+          bypass_aggregation = !filters.charge_ids.include?(charge.id)
           Fees::ChargeService.call(invoice:, charge:, subscription:, boundaries:, context:, bypass_aggregation:).raise_if_error!
         end
     end
@@ -346,12 +346,10 @@ module Invoices
       context == :finalize || Invoice::GENERATED_INVOICE_STATUSES.include?(invoice.status)
     end
 
-    def distinct_event_codes(subscription, boundaries)
-      Events::Stores::StoreFactory.new_instance(
-        organization: invoice.organization,
-        subscription:,
-        boundaries: {from_datetime: boundaries.charges_from_datetime, to_datetime: boundaries.charges_to_datetime}
-      ).distinct_codes
+    def event_filters(subscription, boundaries)
+      Events::BillingPeriodFilterService.call!(
+        subscription:, boundaries:
+      )
     end
   end
 end

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::BillingPeriodFilterService do
+  subject(:filter_service) { described_class.new(subscription:, boundaries:) }
+
+  let(:organization) { create(:organization) }
+
+  let(:subscription) do
+    create(
+      :subscription,
+      organization:,
+      plan:,
+      started_at:,
+      subscription_at: started_at,
+      external_id: "sub_id"
+    )
+  end
+
+  let(:started_at) { Time.zone.parse("2022-01-01 00:01") }
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+
+  let(:boundaries) do
+    BillingPeriodBoundaries.new(
+      from_datetime: Time.zone.parse("2022-03-01 00:00:00"),
+      to_datetime: Time.zone.parse("2022-03-31 23:59:59"),
+      charges_from_datetime: Time.zone.parse("2022-03-01 00:00:00"),
+      charges_to_datetime: Time.zone.parse("2022-03-31 23:59:59"),
+      charges_duration: 31.days,
+      timestamp: Time.zone.parse("2022-04-02 00:00").end_of_month.to_i
+    )
+  end
+
+  before { charge }
+
+  describe "#call" do
+    it "returns the filtered charge_ids" do
+      result = filter_service.call
+
+      expect(result).to be_success
+      expect(result.charge_ids).to eq([])
+    end
+
+    context "with events matching the boundaries" do
+      before do
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          timestamp: boundaries.charges_from_datetime + 5.days,
+          code: billable_metric.code
+        )
+
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          timestamp: boundaries.charges_from_datetime + 5.days,
+          code: billable_metric.code
+        )
+      end
+
+      it "returns filtered charge_ids" do
+        result = filter_service.call
+
+        expect(result).to be_success
+        expect(result.charge_ids).to eq([charge.id])
+      end
+
+      context "with multiple charges for the same billable_metric" do
+        let(:charge_2) { create(:standard_charge, plan:, billable_metric:) }
+
+        before { charge_2 }
+
+        it "returns filtered charge_ids" do
+          result = filter_service.call
+
+          expect(result).to be_success
+          expect(result.charge_ids).to match_array([charge.id, charge_2.id])
+        end
+      end
+
+      context "with multiple billable metrics" do
+        let(:billable_metric_2) { create(:billable_metric, organization:) }
+        let(:charge_2) { create(:standard_charge, plan:, billable_metric: billable_metric_2) }
+
+        before do
+          charge_2
+
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            timestamp: boundaries.charges_from_datetime + 10.days,
+            code: billable_metric_2.code
+          )
+        end
+
+        it "returns charge_ids for all billable metrics with matching events" do
+          result = filter_service.call
+
+          expect(result).to be_success
+          expect(result.charge_ids).to match_array([charge.id, charge_2.id])
+        end
+      end
+    end
+
+    context "with recurring billable metric" do
+      let(:recurring_billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+      let(:recurring_charge) { create(:standard_charge, plan:, billable_metric: recurring_billable_metric) }
+
+      before { recurring_charge }
+
+      it "returns recurring charge_ids even without events" do
+        result = filter_service.call
+
+        expect(result).to be_success
+        expect(result.charge_ids).to eq([recurring_charge.id])
+      end
+    end
+
+    context "with events that does not match the boundaries" do
+      before do
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          timestamp: boundaries.charges_from_datetime - 5.days,
+          code: billable_metric.code
+        )
+      end
+
+      it "returns filtered charge_ids" do
+        result = filter_service.call
+
+        expect(result).to be_success
+        expect(result.charge_ids).to eq([])
+      end
+    end
+
+    context "with unknown event codes" do
+      before do
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          timestamp: boundaries.charges_from_datetime + 5.days,
+          code: "unknown_code"
+        )
+      end
+
+      it "returns filtered charge_ids" do
+        result = filter_service.call
+
+        expect(result).to be_success
+        expect(result.charge_ids).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/store_factory_spec.rb
+++ b/spec/services/events/stores/store_factory_spec.rb
@@ -3,11 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Events::Stores::StoreFactory do
-  subject(:store_instance) { described_class.new_instance(organization:, current_usage:, **arguments) }
+  subject(:store_instance) { described_class.new_instance(organization:, **arguments) }
 
   let(:organization) { create(:organization, clickhouse_events_store:) }
   let(:clickhouse_events_store) { false }
-  let(:current_usage) { false }
 
   let(:arguments) do
     time = Time.current


### PR DESCRIPTION
## Context

This PR is part of the "pre-filter" events feature.

## Description

The goal of these changes is to extract the logic used to check which billable metrics where reached by events on a specific billing period into a new `Events::BillingPeriodFilterService`. This service will be called by all services performing events aggregations (namely `Invoices::CalculateFeesService` and `Invoices::CustomerUsageService`).

The new service returns a list of `charge_id` rather than a list of billable metric codes. It will be updated later to also returns a list of `charge_filter_ids` allowing the services to perform the aggregation for filters only when required.
