### PR TITLE
feat(wallet): add GraphQL API for consumption/funding traceability

### DIFF
--- a/app/contracts/queries/wallet_transaction_consumptions_query_filters_contract.rb
+++ b/app/contracts/queries/wallet_transaction_consumptions_query_filters_contract.rb
@@ -4,7 +4,7 @@ module Queries
   class WalletTransactionConsumptionsQueryFiltersContract < Dry::Validation::Contract
     params do
       required(:wallet_transaction_id).filled(:string)
-      required(:direction).filled(:string, included_in?: %w[consumptions fundings])
+      required(:direction).filled(:"coercible.string", included_in?: %w[consumptions fundings])
     end
   end
 end

--- a/app/graphql/resolvers/wallet_transaction_consumptions_resolver.rb
+++ b/app/graphql/resolvers/wallet_transaction_consumptions_resolver.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class WalletTransactionConsumptionsResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description "Query wallet transaction consumptions for an inbound transaction"
+
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+    argument :wallet_transaction_id, ID, required: true, description: "Uniq ID of the inbound wallet transaction"
+
+    type Types::WalletTransactionConsumptions::Object.collection_type, null: false
+
+    def resolve(wallet_transaction_id:, page: nil, limit: nil)
+      result = WalletTransactionConsumptionsQuery.call(
+        organization: current_organization,
+        filters: {
+          wallet_transaction_id:,
+          direction: :consumptions
+        },
+        pagination: {page:, limit:}
+      )
+
+      return result_error(result) unless result.success?
+
+      result.wallet_transaction_consumptions
+    end
+  end
+end

--- a/app/graphql/resolvers/wallet_transaction_fundings_resolver.rb
+++ b/app/graphql/resolvers/wallet_transaction_fundings_resolver.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class WalletTransactionFundingsResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description "Query wallet transaction fundings for an outbound transaction"
+
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+    argument :wallet_transaction_id, ID, required: true, description: "Uniq ID of the outbound wallet transaction"
+
+    type Types::WalletTransactionFundings::Object.collection_type, null: false
+
+    def resolve(wallet_transaction_id:, page: nil, limit: nil)
+      result = WalletTransactionConsumptionsQuery.call(
+        organization: current_organization,
+        filters: {
+          wallet_transaction_id:,
+          direction: :fundings
+        },
+        pagination: {page:, limit:}
+      )
+
+      return result_error(result) unless result.success?
+
+      result.wallet_transaction_consumptions
+    end
+  end
+end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -32,6 +32,8 @@ module Types
       field :credit_notes_amount_cents, GraphQL::Types::BigInt, null: false
       field :fees_amount_cents, GraphQL::Types::BigInt, null: false
       field :prepaid_credit_amount_cents, GraphQL::Types::BigInt, null: false
+      field :prepaid_granted_credit_amount_cents, GraphQL::Types::BigInt, null: true
+      field :prepaid_purchased_credit_amount_cents, GraphQL::Types::BigInt, null: true
       field :progressive_billing_credit_amount_cents, GraphQL::Types::BigInt, null: false
       field :ready_for_payment_processing, Boolean, null: false
       field :sub_total_excluding_taxes_amount_cents, GraphQL::Types::BigInt, null: false

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -95,6 +95,8 @@ module Types
     field :taxes, resolver: Resolvers::TaxesResolver
     field :wallet, resolver: Resolvers::WalletResolver
     field :wallet_transaction, resolver: Resolvers::WalletTransactionResolver
+    field :wallet_transaction_consumptions, resolver: Resolvers::WalletTransactionConsumptionsResolver
+    field :wallet_transaction_fundings, resolver: Resolvers::WalletTransactionFundingsResolver
     field :wallet_transactions, resolver: Resolvers::WalletTransactionsResolver
     field :wallets, resolver: Resolvers::WalletsResolver
     field :webhook, resolver: Resolvers::WebhookResolver

--- a/app/graphql/types/wallet_transaction_consumptions/object.rb
+++ b/app/graphql/types/wallet_transaction_consumptions/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module WalletTransactionConsumptions
+    class Object < Types::BaseObject
+      graphql_name "WalletTransactionConsumption"
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false, method: :consumed_amount_cents
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :credit_amount, String, null: false
+      field :id, ID, null: false
+      field :wallet_transaction, Types::WalletTransactions::Object, null: false, method: :outbound_wallet_transaction
+
+      def credit_amount
+        wallet = object.outbound_wallet_transaction.wallet
+        currency = wallet.currency_for_balance
+        object.consumed_amount_cents.fdiv(currency.subunit_to_unit).fdiv(wallet.rate_amount).to_s
+      end
+    end
+  end
+end

