### PR TITLE
fix(e-invoices): Handle `progressive_billing` invoice type in `delivery_date`

### DIFF
--- a/app/serializers/e_invoices/invoices/common.rb
+++ b/app/serializers/e_invoices/invoices/common.rb
@@ -25,7 +25,7 @@ module EInvoices
         case invoice.invoice_type
         when "one_off", "credit"
           invoice.created_at
-        when "subscription"
+        when "subscription", "progressive_billing"
           invoice.subscriptions.map do |subscription|
             ::Subscriptions::DatesService.new_instance(subscription, Time.current, current_usage: true)
               .charges_from_datetime


### PR DESCRIPTION
## Description

The `delivery_date` method in the e-invoices serializer was missing handling for `progressive_billing` invoice type, causing a `NoMethodError` when calling `strftime` on nil during PDF/XML generation.

Add `progressive_billing` to the case statement alongside `subscription` type, using subscription-based delivery date calculation.
