### PR TITLE
misc: remove zero_amount_fees flag

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -125,7 +125,6 @@ class Organization < ApplicationRecord
     salesforce
     api_permissions
     revenue_share
-    zero_amount_fees
     remove_branding_watermark
     manual_payments
     from_email

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -207,7 +207,6 @@ module Fees
 
     def should_persist_fee?(fee, fees)
       return true if context == :recurring
-      return true if organization.zero_amount_fees_enabled?
       return true if fee.units != 0 || fee.amount_cents != 0 || fee.events_count != 0
       return true if adjusted_fee(charge_filter: fee.charge_filter, grouped_by: fee.grouped_by).present?
       return true if fee.true_up_parent_fee.present?

--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -215,7 +215,6 @@ module Fees
 
     def should_persist_fee?
       return true if context == :recurring
-      return true if organization.zero_amount_fees_enabled?
       return true if result.fee.units != 0 || result.fee.amount_cents != 0
       return true if adjusted_fee.present?
 

--- a/db/migrate/20260202155431_remove_organization_zero_amount_fees_premium_integration.rb
+++ b/db/migrate/20260202155431_remove_organization_zero_amount_fees_premium_integration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveOrganizationZeroAmountFeesPremiumIntegration < ActiveRecord::Migration[8.0]
+  def change
+    organizations = Organization.where("? = ANY(premium_integrations)", "zero_amount_fees")
+
+    organizations.find_each do |organization|
+      organization.update!(premium_integrations: organization.premium_integrations - ["zero_amount_fees"])
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11396,6 +11396,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260202155431'),
 ('20260202134958'),
 ('20260129105200'),
 ('20260127114700'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -6165,7 +6165,6 @@ enum IntegrationTypeEnum {
   revenue_share
   salesforce
   xero
-  zero_amount_fees
 }
 
 type Invite {
@@ -8937,7 +8936,6 @@ enum PremiumIntegrationTypeEnum {
   revenue_share
   salesforce
   xero
-  zero_amount_fees
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -31296,12 +31296,6 @@
               "deprecationReason": null
             },
             {
-              "name": "zero_amount_fees",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "remove_branding_watermark",
               "description": null,
               "isDeprecated": false,
@@ -45488,12 +45482,6 @@
             },
             {
               "name": "revenue_share",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "zero_amount_fees",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
       revenue_share
       salesforce
       xero
-      zero_amount_fees
       remove_branding_watermark
       manual_payments
       from_email

--- a/spec/services/fees/build_pay_in_advance_fixed_charge_service_spec.rb
+++ b/spec/services/fees/build_pay_in_advance_fixed_charge_service_spec.rb
@@ -141,19 +141,6 @@ RSpec.describe Fees::BuildPayInAdvanceFixedChargeService do
       expect(result.fee.units).to eq(0)
       expect(result.fee.amount_cents).to eq(0)
     end
-
-    context "when organization as zero_amount_fees premium integration" do
-      before do
-        organization.update!(premium_integrations: ["zero_amount_fees"])
-      end
-
-      it "creates a zero-amount fee (no refund)" do
-        expect(result).to be_success
-        expect(result.fee).to be_present
-        expect(result.fee.units).to eq(0)
-        expect(result.fee.amount_cents).to eq(0)
-      end
-    end
   end
 
   context "when units stay the same (delta is zero)" do
@@ -196,19 +183,6 @@ RSpec.describe Fees::BuildPayInAdvanceFixedChargeService do
       expect(result.fee).to be_present
       expect(result.fee.units).to eq(0)
       expect(result.fee.amount_cents).to eq(0)
-    end
-
-    context "when organization as zero_amount_fees premium integration" do
-      before do
-        organization.update!(premium_integrations: ["zero_amount_fees"])
-      end
-
-      it "creates a zero-amount fee (no refund)" do
-        expect(result).to be_success
-        expect(result.fee).to be_present
-        expect(result.fee.units).to eq(0)
-        expect(result.fee.amount_cents).to eq(0)
-      end
     end
   end
 
@@ -505,19 +479,6 @@ RSpec.describe Fees::BuildPayInAdvanceFixedChargeService do
         expect(result.fee).to be_present
         expect(result.fee.units).to eq(0)
         expect(result.fee.amount_cents).to eq(0)
-      end
-
-      context "when organization has zero_amount_fees premium integration" do
-        before do
-          organization.update!(premium_integrations: ["zero_amount_fees"])
-        end
-
-        it "creates a zero-amount fee" do
-          expect(result).to be_success
-          expect(result.fee).to be_present
-          expect(result.fee.units).to eq(0)
-          expect(result.fee.amount_cents).to eq(0)
-        end
       end
     end
 


### PR DESCRIPTION
## Context

We used to support a special flag for organizations that needed to generate a fee with zero units when an invoice was created. 

This has mostly been implemented because we wanted to fall back on previous customer usage and the way to build the customers. 

While we slowly migrated them to the new way to create the invoices and integrate with Lago, this feature is no longer used in production. 
Please note that we don't consider it as a breaking change as this was specifically done for cloud customers and we are not expecting open source users to be breaking as it was never pushed to them for usage. 

## Description

This will request to remove all code related to this premium feature flag `zero_amount_fees`