--- a/app/graphql/types/wallet_transaction_fundings/object.rb
+++ b/app/graphql/types/wallet_transaction_fundings/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module WalletTransactionFundings
+    class Object < Types::BaseObject
+      graphql_name "WalletTransactionFunding"
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false, method: :consumed_amount_cents
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :credit_amount, String, null: false
+      field :id, ID, null: false
+      field :wallet_transaction, Types::WalletTransactions::Object, null: false, method: :inbound_wallet_transaction
+
+      def credit_amount
+        wallet = object.inbound_wallet_transaction.wallet
+        currency = wallet.currency_for_balance
+        object.consumed_amount_cents.fdiv(currency.subunit_to_unit).fdiv(wallet.rate_amount).to_s
+      end
+    end
+  end
+end

--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -23,6 +23,8 @@ module Types
       field :failed_at, GraphQL::Types::ISO8601DateTime, null: true
       field :invoice, Types::Invoices::Object, null: true
       field :metadata, [Types::WalletTransactions::MetadataObject], null: true
+      field :remaining_amount_cents, GraphQL::Types::BigInt, null: true
+      field :remaining_credit_amount, String, null: true
       field :settled_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
@@ -31,6 +33,14 @@ module Types
 
       def invoice
         object.invoice&.visible? ? object.invoice : nil
+      end
+
+      def remaining_credit_amount
+        return nil if object.remaining_amount_cents.nil?
+
+        wallet = object.wallet
+        currency = wallet.currency_for_balance
+        object.remaining_amount_cents.fdiv(currency.subunit_to_unit).fdiv(wallet.rate_amount).to_s
       end
 
       def wallet_name

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -53,6 +53,7 @@ module WalletTransactions
     def initial_remaining_amount_cents
       return nil unless wallet.traceable?
       return nil unless transaction_params[:transaction_type]&.to_sym == :inbound
