### PR TITLE
feat(charge-filters): Add CRUD endpoints for charge filters

### DIFF
--- a/app/controllers/api/v1/plans/charges/filters_controller.rb
+++ b/app/controllers/api/v1/plans/charges/filters_controller.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Plans
+      module Charges
+        class FiltersController < Api::BaseController
+          before_action :find_plan
+          before_action :find_charge
+          before_action :find_charge_filter, only: %i[show update destroy]
+
+          def index
+            charge_filters = charge.filters
+              .includes(:charge, :billable_metric_filters)
+              .page(params[:page])
+              .per(params[:per_page] || PER_PAGE)
+
+            render(
+              json: ::CollectionSerializer.new(
+                charge_filters,
+                ::V1::ChargeFilterSerializer,
+                collection_name: "filters",
+                meta: pagination_metadata(charge_filters)
+              )
+            )
+          end
+
+          def show
+            render(json: ::V1::ChargeFilterSerializer.new(charge_filter, root_name: "filter"))
+          end
+
+          def create
+            result = ChargeFilters::CreateService.call(charge:, params: input_params.to_h.deep_symbolize_keys)
+
+            if result.success?
+              render(
+                json: ::V1::ChargeFilterSerializer.new(
+                  result.charge_filter,
+                  root_name: "filter"
+                )
+              )
+            else
+              render_error_response(result)
+            end
+          end
+
+          def update
+            result = ChargeFilters::UpdateService.call(charge_filter:, params: input_params.to_h.deep_symbolize_keys)
+
+            if result.success?
+              render(
+                json: ::V1::ChargeFilterSerializer.new(
+                  result.charge_filter,
+                  root_name: "filter"
+                )
+              )
+            else
+              render_error_response(result)
+            end
+          end
+
+          def destroy
+            result = ChargeFilters::DestroyService.call(charge_filter:)
+
+            if result.success?
+              render(
+                json: ::V1::ChargeFilterSerializer.new(
+                  result.charge_filter,
+                  root_name: "filter"
+                )
+              )
+            else
+              render_error_response(result)
+            end
+          end
+
+          private
+
+          attr_reader :plan, :charge, :charge_filter
+
+          def input_params
+            params.require(:filter).permit(
+              :invoice_display_name,
+              properties: {},
+              values: {}
+            )
+          end
+
+          def find_plan
+            @plan = current_organization.plans.parents.find_by!(code: params[:plan_code])
+          rescue ActiveRecord::RecordNotFound
+            not_found_error(resource: "plan")
+          end
+
+          def find_charge
+            @charge = plan.charges.parents.find_by!(code: params[:charge_code])
+          rescue ActiveRecord::RecordNotFound
+            not_found_error(resource: "charge")
+          end
+
+          def find_charge_filter
+            @charge_filter = charge.filters.find_by!(id: params[:id])
+          rescue ActiveRecord::RecordNotFound
+            not_found_error(resource: "charge_filter")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/plans/charges_controller.rb
+++ b/app/controllers/api/v1/plans/charges_controller.rb
@@ -37,7 +37,7 @@ module Api
         end
 
         def create
