### PR TITLE
chore(dependency): Update dev and test dependencies to latest minor version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,6 +139,7 @@ group :development, :test do
   gem "shoulda-matchers"
 
   gem "i18n-tasks", git: "https://github.com/glebm/i18n-tasks.git", require: false
+
   gem "rubocop-rails", require: false
   gem "rubocop-graphql", require: false
   gem "rubocop-performance", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,13 +24,13 @@ GIT
 
 GIT
   remote: https://github.com/glebm/i18n-tasks.git
-  revision: d22542021e7e8cea106fb81d792b64974d2868c7
+  revision: b7db1cb2fe1484d93ee1cf14b5100c321d16392a
   specs:
-    i18n-tasks (1.0.15)
+    i18n-tasks (1.1.2)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
-      highline (>= 2.0.0)
+      highline (>= 3.0.0)
       i18n
       parser (>= 3.2.2.1)
       prism
@@ -41,9 +41,9 @@ GIT
 
 GIT
   remote: https://github.com/rmosolgo/graphiql-rails.git
-  revision: 1d4c70055c0e3b601e18c8c8d69892bf6bb8e0c2
+  revision: 41c98ace618c824b141cf3f79824ed7d208e156e
   specs:
-    graphiql-rails (1.10.1)
+    graphiql-rails (1.10.5)
       railties
 
 GEM
@@ -146,7 +146,9 @@ GEM
       activerecord (>= 4.2)
       activesupport
     analytics-ruby (2.4.0)
-    annotaterb (4.14.0)
+    annotaterb (4.20.0)
+      activerecord (>= 6.0.0)
+      activesupport (>= 6.0.0)
     anyway_config (2.7.2)
       ruby-next-core (~> 1.0)
     ast (2.4.3)
@@ -175,7 +177,7 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
-    bullet (8.0.7)
+    bullet (8.1.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (12.0.0)
@@ -205,9 +207,9 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.3.2)
-    database_cleaner-active_record (2.2.0)
+    database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
+      database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     datadog (2.22.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
@@ -217,18 +219,18 @@ GEM
       msgpack
     datadog-ruby_core_source (3.4.1)
     date (3.4.1)
-    debug (1.10.0)
+    debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
     declarative (0.0.20)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.2)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     discard (1.4.0)
       activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    dotenv (3.1.7)
+    dotenv (3.2.0)
     drb (2.2.3)
     dry-configurable (1.2.0)
       dry-core (~> 1.0, < 2)
@@ -270,10 +272,10 @@ GEM
     execjs (2.9.1)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
-    factory_bot_rails (6.4.4)
+    factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
-      railties (>= 5.0.0)
-    faker (3.4.2)
+      railties (>= 6.1.0)
+    faker (3.5.3)
       i18n (>= 1.8.11, < 2)
     faraday (2.10.1)
       faraday-net_http (>= 2.0, < 3.2)
@@ -422,8 +424,8 @@ GEM
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
-    karafka-testing (2.5.3)
-      karafka (>= 2.5.0.beta1, < 2.6.0)
+    karafka-testing (2.5.5)
+      karafka (>= 2.5.0, < 2.6.0)
       waterdrop (>= 2.8.0)
     karafka-web (0.11.3)
       erubi (~> 1.4)
@@ -431,7 +433,7 @@ GEM
       karafka-core (>= 2.5.0, < 2.6.0)
       roda (~> 3.68, >= 3.69)
       tilt (~> 2.0)
-    knapsack_pro (8.1.0)
+    knapsack_pro (8.4.0)
       rake
     language_server-protocol (3.17.0.5)
     libdatadog (22.0.1.1.0)
@@ -729,7 +731,7 @@ GEM
       activerecord (>= 6.1)
       request_store (~> 1.4)
     parallel (1.27.0)
-    parallel_tests (5.3.0)
+    parallel_tests (5.5.0)
       parallel
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -877,7 +879,7 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.44.1)
+    rubocop-ast (1.48.0)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-capybara (2.21.0)
@@ -904,13 +906,12 @@ GEM
       rubocop (~> 1.61)
     rubocop-thread_safety (0.5.1)
       rubocop (>= 0.90.0)
-    ruby-lsp (0.23.6)
+    ruby-lsp (0.26.4)
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
-      rbs (>= 3, < 4)
-      sorbet-runtime (>= 0.5.10782)
-    ruby-lsp-rails (0.3.30)
-      ruby-lsp (>= 0.23.0, < 0.24.0)
+      rbs (>= 3, < 5)
+    ruby-lsp-rails (0.4.8)
+      ruby-lsp (>= 0.26.0, < 0.27.0)
     ruby-next-core (1.1.2)
     ruby-progressbar (1.13.0)
     sass-rails (6.0.0)
@@ -937,7 +938,7 @@ GEM
       sentry-ruby (~> 5.18.2)
       sidekiq (>= 3.0)
     shellany (0.0.1)
-    shoulda-matchers (6.4.0)
+    shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
     sidekiq (7.3.7)
       connection_pool (>= 2.3.0)
