### PR TITLE
fix(netsuite): Fix Netsuite error message reporting

### DIFF
--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -147,13 +147,17 @@ module Integrations
 
       def code(error)
         json = error.json_message
-        json["type"].presence || json.dig("error", "payload", "name").presence || json.dig("error", "code")
+        json["type"].presence ||
+          json.dig("error", "payload", "name").presence ||
+          json.dig("error", "payload", "error", "code").presence ||
+          json.dig("error", "code")
       end
 
       def message(error)
         json = error.json_message
         json.dig("payload", "message").presence ||
           json.dig("error", "payload", "message").presence ||
+          json.dig("error", "payload", "error", "message").presence ||
           json.dig("error", "message")
       end
 


### PR DESCRIPTION
## Context

When the Netsuite credentials are invalid, we receive the following payload from Nango:

```
{"error":{"payload":{"error":{"code":"INVALID_LOGIN_ATTEMPT","message":"Invalid login attempt."}}
```

This payload is not properly handled and result in an error with the following message: `:`.

## Description

This fixes it.
