### PR TITLE
Feat(metadata): extend object flexibility

### DIFF
--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -46,7 +46,7 @@ module Metadata
           end
 
           # validation: hashes inside the main object cannot be bigger than 500 characters
-          next if val.values.all? { |v| [String, Array, Hash].include?(v.class) && v.to_json.size <= MAX_INNER_HASH_SIZE }
+          next if val.values.all? { |v| [String, Array, Hash].include?(v.class) ? v.to_json.size <= MAX_INNER_HASH_SIZE : true }
           errors.add(:value, "all values in hash for key '#{key}' must have max json size of #{MAX_INNER_HASH_SIZE} characters")
         when "Array"
           if val.size > MAX_NUMBER_OF_KEYS


### PR DESCRIPTION
## Context

sometimes it's required to store more complex structures of values inside of metadata. Current PR allow to store arrays, hashes, and other types inside of the top-level objects, however hashes inside top-level hashes cannot have objects with json-size more than 500 symbols

## Description

Changed validation on item_metadata value