### PR TITLE
misc(webhook): Sent invoice.payment_failure when retry without payment provider

### DIFF
--- a/app/services/invoices/payments/retry_service.rb
+++ b/app/services/invoices/payments/retry_service.rb
@@ -20,7 +20,8 @@ module Invoices
           return result.not_allowed_failure!(code: "payment_processor_is_currently_handling_payment")
         end
 
-        Invoices::Payments::CreateService.call_async(invoice:)
+        create_result = Invoices::Payments::CreateService.call_async(invoice:)
+        deliver_webhook if create_result.payment_provider.nil?
 
         result.invoice = invoice
 
@@ -32,6 +33,12 @@ module Invoices
       attr_reader :invoice
 
       delegate :customer, to: :invoice
+
+      def deliver_webhook
+        SendWebhookJob.perform_later(
+          "invoice.payment_failure", invoice, error_details: {code: "customer_must_have_payment_provider"}
+        )
+      end
     end
   end
 end

--- a/spec/services/invoices/payments/retry_service_spec.rb
+++ b/spec/services/invoices/payments/retry_service_spec.rb
@@ -90,5 +90,19 @@ RSpec.describe Invoices::Payments::RetryService do
         expect(result.error.code).to eq("payment_processor_is_currently_handling_payment")
       end
     end
+
+    context "when no payment provider" do
+      let(:payment_provider) { nil }
+
+      it "delivers an error webhook" do
+        expect { retry_service.call }
+          .to enqueue_job(SendWebhookJob)
+          .with(
+            "invoice.payment_failure",
+            invoice,
+            error_details: {code: "customer_must_have_payment_provider"}
+          ).on_queue(webhook_queue)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

The `invoice.created` webhook was recently removed from the payment retry flow, because the invoice was not really created.

However, some customer have built a flow around this webhook message. They are collecting payments outside of Lago, but they are relying on the `invoice.created` webhook that was sent when an invoice was resent for collection. 

As in this case, no payment method is attached to the customers, the payment retry on an an invoice does not trigger any webhook message. 

## Description

This PR make sure we send the existing `invoice.payment_failure` webhook in this case