### PR TITLE
fix: fee invoice name

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -147,7 +147,7 @@ class Fee < ApplicationRecord
     return invoice_display_name if invoice_display_name.present?
     return charge.invoice_display_name.presence || billable_metric.name if charge?
     return add_on.invoice_name if add_on?
-    return invoiceable.name.presence || fee_type if credit?
+    return invoiceable&.name.presence || fee_type if credit?
     return fixed_charge.invoice_display_name.presence || fixed_charge_add_on.invoice_name if fixed_charge?
 
     subscription.plan.invoice_display_name

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -198,6 +198,14 @@ RSpec.describe Fee do
             expect(fee_invoice_name).to eq("credit")
           end
         end
+
+        context "when invoiceable is nil" do
+          let(:fee) { build(:fee, fee_type: "credit", invoice_display_name:, invoiceable: nil) }
+
+          it "returns 'credit'" do
+            expect(fee_invoice_name).to eq("credit")
+          end
+        end
       end
 
       context "when it is an pay_in_advance charge fee" do


### PR DESCRIPTION
## Context

The `Fee#invoice_name` method was raising a `NoMethodError` when called on credit fees with a nil `invoiceable` association. Since `invoiceable` is optional we need to fallback to credit on this cases

## Description

Added safe navigation operator (`&.`) to the `invoiceable.name`. When `invoiceable` is nil, the method now gracefully falls back to returning the `fee_type` ("credit") instead of raising an error.

related to Sidekiq issue 
```
undefined method 'name' for nil (NoMethodError)
    return invoiceable.name.presence || fee_type if credit?
```