### PR TITLE
feat(thresholds): applicable usage threshold should never show ID or useless dates

### DIFF
--- a/app/serializers/v1/applicable_usage_threshold_serializer.rb
+++ b/app/serializers/v1/applicable_usage_threshold_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  class ApplicableUsageThresholdSerializer < ModelSerializer
+    def serialize
+      {
+        threshold_display_name: model.threshold_display_name,
+        amount_cents: model.amount_cents,
+        recurring: model.recurring
+      }
+    end
+  end
+end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -72,7 +72,7 @@ module V1
     def applicable_usage_thresholds
       ::CollectionSerializer.new(
         model.applicable_usage_thresholds,
-        ::V1::UsageThresholdSerializer,
+        ::V1::ApplicableUsageThresholdSerializer,
         collection_name: "applicable_usage_thresholds"
       ).serialize
     end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -86,11 +86,11 @@ RSpec.describe Api::V1::SubscriptionsController do
           overrides: {}
         })
         expect(json[:subscription][:applicable_usage_thresholds]).to contain_exactly(
-          hash_including(
+          {
             amount_cents: override_amount_cents,
             threshold_display_name: override_display_name,
             recurring: false
-          )
+          }
         )
         expect(json[:subscription][:plan]).to include(
           amount_cents: 100,
@@ -1252,7 +1252,7 @@ RSpec.describe Api::V1::SubscriptionsController do
 
     it "returns a subscription" do
       create(:entitlement, :subscription, organization:, subscription:)
-      create(:usage_threshold, :for_subscription, subscription:)
+      usage_threshold = create(:usage_threshold, :for_subscription, subscription:)
       subject
 
       expect(response).to have_http_status(:success)
@@ -1268,11 +1268,11 @@ RSpec.describe Api::V1::SubscriptionsController do
         overrides: {}
       })
       expect(json[:subscription][:applicable_usage_thresholds]).to contain_exactly(
-        hash_including(
+        {
           amount_cents: 100,
-          threshold_display_name: String,
+          threshold_display_name: usage_threshold.threshold_display_name,
           recurring: false
-        )
+        }
       )
     end
 

--- a/spec/serializers/v1/applicable_usage_threshold_serializer_spec.rb
+++ b/spec/serializers/v1/applicable_usage_threshold_serializer_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe V1::ApplicableUsageThresholdSerializer do
+  subject(:serializer) { described_class.new(usage_threshold, root_name: "applicable_usage_threshold") }
+
+  let(:usage_threshold) { create(:usage_threshold) }
+
+  it "serializes the object without lago_id, created_at, and updated_at" do
+    result = JSON.parse(serializer.to_json)
+
+    expect(result["applicable_usage_threshold"]).to eq(
+      "threshold_display_name" => usage_threshold.threshold_display_name,
+      "amount_cents" => usage_threshold.amount_cents,
+      "recurring" => usage_threshold.recurring?
+    )
+  end
+end


### PR DESCRIPTION
Users will migrate to `applicable_usage_thresholds` but I forgot to introduce the new seriazlization (to remove lago_id and db timestamps)