### PR TITLE
fix: fee item name

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -120,7 +120,7 @@ class Fee < ApplicationRecord
   def item_name
     return billable_metric.name if charge?
     return add_on.name if add_on?
-    return invoiceable.name.presence || fee_type if credit?
+    return invoiceable&.name.presence || fee_type if credit?
     return fixed_charge_add_on.name if fixed_charge?
 
     subscription.plan.name

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -286,6 +286,14 @@ RSpec.describe Fee do
           expect(fee.item_name).to eq("credit")
         end
       end
+
+      context "when invoiceable is nil" do
+        let(:fee) { described_class.new(fee_type: "credit", invoiceable: nil) }
+
+        it "returns 'credit'" do
+          expect(fee.item_name).to eq("credit")
+        end
+      end
     end
 
     context "when it is an pay_in_advance charge fee" do


### PR DESCRIPTION
## Context

The `Fee#item_name` method was raising a `NoMethodError` when called on credit fees with a nil `invoiceable` association. Since `invoiceable` is optional we need to fallback to credit on this cases

## Description

Added safe navigation operator (`&.`) to the `invoiceable.name`. When `invoiceable` is nil, the method now gracefully falls back to returning the `fee_type` ("credit") instead of raising an error.

related to Sidekiq issue 
```
undefined method 'name' for nil (NoMethodError)
    return invoiceable.name.presence || fee_type if credit?
```