### PR TITLE
Feat(charges): add accepts wallet targets

### DIFF
--- a/app/services/charges/update_service.rb
+++ b/app/services/charges/update_service.rb
@@ -32,7 +32,7 @@ module Charges
 
         accepts_target_wallet = params.delete(:accepts_target_wallet)
         if plan.organization.events_targeting_wallets_enabled?
-          charge.accepts_target_wallet = accepts_target_wallet
+          charge.accepts_target_wallet = accepts_target_wallet unless accepts_target_wallet.nil?
         end
 
         charge.save!

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -140,6 +140,22 @@ RSpec.describe Charges::UpdateService do
                 expect { subject }.to change { charge.reload.accepts_target_wallet }.from(true).to(false)
               end
             end
+
+            context "when accepts_target_wallet is nil in params" do
+              let(:params) do
+                {
+                  id: charge.id,
+                  charge_model: "standard",
+                  properties: {amount: "400"}
+                }
+              end
+
+              it "does not update accepts_target_wallet" do
+                charge.update!(accepts_target_wallet: true)
+
+                expect { subject }.not_to change { charge.reload.accepts_target_wallet }
+              end
+            end
           end
 
           context "when events_targeting_wallets is not enabled" do


### PR DESCRIPTION
Update: when not sending the parameters in update charges, the value should not be changed