### PR TITLE
feat(subscription): Add charge override endpoints

### DIFF
--- a/app/controllers/api/v1/subscriptions/charges_controller.rb
+++ b/app/controllers/api/v1/subscriptions/charges_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Subscriptions
+      class ChargesController < BaseController
+        before_action :find_charge, only: %i[show update]
+
+        def index
+          charges = subscription.plan.charges
+            .includes(:billable_metric, :taxes, :applied_pricing_unit, :pricing_unit, filters: :billable_metric_filters)
+            .order(created_at: :desc)
+            .page(params[:page])
+            .per(params[:per_page] || PER_PAGE)
+
+          render(
+            json: ::CollectionSerializer.new(
+              charges,
+              ::V1::ChargeSerializer,
+              collection_name: "charges",
+              meta: pagination_metadata(charges),
+              includes: %i[taxes]
+            )
+          )
+        end
+
+        def show
+          render(
+            json: ::V1::ChargeSerializer.new(
+              charge,
+              root_name: "charge",
+              includes: %i[taxes]
+            )
+          )
+        end
+
+        def update
+          result = ::Subscriptions::OverrideChargeService.call(
+            subscription:,
+            charge:,
+            params: input_params.to_h.deep_symbolize_keys
+          )
+
+          if result.success?
+            render(
+              json: ::V1::ChargeSerializer.new(
+                result.charge,
+                root_name: "charge",
+                includes: %i[taxes]
+              )
+            )
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        attr_reader :charge
+
+        def resource_name
+          "subscription"
+        end
+
+        def input_params
+          params.require(:charge).permit(
+            :invoice_display_name,
+            :min_amount_cents,
+            properties: {},
+            filters: [
+              :invoice_display_name,
+              {
+                properties: {},
+                values: {}
+              }
+            ],
+            tax_codes: [],
+            applied_pricing_unit: %i[code conversion_rate]
+          )
+        end
+
+        def find_charge
+          @charge = subscription.plan.charges.find_by(code: params[:code])
+          not_found_error(resource: "charge") unless @charge
+        end
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/override_charge_service.rb
+++ b/app/services/subscriptions/override_charge_service.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class OverrideChargeService < BaseService
+    Result = BaseResult[:charge]
+
+    def initialize(subscription:, charge:, params:)
+      @subscription = subscription
+      @charge = charge
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+
+      ActiveRecord::Base.transaction do
+        target_plan = ensure_plan_override
+        target_charge = find_or_create_charge_override(target_plan)
+
+        result.charge = target_charge
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :subscription, :charge, :params
+
+    def ensure_plan_override
+      current_plan = subscription.plan
+
+      if current_plan.parent_id
+        current_plan
+      else
+        override_result = Plans::OverrideService.call!(
+          plan: current_plan,
+          params: {},
+          subscription:
+        )
+        subscription.update!(plan: override_result.plan)
+        override_result.plan
+      end
+    end
+
+    def find_or_create_charge_override(target_plan)
+      parent_charge = find_parent_charge
+      existing_override = target_plan.charges.find_by(parent_id: parent_charge.id)
+
+      if existing_override
+        update_charge_override(existing_override)
+      else
+        create_charge_override(parent_charge, target_plan)
+      end
+    end
+
+    def find_parent_charge
+      if charge.parent_id
+        charge.parent
+      else
+        charge
+      end
+    end
+
+    def create_charge_override(parent_charge, target_plan)
+      override_result = Charges::OverrideService.call!(
+        charge: parent_charge,
+        params: params.merge(plan_id: target_plan.id)
+      )
+      override_result.charge
+    end
+
+    def update_charge_override(existing_charge)
+      existing_charge.properties = params[:properties] if params.key?(:properties)
+      existing_charge.min_amount_cents = params[:min_amount_cents] if params.key?(:min_amount_cents)
+      existing_charge.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+      existing_charge.save!
+
+      if params.key?(:filters)
+        filters_result = ChargeFilters::CreateOrUpdateBatchService.call(
+          charge: existing_charge,
+          filters_params: params[:filters]
+        )
+        filters_result.raise_if_error!
+      end
+
+      if params.key?(:applied_pricing_unit) && existing_charge.applied_pricing_unit
+        existing_charge.applied_pricing_unit.update!(
+          conversion_rate: params[:applied_pricing_unit][:conversion_rate]
+        )
+      end
+
+      if params.key?(:tax_codes)
+        taxes_result = Charges::ApplyTaxesService.call(charge: existing_charge, tax_codes: params[:tax_codes])
+        taxes_result.raise_if_error!
+      end
+
+      existing_charge.reload
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
         end
         patch :entitlements, to: "subscriptions/entitlements#update"
         resources :fixed_charges, only: %i[index], controller: "subscriptions/fixed_charges"
