### PR TITLE
misc(customer): Add index on sequential_id

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -396,6 +396,7 @@ end
 #  index_customers_on_deleted_at                       (deleted_at)
 #  index_customers_on_external_id_and_organization_id  (external_id,organization_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_customers_on_organization_id                  (organization_id)
+#  index_customers_on_sequential_id                    (sequential_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20260202134958_add_index_on_customer_sequential_id.rb
+++ b/db/migrate/20260202134958_add_index_on_customer_sequential_id.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexOnCustomerSequentialId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :customers, :sequential_id, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -598,6 +598,7 @@ DROP INDEX IF EXISTS public.index_customers_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_customers_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_customers_taxes_on_customer_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_customers_taxes_on_customer_id;
+DROP INDEX IF EXISTS public.index_customers_on_sequential_id;
 DROP INDEX IF EXISTS public.index_customers_on_organization_id;
 DROP INDEX IF EXISTS public.index_customers_on_external_id_and_organization_id;
 DROP INDEX IF EXISTS public.index_customers_on_deleted_at;
@@ -7068,6 +7069,13 @@ CREATE INDEX index_customers_on_organization_id ON public.customers USING btree 
 
 
 --
+-- Name: index_customers_on_sequential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_customers_on_sequential_id ON public.customers USING btree (sequential_id);
+
+
+--
 -- Name: index_customers_taxes_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11379,6 +11387,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260202134958'),
 ('20260129105200'),
 ('20260127114700'),
 ('20260121112929'),


### PR DESCRIPTION
## Context

After checking pg hero, it seems that an index is missing on `customers#sequential_id`.

## Description

This PR adds the missing index to speed up a bit the customer creation.
