### PR TITLE
fix(redis): Do not force ssl if not explicit

### DIFF
--- a/app/services/subscriptions/consume_subscription_refreshed_queue_service.rb
+++ b/app/services/subscriptions/consume_subscription_refreshed_queue_service.rb
@@ -48,7 +48,7 @@ module Subscriptions
       config[:password] = ENV["LAGO_REDIS_STORE_PASSWORD"] if ENV["LAGO_REDIS_STORE_PASSWORD"].present?
       config[:db] = ENV["LAGO_REDIS_STORE_DB"] if ENV["LAGO_REDIS_STORE_DB"].present?
 
-      if ENV["LAGO_REDIS_STORE_SSL"].present? || ENV["LAGO_REDIS_STORE_URL"].start_with?(/rediss?:/)
+      if ENV["LAGO_REDIS_STORE_SSL"].present? || ENV["LAGO_REDIS_STORE_URL"].start_with?("rediss:")
         config[:ssl] = true
       end
 


### PR DESCRIPTION
This PR follows https://github.com/getlago/lago-api/pull/4855 it make sure that the `ssl` ooption is passed to the redis client only if it's explicitly set in the config via `LAGO_REDIS_STORE_SSL` or `rediss:`