### PR TITLE
feat(charge): Add code to Charge and FixedCharge

### DIFF
--- a/app/models/analytics/invoiced_usage.rb
+++ b/app/models/analytics/invoiced_usage.rb
@@ -67,7 +67,7 @@ module Analytics
             FROM usage_fees uf
             LEFT JOIN charges c ON c.id = uf.charge_id
             LEFT JOIN billable_metrics bm ON bm.id = c.billable_metric_id
-            GROUP BY month, code, currency
+            GROUP BY month, bm.code, currency
             ORDER BY month
           )
           SELECT

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -47,6 +47,7 @@ class Charge < ApplicationRecord
   validates :min_amount_cents, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
   validates :charge_model, presence: true
 
+  validate :validate_code_unique, if: -> { code.present? }
   validate :charge_model_allowance
   validate :validate_pay_in_advance
   validate :validate_regroup_paid_fees
@@ -58,6 +59,7 @@ class Charge < ApplicationRecord
   default_scope -> { kept }
 
   scope :pay_in_advance, -> { where(pay_in_advance: true) }
+  scope :parents, -> { where(parent_id: nil) }
 
   def pricing_group_keys
     properties["pricing_group_keys"].presence || properties["grouped_by"]
@@ -154,6 +156,14 @@ class Charge < ApplicationRecord
       errors.add(:charge_model, :graduated_percentage_requires_premium_license)
     end
   end
+
+  def validate_code_unique
+    return unless plan
+    return if parent_id?
+
+    charge = plan.charges.parents.where(code:).first
+    errors.add(:code, :taken) if charge && charge != self
+  end
 end
 
 # == Schema Information
@@ -164,6 +174,7 @@ end
 #  id                   :uuid             not null, primary key
 #  amount_currency      :string
 #  charge_model         :integer          default("standard"), not null
+#  code                 :string
 #  deleted_at           :datetime
 #  invoice_display_name :string
 #  invoiceable          :boolean          default(TRUE), not null
@@ -187,6 +198,7 @@ end
 #  index_charges_on_organization_id                             (organization_id)
 #  index_charges_on_parent_id                                   (parent_id)
 #  index_charges_on_plan_id                                     (plan_id)
+#  index_charges_on_plan_id_and_code                            (plan_id,code) UNIQUE WHERE ((deleted_at IS NULL) AND (parent_id IS NULL))
 #  index_charges_pay_in_advance                                 (billable_metric_id) WHERE ((deleted_at IS NULL) AND (pay_in_advance = true))
 #
 # Foreign Keys

--- a/db/migrate/20251226145247_add_code_to_charges.rb
+++ b/db/migrate/20251226145247_add_code_to_charges.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddCodeToCharges < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :charges, :code, :string
+    add_column :fixed_charges, :code, :string
+
+    add_index :charges,
+      [:plan_id, :code],
+      unique: true,
+      where: "deleted_at IS NULL AND parent_id IS NULL",
+      name: "index_charges_on_plan_id_and_code",
+      algorithm: :concurrently
+
+    add_index :fixed_charges,
+      [:plan_id, :code],
+      unique: true,
+      where: "deleted_at IS NULL AND parent_id IS NULL",
+      name: "index_fixed_charges_on_plan_id_and_code",
+      algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -507,6 +507,7 @@ DROP INDEX IF EXISTS public.index_fixed_charges_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_fixed_charges_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_fixed_charges_taxes_on_fixed_charge_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_fixed_charges_taxes_on_fixed_charge_id;
+DROP INDEX IF EXISTS public.index_fixed_charges_on_plan_id_and_code;
 DROP INDEX IF EXISTS public.index_fixed_charges_on_plan_id;
 DROP INDEX IF EXISTS public.index_fixed_charges_on_parent_id;
 DROP INDEX IF EXISTS public.index_fixed_charges_on_organization_id;
@@ -620,6 +621,7 @@ DROP INDEX IF EXISTS public.index_charges_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_charge_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_charge_id;
 DROP INDEX IF EXISTS public.index_charges_pay_in_advance;
+DROP INDEX IF EXISTS public.index_charges_on_plan_id_and_code;
 DROP INDEX IF EXISTS public.index_charges_on_plan_id;
 DROP INDEX IF EXISTS public.index_charges_on_parent_id;
 DROP INDEX IF EXISTS public.index_charges_on_organization_id;
@@ -1730,7 +1732,8 @@ CREATE TABLE public.charges (
     invoice_display_name character varying,
     regroup_paid_fees integer,
     parent_id uuid,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    code character varying
 );
 
 
@@ -3672,7 +3675,8 @@ CREATE TABLE public.fixed_charges (
     units numeric(30,10) DEFAULT 0.0 NOT NULL,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    code character varying
 );
 
 
@@ -6281,6 +6285,13 @@ CREATE INDEX index_charges_on_plan_id ON public.charges USING btree (plan_id);
 
 
 --
+-- Name: index_charges_on_plan_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_charges_on_plan_id_and_code ON public.charges USING btree (plan_id, code) WHERE ((deleted_at IS NULL) AND (parent_id IS NULL));
+
+
+--
 -- Name: index_charges_pay_in_advance; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7069,6 +7080,13 @@ CREATE INDEX index_fixed_charges_on_parent_id ON public.fixed_charges USING btre
 --
 
 CREATE INDEX index_fixed_charges_on_plan_id ON public.fixed_charges USING btree (plan_id);
+
+
+--
+-- Name: index_fixed_charges_on_plan_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_fixed_charges_on_plan_id_and_code ON public.fixed_charges USING btree (plan_id, code) WHERE ((deleted_at IS NULL) AND (parent_id IS NULL));
 
 
 --
@@ -10708,6 +10726,7 @@ ALTER TABLE ONLY public.wallet_transactions_invoice_custom_sections
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251226145247'),
 ('20251219115429'),
 ('20251216100247'),
 ('20251211154309'),
@@ -11592,3 +11611,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     billable_metric
     plan
     organization { billable_metric&.organization || plan&.organization || association(:organization) }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
     invoice_display_name { Faker::Fantasy::Tolkien.location }
 
     factory :standard_charge do

--- a/spec/factories/fixed_charges.rb
+++ b/spec/factories/fixed_charges.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     organization { add_on&.organization || plan&.organization || association(:organization) }
     plan
     add_on
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
     charge_model { "standard" }
     units { 1 }
     properties { {amount: Faker::Number.between(from: 100, to: 500).to_s} }


### PR DESCRIPTION
## Context

We want to make charges and charge filters independent from the plan/subscription object, enabling
add/update of a single charge or charge filter without sending the entire plan's payload.

## Description

The goal of this PR is to add a `code` attribute to both Charge and FixedCharge models to allow identifying charges by a user-defined code within a plan.

- Add nullable `code` column to charges and fixed_charges tables
- Add unique partial index on (plan_id, code) for non-deleted parent records
- Add code uniqueness validation (only when code is present)
- Add `parents` scope to both models
- Remove `delegate :code, to: :add_on` from FixedCharge
- Update factories to generate random codes for testing

## What's next?

The plan is to merge this code as `nullable` for now and **add the not-null constraint later** (at the release) with the backfill script. [Here is the PR](https://github.com/getlago/lago-api/pull/4783).