-          result = Charges::CreateService.call(plan:, params: input_params.to_h.deep_symbolize_keys)
+          result = ::Charges::CreateService.call(plan:, params: input_params.to_h.deep_symbolize_keys)
 
           if result.success?
             render(
@@ -53,7 +53,7 @@ module Api
         end
 
         def update
-          result = Charges::UpdateService.call(charge:, params: input_params.to_h.deep_symbolize_keys)
+          result = ::Charges::UpdateService.call(charge:, params: input_params.to_h.deep_symbolize_keys)
 
           if result.success?
             render(
@@ -69,7 +69,7 @@ module Api
         end
 
         def destroy
-          result = Charges::DestroyService.call(charge:)
+          result = ::Charges::DestroyService.call(charge:)
 
           if result.success?
             render(

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -39,7 +39,7 @@ module V1
 
     def charge_filters
       ::CollectionSerializer.new(
-        model.filters.includes(:billable_metric_filters),
+        model.filters.includes(:charge, :billable_metric_filters),
         ::V1::ChargeFilterSerializer,
         collection_name: "filters"
       ).serialize

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -131,7 +131,7 @@ module ChargeFilters
     end
 
     def remove_filter(filter)
-      filter.values.each(&:discard!)
+      filter.values.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
       filter.discard!
     end
 

--- a/app/services/charge_filters/create_service.rb
+++ b/app/services/charge_filters/create_service.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  class CreateService < BaseService
+    Result = BaseResult[:charge_filter]
+
+    def initialize(charge:, params:)
+      @charge = charge
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "charge") unless charge
+      return result.single_validation_failure!(field: :values, error_code: "value_is_mandatory") if params[:values].blank?
+
+      ActiveRecord::Base.transaction do
+        charge_filter = charge.filters.create!(
+          organization_id: charge.organization_id,
+          invoice_display_name: params[:invoice_display_name],
+          properties: filtered_properties
+        )
+
+        create_filter_values(charge_filter)
+
+        result.charge_filter = charge_filter
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :charge, :params
+
+    def filtered_properties
+      ChargeModels::FilterPropertiesService.call(
+        chargeable: charge,
+        properties: params[:properties]
+      ).properties
+    end
+
+    def create_filter_values(charge_filter)
+      params[:values].each do |key, values|
+        billable_metric_filter = charge.billable_metric.filters.find_by(key:)
+
+        filter_value = charge_filter.values.new(
+          billable_metric_filter_id: billable_metric_filter&.id,
+          organization_id: charge.organization_id
+        )
+        filter_value.values = values
+        filter_value.save!
+      end
+    end
+  end
+end

--- a/app/services/charge_filters/destroy_service.rb
+++ b/app/services/charge_filters/destroy_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  class DestroyService < BaseService
+    Result = BaseResult[:charge_filter]
+
+    def initialize(charge_filter:)
+      @charge_filter = charge_filter
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "charge_filter") unless charge_filter
+
+      ActiveRecord::Base.transaction do
+        charge_filter.values.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+        charge_filter.discard!
+
+        result.charge_filter = charge_filter
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :charge_filter
+  end
+end

--- a/app/services/charge_filters/update_service.rb
+++ b/app/services/charge_filters/update_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  class UpdateService < BaseService
+    Result = BaseResult[:charge_filter]
+
+    def initialize(charge_filter:, params:)
+      @charge_filter = charge_filter
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "charge_filter") unless charge_filter
+
+      ActiveRecord::Base.transaction do
+        charge_filter.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+        charge_filter.properties = filtered_properties if params.key?(:properties)
+        charge_filter.save!
+
+        result.charge_filter = charge_filter
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :charge_filter, :params
+
+    delegate :charge, to: :charge_filter
+
+    def filtered_properties
+      ChargeModels::FilterPropertiesService.call(
+        chargeable: charge,
+        properties: params[:properties]
+      ).properties
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,9 @@ Rails.application.routes.draw do
       resources :payment_requests, only: %i[create index show]
       resources :payments, only: %i[create index show]
       resources :plans, param: :code, code: /.*/ do
-        resources :charges, only: %i[index show create update destroy], param: :code, code: /.*/, controller: "plans/charges"
+        resources :charges, only: %i[index show create update destroy], param: :code, code: /.*/, controller: "plans/charges" do
+          resources :filters, only: %i[index show create update destroy], controller: "plans/charges/filters"
+        end
         resources :fixed_charges, only: %i[index show create update destroy], param: :code, code: /.*/, controller: "plans/fixed_charges"
         resources :entitlements, only: %i[index show create destroy], param: :code, code: /.*/, controller: "plans/entitlements" do
           resources :privileges, only: %i[destroy], param: :code, code: /.*/, controller: "plans/entitlements/privileges"

