### PR TITLE
Fix(upgrade-verification): update condition to continue the check on upgrade_verification

### DIFF
--- a/lib/tasks/upgrade_verification.rake
+++ b/lib/tasks/upgrade_verification.rake
@@ -48,7 +48,7 @@ namespace :upgrade do
       to_fill.each do |resource|
         model = resource[:model]
         pp "- Checking #{model.name}: 🔎"
-        count = model.where(customer_id: nil).count
+        count = model.where(code: nil).count
 
         if count > 0
           pp "  -> #{count} remaining 🧮"


### PR DESCRIPTION
When updating the script that runs required job for the new version, forgot to update the check in one place