### PR TITLE
fix(entitlements): remove Premium license check left

### DIFF
--- a/app/controllers/api/v1/features/privileges_controller.rb
+++ b/app/controllers/api/v1/features/privileges_controller.rb
@@ -4,8 +4,6 @@ module Api
   module V1
     module Features
       class PrivilegesController < Api::BaseController
-        include PremiumFeatureOnly
-
         def destroy
           feature = current_organization.features.find_by(code: params[:feature_code])
           return not_found_error(resource: "feature") unless feature

--- a/app/controllers/api/v1/features_controller.rb
+++ b/app/controllers/api/v1/features_controller.rb
@@ -3,8 +3,6 @@
 module Api
   module V1
     class FeaturesController < Api::BaseController
-      include PremiumFeatureOnly
-
       def index
         result = ::Entitlement::FeaturesQuery.call(
           organization: current_organization,

--- a/spec/requests/api/v1/features/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/features/privileges_controller_spec.rb
@@ -12,15 +12,11 @@ RSpec.describe Api::V1::Features::PrivilegesController do
     privilege2
   end
 
-  around { |test| lago_premium!(&test) }
-
   describe "DELETE /api/v1/features/:feature_code/privileges/:code" do
     subject { delete_with_token(organization, "/api/v1/features/#{feature_code}/privileges/#{privilege_code}") }
 
     let(:feature_code) { feature1.code }
     let(:privilege_code) { privilege1.code }
-
-    it_behaves_like "a Premium API endpoint"
 
     it "discards the privilege" do
       expect { subject }.to change { privilege1.reload.discarded? }.from(false).to(true)

--- a/spec/requests/api/v1/features_controller_spec.rb
+++ b/spec/requests/api/v1/features_controller_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Api::V1::FeaturesController do
   let(:privilege1) { create(:privilege, feature: feature1, code: "max_admins", name: "", value_type: "integer") }
   let(:privilege2) { create(:privilege, feature: feature1, code: "max", name: "Maximum", value_type: "integer") }
 
-  around { |test| lago_premium!(&test) }
-
   before do
     feature1
     feature2
@@ -40,8 +38,6 @@ RSpec.describe Api::V1::FeaturesController do
         }
       }
     end
-
-    it_behaves_like "a Premium API endpoint"
 
     it "creates a new feature with privileges" do
       expect { subject }.to change(organization.features, :count).by(1)
@@ -206,8 +202,6 @@ RSpec.describe Api::V1::FeaturesController do
 
     let(:params) { {} }
 
-    it_behaves_like "a Premium API endpoint"
-
     it "returns a paginated list of features" do
       subject
 
@@ -277,8 +271,6 @@ RSpec.describe Api::V1::FeaturesController do
 
     let(:feature_code) { feature1.code }
 
-    it_behaves_like "a Premium API endpoint"
-
     it "returns a feature" do
       subject
 
@@ -326,8 +318,6 @@ RSpec.describe Api::V1::FeaturesController do
         }
       }
     end
-
-    it_behaves_like "a Premium API endpoint"
 
     it "updates the feature and privilege attributes" do
       subject
@@ -464,8 +454,6 @@ RSpec.describe Api::V1::FeaturesController do
     subject { delete_with_token(organization, "/api/v1/features/#{feature_code}") }
 
     let(:feature_code) { feature1.code }
-
-    it_behaves_like "a Premium API endpoint"
 
     it "discards the feature" do
       expect { subject }.to change { feature1.reload.discarded? }.from(false).to(true)


### PR DESCRIPTION
In https://github.com/getlago/lago-api/pull/4525 the entire Entitlement feature was open to OSS release. 
Unfortunately, 2 controllers still had the License check.