### PR TITLE
feat(wallet): Implement prepaid credit consumption tracking for wallet traceability

### DIFF
--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -153,7 +153,7 @@ end
 #  index_invoice_subscriptions_on_regenerated_invoice_id          (regenerated_invoice_id)
 #  index_invoice_subscriptions_on_subscription_id                 (subscription_id)
 #  index_uniq_invoice_subscriptions_on_charges_from_to_datetime   (subscription_id,charges_from_datetime,charges_to_datetime) UNIQUE WHERE ((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE) AND (regenerated_invoice_id IS NULL))
-#  index_uniq_invoice_subscriptions_on_fixed_charges_boundaries   (subscription_id,fixed_charges_from_datetime,fixed_charges_to_datetime) UNIQUE WHERE ((fixed_charges_from_datetime IS NOT NULL) AND (recurring = true) AND (regenerated_invoice_id IS NULL))
+#  index_uniq_invoice_subscriptions_on_fixed_charges_boundaries   (subscription_id,fixed_charges_from_datetime,fixed_charges_to_datetime) UNIQUE WHERE ((fixed_charges_from_datetime IS NOT NULL) AND (recurring IS TRUE) AND (regenerated_invoice_id IS NULL))
 #  index_unique_starting_invoice_subscription                     (subscription_id,invoicing_reason) UNIQUE WHERE ((invoicing_reason = 'subscription_starting'::subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL))
 #  index_unique_terminating_invoice_subscription                  (subscription_id,invoicing_reason) UNIQUE WHERE ((invoicing_reason = 'subscription_terminating'::subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL))
 #

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -148,6 +148,7 @@ end
 #  skip_invoice_custom_sections        :boolean          default(FALSE), not null
 #  status                              :integer          not null
 #  terminated_at                       :datetime
+#  traceable                           :boolean          default(FALSE), not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
 #  customer_id                         :uuid             not null

--- a/app/models/wallet_transaction_consumption.rb
+++ b/app/models/wallet_transaction_consumption.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class WalletTransactionConsumption < ApplicationRecord
+  belongs_to :organization
+  belongs_to :inbound_wallet_transaction, class_name: "WalletTransaction", inverse_of: :consumptions
+  belongs_to :outbound_wallet_transaction, class_name: "WalletTransaction", inverse_of: :fundings
+
+  validates :consumed_amount_cents, numericality: {greater_than: 0}
+  validate :inbound_transaction_must_be_inbound
+  validate :outbound_transaction_must_be_outbound
+
+  private
+
+  def inbound_transaction_must_be_inbound
+    return if inbound_wallet_transaction.nil?
+    return if inbound_wallet_transaction.inbound?
+
+    errors.add(:inbound_wallet_transaction, :invalid)
+  end
+
+  def outbound_transaction_must_be_outbound
+    return if outbound_wallet_transaction.nil?
+    return if outbound_wallet_transaction.outbound?
+
+    errors.add(:outbound_wallet_transaction, :invalid)
+  end
+end
+
+# == Schema Information
+#
+# Table name: wallet_transaction_consumptions
+# Database name: primary
+#
+#  id                             :uuid             not null, primary key
+#  consumed_amount_cents          :bigint           not null
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  inbound_wallet_transaction_id  :uuid             not null
+#  organization_id                :uuid             not null
+#  outbound_wallet_transaction_id :uuid             not null
+#
+# Indexes
+#
+#  idx_on_inbound_wallet_transaction_id_e54d00758d           (inbound_wallet_transaction_id)
+#  idx_on_outbound_wallet_transaction_id_cf6ff733c6          (outbound_wallet_transaction_id)
+#  idx_wallet_tx_consumptions_inbound_outbound               (inbound_wallet_transaction_id,outbound_wallet_transaction_id) UNIQUE
+#  index_wallet_transaction_consumptions_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (inbound_wallet_transaction_id => wallet_transactions.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (outbound_wallet_transaction_id => wallet_transactions.id)
+#

--- a/app/services/credits/applied_prepaid_credits_service.rb
+++ b/app/services/credits/applied_prepaid_credits_service.rb
@@ -59,6 +59,12 @@ module Credits
           wallet_transaction = create_wallet_transaction(wallet, total_amount_cents)
           amount_cents = wallet_transaction.amount_cents
 
