### PR TITLE
fix(forecasted-usage): Fallback to GraduatedService when we are forecasting amounts for ProratedGraduatedService

### DIFF
--- a/app/services/charge_models/factory.rb
+++ b/app/services/charge_models/factory.rb
@@ -28,6 +28,10 @@ module ChargeModels
       end
     end
 
+    # The has_aggregator param determines whether to use prorated charge models.
+    # When forecasting (no aggregator available), prorated graduated charges fall back to
+    # the non-prorated GraduatedService since per-event aggregation data is not available.
+    # This allows forecasting to work for all charge types without failing on nil aggregator.
     def self.charge_model_class(chargeable:, has_aggregator: true)
       case chargeable.charge_model.to_sym
       when :standard

--- a/spec/services/charge_models/factory_spec.rb
+++ b/spec/services/charge_models/factory_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe ChargeModels::Factory do
 
           it { expect(result).to be_a(ChargeModels::ProratedGraduatedService) }
         end
+
+        context "when charge is prorated, but we are forecasting amounts" do
+          let(:charge) { build(:graduated_charge, prorated: true) }
+
+          it { expect(result).to be_a(ChargeModels::GraduatedService) }
+        end
       end
 
       context "with graduated_percentage charge model" do


### PR DESCRIPTION
## Context

Prorated calculations considers event data that we don't have when forecasting units on the data side, so we fall back to a default approach of using `GraduatedService` for that.

## Description

Added a default param to the charge model class that checks if the factory has an `aggregator`. When we are forecasting, we do not have this `aggregator`, so it fallback to the `GraduatedService`.