### PR TITLE
fix(events-processor): Make sure the Flag Refresh job is performed without events worker

### DIFF
--- a/app/jobs/subscriptions/flag_refreshed_job.rb
+++ b/app/jobs/subscriptions/flag_refreshed_job.rb
@@ -2,7 +2,13 @@
 
 module Subscriptions
   class FlagRefreshedJob < ApplicationJob
-    queue_as :events
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_EVENTS"])
+        :events
+      else
+        :default
+      end
+    end
 
     def perform(subscription_id)
       Subscriptions::FlagRefreshedService.call!(subscription_id)

--- a/spec/jobs/subscriptions/flag_refreshed_job_spec.rb
+++ b/spec/jobs/subscriptions/flag_refreshed_job_spec.rb
@@ -3,9 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Subscriptions::FlagRefreshedJob do
-  describe "#perform" do
-    let(:subscription_id) { SecureRandom.uuid }
+  let(:subscription_id) { SecureRandom.uuid }
 
+  it_behaves_like "a configurable queues", "events", "SIDEKIQ_EVENTS" do
+    let(:arguments) { subscription_id }
+  end
+
+  describe "#perform" do
     it "calls the subscriptions flag refreshed job" do
       allow(Subscriptions::FlagRefreshedService).to receive(:call!)
 

--- a/spec/support/shared_examples/jobs/configurable_queues.rb
+++ b/spec/support/shared_examples/jobs/configurable_queues.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a configurable queues" do |dedicated_queue, env_variable, default_queue = "default"|
+  let(:arguments) { nil }
+
+  context "when #{env_variable} is true" do
+    before { ENV[env_variable] = "true" }
+    after { ENV.delete(env_variable) }
+
+    it "uses the #{dedicated_queue} queue" do
+      expect {
+        described_class.perform_later(arguments)
+      }.to have_enqueued_job.on_queue(dedicated_queue)
+    end
+  end
+
+  context "when SIDEKIQ_EVENTS is false or not set" do
+    before { ENV.delete(env_variable) }
+
+    it "uses the #{default_queue} queue" do
+      expect {
+        described_class.perform_later(arguments)
+      }.to have_enqueued_job.on_queue(default_queue)
+    end
+  end
+end


### PR DESCRIPTION
## Context

`Subscriptions::FlagRefreshedJob` are not performed when the Sidekiq dedicated events worker is not configured. It is especially the case on staging.

## Description

This PR makes sure that the jobs fall-back to the default queue when the events worker is not configured, by checking for the presence of the  `SIDEKIQ_EVENTS` environment variable.

A new reusable `a configurable queues"` shared example as also been created to make testing this configurable behavior easier.
