### PR TITLE
chore(migration): Add Rubocop cop to limit dangerous migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ require:
   - standard
   - ./dev/cops/service_call_cop.rb
   - ./dev/cops/discard_all_cop.rb
+  - ./dev/cops/no_drop_column_or_table_cop.rb
 
 inherit_gem:
   standard: config/base.yml
@@ -30,6 +31,22 @@ AllCops:
     - "tmp/**/*"
     - "coverage/**/*"
     - "log/**/*"
+
+Lago/NoDropColumnOrTable:
+  Include:
+    - "db/migrate/**/*.rb"
+  Exclude:
+    - "db/migrate/20250218165958_drop_invoice_error_table.rb"
+    - "db/migrate/20250227091909_remove_is_default_from_billing_entity.rb"
+    - "db/migrate/20250526133654_drop_clickhouse_aggregation_from_organizations.rb"
+    - "db/migrate/20250912081524_change_wallet_min_max_to_big_int.rb"
+    - "db/migrate/20251020090137_remove_event_id_from_cached_aggregation.rb"
+    - "db/migrate/20251221174251_create_roles.rb"
+    - "db/migrate/20251221174733_create_membership_roles.rb"
+    - "db/migrate/20251221174938_add_roles_to_invites.rb"
+    - "db/migrate/20260116121015_remove_role_from_memberships.rb"
+    - "db/migrate/20260116121019_remove_role_from_invites.rb"
+    - "db/migrate/20260119162712_drop_subscription_fixed_charge_units_overrides.rb"
 
 # TODO: Fix these services
 Lago/ServiceCall:
@@ -150,3 +167,4 @@ ThreadSafety/NewThread:
 ThreadSafety/DirChdir:
   Exclude:
     - "spec/**/*"
+

--- a/db/migrate/20251221174251_create_roles.rb
+++ b/db/migrate/20251221174251_create_roles.rb
@@ -60,7 +60,7 @@ class CreateRoles < ActiveRecord::Migration[8.0]
               now(),
               now()
             );
-  
+
         CREATE FUNCTION ensure_role_consistency() RETURNS TRIGGER AS $$
           BEGIN
             IF OLD.organization_id IS NULL THEN

