### PR TITLE
feat(pre-enrich): Ignore enriched_events#properties column

### DIFF
--- a/app/models/enriched_event.rb
+++ b/app/models/enriched_event.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EnrichedEvent < EventsRecord
+  self.ignored_columns += [:properties]
+
   belongs_to :event
 
   validates :code,

--- a/spec/factories/enriched_events.rb
+++ b/spec/factories/enriched_events.rb
@@ -19,8 +19,6 @@ FactoryBot.define do
     plan_id { subscription.plan_id }
     charge_id { charge.id }
 
-    properties { event.properties }
-
     enriched_at { Time.current }
   end
 end


### PR DESCRIPTION
## Description

This PR marks the `enriched_events#properties` column for deletion.

This column was introduced by a previous migration already deployed on cloud but not yet released in open source.