### PR TITLE
fix(fixed-charges): Use consistent timestamp for pay-in-advance fixed charges on activation

### DIFF
--- a/spec/scenarios/subscriptions/activation_spec.rb
+++ b/spec/scenarios/subscriptions/activation_spec.rb
@@ -19,6 +19,9 @@ describe "Subscriptions Activation Scenario" do
 
   let(:subscription_at) { DateTime.new(2023, 8, 24, 4, 17) }
   let(:creation_time) { DateTime.new(2023, 8, 24, 0, 7) }
+  let(:fixed_charge) { create(:fixed_charge, plan:, pay_in_advance: true) }
+
+  before { fixed_charge }
 
   it "activates the subscription when it reaches its subscription date" do
     subscription = nil
@@ -42,6 +45,36 @@ describe "Subscriptions Activation Scenario" do
       Subscriptions::ActivateService.new(timestamp: Time.current.to_i).activate_all_pending
 
       expect(subscription.reload).to be_active
+    end
+  end
+
+  it "generates a pay in advance invoice for the fixed charge" do
+    subscription = nil
+
+    travel_to(creation_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time: "calendar",
+          subscription_at: subscription_at.iso8601
+        }
+      )
+
+      subscription = customer.subscriptions.first
+      expect(subscription).to be_pending
+    end
+
+    travel_to(subscription_at) do
+      Subscriptions::ActivateService.new(timestamp: Time.current.to_i).activate_all_pending
+      perform_enqueued_jobs
+
+      expect(subscription.reload).to be_active
+
+      expect(subscription.invoices.count).to eq(1)
+      expect(subscription.invoices.first.fees.count).to eq(1)
+      expect(subscription.invoices.first.fees.first.fixed_charge.id).to eq(fixed_charge.id)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Fix timestamp inconsistency when billing pay-in-advance fixed charges during subscription activation
- Add scenario test for pay-in-advance fixed charge invoice generation on activation

## Context

When a subscription is activated with pay-in-advance fixed charges (on a pay-in-arrears plan), the `CreatePayInAdvanceFixedChargesJob` was using a different timestamp than `EmitFixedChargeEventsService`. This caused invoice generation issues because the fixed charge events and the billing job were operating on different time references.

## Description

Use the same `fixed_charge_timestamp` (subscription.started_at + 1.second) for both `EmitFixedChargeEventsService` and `CreatePayInAdvanceFixedChargesJob` to ensure consistent invoice boundaries and proper fee generation.

## Test plan

- [x] Add scenario test verifying pay-in-advance fixed charge generates invoice on subscription activation
- [x] Verify invoice contains the correct fixed charge fee