### PR TITLE
feat(fixed-charges): Subs start in the past does not bill pay in advance fixed charges

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -102,6 +102,10 @@ module Subscriptions
       sub.active? && sub.subscription_at.today? && plan.pay_in_advance? && !sub.in_trial_period?
     end
 
+    def fixed_charges_billed_today?(sub)
+      sub.active? && sub.fixed_charges.pay_in_advance.any? && !sub.plan.pay_in_advance? && sub.started_at.today? && !sub.in_trial_period?
+    end
+
     def create_subscription
       new_subscription = Subscription.new(
         organization_id: customer.organization_id,
@@ -134,7 +138,7 @@ module Subscriptions
         )
 
         after_commit do
-          if plan.fixed_charges.pay_in_advance.any? && !should_be_billed_today?(new_subscription)
+          if fixed_charges_billed_today?(new_subscription)
             Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(
               new_subscription,
               new_subscription.started_at + 1.second

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -99,10 +99,12 @@ module Subscriptions
           timestamp: subscription.started_at + 1.second
         )
 
-        if subscription.plan.pay_in_advance? && subscription.subscription_at.today?
-          BillSubscriptionJob.perform_after_commit([subscription], Time.current.to_i, invoicing_reason: :subscription_starting)
-        elsif subscription.fixed_charges.pay_in_advance.any?
-          Invoices::CreatePayInAdvanceFixedChargesJob.perform_after_commit(subscription, subscription.started_at + 1.second)
+        if subscription.subscription_at.today?
+          if subscription.plan.pay_in_advance?
+            BillSubscriptionJob.perform_after_commit([subscription], Time.current.to_i, invoicing_reason: :subscription_starting)
+          elsif subscription.fixed_charges.pay_in_advance.any?
+            Invoices::CreatePayInAdvanceFixedChargesJob.perform_after_commit(subscription, subscription.started_at + 1.second)
+          end
         end
       else
         subscription.save!

--- a/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
+++ b/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
@@ -1178,7 +1178,6 @@ describe "Pay in advance fixed charge units change mid-period" do
     # The delta billing should correctly find the previous fee from the parent
     # fixed charge, not just by the new fixed charge ID.
     let(:subscription_date) { DateTime.new(2024, 12, 1) }
-    let(:current_date) { DateTime.new(2024, 12, 3) }
     let(:subscription) { customer.subscriptions.first }
 
     # Fixed charge: $10 per unit, 5 units, pay in advance
@@ -1187,8 +1186,7 @@ describe "Pay in advance fixed charge units change mid-period" do
     before do
       parent_fixed_charge
 
-      # Create subscription on Dec 3rd with subscription_at Dec 1st (in the past)
-      travel_to current_date do
+      travel_to subscription_date do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -1220,7 +1218,7 @@ describe "Pay in advance fixed charge units change mid-period" do
 
     context "when subscription is updated with plan_overrides to increase units to 15 with apply_units_immediately" do
       before do
-        travel_to current_date + 1.hour do
+        travel_to subscription_date + 1.hour do
           update_subscription(
             subscription,
             {
@@ -1292,7 +1290,7 @@ describe "Pay in advance fixed charge units change mid-period" do
 
     context "when subscription is updated to decrease units (10 -> 3) via plan_overrides" do
       before do
-        travel_to current_date + 1.hour do
+        travel_to subscription_date + 1.hour do
           update_subscription(
             subscription,
             {
@@ -1335,7 +1333,7 @@ describe "Pay in advance fixed charge units change mid-period" do
     context "when subscription is updated twice via plan_overrides (10 -> 3 -> 15)" do
       before do
         # First update: decrease from 10 to 3 (no refund expected)
-        travel_to current_date + 1.hour do
+        travel_to subscription_date + 1.hour do
           update_subscription(
             subscription,
             {
@@ -1356,7 +1354,7 @@ describe "Pay in advance fixed charge units change mid-period" do
 
         # Second update: increase from 3 to 15
         # Should only charge for delta from max paid (10), not from current (3)
-        travel_to current_date + 2.hours do
+        travel_to subscription_date + 2.hours do
           # After first override, the subscription has a child plan
           child_fixed_charge = subscription.reload.plan.fixed_charges.first
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -467,6 +467,16 @@ RSpec.describe Subscriptions::CreateService do
           expect { create_service.call }.not_to have_enqueued_job(BillSubscriptionJob)
         end
       end
+
+      context "when plan has pay in advance fixed charges" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, pay_in_advance: true) }
+
+        before { fixed_charge }
+
+        it "does not enqueue a job to bill the pay in advance fixed charges" do
+          expect { create_service.call }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+        end
+      end
     end
 
     context "when plan is not pay_in_advance, subscription_at is current date and there are fixed charges" do
@@ -482,6 +492,14 @@ RSpec.describe Subscriptions::CreateService do
 
         it "enqueues a job to bill the subscription" do
           expect { create_service.call }.to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+        end
+
+        context "when plan has a trial period" do
+          let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true, trial_period: 10) }
+
+          it "does not enqueue a job to bill the pay in advance fixed charges" do
+            expect { create_service.call }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+          end
         end
       end
 
@@ -600,6 +618,16 @@ RSpec.describe Subscriptions::CreateService do
           expect(subscription.lifetime_usage).to be_present
           expect(subscription.lifetime_usage.recalculate_invoiced_usage).to eq(true)
           expect(subscription.lifetime_usage.recalculate_current_usage).to eq(false)
+        end
+      end
+
+      context "when plan has pay in advance fixed charges" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, pay_in_advance: true) }
+
+        before { fixed_charge }
+
+        it "does not enqueue a job to bill the pay in advance fixed charges" do
+          expect { create_service.call }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
         end
       end
     end


### PR DESCRIPTION
 ## Context

 When subscription is created or updated starting in the past and has
 pay in advance fixed charges it was generating an invoice for those
 with the starting period boundaries. While we don't bill subscription
 fees for pay in advance plan starting in the past subscription.

 ## Description

This change skip billing of pay in advance fixed charges of subscriptions starting in the past to align with subscription fees for pay in advance plans.