### PR TITLE
misc(clickhouse): Add service to remove duplicated events

### DIFF
--- a/app/services/events/stores/clickhouse/clean_duplicated_service.rb
+++ b/app/services/events/stores/clickhouse/clean_duplicated_service.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      class CleanDuplicatedService < BaseService
+        Result = BaseResult
+
+        def initialize(subscription:, timestamp: Time.current)
+          @subscription = subscription
+          @timestamp = timestamp
+          super
+        end
+
+        def call
+          remove_duplicated_events
+          Subscriptions::ChargeCacheService.expire_for_subscription(subscription)
+
+          result
+        end
+
+        private
+
+        attr_reader :subscription, :timestamp
+
+        delegate :organization, to: :subscription
+
+        def boundaries
+          return @boundaries if @boundaries.present?
+
+          date_service = Subscriptions::DatesService.new_instance(
+            subscription,
+            timestamp,
+            current_usage: true
+          )
+
+          @boundaries = BillingPeriodBoundaries.new(
+            from_datetime: date_service.from_datetime,
+            to_datetime: date_service.to_datetime,
+            charges_from_datetime: date_service.charges_from_datetime,
+            charges_to_datetime: date_service.charges_to_datetime,
+            issuing_date: date_service.next_end_of_period,
+            charges_duration: date_service.charges_duration_in_days,
+            timestamp:
+          )
+        end
+
+        def duplicated_events
+          ::Clickhouse::EventsEnriched
+            .where(organization_id: organization.id)
+            .where(external_subscription_id: subscription.external_id)
+            .where(timestamp: boundaries.charges_from_datetime...boundaries.charges_to_datetime)
+            .group(:transaction_id, :timestamp)
+            .having("count() > 1")
+            .pluck(:transaction_id, :timestamp)
+        end
+
+        def remove_duplicated_events
+          duplicates = duplicated_events.to_a
+          return if duplicates.empty?
+
+          duplicates.each do |transaction_id, event_timestamp|
+            # Fetch all enriched_at timestamps for the duplicated events
+            enriched_at = ::Clickhouse::EventsEnriched
+              .where(organization_id: organization.id)
+              .where(external_subscription_id: subscription.external_id)
+              .where(timestamp: event_timestamp)
+              .where(transaction_id: transaction_id)
+              .order(enriched_at: :desc)
+              .pluck(:enriched_at)
+
+            ::Clickhouse::EventsEnriched
+              .where(organization_id: organization.id)
+              .where(external_subscription_id: subscription.external_id)
+              .where(timestamp: event_timestamp)
+              .where(transaction_id: transaction_id)
+              .where(enriched_at: enriched_at[1..])
+              .delete_all
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse do
+  subject(:clean_service) { described_class.new(subscription:, timestamp:) }
+
+  let(:organization) { create(:organization, clickhouse_events_store: true) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:timestamp) { Time.current }
+
+  describe "#call" do
+    let(:transaction_id) { SecureRandom.uuid }
+    let(:timestamp) { Time.current.change(usec: 0) }
+
+    let(:base_enriched_at) { Time.current - 10.minutes }
+
+    before do
+      3.times do |i|
+        create(
+          :clickhouse_events_enriched,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          transaction_id: transaction_id,
+          timestamp: timestamp,
+          code: "event_code_#{SecureRandom.hex(4)}",
+          enriched_at: base_enriched_at + i.minutes
+        )
+      end
+
+      allow(Subscriptions::ChargeCacheService).to receive(:expire_for_subscription)
+    end
+
+    it "removes duplicated events" do
+      expect(::Clickhouse::EventsEnriched.where(transaction_id:, timestamp:).count).to eq(3)
+
+      result = clean_service.call
+
+      expect(result).to be_success
+      expect(::Clickhouse::EventsEnriched.where(transaction_id:, timestamp:).count).to eq(1)
+
+      event = ::Clickhouse::EventsEnriched.find_by(transaction_id:, timestamp:)
+      expect(event.enriched_at).to match_datetime(base_enriched_at + 2.minutes)
+
+      expect(Subscriptions::ChargeCacheService).to have_received(:expire_for_subscription).with(subscription)
+    end
+  end
+end


### PR DESCRIPTION
## Context

An issue has been raised with the Clickhouse implementation, leading to a risk of duplicated events when the same transaction_id/timestamp are sent multiple time.

## Description

A fix to allow a full deduplication is ongoing but it's not ready yet. In the meantime, this PR is adding a small utility service to allow a manual cleanup of all duplicated events for a given subscription on a given billing period.

```ruby
Events::Stores::Clickhouse::CleanDuplicatedService.call!(subscription:)
```

It will remove all duplicated events except the last received one (ordered by `enriched_at`)
