### PR TITLE
fix: due amount 0 when voided

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -283,6 +283,7 @@ class Invoice < ApplicationRecord
   end
 
   def total_due_amount_cents
+    return 0 if voided?
     total_amount_cents - total_paid_amount_cents - offset_amount_cents
   end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1930,6 +1930,11 @@ RSpec.describe Invoice do
       expect(invoice.total_due_amount_cents).to eq(700)
     end
 
+    it "returns 0 when invoice is voided" do
+      invoice.update!(status: :voided)
+      expect(invoice.total_due_amount_cents).to eq(0)
+    end
+
     it "deducts offset amount from total due" do
       create(:credit_note, invoice:, status: :finalized, offset_amount_cents: 200)
       expect(invoice.total_due_amount_cents).to eq(500) # 1000 - 300 - 200


### PR DESCRIPTION
## Context
The #total_due_amount_cents method on Invoice should return 0 when the invoice is voided 
