### PR TITLE
feat(pg_enrich): Add enriched_events

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15-alpine
+        image: getlago/postgres-partman:15.0-alpine
         ports:
           - "5432:5432"
         env:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15-alpine
+        image: getlago/postgres-partman:15.0-alpine
         ports:
           - "5432:5432"
         env:

--- a/app/models/enriched_event.rb
+++ b/app/models/enriched_event.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class EnrichedEvent < EventsRecord
+  belongs_to :event
+
+  validates :code,
+    :timestamp,
+    :transaction_id,
+    :external_subscription_id,
+    :organization_id,
+    :subscription_id,
+    :plan_id,
+    :charge_id,
+    :enriched_at, presence: true
+end
+
+# == Schema Information
+#
+# Table name: enriched_events
+# Database name: events
+#
+#  id                       :uuid             not null
+#  code                     :string           not null
+#  decimal_value            :decimal(40, 15)  default(0.0), not null
+#  enriched_at              :datetime         not null
+#  grouped_by               :jsonb            not null
+#  properties               :jsonb            not null
+#  timestamp                :datetime         not null
+#  value                    :string
+#  charge_filter_id         :uuid
+#  charge_id                :uuid             not null
+#  event_id                 :uuid             not null
+#  external_subscription_id :string           not null
+#  organization_id          :uuid             not null
+#  plan_id                  :uuid             not null
+#  subscription_id          :uuid             not null
+#  transaction_id           :string           not null
+#
+# Indexes
+#
+#  idx_billing_on_enriched_events     (organization_id,subscription_id,charge_id,charge_filter_id,timestamp)
+#  idx_lookup_on_enriched_events      (organization_id,external_subscription_id,code,timestamp)
+#  idx_unique_on_enriched_events      (organization_id,external_subscription_id,transaction_id,timestamp,charge_id) UNIQUE
+#  index_enriched_events_on_event_id  (event_id)
+#

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < EventsRecord
   include OrganizationTimezone
 
   belongs_to :organization
+  has_many :enriched_events
 
   validates :transaction_id, presence: true
   validates :code, presence: true

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -153,7 +153,7 @@ end
 #  index_invoice_subscriptions_on_regenerated_invoice_id          (regenerated_invoice_id)
 #  index_invoice_subscriptions_on_subscription_id                 (subscription_id)
 #  index_uniq_invoice_subscriptions_on_charges_from_to_datetime   (subscription_id,charges_from_datetime,charges_to_datetime) UNIQUE WHERE ((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE) AND (regenerated_invoice_id IS NULL))
-#  index_uniq_invoice_subscriptions_on_fixed_charges_boundaries   (subscription_id,fixed_charges_from_datetime,fixed_charges_to_datetime) UNIQUE WHERE ((fixed_charges_from_datetime IS NOT NULL) AND (recurring = true) AND (regenerated_invoice_id IS NULL))
+#  index_uniq_invoice_subscriptions_on_fixed_charges_boundaries   (subscription_id,fixed_charges_from_datetime,fixed_charges_to_datetime) UNIQUE WHERE ((fixed_charges_from_datetime IS NOT NULL) AND (recurring IS TRUE) AND (regenerated_invoice_id IS NULL))
 #  index_unique_starting_invoice_subscription                     (subscription_id,invoicing_reason) UNIQUE WHERE ((invoicing_reason = 'subscription_starting'::subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL))
 #  index_unique_terminating_invoice_subscription                  (subscription_id,invoicing_reason) UNIQUE WHERE ((invoicing_reason = 'subscription_terminating'::subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL))
 #

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,14 @@ module LagoApi
     config.active_record.encryption.deterministic_key = ENV["ENCRYPTION_DETERMINISTIC_KEY"] || ENV["LAGO_ENCRYPTION_DETERMINISTIC_KEY"]
     config.active_record.encryption.key_derivation_salt = ENV["ENCRYPTION_KEY_DERIVATION_SALT"] || ENV["LAGO_ENCRYPTION_KEY_DERIVATION_SALT"]
     config.active_record.schema_format = :sql
-    ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = ["--clean", "--if-exists", "--no-comments", "--no-publications"]
+
+    ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = [
+      "--clean",
+      "--if-exists",
+      "--no-comments",
+      "--no-publications",
+      "--exclude-table=enriched_events_p*"
+    ]
 
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]
     config.i18n.available_locales = %i[en fr nb de it es sv pt-BR zh-TW]

