### PR TITLE
fix(forecasted-usage): Add a missing key to AggregationResult

### DIFF
--- a/app/services/charges/calculate_price_service.rb
+++ b/app/services/charges/calculate_price_service.rb
@@ -3,7 +3,7 @@
 module Charges
   class CalculatePriceService < BaseService
     Result = BaseResult[:charge_amount_cents, :subscription_amount_cents, :total_amount_cents]
-    AggregationResult = Struct.new(:aggregations, :aggregation, :total_aggregated_units, :current_usage_units, :full_units_number, :precise_total_amount_cents, :custom_aggregation, :options)
+    AggregationResult = Struct.new(:aggregator, :aggregations, :aggregation, :total_aggregated_units, :current_usage_units, :full_units_number, :precise_total_amount_cents, :custom_aggregation, :options)
 
     def initialize(units:, charge:, charge_filter: nil)
       @units = BigDecimal(units || 0)
@@ -48,7 +48,7 @@ module Charges
     end
 
     def aggregation_result
-      AggregationResult.new(nil, units, units, units, units, 0, nil, running_total: [])
+      AggregationResult.new(nil, nil, units, units, units, units, 0, nil, running_total: [])
     end
   end
 end


### PR DESCRIPTION
## Context

Some records failed to update when the calling a charge model with the aggregator key.

## Description

Added the missing initialize parameter to bypass this calculation with the base value.