### PR TITLE
fix(issuing-date): Fix preview issuing_date for keep anchor + pay in advance plans

### DIFF
--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -133,7 +133,7 @@ module Invoices
       return @issuing_date if defined?(@issuing_date)
 
       terminated = subscription_context == :terminated
-      recurring = !terminated && !first_subscription.plan.pay_in_advance?
+      recurring = !terminated && (first_subscription.persisted? || !first_subscription.plan.pay_in_advance?)
 
       date = billing_time.in_time_zone(customer.applicable_timezone).to_date
       issuing_date_service = Invoices::IssuingDateService.new(customer_settings: customer, recurring:)


### PR DESCRIPTION
## Context

Preview returns the wrong `issuing_date` with the `keep_anchor` setting for a pay-in-advance plan on an existing subscription.

## Description

The PR fixes it so the preview issuing date matches the actual invoice creation. It also adds a bunch of specs to cover all preview cases – with or without existing subscriptions, and for both arrears and pay-in-advance plans.
