### PR TITLE
fix(integration): Fix customer integration creation concurrency

### DIFF
--- a/app/jobs/integration_customers/create_job.rb
+++ b/app/jobs/integration_customers/create_job.rb
@@ -3,14 +3,23 @@
 module IntegrationCustomers
   class CreateJob < ApplicationJob
     include ConcurrencyThrottlable
+
     queue_as "integrations"
 
     retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
     retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
+    # It may happen that a customer was updated in a short time after it was created. As creating integration customers is a
+    # long operation, by the time we receive the update we still haven't created the integration customer. Therefore we will
+    # schedule a second `IntegrationCustomers::CreateJob`. This second job should be ignored if the first one is still
+    # running.
+    #
+    # Note that we kept the `integration_customer_params` in the lock key arguments to ensure we still raise an error if the
+    # update changes the integration customer settings.
+    unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+
     def perform(integration_customer_params:, integration:, customer:)
-      result = IntegrationCustomers::CreateService.call(params: integration_customer_params, integration:, customer:)
-      result.raise_if_error!
+      IntegrationCustomers::CreateService.call!(params: integration_customer_params, integration:, customer:)
     end
   end
 end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -108,7 +108,7 @@ module Customers
 
       result.customer = customer
 
-      IntegrationCustomers::CreateOrUpdateService.call(
+      IntegrationCustomers::CreateOrUpdateBatchService.call(
         integration_customers: args[:integration_customers],
         customer: result.customer,
         new_customer: true

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -187,7 +187,7 @@ module Customers
 
       result.customer = customer
 
-      IntegrationCustomers::CreateOrUpdateService.call(
+      IntegrationCustomers::CreateOrUpdateBatchService.call(
         integration_customers: args[:integration_customers],
         customer: result.customer,
         new_customer: false

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -126,7 +126,7 @@ module Customers
 
       result.customer = customer.reload
 
-      IntegrationCustomers::CreateOrUpdateService.call(
+      IntegrationCustomers::CreateOrUpdateBatchService.call(
         integration_customers: params[:integration_customers],
         customer: result.customer,
         new_customer:

--- a/app/services/integration_customers/create_or_update_batch_service.rb
+++ b/app/services/integration_customers/create_or_update_batch_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module IntegrationCustomers
-  class CreateOrUpdateService < ::BaseService
+  class CreateOrUpdateBatchService < ::BaseService
     SYNC_INTEGRATIONS = ["Integrations::SalesforceIntegration"].freeze
     def initialize(integration_customers:, customer:, new_customer:)
       @integration_customers = integration_customers&.map { |c| c.to_h.deep_symbolize_keys }

--- a/spec/jobs/integration_customers/create_job_spec.rb
+++ b/spec/jobs/integration_customers/create_job_spec.rb
@@ -3,24 +3,39 @@
 require "rails_helper"
 
 RSpec.describe IntegrationCustomers::CreateJob do
-  subject(:create_job) { described_class }
-
   let(:integration) { create(:netsuite_integration) }
   let(:customer) { create(:customer) }
-  let(:result) { BaseService::Result.new }
   let(:integration_customer_params) do
     {
       sync_with_provider: true
     }
   end
 
-  before do
-    allow(IntegrationCustomers::CreateService).to receive(:call).and_return(result)
+  describe "#perform" do
+    subject(:create_job) { described_class }
+
+    before do
+      allow(IntegrationCustomers::CreateService).to receive(:call!)
+    end
+
+    it "calls the create service" do
+      described_class.perform_now(integration_customer_params:, integration:, customer:)
+
+      expect(IntegrationCustomers::CreateService).to have_received(:call!)
+    end
   end
 
-  it "calls the create service" do
-    described_class.perform_now(integration_customer_params:, integration:, customer:)
+  describe "#lock_key_arguments" do
+    it "returns customer and integration for the lock key" do
+      job = described_class.new(
+        integration_customer_params: integration_customer_params,
+        integration: integration,
+        customer: customer
+      )
 
-    expect(IntegrationCustomers::CreateService).to have_received(:call)
+      expect(job.lock_key_arguments).to eq([integration_customer_params: integration_customer_params,
+                                            integration: integration,
+                                            customer: customer])
+    end
   end
 end

--- a/spec/services/integration_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_batch_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::CreateOrUpdateService do
+RSpec.describe IntegrationCustomers::CreateOrUpdateBatchService do
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }


### PR DESCRIPTION
## Context

It may happen that a customer was updated in a short time after it was created. As creating integration customers is a long operation, by the time we receive the update we still haven't created the integration customer. Therefore we will schedule a second `IntegrationCustomers::CreateJob`.

## Description

This fixes it by adding job uniqueness until executed. Note that we kept the `integration_customer_params` in the lock key arguments to ensure we still raise an error if the customer update changed the integration customer settings.

I also used this change to rename `IntegrationCustomers::CreateOrUpdateService` to `IntegrationCustomers::CreateOrUpdateBatchService` for consistency.