### PR TITLE
fix(netsuite): Improve error message extraction robustness

### DIFF
--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -249,6 +249,28 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
 
         [
           {
+            ctx: "when the error is not handled specifically",
+            payload: {
+              error: "An unexpected error occurred"
+            },
+            code: "unexpected_error",
+            message: "{\"error\":\"An unexpected error occurred\"}"
+          },
+          {
+            ctx: "when error is nested in `error.payload`",
+            payload: {
+              error: {
+                message: "The action script failed with an error: {}",
+                code: "action_script_failure",
+                payload: {
+                  error: "Error starting integration 'netsuite-customer-create': {\n  \"name\": \"TRPCClientError\",\n  \"message\": \"fetch failed\"\n}"
+                }
+              }
+            },
+            code: "action_script_failure",
+            message: "Error starting integration 'netsuite-customer-create': {\n  \"name\": \"TRPCClientError\",\n  \"message\": \"fetch failed\"\n}"
+          },
+          {
             ctx: "when error is nested in `error.payload.error`",
             payload: {
               integration: "netsuite-tba",


### PR DESCRIPTION
## Context

The Netsuite integration error handling was fragile when dealing with unexpected error response formats. The `dig` method would fail on non-Hash values in the response chain. For instance, `json.dig("error", "payload", "error", "message")` would fail with the following payload:

```ruby
{
  error: {
    message: "The action script failed with an error: {}",
    code: "action_script_failure",
    payload: {
      error: "Error starting integration 'netsuite-customer-create': {\n  \"name\": \"TRPCClientError\",\n  \"message\": \"fetch failed\"\n}"
    }
  }
}
```

## Description

This handles this new error and adds `safe_dig_str` method that safely traverses nested hashes and only returns string values to avoid unexpected behaviors.

The `code` and `message` were also updated to fallback to a default code and the json payload as message when no specific error details could be extracted.