### PR TITLE
feat(plan): Introduce `plan.applicable_usage_thresholds`

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -91,7 +91,7 @@ module Api
               ::V1::PlanSerializer,
               collection_name: "plans",
               meta: pagination_metadata(result.plans),
-              includes: %i[charges usage_thresholds taxes minimum_commitment entitlements]
+              includes: %i[charges usage_thresholds applicable_usage_thresholds taxes minimum_commitment entitlements]
             )
           )
         else
@@ -178,7 +178,7 @@ module Api
           json: ::V1::PlanSerializer.new(
             plan,
             root_name: "plan",
-            includes: %i[charges fixed_charges usage_thresholds taxes minimum_commitment entitlements]
+            includes: %i[charges fixed_charges usage_thresholds applicable_usage_thresholds taxes minimum_commitment entitlements]
           )
         )
       end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -124,7 +124,7 @@ module Api
         )
 
         if result.success?
-          render_subscription(result.subscription)
+          render_subscription(result.subscription, includes: %i[plan applicable_usage_thresholds])
         else
           render_error_response(result)
         end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -58,6 +58,10 @@ class Plan < ApplicationRecord
     %w[name code]
   end
 
+  def applicable_usage_thresholds
+    (parent || self).usage_thresholds
+  end
+
   def pay_in_arrears?
     !pay_in_advance
   end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -28,6 +28,7 @@ module V1
       payload.merge!(fixed_charges) if include?(:fixed_charges)
       payload.merge!(entitlements) if include?(:entitlements)
       payload.merge!(usage_thresholds) if include?(:usage_thresholds)
+      payload.merge!(applicable_usage_thresholds) if include?(:applicable_usage_thresholds)
       payload.merge!(taxes) if include?(:taxes)
       payload.merge!(minimum_commitment) if include?(:minimum_commitment) && model.minimum_commitment
 
@@ -67,6 +68,14 @@ module V1
         model.usage_thresholds,
         ::V1::UsageThresholdSerializer,
         collection_name: "usage_thresholds"
+      ).serialize
+    end
+
+    def applicable_usage_thresholds
+      ::CollectionSerializer.new(
+        model.applicable_usage_thresholds,
+        ::V1::ApplicableUsageThresholdSerializer,
+        collection_name: "applicable_usage_thresholds"
       ).serialize
     end
 

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -55,7 +55,7 @@ module V1
     def plan
       ::V1::PlanSerializer.new(
         model.plan,
-        includes: %i[charges usage_thresholds taxes minimum_commitment]
+        includes: %i[charges usage_thresholds applicable_usage_thresholds taxes minimum_commitment]
       ).serialize
     end
 

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -46,6 +46,29 @@ RSpec.describe Plan do
     end
   end
 
+  describe "#applicable_usage_thresholds" do
+    let(:plan) { create(:plan) }
+
+    it "returns usage thresholds plan is a parent" do
+      threshold = create(:usage_threshold, plan: plan)
+      expect(plan.applicable_usage_thresholds).to contain_exactly(threshold)
+    end
+
+    it "returns parent usage thresholds if plan is a child" do
+      create(:usage_threshold, plan: plan, amount_cents: 99_00)
+      parent = create(:plan)
+      threshold = create(:usage_threshold, plan: parent)
+      plan.update!(parent: parent)
+
+      expect(plan.applicable_usage_thresholds).to contain_exactly(threshold)
+    end
+
+    it "returns an empty array if neither plan nor parent has thresholds" do
+      plan.update!(parent: create(:plan))
+      expect(plan.applicable_usage_thresholds).to eq([])
+    end
+  end
+
   describe "#has_trial?" do
     it "returns true when trial_period" do
       expect(plan).to have_trial

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -166,7 +166,9 @@ RSpec.describe Api::V1::PlansController do
 
               expect(response).to have_http_status(:success)
               expect(json[:plan][:usage_thresholds].first[:lago_id]).to be_present
