### PR TITLE
chore(deps): Update test dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ group :development, :test do
   gem "webmock"
   gem "awesome_print"
   gem "pry-byebug"
-  gem "knapsack_pro", "~> 8.1"
+  gem "knapsack_pro", "~> 9.0"
   gem "parallel_tests", "~> 5.3"
 
   gem "database_cleaner-active_record"
@@ -147,7 +147,7 @@ group :development, :test do
   gem "rubocop-thread_safety", require: false
 
   gem "vernier", "~> 1.0", require: false
-  gem "super_diff", "~> 0.16.0"
+  gem "super_diff", "~> 0.18.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
       msgpack
     datadog-ruby_core_source (3.4.1)
     date (3.4.1)
-    debug (1.11.0)
+    debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
     declarative (0.0.20)
@@ -387,7 +387,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.12.0)
+    json (2.18.0)
     jwt (2.8.2)
       base64
     kaminari-activerecord (1.2.2)
@@ -436,7 +436,7 @@ GEM
       karafka-core (>= 2.5.0, < 2.6.0)
       roda (~> 3.68, >= 3.69)
       tilt (~> 2.0)
-    knapsack_pro (8.4.0)
+    knapsack_pro (9.0.0)
       rake
     language_server-protocol (3.17.0.5)
     libdatadog (22.0.1.1.0)
@@ -476,7 +476,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.26.0)
+    minitest (6.0.0)
+      prism (~> 1.5)
     monetize (1.13.0)
       money (~> 6.12)
     money (6.19.0)
@@ -736,7 +737,7 @@ GEM
     parallel (1.27.0)
     parallel_tests (5.5.0)
       parallel
-    parser (3.3.8.0)
+    parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
     patience_diff (1.2.0)
@@ -745,7 +746,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.4.0)
+    prism (1.7.0)
     prometheus-client (4.2.5)
       base64
     pry (0.14.2)
@@ -805,7 +806,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.0)
+    rake (13.3.1)
     rake-compiler (1.3.0)
       rake
     rake-compiler-dock (1.9.1)
@@ -831,7 +832,7 @@ GEM
     redis-prescription (2.6.0)
     redlock (2.0.6)
       redis-client (>= 0.14.1, < 1.0.0)
-    regexp_parser (2.10.0)
+    regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
     representable (3.2.0)
@@ -946,8 +947,8 @@ GEM
       sentry-ruby (~> 5.18.2)
       sidekiq (>= 3.0)
     shellany (0.0.1)
-    shoulda-matchers (6.5.0)
-      activesupport (>= 5.2.0)
+    shoulda-matchers (7.0.1)
+      activesupport (>= 7.1)
     sidekiq (7.3.7)
       connection_pool (>= 2.3.0)
       logger
@@ -1002,7 +1003,7 @@ GEM
     stripe (6.5.0)
     strong_migrations (2.0.2)
       activerecord (>= 6.1)
-    super_diff (0.16.0)
+    super_diff (0.18.0)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
@@ -1024,9 +1025,9 @@ GEM
     uglifier (4.2.1)
       execjs (>= 0.3.0, < 3)
     unaccent (0.4.0)
-    unicode-display_width (3.1.4)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uniform_notifier (1.17.0)
     uri (1.0.4)
     useragent (0.16.11)
@@ -1123,7 +1124,7 @@ DEPENDENCIES
   karafka (~> 2.5.0)
   karafka-testing
   karafka-web (~> 0.11.3)
-  knapsack_pro (~> 8.1)
+  knapsack_pro (~> 9.0)
   lago-expression!
   lograge
   logstash-event
@@ -1172,7 +1173,7 @@ DEPENDENCIES
   standard
   stripe
   strong_migrations
-  super_diff (~> 0.16.0)
+  super_diff (~> 0.18.0)
   throttling
   timecop
   tzinfo-data


### PR DESCRIPTION
## Description

Upgrade test-related gems to their latest versions:
- `knapsack_pro`: `~> 8.1` -> `~> 9.0`
- `super_diff`: `~> 0.16.0` -> `~> 0.18.0`