--- a/spec/requests/api/v1/plans/charges/filters_controller_spec.rb
+++ b/spec/requests/api/v1/plans/charges/filters_controller_spec.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Plans::Charges::FiltersController do
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+  let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
+
+  describe "GET /api/v1/plans/:plan_code/charges/:charge_code/filters" do
+    subject { get_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge.code}/filters") }
+
+    let(:charge_filter) { create(:charge_filter, charge:) }
+
+    before do
+      create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["us"])
+    end
+
+    it "returns a list of charge filters" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:filters]).to be_present
+      expect(json[:filters].length).to eq(1)
+      expect(json[:filters].first[:lago_id]).to eq(charge_filter.id)
+    end
+
+    it "returns pagination metadata" do
+      subject
+
+      expect(json[:meta]).to include(
+        current_page: 1,
+        next_page: nil,
+        prev_page: nil,
+        total_pages: 1,
+        total_count: 1
+      )
+    end
+
+    context "when plan does not exist" do
+      subject { get_with_token(organization, "/api/v1/plans/invalid_code/charges/#{charge.code}/filters") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("plan")
+      end
+    end
+
+    context "when charge does not exist" do
+      subject { get_with_token(organization, "/api/v1/plans/#{plan.code}/charges/invalid_code/filters") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge")
+      end
+    end
+  end
+
+  describe "GET /api/v1/plans/:plan_code/charges/:charge_code/filters/:id" do
+    subject { get_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge.code}/filters/#{charge_filter.id}") }
+
+    let(:charge_filter) { create(:charge_filter, charge:, invoice_display_name: "US Region") }
+
+    before do
+      create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["us"])
+    end
+
+    it "returns the charge filter" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:filter][:lago_id]).to eq(charge_filter.id)
+      expect(json[:filter][:invoice_display_name]).to eq("US Region")
+      expect(json[:filter][:values]).to eq({region: ["us"]})
+    end
+
+    context "when plan does not exist" do
+      subject { get_with_token(organization, "/api/v1/plans/invalid_code/charges/#{charge.code}/filters/#{charge_filter.id}") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("plan")
+      end
+    end
+
+    context "when charge does not exist" do
+      subject { get_with_token(organization, "/api/v1/plans/#{plan.code}/charges/invalid_code/filters/#{charge_filter.id}") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge")
+      end
+    end
+
+    context "when charge filter does not exist" do
+      subject { get_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge.code}/filters/#{SecureRandom.uuid}") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge_filter")
+      end
+    end
+  end
+
+  describe "POST /api/v1/plans/:plan_code/charges/:charge_code/filters" do
+    subject { post_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge.code}/filters", {filter: create_params}) }
+
+    let(:create_params) do
+      {
+        invoice_display_name: "US Region Filter",
+        properties: {amount: "50"},
+        values: {billable_metric_filter.key => ["us"]}
+      }
+    end
+
+    it "creates a new charge filter" do
+      expect { subject }.to change { charge.filters.count }.by(1)
+
+      expect(response).to have_http_status(:success)
+      expect(json[:filter][:invoice_display_name]).to eq("US Region Filter")
+      expect(json[:filter][:properties]).to include(amount: "50")
+      expect(json[:filter][:values]).to eq({region: ["us"]})
+    end
+
+    context "when plan does not exist" do
+      subject { post_with_token(organization, "/api/v1/plans/invalid_code/charges/#{charge.code}/filters", {filter: create_params}) }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("plan")
+      end
+    end
+
+    context "when charge does not exist" do
+      subject { post_with_token(organization, "/api/v1/plans/#{plan.code}/charges/invalid_code/filters", {filter: create_params}) }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge")
+      end
+    end
+
+    context "when values are missing" do
+      let(:create_params) do
+        {
+          invoice_display_name: "US Region Filter",
+          properties: {amount: "50"}
+        }
+      end
+
+      it "returns validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details]).to include(:values)
+      end
+    end
+  end
+
+  describe "PUT /api/v1/plans/:plan_code/charges/:charge_code/filters/:id" do
+    subject { put_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge.code}/filters/#{charge_filter.id}", {filter: update_params}) }
+
+    let(:charge_filter) { create(:charge_filter, charge:, invoice_display_name: "Original Name", properties: {"amount" => "10"}) }
+    let(:update_params) do
+      {
+        invoice_display_name: "Updated Name",
+        properties: {amount: "100"}
+      }
+    end
+
+    before do
+      create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["us"])
+    end
+
+    it "updates the charge filter" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:filter][:invoice_display_name]).to eq("Updated Name")
+      expect(json[:filter][:properties]).to include(amount: "100")
+    end
+
+    context "when plan does not exist" do
+      subject { put_with_token(organization, "/api/v1/plans/invalid_code/charges/#{charge.code}/filters/#{charge_filter.id}", {filter: update_params}) }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("plan")
+      end
+    end
+
+    context "when charge does not exist" do
+      subject { put_with_token(organization, "/api/v1/plans/#{plan.code}/charges/invalid_code/filters/#{charge_filter.id}", {filter: update_params}) }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge")
+      end
+    end
+
+    context "when charge filter does not exist" do
+      subject { put_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge.code}/filters/#{SecureRandom.uuid}", {filter: update_params}) }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge_filter")
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/plans/:plan_code/charges/:charge_code/filters/:id" do
+    subject { delete_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge.code}/filters/#{charge_filter.id}") }
+
+    let(:charge_filter) { create(:charge_filter, charge:) }
+    let(:charge_filter_value) do
+      create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["us"])
+    end
+
+    before { charge_filter_value }
+
+    it "soft deletes the charge filter" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:filter][:lago_id]).to eq(charge_filter.id)
+      expect(charge_filter.reload.deleted_at).to be_present
+    end
+
+    it "soft deletes the charge filter values" do
+      subject
+
+      expect(charge_filter_value.reload.deleted_at).to be_present
+    end
+
+    context "when plan does not exist" do
+      subject { delete_with_token(organization, "/api/v1/plans/invalid_code/charges/#{charge.code}/filters/#{charge_filter.id}") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("plan")
+      end
+    end
+
+    context "when charge does not exist" do
+      subject { delete_with_token(organization, "/api/v1/plans/#{plan.code}/charges/invalid_code/filters/#{charge_filter.id}") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge")
+      end
+    end
+
+    context "when charge filter does not exist" do
+      subject { delete_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge.code}/filters/#{SecureRandom.uuid}") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge_filter")
+      end
+    end
+  end
+end

--- a/spec/services/charge_filters/create_service_spec.rb
+++ b/spec/services/charge_filters/create_service_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeFilters::CreateService do
+  subject(:service) { described_class.call(charge:, params:) }
+
+  let(:charge) { create(:standard_charge) }
+  let(:params) { {} }
+
+  let(:card_location_filter) do
+    create(
+      :billable_metric_filter,
+      billable_metric: charge.billable_metric,
+      key: "card_location",
+      values: %w[domestic international]
+    )
+  end
+
+  let(:scheme_filter) do
+    create(
+      :billable_metric_filter,
+      billable_metric: charge.billable_metric,
+      key: "scheme",
+      values: %w[visa mastercard]
+    )
+  end
+
+  describe "#call" do
+    context "when charge is nil" do
+      let(:charge) { nil }
+
+      it "returns not found failure" do
+        expect(service).not_to be_success
+        expect(service.error).to be_a(BaseService::NotFoundFailure)
+        expect(service.error.resource).to eq("charge")
+      end
+    end
+
+    context "when values are empty" do
+      let(:params) do
+        {
+          invoice_display_name: "Test Filter",
+          properties: {amount: "10"},
+          values: {}
+        }
+      end
+
+      before { card_location_filter }
+
+      it "returns a validation failure" do
+        expect(service).not_to be_success
+        expect(service.error).to be_a(BaseService::ValidationFailure)
+        expect(service.error.messages[:values]).to eq(["value_is_mandatory"])
+      end
+    end
+
+    context "when values are missing" do
+      let(:params) do
+        {
+          invoice_display_name: "Test Filter",
+          properties: {amount: "10"}
+        }
+      end
+
+      before { card_location_filter }
+
+      it "returns a validation failure" do
+        expect(service).not_to be_success
+        expect(service.error).to be_a(BaseService::ValidationFailure)
+        expect(service.error.messages[:values]).to eq(["value_is_mandatory"])
+      end
+    end
+
+    context "with valid params" do
+      let(:params) do
+        {
+          invoice_display_name: "Domestic Visa",
+          properties: {amount: "50"},
+          values: {
+            card_location_filter.key => ["domestic"],
+            scheme_filter.key => ["visa"]
+          }
+        }
+      end
+
+      it "creates a charge filter" do
+        expect { service }.to change(ChargeFilter, :count).by(1)
+        expect(service).to be_success
+
+        charge_filter = service.charge_filter
+        expect(charge_filter).to have_attributes(
+          invoice_display_name: "Domestic Visa",
+          properties: {"amount" => "50"},
+          organization_id: charge.organization_id
+        )
+      end
+
+      it "creates charge filter values" do
+        expect { service }.to change(ChargeFilterValue, :count).by(2)
+
+        charge_filter = service.charge_filter
+        expect(charge_filter.values.count).to eq(2)
+        expect(charge_filter.to_h).to eq({
+          "card_location" => ["domestic"],
+          "scheme" => ["visa"]
+        })
+      end
+    end
+
+    context "with graduated charge model" do
+      let(:charge) { create(:graduated_charge) }
+      let(:params) do
+        {
+          invoice_display_name: "Domestic Filter",
+          properties: {
+            amount: "10",
+            graduated_ranges: [{from_value: 0, to_value: nil, per_unit_amount: "0", flat_amount: "200"}]
+          },
+          values: {card_location_filter.key => ["domestic"]}
+        }
+      end
+
+      it "filters properties based on charge model" do
+        expect(service).to be_success
+
+        charge_filter = service.charge_filter
+        expect(charge_filter.properties).to eq(
+          "graduated_ranges" => [
+            {"from_value" => 0, "to_value" => nil, "per_unit_amount" => "0", "flat_amount" => "200"}
+          ]
+        )
+        expect(charge_filter.properties).not_to have_key("amount")
+      end
+    end
+
+    context "with pricing_group_keys in properties" do
+      let(:params) do
+        {
+          invoice_display_name: "Grouped Filter",
+          properties: {amount: "30", pricing_group_keys: ["region"]},
+          values: {card_location_filter.key => ["domestic"]}
+        }
+      end
+
+      it "preserves pricing_group_keys in properties" do
+        expect(service).to be_success
+
+        charge_filter = service.charge_filter
+        expect(charge_filter.properties).to eq({
+          "amount" => "30",
+          "pricing_group_keys" => ["region"]
+        })
+      end
+    end
+  end
+end

--- a/spec/services/charge_filters/destroy_service_spec.rb
+++ b/spec/services/charge_filters/destroy_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeFilters::DestroyService do
+  subject(:service) { described_class.call(charge_filter:) }
+
+  let(:charge) { create(:standard_charge) }
+  let(:charge_filter) { create(:charge_filter, charge:) }
+
+  let(:card_location_filter) do
+    create(
+      :billable_metric_filter,
+      billable_metric: charge.billable_metric,
+      key: "card_location",
+      values: %w[domestic international]
+    )
+  end
+
+  describe "#call" do
+    context "when charge_filter is nil" do
+      subject(:service) { described_class.call(charge_filter: nil) }
+
+      it "returns not found failure" do
+        expect(service).not_to be_success
+        expect(service.error).to be_a(BaseService::NotFoundFailure)
+        expect(service.error.resource).to eq("charge_filter")
+      end
+    end
+
+    context "with valid charge_filter" do
+      let(:filter_value) do
+        create(:charge_filter_value, charge_filter:, billable_metric_filter: card_location_filter, values: ["domestic"])
+      end
+
+      before { filter_value }
+
+      it "soft deletes the charge filter" do
+        expect { service }.to change { charge_filter.reload.discarded? }.from(false).to(true)
+        expect(service).to be_success
+        expect(service.charge_filter).to eq(charge_filter)
+      end
+
+      it "soft deletes the charge filter values" do
+        expect { service }.to change { filter_value.reload.discarded? }.from(false).to(true)
+      end
+
+      it "returns the discarded charge filter" do
+        result = service
+        expect(result.charge_filter.deleted_at).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/charge_filters/update_service_spec.rb
+++ b/spec/services/charge_filters/update_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeFilters::UpdateService do
+  subject(:service) { described_class.call(charge_filter:, params:) }
+
+  let(:charge) { create(:standard_charge) }
+  let(:charge_filter) { create(:charge_filter, charge:, invoice_display_name: "Original Name", properties: {"amount" => "10"}) }
+  let(:params) { {} }
+
+  let(:card_location_filter) do
+    create(
+      :billable_metric_filter,
+      billable_metric: charge.billable_metric,
+      key: "card_location",
+      values: %w[domestic international]
+    )
+  end
+
+  describe "#call" do
+    context "when charge_filter is nil" do
+      subject(:service) { described_class.call(charge_filter: nil, params: {}) }
+
+      it "returns not found failure" do
+        expect(service).not_to be_success
+        expect(service.error).to be_a(BaseService::NotFoundFailure)
+        expect(service.error.resource).to eq("charge_filter")
+      end
+    end
+
+    context "when updating invoice_display_name and properties" do
+      let(:params) do
+        {
+          invoice_display_name: "New Display Name",
+          properties: {amount: "200"}
+        }
+      end
+
+      before do
+        create(:charge_filter_value, charge_filter:, billable_metric_filter: card_location_filter, values: ["domestic"])
+      end
+
+      it "updates both attributes" do
+        expect(service).to be_success
+        expect(charge_filter.reload).to have_attributes(
+          invoice_display_name: "New Display Name",
+          properties: {"amount" => "200"}
+        )
+      end
+    end
+
+    context "with graduated charge model" do
+      let(:charge) { create(:graduated_charge) }
+      let(:charge_filter) { create(:charge_filter, charge:, properties: {"graduated_ranges" => [{"from_value" => 0, "to_value" => nil, "per_unit_amount" => "0", "flat_amount" => "100"}]}) }
+      let(:params) do
+        {
+          properties: {
+            amount: "10",
+            graduated_ranges: [{from_value: 0, to_value: nil, per_unit_amount: "0", flat_amount: "200"}]
+          }
+        }
+      end
+
+      it "filters properties based on charge model" do
+        expect(service).to be_success
+        expect(charge_filter.reload.properties).to eq(
+          "graduated_ranges" => [
+            {"from_value" => 0, "to_value" => nil, "per_unit_amount" => "0", "flat_amount" => "200"}
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to make charges and charge filters independent from the plan/subscription object, enabling
add/update of a single charge or charge filter without sending the entire plan's payload.

## Description

This adds the ability to manage charge filters individually through dedicated API endpoints, rather than only through the batch update mechanism on charges.

Add new REST API endpoints for charge filters nested under charges:
- `GET /api/v1/plans/:plan_code/charges/:charge_code/filters`
- `GET /api/v1/plans/:plan_code/charges/:charge_code/filters/:id`
- `POST /api/v1/plans/:plan_code/charges/:charge_code/filters`
- `PUT /api/v1/plans/:plan_code/charges/:charge_code/filters/:id`
- `DELETE /api/v1/plans/:plan_code/charges/:charge_code/filters/:id`

Create dedicated services for filter management:
- `ChargeFilters::CreateService` for creating individual filters
- `ChargeFilters::UpdateService` for updating filter properties
- `ChargeFilters::DestroyService` for soft-deleting filters