+          if wallet.traceable?
+            WalletTransactions::TrackConsumptionService.call!(
+              outbound_wallet_transaction: wallet_transaction
+            )
+          end
+
           with_optimistic_lock_retry(wallet) do
             Wallets::Balance::DecreaseService.call(wallet:, wallet_transaction:, skip_refresh: true)
           end

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -29,7 +29,8 @@ module WalletTransactions
         organization_id: wallet.organization_id,
         amount:,
         credit_amount:,
-        metadata: transaction_params[:metadata] || []
+        metadata: transaction_params[:metadata] || [],
+        remaining_amount_cents: initial_remaining_amount_cents
       )
 
       if transaction_params[:payment_method].present?
@@ -48,5 +49,12 @@ module WalletTransactions
     attr_reader :wallet, :wallet_credit, :transaction_params
 
     delegate :credit_amount, :amount, to: :wallet_credit
+
+    def initial_remaining_amount_cents
+      return nil unless wallet.traceable?
+      return nil unless transaction_params[:transaction_type]&.to_sym == :inbound
+
+      wallet_credit.amount_cents
+    end
   end
 end

--- a/app/services/wallet_transactions/track_consumption_service.rb
+++ b/app/services/wallet_transactions/track_consumption_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module WalletTransactions
+  class TrackConsumptionService < BaseService
+    Result = BaseResult
+
+    def initialize(outbound_wallet_transaction:)
+      @outbound_wallet_transaction = outbound_wallet_transaction
+
+      super
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        consume_by_priority
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :outbound_wallet_transaction
+
+    delegate :wallet, to: :outbound_wallet_transaction
+
+    def consume_by_priority
+      amount_cents = outbound_wallet_transaction.amount_cents
+      inbounds = available_inbounds.to_a
+      available_amount = inbounds.sum(&:remaining_amount_cents)
+
+      if amount_cents > available_amount
+        return result.single_validation_failure!(
+          field: :amount_cents,
+          error_code: "exceeds_available_amount"
+        )
+      end
+
+      amount_left = amount_cents
+
+      inbounds.each do |inbound|
+        break if amount_left <= 0
+
+        consume_amount = [inbound.remaining_amount_cents, amount_left].min
+
+        create_consumption(inbound, consume_amount)
+        amount_left -= consume_amount
+      end
+    end
+
+    def create_consumption(inbound, amount_cents)
+      WalletTransactionConsumption.create!(
+        organization: wallet.organization,
+        inbound_wallet_transaction: inbound,
+        outbound_wallet_transaction: outbound_wallet_transaction,
+        consumed_amount_cents: amount_cents
+      )
+
+      # this raises a DB error if the remaining_amount_cents goes below zero
+      inbound.decrement!(:remaining_amount_cents, amount_cents) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    def available_inbounds
+      wallet.wallet_transactions.available_inbound.in_consumption_order
+    end
+  end
+end

--- a/db/migrate/20251224152732_create_wallet_transaction_consumptions.rb
+++ b/db/migrate/20251224152732_create_wallet_transaction_consumptions.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateWalletTransactionConsumptions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :wallet_transaction_consumptions, id: :uuid do |t|
+      t.references :organization,
+        foreign_key: true,
+        type: :uuid,
+        null: false
+      t.references :inbound_wallet_transaction,
+        foreign_key: {to_table: :wallet_transactions},
+        type: :uuid,
+        null: false
+      t.references :outbound_wallet_transaction,
+        foreign_key: {to_table: :wallet_transactions},
+        type: :uuid,
+        null: false
+      t.bigint :consumed_amount_cents, null: false
+
+      t.timestamps
+    end
+
+    add_index :wallet_transaction_consumptions,
+      [:inbound_wallet_transaction_id, :outbound_wallet_transaction_id],
+      unique: true,
+      name: "idx_wallet_tx_consumptions_inbound_outbound"
+  end
+end

--- a/db/migrate/20251224152733_add_remaining_amount_cents_to_wallet_transactions.rb
+++ b/db/migrate/20251224152733_add_remaining_amount_cents_to_wallet_transactions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddRemainingAmountCentsToWalletTransactions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :wallet_transactions, :remaining_amount_cents, :bigint
+
+    add_check_constraint :wallet_transactions,
+      "remaining_amount_cents >= 0 OR remaining_amount_cents IS NULL",
+      name: "remaining_amount_cents_non_negative",
+      validate: false
+  end
+end

