### PR TITLE
feat(alerting): Better errors for thresholds

### DIFF
--- a/app/services/usage_monitoring/concerns/create_or_update_concern.rb
+++ b/app/services/usage_monitoring/concerns/create_or_update_concern.rb
@@ -16,6 +16,30 @@ module UsageMonitoring
       rescue ActiveRecord::RecordNotFound
         result.not_found_failure!(resource: "billable_metric")
       end
+
+      def all_threshold_values_present?(thresholds)
+        thresholds.none? { it[:value].nil? }
+      end
+
+      def all_threshold_values_numeric?(thresholds)
+        thresholds.all? { |t| valid_numeric_value?(t[:value]) }
+      end
+
+      def valid_numeric_value?(value)
+        case value
+        when Numeric
+          true
+        when String
+          return false if value.blank?
+
+          Float(value)
+          true
+        else
+          false
+        end
+      rescue ArgumentError
+        false
+      end
     end
   end
 end

--- a/app/services/usage_monitoring/create_alert_service.rb
+++ b/app/services/usage_monitoring/create_alert_service.rb
@@ -31,6 +31,14 @@ module UsageMonitoring
         return result.single_validation_failure!(field: :thresholds, error_code: "duplicate_threshold_values")
       end
 
+      if !all_threshold_values_present?(params[:thresholds])
+        return result.single_validation_failure!(field: "thresholds:value", error_code: "value_is_mandatory")
+      end
+
+      if !all_threshold_values_numeric?(params[:thresholds])
+        return result.single_validation_failure!(field: "thresholds:value", error_code: "value_is_invalid")
+      end
+
       billable_metric = find_billable_metric_from_params!
       return result unless result.success?
 

--- a/app/services/usage_monitoring/update_alert_service.rb
+++ b/app/services/usage_monitoring/update_alert_service.rb
@@ -24,6 +24,14 @@ module UsageMonitoring
         if threshold_values.size != threshold_values.uniq.size
           return result.single_validation_failure!(field: :thresholds, error_code: "duplicate_threshold_values")
         end
+
+        if !all_threshold_values_present?(params[:thresholds])
+          return result.single_validation_failure!(field: "thresholds:value", error_code: "value_is_mandatory")
+        end
+
+        if !all_threshold_values_numeric?(params[:thresholds])
+          return result.single_validation_failure!(field: "thresholds:value", error_code: "value_is_invalid")
+        end
       end
 
       result.alert = alert

--- a/spec/services/usage_monitoring/create_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/create_alert_service_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe UsageMonitoring::CreateAlertService do
     end
 
     context "when code is blank" do
-      let(:params) { {alert_type: "current_usage_amount", code: nil, thresholds: [{value: nil}]} }
+      let(:params) { {alert_type: "current_usage_amount", code: nil, thresholds: [{value: 100}]} }
 
       it "returns a validation failure result" do
         expect(result).to be_failure
@@ -100,7 +100,7 @@ RSpec.describe UsageMonitoring::CreateAlertService do
     end
 
     context "when alert_type is blank" do
-      let(:params) { {alert_type: nil, code: "ok", thresholds: [{value: nil}]} }
+      let(:params) { {alert_type: nil, code: "ok", thresholds: [{value: 100}]} }
 
       it "returns a validation failure result" do
         expect(result).to be_failure
@@ -123,6 +123,33 @@ RSpec.describe UsageMonitoring::CreateAlertService do
       it "returns a validation failure result" do
         expect(result).to be_failure
         expect(result.error.messages[:thresholds]).to include("duplicate_threshold_values")
+      end
+    end
+
+    context "when a threshold value is nil" do
+      let(:params) { {alert_type: "current_usage_amount", code: "ok", thresholds: [{value: nil}]} }
+
+      it "returns a validation failure result" do
+        expect(result).to be_failure
+        expect(result.error.messages[:"thresholds:value"]).to include("value_is_mandatory")
+      end
+    end
+
+    context "when a threshold value is not a valid number" do
+      let(:params) { {alert_type: "current_usage_amount", code: "ok", thresholds: [{value: "abc"}]} }
+
+      it "returns a validation failure result" do
+        expect(result).to be_failure
+        expect(result.error.messages[:"thresholds:value"]).to include("value_is_invalid")
+      end
+    end
+
+    context "when threshold values are valid numeric strings" do
+      let(:params) { {alert_type: "current_usage_amount", code: "ok", thresholds: [{value: "100"}, {value: "200.5"}]} }
+
+      it "creates the alert" do
+        expect(result).to be_success
+        expect(result.alert).to be_persisted
       end
     end
 

--- a/spec/services/usage_monitoring/update_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/update_alert_service_spec.rb
@@ -93,5 +93,32 @@ RSpec.describe UsageMonitoring::UpdateAlertService do
         expect(result.error.messages[:thresholds]).to include("duplicate_threshold_values")
       end
     end
+
+    context "when a threshold value is nil" do
+      let(:params) { {thresholds: [{value: nil}]} }
+
+      it "returns a validation failure result" do
+        expect(result).to be_failure
+        expect(result.error.messages[:"thresholds:value"]).to include("value_is_mandatory")
+      end
+    end
+
+    context "when a threshold value is not a valid number" do
+      let(:params) { {thresholds: [{value: "abc"}]} }
+
+      it "returns a validation failure result" do
+        expect(result).to be_failure
+        expect(result.error.messages[:"thresholds:value"]).to include("value_is_invalid")
+      end
+    end
+
+    context "when threshold values are valid numeric strings" do
+      let(:params) { {thresholds: [{value: "100"}, {value: "200.5"}]} }
+
+      it "updates the alert" do
+        expect(result).to be_success
+        expect(alert.reload.thresholds.map(&:value)).to eq [100, 200.5]
+      end
+    end
   end
 end


### PR DESCRIPTION
As I'm doing some [QA on wallet alerts](https://github.com/getlago/lago-api/pull/4925), I realized the error for wrong thresholds params was not handled.

I'm doing it separately because I don't know when wallet alerts would be merged, even if it's going to be annoying to rebase.

## BEFORE

<img width="2770" height="2406" alt="CleanShot 2026-01-30 at 10 41 34@2x" src="https://github.com/user-attachments/assets/c471bbc4-e47e-4788-b5a0-0231491ae461" />

## AFTER

<img width="2770" height="2406" alt="CleanShot 2026-01-30 at 10 56 24@2x" src="https://github.com/user-attachments/assets/a2b5f049-8482-4ec8-9e11-7fd46bfd2f9d" />

<img width="2770" height="2406" alt="CleanShot 2026-01-30 at 10 56 03@2x" src="https://github.com/user-attachments/assets/c3c6f692-8303-4888-86e6-b5d08002fb12" />
