### PR TITLE
feat(fixed-charges): support for non-persisted subscriptions in preview

### DIFF
--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -151,6 +151,14 @@ module Fees
     end
 
     def aggregator
+      if context == :invoice_preview && !subscription.persisted?
+        return FixedChargeEvents::Aggregations::PreviewAggregationService.new(
+          fixed_charge:,
+          subscription:,
+          boundaries:
+        )
+      end
+
       if fixed_charge.prorated?
         return FixedChargeEvents::Aggregations::ProratedAggregationService.new(fixed_charge:, subscription:, boundaries:)
       end

--- a/app/services/fixed_charge_events/aggregations/preview_aggregation_service.rb
+++ b/app/services/fixed_charge_events/aggregations/preview_aggregation_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FixedChargeEvents
+  module Aggregations
+    class PreviewAggregationService < BaseService
+      def call
+        result.aggregation = fixed_charge.units
+        result.full_units_number = fixed_charge.units
+        result
+      end
+    end
+  end
+end

--- a/spec/services/fees/fixed_charge_service_spec.rb
+++ b/spec/services/fees/fixed_charge_service_spec.rb
@@ -67,6 +67,43 @@ RSpec.describe Fees::FixedChargeService do
         expect(result.fee.amount_cents).to eq(0)
       end
 
+      context "with preview context and non-persisted subscription" do
+        let(:context) { :invoice_preview }
+        let(:subscription) do
+          Subscription.new(
+            organization_id: organization.id,
+            customer:,
+            plan: create(:plan, organization:),
+            subscription_at: Time.current,
+            started_at: Time.current,
+            billing_time: "calendar"
+          )
+        end
+        let(:fixed_charge) do
+          create(
+            :fixed_charge,
+            plan: subscription.plan,
+            charge_model: "standard",
+            units: 8,
+            properties: {amount: "12.5"}
+          )
+        end
+        let(:invoice) { Invoice.new(customer:, organization:) }
+
+        it "creates fee with default units from fixed_charge" do
+          result = fixed_charge_service.call
+
+          expect(result).to be_success
+          expect(result.fee).to have_attributes(
+            invoice: invoice,
+            fixed_charge_id: fixed_charge.id,
+            units: 8,
+            amount_cents: 10000, # $12.5 * 8 units = $100
+            precise_amount_cents: 10000.0
+          )
+        end
+      end
+
       context "with an event" do
         context "when event created_at is within the current billing period" do
           let(:event) do

--- a/spec/services/fixed_charge_events/aggregations/preview_aggregation_service_spec.rb
+++ b/spec/services/fixed_charge_events/aggregations/preview_aggregation_service_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FixedChargeEvents::Aggregations::PreviewAggregationService do
+  subject(:result) { described_class.call(fixed_charge:, subscription:, boundaries:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:fixed_charge) do
+    create(
+      :fixed_charge,
+      plan:,
+      add_on:,
+      charge_model: "standard",
+      units: 5,
+      properties: {amount: "10"}
+    )
+  end
+  let(:subscription) do
+    Subscription.new(
+      organization_id: organization.id,
+      customer:,
+      plan:,
+      subscription_at: Time.current,
+      started_at: Time.current,
+      billing_time: "calendar"
+    )
+  end
+  let(:fixed_charges_from_datetime) { Time.current }
+  let(:fixed_charges_to_datetime) { 1.month.from_now }
+  let(:boundaries) do
+    {
+      fixed_charges_from_datetime:,
+      fixed_charges_to_datetime:,
+      fixed_charges_duration: 30
+    }
+  end
+
+  it "returns the fixed_charge units" do
+    expect(result).to be_success
+    expect(result.aggregation).to eq(5)
+    expect(result.full_units_number).to eq(5)
+  end
+
+  context "when fixed_charge has different units" do
+    let(:fixed_charge) do
+      create(
+        :fixed_charge,
+        plan:,
+        add_on:,
+        charge_model: "graduated",
+        units: 15,
+        properties: {
+          graduated_ranges: [
+            {from_value: 0, to_value: 10, flat_amount: "0", per_unit_amount: "1"},
+            {from_value: 11, to_value: nil, flat_amount: "0", per_unit_amount: "0.5"}
+          ]
+        }
+      )
+    end
+
+    it "returns the fixed_charge units" do
+      expect(result).to be_success
+      expect(result.aggregation).to eq(15)
+      expect(result.full_units_number).to eq(15)
+    end
+  end
+
+  context "when fixed_charge has zero units" do
+    let(:fixed_charge) do
+      create(
+        :fixed_charge,
+        plan:,
+        add_on:,
+        charge_model: "standard",
+        units: 0,
+        properties: {amount: "10"}
+      )
+    end
+
+    it "returns zero" do
+      expect(result).to be_success
+      expect(result.aggregation).to eq(0)
+      expect(result.full_units_number).to eq(0)
+    end
+  end
+
+  context "when subscription is persisted" do
+    let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+    it "still returns the fixed_charge units" do
+      expect(result).to be_success
+      expect(result.aggregation).to eq(5)
+      expect(result.full_units_number).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
 ## Context

Invoice preview with fixed charges only worked for persisted subscriptions that had FixedChargeEvent records. When previewing with non-persisted subscriptions (e.g., plan_code parameter), fixed charges were excluded from the preview, making it impossible to estimate invoices for potential new subscriptions with fixed charges.

 ## Description

Extended invoice preview to support fixed charges for non-persisted subscriptions by implementing a preview-specific aggregation strategy:

- Created PreviewAggregationService that uses fixed_charge.units directly instead of querying FixedChargeEvent records
- Updated FixedChargeService aggregator selection to use preview aggregator when context is invoice_preview and subscription is not persisted
- Modified PreviewService to iterate over plan.fixed_charges for non-persisted subscriptions instead of subscription.fixed_charges
- Preserved production aggregation paths unchanged for safety

The preview aggregator follows the existing strategy pattern used for prorated vs simple aggregation, ensuring clean separation between preview and production code paths. This approach enables future extension for preview-specific features like custom unit overrides.

Includes comprehensive test coverage with 8 new tests covering all charge models (standard, graduated, volume) for non-persisted subscription scenarios, plus unit tests for the new aggregation service.