--- a/db/migrate/20251224152734_add_traceable_to_wallets.rb
+++ b/db/migrate/20251224152734_add_traceable_to_wallets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTraceableToWallets < ActiveRecord::Migration[8.0]
+  def change
+    add_column :wallets, :traceable, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20251224152736_validate_remaining_amount_cents_constraint.rb
+++ b/db/migrate/20251224152736_validate_remaining_amount_cents_constraint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateRemainingAmountCentsConstraint < ActiveRecord::Migration[8.0]
+  def change
+    validate_check_constraint :wallet_transactions, name: "remaining_amount_cents_non_negative"
+  end
+end

--- a/db/migrate/20251224152737_add_available_inbound_index_to_wallet_transactions.rb
+++ b/db/migrate/20251224152737_add_available_inbound_index_to_wallet_transactions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddAvailableInboundIndexToWalletTransactions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :wallet_transactions,
+      "wallet_id, priority, (CASE WHEN transaction_status = 1 THEN 0 ELSE 1 END), created_at",
+      where: "remaining_amount_cents > 0 AND transaction_type = 0 AND status = 1",
+      name: "idx_wallet_transactions_available_inbound",
+      algorithm: :concurrently
+  end
+end

--- a/spec/factories/wallet_transaction_consumptions.rb
+++ b/spec/factories/wallet_transaction_consumptions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :wallet_transaction_consumption do
+    organization { inbound_wallet_transaction&.organization || association(:organization) }
+    inbound_wallet_transaction do
+      association(:wallet_transaction,
+        transaction_type: "inbound",
+        organization:,
+        remaining_amount_cents: 10000)
+    end
+    outbound_wallet_transaction do
+      association(:wallet_transaction,
+        transaction_type: "outbound",
+        wallet: inbound_wallet_transaction.wallet,
+        organization:)
+    end
+    consumed_amount_cents { 100 }
+  end
+end

--- a/spec/models/wallet_transaction_consumption_spec.rb
+++ b/spec/models/wallet_transaction_consumption_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WalletTransactionConsumption do
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:inbound_wallet_transaction).class_name("WalletTransaction").inverse_of(:consumptions)
+      expect(subject).to belong_to(:outbound_wallet_transaction).class_name("WalletTransaction").inverse_of(:fundings)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_numericality_of(:consumed_amount_cents).is_greater_than(0) }
+
+    describe "inbound_transaction_must_be_inbound" do
+      let(:wallet) { create(:wallet) }
+      let(:inbound_transaction) { create(:wallet_transaction, wallet:, transaction_type: :inbound, remaining_amount_cents: 10000) }
+      let(:outbound_transaction) { create(:wallet_transaction, wallet:, transaction_type: :outbound) }
+
+      it "is valid when inbound_wallet_transaction is inbound" do
+        consumption = build(:wallet_transaction_consumption,
+          inbound_wallet_transaction: inbound_transaction,
+          outbound_wallet_transaction: outbound_transaction)
+
+        expect(consumption).to be_valid
+      end
+
+      it "is invalid when inbound_wallet_transaction is outbound" do
+        consumption = build(:wallet_transaction_consumption,
+          inbound_wallet_transaction: outbound_transaction,
+          outbound_wallet_transaction: outbound_transaction)
+
+        expect(consumption).not_to be_valid
+        expect(consumption.errors.where(:inbound_wallet_transaction, :invalid)).to be_present
+      end
+    end
+
+    describe "outbound_transaction_must_be_outbound" do
+      let(:wallet) { create(:wallet) }
+      let(:inbound_transaction) { create(:wallet_transaction, wallet:, transaction_type: :inbound, remaining_amount_cents: 10000) }
+      let(:outbound_transaction) { create(:wallet_transaction, wallet:, transaction_type: :outbound) }
+
+      it "is valid when outbound_wallet_transaction is outbound" do
+        consumption = build(:wallet_transaction_consumption,
+          inbound_wallet_transaction: inbound_transaction,
+          outbound_wallet_transaction: outbound_transaction)
+
+        expect(consumption).to be_valid
+      end
+
+      it "is invalid when outbound_wallet_transaction is inbound" do
+        consumption = build(:wallet_transaction_consumption,
+          inbound_wallet_transaction: inbound_transaction,
+          outbound_wallet_transaction: inbound_transaction)
+
+        expect(consumption).not_to be_valid
+        expect(consumption.errors.where(:outbound_wallet_transaction, :invalid)).to be_present
+      end
+    end
+  end
+end

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -12,6 +12,30 @@ RSpec.describe WalletTransaction do
     it { is_expected.to validate_presence_of(:transaction_type) }
     it { is_expected.to validate_presence_of(:source) }
     it { is_expected.to validate_presence_of(:transaction_status) }
