### PR TITLE
feat(multiple-payment-methods): expose payment method details in API for wallet and recurring rules

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -100,6 +100,10 @@ module Api
             transaction_metadata: [
               :key,
               :value
+            ],
+            payment_method: [
+              :payment_method_type,
+              :payment_method_id
             ]
           ],
           applies_to: [
@@ -109,6 +113,10 @@ module Api
           invoice_custom_section: [
             :skip_invoice_custom_sections,
             {invoice_custom_section_codes: []}
+          ],
+          payment_method: [
+            :payment_method_type,
+            :payment_method_id
           ]
         )
       end
@@ -146,6 +154,10 @@ module Api
             transaction_metadata: [
               :key,
               :value
+            ],
+            payment_method: [
+              :payment_method_type,
+              :payment_method_id
             ]
           ],
           applies_to: [
@@ -155,6 +167,10 @@ module Api
           invoice_custom_section: [
             :skip_invoice_custom_sections,
             {invoice_custom_section_codes: []}
+          ],
+          payment_method: [
+            :payment_method_type,
+            :payment_method_id
           ]
         )
       end

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -32,6 +32,7 @@ module V1
       payload.merge!(recurring_transaction_rules) if include?(:recurring_transaction_rules)
       payload.merge!(limitations) if include?(:limitations)
       payload.merge!(applied_invoice_custom_sections) if include?(:applied_invoice_custom_sections)
+      payload.merge!(payment_method)
 
       payload
     end
@@ -51,6 +52,15 @@ module V1
         applies_to: {
           fee_types: model.allowed_fee_types,
           billable_metric_codes: model.billable_metrics.pluck(:code)
+        }
+      }
+    end
+
+    def payment_method
+      {
+        payment_method: {
+          payment_method_id: model.payment_method_id,
+          payment_method_type: model.payment_method_type
         }
       }
     end

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -4,7 +4,7 @@ module V1
   module Wallets
     class RecurringTransactionRuleSerializer < ModelSerializer
       def serialize
-        {
+        payload = {
           lago_id: model.id,
           paid_credits: model.paid_credits,
           granted_credits: model.granted_credits,
@@ -21,7 +21,12 @@ module V1
           transaction_metadata: model.transaction_metadata,
           transaction_name: model.transaction_name,
           ignore_paid_top_up_limits: model.ignore_paid_top_up_limits
-        }.merge(applied_invoice_custom_sections)
+        }
+
+        payload.merge!(applied_invoice_custom_sections)
+        payload.merge!(payment_method)
+
+        payload
       end
 
       private
@@ -32,6 +37,15 @@ module V1
           ::V1::AppliedInvoiceCustomSectionSerializer,
           collection_name: "applied_invoice_custom_sections"
         ).serialize
+      end
+
+      def payment_method
+        {
+          payment_method: {
+            payment_method_id: model.payment_method_id,
+            payment_method_type: model.payment_method_type
+          }
+        }
       end
     end
   end

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -48,5 +48,7 @@ RSpec.describe ::V1::WalletSerializer do
     expect(result["wallet"]["applies_to"]["billable_metric_codes"]).to eq([wallet_target.billable_metric.code])
     expect(result["wallet"]["recurring_transaction_rules"].first["lago_id"]).to eq(recurring_transaction_rule.id)
     expect(result["wallet"]["applied_invoice_custom_sections"].first["lago_id"]).to eq(applied_invoice_custom_section.id)
+    expect(result["wallet"]["payment_method"]["payment_method_id"]).to eq(nil)
+    expect(result["wallet"]["payment_method"]["payment_method_type"]).to eq("provider")
   end
 end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -29,5 +29,7 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
       "ignore_paid_top_up_limits" => recurring_transaction_rule.ignore_paid_top_up_limits,
       "applied_invoice_custom_sections" => recurring_transaction_rule.applied_invoice_custom_sections
     )
+    expect(result["recurring_transaction_rule"]["payment_method"]["payment_method_id"]).to eq(nil)
+    expect(result["recurring_transaction_rule"]["payment_method"]["payment_method_type"]).to eq("provider")
   end
 end


### PR DESCRIPTION
## Context

With `multiple payment methods` feature, it will be possible to attach multiple payment methods on customer, but also attach payment method on resources like subscription, wallet, recurring rules or wallet transaction.

## Description

This PR is missing part that just expose needed params for wallet and recurring rule. The logic itself is already covered in the services and GQL part is already updated
