### PR TITLE
fix(ci): Fix Clickhouse test on CI

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -53,7 +53,7 @@ jobs:
           postgresql-version: "15"
       - name: Start Clickhouse database
         run: |
-          docker run -d --rm -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 -v ./clickhouse-s3:/var/lib/clickhouse-s3 -v ./ci/clickhouse/config.xml:/etc/clickhouse-server/config.d/config.xml -e CLICKHOUSE_PASSWORD=password clickhouse/clickhouse-server
+          docker run -d --rm -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 -v ./clickhouse-s3:/var/lib/clickhouse-s3 -v ./ci/clickhouse/config.xml:/etc/clickhouse-server/config.d/config.xml -e CLICKHOUSE_PASSWORD=password clickhouse/clickhouse-server:25.12-alpine
         shell: bash
       - name: Generate RSA keys
         run: ./scripts/generate.rsa.sh

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -73,7 +73,8 @@ jobs:
           bundler-cache: true
       - name: Start Clickhouse database
         run: |
-          docker run -d --rm -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 -v ./clickhouse-s3:/var/lib/clickhouse-s3 -v ./ci/clickhouse/config.xml:/etc/clickhouse-server/config.d/config.xml -e CLICKHOUSE_PASSWORD=password clickhouse/clickhouse-server
+          docker run -d --rm -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 -v ./clickhouse-s3:/var/lib/clickhouse-s3 -v ./ci/clickhouse/config.xml:/etc/clickhouse-server/config.d/config.xml -e CLICKHOUSE_PASSWORD=password clickhouse/clickhouse-server:25.12-alpine
+
         shell: bash
       - name: Generate RSA keys
         run: ./scripts/generate.rsa.sh


### PR DESCRIPTION
## Context

For some unknown reasons, some Clickhouse event store tests seem to be failing on the CI:

```ruby
  1) Events::Stores::ClickhouseStore without deduplication behaves like an event store #grouped_max with filters returns the max events filtered and grouped
     Failure/Error: 
       expect(result).to match_array([
         {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
         {groups: {"country" => "france", "region" => "europe"}, value: 3}
       ])

                  Expected [{ groups: { "region" => "europe", "country" => "united kingdom" }, value: -1 }, { groups: { "region" => "europe", "country" => "france" }, value: -2 }]
       to match array with { groups: { "country" => "united kingdom", "region" => "europe" }, value: -1 } and { groups: { "country" => "france", "region" => "europe" }, value: 3 }

       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         [
           {
             groups: {
               "region" => "europe",
               "country" => "united kingdom"
             },
             value: -1
           },
       +   {
       +     groups: {
       +       "region" => "europe",
       +       "country" => "france"
       +     },
       +     value: -2
       +   },
       -   {
       -     groups: {
       -       "country" => "france",
       -       "region" => "europe"
       -     },
       -     value: 3
       -   },
         ]
     Shared Example Group: "an event store" called from ./spec/services/events/stores/clickhouse_store_spec.rb:28
     # ./spec/services/events/stores/shared_examples/an_event_store.rb:746:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:220:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'

Progress: |==================================

  2) Events::Stores::ClickhouseStore with deduplication behaves like an event store #grouped_max with filters returns the max events filtered and grouped
     Failure/Error: 
       expect(result).to match_array([
         {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
         {groups: {"country" => "france", "region" => "europe"}, value: 3}
       ])

                  Expected [{ groups: { "region" => "europe", "country" => "united kingdom" }, value: -1 }, { groups: { "region" => "europe", "country" => "france" }, value: -2 }]
       to match array with { groups: { "country" => "united kingdom", "region" => "europe" }, value: -1 } and { groups: { "country" => "france", "region" => "europe" }, value: 3 }

       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         [
           {
             groups: {
               "region" => "europe",
               "country" => "united kingdom"
             },
             value: -1
           },
       +   {
       +     groups: {
       +       "region" => "europe",
       +       "country" => "france"
       +     },
       +     value: -2
       +   },
       -   {
       -     groups: {
       -       "country" => "france",
       -       "region" => "europe"
       -     },
       -     value: 3
       -   },
         ]
     Shared Example Group: "an event store" called from ./spec/services/events/stores/clickhouse_store_spec.rb:283
     # ./spec/services/events/stores/shared_examples/an_event_store.rb:746:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:220:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:212:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:211:in 'block (2 levels) in <top (required)>'

Progress: |====================================================================|

Finished in 1.24 seconds (files took 5.55 seconds to load)
2 examples, 2 failures

Failed examples:

rspec ./spec/services/events/stores/clickhouse_store_spec.rb[1:1:1:15:3:1] # Events::Stores::ClickhouseStore without deduplication behaves like an event store #grouped_max with filters returns the max events filtered and grouped
rspec ./spec/services/events/stores/clickhouse_store_spec.rb[1:2:1:15:3:1] # Events::Stores::ClickhouseStore with deduplication behaves like an event store #grouped_max with filters returns the max events filtered and grouped
```

We couldn't reproduce this issue locally. So we assumed it might be related to the latest Docker image which upgraded to version 26 of Clickhouse.

## Description

This seems to solve the issue by fixing the version of Clickhouse used in CI to `25.12`.