+
+    describe "remaining_amount_cents validation" do
+      it "allows remaining_amount_cents on inbound transactions" do
+        transaction = build(:wallet_transaction, transaction_type: :inbound, remaining_amount_cents: 1000)
+        expect(transaction).to be_valid
+      end
+
+      it "rejects negative remaining_amount_cents on inbound transactions" do
+        transaction = build(:wallet_transaction, transaction_type: :inbound, remaining_amount_cents: -100)
+        expect(transaction).not_to be_valid
+        expect(transaction.errors.where(:remaining_amount_cents, :greater_than_or_equal_to)).to be_present
+      end
+
+      it "allows nil remaining_amount_cents on outbound transactions" do
+        transaction = build(:wallet_transaction, transaction_type: :outbound, remaining_amount_cents: nil)
+        expect(transaction).to be_valid
+      end
+
+      it "rejects remaining_amount_cents on outbound transactions" do
+        transaction = build(:wallet_transaction, transaction_type: :outbound, remaining_amount_cents: 1000)
+        expect(transaction).not_to be_valid
+        expect(transaction.errors.where(:remaining_amount_cents, :present)).to be_present
+      end
+    end
   end
 
   describe "associations" do
@@ -19,6 +43,8 @@ RSpec.describe WalletTransaction do
     it { is_expected.to belong_to(:invoice).optional }
     it { is_expected.to belong_to(:credit_note).optional }
     it { is_expected.to belong_to(:organization) }
+    it { is_expected.to have_many(:consumptions).class_name("WalletTransactionConsumption").with_foreign_key(:inbound_wallet_transaction_id).inverse_of(:inbound_wallet_transaction).dependent(:destroy) }
+    it { is_expected.to have_many(:fundings).class_name("WalletTransactionConsumption").with_foreign_key(:outbound_wallet_transaction_id).inverse_of(:outbound_wallet_transaction).dependent(:destroy) }
     it { is_expected.to have_many(:applied_invoice_custom_sections).class_name("WalletTransaction::AppliedInvoiceCustomSection").dependent(:destroy) }
     it { is_expected.to have_many(:selected_invoice_custom_sections).through(:applied_invoice_custom_sections).source(:invoice_custom_section) }
   end
@@ -31,6 +57,44 @@ RSpec.describe WalletTransaction do
         "transaction_type" => hash_including("inbound", "outbound"),
         "source" => hash_including("manual", "interval", "threshold")
       )
+    end
+  end
+
+  describe "Scopes" do
+    describe ".available_inbound" do
+      let(:wallet) { create(:wallet) }
+      let(:inbound_settled_available) { create(:wallet_transaction, wallet:, transaction_type: :inbound, status: :settled, remaining_amount_cents: 1000) }
+      let(:inbound_settled_exhausted) { create(:wallet_transaction, wallet:, transaction_type: :inbound, status: :settled, remaining_amount_cents: 0) }
+      let(:inbound_pending) { create(:wallet_transaction, wallet:, transaction_type: :inbound, status: :pending, remaining_amount_cents: 1000) }
+      let(:outbound_settled) { create(:wallet_transaction, wallet:, transaction_type: :outbound, status: :settled) }
+
+      before do
+        inbound_settled_available
+        inbound_settled_exhausted
+        inbound_pending
+        outbound_settled
+      end
+
+      it "returns only inbound settled transactions with remaining balance" do
+        expect(described_class.available_inbound).to eq([inbound_settled_available])
+      end
+    end
+
+    describe ".in_consumption_order" do
+      let(:wallet) { create(:wallet) }
+      let!(:granted_priority_10) { create(:wallet_transaction, wallet:, transaction_status: :granted, priority: 10, created_at: 1.day.ago) }
+      let!(:purchased_priority_5) { create(:wallet_transaction, wallet:, transaction_status: :purchased, priority: 5, created_at: 2.days.ago) }
+      let!(:granted_priority_5) { create(:wallet_transaction, wallet:, transaction_status: :granted, priority: 5, created_at: 3.days.ago) }
+      let!(:granted_priority_5_newer) { create(:wallet_transaction, wallet:, transaction_status: :granted, priority: 5, created_at: 1.day.ago) }
+
+      it "orders by priority, then granted before purchased, then by created_at" do
+        expect(described_class.in_consumption_order).to eq([
+          granted_priority_5, # priority 5, granted, oldest
+          granted_priority_5_newer, # priority 5, granted, newer
+          purchased_priority_5, # priority 5, purchased
+          granted_priority_10 # priority 10, granted
+        ])
+      end
     end
   end
 

