### PR TITLE
feat(charge): Auto-generate codes for charges and fixed charges

### DIFF
--- a/app/services/charges/generate_code_service.rb
+++ b/app/services/charges/generate_code_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Charges
+  class GenerateCodeService < BaseService
+    Result = BaseResult[:code]
+
+    def initialize(plan:, billable_metric:)
+      @plan = plan
+      @billable_metric = billable_metric
+
+      super
+    end
+
+    def call
+      result.code = generate_unique_code
+      result
+    end
+
+    private
+
+    attr_reader :plan, :billable_metric
+
+    def generate_unique_code
+      base_code = billable_metric.code
+
+      return base_code unless plan.charges.parents.exists?(code: base_code)
+
+      existing_suffixes = plan.charges.parents
+        .where("code ~ ?", "^#{Regexp.escape(base_code)}_\\d+$")
+        .pluck(:code)
+        .map { |code| code.delete_prefix("#{base_code}_").to_i }
+
+      next_suffix = (existing_suffixes.max || 1) + 1
+
+      "#{base_code}_#{next_suffix}"
+    end
+  end
+end

--- a/app/services/fixed_charges/create_service.rb
+++ b/app/services/fixed_charges/create_service.rb
@@ -64,7 +64,7 @@ module FixedCharges
     delegate :organization, to: :plan
 
     def add_on
-      if params[:add_on_id].present?
+      @add_on ||= if params[:add_on_id].present?
         organization.add_ons.find(params[:add_on_id])
       elsif params[:add_on_code].present?
         organization.add_ons.find_by!(code: params[:add_on_code])

--- a/app/services/fixed_charges/generate_code_service.rb
+++ b/app/services/fixed_charges/generate_code_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module FixedCharges
+  class GenerateCodeService < BaseService
+    Result = BaseResult[:code]
+
+    def initialize(plan:, add_on:)
+      @plan = plan
+      @add_on = add_on
+
+      super
+    end
+
+    def call
+      result.code = generate_unique_code
+      result
+    end
+
+    private
+
+    attr_reader :plan, :add_on
+
+    def generate_unique_code
+      base_code = add_on.code
+
+      return base_code unless plan.fixed_charges.parents.exists?(code: base_code)
+
+      existing_suffixes = plan.fixed_charges.parents
+        .where("code ~ ?", "^#{Regexp.escape(base_code)}_\\d+$")
+        .pluck(:code)
+        .map { |code| code.delete_prefix("#{base_code}_").to_i }
+
+      next_suffix = (existing_suffixes.max || 1) + 1
+
+      "#{base_code}_#{next_suffix}"
+    end
+  end
+end

--- a/spec/services/charges/generate_code_service_spec.rb
+++ b/spec/services/charges/generate_code_service_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Charges::GenerateCodeService do
+  subject(:result) { described_class.call(plan:, billable_metric:) }
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+
+  describe "#call" do
+    context "when no charges exist for the plan" do
+      it "generates code without suffix" do
+        expect(result.code).to eq("api_calls")
+      end
+    end
+
+    context "when a charge exists with the base code" do
+      before do
+        create(:standard_charge, plan:, billable_metric:, code: "api_calls")
+      end
+
+      it "generates code with suffix _2" do
+        expect(result.code).to eq("api_calls_2")
+      end
+    end
+
+    context "when charges exist with numeric suffixes" do
+      before do
+        create(:standard_charge, plan:, billable_metric:, code: "api_calls")
+        create(:standard_charge, plan:, billable_metric:, code: "api_calls_2")
+      end
+
+      it "generates code with next available suffix" do
+        expect(result.code).to eq("api_calls_3")
+      end
+    end
+
+    context "when multiple charges exist with gaps in suffixes" do
+      before do
+        create(:standard_charge, plan:, billable_metric:, code: "api_calls")
+        create(:standard_charge, plan:, billable_metric:, code: "api_calls_3")
+        create(:standard_charge, plan:, billable_metric:, code: "api_calls_5")
+      end
+
+      it "generates code with suffix one greater than the maximum" do
+        expect(result.code).to eq("api_calls_6")
+      end
+    end
+
+    context "when charges exist with similar but non-matching prefixes" do
+      before do
+        other_billable_metric = create(:billable_metric, organization:, code: "api_calls_premium")
+        create(:standard_charge, plan:, billable_metric: other_billable_metric, code: "api_calls_premium")
+      end
+
+      it "generates code without suffix" do
+        expect(result.code).to eq("api_calls")
+      end
+    end
+
+    context "when charges exist without numeric suffixes" do
+      before do
+        create(:standard_charge, plan:, billable_metric:, code: "api_calls_custom")
+      end
+
+      it "generates code without suffix" do
+        expect(result.code).to eq("api_calls")
+      end
+    end
+
+    context "when child charges exist with base code" do
+      let(:parent_plan) { create(:plan, organization:) }
+      let(:parent_charge) { create(:standard_charge, plan: parent_plan, billable_metric:, code: "api_calls") }
+
+      before do
+        create(:standard_charge, plan:, billable_metric:, code: "api_calls", parent: parent_charge)
+      end
+
+      it "ignores child charges and generates code without suffix" do
+        expect(result.code).to eq("api_calls")
+      end
+    end
+  end
+end

