### PR TITLE
fix: change method name to not mix it with association

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -80,7 +80,7 @@ class Payment < ApplicationRecord
     payment_provider&.payment_type
   end
 
-  def payment_method_display
+  def method_display_name
     return nil if provider_payment_method_data.blank?
 
     type = provider_payment_method_data["type"]

--- a/app/views/templates/payment_receipts/v1.slim
+++ b/app/views/templates/payment_receipts/v1.slim
@@ -29,10 +29,10 @@ html
                 td.body-2
                   a style="text-decoration: none" target="_blank" href=payment.payable.file_url
                     = payment.payable.number
-            -if payment.payment_method_display.present?
+            -if payment.method_display_name.present?
               tr
                 td.body-1 = I18n.t('payment_receipt.payment_method')
-                td.body-2 = payment.payment_method_display
+                td.body-2 = payment.method_display_name
             tr
               td.body-1 = I18n.t('payment_receipt.payment_date')
               td.body-2 = I18n.l(payment.created_at.to_date, format: :default)

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -395,14 +395,14 @@ RSpec.describe Payment do
     end
   end
 
-  describe "#payment_method_display" do
-    subject(:payment_method_display) { payment.payment_method_display }
+  describe "#method_display_name" do
+    subject(:method_display_name) { payment.method_display_name }
 
     context "when provider_payment_method_data is empty" do
       let(:payment) { build(:payment, provider_payment_method_data: {}) }
 
       it "returns nil" do
-        expect(payment_method_display).to be_nil
+        expect(method_display_name).to be_nil
       end
     end
 
@@ -416,7 +416,7 @@ RSpec.describe Payment do
       end
 
       it "returns formatted card details" do
-        expect(payment_method_display).to eq("Visa **** 1234")
+        expect(method_display_name).to eq("Visa **** 1234")
       end
     end
 
@@ -428,7 +428,7 @@ RSpec.describe Payment do
       end
 
       it "returns the payment method type" do
-        expect(payment_method_display).to eq("Bank Transfer")
+        expect(method_display_name).to eq("Bank Transfer")
       end
     end
   end


### PR DESCRIPTION
## Context

In payment model, payment_method association share the same name with existing method

## Description

This PR changes the method name so that we have clear distinction
