### PR TITLE
feat(thresholds): Subscription create and update

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -168,6 +168,7 @@ module Api
             :billing_time,
             :subscription_at,
             :ending_at,
+            :progressive_billing_disabled,
             invoice_custom_section: [
               :skip_invoice_custom_sections,
               {invoice_custom_section_codes: []}
@@ -176,6 +177,7 @@ module Api
               :payment_method_type,
               :payment_method_id
             ],
+            usage_thresholds: usage_thresholds_params,
             plan_overrides:
           )
       end
@@ -187,6 +189,7 @@ module Api
           :ending_at,
           :on_termination_credit_note,
           :on_termination_invoice,
+          :progressive_billing_disabled,
           invoice_custom_section: [
             :skip_invoice_custom_sections,
             {invoice_custom_section_codes: []}
@@ -195,8 +198,17 @@ module Api
             :payment_method_type,
             :payment_method_id
           ],
+          usage_thresholds: usage_thresholds_params,
           plan_overrides:
         )
+      end
+
+      def usage_thresholds_params
+        [
+          :amount_cents,
+          :threshold_display_name,
+          :recurring
+        ]
       end
 
       def plan_overrides

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -63,6 +63,14 @@ class Plan < ApplicationRecord
     %w[name code]
   end
 
+  def is_parent?
+    !is_child?
+  end
+
+  def is_child?
+    parent_id.present?
+  end
+
   def applicable_usage_thresholds
     (parent || self).usage_thresholds
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -260,14 +260,13 @@ class Subscription < ApplicationRecord
     applicable_usage_thresholds.any?
   end
 
-  # If the subscription has direct usage thresholds, they are override and take precedence
-  # If it has a plan override with thresholds, we use them. Ultimately, they will be migrated
-  #   to subscription usage thresholds.
-  # Once migrated, this method should also return parent plan thresholds if nothing else is set.
+  # If the subscription has direct usage thresholds, these overrides take precedence.
+  # Thresholds attached to plan override (child plans) are being rmeoved and kept temporarily until the ata is migrated
+  # If no override, we always use the parent plan thresholds
   def applicable_usage_thresholds
     return [] if progressive_billing_disabled?
 
-    usage_thresholds.any? ? usage_thresholds : plan.usage_thresholds
+    usage_thresholds.presence || plan.usage_thresholds.presence || plan.applicable_usage_thresholds
   end
 end
 

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -27,7 +27,8 @@ module V1
         current_billing_period_started_at: dates_service.charges_from_datetime&.iso8601,
         current_billing_period_ending_at: dates_service.charges_to_datetime&.iso8601,
         on_termination_credit_note: model.on_termination_credit_note,
-        on_termination_invoice: model.on_termination_invoice
+        on_termination_invoice: model.on_termination_invoice,
+        progressive_billing_disabled: model.progressive_billing_disabled
       }
 
       payload = payload.merge(customer:) if include?(:customer)

--- a/app/services/lifetime_usages/usage_thresholds/check_service.rb
+++ b/app/services/lifetime_usages/usage_thresholds/check_service.rb
@@ -8,7 +8,7 @@ module LifetimeUsages
       def initialize(lifetime_usage:, progressive_billed_amount: 0)
         @lifetime_usage = lifetime_usage
         @progressive_billed_amount = progressive_billed_amount
-        @thresholds = lifetime_usage.subscription.plan.usage_thresholds
+        @thresholds = lifetime_usage.subscription.applicable_usage_thresholds
         super
       end
 

--- a/app/services/lifetime_usages/usage_thresholds_completion_service.rb
+++ b/app/services/lifetime_usages/usage_thresholds_completion_service.rb
@@ -4,7 +4,7 @@ module LifetimeUsages
   class UsageThresholdsCompletionService < BaseService
     def initialize(lifetime_usage:)
       @lifetime_usage = lifetime_usage
-      @usage_thresholds = lifetime_usage.subscription.plan.usage_thresholds
+      @usage_thresholds = lifetime_usage.subscription.applicable_usage_thresholds
 
       super
     end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -44,12 +44,8 @@ module Plans
           taxes_result.raise_if_error!
         end
 
-        if args[:usage_thresholds].present? &&
-            License.premium? &&
-            plan.organization.progressive_billing_enabled?
-          args[:usage_thresholds].each do |threshold_args|
-            create_usage_threshold(plan, threshold_args)
-          end
+        if args[:usage_thresholds].present? && plan.organization.progressive_billing_enabled?
+          UsageThresholds::UpdateService.call!(model: plan, usage_thresholds_params: args[:usage_thresholds], partial: false)
         end
 
         if args[:charges].present?

--- a/app/services/plans/update_usage_thresholds_service.rb
+++ b/app/services/plans/update_usage_thresholds_service.rb
@@ -14,81 +14,17 @@ module Plans
       result.plan = plan
       return result unless plan.organization.progressive_billing_enabled?
 
-      if usage_thresholds_params.empty?
-        plan.usage_thresholds.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-      else
-        process_usage_thresholds
-        LifetimeUsages::FlagRefreshFromPlanUpdateJob.perform_later(plan)
+      ActiveRecord::Base.transaction do
+        UsageThresholds::UpdateService.call!(model: plan, usage_thresholds_params:, partial: false)
       end
+
+      plan.usage_thresholds.reload
+      LifetimeUsages::FlagRefreshFromPlanUpdateJob.perform_after_commit(plan) if plan.usage_thresholds.size > 0
 
       result
     end
 
     private
-
-    def process_usage_thresholds
-      created_thresholds_ids = []
-
-      hash_thresholds = usage_thresholds_params.map { |c| c.to_h.deep_symbolize_keys }
-      hash_thresholds.each do |payload_threshold|
-        usage_threshold = plan.usage_thresholds.find_by(id: payload_threshold[:id])
-
-        if usage_threshold
-          if payload_threshold.key?(:threshold_display_name)
-            usage_threshold.threshold_display_name = payload_threshold[:threshold_display_name]
-          end
-
-          if payload_threshold.key?(:amount_cents)
-            usage_threshold.amount_cents = payload_threshold[:amount_cents]
-          end
-
-          if payload_threshold.key?(:recurring)
-            usage_threshold.recurring = payload_threshold[:recurring]
-          end
-
-          # This means that in the UI we just removed an existing threshold
-          # and then just re-added a threshold (which no longer has an id) with the same amount
-          # so we discard the existing one and we're inserting a new one instead
-          if !usage_threshold.valid? && usage_threshold.errors.where(:amount_cents, :taken).present?
-            usage_threshold.discard!
-          else
-            usage_threshold.save!
-            next
-          end
-        end
-
-        created_threshold = create_usage_threshold(plan.reload, payload_threshold)
-        created_thresholds_ids.push(created_threshold.id)
-      end
-      # NOTE: Delete thresholds that are no more linked to the plan
-      sanitize_thresholds(plan, hash_thresholds, created_thresholds_ids)
-    end
-
-    def sanitize_thresholds(plan, args_thresholds, created_thresholds_ids)
-      args_thresholds_ids = args_thresholds.map { |c| c[:id] }.compact
-      thresholds_ids = plan.usage_thresholds.pluck(:id) - args_thresholds_ids - created_thresholds_ids
-      plan.usage_thresholds.where(id: thresholds_ids).update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-    end
-
-    def create_usage_threshold(plan, params)
-      usage_threshold = plan.usage_thresholds.find_or_initialize_by(
-        recurring: params[:recurring] || false,
-        amount_cents: params[:amount_cents]
-      )
-
-      existing_recurring_threshold = plan.usage_thresholds.recurring.first
-
-      if params[:recurring] && existing_recurring_threshold
-        usage_threshold = existing_recurring_threshold
-      end
-
-      usage_threshold.threshold_display_name = params[:threshold_display_name]
-      usage_threshold.amount_cents = params[:amount_cents]
-      usage_threshold.organization_id = plan.organization_id
-
-      usage_threshold.save!
-      usage_threshold
-    end
 
     attr_reader :plan, :usage_thresholds_params
   end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -26,6 +26,14 @@ module Subscriptions
       return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
       return result.validation_failure!(errors: {external_customer_id: ["value_is_mandatory"]}) if params[:external_customer_id].blank? && api_context?
 
