### PR TITLE
feat(thresholds): Use subscription applicable thresholds

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -265,13 +265,12 @@ class Subscription < ApplicationRecord
   end
 
   # If the subscription has direct usage thresholds, these overrides take precedence.
-  # If it has a plan override with thresholds, we use them. Ultimately, they will be migrated to subscription usage thresholds.
-  # Once migrated, this method should also return parent plan thresholds if nothing else is set.
-  # TODO: usage_thresholds return parent plan thresholds
+  # Thresholds attached to plan override (child plans) are being rmeoved and kept temporarily until the ata is migrated
+  # If no override, we always use the parent plan thresholds
   def applicable_usage_thresholds
     return [] if progressive_billing_disabled?
 
-    usage_thresholds.any? ? usage_thresholds : plan.usage_thresholds
+    usage_thresholds.presence || plan.usage_thresholds.presence || plan.applicable_usage_thresholds
   end
 end
 

--- a/app/services/lifetime_usages/usage_thresholds/check_service.rb
+++ b/app/services/lifetime_usages/usage_thresholds/check_service.rb
@@ -8,7 +8,7 @@ module LifetimeUsages
       def initialize(lifetime_usage:, progressive_billed_amount: 0)
         @lifetime_usage = lifetime_usage
         @progressive_billed_amount = progressive_billed_amount
-        @thresholds = lifetime_usage.subscription.plan.usage_thresholds
+        @thresholds = lifetime_usage.subscription.applicable_usage_thresholds
         super
       end
 

--- a/app/services/lifetime_usages/usage_thresholds_completion_service.rb
+++ b/app/services/lifetime_usages/usage_thresholds_completion_service.rb
@@ -4,7 +4,7 @@ module LifetimeUsages
   class UsageThresholdsCompletionService < BaseService
     def initialize(lifetime_usage:)
       @lifetime_usage = lifetime_usage
-      @usage_thresholds = lifetime_usage.subscription.plan.usage_thresholds
+      @usage_thresholds = lifetime_usage.subscription.applicable_usage_thresholds
 
       super
     end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -839,9 +839,9 @@ RSpec.describe Subscription do
         let(:plan) { create(:plan, parent: parent_plan) }
         let(:plan_threshold) { create(:usage_threshold, plan: parent_plan) }
 
-        it "returns plan usage thresholds" do
+        it "returns the parent plan usage thresholds" do
           plan_threshold
-          expect(subscription.applicable_usage_thresholds).to be_empty
+          expect(subscription.applicable_usage_thresholds).to contain_exactly(plan_threshold)
         end
       end
     end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -844,8 +844,7 @@ RSpec.describe Api::V1::SubscriptionsController do
       expect(subscription).to include(
         lago_id: Regex::UUID,
         name: "subscription name new",
-        subscription_at: "2022-09-05T12:23:12Z",
-        applicable_usage_thresholds: []
+        subscription_at: "2022-09-05T12:23:12Z"
       )
 
       plan_json = subscription[:plan]

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -14,12 +14,19 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService do
   let(:customer) { create(:customer) }
   let(:historical_usage_amount_cents) { 0 }
 
-  def create_thresholds(subscription, amounts:, recurring: nil)
+  def create_thresholds(subscription, amounts:, attach_to:, recurring: nil)
+    model = if attach_to == :subscription
+      subscription
+    elsif attach_to == :plan
+      subscription.plan
+    else
+      raise "invalid attach_to: #{attach_to}"
+    end
     amounts.each do |amount|
-      subscription.plan.usage_thresholds.create!(amount_cents: amount, organization:)
+      model.usage_thresholds.create!(amount_cents: amount, organization:)
     end
     if recurring
-      subscription.plan.usage_thresholds.create!(amount_cents: recurring, recurring: true, organization:)
+      model.usage_thresholds.create!(amount_cents: recurring, recurring: true, organization:)
     end
   end
 
@@ -32,294 +39,298 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService do
       expect(result.passed_thresholds.map(&:amount_cents)).to eq(expected_threshold_amounts), "invoiced:#{invoiced} current:#{current} expected_thresholds: #{expected_threshold_amounts} got: #{result.passed_thresholds.map(&:amount_cents)}"
     end
   end
