### PR TITLE
feat(credit_notes): Improve performance for exporting invoices

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -286,12 +286,14 @@ class Invoice < ApplicationRecord
     }
   end
 
-  def preload_offset_amount_cents(offset_amount_cents)
-    @preloaded_offset_amount_cents = offset_amount_cents
+  # Caches offset_amount_cents in the invoice instance to avoid N+1 queries when exporting invoices.
+  # Allows batch calculation of offset amounts for many invoices in a single aggregated query.
+  def save_precalculated_offset_amount_cents(offset_amount_cents)
+    @precalculated_offset_amount_cents = offset_amount_cents
   end
 
   def offset_amount_cents
-    return @preloaded_offset_amount_cents if instance_variable_defined?(:@preloaded_offset_amount_cents)
+    return @precalculated_offset_amount_cents if instance_variable_defined?(:@precalculated_offset_amount_cents)
 
     credit_notes.finalized.sum(:offset_amount_cents)
   end

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -113,7 +113,7 @@ module DataExports
           .sum(:offset_amount_cents)
 
         invoices.each do |invoice|
-          invoice.preload_offset_amount_cents(offset_amounts[invoice.id] || 0)
+          invoice.save_precalculated_offset_amount_cents(offset_amounts[invoice.id] || 0)
         end
 
         invoices

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe DataExports::Csv::Invoices do
       # Preloading should result in only ONE query to credit_notes (the GROUP BY SUM query)
       query_count = 0
       counter = ->(_name, _start, _finish, _id, payload) {
-        query_count += 1 if /SELECT.*FROM.*credit_notes/i.match?(payload[:sql])
+        query_count += 1 if /SELECT SUM.*offset_amount_cents.*FROM.*credit_notes/i.match?(payload[:sql])
       }
 
       result = nil


### PR DESCRIPTION
## Context
Related PR: https://github.com/getlago/lago-api/pull/4892
As we’re introducing a new credit note attribute that also reduces the invoice amount due, we should update the Simple exports for both Invoices and Credit Notes to include this information (and ensure the exported “amount due” reflects applied credit notes).

## Description
As the `total_due_amount_cents` method uses `offset_amount_cents`, it should use the preloaded values to avoid N+1 queries when exporting.
The new approach overrides the `offset_amount_cents` method for each invoice object with the preloaded value.

**Previous approach:**
- Single query for `total_offsetted_credit_note_amount_cents`, N+1 queries for `total_due_amount_cents`.

**This approach:**
- Single query that preloads `offset_amount_cents` for both fields.
- Exporting 20k invoices is ~37% faster than the previous approach.