### PR TITLE
fix(email): Retry email delivery job on Net::SMTPServerBusy error

### DIFF
--- a/app/jobs/send_email_job.rb
+++ b/app/jobs/send_email_job.rb
@@ -6,4 +6,5 @@ class SendEmailJob < ActionMailer::MailDeliveryJob
   retry_on ActiveJob::DeserializationError, wait: :polynomially_longer, attempts: 6
   retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 6
   retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 6
+  retry_on Net::SMTPServerBusy, wait: :polynomially_longer, attempts: 25
 end


### PR DESCRIPTION
## Description

This PR adds an auto-retry logic for email delivery in case of `Net::SMTPServerBusy` error

Error message is `454 Throttling failure: Maximum sending rate exceeded. (Net::SMTPServerBusy)`, meaning the job can be retried after a wait period. It appens when too many `SendEmailJob` are executed in parallel.