-  context "without progressive_billed_amount" do
-    context "without recurring thresholds" do
-      context "with no fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [])
+
+  # TODO: usage_thresholds remove loop to always attach to sub
+  [:subscription, :plan].each do |attach_to|
+    context "without progressive_billed_amount" do
+      context "without recurring thresholds" do
+        context "with no fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [],
+              [9, 2] => [],
+              [11, 1] => [],
+              [11, 10] => []
+            })
+          end
         end
 
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [],
-            [9, 2] => [],
-            [11, 1] => [],
-            [11, 10] => []
-          })
+        context "with 1 fixed threshold" do
+          before do
+            create_thresholds(subscription, amounts: [10], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [9, 2] => [10],
+              [11, 1] => [],
+              [11, 10] => []
+            })
+          end
+        end
+
+        context "with multiple fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [10, 20, 31, 40], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [0, 31] => [10, 20, 31],
+              [9, 2] => [10],
+              [9, 20] => [10, 20],
+              [9, 31] => [10, 20, 31, 40],
+              [11, 1] => [],
+              [11, 10] => [20],
+              [21, 20] => [31, 40],
+              [40, 2] => [],
+              [50, 0] => []
+            })
+          end
         end
       end
 
-      context "with 1 fixed threshold" do
-        before do
-          create_thresholds(subscription, amounts: [10])
+      context "with recurring thresholds" do
+        context "with no fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [], recurring: 10, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [9, 2] => [10],
+              [11, 1] => [],
+              [11, 8] => [],
+              [11, 9] => [10],
+              [11, 10] => [10],
+              [11, 20] => [10],
+              [202, 7] => [],
+              [202, 8] => [10]
+            })
+          end
         end
 
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [10],
-            [9, 2] => [10],
-            [11, 1] => [],
-            [11, 10] => []
-          })
+        context "with 1 fixed threshold" do
+          before do
+            create_thresholds(subscription, amounts: [10], recurring: 5, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [0, 15] => [10, 5],
+              [0, 20] => [10, 5],
+              [9, 2] => [10],
+              [9, 6] => [10, 5],
+              [9, 20] => [10, 5],
+              [11, 3] => [],
+              [11, 4] => [5],
+              [11, 20] => [5]
+            })
+          end
+        end
+
+        context "with multiple fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [10],
+              [0, 31] => [10, 20, 31],
+              [0, 44] => [10, 20, 31, 40],
+              [0, 45] => [10, 20, 31, 40, 5],
+              [9, 2] => [10],
+              [9, 20] => [10, 20],
+              [9, 31] => [10, 20, 31, 40],
+              [9, 37] => [10, 20, 31, 40, 5],
+              [11, 1] => [],
+              [11, 10] => [20],
+              [21, 20] => [31, 40],
+              [21, 24] => [31, 40, 5],
+              [40, 2] => [],
+              [40, 5] => [5],
+              [41, 4] => [5],
+              [49, 1] => [5],
+              [50, 0] => [],
+              [50, 5] => [5]
+            })
+          end
         end
       end
