### PR TITLE
misc(graphQL) expose invoice_id on fee object

### DIFF
--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -15,6 +15,7 @@ module Types
       field :fixed_charge, Types::FixedCharges::Object, null: true
       field :grouped_by, GraphQL::Types::JSON, null: false
       field :invoice_display_name, String, null: true
+      field :invoice_id, ID, null: true
       field :invoice_name, String, null: true
       field :subscription, Types::Subscriptions::Object, null: true
       field :true_up_fee, Types::Fees::Object, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -5367,6 +5367,7 @@ type Fee implements InvoiceItem {
   groupedBy: JSON!
   id: ID!
   invoiceDisplayName: String
+  invoiceId: ID
   invoiceName: String
   itemCode: String!
   itemName: String!

--- a/schema.json
+++ b/schema.json
@@ -25801,6 +25801,18 @@
               "deprecationReason": null
             },
             {
+              "name": "invoiceId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "invoiceName",
               "description": null,
               "args": [],

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Types::Fees::Object do
     expect(subject).to have_field(:grouped_by).of_type("JSON!")
     expect(subject).to have_field(:fixed_charge).of_type("FixedCharge")
     expect(subject).to have_field(:invoice_display_name).of_type("String")
+    expect(subject).to have_field(:invoice_id).of_type("ID")
     expect(subject).to have_field(:invoice_name).of_type("String")
     expect(subject).to have_field(:subscription).of_type("Subscription")
     expect(subject).to have_field(:true_up_fee).of_type("Fee")


### PR DESCRIPTION
## Context

I need to retrieve the invoice ID from a fee in the FE app.

This attribute it not exposed tho.

## Description

This pull request exposes this invoice ID attribute that is already present on the fee model. 