### PR TITLE
fix(seeds): Fix seed webhook in staging env

### DIFF
--- a/db/seeds/01_base.rb
+++ b/db/seeds/01_base.rb
@@ -20,8 +20,10 @@ organization.update!({
 })
 BillingEntity.find_or_create_by!(organization:, name: "Hooli", code: "hooli")
 Membership.find_or_create_by!(user:, organization:, role: :admin)
-WebhookEndpoint.find_or_create_by!(organization:, webhook_url: "http://webhook/#{organization.id}")
-
+if Rails.env.development?
+  # In development, we create a webhook endpoint to the local webhook-tester service.
+  WebhookEndpoint.find_or_create_by!(organization:, webhook_url: "http://webhook/#{organization.id}")
+end
 organization.api_keys.destroy_all
 organization.api_keys.create!(name: "Expired Key", expires_at: 1.day.ago, last_used_at: 36.hours.ago, permissions: {"customer" => ["read", "write"]})
 k = organization.api_keys.create!(name: "Hooli Key", permissions: ApiKey.default_permissions)


### PR DESCRIPTION
## Context

The seeds currently create a webhook endpoint set to `http://webhook/` which expected to be the [`webhook-tester`](https://github.com/tarampampam/webhook-tester) service. This service is set in the developer docker compose.

The issue is that this service is not defined in staging, causing webhooks to fail and use Sidekiq resources unnecessarily.

## Description

This updates the seeds to only define the webhook endpoint in development environment.