-              expect(json[:plan][:usage_thresholds].first[:amount_cents]).to eq(json[:plan][:amount_cents])
+              expect(json[:plan][:usage_thresholds].first[:amount_cents]).to eq(100)
+              expect(json[:plan][:applicable_usage_thresholds].first[:amount_cents]).to eq(100)
+              expect(json[:plan][:applicable_usage_thresholds].first[:threshold_display_name]).to eq("Threshold 1")
             end
           end
 
@@ -384,7 +386,6 @@ RSpec.describe Api::V1::PlansController do
       [
         {
           amount_cents: 7_000,
-          amount_currency: "EUR",
           threshold_display_name: "Updated threshold"
         }
       ]
@@ -514,8 +515,13 @@ RSpec.describe Api::V1::PlansController do
         expect(charge[:invoiceable]).to be false
         expect(charge[:regroup_paid_fees]).to eq "invoice"
 
-        usage_threshold = json[:plan][:usage_thresholds].first
+        usage_threshold = json[:plan][:usage_thresholds].sole
         expect(usage_threshold[:amount_cents]).to eq(7_000)
+        expect(usage_threshold[:threshold_display_name]).to eq("Updated threshold")
+
+        applicable_usage_threshold = json[:plan][:applicable_usage_thresholds].sole
+        expect(applicable_usage_threshold[:amount_cents]).to eq(7_000)
+        expect(applicable_usage_threshold[:threshold_display_name]).to eq("Updated threshold")
       end
     end
 
@@ -918,6 +924,7 @@ RSpec.describe Api::V1::PlansController do
         expect(json[:plan][:lago_id]).to eq(plan.id)
         expect(json[:plan][:code]).to eq(plan.code)
         expect(json[:plan][:usage_thresholds].count).to eq(2)
+        expect(json[:plan][:applicable_usage_thresholds].count).to eq(2)
       end
     end
 
@@ -976,6 +983,7 @@ RSpec.describe Api::V1::PlansController do
         expect(response).to have_http_status(:success)
         expect(json[:plan][:lago_id]).to eq(plan.id)
         expect(json[:plan][:code]).to eq(plan.code)
+        expect(json[:plan][:applicable_usage_thresholds]).to be_empty
         expect(json[:plan][:entitlements]).to be_empty
       end
     end
@@ -1008,6 +1016,7 @@ RSpec.describe Api::V1::PlansController do
       expect(json[:plans].first[:lago_id]).to eq(plan.id)
       expect(json[:plans].first[:code]).to eq(plan.code)
       expect(json[:plans].first[:usage_thresholds].count).to eq(1)
+      expect(json[:plans].first[:applicable_usage_thresholds].count).to eq(1)
     end
 
     context "when pending for deletion plan exists" do

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -189,4 +189,25 @@ RSpec.describe ::V1::PlanSerializer do
       })
     end
   end
+
+  context "when applicable_usage_thresholds is included" do
+    subject(:serializer) do
+      described_class.new(
+        plan,
+        root_name: "plan",
+        includes: %i[applicable_usage_thresholds]
+      )
+    end
+
+    it "serializes applicable_usage_thresholds without lago_id, created_at, and updated_at" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["plan"]["applicable_usage_thresholds"].count).to eq(1)
+      expect(result["plan"]["applicable_usage_thresholds"].first).to eq(
+        "threshold_display_name" => usage_threshold.threshold_display_name,
+        "amount_cents" => usage_threshold.amount_cents,
+        "recurring" => usage_threshold.recurring?
+      )
+    end
+  end
 end


### PR DESCRIPTION
See `subscription.applicable_usage_thresholds` introduced in https://github.com/getlago/lago-api/pull/4729

Remember we're removing usage thresholds attached to child plans.

With `applicable_usage_thresholds` on both subscription and plan, our users can move the new attributes without breaking change. The write part (sending usage_threshold override via the API) is coming in the next PR.

In this case, the `applicable_usage_thresholds` of plan are:
- the thresholds of the parent if the plan is a child 
- or the thresholds of the plan itself if it's a parent plan

The data is serialized using the new serializer so users can start migrating their code to the new `applicable_*` fields. 

**In January, the usage_thresholds fields will be removed.** Note that this feature is only used with ProgressiveBilling.