### PR TITLE
fix(fixed-charges): Fix adjusted fee boundaries

### DIFF
--- a/app/services/adjusted_fees/estimate_service.rb
+++ b/app/services/adjusted_fees/estimate_service.rb
@@ -209,11 +209,22 @@ module AdjustedFees
     def initialize_empty_fee(subscription, invoiceable, fee_type)
       invoice_subscription = invoice.invoice_subscriptions.find_by(subscription_id: subscription.id)
 
-      boundaries = {
-        timestamp: invoice_subscription.timestamp,
-        charges_from_datetime: invoice_subscription.charges_from_datetime,
-        charges_to_datetime: invoice_subscription.charges_to_datetime
-      }
+      boundaries = {timestamp: invoice_subscription.timestamp}
+
+      boundaries.merge!(
+        case fee_type
+        when :charge
+          {
+            charges_from_datetime: invoice_subscription.charges_from_datetime,
+            charges_to_datetime: invoice_subscription.charges_to_datetime
+          }
+        when :fixed_charge
+          {
+            fixed_charges_from_datetime: invoice_subscription.fixed_charges_from_datetime,
+            fixed_charges_to_datetime: invoice_subscription.fixed_charges_to_datetime
+          }
+        end
+      )
 
       Fee.new(
         organization:,

--- a/spec/services/adjusted_fees/estimate_service_spec.rb
+++ b/spec/services/adjusted_fees/estimate_service_spec.rb
@@ -240,6 +240,19 @@ RSpec.describe AdjustedFees::EstimateService do
           precise_unit_amount: 30.0
         )
       end
+
+      it "sets fixed charge boundaries in properties" do
+        invoice_subscription = invoice.invoice_subscriptions.find_by(subscription_id: subscription.id)
+
+        expect(invoice_subscription.fixed_charges_from_datetime).to be_present
+        expect(invoice_subscription.fixed_charges_to_datetime).to be_present
+
+        expect(result.fee.properties).to eq(
+          "timestamp" => invoice_subscription.timestamp.iso8601(3),
+          "fixed_charges_from_datetime" => invoice_subscription.fixed_charges_from_datetime.iso8601(3),
+          "fixed_charges_to_datetime" => invoice_subscription.fixed_charges_to_datetime.iso8601(3)
+        )
+      end
     end
 
     context "when fixed_charge does not exist" do
@@ -383,6 +396,19 @@ RSpec.describe AdjustedFees::EstimateService do
           units: 5.0,
           unit_amount_cents: 3000,
           precise_unit_amount: 30.0
+        )
+      end
+
+      it "sets charge boundaries in properties" do
+        invoice_subscription = invoice.invoice_subscriptions.find_by(subscription_id: subscription.id)
+
+        expect(invoice_subscription.charges_from_datetime).to be_present
+        expect(invoice_subscription.charges_to_datetime).to be_present
+
+        expect(result.fee.properties).to eq(
+          "timestamp" => invoice_subscription.timestamp.iso8601(3),
+          "charges_from_datetime" => invoice_subscription.charges_from_datetime.iso8601(3),
+          "charges_to_datetime" => invoice_subscription.charges_to_datetime.iso8601(3)
         )
       end
     end


### PR DESCRIPTION
 ## Context

When estimating adjusted fees for fixed charges, the service was incorrectly using charge boundaries (`charges_from_datetime` and `charges_to_datetime`) instead of the specific fixed charge boundaries.

 ## Description

The `initialize_empty_fee` method now determines the correct boundary fields based on fee type:
- `:charge` uses `charges_from_datetime`/`charges_to_datetime`
- `:fixed_charge` uses `fixed_charges_from_datetime`/`fixed_charges_to_datetime`

This ensures that adjusted fixed charge fees have the proper time boundaries in their properties, matching the invoice subscription's fixed charge period rather than the regular charge period.
