### PR TITLE
test: Fix broken tests

### DIFF
--- a/spec/requests/api/v1/features_controller_spec.rb
+++ b/spec/requests/api/v1/features_controller_spec.rb
@@ -165,8 +165,7 @@ RSpec.describe Api::V1::FeaturesController do
       end
 
       it "creates a feature without privileges" do
-        expect { subject }.to change(Entitlement::Feature, :count).by(1)
-        expect { subject }.not_to change(Entitlement::Privilege, :count)
+        expect { subject }.to change(Entitlement::Feature, :count).by(1).and(not_change(Entitlement::Privilege, :count))
 
         expect(response).to have_http_status(:success)
         expect(json[:feature][:code]).to eq("new_feature")

--- a/spec/services/auth/token_service_spec.rb
+++ b/spec/services/auth/token_service_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Auth::TokenService do
           renew = described_class.decode(token: subject)
 
           expect(renew["sub"]).to eq(old["sub"])
-          expect(renew["login_method"]).to eq(renew["login_method"])
+          expect(renew["login_method"]).to eq(old["login_method"])
           expect(renew["exp"].to_i).to be > old["exp"].to_i
         end
       end

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -395,12 +395,12 @@ RSpec.describe Customers::UpdateService do
             aggregate_failures do
               expect(result).to be_success
 
-              customer = result.customer
-              expect(customer.id).to eq(customer.id)
-              expect(customer.payment_provider).to be_nil
+              result_customer = result.customer
+              expect(result_customer.id).to eq(customer.id)
+              expect(result_customer.payment_provider).to be_nil
 
-              expect(customer.stripe_customer).to eq(stripe_customer)
-              expect(customer.stripe_customer.provider_customer_id).to be_nil
+              expect(result_customer.stripe_customer).to eq(stripe_customer)
+              expect(result_customer.stripe_customer.provider_customer_id).to be_nil
             end
           end
         end

--- a/spec/services/entitlement/feature_create_service_spec.rb
+++ b/spec/services/entitlement/feature_create_service_spec.rb
@@ -203,8 +203,7 @@ RSpec.describe Entitlement::FeatureCreateService do
       end
 
       it "creates a feature without privileges" do
-        expect { subject }.to change(Entitlement::Feature, :count).by(1)
-        expect { subject }.not_to change(Entitlement::Privilege, :count)
+        expect { subject }.to change(Entitlement::Feature, :count).by(1).and(not_change(Entitlement::Privilege, :count))
 
         result = subject
         expect(result).to be_success

--- a/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
@@ -174,8 +174,7 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService do
       end
 
       it "creates entitlement without values" do
-        expect { result }.to change { plan.entitlements.count }.by(1)
-        expect { result }.not_to change(Entitlement::EntitlementValue, :count)
+        expect { result }.to change { plan.entitlements.count }.by(1).and(not_change(Entitlement::EntitlementValue, :count))
       end
     end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -313,15 +313,15 @@ RSpec.describe Fees::ChargeService do
 
           context "with custom aggregation" do
             let(:billable_metric) do
-              create(:custom_aggregation_billable_metric, organization:)
+              create(:custom_billable_metric, :recurring, organization:)
+            end
 
-              it "creates a fee and a cached aggregation" do
-                result = charge_subscription_service.call
-                expect(result).to be_success
+            it "creates a fee and a cached aggregation" do
+              result = charge_subscription_service.call
+              expect(result).to be_success
 
-                expect(result.fees.count).to eq(2)
-                expect(result.cached_aggregation.count).to eq(2)
-              end
+              expect(result.fees.count).to eq(2)
+              expect(result.cached_aggregations.count).to eq(2)
             end
           end
         end
@@ -658,15 +658,15 @@ RSpec.describe Fees::ChargeService do
 
           context "with custom aggregation" do
             let(:billable_metric) do
-              create(:custom_aggregation_billable_metric, organization:)
+              create(:custom_billable_metric, :recurring, organization:)
+            end
 
-              it "creates a fee and a cached aggregation" do
-                result = charge_subscription_service.call
-                expect(result).to be_success
+            it "creates a fee and a cached aggregation" do
+              result = charge_subscription_service.call
+              expect(result).to be_success
 
