### PR TITLE
Feat(fixed_charges): move fee dates logic into model and reuse it for graphql

### DIFF
--- a/app/graphql/types/fees/properties.rb
+++ b/app/graphql/types/fees/properties.rb
@@ -9,11 +9,11 @@ module Types
       field :to_datetime, GraphQL::Types::ISO8601DateTime, null: true
 
       def from_datetime
-        object.properties["from_datetime"]
+        object.date_boundaries[:from_date]
       end
 
       def to_datetime
-        object.properties["to_datetime"]
+        object.date_boundaries[:to_date]
       end
     end
   end

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -99,16 +99,16 @@ RSpec.describe Mutations::Invoices::Create do
           "units" => 2.0,
           "preciseUnitAmount" => 12.0,
           "properties" => {
-            "fromDatetime" => current_time.to_time.utc.iso8601,
-            "toDatetime" => current_time.to_time.utc.iso8601
+            "fromDatetime" => current_time.to_time.iso8601,
+            "toDatetime" => current_time.to_time.iso8601
           }
         },
         {
           "units" => 1.0,
           "preciseUnitAmount" => 4.0,
           "properties" => {
-            "fromDatetime" => current_time.to_time.utc.iso8601,
-            "toDatetime" => current_time.to_time.utc.iso8601
+            "fromDatetime" => current_time.to_time.iso8601,
+            "toDatetime" => current_time.to_time.iso8601
           }
         }
       )


### PR DESCRIPTION
## Context

On the API we already send actual boundaries of the fee, while in the graphql in fee we send subscription boundaries, but in the subscription we send boundaries of the current period and paid in advance period. Instead, we can always send correct boundaries on the fee
