### PR TITLE
fix(fee): Pricing group keys for pay in advance fees

### DIFF
--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -197,9 +197,10 @@ module Fees
     end
 
     def format_grouped_by
-      return {} if properties["grouped_by"].blank?
+      grouped_by = properties["pricing_group_keys"].presence || properties["grouped_by"]
+      return {} if grouped_by.blank?
 
-      properties["grouped_by"].index_with { event.properties[it] }
+      grouped_by.index_with { event.properties[it] }
     end
 
     def customer_provider_taxation?

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -307,7 +307,52 @@ RSpec.describe Fees::CreatePayInAdvanceService do
         expect(result.fees.first.applied_taxes.count).to eq(1)
       end
 
-      context "when chargefilter has a grouped_by defined" do
+      context "when charge filter has pricing_group_keys defined" do
+        let(:charge_filter) { create(:charge_filter, charge:, properties: {:amount => "1", "pricing_group_keys" => ["group_key"]}) }
+        let(:event_properties) do
+          {
+            payment_method: "card",
+            card_location: "international",
+            scheme: "visa",
+            card_type: "credit",
+            group_key: "group_value"
+          }
+        end
+
+        it "creates a fee" do
+          result = fee_service.call
+
+          expect(result).to be_success
+
+          expect(result.fees.count).to eq(1)
+          expect(result.fees.first).to have_attributes(
+            subscription:,
+            charge:,
+            amount_cents: 10,
+            precise_amount_cents: 10.0,
+            amount_currency: "EUR",
+            fee_type: "charge",
+            pay_in_advance: true,
+            invoiceable: charge,
+            units: 9,
+            properties: Hash,
+            events_count: 1,
+            charge_filter:,
+            pay_in_advance_event_id: event.id,
+            pay_in_advance_event_transaction_id: event.transaction_id,
+            unit_amount_cents: 1,
+            precise_unit_amount: 0.01111111111,
+            grouped_by: {"group_key" => "group_value"},
+
+            taxes_rate: 20.0,
+            taxes_amount_cents: 2,
+            taxes_precise_amount_cents: 2.0
+          )
+          expect(result.fees.first.applied_taxes.count).to eq(1)
+        end
+      end
+
+      context "when charge filter has a grouped_by defined" do
         let(:charge_filter) { create(:charge_filter, charge:, properties: {:amount => "1", "grouped_by" => ["group_key"]}) }
         let(:event_properties) do
           {


### PR DESCRIPTION
## Context

With the changes introduced by PR https://github.com/getlago/lago-api/pull/3681, the migration from `grouped_by` to `pricing_group_keys` was not migrated correctly in the `Fees::CreatePayInAdvanceService`. The service was not assigning correctly the `pricing_group_keys` to the resulting fee as it was still relying only on the `grouped_by` attribute.

NOTE: the issue as no impact to the billing itself, as the `fees#grouped_by` attribute is only informative and is not use for billing purpse

## Description

This PR makes sure that the `pricing_group_keys` is assigned correctly to the in advance fees.