### PR TITLE
fix(webhooks): race condition when deleting end-points

### DIFF
--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -25,6 +25,10 @@ module Webhooks
       current_organization.webhook_endpoints.each do |webhook_endpoint|
         webhook = create_webhook(webhook_endpoint, payload)
         SendHttpWebhookJob.perform_later(webhook)
+      rescue ActiveRecord::InvalidForeignKey
+        # The webhook endpoint was deleted while the transaction was in progress
+        Rails.logger.error("SendWebhookJob failed for deleted webhook endpoint #{webhook_endpoint.id}")
+        next
       end
     end
 


### PR DESCRIPTION
## Description
In some rare situation, a `SendWebhookJob` is processed while a Webhook endpoint is removed from the database, this leads to a `ActiveRecord::InvalidForeignKey` error when we try to persist the webhook.

This PR simply rescues the error, logs it and continue the process of delivering the webhooks to other end-points
