### PR TITLE
misc(clickhouse): Remove wrong limit by

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -16,7 +16,6 @@ module Events
 
           scope = scope.where("events_enriched.timestamp >= ?", from_datetime) if force_from || use_from_boundary
           scope = scope.where("events_enriched.timestamp <= ?", applicable_to_datetime) if applicable_to_datetime
-          scope = scope.limit_by(1, "events_enriched.transaction_id")
 
           scope = apply_grouped_by_values(scope) if grouped_by_values?
           filters_scope(scope)
@@ -34,7 +33,6 @@ module Events
 
         query = query.where(arel_table[:timestamp].gteq(from_datetime)) if force_from || use_from_boundary
         query = query.where(arel_table[:timestamp].lteq(applicable_to_datetime)) if applicable_to_datetime
-        query = query.limit_by(1, "events_enriched.transaction_id")
 
         query = apply_arel_grouped_by_values(query) if grouped_by_values?
         query = arel_filters_scope(query)


### PR DESCRIPTION
## Context

Attempts to handle clickhouse deduplication were made using the `limit_by(1` scope.
It was working with `ActiveRecord` scopes within `Events::Stores::ClickhouseStore#events` method, without deduplicating on both `transaction_id` and `timestamp`, but only on `transaction_id` which is not the behavior documented on Lago's doc. 

Most of the aggregation query does not rely on the `events` method, but on the `events_sql` one, written using `arel`. In this case, the `limit_by` is used, but is actually doing nothing. Last attempt to fix it leads us to a MAJOR bug in production (https://github.com/getlago/lago-api/pull/4418)

## Description

This PR is removing this wrong `limit_by`. It will be replaced by a better deduplication approach