### PR TITLE
feat(thresholds): Use shared UpdateService between subscription and plan

### DIFF
--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -43,12 +43,8 @@ module Plans
           taxes_result.raise_if_error!
         end
 
-        if args[:usage_thresholds].present? &&
-            License.premium? &&
-            plan.organization.progressive_billing_enabled?
-          args[:usage_thresholds].each do |threshold_args|
-            create_usage_threshold(plan, threshold_args)
-          end
+        if args[:usage_thresholds].present? && plan.organization.progressive_billing_enabled?
+          UsageThresholds::UpdateService.call!(model: plan, usage_thresholds_params: args[:usage_thresholds], partial: false)
         end
 
         if args[:charges].present?

--- a/app/services/plans/update_usage_thresholds_service.rb
+++ b/app/services/plans/update_usage_thresholds_service.rb
@@ -14,81 +14,17 @@ module Plans
       result.plan = plan
       return result unless plan.organization.progressive_billing_enabled?
 
-      if usage_thresholds_params.empty?
-        plan.usage_thresholds.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-      else
-        process_usage_thresholds
-        LifetimeUsages::FlagRefreshFromPlanUpdateJob.perform_later(plan)
+      ActiveRecord::Base.transaction do
+        UsageThresholds::UpdateService.call!(model: plan, usage_thresholds_params:, partial: false)
       end
+
+      plan.usage_thresholds.reload
+      LifetimeUsages::FlagRefreshFromPlanUpdateJob.perform_after_commit(plan) if plan.usage_thresholds.size > 0
 
       result
     end
 
     private
-
-    def process_usage_thresholds
-      created_thresholds_ids = []
-
-      hash_thresholds = usage_thresholds_params.map { |c| c.to_h.deep_symbolize_keys }
-      hash_thresholds.each do |payload_threshold|
-        usage_threshold = plan.usage_thresholds.find_by(id: payload_threshold[:id])
-
-        if usage_threshold
-          if payload_threshold.key?(:threshold_display_name)
-            usage_threshold.threshold_display_name = payload_threshold[:threshold_display_name]
-          end
-
-          if payload_threshold.key?(:amount_cents)
-            usage_threshold.amount_cents = payload_threshold[:amount_cents]
-          end
-
-          if payload_threshold.key?(:recurring)
-            usage_threshold.recurring = payload_threshold[:recurring]
-          end
-
-          # This means that in the UI we just removed an existing threshold
-          # and then just re-added a threshold (which no longer has an id) with the same amount
-          # so we discard the existing one and we're inserting a new one instead
-          if !usage_threshold.valid? && usage_threshold.errors.where(:amount_cents, :taken).present?
-            usage_threshold.discard!
-          else
-            usage_threshold.save!
-            next
-          end
-        end
-
-        created_threshold = create_usage_threshold(plan.reload, payload_threshold)
-        created_thresholds_ids.push(created_threshold.id)
-      end
-      # NOTE: Delete thresholds that are no more linked to the plan
-      sanitize_thresholds(plan, hash_thresholds, created_thresholds_ids)
-    end
-
-    def sanitize_thresholds(plan, args_thresholds, created_thresholds_ids)
-      args_thresholds_ids = args_thresholds.map { |c| c[:id] }.compact
-      thresholds_ids = plan.usage_thresholds.pluck(:id) - args_thresholds_ids - created_thresholds_ids
-      plan.usage_thresholds.where(id: thresholds_ids).discard_all
-    end
-
-    def create_usage_threshold(plan, params)
-      usage_threshold = plan.usage_thresholds.find_or_initialize_by(
-        recurring: params[:recurring] || false,
-        amount_cents: params[:amount_cents]
-      )
-
-      existing_recurring_threshold = plan.usage_thresholds.recurring.first
-
-      if params[:recurring] && existing_recurring_threshold
-        usage_threshold = existing_recurring_threshold
-      end
-
-      usage_threshold.threshold_display_name = params[:threshold_display_name]
-      usage_threshold.amount_cents = params[:amount_cents]
-      usage_threshold.organization_id = plan.organization_id
-
-      usage_threshold.save!
-      usage_threshold
-    end
 
     attr_reader :plan, :usage_thresholds_params
   end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -177,8 +177,6 @@ RSpec.describe Api::V1::SubscriptionsController do
 
         expect(response).to have_http_status(:ok)
 
-        pps json
-
         expect(plan.usage_thresholds).to contain_exactly(plan_usage_threshold)
         subscription = Subscription.find json[:subscription][:lago_id]
         expect(subscription.plan).to be_child
@@ -1263,8 +1261,10 @@ RSpec.describe Api::V1::SubscriptionsController do
           expect(usage_thresholds.length).to eq(2)
           expect(usage_thresholds.first).to match(
             {
-              lago_id: overriden_usage_threshold.id,
-              threshold_display_name: "Threshold 1",
+              # previous threshold was removed and a new one created
+              # so ID as changed and threshold was lost
+              lago_id: Regex::UUID,
+              threshold_display_name: nil,
               amount_cents: 999,
               recurring: false,
               created_at: Regex::ISO8601_DATETIME,

--- a/spec/services/plans/update_usage_thresholds_service_spec.rb
+++ b/spec/services/plans/update_usage_thresholds_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
   let(:plan) { create(:plan, organization:) }
 
   before do
-    allow(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to receive(:perform_later).with(plan)
+    allow(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to receive(:perform_after_commit)
   end
 
   context "when usage_thresholds_params is empty" do
@@ -26,7 +26,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
 
       it "does not update the plan" do
         expect(subject.plan.usage_thresholds).to be_empty
-        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_later).with(plan)
+        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_after_commit)
       end
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
     context "when progressive_billing is not enabled" do
       it "does not update the plan" do
         expect(subject.plan.usage_thresholds).to be_empty
-        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_later).with(plan)
+        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_after_commit).with(plan)
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
         expect(thresholds.size).to eq(1)
         expect(thresholds.first.threshold_display_name).to eq("Threshold 1")
         expect(thresholds.first.amount_cents).to eq(1000)
-        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to have_received(:perform_later).with(plan)
+        expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to have_received(:perform_after_commit)
       end
     end
   end
@@ -89,7 +89,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
 
         it "clears the thresholds" do
           expect(subject.plan.usage_thresholds).to be_empty
-          expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_later).with(plan)
+          expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).not_to have_received(:perform_after_commit)
         end
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe Plans::UpdateUsageThresholdsService do
           expect(thresholds.size).to eq(1)
           expect(thresholds.first.threshold_display_name).to eq("Other threshold")
           expect(thresholds.first.amount_cents).to eq(1000)
-          expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to have_received(:perform_later).with(plan)
+          expect(LifetimeUsages::FlagRefreshFromPlanUpdateJob).to have_received(:perform_after_commit).with(plan)
         end
       end
     end


### PR DESCRIPTION
Reuse the same service to update thresholds attached to plan and subscriptions.

Notice the PR is stacked.

---

Technically, this is a small breaking change as I ignore the IDs now:
- you cannot change the amount and keep the display_name by passing the db id 🤔 (which nobody does)
- updating thresholds in the UI, will update the IDs