+      # TODO: Remove check we stop supporting `plan_overrides.usage_thresholds`
+      if params[:usage_thresholds].present? && plan_overrides[:usage_thresholds].present?
+        return result.validation_failure!(errors: {
+          "plan_overrides.usage_thresholds": ["incompatible_params"],
+          usage_thresholds: ["incompatible_params"]
+        })
+      end
+
       plan.amount_currency = plan_overrides[:amount_currency] if plan_overrides[:amount_currency]
       plan.amount_cents = plan_overrides[:amount_cents] if plan_overrides[:amount_cents]
 
@@ -44,6 +52,10 @@ module Subscriptions
             .first
 
           subscription = handle_subscription
+
+          if params[:usage_thresholds].present?
+            UpdateUsageThresholdsService.call!(subscription:, usage_thresholds_params: params[:usage_thresholds], partial: false)
+          end
           InvoiceCustomSections::AttachToResourceService.call(resource: subscription, params:) unless downgrade?
 
           result.subscription = subscription
@@ -118,7 +130,8 @@ module Subscriptions
         name:,
         external_id:,
         billing_time: billing_time || :calendar,
-        ending_at: params[:ending_at]
+        ending_at: params[:ending_at],
+        progressive_billing_disabled: params[:progressive_billing_disabled] || false
       )
 
       if params.key?(:payment_method)
@@ -202,7 +215,8 @@ module Subscriptions
         subscription_at: current_subscription.subscription_at,
         status: :pending,
         billing_time: current_subscription.billing_time,
-        ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at
+        ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
+        progressive_billing_disabled: params[:progressive_billing_disabled] || false
       )
 
       if params.key?(:payment_method)

--- a/app/services/subscriptions/update_usage_thresholds_service.rb
+++ b/app/services/subscriptions/update_usage_thresholds_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class UpdateUsageThresholdsService < BaseService
+    Result = BaseResult
+
+    def initialize(subscription:, usage_thresholds_params:, partial:)
+      @subscription = subscription
+      @usage_thresholds_params = usage_thresholds_params
+      @partial = partial
+      super
+    end
+
+    def call
+      return result unless subscription.organization.progressive_billing_enabled?
+
+      ActiveRecord::Base.transaction do
+        UsageThresholds::UpdateService.call!(model: subscription, usage_thresholds_params:, partial:)
+        # NOTE: Once we attach UT to the subscription, we should delete all UT attached to the plan override
+        plan.usage_thresholds.update_all(deleted_at: Time.current) if plan.is_child? # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      subscription.usage_thresholds.reload
+      subscription&.lifetime_usage&.update recalculate_invoiced_usage: true if subscription.usage_thresholds.size > 0
+
+      result
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :subscription, :usage_thresholds_params, :partial
+    delegate :plan, to: :subscription
+  end
+end

--- a/app/services/usage_thresholds/update_service.rb
+++ b/app/services/usage_thresholds/update_service.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module UsageThresholds
+  class UpdateService < BaseService
+    Result = BaseResult
+
+    def initialize(model:, usage_thresholds_params:, partial:)
+      @model = model
+      @usage_thresholds_params = sanitize_params(usage_thresholds_params)
+      @partial = partial
+
+      super
+    end
+
+    def call
+      return result if usage_thresholds_params.empty? && partial?
+
+      return result.single_validation_failure!(error_code: "missing_amount_cents", field: :usage_thresholds) if missing_amount_cents?
+      return result.single_validation_failure!(error_code: "duplicated_values", field: :usage_thresholds) if duplicated_amount_cents?
+      return result.single_validation_failure!(error_code: "multiple_recurring_thresholds", field: :usage_thresholds) if multiple_recurring_thresholds?
+
+      ActiveRecord::Base.transaction do
+        delete_all_thresholds if full?
+
+        update_recurring_threshold
+        update_or_create_thresholds
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :model, :usage_thresholds_params, :partial
+    alias_method :partial?, :partial
+
+    def full?
+      !partial
+    end
+
+    def sanitize_params(usage_thresholds_params)
+      usage_thresholds_params.map do |p|
+        h = p.to_h.deep_symbolize_keys.slice(:threshold_display_name, :amount_cents, :recurring)
+        h[:recurring] ||= false
+        h
+      end
+    end
+
+    def missing_amount_cents?
+      usage_thresholds_params.any? { |p| p[:amount_cents].blank? }
+    end
+
+    def duplicated_amount_cents?
+      grouped = usage_thresholds_params.group_by { |p| [p[:amount_cents], p[:recurring]] }
+      grouped.any? { |_, v| v.size > 1 }
+    end
+
+    def multiple_recurring_thresholds?
+      usage_thresholds_params.count { |p| p[:recurring] } > 1
+    end
+
+    def delete_all_thresholds
+      model.usage_thresholds.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    def update_recurring_threshold
+      recurring_params = usage_thresholds_params.find { |p| p[:recurring] }
+      return unless recurring_params
+
+      existing_threshold = model.usage_thresholds.find { |t| t.recurring }
+
+      if existing_threshold
+        existing_threshold.update!(
+          amount_cents: recurring_params[:amount_cents],
+          threshold_display_name: recurring_params[:threshold_display_name]
+        )
+      else
+        create_threshold(recurring_params, recurring: true)
+      end
+    end
+
+    def update_or_create_thresholds
+      usage_thresholds_params.reject { |p| p[:recurring] }.each do |threshold_params|
+        existing_threshold = model.usage_thresholds.find { |t| t.amount_cents == threshold_params[:amount_cents] && !t.recurring }
+
+        if existing_threshold
+          update_threshold(existing_threshold, threshold_params)
+        else
+          create_threshold(threshold_params)
+        end
+      end
+    end
+
+    def update_threshold(threshold, params)
+      threshold.threshold_display_name = params[:threshold_display_name] if params.key?(:threshold_display_name)
+      threshold.save!
+    end
+
+    def create_threshold(params, recurring: false)
+      model.usage_thresholds.create!(
+        organization: model.organization,
+        threshold_display_name: params[:threshold_display_name],
+        amount_cents: params[:amount_cents],
+        recurring:
+      )
+    end
+  end
+end

--- a/db/seeds/02_john_doe.rb
+++ b/db/seeds/02_john_doe.rb
@@ -111,3 +111,28 @@ if License.premium?
     ]
   )
 end
+
+# == second subscriptions with plan override
+
+sub_2_external_id = sub_external_id + "-2"
+started_at_2 = started_at + 4.days + 1.hour + 13.minutes
+sub2 = john_doe.subscriptions.active.find_by(external_id: sub_2_external_id)
+unless sub2
+  sub = Subscriptions::CreateService.call!(
+    customer: john_doe,
+    plan:,
+    params: {
+      name: "Subscription With Plan Override",
+      billing_time: :calendar,
+      subscription_at: started_at_2,
+      started_at: started_at_2,
+      external_id: sub_2_external_id,
+      plan_overrides: {
+        name: "Premium with Override",
+        description: "This plan is used to test the override functionality",
+        amount_cents: 211_00
+      }
+    }
+  ).subscription
+  sub.update(created_at: started_at_2)
+end