--- a/spec/services/credits/applied_prepaid_credits_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credits_service_spec.rb
@@ -417,6 +417,54 @@ RSpec.describe Credits::AppliedPrepaidCreditsService do
       end
     end
 
+    context "when wallet is traceable" do
+      let(:wallets) { [traceable_wallet] }
+      let(:traceable_wallet) do
+        create(:wallet, name: "traceable", customer:, balance_cents: 1000, credits_balance: 10.0, traceable: true)
+      end
+      let!(:inbound_transaction) do
+        create(:wallet_transaction,
+          wallet: traceable_wallet,
+          organization: traceable_wallet.organization,
+          transaction_type: :inbound,
+          transaction_status: :granted,
+          status: :settled,
+          amount: 10,
+          credit_amount: 10,
+          remaining_amount_cents: 1000)
+      end
+
+      it "tracks consumption from inbound transactions" do
+        expect { result }.to change(WalletTransactionConsumption, :count).by(1)
+      end
+
+      it "creates consumption record linking inbound and outbound" do
+        result
+
+        consumption = WalletTransactionConsumption.last
+        expect(consumption.inbound_wallet_transaction).to eq(inbound_transaction)
+        expect(consumption.outbound_wallet_transaction).to eq(result.wallet_transactions.first)
+        expect(consumption.consumed_amount_cents).to eq(100)
+      end
+
+      it "decrements remaining_amount_cents on inbound transaction" do
+        result
+
+        expect(inbound_transaction.reload.remaining_amount_cents).to eq(900)
+      end
+    end
+
+    context "when wallet is not traceable" do
+      let(:wallets) { [non_traceable_wallet] }
+      let(:non_traceable_wallet) do
+        create(:wallet, name: "non-traceable", customer:, balance_cents: 1000, credits_balance: 10.0, traceable: false)
+      end
+
+      it "does not create consumption records" do
+        expect { result }.not_to change(WalletTransactionConsumption, :count)
+      end
+    end
+
     context "when wallet optimistic lock fails" do
       def mock_wallet_balance_decrease_service(succeed_on_attempt: 5)
         attempts = 0

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -107,5 +107,61 @@ RSpec.describe WalletTransactions::CreateService do
         expect(wallet_transaction.payment_method_type).to eq("provider")
       end
     end
