### PR TITLE
fix(concurrency): Adding lock to avoid CreditNotes applied in race co…

### DIFF
--- a/app/services/credit_notes/lock_service.rb
+++ b/app/services/credit_notes/lock_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class LockService < BaseService
+    def initialize(customer:)
+      @customer = customer
+
+      super
+    end
+
+    def call
+      customer.with_advisory_lock("CREDIT_NOTES-#{customer.id}", timeout_seconds: 5) do
+        yield
+      end
+    end
+
+    def locked?
+      customer.advisory_lock_exists?("CREDIT_NOTES-#{customer.id}")
+    end
+
+    private
+
+    attr_reader :customer
+  end
+end


### PR DESCRIPTION
# Context
In Multiple Payments feature, we are grouping the invoices to be processed by payment methods within a job that could run concurrently. In this job, we do call credits for customer's CreditNotes. These credits can be applied concurrently to multiple invoices, which is not correct. 

# Reproduce
If we call this service concurrently, this would break because the CreditNote will be applied to multiple invoices. 

# Fix
Wrap the credit service with a database lock to not allow this credit note be handled by other threads during the service.
