### PR TITLE
chore(seeds): Add pricing unit to seeds

### DIFF
--- a/db/seeds/07_pricing_unit.rb
+++ b/db/seeds/07_pricing_unit.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+hooli = Organization.find_by!(name: "Hooli")
+
+unless PricingUnit.exists?(code: "xyz")
+  PricingUnits::CreateService.call!(
+    organization: hooli,
+    name: "xyz",
+    code: "xyz",
+    short_name: "XYZ"
+  )
+end


### PR DESCRIPTION
## Context

When testing, manually or automated, we may want to include scenarios with pricing unit. For instance, current usage has different payloads depending on whether pricing unit is applied or not.

There's currently no API to create pricing units so it cannot be automated and it has to be done with the UI. 

## Description

This adds a pricing unit creation as part of the seeds.