+
+    context "with traceable wallet" do
+      let(:credit_amount) { 100 }
+      let(:wallet) { create(:wallet, customer:, currency:, traceable: true) }
+
+      context "when transaction is inbound" do
+        let(:transaction_params) do
+          {
+            status: :settled,
+            transaction_type: :inbound,
+            transaction_status: :purchased
+          }
+        end
+
+        it "initializes remaining_amount_cents to amount_cents" do
+          wallet_transaction = result.wallet_transaction
+
+          expect(wallet_transaction.remaining_amount_cents).to eq(wallet_transaction.amount_cents)
+        end
+      end
+
+      context "when transaction is outbound" do
+        let(:transaction_params) do
+          {
+            status: :settled,
+            transaction_type: :outbound,
+            transaction_status: :invoiced
+          }
+        end
+
+        it "does not set remaining_amount_cents" do
+          wallet_transaction = result.wallet_transaction
+
+          expect(wallet_transaction.remaining_amount_cents).to be_nil
+        end
+      end
+    end
+
+    context "with non-traceable wallet" do
+      let(:credit_amount) { 100 }
+      let(:wallet) { create(:wallet, customer:, currency:, traceable: false) }
+
+      let(:transaction_params) do
+        {
+          status: :settled,
+          transaction_type: :inbound,
+          transaction_status: :purchased
+        }
+      end
+
+      it "does not set remaining_amount_cents" do
+        wallet_transaction = result.wallet_transaction
+
+        expect(wallet_transaction.remaining_amount_cents).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/wallet_transactions/track_consumption_service_spec.rb
+++ b/spec/services/wallet_transactions/track_consumption_service_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WalletTransactions::TrackConsumptionService do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:, organization:, balance_cents: 10000, credits_balance: 100.0) }
+
+  describe "#call" do
+    subject(:result) { described_class.call(outbound_wallet_transaction:) }
+
+    context "when consuming by priority" do
+      let!(:inbound_granted) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :inbound,
+          transaction_status: :granted,
+          status: :settled,
+          amount: 30,
+          credit_amount: 30,
+          remaining_amount_cents: 3000,
+          priority: 10)
+      end
+
+      let!(:inbound_purchased) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :inbound,
+          transaction_status: :purchased,
+          status: :settled,
+          amount: 70,
+          credit_amount: 70,
+          remaining_amount_cents: 7000,
+          priority: 10)
+      end
+
+      let(:outbound_wallet_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :outbound,
+          transaction_status: :invoiced,
+          status: :settled,
+          amount: 50,
+          credit_amount: 50)
+      end
+
+      it "creates consumption records following granted-first priority" do
+        expect { result }.to change(WalletTransactionConsumption, :count).by(2)
+      end
+
+      it "consumes granted credits first" do
+        result
+
+        consumptions = outbound_wallet_transaction.fundings.order(:consumed_amount_cents)
+        expect(consumptions.first.inbound_wallet_transaction).to eq(inbound_purchased)
+        expect(consumptions.first.consumed_amount_cents).to eq(2000)
+
+        expect(consumptions.second.inbound_wallet_transaction).to eq(inbound_granted)
+        expect(consumptions.second.consumed_amount_cents).to eq(3000)
+      end
+
+      it "decrements remaining_amount_cents on inbound transactions" do
+        result
+
+        expect(inbound_granted.reload.remaining_amount_cents).to eq(0)
+        expect(inbound_purchased.reload.remaining_amount_cents).to eq(5000)
+      end
+
+      it "returns a success result" do
+        expect(result).to be_success
+      end
+    end
+
+    context "when outbound amount exceeds available inbound amount" do
+      let(:inbound_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :inbound,
+          transaction_status: :purchased,
+          status: :settled,
+          amount: 30,
+          credit_amount: 30,
+          remaining_amount_cents: 3000)
+      end
+
+      let(:outbound_wallet_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :outbound,
+          transaction_status: :invoiced,
+          status: :settled,
+          amount: 50,
+          credit_amount: 50)
+      end
+
+      before do
+        inbound_transaction
+      end
+
+      it "does not create consumption records" do
+        expect { result }.not_to change(WalletTransactionConsumption, :count)
+      end
+
+      it "returns a failure result" do
+        expect(result).to be_failure
+        expect(result.error.messages[:amount_cents]).to eq(["exceeds_available_amount"])
+      end
+    end
+
+    context "with multiple inbound transactions of different priorities" do
+      let!(:inbound_low_priority) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :inbound,
+          transaction_status: :granted,
+          status: :settled,
+          amount: 50,
+          credit_amount: 50,
+          remaining_amount_cents: 5000,
+          priority: 20,
+          created_at: 2.days.ago)
+      end
+
+      let!(:inbound_high_priority) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :inbound,
+          transaction_status: :granted,
+          status: :settled,
+          amount: 50,
+          credit_amount: 50,
+          remaining_amount_cents: 5000,
+          priority: 10,
+          created_at: 1.day.ago)
+      end
+
+      let(:outbound_wallet_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :outbound,
+          transaction_status: :invoiced,
+          status: :settled,
+          amount: 60,
+          credit_amount: 60)
+      end
+
+      it "consumes from higher priority (lower number) first" do
+        result
+
+        expect(inbound_high_priority.reload.remaining_amount_cents).to eq(0)
+        expect(inbound_low_priority.reload.remaining_amount_cents).to eq(4000)
+      end
+    end
+
+    context "with inbound transactions of same priority but different created_at" do
+      let!(:inbound_older) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :inbound,
+          transaction_status: :granted,
+          status: :settled,
+          amount: 50,
+          credit_amount: 50,
+          remaining_amount_cents: 5000,
+          priority: 10,
+          created_at: 2.days.ago)
+      end
+
+      let!(:inbound_newer) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :inbound,
+          transaction_status: :granted,
+          status: :settled,
+          amount: 50,
+          credit_amount: 50,
+          remaining_amount_cents: 5000,
+          priority: 10,
+          created_at: 1.day.ago)
+      end
+
+      let(:outbound_wallet_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :outbound,
+          transaction_status: :invoiced,
+          status: :settled,
+          amount: 60,
+          credit_amount: 60)
+      end
+
+      it "consumes from older transactions first (FIFO)" do
+        result
+
+        expect(inbound_older.reload.remaining_amount_cents).to eq(0)
+        expect(inbound_newer.reload.remaining_amount_cents).to eq(4000)
+      end
+    end
+
+    context "when no inbound transactions with remaining balance exist" do
+      let(:outbound_wallet_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :outbound,
+          transaction_status: :invoiced,
+          status: :settled,
+          amount: 50,
+          credit_amount: 50)
+      end
+
+      it "returns a failure result" do
+        expect(result).to be_failure
+        expect(result.error.messages[:amount_cents]).to eq(["exceeds_available_amount"])
+      end
+    end
+
+    context "when outbound amount is zero" do
+      let!(:inbound_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :inbound,
+          transaction_status: :purchased,
+          status: :settled,
+          amount: 100,
+          credit_amount: 100,
+          remaining_amount_cents: 10000)
+      end
+
+      let(:outbound_wallet_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          organization:,
+          transaction_type: :outbound,
+          transaction_status: :invoiced,
+          status: :settled,
+          amount: 0,
+          credit_amount: 0)
+      end
+
+      it "does not create any consumption records" do
+        expect { result }.not_to change(WalletTransactionConsumption, :count)
+      end
+
+      it "does not decrement inbound remaining_amount_cents" do
+        result
+
+        expect(inbound_transaction.reload.remaining_amount_cents).to eq(10000)
+      end
+
+      it "returns a success result" do
+        expect(result).to be_success
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Customers can't distinguish when free credits (granted) or prepaid credits (purchased) are used. The wallet traceability feature enables tracking which inbound wallet transactions (purchased/granted credits) are consumed by outbound transactions (invoice applications). This provides visibility into whether free or prepaid credits were used.

