### PR TITLE
feat(multi-payment-methods): add FindOrCreateFromProviderService

### DIFF
--- a/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
@@ -18,14 +18,25 @@ module PaymentProviderCustomers
         stripe_customer.save!
 
         if stripe_customer.organization.feature_flag_enabled?(:multiple_payment_methods)
-          find_or_create_result = PaymentMethods::FindOrCreateFromProviderService.call(
-            customer:,
-            payment_provider_customer: stripe_customer,
-            provider_method_id: payment_method_id,
-            params: {provider_payment_methods: stripe_customer.provider_payment_methods},
-            set_as_default: true
-          )
-          result.payment_method = find_or_create_result.payment_method
+          if payment_method_id
+            payment_method = PaymentMethod.find_by(
+              customer:,
+              payment_provider_customer: stripe_customer,
+              provider_method_id: payment_method_id
+            )
+
+            payment_method ||= PaymentMethods::CreateFromProviderService.call(
+              customer:,
+              params: {provider_payment_methods: stripe_customer.provider_payment_methods},
+              provider_method_id: payment_method_id,
+              payment_provider_id: stripe_customer.payment_provider_id,
+              payment_provider_customer: stripe_customer
+            ).payment_method
+
+            PaymentMethods::SetAsDefaultService.call(payment_method:)
+
+            result.payment_method = payment_method
+          end
         end
 
         reprocess_pending_invoices

--- a/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
@@ -49,20 +49,6 @@ RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService do
           expect(result.payment_method.is_default).to be_truthy
         end
       end
-
-      context "when payment_method_id is nil" do
-        let(:payment_method_id) { nil }
-
-        it "does not create a PaymentMethod" do
-          expect { update_service.call }.not_to change(PaymentMethod, :count)
-        end
-      end
-    end
-
-    context "without multiple_payment_methods feature flag" do
-      it "does not create a PaymentMethod" do
-        expect { update_service.call }.not_to change(PaymentMethod, :count)
-      end
     end
 
     context "with pending invoices" do


### PR DESCRIPTION
## Context
A new `PaymentMethods::FindOrCreateFromProviderService` to find existing or create new payment methods from provider data, to be (re)used by customer providers such as Stripe, Adyen, etc...