### PR TITLE
fix(stripe): Retry HandleEventJob on Stripe::APIConnectionError

### DIFF
--- a/app/jobs/payment_providers/stripe/handle_event_job.rb
+++ b/app/jobs/payment_providers/stripe/handle_event_job.rb
@@ -14,6 +14,7 @@ module PaymentProviders
       # NOTE: Sometimes, the stripe webhook is received before the DB update of the impacted resource
       retry_on BaseService::NotFoundFailure
       retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6, jitter: 0.75
+      retry_on ::Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6, jitter: 0.75
 
       def perform(organization:, event:)
         result = PaymentProviders::Stripe::HandleEventService.call(


### PR DESCRIPTION
## Description

This PR adds an auto retry logic for `::Stripe::APIConnectionError` in the `PaymentProviders::Stripe::HandleEventJob`.

Few errors of this type were raised recently in production. 
```
Timed out connecting to Stripe (https://api.stripe.com). Please check your internet connection and try again. If this problem persists, you should check Stripe's service status at https://status.stripe.com, or let us know at support@stripe.com. (Network error: Failed to open TCP connection to api.stripe.com:443 (execution expired))
```

Since this is a temporary error, it is safe to replay the job automatically