Here's the list of all the high-level implementation steps:

  | #   | Work Breakdown                                 | Description                                                               |
  |-----|------------------------------------------------|---------------------------------------------------------------------------|
  | 1   | Track consumption when applying prepaid credit | Core traceability infrastructure: join table, models, consumption service |
  | 2   | Voiding wallet credits                         | Handle voiding inbound transactions and reverse consumption records       |
  | 3   | Voiding invoice                                | Handle voiding invoices that consumed wallet credits                      |
  | 4   | Credit Notes on Prepaid Credit invoices        | Handle credit notes for invoices paid with wallet credits                 |
  | 5   | API: Retrieving Consumptions and Fundings      | REST API endpoints for consumption/funding data                           |
  | 6   | GraphQL: Retrieving Consumptions and Fundings  | GraphQL API for consumption/funding data                                  |
  | 7   | Invoice PDF Template Changes                   | Display free vs prepaid credits breakdown on invoice PDFs                 |
  | 8   | Migrating wallets to be traceable              | Rake task to backfill existing wallets with consumption records           |

## Description

This implements step #1 of the above breakdown: Implement core traceability infrastructure to track which inbound transactions fund each outbound transaction when prepaid credits are applied to an invoice.

### Join-table approach

The implementation uses a join table approach with a new `wallet_transaction_consumptions` table that links outbound transactions to their source inbound transactions. Each record captures which inbound transaction funded (partially or fully) an outbound transaction and how much was consumed in cents. This approach is non-breaking, doesn't increase the number of wallet transactions, and provides flexibility for complex scenarios like partial consumption and multiple sources.

Each inbound transaction tracks its `remaining_amount_cents` to know how much is still available for consumption. A partial index on `wallet_transactions` enables efficient lookup of available inbound transactions. Database-level constraints (including a trigger) ensure data integrity by validating that inbound transactions are actually inbound and outbound transactions are actually outbound.

*Example 1: Simple Consumption (Single Source)*

Customer tops up $100, then consumes $40:

```
INBOUND                                   OUTBOUND
┌─────────────────────────┐              ┌─────────────────────────┐
│ TX1 (purchased)         │              │ TX2 (invoiced)          │
│ amount: $100            │────$40─────▶ │ amount: $40             │
│ remaining: $60          │              │                         │
└─────────────────────────┘              └─────────────────────────┘

Join table:
│ TX1 │ TX2 │ $40 │
```

