### PR TITLE
chore(dependency): Update dev dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,11 +8,11 @@ plugins:
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-thread_safety
+  - rubocop-rspec
+  - rubocop-rspec_rails
 
 require:
   - standard
-  - rubocop-rspec
-  - rubocop-rspec_rails
   - ./dev/cops/service_call_cop.rb
   - ./dev/cops/discard_all_cop.rb
 
@@ -93,6 +93,31 @@ RSpec/NamedSubject:
 RSpec/DescribeClass:
   Exclude:
     - "spec/scenarios/**/*"
+
+# RSpec rules below are enabled by default in rubocop-rspec 3.X but we disabled to ease migration.
+RSpec/IndexedLet:
+  Enabled: false
+
+RSpec/MatchArray:
+  Enabled: false
+
+RSpec/MetadataStyle:
+  Enabled: false
+
+RSpec/NoExpectationExample:
+  Enabled: false
+
+RSpec/ReceiveMessages:
+  Enabled: false
+
+RSpec/VerifiedDoubleReference:
+  Enabled: false
+
+RSpec/BeEq:
+  Enabled: false
+
+RSpec/BeNil:
+  Enabled: false
 
 # GraphQL
 

--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,8 @@ group :development, :test do
   gem "rubocop-graphql", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rspec", require: false
+  gem "rubocop-rspec_rails", require: false
+  gem "rubocop-factory_bot", require: false
   gem "rubocop-thread_safety", require: false
 
   gem "vernier", "~> 1.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/glebm/i18n-tasks.git
-  revision: b7db1cb2fe1484d93ee1cf14b5100c321d16392a
+  revision: 799cc333012ae43d3ee021d90d3ca1bfcd265d7c
   specs:
     i18n-tasks (1.1.2)
       activesupport (>= 4.0.2)
@@ -376,7 +376,8 @@ GEM
       reline
     htmlbeautifier (1.4.3)
     httpclient (2.8.3)
-    httplog (1.7.3)
+    httplog (1.8.0)
+      benchmark
       rack (>= 2.0)
       rainbow (>= 2.0.0)
     i18n (1.14.7)
@@ -436,7 +437,7 @@ GEM
       karafka-core (>= 2.5.0, < 2.6.0)
       roda (~> 3.68, >= 3.69)
       tilt (~> 2.0)
-    knapsack_pro (9.0.0)
+    knapsack_pro (9.2.1)
       rake
     language_server-protocol (3.17.0.5)
     libdatadog (22.0.1.1.0)
@@ -872,7 +873,7 @@ GEM
       awesome_print (> 1.0.0)
       rspec (> 3.0.0)
     rspec-support (3.13.2)
-    rubocop (1.81.7)
+    rubocop (1.82.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -880,14 +881,12 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.47.1, < 2.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.48.0)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
-    rubocop-capybara (2.21.0)
-      rubocop (~> 1.41)
     rubocop-factory_bot (2.28.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -898,19 +897,19 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.34.2)