+      return nil unless transaction_params[:transaction_status]&.to_sym == :granted
 
       wallet_credit.amount_cents
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6289,6 +6289,8 @@ type Invoice {
   paymentStatus: InvoicePaymentStatusTypeEnum!
   payments: [Payment!]
   prepaidCreditAmountCents: BigInt!
+  prepaidGrantedCreditAmountCents: BigInt
+  prepaidPurchasedCreditAmountCents: BigInt
   progressiveBillingCreditAmountCents: BigInt!
   readyForPaymentProcessing: Boolean!
   refundableAmountCents: BigInt!
@@ -9972,6 +9974,32 @@ type Query {
   ): WalletTransaction
 
   """
+  Query wallet transaction consumptions for an inbound transaction
+  """
+  walletTransactionConsumptions(
+    limit: Int
+    page: Int
+
+    """
+    Uniq ID of the inbound wallet transaction
+    """
+    walletTransactionId: ID!
+  ): WalletTransactionConsumptionCollection!
+
+  """
+  Query wallet transaction fundings for an outbound transaction
+  """
+  walletTransactionFundings(
+    limit: Int
+    page: Int
+
+    """
+    Uniq ID of the outbound wallet transaction
+    """
+    walletTransactionId: ID!
+  ): WalletTransactionFundingCollection!
+
+  """
   Query wallet transactions
   """
   walletTransactions(
@@ -12503,6 +12531,8 @@ type WalletTransaction {
   metadata: [WalletTransactionMetadataObject!]
   name: String
   priority: Int!
+  remainingAmountCents: BigInt
+  remainingCreditAmount: String
   selectedInvoiceCustomSections: [InvoiceCustomSection!]
   settledAt: ISO8601DateTime
   skipInvoiceCustomSections: Boolean
@@ -12523,6 +12553,52 @@ type WalletTransactionCollection {
   A collection of paginated WalletTransactionCollection
   """
   collection: [WalletTransaction!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+type WalletTransactionConsumption {
+  amountCents: BigInt!
+  createdAt: ISO8601DateTime!
+  creditAmount: String!
+  id: ID!
+  walletTransaction: WalletTransaction!
+}
+
+"""
+WalletTransactionConsumptionCollection type
+"""
+type WalletTransactionConsumptionCollection {
+  """
+  A collection of paginated WalletTransactionConsumptionCollection
+  """
+  collection: [WalletTransactionConsumption!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+type WalletTransactionFunding {
+  amountCents: BigInt!
+  createdAt: ISO8601DateTime!
+  creditAmount: String!
+  id: ID!
+  walletTransaction: WalletTransaction!
+}
+
+"""
+WalletTransactionFundingCollection type
+"""
+type WalletTransactionFundingCollection {
+  """
+  A collection of paginated WalletTransactionFundingCollection
+  """
+  collection: [WalletTransactionFunding!]!
 
   """
   Pagination Metadata for navigating the Pagination

--- a/schema.json
+++ b/schema.json
@@ -32540,6 +32540,30 @@
               "deprecationReason": null
             },
             {
+              "name": "prepaidGrantedCreditAmountCents",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "prepaidPurchasedCreditAmountCents",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "progressiveBillingCreditAmountCents",
               "description": null,
               "args": [],
@@ -53989,6 +54013,120 @@
               "deprecationReason": null
             },
             {
+              "name": "walletTransactionConsumptions",
+              "description": "Query wallet transaction consumptions for an inbound transaction",
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "walletTransactionId",
+                  "description": "Uniq ID of the inbound wallet transaction",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WalletTransactionConsumptionCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "walletTransactionFundings",
+              "description": "Query wallet transaction fundings for an outbound transaction",
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "walletTransactionId",
+                  "description": "Uniq ID of the outbound wallet transaction",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WalletTransactionFundingCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "walletTransactions",
               "description": "Query wallet transactions",
               "args": [
@@ -67017,6 +67155,30 @@
               "deprecationReason": null
             },
             {
+              "name": "remainingAmountCents",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "remainingCreditAmount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "selectedInvoiceCustomSections",
               "description": null,
               "args": [],
@@ -67191,6 +67353,290 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "WalletTransaction",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WalletTransactionConsumption",
+          "description": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "creditAmount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "walletTransaction",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WalletTransaction",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WalletTransactionConsumptionCollection",
+          "description": "WalletTransactionConsumptionCollection type",
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated WalletTransactionConsumptionCollection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "WalletTransactionConsumption",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WalletTransactionFunding",
+          "description": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "creditAmount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "walletTransaction",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WalletTransaction",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WalletTransactionFundingCollection",
+          "description": "WalletTransactionFundingCollection type",
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated WalletTransactionFundingCollection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "WalletTransactionFunding",
                       "ofType": null
                     }
                   }

--- a/spec/graphql/resolvers/wallet_transaction_consumptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transaction_consumptions_resolver_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::WalletTransactionConsumptionsResolver do
+  let(:query) do
+    <<~GQL
+      query($walletTransactionId: ID!, $page: Int, $limit: Int) {
+        walletTransactionConsumptions(walletTransactionId: $walletTransactionId, page: $page, limit: $limit) {
+          collection {
+            id
+            amountCents
+            creditAmount
+            createdAt
+            walletTransaction { id }
+          }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:, traceable: true) }
+  let(:inbound_transaction) do
+    create(:wallet_transaction,
+      wallet:,
+      organization:,
+      transaction_type: :inbound,
+      remaining_amount_cents: 10000)
+  end
+  let(:outbound_transaction) do
+    create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound)
+  end
+  let!(:consumption) do
+    create(:wallet_transaction_consumption,
+      organization:,
+      inbound_wallet_transaction: inbound_transaction,
+      outbound_wallet_transaction: outbound_transaction,
+      consumed_amount_cents: 500)
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+
+  it "returns a list of consumptions for an inbound transaction" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: {walletTransactionId: inbound_transaction.id, limit: 5}
+    )
+
+    consumptions_response = result["data"]["walletTransactionConsumptions"]
+
+    expect(consumptions_response["collection"].count).to eq(1)
+    expect(consumptions_response["collection"].first["id"]).to eq(consumption.id)
+    expect(consumptions_response["collection"].first["amountCents"]).to eq("500")
+    expect(consumptions_response["collection"].first["walletTransaction"]["id"]).to eq(outbound_transaction.id)
+    expect(consumptions_response["metadata"]["currentPage"]).to eq(1)
+    expect(consumptions_response["metadata"]["totalCount"]).to eq(1)
+  end
+
+  context "with pagination" do
+    before do
+      outbounds = create_list(:wallet_transaction, 3, wallet:, organization:, transaction_type: :outbound)
+      outbounds.each do |outbound|
+        create(:wallet_transaction_consumption,
+          organization:,
+          inbound_wallet_transaction: inbound_transaction,
+          outbound_wallet_transaction: outbound,
+          consumed_amount_cents: 100)
+      end
+    end
+
+    it "returns paginated results" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: inbound_transaction.id, page: 1, limit: 2}
+      )
+
+      consumptions_response = result["data"]["walletTransactionConsumptions"]
+
+      expect(consumptions_response["collection"].count).to eq(2)
+      expect(consumptions_response["metadata"]["currentPage"]).to eq(1)
+      expect(consumptions_response["metadata"]["totalCount"]).to eq(4)
+    end
+
+    it "returns second page of results" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: inbound_transaction.id, page: 2, limit: 2}
+      )
+
+      consumptions_response = result["data"]["walletTransactionConsumptions"]
+
+      expect(consumptions_response["collection"].count).to eq(2)
+      expect(consumptions_response["metadata"]["currentPage"]).to eq(2)
+      expect(consumptions_response["metadata"]["totalCount"]).to eq(4)
+    end
+  end
+
+  context "when transaction is outbound" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: outbound_transaction.id}
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity")
+    end
+  end
+
+  context "when wallet is not traceable" do
+    let(:wallet) { create(:wallet, customer:, traceable: false) }
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: inbound_transaction.id}
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity")
+    end
+  end
+
+  context "when transaction does not exist" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: "non-existent-id"}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+
+  context "when transaction belongs to another organization" do
+    let(:other_organization) { create(:organization) }
+    let(:other_customer) { create(:customer, organization: other_organization) }
+    let(:other_wallet) { create(:wallet, customer: other_customer, traceable: true) }
+    let(:other_transaction) do
+      create(:wallet_transaction,
+        wallet: other_wallet,
+        organization: other_organization,
+        transaction_type: :inbound,
+        remaining_amount_cents: 10000)
+    end
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: other_transaction.id}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/resolvers/wallet_transaction_fundings_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transaction_fundings_resolver_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::WalletTransactionFundingsResolver do
+  let(:query) do
+    <<~GQL
+      query($walletTransactionId: ID!, $page: Int, $limit: Int) {
+        walletTransactionFundings(walletTransactionId: $walletTransactionId, page: $page, limit: $limit) {
+          collection {
+            id
+            amountCents
+            creditAmount
+            createdAt
+            walletTransaction { id }
+          }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:, traceable: true) }
+  let(:inbound_transaction) do
+    create(:wallet_transaction,
+      wallet:,
+      organization:,
+      transaction_type: :inbound,
+      remaining_amount_cents: 10000)
+  end
+  let(:outbound_transaction) do
+    create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound)
+  end
+  let!(:consumption) do
+    create(:wallet_transaction_consumption,
+      organization:,
+      inbound_wallet_transaction: inbound_transaction,
+      outbound_wallet_transaction: outbound_transaction,
+      consumed_amount_cents: 500)
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+
+  it "returns a list of fundings for an outbound transaction" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: {walletTransactionId: outbound_transaction.id, limit: 5}
+    )
+
+    fundings_response = result["data"]["walletTransactionFundings"]
+
+    expect(fundings_response["collection"].count).to eq(1)
+    expect(fundings_response["collection"].first["id"]).to eq(consumption.id)
+    expect(fundings_response["collection"].first["amountCents"]).to eq("500")
+    expect(fundings_response["collection"].first["walletTransaction"]["id"]).to eq(inbound_transaction.id)
+    expect(fundings_response["metadata"]["currentPage"]).to eq(1)
+    expect(fundings_response["metadata"]["totalCount"]).to eq(1)
+  end
+
+  context "with pagination" do
+    let(:inbounds) { create_list(:wallet_transaction, 3, wallet:, organization:, transaction_type: :inbound, remaining_amount_cents: 10000) }
+
+    before do
+      inbounds.each do |inbound|
+        create(:wallet_transaction_consumption,
+          organization:,
+          inbound_wallet_transaction: inbound,
+          outbound_wallet_transaction: outbound_transaction,
+          consumed_amount_cents: 100)
+      end
+    end
+
+    it "returns paginated results" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: outbound_transaction.id, page: 1, limit: 2}
+      )
+
+      fundings_response = result["data"]["walletTransactionFundings"]
+
+      expect(fundings_response["collection"].count).to eq(2)
+      expect(fundings_response["metadata"]["currentPage"]).to eq(1)
+      expect(fundings_response["metadata"]["totalCount"]).to eq(4)
+    end
+
+    it "returns second page of results" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: outbound_transaction.id, page: 2, limit: 2}
+      )
+
+      fundings_response = result["data"]["walletTransactionFundings"]
+
+      expect(fundings_response["collection"].count).to eq(2)
+      expect(fundings_response["metadata"]["currentPage"]).to eq(2)
+      expect(fundings_response["metadata"]["totalCount"]).to eq(4)
+    end
+  end
+
+  context "when transaction is inbound" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: inbound_transaction.id}
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity")
+    end
+  end
+
+  context "when wallet is not traceable" do
+    let(:wallet) { create(:wallet, customer:, traceable: false) }
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: outbound_transaction.id}
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity")
+    end
+  end
+
+  context "when transaction does not exist" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: "non-existent-id"}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+
+  context "when transaction belongs to another organization" do
+    let(:other_organization) { create(:organization) }
+    let(:other_customer) { create(:customer, organization: other_organization) }
+    let(:other_wallet) { create(:wallet, customer: other_customer, traceable: true) }
+    let(:other_transaction) do
+      create(:wallet_transaction,
+        wallet: other_wallet,
+        organization: other_organization,
+        transaction_type: :outbound)
+    end
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {walletTransactionId: other_transaction.id}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Types::Invoices::Object do
     expect(subject).to have_field(:credit_notes_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:fees_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:prepaid_credit_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:prepaid_granted_credit_amount_cents).of_type("BigInt")