--- a/db/seeds/08_progressive_billing.rb
+++ b/db/seeds/08_progressive_billing.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+subscription = Subscription.find_by!(external_id: "sub_john-doe-main")
+
+UsageThresholds::UpdateService.call!(
+  model: subscription.plan,
+  usage_thresholds_params: [{
+    amount_cents: 120_00,
+    threshold_display_name: "Initial Threshold"
+  }, {
+    amount_cents: 1_000_00,
+    threshold_display_name: "Recurring Threshold",
+    recurring: true
+  }],
+  partial: false
+)
+
+Subscriptions::UpdateUsageThresholdsService.call!(
+  subscription:,
+  usage_thresholds_params: [{
+    amount_cents: 400_00,
+    threshold_display_name: "Initial Threshold"
+  }, {
+    amount_cents: 800_00
+  }, {
+    amount_cents: 2000_00,
+    recurring: true
+  }],
+  partial: false
+)

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe Plan do
     end
   end
 
+  describe "#is_parent? and #is_child?" do
+    it do
+      expect(plan.is_parent?).to be true
+      expect(plan.is_child?).to be false
+
+      plan.parent_id = SecureRandom.uuid
+      expect(plan.is_parent?).to be false
+      expect(plan.is_child?).to be true
+    end
+  end
+
   describe "#applicable_usage_thresholds" do
     let(:plan) { create(:plan) }
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -783,9 +783,9 @@ RSpec.describe Subscription do
         let(:plan) { create(:plan, parent: parent_plan) }
         let(:plan_threshold) { create(:usage_threshold, plan: parent_plan) }
 
-        it "returns plan usage thresholds" do
+        it "returns the parent plan usage thresholds" do
           plan_threshold
-          expect(subscription.applicable_usage_thresholds).to be_empty
+          expect(subscription.applicable_usage_thresholds).to contain_exactly(plan_threshold)
         end
       end
     end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -47,11 +47,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           minimum_commitment: {
             invoice_display_name: commitment_invoice_display_name,
             amount_cents: commitment_amount_cents
-          },
-          usage_thresholds: [
-            amount_cents: override_amount_cents,
-            threshold_display_name: override_display_name
-          ]
+          }
         }
       }
     end
@@ -99,24 +95,11 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           privileges: [],
           overrides: {}
         })
-        expect(json[:subscription][:applicable_usage_thresholds]).to contain_exactly(
-          {
-            amount_cents: override_amount_cents,
-            threshold_display_name: override_display_name,
-            recurring: false
-          }
-        )
         expect(json[:subscription][:plan]).to include(
           amount_cents: plan_amount_cents_override,
           name: "overridden name",
           description: "desc"
         )
-        expect(json[:subscription][:plan][:usage_thresholds].count).to eq 1
-        expect(json[:subscription][:plan][:applicable_usage_thresholds]).to contain_exactly({
-          amount_cents: plan_usage_threshold.amount_cents,
-          threshold_display_name: plan_usage_threshold.threshold_display_name,
-          recurring: false
-        })
         expect(json[:subscription][:plan][:minimum_commitment]).to include(
           invoice_display_name: commitment_invoice_display_name,
           amount_cents: commitment_amount_cents
@@ -128,6 +111,103 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
 
     it "doesn't create a new customer" do
       expect { subject }.not_to change(Customer, :count)
+    end
+
+    context "when usage_thresholds is part of plan_override (legacy)" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          billing_time: "anniversary",
+          subscription_at:,
+          ending_at:,
+          plan_overrides: {
+            usage_thresholds: [
+              amount_cents: override_amount_cents,
+              threshold_display_name: override_display_name
+            ]
+          }
+        }
+      end
+
+      it "attaches the usage_thresholds to the child plan" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+
+        expect(plan.usage_thresholds).to contain_exactly(plan_usage_threshold)
+        subscription = Subscription.find json[:subscription][:lago_id]
+        expect(subscription.plan.is_child?).to be true
+        expect(subscription.plan.usage_thresholds.sole.amount_cents).to eq override_amount_cents
+        expect(subscription.usage_thresholds).to be_empty
+
+        expect(json[:subscription][:applicable_usage_thresholds]).to contain_exactly(
+          {
+            amount_cents: override_amount_cents,
+            threshold_display_name: override_display_name,
+            recurring: false
+          }
+        )
+        expect(json[:subscription][:plan][:usage_thresholds]).to contain_exactly(
+          hash_including(
+            amount_cents: override_amount_cents,
+            threshold_display_name: override_display_name,
+            recurring: false
+          )
+        )
+        expect(json[:subscription][:plan][:applicable_usage_thresholds]).to contain_exactly({
+          amount_cents: plan_usage_threshold.amount_cents,
+          threshold_display_name: plan_usage_threshold.threshold_display_name,
+          recurring: false
+        })
+      end
+    end
+
+    context "when usage_thresholds is part of subscription" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          billing_time: "anniversary",
+          subscription_at:,
+          ending_at:,
+          usage_thresholds: [
+            amount_cents: override_amount_cents,
+            threshold_display_name: override_display_name
+          ],
+          plan_overrides: {
+            amount_cents: 99_99
+          }
+        }
+      end
+
+      it "attaches the usage_thresholds to the subscription" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+
+        expect(plan.usage_thresholds).to contain_exactly(plan_usage_threshold)
+        subscription = Subscription.find json[:subscription][:lago_id]
+        expect(subscription.plan.is_child?).to be true
+        expect(subscription.plan.usage_thresholds).to be_empty
+        expect(subscription.usage_thresholds.sole.amount_cents).to eq override_amount_cents
+
+        expect(json[:subscription][:applicable_usage_thresholds]).to contain_exactly(
+          {
+            amount_cents: override_amount_cents,
+            threshold_display_name: override_display_name,
+            recurring: false
+          }
+        )
+        expect(json[:subscription][:plan][:usage_thresholds]).to be_empty
+        expect(json[:subscription][:plan][:applicable_usage_thresholds]).to contain_exactly({
+          amount_cents: plan_usage_threshold.amount_cents,
+          threshold_display_name: plan_usage_threshold.threshold_display_name,
+          recurring: false
+        })
+      end
     end
 
     context "with external_customer_id, external_id and name as integer" do
@@ -510,6 +590,27 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         end
       end
     end
+
+    context "with progressive_billing_disabled" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          progressive_billing_disabled: true
+        }
+      end
+
+      it "creates a subscription with progressive_billing_disabled set to true" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:progressive_billing_disabled]).to be(true)
+
+        subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
+        expect(subscription.progressive_billing_disabled).to be(true)
+      end
+    end
   end
 
   describe "DELETE /api/v1/subscriptions/:external_id" do
@@ -725,12 +826,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
             invoice_display_name: commitment_invoice_display_name,
             amount_cents: commitment_amount_cents,
             tax_codes: [tax.code]
-          },
-          usage_thresholds: [
-            id: usage_threshold.id,
-            amount_cents: override_amount_cents,
-            threshold_display_name: override_display_name
-          ]
+          }
         }
       }
     end
@@ -742,7 +838,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
     let(:applied_pricing_unit) { create(:applied_pricing_unit, pricing_unitable: package_charge, pricing_unit:, organization:) }
     let(:tax) { create(:tax, organization:) }
     let(:override_amount_cents) { 999 }
