### PR TITLE
Restore migrations that removed role columns

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Invite < ApplicationRecord
-  self.ignored_columns += %i[role]
-
   include PaperTrailTraceable
 
   belongs_to :organization

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Membership < ApplicationRecord
-  self.ignored_columns += %i[role]
-
   include PaperTrailTraceable
 
   belongs_to :organization

--- a/db/migrate/20260116121015_remove_role_from_memberships.rb
+++ b/db/migrate/20260116121015_remove_role_from_memberships.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveRoleFromMemberships < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :memberships, :role, :integer
+    end
+  end
+end

--- a/db/migrate/20260116121019_remove_role_from_invites.rb
+++ b/db/migrate/20260116121019_remove_role_from_invites.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveRoleFromInvites < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :invites, :role, :integer
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4168,7 +4168,6 @@ CREATE TABLE public.invites (
     revoked_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    role integer,
     roles character varying[] DEFAULT '{}'::character varying[] NOT NULL
 );
 
@@ -4285,7 +4284,6 @@ CREATE TABLE public.memberships (
     user_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    role integer,
     status integer DEFAULT 0 NOT NULL,
     revoked_at timestamp(6) without time zone
 );
@@ -11388,6 +11386,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260120195822'),
 ('20260119162712'),
 ('20260116162519'),
+('20260116121019'),
+('20260116121015'),
 ('20260116110125'),
 ('20260115164124'),
 ('20260114153728'),


### PR DESCRIPTION
## Roadmap Task

## Context

This is the continuation of [the commit that fixed the OSS releases](https://github.com/getlago/lago-api/pull/4919).
It restores the migration after ignoring the corresponding columns.

## Description

The PR should be applied
* to the production code along with the previous one (so that the migration remained the same for the production server)
* to the OSS releases AFTER releasing the previous one