### PR TITLE
fix(Add predefined roles seeding for new installations) (#4960)

### DIFF
--- a/lib/tasks/roles.rake
+++ b/lib/tasks/roles.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :roles do
+  desc "Seeds predefined roles (admin, finance, manager) for production deployment"
+  task seed_predefined: :environment do
+    Role.find_or_create_by!(code: "admin", organization_id: nil) do |role|
+      role.admin = true
+      role.name = "Admin"
+      role.description = "Administrator having all permissions"
+      role.permissions = []
+    end
+
+    Role.find_or_create_by!(code: "finance", organization_id: nil) do |role|
+      role.admin = false
+      role.name = "Finance"
+      role.description = "Finance role with permissions to manage financial data"
+      role.permissions = []
+    end
+
+    Role.find_or_create_by!(code: "manager", organization_id: nil) do |role|
+      role.admin = false
+      role.name = "Manager"
+      role.description = "The predefined manager role"
+      role.permissions = []
+    end
+  end
+end

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -7,6 +7,7 @@ then
 else
   bundle exec rake db:create
   bundle exec rails db:migrate
+  bundle exec rails roles:seed_predefined
 
   if [ -v LAGO_CREATE_ORG ] && [ "$LAGO_CREATE_ORG" == "true" ]
   then


### PR DESCRIPTION
Predefined roles (admin, finance, manager) were not created during new opensource installations, which caused system functionality issues.

A rake task has been added to create the system roles and integrated into the migration script for automatic execution during deployment.
