### PR TITLE
feat(sidekiq): add Prometheus metrics exporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "puma", "~> 6.5"
 gem "rails", "~> 8.0"
 gem "redis"
 gem "sidekiq"
+gem "sidekiq-prometheus-exporter"
 group :"sidekiq-pro", optional: true do
   source "https://gems.contribsys.com/" do
     gem "sidekiq-pro"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -953,6 +953,9 @@ GEM
       logger
       rack (>= 2.2.4)
       redis-client (>= 0.22.2)
+    sidekiq-prometheus-exporter (0.3.0)
+      rack (>= 1.6.0)
+      sidekiq (>= 4.1.0)
     sidekiq-throttled (1.4.0)
       concurrent-ruby (>= 1.2.0)
       redis-prescription (~> 2.2)
@@ -1166,6 +1169,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   sidekiq-pro!
+  sidekiq-prometheus-exporter
   sidekiq-throttled (= 1.4.0)
   simplecov
   slim

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -29,6 +29,8 @@ end
 
 if ENV["LAGO_SIDEKIQ_WEB"] == "true"
   require "sidekiq/web"
+  require "sidekiq/prometheus/exporter"
+
   Sidekiq::Web.use(ActionDispatch::Cookies)
   Sidekiq::Web.use(ActionDispatch::Session::CookieStore, key: "_interslice_session")
 end
@@ -51,6 +53,7 @@ def configure_sidekiq_pro_metrics(config)
   config.dogstatsd = -> {
     Datadog::Statsd.new(statsd_host, statsd_port.to_i,
       tags: ["env:#{config[:environment]}", "service:sidekiq"],
+
       namespace: Rails.application.name)
   }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount Sidekiq::Web, at: "/sidekiq" if ENV["LAGO_SIDEKIQ_WEB"] == "true" && defined? Sidekiq::Web
+  if ENV["LAGO_SIDEKIQ_WEB"] == "true"
+    mount Sidekiq::Web, at: "/sidekiq" if defined?(Sidekiq::Web)
+    mount Sidekiq::Prometheus::Exporter, at: "/sidekiq/prometheus/metrics" if defined? Sidekiq::Prometheus::Exporter
+  end
   mount Karafka::Web::App, at: "/karafka" if ENV["LAGO_KARAFKA_WEB"]
   mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql" if Rails.env.development?
   mount Yabeda::Prometheus::Exporter, at: "/metrics"


### PR DESCRIPTION
## Context

Sidekiq job metrics need to be exposed for Prometheus monitoring alongside the existing Yabeda metrics endpoint.

## Description

Add sidekiq-prometheus-exporter gem to expose Sidekiq metrics in Prometheus format. The metrics endpoint is mounted at /sidekiq/prometheus/metrics when LAGO_SIDEKIQ_WEB is enabled.