--- a/spec/services/fixed_charges/generate_code_service_spec.rb
+++ b/spec/services/fixed_charges/generate_code_service_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FixedCharges::GenerateCodeService do
+  subject(:result) { described_class.call(plan:, add_on:) }
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:add_on) { create(:add_on, organization:, code: "setup_fee") }
+
+  describe "#call" do
+    context "when no fixed charges exist for the plan" do
+      it "generates code without suffix" do
+        expect(result.code).to eq("setup_fee")
+      end
+    end
+
+    context "when a fixed charge exists with the base code" do
+      before do
+        create(:fixed_charge, plan:, add_on:, code: "setup_fee")
+      end
+
+      it "generates code with suffix _2" do
+        expect(result.code).to eq("setup_fee_2")
+      end
+    end
+
+    context "when fixed charges exist with numeric suffixes" do
+      before do
+        create(:fixed_charge, plan:, add_on:, code: "setup_fee")
+        create(:fixed_charge, plan:, add_on:, code: "setup_fee_2")
+      end
+
+      it "generates code with next available suffix" do
+        expect(result.code).to eq("setup_fee_3")
+      end
+    end
+
+    context "when multiple fixed charges exist with gaps in suffixes" do
+      before do
+        create(:fixed_charge, plan:, add_on:, code: "setup_fee")
+        create(:fixed_charge, plan:, add_on:, code: "setup_fee_3")
+        create(:fixed_charge, plan:, add_on:, code: "setup_fee_5")
+      end
+
+      it "generates code with suffix one greater than the maximum" do
+        expect(result.code).to eq("setup_fee_6")
+      end
+    end
+
+    context "when fixed charges exist with similar but non-matching prefixes" do
+      before do
+        other_add_on = create(:add_on, organization:, code: "setup_fee_premium")
+        create(:fixed_charge, plan:, add_on: other_add_on, code: "setup_fee_premium")
+      end
+
+      it "generates code without suffix" do
+        expect(result.code).to eq("setup_fee")
+      end
+    end
+
+    context "when fixed charges exist without numeric suffixes" do
+      before do
+        create(:fixed_charge, plan:, add_on:, code: "setup_fee_custom")
+      end
+
+      it "generates code without suffix" do
+        expect(result.code).to eq("setup_fee")
+      end
+    end
+
+    context "when child fixed charges exist with base code" do
+      let(:parent_plan) { create(:plan, organization:) }
+      let(:parent_fixed_charge) { create(:fixed_charge, plan: parent_plan, add_on:, code: "setup_fee") }
+
+      before do
+        create(:fixed_charge, plan:, add_on:, code: "setup_fee", parent: parent_fixed_charge)
+      end
+
+      it "ignores child fixed charges and generates code without suffix" do
+        expect(result.code).to eq("setup_fee")
+      end
+    end
+  end
+end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -264,6 +264,14 @@ RSpec.describe Plans::CreateService do
       )
     end
 
+    it "auto-generates charge codes when not provided" do
+      plan = result.plan
+      charges = plan.charges.order(:created_at)
+
+      expect(charges.first.code).to eq(billable_metric.code)
+      expect(charges.second.code).to eq(sum_billable_metric.code)
+    end
+
     it "creates fixed charges" do
       plan = result.plan
       expect(plan.fixed_charges.count).to eq(1)
@@ -278,6 +286,12 @@ RSpec.describe Plans::CreateService do
         units: 0,
         properties: {"amount" => "0"}
       )
+    end
+
+    it "auto-generates fixed charge codes when not provided" do
+      plan = result.plan
+
+      expect(plan.fixed_charges.first.code).to eq(add_on.code)
     end
 
     it "calls SegmentTrackJob" do

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -564,6 +564,11 @@ RSpec.describe Plans::UpdateService do
           result = plans_service.call
           expect(result.plan.charges.count).to eq(1)
         end
+
+        it "auto-generates charge code when not provided" do
+          result = plans_service.call
+          expect(result.plan.charges.first.code).to eq(sum_billable_metric.code)
+        end
       end
 
       context "with premium charge model" do
@@ -1436,6 +1441,12 @@ RSpec.describe Plans::UpdateService do
           expect(result.plan.bill_fixed_charges_monthly).to eq(true)
           expect(result.plan.fixed_charges.count).to eq(2)
           expect(result.plan.fixed_charges.map(&:invoice_display_name)).to match_array(["fixed_charge1", "fixed_charge2"])
+        end
+
+        it "auto-generates fixed charge codes when not provided" do
+          result = plans_service.call
+
+          expect(result.plan.fixed_charges.pluck(:code)).to match_array([add_on.code, "#{add_on.code}_2"])
         end
       end
 


### PR DESCRIPTION
## Context

When creating charges and fixed charges through plan services, users may not always provide a code. To ensure every charge has a unique identifier, codes should be auto-generated based on the associated billable metric or add-on code.

## Description

Add GenerateCodeService for both Charges and FixedCharges that creates unique codes by appending numeric suffixes (e.g., api_calls_1, api_calls_2) to the base billable metric or add-on code. The services find the highest existing suffix and increment it.

Integrate code generation into Plans::CreateService and Plans::UpdateService so that charges without codes automatically receive generated ones.