+    rubocop-rails (2.34.3)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
-    rubocop-rspec (2.31.0)
-      rubocop (~> 1.40)
-      rubocop-capybara (~> 2.17)
-      rubocop-factory_bot (~> 2.22)
-      rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.29.1)
-      rubocop (~> 1.61)
+    rubocop-rspec (3.9.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.81)
+    rubocop-rspec_rails (2.32.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+      rubocop-rspec (~> 3.5)
     rubocop-thread_safety (0.7.3)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -987,10 +986,10 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     stackprof (0.2.27)
-    standard (1.52.0)
+    standard (1.53.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.81.7)
+      rubocop (~> 1.82.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)
@@ -1151,10 +1150,12 @@ DEPENDENCIES
   rspec-graphql_matchers
   rspec-rails
   rspec-snapshot (~> 2.0)
+  rubocop-factory_bot
   rubocop-graphql
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rubocop-rspec_rails
   rubocop-thread_safety
   ruby-lsp-rails
   sass-rails

--- a/app/jobs/fixed_charges/cascade_plan_update_job.rb
+++ b/app/jobs/fixed_charges/cascade_plan_update_job.rb
@@ -8,15 +8,15 @@ module FixedCharges
       plan.children.joins(:subscriptions)
         .where(subscriptions: {status: %w[active pending]}).distinct
         .find_in_batches do |child_plans|
-        jobs = child_plans.map do |child_plan|
-          FixedCharges::CascadeChildPlanUpdateJob.new(
-            plan: child_plan,
-            cascade_fixed_charges_payload:,
-            timestamp:
-          )
-        end
+          jobs = child_plans.map do |child_plan|
+            FixedCharges::CascadeChildPlanUpdateJob.new(
+              plan: child_plan,
+              cascade_fixed_charges_payload:,
+              timestamp:
+            )
+          end
 
-        ActiveJob.perform_all_later(jobs)
+          ActiveJob.perform_all_later(jobs)
       end
     end
   end

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -69,35 +69,35 @@ module DataExports
           .find_each
           .lazy
           .each do |fee|
-          serialized_fee = fee_serializer_klass.new(fee).serialize
+            serialized_fee = fee_serializer_klass.new(fee).serialize
 
-          serialized_subscription = {
-            external_id: fee.subscription&.external_id,
-            plan_code: fee.subscription&.plan&.code
-          }
+            serialized_subscription = {
+              external_id: fee.subscription&.external_id,
+              plan_code: fee.subscription&.plan&.code
+            }
 
-          csv << [
-            serialized_invoice[:lago_id],
-            serialized_invoice[:number],
-            serialized_invoice[:issuing_date],
-            serialized_fee[:lago_id],
-            serialized_fee.dig(:item, :type),
-            serialized_fee.dig(:item, :code),
-            serialized_fee.dig(:item, :name),
-            serialized_fee.dig(:item, :description),
-            serialized_fee.dig(:item, :invoice_display_name),
-            serialized_fee.dig(:item, :filter_invoice_display_name),
-            serialized_fee.dig(:item, :grouped_by),
-            serialized_subscription[:external_id],
-            serialized_subscription[:plan_code],
-            serialized_fee[:from_date],
-            serialized_fee[:to_date],
-            serialized_fee[:total_amount_currency],
-            serialized_fee[:units],
-            serialized_fee[:precise_unit_amount],
-            serialized_fee[:taxes_amount_cents],
-            serialized_fee[:total_amount_cents]
-          ]
+            csv << [
+              serialized_invoice[:lago_id],
+              serialized_invoice[:number],
+              serialized_invoice[:issuing_date],
+              serialized_fee[:lago_id],
+              serialized_fee.dig(:item, :type),
+              serialized_fee.dig(:item, :code),
+              serialized_fee.dig(:item, :name),
+              serialized_fee.dig(:item, :description),
+              serialized_fee.dig(:item, :invoice_display_name),
+              serialized_fee.dig(:item, :filter_invoice_display_name),
+              serialized_fee.dig(:item, :grouped_by),
+              serialized_subscription[:external_id],
+              serialized_subscription[:plan_code],
+              serialized_fee[:from_date],
+              serialized_fee[:to_date],
+              serialized_fee[:total_amount_currency],
+              serialized_fee[:units],
+              serialized_fee[:precise_unit_amount],
+              serialized_fee[:taxes_amount_cents],
+              serialized_fee[:total_amount_cents]
+            ]
         end
       end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -217,18 +217,18 @@ module Invoices
           }
         )
         .find_each do |charge|
-        next if should_not_create_charge_fee?(charge, subscription)
+          next if should_not_create_charge_fee?(charge, subscription)
 
-        fee_result = Fees::ChargeService.call!(
-          invoice: nil,
-          charge:,
-          subscription:,
-          context: :recurring,
-          boundaries:,
-          apply_taxes: invoice.customer.tax_customer.blank?
-        )
+          fee_result = Fees::ChargeService.call!(
+            invoice: nil,
+            charge:,
+            subscription:,
+            context: :recurring,
+            boundaries:,
+            apply_taxes: invoice.customer.tax_customer.blank?
+          )
 
-        result.non_invoiceable_fees.concat(fee_result.fees)
+          result.non_invoiceable_fees.concat(fee_result.fees)
       end
     end
 

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -153,12 +153,12 @@ module Invoices
       invoice.fees = subscriptions
         .filter { |subscription| should_create_subscription_fee?(subscription) }
         .map do |subscription|