-    let(:override_display_name) { "Overriden Threshold 1" }
+    let(:override_display_name) { "Overridden Threshold 1" }
     let(:usage_threshold) { create(:usage_threshold, plan:, created_at: 1.day.ago) }
 
     before do
@@ -762,12 +858,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       expect(subscription).to include(
         lago_id: Regex::UUID,
         name: "subscription name new",
-        subscription_at: "2022-09-05T12:23:12Z",
-        applicable_usage_thresholds: [{
-          threshold_display_name: override_display_name,
-          amount_cents: override_amount_cents,
-          recurring: usage_threshold.recurring
-        }]
+        subscription_at: "2022-09-05T12:23:12Z"
       )
 
       expect(subscription[:payment_method][:payment_method_type]).to eq("provider")
@@ -793,15 +884,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         parent_id: plan.id,
         pending_deletion: false,
         taxes: [],
-        usage_thresholds: [{
-          lago_id: Regex::UUID,
-          threshold_display_name: override_display_name,
-          amount_cents: override_amount_cents,
-          recurring: usage_threshold.recurring,
-          # NOTE: Notice that even if usage_threshold.id is passed, a new threshold is created
-          created_at: Regex::ISO8601_DATETIME,
-          updated_at: Regex::ISO8601_DATETIME
-        }]
+        usage_thresholds: []
       )
       expect(plan_json[:applicable_usage_thresholds]).to contain_exactly({
         threshold_display_name: usage_threshold.threshold_display_name,
@@ -886,28 +969,108 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       )
     end
 
-    context "when progressive billing premium integration is present", :premium do
-      before do
-        organization.update!(premium_integrations: ["progressive_billing"])
+    context "when updating usage_thresholds" do
+      let(:usage_thresholds) do
+        [{
+          amount_cents: override_amount_cents,
+          threshold_display_name: override_display_name
+        }]
       end
 
-      it "updates subscription with an overriden plan with usage thresholds" do
-        subject
+      context "when usage_thresholds are part of plan_overrides (legacy)" do
+        let(:update_params) do
+          {
+            name: "subscription name new",
+            plan_overrides: {
+              usage_thresholds:
+            }
+          }
+        end
 
-        expect(response).to have_http_status(:success)
+        it "attaches the usage thresholds to the child plan" do
+          subject
 
-        expect(json[:subscription][:plan][:usage_thresholds]).to match_array(
-          [
+          expect(response).to have_http_status(:success)
+
+          subscription = Subscription.find_by(id: json[:subscription][:lago_id])
+          expect(subscription.plan.is_child?).to be true
+          expect(subscription.plan.usage_thresholds.pluck(:amount_cents, :threshold_display_name)).to eq([[override_amount_cents, override_display_name]])
+          expect(subscription.plan.parent.usage_thresholds.count).to eq 2
+          expect(subscription.usage_thresholds).to be_empty
+
+          expect(json[:subscription][:plan][:usage_thresholds]).to contain_exactly(
             {
               lago_id: Regex::UUID,
-              threshold_display_name: "Overriden Threshold 1",
+              threshold_display_name: "Overridden Threshold 1",
               amount_cents: 999,
               recurring: false,
               created_at: Regex::ISO8601_DATETIME,
               updated_at: Regex::ISO8601_DATETIME
             }
-          ]
-        )
+          )
+          expect(json[:subscription][:plan][:applicable_usage_thresholds].count).to eq 2
+          expect(json[:subscription][:applicable_usage_thresholds]).to eq(json[:subscription][:plan][:usage_thresholds].map { |t| t.slice(:threshold_display_name, :amount_cents, :recurring) })
+        end
+      end
+
+      context "when usage_thresholds are part of subscription and has plan_overrides" do
+        let(:update_params) do
+          {
+            name: "subscription name new",
+            usage_thresholds:,
+            plan_overrides: {
+              name: "rename plan to create override"
+            }
+          }
+        end
+
+        it "attaches the usage thresholds to the child plan" do
+          subject
+
+          expect(response).to have_http_status(:success)
+
+          subscription = Subscription.find_by(id: json[:subscription][:lago_id])
+          expect(subscription.plan.is_child?).to be true
+          expect(subscription.plan.usage_thresholds).to be_empty
+          expect(subscription.plan.parent.usage_thresholds.count).to eq 2
+          expect(subscription.usage_thresholds.pluck(:amount_cents, :threshold_display_name)).to eq([[override_amount_cents, override_display_name]])
+
+          expect(json[:subscription][:plan][:usage_thresholds]).to be_empty
+          expect(json[:subscription][:plan][:applicable_usage_thresholds].count).to eq 2
+          expect(json[:subscription][:applicable_usage_thresholds]).to contain_exactly(
+            threshold_display_name: "Overridden Threshold 1",
+            amount_cents: 999,
+            recurring: false
+          )
+        end
+      end
+
+      context "when usage_thresholds are part of subscription without any plan_overrides" do
+        let(:update_params) do
+          {
+            name: "subscription name new",
+            usage_thresholds:
+          }
+        end
+
+        it "attaches the usage thresholds to the child plan" do
+          subject
+
+          expect(response).to have_http_status(:success)
+
+          subscription = Subscription.find_by(id: json[:subscription][:lago_id])
+          expect(subscription.plan.is_parent?).to be true
+          expect(subscription.plan.usage_thresholds.count).to eq 2
+          expect(subscription.usage_thresholds.pluck(:amount_cents, :threshold_display_name)).to eq([[override_amount_cents, override_display_name]])
+
+          expect(json[:subscription][:plan][:usage_thresholds].count).to eq 2
+          expect(json[:subscription][:plan][:applicable_usage_thresholds].count).to eq 2
+          expect(json[:subscription][:applicable_usage_thresholds]).to contain_exactly(
+            threshold_display_name: "Overridden Threshold 1",
+            amount_cents: 999,
+            recurring: false
+          )
+        end
       end
     end
 
@@ -993,7 +1156,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         other_billable_metric
       end
 
-      context "when progressive billing premium integration is present", :premium do
+      context "when progressive billing premium integration is present" do
         before do
           organization.update!(premium_integrations: ["progressive_billing"])
         end
@@ -1142,8 +1305,10 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           expect(usage_thresholds.length).to eq(2)
           expect(usage_thresholds.first).to match(
             {
-              lago_id: overriden_usage_threshold.id,
-              threshold_display_name: "Threshold 1",
+              # previous threshold was removed and a new one created
+              # so ID as changed and threshold was lost
+              lago_id: Regex::UUID,
+              threshold_display_name: nil,
               amount_cents: 999,
               recurring: false,
               created_at: Regex::ISO8601_DATETIME,
@@ -1227,6 +1392,21 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
             expect(subscription.applied_invoice_custom_sections.pluck(:invoice_custom_section_id)).to include(section_1.id)
           end
         end
+      end
+    end
+
+    context "when updating progressive_billing_disabled" do
+      let(:update_params) { {progressive_billing_disabled: true} }
+      let(:subscription) { create(:subscription, customer:, plan:) }
+
+      it "updates progressive_billing_disabled" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:progressive_billing_disabled]).to be(true)
+
+        subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
+        expect(subscription.progressive_billing_disabled).to be(true)
       end
     end
 

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -96,7 +96,8 @@ RSpec.describe ::V1::SubscriptionSerializer do
           "ending_at" => ending_at.iso8601,
           "trial_ended_at" => nil,
           "current_billing_period_started_at" => "2024-05-01T00:00:00Z",
-          "current_billing_period_ending_at" => "2024-05-31T23:59:59Z"
+          "current_billing_period_ending_at" => "2024-05-31T23:59:59Z",
+          "progressive_billing_disabled" => false
         )
 
         expect(result["subscription"]["customer"]["lago_id"]).to be_present

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -14,12 +14,19 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService do
   let(:customer) { create(:customer) }
   let(:historical_usage_amount_cents) { 0 }
 