+    end
+
+    context "with progressive_billed_amount set to 10" do
+      let(:progressive_billed_amount) { 10 }
+
+      context "without recurring thresholds" do
+        context "with no fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [],
+              [9, 2] => [],
+              [11, 1] => [],
+              [11, 10] => []
+            })
+          end
+        end
+
+        context "with 1 fixed threshold" do
+          before do
+            create_thresholds(subscription, amounts: [10], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [9, 2] => [],
+              [9, 20] => [],
+              [11, 10] => [],
+              [11, 20] => []
+            })
+          end
+        end
+
+        context "with multiple fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [10, 20, 31, 40], attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 10] => [],
+              [0, 31] => [20, 31],
+              [9, 10] => [],
+              [9, 12] => [20],
+              [9, 20] => [20],
+              [9, 31] => [20, 31, 40],
+              [11, 11] => [],
+              [11, 20] => [31],
+              [21, 20] => [40],
+              [30, 12] => [],
+              [50, 10] => []
+            })
+          end
+        end
+      end
+
+      context "with recurring thresholds" do
+        context "with no fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [], recurring: 10, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 10] => [],
+              [11, 10] => [],
+              [11, 19] => [10],
+              [202, 17] => [],
+              [202, 18] => [10],
+              [202, 28] => [10]
+            })
+          end
+        end
+
+        context "with 1 fixed threshold" do
+          before do
+            create_thresholds(subscription, amounts: [10], recurring: 5, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [],
+              [0, 15] => [5],
+              [0, 20] => [5],
+              [9, 2] => [],
+              [9, 6] => [],
+              [9, 16] => [5],
+              [11, 3] => [],
+              [11, 4] => [],
+              [11, 14] => [5],
+              [11, 24] => [5]
+            })
+          end
+        end
+
+        context "with multiple fixed thresholds" do
+          before do
+            create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5, attach_to:)
+          end
+
+          it "calculates the passed thresholds correctly" do
+            validate_thresholds({
+              [0, 7] => [],
+              [0, 10] => [],
+              [0, 31] => [20, 31],
+              [0, 44] => [20, 31, 40],
+              [0, 45] => [20, 31, 40, 5],
+              [9, 2] => [],
+              [9, 20] => [20],
+              [9, 31] => [20, 31, 40],
+              [9, 37] => [20, 31, 40, 5],
+              [11, 1] => [],
+              [11, 10] => [],
+              [20, 20] => [31, 40],
+              [21, 20] => [40],
+              [21, 24] => [40, 5],
+              [40, 14] => [],
+              [40, 15] => [5],
+              [41, 14] => [5],
+              [49, 1] => [],
+              [49, 11] => [5],
+              [50, 5] => [],
+              [50, 15] => [5]
+            })
+          end
+        end
+      end
+    end
+
+    context "with historical_usage_amount_cents" do
+      let(:historical_usage_amount_cents) { 11 }
 
       context "with multiple fixed thresholds" do
         before do
-          create_thresholds(subscription, amounts: [10, 20, 31, 40])
+          create_thresholds(subscription, amounts: [10, 20, 31, 40], attach_to:)
         end
 
         it "calculates the passed thresholds correctly" do
           validate_thresholds({
             [0, 7] => [],
-            [0, 10] => [10],
-            [0, 31] => [10, 20, 31],
-            [9, 2] => [10],
-            [9, 20] => [10, 20],
-            [9, 31] => [10, 20, 31, 40],
+            [0, 9] => [20],
+            [0, 10] => [20],
+            [9, 0] => [],
+            [0, 31] => [20, 31, 40],
+            [8, 2] => [20],
+            [8, 20] => [20, 31],
+            [8, 31] => [20, 31, 40],
             [11, 1] => [],
-            [11, 10] => [20],
-            [21, 20] => [31, 40],
+            [11, 10] => [31],
+            [21, 20] => [40],
             [40, 2] => [],
             [50, 0] => []
           })
         end
