### PR TITLE
fix(billing): add pending_vies_check associations

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -33,6 +33,7 @@ class BillingEntity < ApplicationRecord
   has_many :customers
   has_many :fees
   has_many :invoices
+  has_many :pending_vies_checks
   has_many :payment_receipts
   has_many :applied_invoice_custom_sections,
     class_name: "BillingEntity::AppliedInvoiceCustomSection",

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -111,6 +111,7 @@ class Customer < ApplicationRecord
   has_one :moneyhash_customer, class_name: "PaymentProviderCustomers::MoneyhashCustomer"
 
   has_one :default_payment_method, -> { where(is_default: true) }, class_name: "PaymentMethod"
+  has_one :pending_vies_check
 
   PAYMENT_PROVIDERS = %w[stripe gocardless cashfree adyen flutterwave moneyhash].freeze
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -81,6 +81,7 @@ class Organization < ApplicationRecord
   has_many :subscription_activities, class_name: "UsageMonitoring::SubscriptionActivity"
   has_many :alerts, class_name: "UsageMonitoring::Alert"
   has_many :triggered_alerts, class_name: "UsageMonitoring::TriggeredAlert"
+  has_many :pending_vies_checks
 
   has_many :stripe_payment_providers, class_name: "PaymentProviders::StripeProvider"
   has_many :gocardless_payment_providers, class_name: "PaymentProviders::GocardlessProvider"

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe BillingEntity do
   it { is_expected.to have_many(:customers) }
   it { is_expected.to have_many(:invoices) }
   it { is_expected.to have_many(:fees) }
+  it { is_expected.to have_many(:pending_vies_checks) }
   it { is_expected.to have_many(:payment_receipts) }
   it { is_expected.to have_many(:applied_invoice_custom_sections).class_name("BillingEntity::AppliedInvoiceCustomSection").dependent(:destroy) }
   it { is_expected.to have_many(:integration_collection_mappings).class_name("IntegrationCollectionMappings::BaseCollectionMapping").dependent(:destroy) }

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Customer do
   it { is_expected.to have_one(:salesforce_customer) }
 
   it { is_expected.to have_one(:default_payment_method) }
+  it { is_expected.to have_one(:pending_vies_check) }
 
   it { is_expected.to have_many(:applied_invoice_custom_sections).class_name("Customer::AppliedInvoiceCustomSection").dependent(:destroy) }
   it { is_expected.to have_many(:selected_invoice_custom_sections).through(:applied_invoice_custom_sections).source(:invoice_custom_section) }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Organization do
       expect(subject).to have_many(:subscription_feature_removals).class_name("Entitlement::SubscriptionFeatureRemoval")
 
       expect(subject).to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true)
+      expect(subject).to have_many(:pending_vies_checks)
     end
   end
 

--- a/spec/models/pending_vies_check_spec.rb
+++ b/spec/models/pending_vies_check_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 RSpec.describe PendingViesCheck, type: :model do
-  it { is_expected.to belong_to(:organization) }
-  it { is_expected.to belong_to(:billing_entity) }
-  it { is_expected.to belong_to(:customer) }
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:billing_entity)
+      expect(subject).to belong_to(:customer)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Building on the pending_vies_checks table added in a0cc56d9, models need reverse associations to access pending VIES checks from their parent entities.

## Description

Add associations to related models:
- Customer: has_one :pending_vies_check (unique constraint ensures one per customer)
- Organization: has_many :pending_vies_checks
- BillingEntity: has_many :pending_vies_checks

Refactor PendingViesCheck spec to follow project conventions with a describe "associations" block.