-        Fees::SubscriptionService.call!(
-          invoice:,
-          subscription:,
-          boundaries: boundaries(subscription),
-          context: :preview
-        ).fee
+          Fees::SubscriptionService.call!(
+            invoice:,
+            subscription:,
+            boundaries: boundaries(subscription),
+            context: :preview
+          ).fee
       end
     end
 

--- a/spec/controllers/concerns/common_spec.rb
+++ b/spec/controllers/concerns/common_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Common do
     context "when a malformed date sis provided" do
       let(:date) { "not-a-date" }
 
-      it "returns false " do
+      it "returns false" do
         expect(subject).to be false
       end
     end

--- a/spec/graphql/mutations/invites/accept_spec.rb
+++ b/spec/graphql/mutations/invites/accept_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Mutations::Invites::Accept do
     context "with a new user" do
       let(:invite) { create(:invite, organization:) }
 
-      it "accepts the invite " do
+      it "accepts the invite" do
         result = execute_graphql(
           current_user: membership.user,
           current_organization: organization,

--- a/spec/graphql/resolvers/events_resolver_spec.rb
+++ b/spec/graphql/resolvers/events_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::EventsResolver, transaction: false, clickhouse: true do
+RSpec.describe Resolvers::EventsResolver, clickhouse: true, transaction: false do
   let(:query) do
     <<~GQL
       query($page: Int) {

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::DeleteEventsJob, transaction: false, clickhouse: true do
+RSpec.describe BillableMetrics::DeleteEventsJob, clickhouse: true, transaction: false do
   let(:billable_metric) { create(:billable_metric, :deleted) }
   let(:subscription) { create(:subscription) }
 

--- a/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
+++ b/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
@@ -25,7 +25,7 @@ describe Clock::RetryGeneratingSubscriptionInvoicesJob, job: true do
         old_generating_invoice.update(status: :generating)
       end
 
-      it "does enqueue a BillSubscriptionJob for this invoice " do
+      it "does enqueue a BillSubscriptionJob for this invoice" do
         expect do
           described_class.perform_now
         end.to have_enqueued_job(BillSubscriptionJob)

--- a/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
@@ -18,7 +18,7 @@ describe Clock::TerminateEndedSubscriptionsJob, job: true do
       allow(Subscriptions::TerminateService).to receive(:call)
     end
 
-    it "terminates the subscriptions where ending_at matches current data " do
+    it "terminates the subscriptions where ending_at matches current data" do
       current_date = Time.current + 2.months
 
       travel_to(current_date) do

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -441,7 +441,7 @@ RSpec.describe CustomersQuery do
       let(:filters) { {metadata: {id: "1", name: "Jane Smith"}} }
 
       it "returns only the customers with the metadata" do
-        expect(returned_ids).to match_array([])
+        expect(returned_ids).to be_empty
       end
     end
 

--- a/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Analytics::InvoiceCollectionsController do # rubocop:disable RSpec/FilePath
+RSpec.describe Api::V1::Analytics::InvoiceCollectionsController do # rubocop:disable Rails/FilePath
   describe "GET /analytics/invoice_collection" do
     subject { get_with_token(organization, "/api/v1/analytics/invoice_collection", params) }
 

--- a/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Analytics::InvoicedUsagesController do # rubocop:disable RSpec/FilePath
+RSpec.describe Api::V1::Analytics::InvoicedUsagesController do # rubocop:disable Rails/FilePath
   describe "GET /analytics/invoiced_usage" do
     subject { get_with_token(organization, "/api/v1/analytics/invoiced_usage", params) }
 

--- a/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Analytics::MrrsController do # rubocop:disable RSpec/FilePath
+RSpec.describe Api::V1::Analytics::MrrsController do # rubocop:disable Rails/FilePath
   describe "GET /analytics/mrr" do
     subject { get_with_token(organization, "/api/v1/analytics/mrr", params) }
 

--- a/spec/requests/api/v1/data_api/usages_controller_spec.rb
+++ b/spec/requests/api/v1/data_api/usages_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::DataApi::UsagesController do # rubocop:disable RSpec/FilePath
+RSpec.describe Api::V1::DataApi::UsagesController do # rubocop:disable Rails/FilePath
   describe "GET /analytics/usage" do
     subject { get_with_token(organization, "/api/v1/analytics/usage", params) }
 

--- a/spec/requests/data_api/v1/charges_controller_spec.rb
+++ b/spec/requests/data_api/v1/charges_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::V1::ChargesController do # rubocop:disable RSpec/FilePath
+RSpec.describe DataApi::V1::ChargesController do # rubocop:disable Rails/FilePath
   def post_with_data_api_key(path, params = {})
     headers = {
       "Content-Type" => "application/json",

--- a/spec/scenarios/charge_models/clickhouse/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/clickhouse/prorated_graduated_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Charge Models - Prorated Graduated Scenarios", transaction: false, clickhouse: true do
+describe "Charge Models - Prorated Graduated Scenarios", clickhouse: true, transaction: false do
   let(:organization) { create(:organization, webhook_url: nil, clickhouse_events_store: true) }
   let(:customer) { create(:customer, organization:, name: "aaaaaabcd") }
   let(:tax) { create(:tax, organization:, rate: 0) }

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -752,7 +752,7 @@ describe "Pay in advance charges Scenarios", transaction: false do
     let(:field_name) { "amount" }
 
     describe "with free_units_per_events" do
-      it "creates an pay_in_advance fee " do
+      it "creates an pay_in_advance fee" do
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
 
@@ -876,7 +876,7 @@ describe "Pay in advance charges Scenarios", transaction: false do
     end
 
     describe "with free_units_per_total_aggregation" do
-      it "creates an pay_in_advance fee " do
+      it "creates an pay_in_advance fee" do
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
 
@@ -1041,7 +1041,7 @@ describe "Pay in advance charges Scenarios", transaction: false do
     describe "with min / max per transaction" do
       around { |test| lago_premium!(&test) }
 
-      it "creates a pay_in_advance fee " do
+      it "creates a pay_in_advance fee" do
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
 
@@ -1319,7 +1319,7 @@ describe "Pay in advance charges Scenarios", transaction: false do
     let(:field_name) { "amount" }
 
     describe "with free_units_per_events" do
-      it "creates an pay_in_advance fee " do
+      it "creates an pay_in_advance fee" do
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
 

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -189,7 +189,7 @@ describe "Subscriptions Termination Scenario" do
         )
       end
 
-      it "does not issue credit note and does not bill previous period " do
+      it "does not issue credit note and does not bill previous period" do
         subscription = nil
 
         travel_to(creation_time) do

--- a/spec/services/base_result_spec.rb
+++ b/spec/services/base_result_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BaseResult do
   describe "#[]" do
     let(:result_class) { described_class[:property] }
 
-    it { expect(result_class.new).to be_kind_of(described_class) }
+    it { expect(result_class.new).to be_a(described_class) }
 
     it "defines the attributes" do
       expect(result_class.new).to respond_to(:property)

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ::BaseService do
   subject(:service) { described_class.new }
 
-  it { is_expected.to be_kind_of(AfterCommitEverywhere) }
+  it { is_expected.to be_a(AfterCommitEverywhere) }
   it { is_expected.to respond_to(:call) }
   it { is_expected.to respond_to(:call_async) }
   it { is_expected.to respond_to(:call_with_middlewares) }

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -766,7 +766,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
         end
       end
 
-      context "when  charge is pay in advance and just upgraded" do
+      context "when charge is pay in advance and just upgraded" do
         let(:from_datetime) { Time.zone.parse("2023-05-15 00:00:00") }
         let(:is_pay_in_advance) { true }
         let(:latest_events) { nil }

--- a/spec/services/customers/update_invoice_issuing_date_settings_service_spec.rb
+++ b/spec/services/customers/update_invoice_issuing_date_settings_service_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Customers::UpdateInvoiceIssuingDateSettingsService do
         end
       end
 
-      context "with no preferences set on the customer level " do
+      context "with no preferences set on the customer level" do
         let(:billing_entity) do
           create(
             :billing_entity,

--- a/spec/services/error_details/create_service_spec.rb
+++ b/spec/services/error_details/create_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ErrorDetails::CreateService do
         subject(:service_call) { described_class.call(params:, organization:, owner: nil) }
 
         it "does not create an error_detail" do
-          expect { service_call }.to change(ErrorDetail, :count).by(0)
+          expect { service_call }.not_to change(ErrorDetail, :count)
         end
 
         it "returns error for error_detail" do
@@ -62,7 +62,7 @@ RSpec.describe ErrorDetails::CreateService do
         end
 
         it "does not create an error_detail" do
-          expect { service_call }.to change(ErrorDetail, :count).by(0)
+          expect { service_call }.not_to change(ErrorDetail, :count)
         end
 
         it "returns error for error_detail" do

--- a/spec/services/fees/fixed_charge_service_spec.rb
+++ b/spec/services/fees/fixed_charge_service_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe Fees::FixedChargeService do
       end
     end
 
-    context "with graduated charge model " do
+    context "with graduated charge model" do
       let(:fixed_charge) do
         create(
           :fixed_charge,

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -2499,7 +2499,7 @@ RSpec.describe Invoices::CalculateFeesService do
 
           context "when subscription is not terminated" do
             context "when it's the first month" do
-              it "returns true " do
+              it "returns true" do
                 expect(subject).to eq(true)
               end
             end
@@ -2529,7 +2529,7 @@ RSpec.describe Invoices::CalculateFeesService do
             context "when it's the first month" do
               let(:timestamp) { DateTime.parse("01 Jan 2023") }
 
-              it "returns true " do
+              it "returns true" do
                 expect(subject).to eq(true)
               end
             end
@@ -2746,7 +2746,7 @@ RSpec.describe Invoices::CalculateFeesService do
 
           context "when subscription is not terminated" do
             context "when it's the first month" do
-              it "returns true " do
+              it "returns true" do
                 expect(subject).to eq(true)
               end
             end
@@ -2754,7 +2754,7 @@ RSpec.describe Invoices::CalculateFeesService do
             context "when it's the seventh month" do
               let(:timestamp) { DateTime.parse("01 Oct 2022") }
 
-              it "returns true " do
+              it "returns true" do
                 expect(subject).to eq(true)
               end
             end
@@ -2784,7 +2784,7 @@ RSpec.describe Invoices::CalculateFeesService do
             context "when it's the first month" do
               let(:timestamp) { DateTime.parse("01 Jan 2023") }
 
-              it "returns true " do
+              it "returns true" do
                 expect(subject).to eq(true)
               end
             end
@@ -2792,7 +2792,7 @@ RSpec.describe Invoices::CalculateFeesService do
             context "when it's the seventh month" do
               let(:timestamp) { DateTime.parse("01 Jul 2023") }
 
-              it "returns true " do
+              it "returns true" do
                 expect(subject).to eq(true)
               end
             end

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Invoices::CreateGeneratingService do
         end
       end
 
-      context "with no preferences set on the customer level " do
+      context "with no preferences set on the customer level" do
         let(:billing_entity) do
           create(
             :billing_entity,

--- a/spec/services/invoices/issuing_date_service_spec.rb
+++ b/spec/services/invoices/issuing_date_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Invoices::IssuingDateService do
       end
     end
 
-    context "with no preferences set on the customer level " do
+    context "with no preferences set on the customer level" do
       let(:billing_entity) do
         build(
           :billing_entity,
@@ -134,7 +134,7 @@ RSpec.describe Invoices::IssuingDateService do
   describe "#grace_period" do
     let(:recurring) { true }
 
-    context "with preferences set on the customer level " do
+    context "with preferences set on the customer level" do
       let(:invoice_grace_period) { 3 }
 
       it "returns value based on billing entity settings" do
@@ -142,7 +142,7 @@ RSpec.describe Invoices::IssuingDateService do
       end
     end
 
-    context "with no preferences set on the customer level " do
+    context "with no preferences set on the customer level" do
       let(:billing_entity) do
         build(
           :billing_entity,
@@ -159,7 +159,7 @@ RSpec.describe Invoices::IssuingDateService do
       end
     end
 
-    context "with no preferences set on the billing_entity level " do
+    context "with no preferences set on the billing_entity level" do
       let(:billing_entity) { build(:billing_entity, invoice_grace_period: nil) }
       let(:customer) { build(:customer, billing_entity:, invoice_grace_period: nil) }
 

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -2047,7 +2047,7 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
           organization.update!(premium_integrations: ["preview"])
         end
 
-        context "with no preferences set on the customer level " do
+        context "with no preferences set on the customer level" do
           let(:billing_entity) do
             create(
               :billing_entity,

--- a/spec/services/invoices/update_issuing_date_from_billing_entity_service_spec.rb
+++ b/spec/services/invoices/update_issuing_date_from_billing_entity_service_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Invoices::UpdateIssuingDateFromBillingEntityService do
       end
     end
 
-    context "with preferences set on the customer level " do
+    context "with preferences set on the customer level" do
       let(:customer) do
         create(
           :customer,

--- a/spec/services/legacy_result_spec.rb
+++ b/spec/services/legacy_result_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe BaseService::LegacyResult do # rubocop:disable RSpec/FilePath
+RSpec.describe BaseService::LegacyResult do # rubocop:disable RSpec/SpecFilePathFormat
   subject(:result) { described_class.new }
 
   it_behaves_like "a result object"
 
-  it { expect(subject).to be_kind_of(OpenStruct) }
+  it { expect(subject).to be_a(OpenStruct) }
 end

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Subscriptions::DatesService do
       let(:interval) { :weekly }
 
       it "returns a weekly service instance" do
-        expect(result).to be_kind_of(Subscriptions::Dates::WeeklyService)
+        expect(result).to be_a(Subscriptions::Dates::WeeklyService)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Subscriptions::DatesService do
       let(:interval) { :quarterly }
 
       it "returns a quarterly service instance" do
-        expect(result).to be_kind_of(Subscriptions::Dates::QuarterlyService)
+        expect(result).to be_a(Subscriptions::Dates::QuarterlyService)
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe Subscriptions::DatesService do
       let(:interval) { :monthly }
 
       it "returns a monthly service instance" do
-        expect(result).to be_kind_of(Subscriptions::Dates::MonthlyService)
+        expect(result).to be_a(Subscriptions::Dates::MonthlyService)
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Subscriptions::DatesService do
       let(:interval) { :yearly }
 
       it "returns a yearly service instance" do
-        expect(result).to be_kind_of(Subscriptions::Dates::YearlyService)
+        expect(result).to be_a(Subscriptions::Dates::YearlyService)
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.describe Subscriptions::DatesService do
       let(:interval) { :semiannual }
 
       it "returns a semiannual service instance" do
-        expect(result).to be_kind_of(Subscriptions::Dates::SemiannualService)
+        expect(result).to be_a(Subscriptions::Dates::SemiannualService)
       end
     end
 

--- a/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UsageMonitoring::TrackSubscriptionActivityService do
     it "tracks activity" do
       create(:usage_threshold, plan: subscription.plan)
       expect { subject.call }.to change { organization.subscription_activities.count }.by(1)
-      expect { subject.call }.to change { organization.subscription_activities.count }.by(0)
+      expect { subject.call }.not_to change { organization.subscription_activities.count }
     end
   end
 

--- a/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
+++ b/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Validators::WalletTransactionAmountLimitsValidator do
   describe "#valid?" do
     subject { described_class.new(result, wallet:, credits_amount:, ignore_validation:).valid? }
 
-    context "when  ignore_validation is true" do
+    context "when ignore_validation is true" do
       let(:ignore_validation) { true }
 
       it { is_expected.to be true }


### PR DESCRIPTION
## Context

We had some development gems that were still not up-to-date. The main one was `rubocop-rspec` which needed to be updated to a new major version.

## Description

This updates:

- `rubocop-rspec`
- `rubocop-rspec_rails`
- `standard`
- `httplog`
- `knapsack_pro`

The `rubocop-rspec` updates involves new defaults for existing rules. The ones with few occurrences were applied with auto-correction but the ones with more than 10 offenses were simply disabled.