### PR TITLE
fix(alerting): Fix alert when billable_metrics is not part of the plan charges

### DIFF
--- a/app/services/usage_monitoring/process_alert_service.rb
+++ b/app/services/usage_monitoring/process_alert_service.rb
@@ -14,6 +14,10 @@ module UsageMonitoring
     def call
       now = Time.current
       current = alert.find_value(current_metrics)
+
+      # NOTE: If the alert is set for a billable metric which is not part of any charges of the plan
+      return result if current.nil?
+
       crossed_threshold_values = alert.find_thresholds_crossed(current)
 
       ActiveRecord::Base.transaction do


### PR DESCRIPTION
It's possible to create an alert for billable metric `seats` even if there is no charge based on the `seats` billable metric.
In this case, there is no fees with this BM in the current_usage, so the `find_value` method returns nil.

In this case, we should early return. today, we get a `NoMethodError: undefined method '<=' for nil` error 🙄 