*Example 2: Consumption Spanning Multiple Inbounds*

Customer has two top-ups ($30 granted, $50 purchased), then consumes $60:

```
INBOUND                                 OUTBOUND
┌─────────────────────────┐
│ TX1 (granted)           │             ┌─────────────────────────┐
│ amount: $30             │────$30─────▶│ TX3 (invoiced)          │
│ remaining: $0           │         ┌──▶│ amount: $60             │
└─────────────────────────┘         │   └─────────────────────────┘
┌─────────────────────────┐         │
│ TX2 (purchased)         │         │
│ amount: $50             │───$30───┘
│ remaining: $20          │
└─────────────────────────┘

Join table:
│ TX1 │ TX3 │ $30 │  (granted consumed first)
│ TX2 │ TX3 │ $30 │  (then purchased)
```

*Example 3: Multiple Outbounds from Same Inbound*

Customer tops up $100, then has two invoices ($25 and $35):

```
INBOUND                              OUTBOUND
┌─────────────────────────┐              ┌─────────────────────────┐
│ TX1 (purchased)         │────$25──────▶│ TX2 (invoiced)          │
│ amount: $100            │              │ amount: $25             │
│ remaining: $40          │              └─────────────────────────┘
│                         │              ┌─────────────────────────┐
│                         │────$35──────▶│ TX3 (invoiced)          │
│                         │              │ amount: $35             │
└─────────────────────────┘              └─────────────────────────┘

Join table:
│ TX1 │ TX2 │ $25 │
│ TX1 │ TX3 │ $35 │
```

Note that such scenario is bound to create a drift between the sum of the derived consumed credits and the inbound transaction credits:

```
Wallet rate: 0.66666

INBOUND                                  OUTBOUND
┌─────────────────────────┐              ┌─────────────────────────┐
│ TX1 (purchased)         │────$25──────▶│ TX2 (invoiced)          │
│ amount: $100            │              │ amount: $65             │
│ credits: 150.00150      │              │ credits: 97.50099       │
│ remaining: $0           │              │                         │ 
│ remaining_credits: 0    │              └─────────────────────────┘
│                         │              ┌─────────────────────────┐
│                         │────$35──────▶│ TX3 (invoiced)          │
│                         │              │ amount: $35             │
│                         │              │ credits: 52.50053       │
└─────────────────────────┘              └─────────────────────────┘

Join table:
│ TX1 │ TX2 │ $25 │
│ TX1 │ TX3 │ $35 │

Credits of inbound TX = 150.00150
Sum of credits from outbounds = 150.00152 != 150.00150
Sum of credits from consumption table = 150.00152 != 150.00150
```

*Example 4: Complex Scenario with Priority*

Customer has: $20 granted (priority 1), $50 purchased, $30 granted (priority 2).

Then consumes $80:

```
INBOUND (ordered by priority)        OUTBOUND
┌─────────────────────────┐
│ TX1 (granted, prio 1)   │            ┌─────────────────────────┐
│ amount: $20             │────$20────▶│ TX4 (invoiced)          │
│ remaining: $0           │         ┌─▶│ amount: $80             │
└─────────────────────────┘         │  │                         │
┌─────────────────────────┐         │  │                         │
│ TX3 (granted, prio 2)   │         │  │                         │
│ amount: $30             │───$30───┘  │                         │
│ remaining: $0           │         ┌─▶│                         │
└─────────────────────────┘         │  └─────────────────────────┘
┌─────────────────────────┐         │
│ TX2 (purchased)         │         │
│ amount: $50             │───$30───┘
│ remaining: $20          │
└─────────────────────────┘

Consumption order: TX1 (granted, prio 1) → TX3 (granted, prio 2) → TX2 (purchased)

Join table:
│ TX1 │ TX4 │ $20 │  (granted, priority 1)
│ TX3 │ TX4 │ $30 │  (granted, priority 2)
│ TX2 │ TX4 │ $30 │  (purchased, last)
```

### Wallet-Level Traceability Flag

Traceability is controlled per-wallet via a traceable boolean flag, allowing gradual rollout. When credits are applied to an invoice for a traceable wallet, the system calls `WalletTransactions::TrackConsumptionService` which implements a FIFO consumption strategy: granted credits are consumed first (ordered by priority, then created_at), followed by purchased credits in the same order. This ensures free credits are used before paid ones.

Once feature is ready: new wallets will be created with `traceable = true`.