### PR TITLE
feat(ai-agent): Use api key with most permissions

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -28,6 +28,7 @@ class ApiKey < ApplicationRecord
 
   scope :active, -> { where("expires_at IS NULL OR expires_at > ?", Time.current) }
   scope :non_expiring, -> { where(expires_at: nil) }
+  scope :with_most_permissions, -> { order(Arel.sql("(SELECT SUM(jsonb_array_length(value)) FROM jsonb_each(permissions))")).last }
 
   def permit?(resource, mode)
     return true unless organization.api_permissions_enabled?

--- a/app/services/ai_conversations/stream_service.rb
+++ b/app/services/ai_conversations/stream_service.rb
@@ -92,7 +92,7 @@ module AiConversations
     end
 
     def lago_api_key
-      @lago_api_key ||= ai_conversation.organization.api_keys.first.value
+      @lago_api_key ||= ai_conversation.organization.api_keys.with_most_permissions.value
     end
   end
 end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -143,6 +143,23 @@ RSpec.describe ApiKey do
     end
   end
 
+  describe ".with_most_permissions" do
+    subject { organization.api_keys.with_most_permissions }
+
+    let(:organization) { create(:organization) }
+
+    let(:limited_permissions_key) do
+      create(:api_key, organization:, permissions: {add_on: ["read"], customer: ["read"]})
+    end
+
+    before { limited_permissions_key }
+
+    it "returns the API key with the most permissions" do
+      expect(subject).not_to eq(limited_permissions_key)
+      expect(subject.permissions).to eq(described_class.default_permissions)
+    end
+  end
+
   describe "#permit?" do
     subject { api_key.permit?(resource, mode) }
 


### PR DESCRIPTION
When using the AI Agent, we want to select the api key with the most permissions.