--- a/db/migrate/20260109092932_setup_partman.rb
+++ b/db/migrate/20260109092932_setup_partman.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class SetupPartman < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      # Check if pg_partman is available on the server
+      result = execute <<~SQL
+        SELECT 1 FROM pg_available_extensions WHERE name = 'pg_partman';
+      SQL
+
+      if result.ntuples.zero?
+        Rails.logger.debug "pg_partman extension is not available on this PostgreSQL server, skipping..."
+      else
+        execute <<~SQL
+          CREATE SCHEMA IF NOT EXISTS partman;
+          CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20260109110146_create_enriched_events.rb
+++ b/db/migrate/20260109110146_create_enriched_events.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class CreateEnrichedEvents < ActiveRecord::Migration[8.0]
+  def up
+    # Check if pg_partman is available on the server
+    result = safety_assured do
+      execute <<~SQL
+        SELECT 1 FROM pg_available_extensions WHERE name = 'pg_partman';
+      SQL
+    end
+
+    options = if result.ntuples.zero?
+      Rails.logger.debug "pg_partman extension is not available on this PostgreSQL server, skipping partitioning"
+      ""
+    else
+      "PARTITION BY RANGE (timestamp)"
+    end
+
+    create_table :enriched_events, id: false, primary_key: %i[id timestamp], options: do |t|
+      t.uuid :id, null: false, default: -> { "gen_random_uuid()" }
+      t.uuid :organization_id, null: false
+      t.uuid :event_id, null: false, index: true
+      t.string :transaction_id, null: false
+      t.string :external_subscription_id, null: false
+      t.string :code, null: false
+      t.datetime :timestamp, null: false
+      t.uuid :subscription_id, null: false
+      t.uuid :plan_id, null: false
+      t.uuid :charge_id, null: false
+      t.uuid :charge_filter_id
+      t.jsonb :properties, null: false, default: {}
+      t.jsonb :grouped_by, null: false, default: {}
+      t.string :value, null: true
+      t.decimal :decimal_value, precision: 40, scale: 15, null: false, default: 0.0
+      t.datetime :enriched_at, null: false
+
+      t.index %i[organization_id subscription_id charge_id charge_filter_id timestamp], name: "idx_billing_on_enriched_events"
+      t.index %i[organization_id external_subscription_id code timestamp], name: "idx_lookup_on_enriched_events"
+      t.index %i[organization_id external_subscription_id transaction_id timestamp charge_id], unique: true, name: "idx_unique_on_enriched_events"
+    end
+  end
+
+  def down
+    drop_table :enriched_events
+  end
+end

--- a/db/migrate/20260109132143_partition_enriched_events.rb
+++ b/db/migrate/20260109132143_partition_enriched_events.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class PartitionEnrichedEvents < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      # Check if pg_partman is available on the server
+      result = execute <<~SQL
+        SELECT 1 FROM pg_available_extensions WHERE name = 'pg_partman';
+      SQL
+
+      if result.ntuples.zero?
+        Rails.logger.debug "pg_partman extension is not available on this PostgreSQL server, skipping..."
+      else
+        execute <<~SQL
+          SELECT partman.create_parent(
+            p_parent_table := 'public.enriched_events',
+            p_control := 'timestamp',
+            p_interval := '1 month',
+            p_type := 'range',
+            p_premake := 3,                    -- Create 3 months ahead
+            p_start_partition := '2024-12-01'
+          )
+        SQL
+
+        execute <<~SQL
+          UPDATE partman.part_config
+          SET infinite_time_partitions = true,
+              retention = '14 months', -- Handle yearly plan with large grace periods
+              retention_keep_table = true
+          WHERE parent_table = 'public.enriched_events';
+        SQL
+      end
+    end
+  end
+end

--- a/spec/factories/enriched_events.rb
+++ b/spec/factories/enriched_events.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :enriched_event do
+    transient do
+      subscription { create(:subscription) }
+      charge { create(:standard_charge, plan_id: subscription.plan_id) }
+    end
+
+    event { create(:event, organization_id: subscription.organization_id) }
+
+    code { event.code }
+    timestamp { event.timestamp }
+    transaction_id { event.transaction_id }
+    external_subscription_id { subscription.external_id }
+
+    organization_id { event.organization_id }
+    subscription_id { subscription.id }
+    plan_id { subscription.plan_id }
+    charge_id { charge.id }
+
+    properties { event.properties }
+
+    enriched_at { Time.current }
+  end
+end

--- a/spec/models/enriched_event_spec.rb
+++ b/spec/models/enriched_event_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EnrichedEvent do
+  subject { build(:enriched_event) }
+
+  it { is_expected.to belong_to(:event) }
+
+  it { is_expected.to validate_presence_of(:code) }
+  it { is_expected.to validate_presence_of(:timestamp) }
+  it { is_expected.to validate_presence_of(:transaction_id) }
+  it { is_expected.to validate_presence_of(:external_subscription_id) }
+  it { is_expected.to validate_presence_of(:organization_id) }
+  it { is_expected.to validate_presence_of(:subscription_id) }
+  it { is_expected.to validate_presence_of(:plan_id) }
+  it { is_expected.to validate_presence_of(:charge_id) }
+  it { is_expected.to validate_presence_of(:enriched_at) }
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Event do
   subject { build(:event) }
 
+  it { is_expected.to have_many(:enriched_events) }
+
   it { is_expected.to validate_presence_of(:transaction_id) }
   it { is_expected.to validate_presence_of(:code) }
 


### PR DESCRIPTION
## Description

This PR is the first step of the Postgres event's pre-enrichment.

It's main goal is to:
- Add `pg_partman` setup to help managing table partitioning (see https://github.com/getlago/lago/pull/673)
- Create the new `enriched_events` table and its partitions
