### PR TITLE
feat(fixed-charges) GraphQL: expose fixed charge boundaries for InvoiceSubscription

### DIFF
--- a/app/graphql/types/invoice_subscriptions/object.rb
+++ b/app/graphql/types/invoice_subscriptions/object.rb
@@ -20,6 +20,12 @@ module Types
       field :in_advance_charges_from_datetime, GraphQL::Types::ISO8601DateTime, null: true
       field :in_advance_charges_to_datetime, GraphQL::Types::ISO8601DateTime, null: true
 
+      field :fixed_charges_from_datetime, GraphQL::Types::ISO8601DateTime, null: true
+      field :fixed_charges_to_datetime, GraphQL::Types::ISO8601DateTime, null: true
+
+      field :in_advance_fixed_charges_from_datetime, GraphQL::Types::ISO8601DateTime, null: true
+      field :in_advance_fixed_charges_to_datetime, GraphQL::Types::ISO8601DateTime, null: true
+
       field :from_datetime, GraphQL::Types::ISO8601DateTime, null: true
       field :to_datetime, GraphQL::Types::ISO8601DateTime, null: true
 
@@ -49,6 +55,32 @@ module Types
       def charge_pay_in_advance_interval
         @charge_pay_in_advance_interval ||=
           ::Subscriptions::DatesService.charge_pay_in_advance_interval(object.timestamp, object.subscription)
+      end
+
+      def in_advance_fixed_charges_from_datetime
+        return nil unless should_use_in_advance_fixed_charges_interval?
+
+        fixed_charge_pay_in_advance_interval[:fixed_charges_from_datetime]
+      end
+
+      def in_advance_fixed_charges_to_datetime
+        return nil unless should_use_in_advance_fixed_charges_interval?
+
+        fixed_charge_pay_in_advance_interval[:fixed_charges_to_datetime]
+      end
+
+      def should_use_in_advance_fixed_charges_interval?
+        return @should_use_in_advance_fixed_charges_interval if defined? @should_use_in_advance_fixed_charges_interval
+
+        @should_use_in_advance_fixed_charges_interval =
+          object.fees.fixed_charge.any? &&
+          object.subscription.fixed_charges.pay_in_advance.any? &&
+          !object.subscription.plan.pay_in_advance?
+      end
+
+      def fixed_charge_pay_in_advance_interval
+        @fixed_charge_pay_in_advance_interval ||=
+          ::Subscriptions::DatesService.fixed_charge_pay_in_advance_interval(object.timestamp, object.subscription)
       end
 
       def accept_new_charge_fees

--- a/schema.graphql
+++ b/schema.graphql
@@ -6168,9 +6168,13 @@ type InvoiceSubscription {
   chargesFromDatetime: ISO8601DateTime
   chargesToDatetime: ISO8601DateTime
   fees: [Fee!]
+  fixedChargesFromDatetime: ISO8601DateTime
+  fixedChargesToDatetime: ISO8601DateTime
   fromDatetime: ISO8601DateTime
   inAdvanceChargesFromDatetime: ISO8601DateTime
   inAdvanceChargesToDatetime: ISO8601DateTime
+  inAdvanceFixedChargesFromDatetime: ISO8601DateTime
+  inAdvanceFixedChargesToDatetime: ISO8601DateTime
   invoice: Invoice!
   subscription: Subscription!
   subscriptionAmountCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -32141,6 +32141,30 @@
               "deprecationReason": null
             },
             {
+              "name": "fixedChargesFromDatetime",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fixedChargesToDatetime",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "fromDatetime",
               "description": null,
               "args": [],
@@ -32166,6 +32190,30 @@
             },
             {
               "name": "inAdvanceChargesToDatetime",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inAdvanceFixedChargesFromDatetime",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inAdvanceFixedChargesToDatetime",
               "description": null,
               "args": [],
               "type": {

--- a/spec/graphql/types/invoice_subscriptions/object_spec.rb
+++ b/spec/graphql/types/invoice_subscriptions/object_spec.rb
@@ -18,8 +18,14 @@ RSpec.describe Types::InvoiceSubscriptions::Object do
     expect(subject).to have_field(:charges_from_datetime).of_type("ISO8601DateTime")
     expect(subject).to have_field(:charges_to_datetime).of_type("ISO8601DateTime")
 
+    expect(subject).to have_field(:fixed_charges_from_datetime).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:fixed_charges_to_datetime).of_type("ISO8601DateTime")
+
     expect(subject).to have_field(:in_advance_charges_from_datetime).of_type("ISO8601DateTime")
     expect(subject).to have_field(:in_advance_charges_to_datetime).of_type("ISO8601DateTime")
+
+    expect(subject).to have_field(:in_advance_fixed_charges_from_datetime).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:in_advance_fixed_charges_to_datetime).of_type("ISO8601DateTime")
 
     expect(subject).to have_field(:from_datetime).of_type("ISO8601DateTime")
     expect(subject).to have_field(:to_datetime).of_type("ISO8601DateTime")


### PR DESCRIPTION
## Context

Currently frontend uses charge boundaries from invoice subscription to properly render the fees in the right sections depending on its boundaries. However, InvoiceSubscription object type does not expose fixed charge and in advance fixed charge boundaries.

## Description

This change adds these boundaries to InvoiceSubscription in order to ease the UI rendering the fees in the right sections.

Ideally, this information should be rather extracted from the fee object boundaries (from/to datetime) that should have the right set of boundaries based on the fee type and in arrears / in advance configuration.

Update GraphQL schemas