+    expect(subject).to have_field(:prepaid_purchased_credit_amount_cents).of_type("BigInt")
     expect(subject).to have_field(:progressive_billing_credit_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:sub_total_excluding_taxes_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:sub_total_including_taxes_amount_cents).of_type("BigInt!")

--- a/spec/graphql/types/wallet_transaction_consumptions/object_spec.rb
+++ b/spec/graphql/types/wallet_transaction_consumptions/object_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::WalletTransactionConsumptions::Object do
+  subject { described_class }
+
+  it "has the expected fields with correct types" do
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:credit_amount).of_type("String!")
+    expect(subject).to have_field(:wallet_transaction).of_type("WalletTransaction!")
+  end
+
+  describe "#amount_cents" do
+    subject { run_graphql_field("WalletTransactionConsumption.amountCents", consumption) }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:wallet) { create(:wallet, customer:, traceable: true) }
+    let(:inbound_transaction) do
+      create(:wallet_transaction,
+        wallet:,
+        organization:,
+        transaction_type: :inbound,
+        remaining_amount_cents: 10000)
+    end
+    let(:outbound_transaction) do
+      create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound)
+    end
+    let(:consumption) do
+      create(:wallet_transaction_consumption,
+        organization:,
+        inbound_wallet_transaction: inbound_transaction,
+        outbound_wallet_transaction: outbound_transaction,
+        consumed_amount_cents: 5000)
+    end
+
+    it "returns the consumed_amount_cents" do
+      expect(subject).to eq(5000)
+    end
+  end
+
+  describe "#credit_amount" do
+    subject { run_graphql_field("WalletTransactionConsumption.creditAmount", consumption) }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:wallet) { create(:wallet, customer:, traceable: true, rate_amount: 1.5) }
+    let(:inbound_transaction) do
+      create(:wallet_transaction,
+        wallet:,
+        organization:,
+        transaction_type: :inbound,
+        remaining_amount_cents: 10000)
+    end
+    let(:outbound_transaction) do
+      create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound)
+    end
+    let(:consumption) do
+      create(:wallet_transaction_consumption,
+        organization:,
+        inbound_wallet_transaction: inbound_transaction,
+        outbound_wallet_transaction: outbound_transaction,
+        consumed_amount_cents: 3000)
+    end
+
+    it "returns the credit amount by dividing consumed amount by wallet rate" do
+      expect(subject).to eq("20.0")
+    end
+  end
+
+  describe "#wallet_transaction" do
+    subject { run_graphql_field("WalletTransactionConsumption.walletTransaction", consumption) }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:wallet) { create(:wallet, customer:, traceable: true) }
+    let(:inbound_transaction) do
+      create(:wallet_transaction,
+        wallet:,
+        organization:,
+        transaction_type: :inbound,
+        remaining_amount_cents: 10000)
+    end
+    let(:outbound_transaction) do
+      create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound)
+    end
+    let(:consumption) do
+      create(:wallet_transaction_consumption,
+        organization:,
+        inbound_wallet_transaction: inbound_transaction,
+        outbound_wallet_transaction: outbound_transaction,
+        consumed_amount_cents: 5000)
+    end
+
+    it "returns the outbound_wallet_transaction" do
+      expect(subject.id).to eq(outbound_transaction.id)
+    end
+  end
+end