-      end
-    end
-
-    context "with recurring thresholds" do
-      context "with no fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [], recurring: 10)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [10],
-            [9, 2] => [10],
-            [11, 1] => [],
-            [11, 8] => [],
-            [11, 9] => [10],
-            [11, 10] => [10],
-            [11, 20] => [10],
-            [202, 7] => [],
-            [202, 8] => [10]
-          })
-        end
-      end
-
-      context "with 1 fixed threshold" do
-        before do
-          create_thresholds(subscription, amounts: [10], recurring: 5)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [10],
-            [0, 15] => [10, 5],
-            [0, 20] => [10, 5],
-            [9, 2] => [10],
-            [9, 6] => [10, 5],
-            [9, 20] => [10, 5],
-            [11, 3] => [],
-            [11, 4] => [5],
-            [11, 20] => [5]
-          })
-        end
-      end
-
-      context "with multiple fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [10],
-            [0, 31] => [10, 20, 31],
-            [0, 44] => [10, 20, 31, 40],
-            [0, 45] => [10, 20, 31, 40, 5],
-            [9, 2] => [10],
-            [9, 20] => [10, 20],
-            [9, 31] => [10, 20, 31, 40],
-            [9, 37] => [10, 20, 31, 40, 5],
-            [11, 1] => [],
-            [11, 10] => [20],
-            [21, 20] => [31, 40],
-            [21, 24] => [31, 40, 5],
-            [40, 2] => [],
-            [40, 5] => [5],
-            [41, 4] => [5],
-            [49, 1] => [5],
-            [50, 0] => [],
-            [50, 5] => [5]
-          })
-        end
-      end
-    end
-  end
-
-  context "with progressive_billed_amount set to 10" do
-    let(:progressive_billed_amount) { 10 }
-
-    context "without recurring thresholds" do
-      context "with no fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [])
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [],
-            [9, 2] => [],
-            [11, 1] => [],
-            [11, 10] => []
-          })
-        end
-      end
-
-      context "with 1 fixed threshold" do
-        before do
-          create_thresholds(subscription, amounts: [10])
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [9, 2] => [],
-            [9, 20] => [],
-            [11, 10] => [],
-            [11, 20] => []
-          })
-        end
-      end
-
-      context "with multiple fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [10, 20, 31, 40])
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 10] => [],
-            [0, 31] => [20, 31],
-            [9, 10] => [],
-            [9, 12] => [20],
-            [9, 20] => [20],
-            [9, 31] => [20, 31, 40],
-            [11, 11] => [],
-            [11, 20] => [31],
-            [21, 20] => [40],
-            [30, 12] => [],
-            [50, 10] => []
-          })
-        end
-      end
-    end
-
-    context "with recurring thresholds" do
-      context "with no fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [], recurring: 10)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 10] => [],
-            [11, 10] => [],
-            [11, 19] => [10],
-            [202, 17] => [],
-            [202, 18] => [10],
-            [202, 28] => [10]
-          })
-        end
-      end
-
-      context "with 1 fixed threshold" do
-        before do
-          create_thresholds(subscription, amounts: [10], recurring: 5)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [],
-            [0, 15] => [5],
-            [0, 20] => [5],
-            [9, 2] => [],
-            [9, 6] => [],
-            [9, 16] => [5],
-            [11, 3] => [],
-            [11, 4] => [],
-            [11, 14] => [5],
-            [11, 24] => [5]
-          })
-        end
-      end
-
-      context "with multiple fixed thresholds" do
-        before do
-          create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5)
-        end
-
-        it "calculates the passed thresholds correctly" do
-          validate_thresholds({
-            [0, 7] => [],
-            [0, 10] => [],
-            [0, 31] => [20, 31],
-            [0, 44] => [20, 31, 40],
-            [0, 45] => [20, 31, 40, 5],
-            [9, 2] => [],
-            [9, 20] => [20],
-            [9, 31] => [20, 31, 40],
-            [9, 37] => [20, 31, 40, 5],
-            [11, 1] => [],
-            [11, 10] => [],
-            [20, 20] => [31, 40],
-            [21, 20] => [40],
-            [21, 24] => [40, 5],
-            [40, 14] => [],
-            [40, 15] => [5],
-            [41, 14] => [5],
-            [49, 1] => [],
-            [49, 11] => [5],
-            [50, 5] => [],
-            [50, 15] => [5]
-          })
-        end
-      end
-    end
-  end
-
-  context "with historical_usage_amount_cents" do
-    let(:historical_usage_amount_cents) { 11 }
-
-    context "with multiple fixed thresholds" do
-      before do
-        create_thresholds(subscription, amounts: [10, 20, 31, 40])
-      end
-
-      it "calculates the passed thresholds correctly" do
-        validate_thresholds({
-          [0, 7] => [],
-          [0, 9] => [20],
-          [0, 10] => [20],
-          [9, 0] => [],
-          [0, 31] => [20, 31, 40],
-          [8, 2] => [20],
-          [8, 20] => [20, 31],
-          [8, 31] => [20, 31, 40],
-          [11, 1] => [],
-          [11, 10] => [31],
-          [21, 20] => [40],
-          [40, 2] => [],
-          [50, 0] => []
-        })
       end
     end
   end


### PR DESCRIPTION
I have started migrating everything to the main PR but keep doing separte PRs for reviews.

This would break if the `progressive_billing_disabled` if not migrated and childplan has no usage thesholds while parent have thresholds. But:
- we'll migrate data when deploying this
- there are no such case currently in production

https://github.com/getlago/lago-api/blob/b9a3c06c39ebb768405b4135d31f455fd772e06d/app/models/plan.rb#L61-L63