### PR TITLE
fix(migrations): make fixed charges boundaries index migration idempotent

### DIFF
--- a/db/migrate/20251231162838_make_fixed_charges_boundaries_index_unique.rb
+++ b/db/migrate/20251231162838_make_fixed_charges_boundaries_index_unique.rb
@@ -36,6 +36,11 @@ class MakeFixedChargesBoundariesIndexUnique < ActiveRecord::Migration[8.0]
       name: :index_invoice_subscriptions_on_fixed_charges_boundaries,
       if_exists: true
 
+    # Remove the unique index if it already exists (in case migration ran partially before)
+    remove_index :invoice_subscriptions,
+      name: :index_uniq_invoice_subscriptions_on_fixed_charges_boundaries,
+      if_exists: true
+
     # Add unique index (only for non-NULL fixed_charges boundaries)
     add_index :invoice_subscriptions,
       [:subscription_id, :fixed_charges_from_datetime, :fixed_charges_to_datetime],


### PR DESCRIPTION
## Context

The migration to make the fixed charges boundaries index unique was failing in production with "PG::DuplicateTable: relation already exists" because the index had been created in a previous deployment before the feature was reverted and re-merged.

## Description

Drop the unique index if it already exists before creating it to ensure the migration can run successfully even if the index was previously created. This makes the migration idempotent and ensures the index is always created with the correct definition.