### PR TITLE
chore(scripts): add staging migration script

### DIFF
--- a/scripts/migrate.staging.sh
+++ b/scripts/migrate.staging.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+bundle exec rake db:prepare
+
+rm -f ./tmp/pids/server.pid
+
+if [ -v LAGO_CLICKHOUSE_MIGRATIONS_ENABLED ] && [ "$LAGO_CLICKHOUSE_MIGRATIONS_ENABLED" == "true" ]
+then
+  bundle exec rails db:migrate:primary
+  bundle exec rails db:migrate:clickhouse
+else
+  bundle exec rails db:migrate
+fi
+
+bundle exec rails signup:seed_organization


### PR DESCRIPTION
## Context

Staging environments need a dedicated migration script that handles both standard PostgreSQL migrations and optional ClickHouse migrations based on environment configuration.

## Description

Add a shell script for staging database migrations that:
- Prepares the database with db:prepare
- Cleans up stale server PID files
- Conditionally runs ClickHouse migrations when enabled via LAGO_CLICKHOUSE_MIGRATIONS_ENABLED environment variable
- Seeds the signup organization after migrations complete