-  def create_thresholds(subscription, amounts:, recurring: nil)
+  def create_thresholds(subscription, amounts:, attach_to:, recurring: nil)
+    model = if attach_to == :subscription
+      subscription
+    elsif attach_to == :plan
+      subscription.plan
+    else
+      raise "invalid attach_to: #{attach_to}"
+    end
     amounts.each do |amount|
-      subscription.plan.usage_thresholds.create!(amount_cents: amount, organization:)
+      model.usage_thresholds.create!(amount_cents: amount, organization:)
     end
     if recurring
-      subscription.plan.usage_thresholds.create!(amount_cents: recurring, recurring: true, organization:)
+      model.usage_thresholds.create!(amount_cents: recurring, recurring: true, organization:)
     end
   end
 
@@ -32,294 +39,298 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService do
       expect(result.passed_thresholds.map(&:amount_cents)).to eq(expected_threshold_amounts), "invoiced:#{invoiced} current:#{current} expected_thresholds: #{expected_threshold_amounts} got: #{result.passed_thresholds.map(&:amount_cents)}"
     end
   end
-  context "without progressive_billed_amount" do
-    context "without recurring thresholds" do
-      context "with no fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [])
+
+  # TODO: usage_thresholds remove loop to always attach to sub
+  [:subscription, :plan].each do |attach_to|
+    context "without progressive_billed_amount" do
+      context "without recurring thresholds" do
+        context "with no fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [],
+              [9, 2] => [],
+              [11, 1] => [],
+              [11, 10] => []
+            })
+          end
         end
 
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [],
-            [9, 2] => [],
-            [11, 1] => [],
-            [11, 10] => []
-          })
+        context "with 1 fixed threshold" do
+          before do
+            create_thresholds(subscription, amounts: [10], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [9, 2] => [10],
+              [11, 1] => [],
+              [11, 10] => []
+            })
+          end
+        end
+
+        context "with multiple fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [10, 20, 31, 40], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [0, 31] => [10, 20, 31],
+              [9, 2] => [10],
+              [9, 20] => [10, 20],
+              [9, 31] => [10, 20, 31, 40],
+              [11, 1] => [],
+              [11, 10] => [20],
+              [21, 20] => [31, 40],
+              [40, 2] => [],
+              [50, 0] => []
+            })
+          end
         end
       end
 
-      context "with 1 fixed threshold" do
-        before do
-          create_thresholds(subscription, amounts: [10])
+      context "with recurring thresholds" do
+        context "with no fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [], recurring: 10, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [9, 2] => [10],
+              [11, 1] => [],
+              [11, 8] => [],
+              [11, 9] => [10],
+              [11, 10] => [10],
+              [11, 20] => [10],
+              [202, 7] => [],
+              [202, 8] => [10]
+            })
+          end
         end
 
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [10],
-            [9, 2] => [10],
-            [11, 1] => [],
-            [11, 10] => []
-          })
+        context "with 1 fixed threshold" do
+          before do
+            create_thresholds(subscription, amounts: [10], recurring: 5, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [0, 15] => [10, 5],
+              [0, 20] => [10, 5],
+              [9, 2] => [10],
+              [9, 6] => [10, 5],
+              [9, 20] => [10, 5],
+              [11, 3] => [],
+              [11, 4] => [5],
+              [11, 20] => [5]
+            })
+          end
+        end
+
+        context "with multiple fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [0, 31] => [10, 20, 31],
+              [0, 44] => [10, 20, 31, 40],
+              [0, 45] => [10, 20, 31, 40, 5],
+              [9, 2] => [10],
+              [9, 20] => [10, 20],
+              [9, 31] => [10, 20, 31, 40],
+              [9, 37] => [10, 20, 31, 40, 5],
+              [11, 1] => [],
+              [11, 10] => [20],
+              [21, 20] => [31, 40],
+              [21, 24] => [31, 40, 5],
+              [40, 2] => [],
+              [40, 5] => [5],
+              [41, 4] => [5],
+              [49, 1] => [5],
+              [50, 0] => [],
+              [50, 5] => [5]
+            })
+          end
         end
       end
+    end
+
+    context "with progressive_billed_amount set to 10" do
+      let(:progressive_billed_amount) { 10 }
+
+      context "without recurring thresholds" do
+        context "with no fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [],
+              [9, 2] => [],
+              [11, 1] => [],
+              [11, 10] => []
+            })
+          end
+        end
+
+        context "with 1 fixed threshold" do
+          before do
+            create_thresholds(subscription, amounts: [10], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [9, 2] => [],
+              [9, 20] => [],
+              [11, 10] => [],
+              [11, 20] => []
+            })
+          end
+        end
+
+        context "with multiple fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [10, 20, 31, 40], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 10] => [],
+              [0, 31] => [20, 31],
+              [9, 10] => [],
+              [9, 12] => [20],
+              [9, 20] => [20],
+              [9, 31] => [20, 31, 40],
+              [11, 11] => [],
+              [11, 20] => [31],
+              [21, 20] => [40],
+              [30, 12] => [],
+              [50, 10] => []
+            })
+          end
+        end
+      end
+
+      context "with recurring thresholds" do
+        context "with no fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [], recurring: 10, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 10] => [],
+              [11, 10] => [],
+              [11, 19] => [10],
+              [202, 17] => [],
+              [202, 18] => [10],
+              [202, 28] => [10]
+            })
+          end
+        end
+
+        context "with 1 fixed threshold" do
+          before do
+            create_thresholds(subscription, amounts: [10], recurring: 5, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [],
+              [0, 15] => [5],
+              [0, 20] => [5],
+              [9, 2] => [],
+              [9, 6] => [],
+              [9, 16] => [5],
+              [11, 3] => [],
+              [11, 4] => [],
+              [11, 14] => [5],
+              [11, 24] => [5]
+            })
+          end
+        end
+
+        context "with multiple fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [],
+              [0, 31] => [20, 31],
+              [0, 44] => [20, 31, 40],
+              [0, 45] => [20, 31, 40, 5],
+              [9, 2] => [],
+              [9, 20] => [20],
+              [9, 31] => [20, 31, 40],
+              [9, 37] => [20, 31, 40, 5],
+              [11, 1] => [],
+              [11, 10] => [],
+              [20, 20] => [31, 40],
+              [21, 20] => [40],
+              [21, 24] => [40, 5],
+              [40, 14] => [],
+              [40, 15] => [5],
+              [41, 14] => [5],
+              [49, 1] => [],
+              [49, 11] => [5],
+              [50, 5] => [],
+              [50, 15] => [5]
+            })
+          end
+        end
+      end
+    end
+
+    context "with historical_usage_amount_cents" do
+      let(:historical_usage_amount_cents) { 11 }
 
       context "with multiple fixed thresholds" do
         before do
