### PR TITLE
feat(billing): add job to finalize VIES-pending invoices

### DIFF
--- a/app/jobs/invoices/finalize_pending_vies_invoice_job.rb
+++ b/app/jobs/invoices/finalize_pending_vies_invoice_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Invoices
+  class FinalizePendingViesInvoiceJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
+        :billing
+      else
+        :invoices
+      end
+    end
+
+    unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+
+    def perform(invoice)
+      Invoices::FinalizePendingViesInvoiceService.call!(invoice:)
+    end
+  end
+end

--- a/spec/jobs/invoices/finalize_pending_vies_invoice_job_spec.rb
+++ b/spec/jobs/invoices/finalize_pending_vies_invoice_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::FinalizePendingViesInvoiceJob do
+  let(:invoice) { create(:invoice, :pending, tax_status: "pending") }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(Invoices::FinalizePendingViesInvoiceService).to receive(:call!)
+      .with(invoice:)
+      .and_return(result)
+  end
+
+  it "delegates to the FinalizePendingViesInvoiceService" do
+    described_class.perform_now(invoice)
+
+    expect(Invoices::FinalizePendingViesInvoiceService).to have_received(:call!).with(invoice:)
+  end
+end


### PR DESCRIPTION
## Context

When VIES validation succeeds after being temporarily unavailable, invoices that were blocked need to be finalized asynchronously.

## Description

Add FinalizePendingViesInvoiceJob that calls the corresponding service. The job uses the billing/invoices queue and has a unique constraint to prevent duplicate finalization attempts for the same invoice.