### PR TITLE
fix(seeds): Fix wallet creation in seeds

### DIFF
--- a/db/seeds/02_john_doe.rb
+++ b/db/seeds/02_john_doe.rb
@@ -51,6 +51,7 @@ end
 
 unless john_doe.wallets.active.exists?
   params = {
+    organization_id: organization.id,
     customer: john_doe,
     name: "Main wallet",
     rate_amount: "3",

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -580,5 +580,46 @@ RSpec.describe Wallets::CreateService do
         end
       end
     end
+
+    context "when organization_id is nil" do
+      let(:params) do
+        {
+          name: "New Wallet",
+          customer:,
+          organization_id: nil,
+          currency: "EUR",
+          rate_amount: "1.00",
+          expiration_at:,
+          paid_credits:,
+          granted_credits:
+        }
+      end
+
+      it "returns an error" do
+        expect(service_result).not_to be_success
+        expect(service_result.error.messages[:organization_id]).to eq(["blank"])
+      end
+    end
+
+    context "when organization_id does not match customer's organization_id" do
+      let(:other_organization) { create(:organization) }
+      let(:params) do
+        {
+          name: "New Wallet",
+          customer:,
+          organization_id: other_organization.id,
+          currency: "EUR",
+          rate_amount: "1.00",
+          expiration_at:,
+          paid_credits:,
+          granted_credits:
+        }
+      end
+
+      it "returns an error" do
+        expect(service_result).not_to be_success
+        expect(service_result.error.messages[:organization_id]).to eq(["invalid"])
+      end
+    end
   end
 end

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -31,6 +31,41 @@ RSpec.describe Wallets::ValidateService do
       expect(validate_service).to be_valid
     end
 
+    context "when organization_id is blank" do
+      let(:args) do
+        {
+          customer:,
+          organization_id: nil,
+          paid_credits:,
+          granted_credits:,
+          expiration_at:
+        }
+      end
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:organization_id]).to eq(["blank"])
+      end
+    end
+
+    context "when organization_id does not match customer's organization_id" do
+      let(:other_organization) { create(:organization) }
+      let(:args) do
+        {
+          customer:,
+          organization_id: other_organization.id,
+          paid_credits:,
+          granted_credits:,
+          expiration_at:
+        }
+      end
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:organization_id]).to eq(["invalid"])
+      end
+    end
+
     context "when customer does not exist" do
       let(:args) do
         {


### PR DESCRIPTION
## Context

The `Wallets::CreateService` was deriving `organization_id` both from `result.current_customer.organization_id` and `params[:organization_id]`, which caused the seeds to silently fail to create wallet transactions because the `organization_id` wasn't provided.

## Description

This refactors the services to require `organization_id` as an explicit parameter and fixes the seeds.