-          create_thresholds(subscription, amounts: [10, 20, 31, 40])
+          create_thresholds(subscription, amounts: [10, 20, 31, 40], attach_to:)
         end
 
         it "calculates the passed thresholds correctly" do
           validate_thresholds({
             [0, 7] => [],
-            [0, 10] => [10],
-            [0, 31] => [10, 20, 31],
-            [9, 2] => [10],
-            [9, 20] => [10, 20],
-            [9, 31] => [10, 20, 31, 40],
+            [0, 9] => [20],
+            [0, 10] => [20],
+            [9, 0] => [],
+            [0, 31] => [20, 31, 40],
+            [8, 2] => [20],
+            [8, 20] => [20, 31],
+            [8, 31] => [20, 31, 40],
             [11, 1] => [],
-            [11, 10] => [20],
-            [21, 20] => [31, 40],
+            [11, 10] => [31],
+            [21, 20] => [40],
             [40, 2] => [],
             [50, 0] => []
           })
         end
-      end
-    end
-
-    context "with recurring thresholds" do
-      context "with no fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [], recurring: 10)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [10],
-            [9, 2] => [10],
-            [11, 1] => [],
-            [11, 8] => [],
-            [11, 9] => [10],
-            [11, 10] => [10],
-            [11, 20] => [10],
-            [202, 7] => [],
-            [202, 8] => [10]
-          })
-        end
-      end
-
-      context "with 1 fixed threshold" do
-        before do
-          create_thresholds(subscription, amounts: [10], recurring: 5)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [10],
-            [0, 15] => [10, 5],
-            [0, 20] => [10, 5],
-            [9, 2] => [10],
-            [9, 6] => [10, 5],
-            [9, 20] => [10, 5],
-            [11, 3] => [],
-            [11, 4] => [5],
-            [11, 20] => [5]
-          })
-        end
-      end
-
-      context "with multiple fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [10],
-            [0, 31] => [10, 20, 31],
-            [0, 44] => [10, 20, 31, 40],
-            [0, 45] => [10, 20, 31, 40, 5],
-            [9, 2] => [10],
-            [9, 20] => [10, 20],
-            [9, 31] => [10, 20, 31, 40],
-            [9, 37] => [10, 20, 31, 40, 5],
-            [11, 1] => [],
-            [11, 10] => [20],
-            [21, 20] => [31, 40],
-            [21, 24] => [31, 40, 5],
-            [40, 2] => [],
-            [40, 5] => [5],
-            [41, 4] => [5],
-            [49, 1] => [5],
-            [50, 0] => [],
-            [50, 5] => [5]
-          })
-        end
-      end
-    end
-  end
-
-  context "with progressive_billed_amount set to 10" do
-    let(:progressive_billed_amount) { 10 }
-
-    context "without recurring thresholds" do
-      context "with no fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [])
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [],
-            [9, 2] => [],
-            [11, 1] => [],
-            [11, 10] => []
-          })
-        end
-      end
-
-      context "with 1 fixed threshold" do
-        before do
-          create_thresholds(subscription, amounts: [10])
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [9, 2] => [],
-            [9, 20] => [],
-            [11, 10] => [],
-            [11, 20] => []
-          })
-        end
-      end
-
-      context "with multiple fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [10, 20, 31, 40])
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 10] => [],
-            [0, 31] => [20, 31],
-            [9, 10] => [],
-            [9, 12] => [20],
-            [9, 20] => [20],
-            [9, 31] => [20, 31, 40],
-            [11, 11] => [],
-            [11, 20] => [31],
-            [21, 20] => [40],
-            [30, 12] => [],
-            [50, 10] => []
-          })
-        end
-      end
-    end
-
-    context "with recurring thresholds" do
-      context "with no fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [], recurring: 10)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 10] => [],
-            [11, 10] => [],
-            [11, 19] => [10],
-            [202, 17] => [],
-            [202, 18] => [10],
-            [202, 28] => [10]
-          })
-        end
-      end
-
-      context "with 1 fixed threshold" do
-        before do
-          create_thresholds(subscription, amounts: [10], recurring: 5)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [],
-            [0, 15] => [5],
-            [0, 20] => [5],
-            [9, 2] => [],
-            [9, 6] => [],
-            [9, 16] => [5],
-            [11, 3] => [],
-            [11, 4] => [],
-            [11, 14] => [5],
-            [11, 24] => [5]
-          })
-        end
-      end
-
-      context "with multiple fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [],
-            [0, 31] => [20, 31],
-            [0, 44] => [20, 31, 40],
-            [0, 45] => [20, 31, 40, 5],
-            [9, 2] => [],
-            [9, 20] => [20],
-            [9, 31] => [20, 31, 40],
-            [9, 37] => [20, 31, 40, 5],
-            [11, 1] => [],
-            [11, 10] => [],
-            [20, 20] => [31, 40],
-            [21, 20] => [40],
-            [21, 24] => [40, 5],
-            [40, 14] => [],
-            [40, 15] => [5],
-            [41, 14] => [5],
-            [49, 1] => [],
-            [49, 11] => [5],
-            [50, 5] => [],
-            [50, 15] => [5]
-          })
-        end
-      end
-    end
-  end
-
-  context "with historical_usage_amount_cents" do
-    let(:historical_usage_amount_cents) { 11 }
-
-    context "with multiple fixed thresholds" do
-      before do
-        create_thresholds(subscription, amounts: [10, 20, 31, 40])
-      end
-
-      it "calculates the passed thresholds correctly" do
-        validate_thresholds({
-          [0, 7] => [],
-          [0, 9] => [20],
-          [0, 10] => [20],
-          [9, 0] => [],
-          [0, 31] => [20, 31, 40],
-          [8, 2] => [20],
-          [8, 20] => [20, 31],
-          [8, 31] => [20, 31, 40],
-          [11, 1] => [],
-          [11, 10] => [31],
-          [21, 20] => [40],
-          [40, 2] => [],
-          [50, 0] => []
-        })
       end
     end
   end

--- a/spec/services/plans/update_usage_thresholds_service_spec.rb
+++ b/spec/services/plans/update_usage_thresholds_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
   let(:plan) { create(:plan, organization:) }
 
   before do
-    allow(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to receive(:perform_later).with(plan)
+    allow(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to receive(:perform_after_commit)
   end
 
   context "when usage_thresholds_params is empty" do
@@ -26,7 +26,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
 
       it "does not update the plan" do
         expect(subject.plan.usage_thresholds).to be_empty
-        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_later).with(plan)
+        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_after_commit)
       end
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
     context "when progressive_billing is not enabled" do
       it "does not update the plan" do
         expect(subject.plan.usage_thresholds).to be_empty
-        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_later).with(plan)
+        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_after_commit).with(plan)
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
         expect(thresholds.size).to eq(1)
         expect(thresholds.first.threshold_display_name).to eq("Threshold 1")
         expect(thresholds.first.amount_cents).to eq(1000)
-        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to have_received(:perform_later).with(plan)
+        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to have_received(:perform_after_commit)
       end
     end
   end
@@ -89,7 +89,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
 
         it "clears the thresholds" do
           expect(subject.plan.usage_thresholds).to be_empty
-          expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_later).with(plan)
+          expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_after_commit)
         end
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
           expect(thresholds.size).to eq(1)
           expect(thresholds.first.threshold_display_name).to eq("Other threshold")
           expect(thresholds.first.amount_cents).to eq(1000)
-          expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to have_received(:perform_later).with(plan)
+          expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to have_received(:perform_after_commit).with(plan)
         end
       end
     end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -24,6 +24,54 @@ RSpec.describe Subscriptions::UpdateService do
       subscription
     end
 
