### PR TITLE
feat(api-logs): Use request_id generated by ActionDispatch

### DIFF
--- a/app/services/utils/api_log.rb
+++ b/app/services/utils/api_log.rb
@@ -12,11 +12,11 @@ module Utils
         ENV["LAGO_KAFKA_API_LOGS_TOPIC"].present?
     end
 
-    def initialize(request, response, organization:, request_id: SecureRandom.uuid, &block)
+    def initialize(request, response, organization:, &block)
       @request = request
       @response = response
       @organization = organization
-      @request_id = request_id
+      @request_id = request.request_id.presence || SecureRandom.uuid
       @block = block
     end
 


### PR DESCRIPTION
When an API call is returned, Rails will automatically generate a request_id, which is set in `x-request-id` header in the response.

This PR sets this ID as the `request_id` of the ApiLog entry instead of random uuid, so you can easily reconsolidate your logs with the Lago ApiLogs.

In clickhouse, the request ID is marked as string, there was never a restriction on the id being UUID.

<img width="1000" height="563" alt="CleanShot 2026-01-09 at 11 44 39@2x" src="https://github.com/user-attachments/assets/2a342786-32d8-4daf-8049-aa5ebc61e546" />

<img width="2572" height="1580" alt="CleanShot 2026-01-09 at 11 50 59@2x" src="https://github.com/user-attachments/assets/c6539fd4-d899-4098-9824-23d97f51d798" />