@@ -969,7 +970,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sorbet-runtime (0.5.11766)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -1024,13 +1024,13 @@ GEM
     useragent (0.16.11)
     valvat (2.0.1)
       rexml (>= 3.3.6, < 4.0.0)
-    vernier (1.8.1)
+    vernier (1.9.0)
     version_gem (1.1.4)
     waterdrop (2.8.11)
       karafka-core (>= 2.4.9, < 3.0.0)
       karafka-rdkafka (>= 0.20.0)
       zeitwerk (~> 2.3)
-    webmock (3.23.1)
+    webmock (3.26.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/app/models/add_on.rb
+++ b/app/models/add_on.rb
@@ -40,6 +40,7 @@ end
 # == Schema Information
 #
 # Table name: add_ons
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  amount_cents         :bigint           not null

--- a/app/models/add_on/applied_tax.rb
+++ b/app/models/add_on/applied_tax.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: add_ons_taxes
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  created_at      :datetime         not null

--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -35,6 +35,7 @@ end
 # == Schema Information
 #
 # Table name: adjusted_fees
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  adjusted_amount           :boolean          default(FALSE), not null

--- a/app/models/ai_conversation.rb
+++ b/app/models/ai_conversation.rb
@@ -10,6 +10,7 @@ end
 # == Schema Information
 #
 # Table name: ai_conversations
+# Database name: primary
 #
 #  id                      :uuid             not null, primary key
 #  name                    :string           not null

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -76,6 +76,7 @@ end
 # == Schema Information
 #
 # Table name: api_keys
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  expires_at      :datetime

--- a/app/models/applied_add_on.rb
+++ b/app/models/applied_add_on.rb
@@ -16,6 +16,7 @@ end
 # == Schema Information
 #
 # Table name: applied_add_ons
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  amount_cents    :bigint           not null

--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -45,6 +45,7 @@ end
 # == Schema Information
 #
 # Table name: applied_coupons
+# Database name: primary
 #
 #  id                           :uuid             not null, primary key
 #  amount_cents                 :bigint

--- a/app/models/applied_invoice_custom_section.rb
+++ b/app/models/applied_invoice_custom_section.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: applied_invoice_custom_sections
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/applied_pricing_unit.rb
+++ b/app/models/applied_pricing_unit.rb
@@ -12,6 +12,7 @@ end
 # == Schema Information
 #
 # Table name: applied_pricing_units
+# Database name: primary
 #
 #  id                    :uuid             not null, primary key
 #  conversion_rate       :decimal(40, 15)  default(0.0), not null

--- a/app/models/applied_usage_threshold.rb
+++ b/app/models/applied_usage_threshold.rb
@@ -26,6 +26,7 @@ end
 # == Schema Information
 #
 # Table name: applied_usage_thresholds
+# Database name: primary
 #
 #  id                          :uuid             not null, primary key
 #  lifetime_usage_amount_cents :bigint           default(0), not null

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -103,6 +103,7 @@ end
 # == Schema Information
 #
 # Table name: billable_metrics
+# Database name: primary
 #
 #  id                 :uuid             not null, primary key
 #  aggregation_type   :integer          not null

--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -20,6 +20,7 @@ end
 # == Schema Information
 #
 # Table name: billable_metric_filters
+# Database name: primary
 #
 #  id                 :uuid             not null, primary key
 #  deleted_at         :datetime

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -176,6 +176,7 @@ end
 # == Schema Information
 #
 # Table name: billing_entities
+# Database name: primary
 #
 #  id                                           :uuid             not null, primary key
 #  address_line1                                :string

--- a/app/models/billing_entity/applied_invoice_custom_section.rb
+++ b/app/models/billing_entity/applied_invoice_custom_section.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: billing_entities_invoice_custom_sections
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  created_at                :datetime         not null

--- a/app/models/billing_entity/applied_tax.rb
+++ b/app/models/billing_entity/applied_tax.rb
@@ -15,6 +15,7 @@ end
 # == Schema Information
 #
 # Table name: billing_entities_taxes
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  created_at        :datetime         not null

--- a/app/models/cached_aggregation.rb
+++ b/app/models/cached_aggregation.rb
@@ -18,6 +18,7 @@ end
 # == Schema Information
 #
 # Table name: cached_aggregations
+# Database name: primary
 #
 #  id                             :uuid             not null, primary key
 #  current_aggregation            :decimal(, )

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -158,6 +158,7 @@ end
 # == Schema Information
 #
 # Table name: charges
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  amount_currency      :string

--- a/app/models/charge/applied_tax.rb
+++ b/app/models/charge/applied_tax.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: charges_taxes
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  created_at      :datetime         not null

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -63,6 +63,7 @@ end
 # == Schema Information
 #
 # Table name: charge_filters
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -34,6 +34,7 @@ end
 # == Schema Information
 #
 # Table name: charge_filter_values
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  deleted_at                :datetime

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -112,6 +112,7 @@ end
 # == Schema Information
 #
 # Table name: activity_logs
+# Database name: clickhouse
 #
 #  activity_object          :string
 #  activity_object_changes  :string

--- a/app/models/clickhouse/api_log.rb
+++ b/app/models/clickhouse/api_log.rb
@@ -28,6 +28,7 @@ end
 # == Schema Information
 #
 # Table name: api_logs
+# Database name: clickhouse
 #
 #  api_version      :string           not null
 #  client           :string           not null

--- a/app/models/clickhouse/events_dead_letter.rb
+++ b/app/models/clickhouse/events_dead_letter.rb
@@ -12,6 +12,7 @@ end
 # == Schema Information
 #
 # Table name: events_dead_letter
+# Database name: clickhouse
 #
 #  code                     :string           not null
 #  error_code               :string           not null

--- a/app/models/clickhouse/events_enriched.rb
+++ b/app/models/clickhouse/events_enriched.rb
@@ -9,6 +9,7 @@ end
 # == Schema Information
 #
 # Table name: events_enriched
+# Database name: clickhouse
 #
 #  code                       :string           not null, primary key
 #  decimal_value              :decimal(38, 26)

--- a/app/models/clickhouse/events_enriched_expanded.rb
+++ b/app/models/clickhouse/events_enriched_expanded.rb
@@ -9,6 +9,7 @@ end
 # == Schema Information
 #
 # Table name: events_enriched_expanded
+# Database name: clickhouse
 #
 #  aggregation_type           :string           not null
 #  charge_filter_version      :datetime

--- a/app/models/clickhouse/events_raw.rb
+++ b/app/models/clickhouse/events_raw.rb
@@ -49,6 +49,7 @@ end
 # == Schema Information
 #
 # Table name: events_raw
+# Database name: clickhouse
 #
 #  code                       :string           not null
 #  ingested_at                :datetime         not null

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -25,6 +25,7 @@ end
 # == Schema Information
 #
 # Table name: commitments
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  amount_cents         :bigint           not null

--- a/app/models/commitment/applied_tax.rb
+++ b/app/models/commitment/applied_tax.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: commitments_taxes
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  created_at      :datetime         not null

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -93,6 +93,7 @@ end
 # == Schema Information
 #
 # Table name: coupons
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  amount_cents             :bigint

--- a/app/models/coupon_target.rb
+++ b/app/models/coupon_target.rb
@@ -16,6 +16,7 @@ end
 # == Schema Information
 #
 # Table name: coupon_targets
+# Database name: primary
 #
 #  id                 :uuid             not null, primary key
 #  deleted_at         :datetime

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -77,6 +77,7 @@ end
 # == Schema Information
 #
 # Table name: credits
+# Database name: primary
 #
 #  id                             :uuid             not null, primary key
 #  amount_cents                   :bigint           not null

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -190,6 +190,7 @@ end
 # == Schema Information
 #
 # Table name: credit_notes
+# Database name: primary
 #
 #  id                                      :uuid             not null, primary key
 #  balance_amount_cents                    :bigint           default(0), not null

--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -18,6 +18,7 @@ end
 # == Schema Information
 #
 # Table name: credit_notes_taxes
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  amount_cents      :bigint           default(0), not null

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -31,6 +31,7 @@ end
 # == Schema Information
 #
 # Table name: credit_note_items
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  amount_cents         :bigint           default(0), not null

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -322,6 +322,7 @@ end
 # == Schema Information
 #
 # Table name: customers
+# Database name: primary
 #
 #  id                                           :uuid             not null, primary key
 #  account_type                                 :enum             default("customer"), not null

--- a/app/models/customer/applied_invoice_custom_section.rb
+++ b/app/models/customer/applied_invoice_custom_section.rb
@@ -12,6 +12,7 @@ end
 # == Schema Information
 #
 # Table name: customers_invoice_custom_sections
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  created_at                :datetime         not null

--- a/app/models/customer/applied_tax.rb
+++ b/app/models/customer/applied_tax.rb
@@ -15,6 +15,7 @@ end
 # == Schema Information
 #
 # Table name: customers_taxes
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  created_at      :datetime         not null

--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -19,6 +19,7 @@ end
 # == Schema Information
 #
 # Table name: daily_usages
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  from_datetime            :datetime         not null

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -66,6 +66,7 @@ end
 # == Schema Information
 #
 # Table name: data_exports
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  completed_at    :datetime

--- a/app/models/data_export_part.rb
+++ b/app/models/data_export_part.rb
@@ -10,6 +10,7 @@ end
 # == Schema Information
 #
 # Table name: data_export_parts
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  completed       :boolean          default(FALSE), not null

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -52,6 +52,7 @@ end
 # == Schema Information
 #
 # Table name: dunning_campaigns
+# Database name: primary
 #
 #  id                    :uuid             not null, primary key
 #  bcc_emails            :string           default([]), is an Array

--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -21,6 +21,7 @@ end
 # == Schema Information
 #
 # Table name: dunning_campaign_thresholds
+# Database name: primary
 #
 #  id                  :uuid             not null, primary key
 #  amount_cents        :bigint           not null

--- a/app/models/entitlement/entitlement.rb
+++ b/app/models/entitlement/entitlement.rb
@@ -29,6 +29,7 @@ end
 # == Schema Information
 #
 # Table name: entitlement_entitlements
+# Database name: primary
 #
 #  id                     :uuid             not null, primary key
 #  deleted_at             :datetime

--- a/app/models/entitlement/entitlement_value.rb
+++ b/app/models/entitlement/entitlement_value.rb
@@ -20,6 +20,7 @@ end
 # == Schema Information
 #
 # Table name: entitlement_entitlement_values
+# Database name: primary
 #
 #  id                         :uuid             not null, primary key
 #  deleted_at                 :datetime

--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -31,6 +31,7 @@ end
 # == Schema Information
 #
 # Table name: entitlement_features
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/entitlement/privilege.rb
+++ b/app/models/entitlement/privilege.rb
@@ -44,6 +44,7 @@ end
 # == Schema Information
 #
 # Table name: entitlement_privileges
+# Database name: primary
 #
 #  id                     :uuid             not null, primary key
 #  code                   :string           not null

--- a/app/models/entitlement/subscription_feature_removal.rb
+++ b/app/models/entitlement/subscription_feature_removal.rb
@@ -17,6 +17,7 @@ end
 # == Schema Information
 #
 # Table name: entitlement_subscription_feature_removals
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  deleted_at               :datetime

--- a/app/models/error_detail.rb
+++ b/app/models/error_detail.rb
@@ -34,6 +34,7 @@ end
 # == Schema Information
 #
 # Table name: error_details
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  deleted_at      :datetime

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -63,6 +63,7 @@ end
 # == Schema Information
 #
 # Table name: events
+# Database name: events
 #
 #  id                         :uuid             not null, primary key
 #  code                       :string           not null

--- a/app/models/events/last_hour_mv.rb
+++ b/app/models/events/last_hour_mv.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: last_hour_events_mv
+# Database name: primary
 #
 #  billable_metric_code    :string
 #  field_name_mandatory    :boolean

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -230,6 +230,7 @@ end
 # == Schema Information
 #
 # Table name: fees
+# Database name: primary
 #
 #  id                                  :uuid             not null, primary key
 #  amount_cents                        :bigint           not null

--- a/app/models/fee/applied_tax.rb
+++ b/app/models/fee/applied_tax.rb
@@ -17,6 +17,7 @@ end
 # == Schema Information
 #
 # Table name: fees_taxes
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  amount_cents         :bigint           default(0), not null

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -86,6 +86,7 @@ end
 # == Schema Information
 #
 # Table name: fixed_charges
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  charge_model         :enum             default("standard"), not null

--- a/app/models/fixed_charge/applied_tax.rb
+++ b/app/models/fixed_charge/applied_tax.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: fixed_charges_taxes
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  created_at      :datetime         not null

--- a/app/models/fixed_charge_event.rb
+++ b/app/models/fixed_charge_event.rb
@@ -16,6 +16,7 @@ end
 # == Schema Information
 #
 # Table name: fixed_charge_events
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  deleted_at      :datetime

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -30,6 +30,7 @@ end
 # == Schema Information
 #
 # Table name: groups
+# Database name: primary
 #
 #  id                 :uuid             not null, primary key
 #  deleted_at         :datetime

--- a/app/models/group_property.rb
+++ b/app/models/group_property.rb
@@ -16,6 +16,7 @@ end
 # == Schema Information
 #
 # Table name: group_properties
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/idempotency_record.rb
+++ b/app/models/idempotency_record.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: idempotency_records
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  idempotency_key :binary           not null

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -28,6 +28,7 @@ end
 # == Schema Information
 #
 # Table name: inbound_webhooks
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string

--- a/app/models/integration_collection_mappings/anrok_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/anrok_collection_mapping.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_collection_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mapping_type      :integer          not null

--- a/app/models/integration_collection_mappings/avalara_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/avalara_collection_mapping.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_collection_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mapping_type      :integer          not null

--- a/app/models/integration_collection_mappings/base_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/base_collection_mapping.rb
@@ -47,6 +47,7 @@ end
 # == Schema Information
 #
 # Table name: integration_collection_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mapping_type      :integer          not null

--- a/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
@@ -50,6 +50,7 @@ end
 # == Schema Information
 #
 # Table name: integration_collection_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mapping_type      :integer          not null

--- a/app/models/integration_collection_mappings/xero_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/xero_collection_mapping.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_collection_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mapping_type      :integer          not null

--- a/app/models/integration_customers/anrok_customer.rb
+++ b/app/models/integration_customers/anrok_customer.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  settings             :jsonb            not null

--- a/app/models/integration_customers/avalara_customer.rb
+++ b/app/models/integration_customers/avalara_customer.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  settings             :jsonb            not null

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -78,6 +78,7 @@ end
 # == Schema Information
 #
 # Table name: integration_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  settings             :jsonb            not null

--- a/app/models/integration_customers/hubspot_customer.rb
+++ b/app/models/integration_customers/hubspot_customer.rb
@@ -17,6 +17,7 @@ end
 # == Schema Information
 #
 # Table name: integration_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  settings             :jsonb            not null

--- a/app/models/integration_customers/netsuite_customer.rb
+++ b/app/models/integration_customers/netsuite_customer.rb
@@ -9,6 +9,7 @@ end
 # == Schema Information
 #
 # Table name: integration_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  settings             :jsonb            not null

--- a/app/models/integration_customers/salesforce_customer.rb
+++ b/app/models/integration_customers/salesforce_customer.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  settings             :jsonb            not null

--- a/app/models/integration_customers/xero_customer.rb
+++ b/app/models/integration_customers/xero_customer.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  settings             :jsonb            not null

--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -24,6 +24,7 @@ end
 # == Schema Information
 #
 # Table name: integration_items
+# Database name: primary
 #
 #  id                    :uuid             not null, primary key
 #  external_account_code :string

--- a/app/models/integration_mappings/anrok_mapping.rb
+++ b/app/models/integration_mappings/anrok_mapping.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mappable_type     :string           not null

--- a/app/models/integration_mappings/avalara_mapping.rb
+++ b/app/models/integration_mappings/avalara_mapping.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mappable_type     :string           not null

--- a/app/models/integration_mappings/base_mapping.rb
+++ b/app/models/integration_mappings/base_mapping.rb
@@ -34,6 +34,7 @@ end
 # == Schema Information
 #
 # Table name: integration_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mappable_type     :string           not null

--- a/app/models/integration_mappings/netsuite_mapping.rb
+++ b/app/models/integration_mappings/netsuite_mapping.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mappable_type     :string           not null

--- a/app/models/integration_mappings/xero_mapping.rb
+++ b/app/models/integration_mappings/xero_mapping.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: integration_mappings
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  mappable_type     :string           not null

--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -15,6 +15,7 @@ end
 # == Schema Information
 #
 # Table name: integration_resources
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  resource_type   :integer          default("invoice"), not null

--- a/app/models/integrations/anrok_integration.rb
+++ b/app/models/integrations/anrok_integration.rb
@@ -15,6 +15,7 @@ end
 # == Schema Information
 #
 # Table name: integrations
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/integrations/avalara_integration.rb
+++ b/app/models/integrations/avalara_integration.rb
@@ -16,6 +16,7 @@ end
 # == Schema Information
 #
 # Table name: integrations
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/integrations/base_integration.rb
+++ b/app/models/integrations/base_integration.rb
@@ -57,6 +57,7 @@ end
 # == Schema Information
 #
 # Table name: integrations
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/integrations/hubspot_integration.rb
+++ b/app/models/integrations/hubspot_integration.rb
@@ -24,6 +24,7 @@ end
 # == Schema Information
 #
 # Table name: integrations
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/integrations/netsuite_integration.rb
+++ b/app/models/integrations/netsuite_integration.rb
@@ -26,6 +26,7 @@ end
 # == Schema Information
 #
 # Table name: integrations
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/integrations/okta_integration.rb
+++ b/app/models/integrations/okta_integration.rb
@@ -31,6 +31,7 @@ end
 # == Schema Information
 #
 # Table name: integrations
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/integrations/salesforce_integration.rb
+++ b/app/models/integrations/salesforce_integration.rb
@@ -12,6 +12,7 @@ end
 # == Schema Information
 #
 # Table name: integrations
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/integrations/xero_integration.rb
+++ b/app/models/integrations/xero_integration.rb
@@ -12,6 +12,7 @@ end
 # == Schema Information
 #
 # Table name: integrations
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -32,6 +32,7 @@ end
 # == Schema Information
 #
 # Table name: invites
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  accepted_at     :datetime

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -594,6 +594,7 @@ end
 # == Schema Information
 #
 # Table name: invoices
+# Database name: primary
 #
 #  id                                      :uuid             not null, primary key
 #  applied_grace_period                    :integer

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -39,6 +39,7 @@ end
 # == Schema Information
 #
 # Table name: invoices_taxes
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  amount_cents              :bigint           default(0), not null

--- a/app/models/invoice_custom_section.rb
+++ b/app/models/invoice_custom_section.rb
@@ -26,6 +26,7 @@ end
 # == Schema Information
 #
 # Table name: invoice_custom_sections
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -114,6 +114,7 @@ end
 # == Schema Information
 #
 # Table name: invoice_subscriptions
+# Database name: primary
 #
 #  id                          :uuid             not null, primary key
 #  charges_from_datetime       :datetime

--- a/app/models/lifetime_usage.rb
+++ b/app/models/lifetime_usage.rb
@@ -29,6 +29,7 @@ end
 # == Schema Information
 #
 # Table name: lifetime_usages
+# Database name: primary
 #
 #  id                                 :uuid             not null, primary key
 #  current_usage_amount_cents         :bigint           default(0), not null

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -50,6 +50,7 @@ end
 # == Schema Information
 #
 # Table name: memberships
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  revoked_at      :datetime

--- a/app/models/metadata/customer_metadata.rb
+++ b/app/models/metadata/customer_metadata.rb
@@ -17,6 +17,7 @@ end
 # == Schema Information
 #
 # Table name: customer_metadata
+# Database name: primary
 #
 #  id                 :uuid             not null, primary key
 #  display_in_invoice :boolean          default(FALSE), not null

--- a/app/models/metadata/invoice_metadata.rb
+++ b/app/models/metadata/invoice_metadata.rb
@@ -15,6 +15,7 @@ end
 # == Schema Information
 #
 # Table name: invoice_metadata
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  key             :string           not null

--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -42,6 +42,7 @@ end
 # == Schema Information
 #
 # Table name: item_metadata
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  owner_type      :string           not null

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -277,6 +277,7 @@ end
 # == Schema Information
 #
 # Table name: organizations
+# Database name: primary
 #
 #  id                           :uuid             not null, primary key
 #  address_line1                :string

--- a/app/models/password_reset.rb
+++ b/app/models/password_reset.rb
@@ -10,6 +10,7 @@ end
 # == Schema Information
 #
 # Table name: password_resets
+# Database name: primary
 #
 #  id         :uuid             not null, primary key
 #  expire_at  :datetime         not null

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -127,6 +127,7 @@ end
 # == Schema Information
 #
 # Table name: payments
+# Database name: primary
 #
 #  id                           :uuid             not null, primary key
 #  amount_cents                 :bigint           not null

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -20,6 +20,7 @@ end
 # == Schema Information
 #
 # Table name: payment_intents
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  expires_at      :datetime         not null

--- a/app/models/payment_method.rb
+++ b/app/models/payment_method.rb
@@ -28,6 +28,7 @@ end
 # == Schema Information
 #
 # Table name: payment_methods
+# Database name: primary
 #
 #  id                           :uuid             not null, primary key
 #  deleted_at                   :datetime

--- a/app/models/payment_provider_customers/adyen_customer.rb
+++ b/app/models/payment_provider_customers/adyen_customer.rb
@@ -9,6 +9,7 @@ end
 # == Schema Information
 #
 # Table name: payment_provider_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -41,6 +41,7 @@ end
 # == Schema Information
 #
 # Table name: payment_provider_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/payment_provider_customers/cashfree_customer.rb
+++ b/app/models/payment_provider_customers/cashfree_customer.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: payment_provider_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/payment_provider_customers/flutterwave_customer.rb
+++ b/app/models/payment_provider_customers/flutterwave_customer.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: payment_provider_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/payment_provider_customers/gocardless_customer.rb
+++ b/app/models/payment_provider_customers/gocardless_customer.rb
@@ -8,6 +8,7 @@ end
 # == Schema Information
 #
 # Table name: payment_provider_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/payment_provider_customers/moneyhash_customer.rb
+++ b/app/models/payment_provider_customers/moneyhash_customer.rb
@@ -46,6 +46,7 @@ end
 # == Schema Information
 #
 # Table name: payment_provider_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -55,6 +55,7 @@ end
 # == Schema Information
 #
 # Table name: payment_provider_customers
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  deleted_at           :datetime

--- a/app/models/payment_providers/adyen_provider.rb
+++ b/app/models/payment_providers/adyen_provider.rb
@@ -34,6 +34,7 @@ end
 # == Schema Information
 #
 # Table name: payment_providers
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -41,6 +41,7 @@ end
 # == Schema Information
 #
 # Table name: payment_providers
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/payment_providers/cashfree_provider.rb
+++ b/app/models/payment_providers/cashfree_provider.rb
@@ -27,6 +27,7 @@ end
 # == Schema Information
 #
 # Table name: payment_providers
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/payment_providers/flutterwave_provider.rb
+++ b/app/models/payment_providers/flutterwave_provider.rb
@@ -36,6 +36,7 @@ end
 # == Schema Information
 #
 # Table name: payment_providers
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/payment_providers/gocardless_provider.rb
+++ b/app/models/payment_providers/gocardless_provider.rb
@@ -38,6 +38,7 @@ end
 # == Schema Information
 #
 # Table name: payment_providers
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/payment_providers/moneyhash_provider.rb
+++ b/app/models/payment_providers/moneyhash_provider.rb
@@ -61,6 +61,7 @@ end
 # == Schema Information
 #
 # Table name: payment_providers
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -47,6 +47,7 @@ end
 # == Schema Information
 #
 # Table name: payment_providers
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/payment_receipt.rb
+++ b/app/models/payment_receipt.rb
@@ -26,6 +26,7 @@ end
 # == Schema Information
 #
 # Table name: payment_receipts
+# Database name: primary
 #
 #  id                :uuid             not null, primary key
 #  number            :string           not null

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -59,6 +59,7 @@ end
 # == Schema Information
 #
 # Table name: payment_requests
+# Database name: primary
 #
 #  id                           :uuid             not null, primary key
 #  amount_cents                 :bigint           default(0), not null

--- a/app/models/payment_request/applied_invoice.rb
+++ b/app/models/payment_request/applied_invoice.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: invoices_payment_requests
+# Database name: primary
 #
 #  id                 :uuid             not null, primary key
 #  created_at         :datetime         not null

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -133,6 +133,7 @@ end
 # == Schema Information
 #
 # Table name: plans
+# Database name: primary
 #
 #  id                         :uuid             not null, primary key
 #  amount_cents               :bigint           not null

--- a/app/models/plan/applied_tax.rb
+++ b/app/models/plan/applied_tax.rb
@@ -15,6 +15,7 @@ end
 # == Schema Information
 #
 # Table name: plans_taxes
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  created_at      :datetime         not null

--- a/app/models/pricing_unit.rb
+++ b/app/models/pricing_unit.rb
@@ -25,6 +25,7 @@ end
 # == Schema Information
 #
 # Table name: pricing_units
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null

--- a/app/models/pricing_unit_usage.rb
+++ b/app/models/pricing_unit_usage.rb
@@ -50,6 +50,7 @@ end
 # == Schema Information
 #
 # Table name: pricing_unit_usages
+# Database name: primary
 #
 #  id                   :uuid             not null, primary key
 #  amount_cents         :bigint           not null

--- a/app/models/quantified_event.rb
+++ b/app/models/quantified_event.rb
@@ -22,6 +22,7 @@ end
 # == Schema Information
 #
 # Table name: quantified_events
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  added_at                 :datetime         not null

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -97,6 +97,7 @@ end
 # == Schema Information
 #
 # Table name: recurring_transaction_rules
+# Database name: primary
 #
 #  id                                  :uuid             not null, primary key
 #  expiration_at                       :datetime

--- a/app/models/recurring_transaction_rule/applied_invoice_custom_section.rb
+++ b/app/models/recurring_transaction_rule/applied_invoice_custom_section.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: recurring_transaction_rules_invoice_custom_sections
+# Database name: primary
 #
 #  id                            :uuid             not null, primary key
 #  created_at                    :datetime         not null

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: refunds
+# Database name: primary
 #
 #  id                           :uuid             not null, primary key
 #  amount_cents                 :bigint           default(0), not null

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -267,6 +267,7 @@ end
 # == Schema Information
 #
 # Table name: subscriptions
+# Database name: primary
 #
 #  id                           :uuid             not null, primary key
 #  billing_time                 :integer          default("calendar"), not null

--- a/app/models/subscription/applied_invoice_custom_section.rb
+++ b/app/models/subscription/applied_invoice_custom_section.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: subscriptions_invoice_custom_sections
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  created_at                :datetime         not null

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -68,6 +68,7 @@ end
 # == Schema Information
 #
 # Table name: taxes
+# Database name: primary
 #
 #  id                      :uuid             not null, primary key
 #  applied_to_organization :boolean          default(FALSE), not null

--- a/app/models/usage_monitoring/alert.rb
+++ b/app/models/usage_monitoring/alert.rb
@@ -117,6 +117,7 @@ end
 # == Schema Information
 #
 # Table name: usage_monitoring_alerts
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  alert_type               :enum             not null

--- a/app/models/usage_monitoring/alert_threshold.rb
+++ b/app/models/usage_monitoring/alert_threshold.rb
@@ -12,6 +12,7 @@ end
 # == Schema Information
 #
 # Table name: usage_monitoring_alert_thresholds
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  code                      :string

--- a/app/models/usage_monitoring/billable_metric_current_usage_amount_alert.rb
+++ b/app/models/usage_monitoring/billable_metric_current_usage_amount_alert.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: usage_monitoring_alerts
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  alert_type               :enum             not null

--- a/app/models/usage_monitoring/billable_metric_current_usage_units_alert.rb
+++ b/app/models/usage_monitoring/billable_metric_current_usage_units_alert.rb
@@ -13,6 +13,7 @@ end
 # == Schema Information
 #
 # Table name: usage_monitoring_alerts
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  alert_type               :enum             not null

--- a/app/models/usage_monitoring/current_usage_amount_alert.rb
+++ b/app/models/usage_monitoring/current_usage_amount_alert.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: usage_monitoring_alerts
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  alert_type               :enum             not null

--- a/app/models/usage_monitoring/lifetime_usage_amount_alert.rb
+++ b/app/models/usage_monitoring/lifetime_usage_amount_alert.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: usage_monitoring_alerts
+# Database name: primary
 #
 #  id                       :uuid             not null, primary key
 #  alert_type               :enum             not null

--- a/app/models/usage_monitoring/subscription_activity.rb
+++ b/app/models/usage_monitoring/subscription_activity.rb
@@ -10,6 +10,7 @@ end
 # == Schema Information
 #
 # Table name: usage_monitoring_subscription_activities
+# Database name: primary
 #
 #  id              :bigint           not null, primary key
 #  enqueued        :boolean          default(FALSE), not null

--- a/app/models/usage_monitoring/triggered_alert.rb
+++ b/app/models/usage_monitoring/triggered_alert.rb
@@ -14,6 +14,7 @@ end
 # == Schema Information
 #
 # Table name: usage_monitoring_triggered_alerts
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  crossed_thresholds        :jsonb

--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -49,6 +49,7 @@ end
 # == Schema Information
 #
 # Table name: usage_thresholds
+# Database name: primary
 #
 #  id                     :uuid             not null, primary key
 #  amount_cents           :bigint           not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,7 @@ end
 # == Schema Information
 #
 # Table name: users
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  email           :string

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -104,6 +104,7 @@ end
 # == Schema Information
 #
 # Table name: wallets
+# Database name: primary
 #
 #  id                                  :uuid             not null, primary key
 #  allowed_fee_types                   :string           default([]), not null, is an Array

--- a/app/models/wallet/applied_invoice_custom_section.rb
+++ b/app/models/wallet/applied_invoice_custom_section.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: wallets_invoice_custom_sections
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  created_at                :datetime         not null

--- a/app/models/wallet_target.rb
+++ b/app/models/wallet_target.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: wallet_targets
+# Database name: primary
 #
 #  id                 :uuid             not null, primary key
 #  created_at         :datetime         not null

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -79,6 +79,7 @@ end
 # == Schema Information
 #
 # Table name: wallet_transactions
+# Database name: primary
 #
 #  id                                  :uuid             not null, primary key
 #  amount                              :decimal(30, 5)   default(0.0), not null

--- a/app/models/wallet_transaction/applied_invoice_custom_section.rb
+++ b/app/models/wallet_transaction/applied_invoice_custom_section.rb
@@ -11,6 +11,7 @@ end
 # == Schema Information
 #
 # Table name: wallet_transactions_invoice_custom_sections
+# Database name: primary
 #
 #  id                        :uuid             not null, primary key
 #  created_at                :datetime         not null

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -67,6 +67,7 @@ end
 # == Schema Information
 #
 # Table name: webhooks
+# Database name: primary
 #
 #  id                  :uuid             not null, primary key
 #  endpoint            :string

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -32,6 +32,7 @@ end
 # == Schema Information
 #
 # Table name: webhook_endpoints
+# Database name: primary
 #
 #  id              :uuid             not null, primary key
 #  signature_algo  :integer          default("jwt"), not null


### PR DESCRIPTION
## Context

A few of the development and test dependencies were not up-to-date:

```sh
$ bundle outdated | rg '(test|development)'
Gem                                                     Current         Latest          Requested  Groups
annotaterb                                              4.14.0          4.20.0          >= 0       development
bullet                                                  8.0.7           8.1.0           >= 0       development, test
database_cleaner-active_record                          2.2.0           2.2.2           >= 0       development, test
debug                                                   1.10.0          1.11.0          >= 0       development, test
dotenv                                                  3.1.7           3.2.0           >= 0       development, test
factory_bot_rails                                       6.4.4           6.5.1           >= 0       development, test, staging
faker                                                   3.4.2           3.5.3           >= 0       development, test, staging
graphiql-rails                                          1.10.1 1d4c700  1.10.5 41c98ac  >= 0       development
i18n-tasks                                              1.0.15 d225420  1.1.2 b7db1cb   >= 0       development, test
karafka-testing                                         2.5.3           2.5.5           >= 0       test
knapsack_pro                                            8.1.0           9.0.0           ~> 8.1     development, test
minitest                                                5.26.0          5.27.0
parallel_tests                                          5.3.0           5.5.0           ~> 5.3     development, test
rspec-rails                                             6.1.5           8.0.2           >= 0       development, test
rubocop-graphql                                         1.5.4           1.5.6           >= 0       development, test
rubocop-performance                                     1.25.0          1.26.1          >= 0       development, test
rubocop-rails                                           2.25.1          2.34.2          >= 0       development, test
rubocop-rspec                                           2.31.0          3.8.0           >= 0       development, test
rubocop-thread_safety                                   0.5.1           0.7.3           >= 0       development, test
ruby-lsp-rails                                          0.3.30          0.4.8           >= 0       development
shoulda-matchers                                        6.4.0           7.0.1           >= 0       development, test
standard                                                1.49.0          1.52.0          >= 0       development
super_diff                                              0.16.0          0.18.0          ~> 0.16.0  development, test
vernier                                                 1.8.1           1.9.0           ~> 1.0     development, test
webmock                                                 3.23.1          3.26.1          >= 0       development, test
```

## Description

This updates them to the latest minor version using a conservative approach:

```sh
$ bundle update --minor --conservative --group='development'
$ bundle update --minor --conservative --group='test'
$ bundle outdated | rg '(test|development)'
Gem                                                     Current     Latest      Requested  Groups
knapsack_pro                                            8.4.0       9.0.0       ~> 8.1     development, test
minitest                                                5.26.0      6.0.0
rspec-rails                                             6.1.5       8.0.2       >= 0       development, test
rubocop-graphql                                         1.5.4       1.5.6       >= 0       development, test
rubocop-performance                                     1.25.0      1.26.1      >= 0       development, test
rubocop-rails                                           2.25.1      2.34.2      >= 0       development, test
rubocop-rspec                                           2.31.0      3.8.0       >= 0       development, test
rubocop-thread_safety                                   0.5.1       0.7.3       >= 0       development, test
shoulda-matchers                                        6.5.0       7.0.1       >= 0       development, test
standard                                                1.49.0      1.52.0      >= 0       development
super_diff                                              0.16.0      0.18.0      ~> 0.16.0  development, test
```

Note that the `rubocop` gems were not committed to avoid fixing cop updates.
