### PR TITLE
fix(plan): Fix plan creation and update bugs

### DIFF
--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -25,6 +25,8 @@ module ChargeFilters
         return result
       end
 
+      return result.single_validation_failure!(field: :values, error_code: "value_is_mandatory") if empty_filter_values?
+
       # We only care about order when you have less than 100 filters.
       touch = filters_params.size < 100
 
@@ -163,6 +165,10 @@ module ChargeFilters
         filter.properties.delete("pricing_group_keys")
         filter.properties.delete("grouped_by")
       end
+    end
+
+    def empty_filter_values?
+      filters_params.any? { |filter_param| filter_param[:values].blank? }
     end
   end
 end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -7,10 +7,14 @@ RSpec.describe ChargeFilter do
 
   it_behaves_like "paper_trail traceable"
 
-  it { is_expected.to belong_to(:charge) }
-  it { is_expected.to belong_to(:organization) }
-  it { is_expected.to have_many(:values).dependent(:destroy) }
-  it { is_expected.to have_many(:fees) }
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:charge)
+      expect(subject).to belong_to(:organization)
+      expect(subject).to have_many(:values).dependent(:destroy)
+      expect(subject).to have_many(:fees)
+    end
+  end
 
   describe "#validate_properties" do
     subject(:charge_filter) { build(:charge_filter, charge:, properties: charge_properties) }

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -7,11 +7,19 @@ RSpec.describe ChargeFilterValue do
 
   it_behaves_like "paper_trail traceable"
 
-  it { is_expected.to belong_to(:charge_filter) }
-  it { is_expected.to belong_to(:billable_metric_filter) }
-  it { is_expected.to belong_to(:organization) }
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:charge_filter)
+      expect(subject).to belong_to(:billable_metric_filter)
+      expect(subject).to belong_to(:organization)
+    end
+  end
 
-  it { is_expected.to validate_presence_of(:values) }
+  describe "validations" do
+    it do
+      expect(subject).to validate_presence_of(:values)
+    end
+  end
 
   describe "#valdiate_values" do
     subject(:charge_filter_value) do

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe Charge do
 
   it_behaves_like "paper_trail traceable"
 
-  it { is_expected.to belong_to(:organization) }
-  it { is_expected.to have_many(:filters).dependent(:destroy) }
-
-  it { is_expected.to have_one(:applied_pricing_unit) }
-  it { is_expected.to have_one(:pricing_unit).through(:applied_pricing_unit) }
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to have_many(:filters).dependent(:destroy)
+      expect(subject).to have_one(:applied_pricing_unit)
+      expect(subject).to have_one(:pricing_unit).through(:applied_pricing_unit)
+    end
+  end
 
   describe "#validate_graduated" do
     subject(:charge) do

--- a/spec/models/usage_threshold_spec.rb
+++ b/spec/models/usage_threshold_spec.rb
@@ -9,16 +9,13 @@ RSpec.describe UsageThreshold do
 
   it { expect(described_class).to be_soft_deletable }
 
-  it { is_expected.to belong_to(:organization) }
-  it { is_expected.to have_many(:applied_usage_thresholds) }
-  it { is_expected.to have_many(:invoices).through(:applied_usage_thresholds) }
-
   describe "associations" do
     it do
       expect(subject).to belong_to(:organization)
       expect(subject).to belong_to(:plan).without_validating_presence
       expect(subject).to belong_to(:subscription).without_validating_presence
       expect(subject).to have_many(:applied_usage_thresholds)
+      expect(subject).to have_many(:invoices).through(:applied_usage_thresholds)
     end
   end
 

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -36,6 +36,30 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
     )
   end
 
+  context "when filter values hash is empty" do
+    let(:filters_params) do
+      [
+        {
+          values: {},
+          invoice_display_name: "Invalid filter",
+          properties: {amount: "10"}
+        }
+      ]
+    end
+
+    before { card_location_filter }
+
+    it "returns a validation failure" do
+      expect(service).not_to be_success
+      expect(service.error).to be_a(BaseService::ValidationFailure)
+      expect(service.error.messages[:values]).to eq(["value_is_mandatory"])
+    end
+
+    it "does not create any filters" do
+      expect { service }.not_to change(ChargeFilter, :count)
+    end
+  end
+
   context "when filter params is empty" do
     it "does not create any filters" do
       expect { service }.not_to change(ChargeFilter, :count)


### PR DESCRIPTION
## Context

When creating a plan with charges, two bugs are currently present:

- Sending a `charge` without `billable_metric_id` will result in an `undefined method 'custom_agg?' for nil (NoMethodError)` error.
- Sending a null `values` for a charge filter will result in an `undefined method 'each' for nil:NilClass (NoMethodError)` error. This also occurred for plan update.
- Sending a empty `values` for a charge filter will result in a filter without values. This doesn't actually match the behavior expected by our OpenAPI which marks the `values` as required. This also occurred for plan update.

## Description

The first bug occured because `Plans::CreateService` had a private `create_charge` method that didn't properly check that the `charge` was valid (billable metric present) before proceeding to create it. The charge creation logic was already present in `Charges::CreateService` with proper validations. This replaces the inline charge creation logic in `Plans::CreateService` with a call to `Charges::CreateService`.

The second bug occurred because the `ChargeFilters::CreateOrUpdateBatchService` service assumed that `filter_params[:values]` would always be present and iterable.

The last bug occurred because we didn't validate that `values` had at least one element.