### PR TITLE
feat(charge): Add NOT NULL constraint and backfill for code

### DIFF
--- a/app/jobs/database_migrations/backfill_charges_code_job.rb
+++ b/app/jobs/database_migrations/backfill_charges_code_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillChargesCodeJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1_000
+
+    def perform(batch_number = 1)
+      return Rails.logger.info("Finished populating charge codes") unless Charge.unscoped.where(code: nil).exists?
+
+      result = ActiveRecord::Base.connection.execute(<<-SQL.squish)
+        WITH plan_batch AS (
+          SELECT DISTINCT plan_id
+          FROM charges
+          WHERE code IS NULL
+          LIMIT #{BATCH_SIZE}
+        ),
+        ranked_codes AS (
+          SELECT
+            c.id,
+            bm.code AS base_code,
+            ROW_NUMBER() OVER (PARTITION BY c.plan_id, bm.code ORDER BY c.created_at, c.id) AS rn
+          FROM charges c
+          INNER JOIN plan_batch pb ON pb.plan_id = c.plan_id
+          INNER JOIN billable_metrics bm ON bm.id = c.billable_metric_id
+          WHERE c.code IS NULL
+        )
+        UPDATE charges
+        SET code = CASE
+          WHEN ranked_codes.rn = 1 THEN ranked_codes.base_code
+          ELSE ranked_codes.base_code || '_' || ranked_codes.rn
+        END
+        FROM ranked_codes
+        WHERE charges.id = ranked_codes.id
+      SQL
+
+      if result.cmd_tuples.positive?
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished populating charge codes")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/jobs/database_migrations/backfill_fixed_charges_code_job.rb
+++ b/app/jobs/database_migrations/backfill_fixed_charges_code_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillFixedChargesCodeJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1_000
+
+    def perform(batch_number = 1)
+      return Rails.logger.info("Finished populating fixed charge codes") unless FixedCharge.unscoped.where(code: nil).exists?
+
+      result = ActiveRecord::Base.connection.execute(<<-SQL.squish)
+        WITH plan_batch AS (
+          SELECT DISTINCT plan_id
+          FROM fixed_charges
+          WHERE code IS NULL
+          LIMIT #{BATCH_SIZE}
+        ),
+        ranked_codes AS (
+          SELECT
+            fc.id,
+            ao.code AS base_code,
+            ROW_NUMBER() OVER (PARTITION BY fc.plan_id, ao.code ORDER BY fc.created_at, fc.id) AS rn
+          FROM fixed_charges fc
+          INNER JOIN plan_batch pb ON pb.plan_id = fc.plan_id
+          INNER JOIN add_ons ao ON ao.id = fc.add_on_id
+          WHERE fc.code IS NULL
+        )
+        UPDATE fixed_charges
+        SET code = CASE
+          WHEN ranked_codes.rn = 1 THEN ranked_codes.base_code
+          ELSE ranked_codes.base_code || '_' || ranked_codes.rn
+        END
+        FROM ranked_codes
+        WHERE fixed_charges.id = ranked_codes.id
+      SQL
+
+      if result.cmd_tuples.positive?
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished populating fixed charge codes")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -45,9 +45,9 @@ class Charge < ApplicationRecord
   validate :validate_properties
   validate :validate_dynamic, if: -> { dynamic? }
   validates :min_amount_cents, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
-  validates :charge_model, presence: true
+  validates :charge_model, :code, presence: true
 
-  validate :validate_code_unique, if: -> { code.present? }
+  validate :validate_code_unique
   validate :charge_model_allowance
   validate :validate_pay_in_advance
   validate :validate_regroup_paid_fees
@@ -178,26 +178,24 @@ end
 # Table name: charges
 # Database name: primary
 #
-#  id                    :uuid             not null, primary key
-#  accepts_target_wallet :boolean          default(FALSE), not null
-#  amount_currency       :string
-#  charge_model          :integer          default("standard"), not null
-#  code                  :string
-#  deleted_at            :datetime
-#  group_by_wallet       :boolean          default(FALSE), not null
-#  invoice_display_name  :string
-#  invoiceable           :boolean          default(TRUE), not null
-#  min_amount_cents      :bigint           default(0), not null
-#  pay_in_advance        :boolean          default(FALSE), not null
-#  properties            :jsonb            not null
-#  prorated              :boolean          default(FALSE), not null
-#  regroup_paid_fees     :integer
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  billable_metric_id    :uuid
-#  organization_id       :uuid             not null
-#  parent_id             :uuid
-#  plan_id               :uuid
+#  id                   :uuid             not null, primary key
+#  amount_currency      :string
+#  charge_model         :integer          default("standard"), not null
+#  code                 :string           not null
+#  deleted_at           :datetime
+#  invoice_display_name :string
+#  invoiceable          :boolean          default(TRUE), not null
+#  min_amount_cents     :bigint           default(0), not null
+#  pay_in_advance       :boolean          default(FALSE), not null
+#  properties           :jsonb            not null
+#  prorated             :boolean          default(FALSE), not null
+#  regroup_paid_fees    :integer
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  billable_metric_id   :uuid
+#  organization_id      :uuid             not null
+#  parent_id            :uuid
+#  plan_id              :uuid
 #
 # Indexes
 #

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -34,12 +34,12 @@ class FixedCharge < ApplicationRecord
   enum :charge_model, CHARGE_MODELS
 
   validates :units, numericality: {greater_than_or_equal_to: 0}
