### PR TITLE
fix(seeders): ensure seeders can be run multiple times

### DIFF
--- a/db/seeds/01_base.rb
+++ b/db/seeds/01_base.rb
@@ -29,7 +29,7 @@ k.update_columns(value: "lago_key-hooli-1234567890") # rubocop:disable Rails/Ski
 
 # == BillableMetrics
 
-sum_bm = BillableMetrics::CreateService.call!(
+sum_bm = BillableMetric.find_by(organization:, code: "sum_bm") || BillableMetrics::CreateService.call!(
   organization_id: organization.id,
   aggregation_type: "sum_agg",
   name: "Sum BM",
@@ -37,7 +37,7 @@ sum_bm = BillableMetrics::CreateService.call!(
   field_name: "custom_field"
 ).billable_metric
 
-count_bm = BillableMetrics::CreateService.call!(
+count_bm = BillableMetric.find_by(organization:, code: "count_bm") || BillableMetrics::CreateService.call!(
   organization_id: organization.id,
   aggregation_type: "count_agg",
   name: "Count BM",

--- a/db/seeds/50_invoices.rb
+++ b/db/seeds/50_invoices.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-# NOTE: Generate invoices for the customers
-Subscription.all.find_each do |subscription|
-  invoice_count = (Time.current - subscription.subscription_at).fdiv(1.month).round
+if Invoice.count.zero?
+  Subscription.all.find_each do |subscription|
+    invoice_count = (Time.current - subscription.subscription_at).fdiv(1.month).round
 
-  (1..invoice_count).each do |offset|
-    Invoices::SubscriptionService.call(
-      subscriptions: [subscription],
-      timestamp: subscription.subscription_at + offset.months,
-      invoicing_reason: :subscription_periodic
-    )
+    (1..invoice_count).each do |offset|
+      Invoices::SubscriptionService.call(
+        subscriptions: [subscription],
+        timestamp: subscription.subscription_at + offset.months,
+        invoicing_reason: :subscription_periodic
+      )
+    end
   end
 end


### PR DESCRIPTION
If billable metrics exists, use it.
If there are invoices in the system, no need to create more fake (it avoids error of "invoice already exists for this period).