--- a/spec/graphql/types/wallet_transaction_fundings/object_spec.rb
+++ b/spec/graphql/types/wallet_transaction_fundings/object_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::WalletTransactionFundings::Object do
+  subject { described_class }
+
+  it "has the expected fields with correct types" do
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:credit_amount).of_type("String!")
+    expect(subject).to have_field(:wallet_transaction).of_type("WalletTransaction!")
+  end
+
+  describe "#amount_cents" do
+    subject { run_graphql_field("WalletTransactionFunding.amountCents", consumption) }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:wallet) { create(:wallet, customer:, traceable: true) }
+    let(:inbound_transaction) do
+      create(:wallet_transaction,
+        wallet:,
+        organization:,
+        transaction_type: :inbound,
+        remaining_amount_cents: 10000)
+    end
+    let(:outbound_transaction) do
+      create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound)
+    end
+    let(:consumption) do
+      create(:wallet_transaction_consumption,
+        organization:,
+        inbound_wallet_transaction: inbound_transaction,
+        outbound_wallet_transaction: outbound_transaction,
+        consumed_amount_cents: 5000)
+    end
+
+    it "returns the consumed_amount_cents" do
+      expect(subject).to eq(5000)
+    end
+  end
+
+  describe "#credit_amount" do
+    subject { run_graphql_field("WalletTransactionFunding.creditAmount", consumption) }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:wallet) { create(:wallet, customer:, traceable: true, rate_amount: 1.5) }
+    let(:inbound_transaction) do
+      create(:wallet_transaction,
+        wallet:,
+        organization:,
+        transaction_type: :inbound,
+        remaining_amount_cents: 10000)
+    end
+    let(:outbound_transaction) do
+      create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound)
+    end
+    let(:consumption) do
+      create(:wallet_transaction_consumption,
+        organization:,
+        inbound_wallet_transaction: inbound_transaction,
+        outbound_wallet_transaction: outbound_transaction,
+        consumed_amount_cents: 3000)
+    end
+
+    it "returns the credit amount by dividing consumed amount by wallet rate" do
+      expect(subject).to eq("20.0")
+    end
+  end
+
+  describe "#wallet_transaction" do
+    subject { run_graphql_field("WalletTransactionFunding.walletTransaction", consumption) }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:wallet) { create(:wallet, customer:, traceable: true) }
+    let(:inbound_transaction) do
+      create(:wallet_transaction,
+        wallet:,
+        organization:,
+        transaction_type: :inbound,
+        remaining_amount_cents: 10000)
+    end
+    let(:outbound_transaction) do
+      create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound)
+    end
+    let(:consumption) do
+      create(:wallet_transaction_consumption,
+        organization:,
+        inbound_wallet_transaction: inbound_transaction,
+        outbound_wallet_transaction: outbound_transaction,
+        consumed_amount_cents: 5000)
+    end
+
+    it "returns the inbound_wallet_transaction" do
+      expect(subject.id).to eq(inbound_transaction.id)
+    end
+  end
+end

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Types::WalletTransactions::Object do
 
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:failed_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:remaining_amount_cents).of_type("BigInt")
+    expect(subject).to have_field(:remaining_credit_amount).of_type("String")
     expect(subject).to have_field(:invoice).of_type("Invoice")
     expect(subject).to have_field(:metadata).of_type("[WalletTransactionMetadataObject!]")
     expect(subject).to have_field(:settled_at).of_type("ISO8601DateTime")
