### PR TITLE
fix(plan): Avoid raise when discarding a discarded plan

### DIFF
--- a/app/jobs/plans/destroy_job.rb
+++ b/app/jobs/plans/destroy_job.rb
@@ -8,12 +8,10 @@ module Plans
 
     def perform(plan)
       plan.children.each do |children_plan|
-        children_result = Plans::DestroyService.call(plan: children_plan)
-        children_result.raise_if_error!
+        Plans::DestroyService.call!(plan: children_plan)
       end
 
-      result = Plans::DestroyService.call(plan:)
-      result.raise_if_error!
+      Plans::DestroyService.call!(plan:)
     end
   end
 end

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -109,5 +109,16 @@ RSpec.describe Plans::DestroyService do
         expect(entitlement_value.reload).to be_discarded
       end
     end
+
+    context "when plan is already discarded" do
+      let(:plan) { create(:plan, :deleted, organization:) }
+
+      it "returns the deleted plan" do
+        result = destroy_service.call
+
+        expect(result).to be_success
+        expect(result.plan).to eq(plan)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

This PR handles the `Discard::RecordNotDiscarded` that can be raised by the `Plans::DestroyService`, to reduce noise in the dead job queue on sidekiq.

## Description

In case of `Discard::RecordNotDiscarded`, the service reload the plan record and check if it was already discarded.
If it's the case, it just ignore the error and return the reloaded plan