### PR TITLE
misc(clickhouse): Bump clickhouse-activerecord to 1.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "rack-cors"
 
 # Database
 gem "after_commit_everywhere"
-gem "clickhouse-activerecord", "~> 1.3.0"
+gem "clickhouse-activerecord", "~> 1.5.1"
 gem "discard", "~> 1.2"
 gem "kaminari-activerecord"
 gem "paper_trail"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (12.0.0)
-    clickhouse-activerecord (1.3.1)
+    clickhouse-activerecord (1.5.1)
       activerecord (>= 7.1, < 9.0)
       bundler (>= 1.13.4)
     clockwork (3.0.2)
@@ -1092,7 +1092,7 @@ DEPENDENCIES
   bigdecimal
   bootsnap
   bullet
-  clickhouse-activerecord (~> 1.3.0)
+  clickhouse-activerecord (~> 1.5.1)
   clockwork
   clockwork-test
   coffee-rails


### PR DESCRIPTION
## Description

This PR bumps clickhouse-activerecord from `v1.3.1` to `v1.5.1`.

The key improvement will be the fix of the schema export including `ar_internal_metadata` and `schema_migrations` tables.

Check https://github.com/PNixx/clickhouse-activerecord/releases for more details about other changes