### PR TITLE
fix(event): Fix event batch with duplicate record

### DIFF
--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -69,8 +69,8 @@ module Events
             event.save!
           rescue ActiveRecord::RecordNotUnique
             result.errors[index] = {transaction_id: ["value_already_exist"]}
+            raise ActiveRecord::Rollback
           end
-          raise ActiveRecord::Rollback if result.errors.any?
         end
         return if result.errors.any?
       end


### PR DESCRIPTION
## Context

When sending events through the event batch endpoint, if a record already existing with the same `transaction_id` or duplicate `transaction_id` in the payload, we would fail the request but we still store the events for which there was no error. Another issue is that we didn't trigger the post-processing nor produce Kafka messages for those stored events.

This is because we relied on `ApplicationRecord.transaction` which created the transaction within another database connection. Therefore the rollback did not apply to the events.

Note that this only applied to the Postgres store, not Clickhouse.

## Description

This fixes the issue and improves the tests.