+    context "when both usage_thresholds and plan_overrides.usage_thresholds are present" do
+      let(:params) do
+        {
+          name: "new name",
+          ending_at:,
+          subscription_at:,
+          usage_thresholds: [{threshold_display_name: "Threshold 1"}],
+          plan_overrides: {
+            usage_thresholds: [{threshold_display_name: "Override Threshold"}]
+          }
+        }
+      end
+
+      it "returns a validation error", :premium do
+        result = update_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:"plan_overrides.usage_thresholds"]).to eq(["incompatible_params"])
+        expect(result.error.messages[:usage_thresholds]).to eq(["incompatible_params"])
+      end
+    end
+
+    context "when usage_thresholds are present", :premium do
+      let(:usage_thresholds) { [amount_cents: 99_00] }
+
+      before do
+        subscription.organization.update!(premium_integrations: ["progressive_billing"])
+        allow(Subscriptions::UpdateUsageThresholdsService).to receive(:call!).and_return(BaseResult.new)
+      end
+
+      context "when under subscription" do
+        let(:params) { {usage_thresholds:} }
+
+        it "calls UpdateUsageThresholdsService" do
+          update_service.call
+          expect(Subscriptions::UpdateUsageThresholdsService).to have_received(:call!).with(subscription:, usage_thresholds_params: params[:usage_thresholds], partial: false)
+        end
+      end
+
+      context "when under plan_overrides" do
+        it "ignores UpdateUsageThresholdsService" do
+          update_service.call
+          expect(Subscriptions::UpdateUsageThresholdsService).not_to have_received(:call!)
+        end
+      end
+    end
+
     context "when subscription is already active" do
       it "updates the subscription and ignores subscription_at" do
         result = update_service.call
@@ -121,6 +169,29 @@ RSpec.describe Subscriptions::UpdateService do
               expect(result).to be_success
               expect(result.subscription.on_termination_invoice).to eq(value)
             end
+          end
+        end
+      end
+
+      context "when updating progressive_billing_disabled" do
+        let(:params) { {progressive_billing_disabled: true} }
+
+        it "updates progressive_billing_disabled" do
+          result = update_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.progressive_billing_disabled).to be(true)
+        end
+
+        context "when setting to false" do
+          let(:subscription) { create(:subscription, progressive_billing_disabled: true) }
+          let(:params) { {progressive_billing_disabled: false} }
+
+          it "updates progressive_billing_disabled to false" do
+            result = update_service.call
+
+            expect(result).to be_success
+            expect(result.subscription.progressive_billing_disabled).to be(false)
           end
         end
       end

