### PR TITLE
misc: expose billing entity billing config on customer portal

### DIFF
--- a/app/graphql/types/customer_portal/customers/object.rb
+++ b/app/graphql/types/customer_portal/customers/object.rb
@@ -22,6 +22,7 @@ module Types
         field :tax_identification_number, String, null: true
 
         field :billing_configuration, Types::Customers::BillingConfiguration, null: true
+        field :billing_entity_billing_configuration, Types::BillingEntities::BillingConfiguration, null: false
 
         # Billing address
         field :address_line1, String, null: true
@@ -39,6 +40,13 @@ module Types
           {
             id: "#{object&.id}-c0nf",
             document_locale: object&.document_locale
+          }
+        end
+
+        def billing_entity_billing_configuration
+          {
+            id: "#{object&.billing_entity&.id}-c1nf",
+            document_locale: object&.billing_entity&.document_locale
           }
         end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4260,6 +4260,7 @@ type CustomerPortalCustomer {
   addressLine2: String
   applicableTimezone: TimezoneEnum!
   billingConfiguration: CustomerBillingConfiguration
+  billingEntityBillingConfiguration: BillingEntityBillingConfiguration!
   city: String
   country: CountryCode
   currency: CurrencyEnum

--- a/schema.json
+++ b/schema.json
@@ -18902,6 +18902,22 @@
               "deprecationReason": null
             },
             {
+              "name": "billingEntityBillingConfiguration",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "BillingEntityBillingConfiguration",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "city",
               "description": null,
               "args": [],

--- a/spec/graphql/mutations/customer_portal/update_customer_spec.rb
+++ b/spec/graphql/mutations/customer_portal/update_customer_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe Mutations::CustomerPortal::UpdateCustomer do
           billingConfiguration {
             documentLocale
           }
+          billingEntityBillingConfiguration {
+            documentLocale
+          }
           shippingAddress {
             addressLine1
             addressLine2
@@ -94,6 +97,7 @@ RSpec.describe Mutations::CustomerPortal::UpdateCustomer do
     expect(result_data["state"]).to eq(input[:state])
     expect(result_data["country"]).to eq(input[:country])
     expect(result_data["billingConfiguration"]["documentLocale"]).to eq(input[:documentLocale])
+    expect(result_data["billingEntityBillingConfiguration"]["documentLocale"]).to eq(customer.billing_entity.document_locale)
     expect(result_data["shippingAddress"]["addressLine1"]).to eq(input[:shippingAddress][:addressLine1])
     expect(result_data["shippingAddress"]["addressLine2"]).to eq(input[:shippingAddress][:addressLine2])
     expect(result_data["shippingAddress"]["zipcode"]).to eq(input[:shippingAddress][:zipcode])

--- a/spec/graphql/resolvers/customer_portal/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customer_resolver_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe Resolvers::CustomerPortal::CustomerResolver do
           id
           name
           currency
+          billingEntityBillingConfiguration {
+            documentLocale
+          }
         }
       }
     GQL
@@ -35,6 +38,7 @@ RSpec.describe Resolvers::CustomerPortal::CustomerResolver do
       expect(customer_response["id"]).to eq(customer.id)
       expect(customer_response["name"]).to eq(customer.name)
       expect(customer_response["currency"]).to eq("EUR")
+      expect(customer_response["billingEntityBillingConfiguration"]["documentLocale"]).to eq(customer.billing_entity.document_locale)
     end
   end
 


### PR DESCRIPTION
## Context

Frontend app relies on either the customer document locale OR the customer billing entity locale.

Issue is that today, Frontend relies on previous customer organization document locale, which is deprecated and should not be used anymore

## Description

This PR exposes the correct document locale, and only exposes the required fields as this is used in portal context.

Had to `def billing_entity_billing_configuration` and not expose the billing entity object directly as rewriting the attribute returns a Hash and not an object, leading to fail at runtime during fetch