+        resources :charges, only: %i[index show update], param: :code, code: /.*/, controller: "subscriptions/charges"
       end
       delete "/subscriptions/:external_id", to: "subscriptions#terminate", as: :terminate
 

--- a/spec/requests/api/v1/subscriptions/charges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/charges_controller_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Subscriptions::ChargesController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:external_id) { "sub_123" }
+  let(:external_id_query_param) { external_id }
+  let(:subscription) { create(:subscription, customer:, plan:, external_id:) }
+  let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+
+  before do
+    subscription
+    charge
+  end
+
+  describe "GET /api/v1/subscriptions/:external_id/charges" do
+    subject { get_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/charges") }
+
+    it_behaves_like "requires API permission", "subscription", "read"
+
+    it "returns a list of charges" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:charges]).to be_present
+      expect(json[:charges].length).to eq(1)
+      expect(json[:charges].first[:lago_id]).to eq(charge.id)
+      expect(json[:charges].first[:code]).to eq(charge.code)
+    end
+
+    it "returns pagination metadata" do
+      subject
+
+      expect(json[:meta]).to include(
+        current_page: 1,
+        next_page: nil,
+        prev_page: nil,
+        total_pages: 1,
+        total_count: 1
+      )
+    end
+
+    context "when subscription does not exist" do
+      let(:external_id_query_param) { "invalid_external_id" }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("subscription")
+      end
+    end
+
+    context "when subscription has plan override with charges" do
+      let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+      let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
+      let(:overridden_charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge) }
+
+      before { overridden_charge }
+
+      it "returns overridden charges" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:charges].length).to eq(1)
+        expect(json[:charges].first[:lago_id]).to eq(overridden_charge.id)
+        expect(json[:charges].first[:lago_parent_id]).to eq(charge.id)
+      end
+    end
+
+    context "with pagination" do
+      let(:charges) { create_list(:standard_charge, 3, plan:, organization:, billable_metric:) }
+
+      before do
+        charge.discard
+        charges
+      end
+
+      it "returns paginated results" do
+        get_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/charges?per_page=2&page=1")
+
+        expect(response).to have_http_status(:success)
+        expect(json[:charges].length).to eq(2)
+        expect(json[:meta][:current_page]).to eq(1)
+        expect(json[:meta][:total_pages]).to eq(2)
+      end
+    end
+
+    context "when charges have applied taxes" do
+      let(:tax) { create(:tax, organization:) }
+
+      before { create(:charge_applied_tax, charge:, tax:) }
+
+      it "includes taxes in the response" do
+        subject
+
+        expect(json[:charges].first[:taxes]).to be_an(Array)
+        expect(json[:charges].first[:taxes]).not_to be_empty
+        expect(json[:charges].first[:taxes].first[:code]).to eq(tax.code)
+      end
+    end
+  end
+
+  describe "GET /api/v1/subscriptions/:external_id/charges/:code" do
+    subject { get_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/charges/#{charge.code}") }
+
+    it_behaves_like "requires API permission", "subscription", "read"
+
+    it "returns the charge" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:charge][:lago_id]).to eq(charge.id)
+      expect(json[:charge][:code]).to eq(charge.code)
+      expect(json[:charge][:charge_model]).to eq("standard")
+      expect(json[:charge][:lago_billable_metric_id]).to eq(billable_metric.id)
+    end
+
+    context "when subscription does not exist" do
+      let(:external_id_query_param) { "invalid_external_id" }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("subscription")
+      end
+    end
+
+    context "when charge does not exist" do
+      subject { get_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/charges/invalid_code") }
+
+      it "returns not found error" do
+        subject
+
+        expect(response).to be_not_found_error("charge")
+      end
+    end
+
+    context "when subscription has plan override with charge override" do
+      let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+      let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
+      let(:overridden_charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge, code: charge.code) }
+
+      before { overridden_charge }
+
+      it "returns the overridden charge" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:charge][:lago_id]).to eq(overridden_charge.id)
+        expect(json[:charge][:lago_parent_id]).to eq(charge.id)
+      end
+    end
+  end
+
+  describe "PUT /api/v1/subscriptions/:external_id/charges/:code" do
+    subject { put_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/charges/#{charge.code}", {charge: update_params}) }
+
+    let(:update_params) do
+      {
+        invoice_display_name: "Updated Charge Name",
+        min_amount_cents: 500,
+        properties: {amount: "200"}
+      }
+    end
+
+    context "with premium license" do
+      around { |test| lago_premium!(&test) }
+
+      it_behaves_like "requires API permission", "subscription", "write"
+
+      it "creates a plan override and charge override" do
+        expect { subject }.to change(Plan, :count).by(1).and change(Charge, :count).by(1)
+
+        expect(response).to have_http_status(:success)
+        expect(json[:charge][:invoice_display_name]).to eq("Updated Charge Name")
+        expect(json[:charge][:min_amount_cents]).to eq(500)
+        expect(json[:charge][:properties][:amount]).to eq("200")
+        expect(json[:charge][:lago_parent_id]).to eq(charge.id)
+      end
+
+      it "updates the subscription to use the overridden plan" do
+        subject
+
+        subscription.reload
+        expect(subscription.plan.parent_id).to eq(plan.id)
+      end
+
+      context "when subscription does not exist" do
+        let(:external_id_query_param) { "invalid_external_id" }
+
+        it "returns not found error" do
+          subject
+
+          expect(response).to be_not_found_error("subscription")
+        end
+      end
+
+      context "when charge does not exist" do
+        subject { put_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/charges/invalid_code", {charge: update_params}) }
+
+        it "returns not found error" do
+          subject
+
+          expect(response).to be_not_found_error("charge")
+        end
+      end
+
+      context "when subscription already has plan override" do
+        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
+        let(:overridden_charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge, code: charge.code) }
+
+        before { overridden_charge }
+
+        it "does not create a new plan" do
+          expect { subject }.not_to change(Plan, :count)
+        end
+
+        it "updates the existing charge override" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:charge][:lago_id]).to eq(overridden_charge.id)
+          expect(json[:charge][:invoice_display_name]).to eq("Updated Charge Name")
+          expect(json[:charge][:min_amount_cents]).to eq(500)
+        end
+      end
+
+      context "with taxes" do
+        let(:tax) { create(:tax, organization:) }
+        let(:update_params) do
+          {
+            invoice_display_name: "Taxed Charge",
+            tax_codes: [tax.code]
+          }
+        end
+
+        it "creates a charge override with taxes" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:charge][:taxes]).to be_present
+          expect(json[:charge][:taxes].length).to eq(1)
+          expect(json[:charge][:taxes].first[:code]).to eq(tax.code)
+        end
+      end
+    end
+
+    context "without premium license" do
+      it "returns forbidden error" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/override_charge_service_spec.rb
+++ b/spec/services/subscriptions/override_charge_service_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::OverrideChargeService do
+  subject(:service) { described_class.new(subscription:, charge:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
+  let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+  let(:params) do
+    {
+      invoice_display_name: "Overridden Charge",
+      min_amount_cents: 500,
+      properties: {amount: "150"}
+    }
+  end
+
+  describe "#call" do
+    context "without premium license" do
+      it "returns forbidden failure" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+      end
+    end
+
+    context "with premium license" do
+      around { |test| lago_premium!(&test) }
+
+      before do
+        charge
+        subscription
+      end
+
+      it "creates a plan override" do
+        expect { service.call }.to change(Plan, :count).by(1)
+
+        new_plan = subscription.reload.plan
+        expect(new_plan.parent_id).to eq(plan.id)
+      end
+
+      it "creates charge override via plan override" do
+        expect { service.call }.to change(Charge, :count).by(1)
+      end
+
+      it "returns the charge override with parent_id" do
+        result = service.call
+
+        expect(result.charge.parent_id).to eq(charge.id)
+      end
+
+      it "assigns the charge override to the new plan" do
+        result = service.call
+
+        expect(result.charge.plan_id).not_to eq(plan.id)
+        expect(result.charge.plan.parent_id).to eq(plan.id)
+      end
+
+      it "updates the subscription to use the overridden plan" do
+        service.call
+
+        subscription.reload
+        expect(subscription.plan.parent_id).to eq(plan.id)
+      end
+
+      it "applies the override params to the charge" do
+        result = service.call
+
+        expect(result.charge.invoice_display_name).to eq("Overridden Charge")
+        expect(result.charge.min_amount_cents).to eq(500)
+        expect(result.charge.properties).to eq({"amount" => "150"})
+      end
+
+      context "when subscription already has a plan override" do
+        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
+
+        it "does not create a new plan" do
+          expect { service.call }.not_to change(Plan, :count)
+        end
+
+        it "creates the charge override on the existing overridden plan" do
+          result = service.call
+
+          expect(result.charge.plan_id).to eq(overridden_plan.id)
+          expect(result.charge.parent_id).to eq(charge.id)
+        end
+      end
+
+      context "when charge override already exists" do
+        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
+        let!(:existing_override) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: charge, code: charge.code) }
+
+        it "does not create a new charge" do
+          expect { service.call }.not_to change(Charge, :count)
+        end
+
+        it "updates the existing charge override" do
+          result = service.call
+
+          expect(result.charge.id).to eq(existing_override.id)
+          expect(result.charge.invoice_display_name).to eq("Overridden Charge")
+          expect(result.charge.min_amount_cents).to eq(500)
+        end
+      end
+
+      context "when the charge passed is itself an override" do
+        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
+        let(:parent_charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+        let!(:charge) { create(:standard_charge, plan: overridden_plan, organization:, billable_metric:, parent: parent_charge, code: parent_charge.code) }
+
+        it "does not create a new charge" do
+          expect { service.call }.not_to change(Charge, :count)
+        end
+
+        it "updates the existing charge override" do
+          result = service.call
+
+          expect(result.charge.id).to eq(charge.id)
+          expect(result.charge.invoice_display_name).to eq("Overridden Charge")
+        end
+      end
+
+      context "with tax_codes" do
+        let(:tax) { create(:tax, organization:) }
+        let(:params) do
+          {
+            invoice_display_name: "Taxed Charge",
+            tax_codes: [tax.code]
+          }
+        end
+
+        it "applies taxes to the charge override" do
+          result = service.call
+
+          expect(result.charge.taxes).to include(tax)
+        end
+      end
+
+      context "with filters" do
+        let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
+        let(:params) do
+          {
+            invoice_display_name: "Filtered Charge",
+            filters: [
+              {
+                invoice_display_name: "Filter Override",
+                properties: {amount: "75"},
+                values: {billable_metric_filter.key => [billable_metric_filter.values.first]}
+              }
+            ]
+          }
+        end
+
+        it "applies filters to the charge override" do
+          result = service.call
+
+          expect(result.charge.filters).to be_present
+          expect(result.charge.filters.first.invoice_display_name).to eq("Filter Override")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description**

Subscriptions can have plan overrides that allow customization of charges at the subscription level. Previously, charge overrides could only be created through the subscription update endpoint with plan_overrides. This adds dedicated endpoints for managing charge overrides independently.

Add subscription-level charge override API endpoints that allow:
- Listing effective charges for a subscription (GET)
- Getting a specific effective charge by code (GET)
- Overriding a charge for a subscription (PUT)