-  validates :charge_model, presence: true
+  validates :charge_model, :code, presence: true
   validates :pay_in_advance, exclusion: [nil]
   validates :prorated, exclusion: [nil]
   validates :properties, presence: true
 
-  validate :validate_code_unique, if: -> { code.present? }
+  validate :validate_code_unique
   validate :validate_pay_in_advance
   validate :validate_prorated
   validate :validate_properties
@@ -105,7 +105,7 @@ end
 #
 #  id                   :uuid             not null, primary key
 #  charge_model         :enum             default("standard"), not null
-#  code                 :string
+#  code                 :string           not null
 #  deleted_at           :datetime
 #  invoice_display_name :string
 #  pay_in_advance       :boolean          default(FALSE), not null

--- a/db/migrate/20251229153718_add_code_not_null_check_constraint_to_charges.rb
+++ b/db/migrate/20251229153718_add_code_not_null_check_constraint_to_charges.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCodeNotNullCheckConstraintToCharges < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :charges, "code IS NOT NULL", name: "charges_code_not_null", validate: false
+    add_check_constraint :fixed_charges, "code IS NOT NULL", name: "fixed_charges_code_not_null", validate: false
+  end
+end

--- a/db/migrate/20251229153734_validate_charges_code_not_null.rb
+++ b/db/migrate/20251229153734_validate_charges_code_not_null.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ValidateChargesCodeNotNull < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    validate_check_constraint :charges, name: "charges_code_not_null"
+    change_column_null :charges, :code, false
+    remove_check_constraint :charges, name: "charges_code_not_null"
+
+    validate_check_constraint :fixed_charges, name: "fixed_charges_code_not_null"
+    change_column_null :fixed_charges, :code, false
+    remove_check_constraint :fixed_charges, name: "fixed_charges_code_not_null"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1847,7 +1847,7 @@ CREATE TABLE public.charges (
     regroup_paid_fees integer,
     parent_id uuid,
     organization_id uuid NOT NULL,
-    code character varying,
+    code character varying NOT NULL,
     accepts_target_wallet boolean DEFAULT false NOT NULL
 );
 
@@ -3968,7 +3968,7 @@ CREATE TABLE public.fixed_charges (
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    code character varying
+    code character varying NOT NULL
 );
 
 
@@ -11448,6 +11448,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260105144123'),
 ('20251231162838'),
 ('20251230154408'),
+('20251229153734'),
+('20251229153718'),
 ('20251226145247'),
 ('20251224152737'),
 ('20251224152736'),

--- a/lib/tasks/upgrade_verification.rake
+++ b/lib/tasks/upgrade_verification.rake
@@ -12,6 +12,8 @@ namespace :upgrade do
 
     resources_to_fill = [
       {model: Wallet, job: DatabaseMigrations::PopulateWalletsWithCodeJob},
+      {model: Charge, job: DatabaseMigrations::BackfillChargesCodeJob},
+      {model: FixedCharge, job: DatabaseMigrations::BackfillFixedChargesCodeJob}
     ]
 
     puts "##################################\nStarting required jobs"

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Charge do
 
   it_behaves_like "paper_trail traceable"
 
+  it { is_expected.to validate_presence_of(:code) }
+
   describe "associations" do
     it do
       expect(subject).to belong_to(:organization)

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe FixedCharge do
 
   it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_presence_of(:charge_model) }
+  it { is_expected.to validate_presence_of(:code) }
   it { is_expected.to validate_exclusion_of(:pay_in_advance).in_array([nil]) }
   it { is_expected.to validate_exclusion_of(:prorated).in_array([nil]) }
   it { is_expected.to validate_presence_of(:properties) }

--- a/spec/services/fixed_charges/create_service_spec.rb
+++ b/spec/services/fixed_charges/create_service_spec.rb
@@ -409,6 +409,7 @@ RSpec.describe FixedCharges::CreateService do
       let(:params) do
         {
           add_on_id: add_on.id,
+          code: "timestamp_fixed_charge",
           charge_model: "standard",
           units: 5,
           properties: {amount: "100"},


### PR DESCRIPTION
## Context

We want to make charges and charge filters independent from the plan/subscription object, enabling
add/update of a single charge or charge filter without sending the entire plan's payload.

## Description

This adds the NOT NULL constraint to the code column on charges and fixed_charges tables, along with the necessary backfill migration.

- Add backfill migration to populate code from billable_metric/add_on code
- Add check constraint migration for NOT NULL validation
- Add final migration to enforce NOT NULL and remove check constraint
- Update model validations to require code presence
- Update specs to test code presence validation

## Important

This PR should **not be merged before releasing the entire feature**.
