### PR TITLE
misc(lifetime_usage): Change default queue for calculate job

### DIFF
--- a/app/jobs/lifetime_usages/recalculate_and_check_job.rb
+++ b/app/jobs/lifetime_usages/recalculate_and_check_job.rb
@@ -4,7 +4,7 @@ module LifetimeUsages
   class RecalculateAndCheckJob < ApplicationJob
     queue_as do
       if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
-        :billing
+        :billing_low_priority
       else
         :default
       end

--- a/config/sidekiq/sidekiq.yml
+++ b/config/sidekiq/sidekiq.yml
@@ -9,7 +9,6 @@ queues:
   - providers
   - webhook
   - invoices
-  - wallets # Remove as all wallet jobs have moved to other queues
   - integrations
   - low_priority
   - long_running

--- a/config/sidekiq/sidekiq_billing.yml
+++ b/config/sidekiq/sidekiq_billing.yml
@@ -3,6 +3,7 @@ timeout: 25
 retry: 1
 queues:
   - billing
+  - billing_low_priority
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 5) %>

--- a/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
+++ b/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckJob do
 
   let(:premium_integrations) { ["progressive_billing"] }
 
+  it_behaves_like "a configurable queues", "billing_low_priority", "SIDEKIQ_BILLING" do
+    let(:arguments) { lifetime_usage }
+  end
+
   it "delegates to the Calculate service" do
     allow(LifetimeUsages::CalculateService).to receive(:call!)
     allow(LifetimeUsages::CheckThresholdsService).to receive(:call!)


### PR DESCRIPTION
## Context

`LifetimeUsage::RecalculateAndCheckJob` jobs are enqueue in the `billing` queue. This is causing issue during large billing run as those jobs are sharing the same queue with the regular invoice process.

## Description

Since the recalculate job is less critical but still remain "billing" related, the jobs are now pushed in a new dedicated `billing_low_priority` queue. This will make sure that they will not take precedence over the invoices during the billing run.