### PR TITLE
fix(credit_notes): Add customer object to credit note API response

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -103,7 +103,7 @@ module Api
             json: ::V1::CreditNoteSerializer.new(
               credit_note,
               root_name: "credit_note",
-              includes: %i[items applied_taxes]
+              includes: %i[customer items applied_taxes]
             )
           )
         else

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -675,6 +675,7 @@ RSpec.describe Api::V1::CreditNotesController do
       expect(json[:credit_note][:lago_id]).to eq(credit_note.id)
       expect(json[:credit_note][:credit_status]).to eq("voided")
       expect(json[:credit_note][:balance_amount_cents]).to eq(0)
+      expect(json[:credit_note][:customer][:lago_id]).to eq(customer.id)
     end
 
     context "when credit note does not exist" do


### PR DESCRIPTION
## Context

We currently don't provide the customer object when you retrieve a credit note (we do it for invoices), which is blocking to estimate tax for a customer for example.

## Description

This PR includes a customer object payload to Credit Notes responses (show, create, update).