--- a/dev/cops/no_drop_column_or_table_cop.rb
+++ b/dev/cops/no_drop_column_or_table_cop.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module Cops
+  class NoDropColumnOrTableCop < ::RuboCop::Cop::Base
+    MSG = "Dropping columns or tables is disabled due to the risks involved. " \
+          "See docs/dropping_columns_and_tables.md for more information."
+
+    FORBIDDEN_METHODS = %i[remove_column drop_table remove_columns].freeze
+
+    # Matches direct calls like `remove_column :users, :email`
+    def_node_matcher :forbidden_migration_method?, <<~PATTERN
+      (send nil? {#{FORBIDDEN_METHODS.map { |m| ":#{m}" }.join(" ")}} ...)
+    PATTERN
+
+    # Matches calls on a receiver like `t.remove_column :email` inside change_table blocks
+    def_node_matcher :forbidden_table_method?, <<~PATTERN
+      (send _ {#{FORBIDDEN_METHODS.map { |m| ":#{m}" }.join(" ")}} ...)
+    PATTERN
+
+    def self.badge
+      @badge ||= ::RuboCop::Cop::Badge.for("Lago/NoDropColumnOrTable") # rubocop:disable ThreadSafety/ClassInstanceVariable
+    end
+
+    def on_send(node)
+      return unless forbidden_migration_method?(node) || forbidden_table_method?(node)
+
+      add_offense(node)
+    end
+  end
+end

--- a/docs/dropping_columns_and_tables.md
+++ b/docs/dropping_columns_and_tables.md
@@ -1,0 +1,77 @@
+# Dropping Columns and Tables
+
+Dropping columns or tables in migrations is **not recommended** and will be flagged by our custom RuboCop cop `Lago/NoDropColumnOrTable`.
+
+## Why is dropping columns or tables problematic ?
+
+Dropping columns or tables can lead to significant issues in a production environment and requires careful planning and coordination, especially in an open source context.
+
+### 1. Two-step migration complexity
+
+Safely removing a column requires a two-step process:
+
+1. **First deploy**: Remove all code references to the column and add the column to `ignored_columns` in the model
+2. **Second deploy**: Actually drop the column from the database
+
+This two-step process is error-prone because:
+
+- If code still references the column when it's dropped, the application will crash during deployment
+- Rolling back becomes complex if issues arise between the two deploys
+- It requires careful coordination between code changes and database changes
+
+### 2. Open source release constraints
+
+As an open source application, this two-step migration has additional implications:
+
+- **Two separate OSS releases** are required (one to ignore the column, one to drop it)
+- **Migration documentation** must be provided to users explaining the upgrade path:
+  - Users running self-hosted instances need clear instructions on when and how to upgrade
+  - Skipping versions becomes risky if column drops are not properly documented
+
+## How to properly drop a column or table
+
+If you absolutely need to drop a column or table, follow this process:
+
+### Step 1: Deprecate the column or table (Release N)
+
+1. Remove all code references to the column or table
+2. For columns drop, add the column to `ignored_columns` in the model:
+
+    ```ruby
+    class User < ApplicationRecord
+      # TODO: Remove after version X.Y.Z
+      self.ignored_columns += %w[deprecated_column_name]
+    end
+    ```
+
+3. Create a specific release including this change
+4. Document this in the release notes
+
+### Step 2: Drop the column or table (Release N+1 or later)
+
+1. Create a dedicated migration commit that:
+
+   - **Contains ONLY the column or table drop** - no other code changes
+   - **May contain multiple column or table drops** if they were all properly deprecated in previous releases
+   - **Documents the version** that removed the references to the column/table and eventually introduced the `ignored_columns` entry
+   - Add the migration to the exclusion list in the `.rubocop.yml`
+
+    Example commit message:
+
+    ```md
+    chore(db): drop deprecated columns
+
+    ## Context
+
+    These columns were deprecated in previous version and have been in
+    `ignored_columns` since then.
+
+    ## Description
+
+    Drop the following columns:
+    - `users.deprecated_column_name` (ignored since vX.Y.Z)
+    - `subscriptions.old_status` (ignored since vX.Y.Z)
+    ```
+
+2. Create a specific release including this change
+3. Add a release note documenting the column or table drops and the upgrade path from the previous release. You can find such an example here: <https://www.getlago.com/docs/guide/migration/migration-to-v1.32.0#what-should-self-hosted-users-do>.

--- a/spec/lib/cops/no_drop_column_or_table_cop_spec.rb
+++ b/spec/lib/cops/no_drop_column_or_table_cop_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "cop_helper"
+
+RSpec.describe Cops::NoDropColumnOrTableCop, :config do
+  describe "remove_column" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        remove_column :users, :email
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
+      RUBY
+    end
+
+    it "registers an offense inside change_table block" do
+      expect_offense(<<~RUBY)
+        change_table :users do |t|
+          t.remove_column :email
+          ^^^^^^^^^^^^^^^^^^^^^^ Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
+        end
+      RUBY
+    end
+  end
+
+  describe "remove_columns" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        remove_columns :users, :email, :name
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
+      RUBY
+    end
+  end
+
+  describe "drop_table" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        drop_table :users
+        ^^^^^^^^^^^^^^^^^ Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
+      RUBY
+    end
+
+    it "registers an offense with a block" do
+      expect_offense(<<~RUBY)
+        drop_table :users do |t|
+        ^^^^^^^^^^^^^^^^^ Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
+          t.string :email
+        end
+      RUBY
+    end
+  end
+
+  describe "allowed methods" do
+    it "does not register an offense for add_column" do
+      expect_no_offenses(<<~RUBY)
+        add_column :users, :email, :string
+      RUBY
+    end
+
+    it "does not register an offense for create_table" do
+      expect_no_offenses(<<~RUBY)
+        create_table :users do |t|
+          t.string :email
+        end
+      RUBY
+    end
+
+    it "does not register an offense for rename_column" do
+      expect_no_offenses(<<~RUBY)
+        rename_column :users, :email, :email_address
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## Context

Dropping columns or tables can lead to significant issues in a production environment and requires careful planning and coordination, especially in an open source context.

### 1. Two-step migration complexity

Safely removing a column requires a two-step process:

1. **First deploy**: Remove all code references to the column and add the column to `ignored_columns` in the model
2. **Second deploy**: Actually drop the column from the database

This two-step process is error-prone because:

- If code still references the column when it's dropped, the application will crash during deployment
- Rolling back becomes complex if issues arise between the two deploys
- It requires careful coordination between code changes and database changes

### 2. Open source release constraints

As an open source application, this two-step migration has additional implications:

- **Two separate OSS releases** are required (one to ignore the column, one to drop it)
- **Migration documentation** must be provided to users explaining the upgrade path:
  - Users running self-hosted instances need clear instructions on when and how to upgrade
  - Skipping versions becomes risky if column drops are not properly documented

## Description

For those reasons, this adds a Rubocop rule to limit such destructive actions:

```bash
Inspecting 4 files
.C..

Offenses:

db/migrate/20260121112930_drop_wallets.rb:5:5: C: Lago/NoDropColumnOrTable: Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
    remove_column :wallets, :code
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
db/migrate/20260121112930_drop_wallets.rb:6:5: C: Lago/NoDropColumnOrTable: Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
    remove_columns :wallets, :code
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
db/migrate/20260121112930_drop_wallets.rb:8:7: C: Lago/NoDropColumnOrTable: Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
      t.remove_column :code
      ^^^^^^^^^^^^^^^^^^^^^
db/migrate/20260121112930_drop_wallets.rb:10:5: C: Lago/NoDropColumnOrTable: Dropping columns or tables is disabled due to the risks involved. See docs/dropping_columns_and_tables.md for more information.
    drop_table :wallets
    ^^^^^^^^^^^^^^^^^^^
```

Note that `strong_migrations` already includes a rule to prevent including such migrations by mistake but it doesn't help ensuring the OSS release would be done properly.