-                expect(result.fees.count).to eq(2)
-                expect(result.cached_aggregation.count).to eq(2)
-              end
+              expect(result.fees.count).to eq(2)
+              expect(result.cached_aggregations.count).to eq(2)
             end
           end
         end

--- a/spec/services/integration_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_batch_service_spec.rb
@@ -267,10 +267,7 @@ RSpec.describe IntegrationCustomers::CreateOrUpdateBatchService do
         end
 
         it "processes the job immediately" do
-          aggregate_failures do
-            expect { service_call }.to change(IntegrationCustomers::BaseCustomer, :count).by(1)
-            expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::CreateJob)
-          end
+          expect { service_call }.to change(IntegrationCustomers::BaseCustomer, :count).by(1).and(not_have_enqueued_job(IntegrationCustomers::CreateJob))
         end
       end
     end

--- a/spec/services/invoices/preview/find_subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/find_subscriptions_service_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService do
       context "when subscription has a next subscription" do
         let(:current_plan) { create(:plan, organization:, pay_in_advance: true) }
         let(:next_plan) { create(:plan, organization:, pay_in_advance:, amount_cents:) }
-        let(:subscription) { create(:subscription, plan: current_plan, customer:, organization:, next_subscriptions: [next_subscription]) }
-        let(:next_subscription) { create(:subscription, :pending, plan: next_plan, customer:, organization:) }
+        let!(:subscription) { create(:subscription, plan: current_plan, customer:, organization:, next_subscriptions: [next_subscription]) }
+        let!(:next_subscription) { create(:subscription, :pending, plan: next_plan, customer:, organization:) }
 
         let(:subscriptions) { [subscription] }
 
@@ -74,8 +74,7 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService do
             end
 
             it "does not persist any changes to the subscriptions" do
-              expect { subject }.not_to change { subscription.reload.attributes }
-              expect { subject }.not_to change { next_subscription.reload.attributes }
+              expect { subject }.to not_change { subscription.reload.attributes }.and(not_change { next_subscription.reload.attributes })
             end
           end
 
@@ -101,8 +100,7 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService do
             end
 
             it "does not persist any changes to the subscriptions" do
-              expect { subject }.not_to change { subscription.reload.attributes }
-              expect { subject }.not_to change { next_subscription.reload.attributes }
+              expect { subject }.to not_change { subscription.reload.attributes }.and(not_change { next_subscription.reload.attributes })
             end
           end
         end
@@ -119,8 +117,8 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService do
             end
 
             it "does not persist any changes to the subscriptions" do
-              expect { subject }.not_to change { subscription.reload.attributes }
-              expect { subject }.not_to change { next_subscription.reload.attributes }
+              expect { subject }.to not_change { subscription.reload.attributes }
+                .and(not_change { next_subscription.reload.attributes })
             end
           end
 
@@ -140,8 +138,7 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService do
             end
 
             it "does not persist any changes to the subscriptions" do
-              expect { subject }.not_to change { subscription.reload.attributes }
-              expect { subject }.not_to change { next_subscription.reload.attributes }
+              expect { subject }.to not_change { subscription.reload.attributes }.and(not_change { next_subscription.reload.attributes })
             end
           end
         end

--- a/spec/support/matchers/job_matcher.rb
+++ b/spec/support/matchers/job_matcher.rb
@@ -70,3 +70,5 @@ RSpec::Matchers.define :have_enqueued_job_after_commit do |job|
     @expectation_type || :exactly
   end
 end
+
+RSpec::Matchers.define_negated_matcher :not_have_enqueued_job, :have_enqueued_job


### PR DESCRIPTION
## Context

Some tests are currently broken but still passes because of failed syntax and memoization and other tests have useless assertions:

* Some tests includes multiple calls to ` expect { subject }.to ...`. The issue here is that the `subject` is memoized on the first call and the following calls do not actually do anything. So assertions like `.not_to change` will always pass.
* Some tests includes assertions like `expect(a.attribute).to eq(a.attribute)`.
* Some tests have the `it` block in a `let` block.

## Description

To fix the first one, I had to define a `not_have_enqueued_job` matcher because it is not possible to negate with the `.and` compound expectation (i.e. there's `and_not_to` or `and(not_to())`.