### PR TITLE
fix(projected_usage): Last day of period is not correct

### DIFF
--- a/app/services/utils/datetime.rb
+++ b/app/services/utils/datetime.rb
@@ -30,7 +30,8 @@ module Utils
 
       to = to_datetime
       to = Time.zone.parse(to.to_s) unless to.is_a?(ActiveSupport::TimeWithZone)
-      to += 1.second if to == to.beginning_of_day # To make sure we do not miss a day
+      to_in_time = to.in_time_zone(timezone)
+      to += 1.second if to_in_time == to_in_time.beginning_of_day # To make sure we do not miss a day
 
       from_offset = from.in_time_zone(timezone).utc_offset
       to_offset = to.in_time_zone(timezone).utc_offset

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -132,5 +132,15 @@ RSpec.describe Utils::Datetime do
         expect(result).to eq(7)
       end
     end
+
+    context "with to date at the beginning of the day in timezone" do
+      let(:from_datetime) { Time.zone.parse("2023-12-01T00:00:00").in_time_zone(timezone).beginning_of_day.utc }
+      let(:to_datetime) { Time.zone.parse("2023-12-07T00:00:00").in_time_zone(timezone).beginning_of_day.utc }
+      let(:timezone) { "America/New_York" }
+
+      it "ensures it counts the full days" do
+        expect(result).to eq(7)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

This PR fixes the the `Fees::ProjectionService` to make sure that the projection is correct on the last days of the billing period.

The PR also:
- Fixes the `period_ratio` computation when subscription is not on an `UTC` timezone
- Ensures that aggregations are computed using times and not dates
- Improves the specs to move from instance doubles to factories

NOTE:
This service will be completely reworked soon as the current implementation is causing performance issues. The service is called from serializer and GraphQL types for each usage fees, recomputing the aggregation for everyone of them without relying on any cache or pre-filtering logic that where added lately to address the performance issues of the usage computation