### PR TITLE
chore(rubocop): Fix plugin warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,14 +2,16 @@ inherit_mode:
   merge:
     - Exclude
 
+plugins:
+  - rubocop-rails
+  - rubocop-graphql
+  - rubocop-factory_bot
+  - rubocop-performance
+  - rubocop-thread_safety
+
 require:
   - standard
   - rubocop-rspec
-  - rubocop-performance
-  - rubocop-rails
-  - rubocop-thread_safety
-  - rubocop-graphql
-  - rubocop-factory_bot
   - rubocop-rspec_rails
   - ./dev/cops/service_call_cop.rb
 


### PR DESCRIPTION
Fix warning by using `plugins: ` config

### BEFORE

<img width="3202" height="1232" alt="CleanShot 2025-12-23 at 09 12 33@2x" src="https://github.com/user-attachments/assets/eeae3aff-ce52-4f8a-8d97-3b261079c142" />

AFTER

<img width="2624" height="428" alt="CleanShot 2025-12-23 at 09 12 43@2x" src="https://github.com/user-attachments/assets/587535a1-a0b9-495e-842e-6d98237013d2" />