--- a/spec/services/subscriptions/update_usage_thresholds_service_spec.rb
+++ b/spec/services/subscriptions/update_usage_thresholds_service_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::UpdateUsageThresholdsService, :premium do
+  subject(:service) { described_class.new(subscription:, usage_thresholds_params:, partial:) }
+
+  let(:organization) { create(:organization, premium_integrations:) }
+  let(:premium_integrations) { ["progressive_billing"] }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, customer:, plan:, organization:) }
+  let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:) }
+  let(:usage_thresholds_params) { [{amount_cents: 1000, threshold_display_name: "Test"}] }
+  let(:partial) { false }
+
+  before do
+    lifetime_usage
+    allow(UsageThresholds::UpdateService).to receive(:call!).and_return(BaseResult.new)
+  end
+
+  describe "#call" do
+    context "when progressive_billing is not enabled" do
+      let(:premium_integrations) { [] }
+
+      it "returns early without calling UsageThresholds::UpdateService" do
+        result = service.call
+
+        expect(result).to be_success
+        expect(UsageThresholds::UpdateService).not_to have_received(:call!)
+      end
+    end
+
+    context "when progressive_billing is enabled" do
+      it "calls UsageThresholds::UpdateService with correct arguments" do
+        service.call
+
+        expect(UsageThresholds::UpdateService).to have_received(:call!).with(
+          model: subscription,
+          usage_thresholds_params:,
+          partial:
+        )
+      end
+
+      context "when partial is true" do
+        let(:partial) { true }
+
+        it "passes partial: true to UsageThresholds::UpdateService" do
+          service.call
+
+          expect(UsageThresholds::UpdateService).to have_received(:call!).with(
+            model: subscription,
+            usage_thresholds_params:,
+            partial: true
+          )
+        end
+      end
+
+      context "when plan is a child plan (override)" do
+        let(:parent_plan) { create(:plan, organization:) }
+        let(:plan) { create(:plan, organization:, parent: parent_plan) }
+        let!(:plan_usage_threshold) { create(:usage_threshold, plan:, organization:) }
+
+        it "soft deletes usage thresholds attached to the plan override" do
+          expect { service.call }.to change { plan_usage_threshold.reload.deleted_at }.from(nil)
+        end
+      end
+
+      context "when plan is not a child plan" do
+        let!(:plan_usage_threshold) { create(:usage_threshold, plan:, organization:) }
+
+        it "does not delete usage thresholds attached to the plan" do
+          expect { service.call }.not_to change { plan_usage_threshold.reload.deleted_at }
+        end
+      end
+
+      context "when subscription has usage thresholds after update" do
+        before { create(:usage_threshold, :for_subscription, subscription:, organization:) }
+
+        it "updates lifetime_usage recalculate_invoiced_usage to true" do
+          expect { service.call }.to change { lifetime_usage.reload.recalculate_invoiced_usage }.to(true)
+        end
+      end
+
+      context "when subscription has no usage thresholds after update" do
+        it "does not update lifetime_usage" do
+          expect { service.call }.not_to change { lifetime_usage.reload.recalculate_invoiced_usage }
+        end
+      end
+
+      context "when UsageThresholds::UpdateService fails" do
+        let(:failed_result) { BaseResult.new.tap { |r| r.single_validation_failure!(error_code: "error", field: :test) } }
+
+        before do
+          allow(UsageThresholds::UpdateService).to receive(:call!).and_raise(BaseService::FailedResult.new(failed_result, "error"))
+        end
+
+        it "returns the failed result" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:test]).to include("error")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/usage_thresholds/update_service_table_spec.rb
+++ b/spec/services/usage_thresholds/update_service_table_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsageThresholds::UpdateService, premium: true do
+  subject(:result) { described_class.call(model:, usage_thresholds_params:, partial:) }
+
+  let(:organization) { create(:organization, premium_integrations: ["progressive_billing"]) }
+  let(:model) { create(:plan, organization:) }
+
+  before do
+    allow(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to receive(:perform_after_commit)
+  end
+
+  # Helper to build threshold attributes for comparison
+  def threshold_attrs(thresholds)
+    thresholds.map { |t| {amount_cents: t.amount_cents, threshold_display_name: t.threshold_display_name, recurring: t.recurring} }
+  end
+
+  describe "threshold updates" do
+    # rubocop:disable Layout/LineLength
+    test_cases = [
+      {
+        description: "creates new threshold when none exist",
+        partial: false,
+        existing: [],
+        params: [{amount_cents: 100, threshold_display_name: "First"}],
+        expected: [{amount_cents: 100, threshold_display_name: "First", recurring: false}]
+      },
+      {
+        description: "updates existing threshold matched by amount_cents",
+        partial: false,
+        existing: [{amount_cents: 100, threshold_display_name: "Old Name"}],
+        params: [{amount_cents: 100, threshold_display_name: "New Name"}],
+        expected: [{amount_cents: 100, threshold_display_name: "New Name", recurring: false}]
+      },
+      {
+        description: "removes thresholds not in params (full update)",
+        partial: false,
+        existing: [
+          {amount_cents: 100, threshold_display_name: "Keep"},
+          {amount_cents: 200, threshold_display_name: "Remove"}
+        ],
+        params: [{amount_cents: 100, threshold_display_name: "Keep"}],
+        expected: [{amount_cents: 100, threshold_display_name: "Keep", recurring: false}]
+      },
+      {
+        description: "creates multiple thresholds",
+        partial: false,
+        existing: [],
+        params: [
+          {amount_cents: 100, threshold_display_name: "First"},
+          {amount_cents: 200, threshold_display_name: "Second"}
+        ],
+        expected: [
+          {amount_cents: 100, threshold_display_name: "First", recurring: false},
+          {amount_cents: 200, threshold_display_name: "Second", recurring: false}
+        ]
+      },
+      {
+        description: "handles recurring threshold update",
+        partial: false,
+        existing: [{amount_cents: 100, threshold_display_name: "Old", recurring: true}],
+        params: [{amount_cents: 200, threshold_display_name: "New", recurring: true}],
+        expected: [{amount_cents: 200, threshold_display_name: "New", recurring: true}]
+      },
+      {
+        description: "clears all thresholds when params empty",
+        partial: false,
+        existing: [{amount_cents: 100, threshold_display_name: "Remove Me"}],
+        params: [],
+        expected: []
+      },
+      {
+        description: "partial add a new item",
+        partial: true,
+        existing: [
+          {amount_cents: 100, recurring: false},
+          {amount_cents: 150, recurring: false}
+        ],
+        params: [{amount_cents: 333}],
+        expected: [
+          {amount_cents: 100, threshold_display_name: nil, recurring: false},
+          {amount_cents: 150, threshold_display_name: nil, recurring: false},
+          {amount_cents: 333, threshold_display_name: nil, recurring: false}
+        ]
+      },
+      {
+        description: "partial creates s recurring threshold update even if using same amount",
+        partial: true,
+        existing: [
+          {amount_cents: 100, recurring: false},
+          {amount_cents: 150, recurring: false}
+        ],
+        params: [{amount_cents: 100, threshold_display_name: "New", recurring: true}],
+        expected: [
+          {amount_cents: 100, threshold_display_name: nil, recurring: false},
+          {amount_cents: 150, threshold_display_name: nil, recurring: false},
+          {amount_cents: 100, threshold_display_name: "New", recurring: true}
+        ]
+      },
+      {
+        description: "partial update of non recurring threshold does not clear existing recurring threshold",
+        partial: true,
+        existing: [
+          {amount_cents: 100, recurring: false},
+          {amount_cents: 100, recurring: true}
+        ],
+        params: [{amount_cents: 100, threshold_display_name: "New", recurring: true}],
+        expected: [
+          {amount_cents: 100, threshold_display_name: nil, recurring: false},
+          {amount_cents: 100, threshold_display_name: "New", recurring: true}
+        ]
+      },
+      {
+        description: "partial update of non recurring threshold does not clear existing recurring threshold",
+        partial: true,
+        existing: [
+          {amount_cents: 100, recurring: false},
+          {amount_cents: 100, recurring: true}
+        ],
+        params: [{amount_cents: 100, threshold_display_name: "New"}],
+        expected: [
+          {amount_cents: 100, threshold_display_name: "New", recurring: false},
+          {amount_cents: 100, threshold_display_name: nil, recurring: true}
+        ]
+      }
+    ]
+    # rubocop:enable Layout/LineLength
+
+    test_cases.each do |tc|
+      context "when #{tc[:description]}" do
+        let(:partial) { tc[:partial] }
+        let(:usage_thresholds_params) { tc[:params] }
+
+        before do
+          tc[:existing].each do |attrs|
+            create(:usage_threshold, plan: model, organization:, threshold_display_name: nil, **attrs)
+          end
+        end
+
+        it do
+          expect(result).to be_success
+          expect(threshold_attrs(model.usage_thresholds.reload)).to match_array(tc[:expected])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**This pull request introduces a new way to manage usage thresholds override on subscriptions, without creating any plan override.**

See also  https://github.com/getlago/lago-api/pull/4729, https://github.com/getlago/lago-api/pull/4743, https://github.com/getlago/lago-api/pull/4735

This is the **last backward compatible PR**.

## New way

### New attributes

2 new attributes are added:

1. `subscriptions.applicable_usage_thresholds` which are exactly what the system will use in progressive billing. It's (in that order): 
  * `subscription.usage_thresholds`
  * `subscription.plan.usage_thresholds`
  * `subscription.plan.parent.usage_thresholds`
2. `subscription.plan.applicable_usage_thresholds` which are always the (parent) plan thresholds, whether there is an override or not

> [!TIP]
> Users should start reading these values.
> If they **write** values using the new attributes, the values will be ignored and not shown in the frontend yet


> [!CAUTION]
> In January, once all users have migrated, we'll remove the old way (breaking change) once the frontend is merged.
> - the `plan_overrides.usage_thresholds` param 🧹
> - the `subscription.plan.usage_thresholds` attribute  🧹
> - migrate all existing thresholds overrides


### Old way (is still working the same way)

`subscription.plan.usage_thresholds` returns the exact same thing: `subscription.plan.usage_thresholds` regardless of plan being a parent or an override.

Passing the thresholds under `plan_overrides` will continue to attach them to the plan override. If plan is not overridden yet, it's created.

In this case, `subscription.usage_thresholds` EQUALS `subscription.plan.usage_thresholds`.

## Examples

Given a subscription and parent plan with 2 thresholds.

```rb
[
  {
    amount_cents: 100_00,
    threshold_display_name: "custom",
    recurring: false
  }, {
    amount_cents: 999_00,
    threshold_display_name: nil,
    recurring: true
  }
]
```



### New Subscription override example

**request**
```rb
{
  subscriptions: {
    name: "subscription name new",
    usage_thresholds: [
      {
        amount_cents: 100_00,
        threshold_display_name: "custom"
      }
    ],
    plan_overrides: {
      name: "rename plan to create override"
    }
  }
}
```

**response**
```rb
{
  subscriptions: {
    name: "subscription name new",
    applicable_usage_thresholds: [
      {
        amount_cents: 100_00,
        threshold_display_name: "custom",
        recurring: false
      }
    ],
    plan: {
      name: "rename plan to create override",
      usage_thresholds: [], # ⬅️ ⬅️ ⬅️  Legacy thresholds from plan or plan override. 
                                       Existing thresholds attached to the plan override are DELETED 
                                       when attaching thresholds to sub
      applicable_usage_thresholds: [] # ⬅️ ⬅️ ⬅️  parent thresholds, cannot be changed when updating sub
    }
  }
}
```

### Using old way

**request**
```rb
{
  subscriptions: {
    name: "subscription name new",
    plan_overrides: {
      name: "rename plan to create override",
      usage_thresholds: [
        {
          amount_cents: 100_00,
          threshold_display_name: "custom"
        }
      ],
    }
  }
}
```

**response**
```rb
{
  subscriptions: {
    name: "subscription name new",
    applicable_usage_thresholds: [ # ⬅️ ⬅️ ⬅️  No thresholds on sub so return the plan override thresholds
      {
        amount_cents: 100_00,
        threshold_display_name: "custom",
        recurring: false
      }
    ],
    plan: {
      name: "rename plan to create override",
      usage_thresholds: [ # ⬅️ ⬅️ ⬅️  thresholds were attached to plan override
        {
          amount_cents: 100_00,
          threshold_display_name: "custom"
        }
      ], 
      applicable_usage_thresholds: [] # ⬅️ ⬅️ ⬅️  parent thresholds, cannot be changed when updating sub
    }
  }
}
```

