### PR TITLE
feat(sidekiq): add Datadog metrics support for Sidekiq Pro

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :"sidekiq-pro", optional: true do
   source "https://gems.contribsys.com/" do
     gem "sidekiq-pro"
   end
+  gem "dogstatsd-ruby"
 end
 gem "sidekiq-throttled", "1.4.0" # '1.5.0' was losing some jobs
 gem "throttling"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,7 @@ GEM
     discard (1.4.0)
       activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
+    dogstatsd-ruby (5.7.1)
     dotenv (3.1.7)
     drb (2.2.3)
     dry-configurable (1.2.0)
@@ -1092,6 +1093,7 @@ DEPENDENCIES
   datadog
   debug
   discard (~> 1.2)
+  dogstatsd-ruby
   dotenv
   dry-validation
   event_stream_parser


### PR DESCRIPTION
## Context

Sidekiq Pro provides built-in metrics capabilities that can be sent to Datadog for monitoring job performance and queue health.

## Description

Add dogstatsd-ruby gem dependency and configure Sidekiq Pro to send metrics to Datadog using the recommended Statsd middleware setup.
