### PR TITLE
feat(billing): add vies_check_in_progress? method to Customer model

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -236,6 +236,12 @@ class Customer < ApplicationRecord
       wallets.none?
   end
 
+  def vies_check_in_progress?
+    return false unless billing_entity.eu_tax_management?
+
+    pending_vies_check.present?
+  end
+
   def preferred_document_locale
     return document_locale.to_sym if document_locale?
 

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -566,6 +566,36 @@ RSpec.describe Customer do
     end
   end
 
+  describe "#vies_check_in_progress?" do
+    subject(:vies_check_in_progress) { customer.vies_check_in_progress? }
+
+    context "when billing entity does not have eu_tax_management enabled" do
+      before { customer.billing_entity.update!(eu_tax_management: false) }
+
+      it "returns false" do
+        expect(vies_check_in_progress).to eq(false)
+      end
+    end
+
+    context "when billing entity has eu_tax_management enabled" do
+      before { customer.billing_entity.update!(eu_tax_management: true) }
+
+      context "when customer has no pending_vies_check" do
+        it "returns false" do
+          expect(vies_check_in_progress).to eq(false)
+        end
+      end
+
+      context "when customer has a pending_vies_check" do
+        before { create(:pending_vies_check, customer:) }
+
+        it "returns true" do
+          expect(vies_check_in_progress).to eq(true)
+        end
+      end
+    end
+  end
+
   describe "#provider_customer" do
     subject(:customer) { create(:customer, organization:, payment_provider:) }
 


### PR DESCRIPTION
## Context

Part of the feature to prevent invoice finalization during VIES validation. We need a way to check if a customer is awaiting VIES retry.

## Description

Add vies_check_in_progress? predicate method that returns true when the customer's billing entity has EU tax management enabled and a pending VIES check record exists. This will be used to block invoice finalization until VIES validation succeeds.