### PR TITLE
feat(billing): add service to finalize VIES-pending invoices

### DIFF
--- a/app/services/invoices/finalize_pending_vies_invoice_service.rb
+++ b/app/services/invoices/finalize_pending_vies_invoice_service.rb
@@ -14,6 +14,7 @@ module Invoices
       return result.not_found_failure!(resource: "invoice") unless invoice
       return result unless invoice.pending? && invoice.tax_pending?
       return result if customer.tax_customer
+      return result if customer.vies_check_in_progress?
 
       ActiveRecord::Base.transaction do
         invoice.issuing_date = issuing_date

--- a/spec/services/invoices/finalize_pending_vies_invoice_service_spec.rb
+++ b/spec/services/invoices/finalize_pending_vies_invoice_service_spec.rb
@@ -115,6 +115,21 @@ RSpec.describe Invoices::FinalizePendingViesInvoiceService do
       end
     end
 
+    context "when VIES check is still in progress" do
+      let(:billing_entity) { create(:billing_entity, organization:, eu_tax_management: true) }
+      let(:pending_vies_check) { create(:pending_vies_check, customer:) }
+
+      before { pending_vies_check }
+
+      it "does not change the invoice" do
+        expect { finalize_service.call }.not_to change { invoice.reload.attributes }
+      end
+
+      it "returns success" do
+        expect(finalize_service.call).to be_success
+      end
+    end
+
     context "when invoice is finalized successfully" do
       it "changes status from pending to finalized" do
         expect { finalize_service.call }


### PR DESCRIPTION
## Context

When an invoice is blocked due to VIES validation pending, it remains in pending status until the VIES check completes. Once VIES validation succeeds, these invoices need to be finalized with the correct taxes.

## Description

Add FinalizePendingViesInvoiceService that handles finalization of invoices that were blocked due to pending VIES validation. The service applies local taxes, sets issuing/payment dates, applies credits, and triggers all finalization jobs (webhooks, document generation, payments, integrations). Customers with tax providers are skipped as their invoices are handled by PullTaxesAndApplyService instead.