@@ -28,6 +30,33 @@ RSpec.describe Types::WalletTransactions::Object do
 
     expect(subject).to have_field(:selected_invoice_custom_sections).of_type("[InvoiceCustomSection!]")
     expect(subject).to have_field(:skip_invoice_custom_sections).of_type("Boolean")
+  end
+
+  describe "#remaining_credit_amount" do
+    subject { run_graphql_field("WalletTransaction.remainingCreditAmount", wallet_transaction) }
+
+    context "when remaining_amount_cents is nil" do
+      let(:wallet_transaction) { create(:wallet_transaction, remaining_amount_cents: nil) }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when remaining_amount_cents is set" do
+      let(:customer) { create(:customer) }
+      let(:wallet) { create(:wallet, customer:, rate_amount: 1.5) }
+      let(:wallet_transaction) do
+        create(:wallet_transaction,
+          wallet:,
+          transaction_type: :inbound,
+          remaining_amount_cents: 3000)
+      end
+
+      it "returns the remaining credit amount as string" do
+        expect(subject).to eq("20.0")
+      end
+    end
   end
 
   describe "#wallet_name" do

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -113,18 +113,36 @@ RSpec.describe WalletTransactions::CreateService do
       let(:wallet) { create(:wallet, customer:, currency:, traceable: true) }
 
       context "when transaction is inbound" do
