### PR TITLE
fix(netsuite): Truncate city name

### DIFF
--- a/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
@@ -7,6 +7,7 @@ module Integrations
         class Netsuite < BasePayload
           BASE_LIMIT = 30
           ADDR1_LIMIT = 150
+          CITY_LIMIT = 50
 
           def create_body
             {
@@ -83,7 +84,7 @@ module Integrations
                       "subObject" => {
                         "addr1" => customer.address_line1&.first(ADDR1_LIMIT),
                         "addr2" => customer.address_line2,
-                        "city" => customer.city,
+                        "city" => customer.city&.first(CITY_LIMIT),
                         "zip" => customer.zipcode,
                         "state" => customer.state&.first(BASE_LIMIT),
                         "country" => customer.country
@@ -104,7 +105,7 @@ module Integrations
                       "subObject" => {
                         "addr1" => customer.address_line1&.first(ADDR1_LIMIT),
                         "addr2" => customer.address_line2,
-                        "city" => customer.city,
+                        "city" => customer.city&.first(CITY_LIMIT),
                         "zip" => customer.zipcode,
                         "state" => customer.state&.first(BASE_LIMIT),
                         "country" => customer.country
@@ -117,7 +118,7 @@ module Integrations
                       "subObject" => {
                         "addr1" => customer.shipping_address_line1&.first(ADDR1_LIMIT),
                         "addr2" => customer.shipping_address_line2,
-                        "city" => customer.shipping_city,
+                        "city" => customer.shipping_city&.first(CITY_LIMIT),
                         "zip" => customer.shipping_zipcode,
                         "state" => customer.shipping_state&.first(BASE_LIMIT),
                         "country" => customer.shipping_country

--- a/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
           it "returns the payload body" do
             expect(subject).to eq payload_body
           end
+
+          context "when city name is too long" do
+            let(:customer) { create(:customer, email:, phone:, state: nil, city: "Lorem ipsum dolor sit amet, consectetur adipiscing elit") }
+
+            it "returns the payload body with truncated city name" do
+              expect(subject["lines"].first["lineItems"].first["subObject"]["city"]).to eq("Lorem ipsum dolor sit amet, consectetur adipiscing")
+            end
+          end
         end
 
         context "when billing address is not present" do


### PR DESCRIPTION
## Description

This PR fix the following error in `IntegrationCustomers::CreateJob` with Netsuite integration:
```
action_script_runtime_error: The field city contained more than the maximum number ( 50 ) of characters allowed.
```

It truncate the city name to 50 characters to make sure it passes the validation on Netsuite's side
