### PR TITLE
chore(seriaizer): Always use external_*_id instead of *_external_id

### DIFF
--- a/app/serializers/v1/dunning_campaign_finished_serializer.rb
+++ b/app/serializers/v1/dunning_campaign_finished_serializer.rb
@@ -4,10 +4,12 @@ module V1
   class DunningCampaignFinishedSerializer < ModelSerializer
     def serialize
       {
-        customer_external_id: model.external_id,
+        external_customer_id: model.external_id,
         dunning_campaign_code: options[:dunning_campaign_code],
         overdue_balance_cents: model.overdue_balance_cents,
-        overdue_balance_currency: model.currency
+        overdue_balance_currency: model.currency,
+
+        customer_external_id: model.external_id # DEPRECATED
       }
     end
   end

--- a/app/serializers/v1/usage_monitoring/alert_serializer.rb
+++ b/app/serializers/v1/usage_monitoring/alert_serializer.rb
@@ -7,7 +7,8 @@ module V1
         {
           lago_id: model.id,
           lago_organization_id: model.organization_id,
-          subscription_external_id: model.subscription_external_id,
+          subscription_external_id: model.subscription_external_id, # DEPRECATED
+          external_subscription_id: model.subscription_external_id,
           alert_type: model.alert_type,
           code: model.code,
           name: model.name,

--- a/app/serializers/v1/usage_monitoring/triggered_alert_serializer.rb
+++ b/app/serializers/v1/usage_monitoring/triggered_alert_serializer.rb
@@ -9,8 +9,8 @@ module V1
           lago_organization_id: model.organization_id,
           lago_alert_id: alert.id,
           lago_subscription_id: model.subscription_id,
-          subscription_external_id: alert.subscription_external_id,
-          customer_external_id: model.subscription.customer.external_id,
+          external_subscription_id: alert.subscription_external_id,
+          external_customer_id: model.subscription.customer.external_id,
           billable_metric_code: alert.billable_metric&.code,
           alert_name: alert.name,
           alert_code: alert.code,
@@ -18,7 +18,10 @@ module V1
           current_value: model.current_value,
           previous_value: model.previous_value,
           crossed_thresholds: model.crossed_thresholds,
-          triggered_at: model.triggered_at.iso8601
+          triggered_at: model.triggered_at.iso8601,
+
+          subscription_external_id: alert.subscription_external_id, # DEPRECATED
+          customer_external_id: model.subscription.customer.external_id # DEPRECATED
         }
       end
 

--- a/spec/serializers/v1/dunning_campaign_finished_serializer_spec.rb
+++ b/spec/serializers/v1/dunning_campaign_finished_serializer_spec.rb
@@ -16,9 +16,12 @@ RSpec.describe ::V1::DunningCampaignFinishedSerializer do
   it "serializes the object" do
     result = JSON.parse(serializer.to_json)
 
-    expect(result["dunning_campaign"]["customer_external_id"]).to eq(customer.external_id)
+    expect(result["dunning_campaign"]["external_customer_id"]).to eq(customer.external_id)
     expect(result["dunning_campaign"]["dunning_campaign_code"]).to eq("campaign_code")
     expect(result["dunning_campaign"]["overdue_balance_cents"]).to eq(customer.overdue_balance_cents)
     expect(result["dunning_campaign"]["overdue_balance_currency"]).to eq(customer.currency)
+
+    # Deprecated fields that must be kept for backward compatibility
+    expect(result["dunning_campaign"]["external_customer_id"]).to eq(customer.external_id)
   end
 end

--- a/spec/serializers/v1/usage_monitoring/alert_serializer_spec.rb
+++ b/spec/serializers/v1/usage_monitoring/alert_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ::V1::UsageMonitoring::AlertSerializer do
   it "serializes the object" do
     payload = result["alert"]
     expect(payload["lago_id"]).to eq(alert.id)
-    expect(payload["subscription_external_id"]).to eq("ext-id")
+    expect(payload["external_subscription_id"]).to eq("ext-id")
     expect(payload["name"]).to eq("General Alert")
     expect(payload["code"]).to eq("yolo")
     expect(payload["alert_type"]).to eq("current_usage_amount")
@@ -25,6 +25,9 @@ RSpec.describe ::V1::UsageMonitoring::AlertSerializer do
     expect(payload["previous_value"]).to eq("800.0")
     expect(payload["last_processed_at"]).to eq("2000-01-01T12:00:00Z")
     expect(payload["billable_metric"]).to be_nil
+
+    # Deprecated fields that must be kept for backward compatibility
+    expect(payload["subscription_external_id"]).to eq("ext-id")
   end
 
   context "with billable_metric_current_usage_amount alert" do

--- a/spec/serializers/v1/usage_monitoring/triggered_alert_serializer_spec.rb
+++ b/spec/serializers/v1/usage_monitoring/triggered_alert_serializer_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe ::V1::UsageMonitoring::TriggeredAlertSerializer do
       expect(payload["lago_organization_id"]).to eq(triggered_alert.organization_id)
       expect(payload["lago_alert_id"]).to eq(triggered_alert.alert.id)
       expect(payload["lago_subscription_id"]).to eq(triggered_alert.subscription.id)
-      expect(payload["subscription_external_id"]).to eq("ext-id")
-      expect(payload["customer_external_id"]).to eq("cust-ext-id")
+      expect(payload["external_subscription_id"]).to eq("ext-id")
+      expect(payload["external_customer_id"]).to eq("cust-ext-id")
       expect(payload["billable_metric_code"]).to be_nil
       expect(payload["alert_name"]).to eq("General Alert")
       expect(payload["alert_code"]).to eq("first")
@@ -34,6 +34,10 @@ RSpec.describe ::V1::UsageMonitoring::TriggeredAlertSerializer do
         {"code" => "repeat", "value" => "2500.0", "recurring" => true}
       ])
       expect(payload["triggered_at"]).to eq("2000-01-01T12:00:00Z")
+
+      # Deprecated fields that must be kept for backward compatibility
+      expect(payload["subscription_external_id"]).to eq("ext-id")
+      expect(payload["customer_external_id"]).to eq("cust-ext-id")
     end
   end
 


### PR DESCRIPTION
Very few serializers used `customer_external_id` while most of them used `external_customer_id`. We'll keep the old one to ensure this is backward compatible

See https://github.com/getlago/lago-openapi/pull/468