-        let(:transaction_params) do
-          {
-            status: :settled,
-            transaction_type: :inbound,
-            transaction_status: :purchased
-          }
+        context "when transaction is granted" do
+          let(:transaction_params) do
+            {
+              status: :settled,
+              transaction_type: :inbound,
+              transaction_status: :granted
+            }
+          end
+
+          it "sets remaining_amount_cents to amount_cents" do
+            wallet_transaction = result.wallet_transaction
+
+            expect(wallet_transaction.remaining_amount_cents).to eq(wallet_transaction.amount_cents)
+          end
         end
 
-        it "initializes remaining_amount_cents to amount_cents" do
-          wallet_transaction = result.wallet_transaction
+        context "when transaction is purchased" do
+          let(:transaction_params) do
+            {
+              status: :settled,
+              transaction_type: :inbound,
+              transaction_status: :purchased
+            }
+          end
 
-          expect(wallet_transaction.remaining_amount_cents).to eq(wallet_transaction.amount_cents)
+          it "does not set remaining_amount_cents" do
+            wallet_transaction = result.wallet_transaction
+
+            expect(wallet_transaction.remaining_amount_cents).to be_nil
+          end
         end
       end
 


### PR DESCRIPTION
## Context

Customers can't distinguish when free credits (granted) or prepaid credits (purchased) are used. The wallet traceability feature enables tracking which inbound wallet transactions (purchased/granted credits) are consumed by outbound transactions (invoice applications). This provides visibility into whether free or prepaid credits were used.

Here's the list of all the high-level implementation steps:

| #   | Work Breakdown                                 | Description                                                               |
|-----|------------------------------------------------|---------------------------------------------------------------------------|
| 1   | Track consumption when applying prepaid credit | Core traceability infrastructure: join table, models, consumption service |
| 2   | Voiding wallet credits                         | Handle voiding inbound transactions and reverse consumption records       |
| 3   | Voiding invoice                                | Handle voiding invoices that consumed wallet credits                      |
| 4   | Credit Notes on Prepaid Credit invoices        | Handle credit notes for invoices paid with wallet credits                 |
| 5   | API: Retrieving Consumptions and Fundings      | REST API endpoints for consumption/funding data                           |
| 6   | GraphQL: Retrieving Consumptions and Fundings  | GraphQL API for consumption/funding data                                  |
| 7   | Invoice PDF Template Changes                   | Display free vs prepaid credits breakdown on invoice PDFs                 |
| 8   | Migrating wallets to be traceable              | Rake task to backfill existing wallets with consumption records           |

## Description

This implements step #6 of the above breakdown: Retrieving Consumptions and Fundings via GraphQL.

Add two new GraphQL queries on wallet transactions:
- `walletTransactionConsumptions` - returns consumption records for inbound transactions showing which outbound transactions consumed from them
- `walletTransactionFundings` - returns funding records for outbound transactions showing which inbound transactions funded them

Both queries include pagination support and nested transaction data. Validation ensures the wallet is traceable and the transaction type matches the query (inbound for consumptions, outbound for fundings).

This also adds `remaining_amount_cents` field to WalletTransaction GraphQL type and fixes a bug which was setting the `remaining_amount_cents` before the transaction was settled.