### PR TITLE
Feat(wallet-targets): grouping fees by target_wallet_code

### DIFF
--- a/app/services/charge_models/factory.rb
+++ b/app/services/charge_models/factory.rb
@@ -20,8 +20,9 @@ module ChargeModels
 
       # TODO(pricing_group_keys): remove after deprecation of grouped_by
       pricing_group_keys = properties["pricing_group_keys"].presence || properties["grouped_by"]
+      use_grouped_service = pricing_group_keys.present? || (chargeable.is_a?(Charge) && chargeable.accepts_target_wallet)
 
-      if pricing_group_keys.present? && !aggregation_result.aggregations.nil?
+      if use_grouped_service && !aggregation_result.aggregations.nil?
         ChargeModels::GroupedService.new(**common_args.merge(charge_model: charge_model_class))
       else
         charge_model_class.new(**common_args)

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -46,9 +46,11 @@ module Charges
       filters = {event:, charge_id: charge.id}
 
       model = charge_filter.presence || charge
-      if model.pricing_group_keys.present?
-        filters[:grouped_by_values] = model.pricing_group_keys.index_with { event.properties[it] }
+      grouped_by_values = model.pricing_group_keys&.index_with { event.properties[it] } || {}
+      if charge.accepts_target_wallet && event.properties["target_wallet_code"].present?
+        grouped_by_values["target_wallet_code"] = event.properties["target_wallet_code"]
       end
+      filters[:grouped_by_values] = grouped_by_values if grouped_by_values.present?
 
       if charge_filter.present?
         result = ChargeFilters::MatchingAndIgnoredService.call(charge:, filter: charge_filter)

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -353,7 +353,11 @@ module Fees
       filters = {charge_id: charge.id}
 
       model = charge_filter.presence || charge
-      filters[:grouped_by] = model.pricing_group_keys if model.pricing_group_keys.present?
+      grouped_by_keys = model.pricing_group_keys&.dup || []
+      if charge.accepts_target_wallet && !grouped_by_keys.include?("target_wallet_code")
+        grouped_by_keys << "target_wallet_code"
+      end
+      filters[:grouped_by] = grouped_by_keys if grouped_by_keys.present?
 
       if charge_filter.present?
         result = ChargeFilters::MatchingAndIgnoredService.call(charge:, filter: charge_filter)

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -197,7 +197,8 @@ module Fees
     end
 
     def format_grouped_by
-      grouped_by = properties["pricing_group_keys"].presence || properties["grouped_by"]
+      grouped_by = properties["pricing_group_keys"].presence || properties["grouped_by"] || []
+      grouped_by << "target_wallet_code" if charge.accepts_target_wallet && event.properties["target_wallet_code"].present?
       return {} if grouped_by.blank?
 
       grouped_by.index_with { event.properties[it] }

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     customer
     organization { customer&.organization || association(:organization) }
     name { Faker::Name.name }
-    code { name&.parameterize(separator: "_") || "default" }
+    code { name.to_s.parameterize(separator: "_").presence || "default" }
     status { "active" }
     rate_amount { "1.00" }
     currency { "EUR" }

--- a/spec/scenarios/events_targeting_wallets_spec.rb
+++ b/spec/scenarios/events_targeting_wallets_spec.rb
@@ -1,0 +1,334 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Events Targeting Wallets Scenarios", transaction: false do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+
+  describe "pay in arrears charges with wallet targeting" do
+    around { |test| lago_premium!(&test) }
+
+    let(:plan) { create(:plan, organization:, amount_cents: 0) }
+    let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "value") }
+
+    let(:charge) do
+      create(
+        :standard_charge,
+        plan:,
+        billable_metric:,
+        accepts_target_wallet: true,
+        properties: {amount: "10"}
+      )
+    end
+
+    let(:wallet1) { create(:wallet, customer:, code: "wallet_1", name: "Wallet 1") }
+    let(:wallet2) { create(:wallet, customer:, code: "wallet_2", name: "Wallet 2") }
+
+    before do
+      organization.update!(premium_integrations: ["events_targeting_wallets"])
+      charge
+    end
+
+    it "groups fees by target_wallet_code in invoice" do
+      jan15 = DateTime.new(2023, 1, 15)
+
+      travel_to(jan15) do
+        wallet1
+        wallet2
+
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: "sub_wallet_test",
+          plan_code: plan.code
+        })
+      end
+
+      subscription = customer.subscriptions.find_by(external_id: "sub_wallet_test")
+
+      # Send events with different target_wallet_code values
+      travel_to(jan15 + 1.day) do
+        create_event({
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: {value: "10", target_wallet_code: "wallet_1"}
+        })
+
+        create_event({
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: {value: "5", target_wallet_code: "wallet_1"}
+        })
+
+        create_event({
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: {value: "20", target_wallet_code: "wallet_2"}
+        })
+      end
+
+      # Bill the subscription at end of month
+      travel_to(DateTime.new(2023, 2, 1)) do
+        perform_billing
+      end
+
+      # Verify invoice has correct grouped fees
+      invoice = subscription.invoices.first
+      expect(invoice).to be_present
+
+      charge_fees = invoice.fees.charge
+      expect(charge_fees.count).to eq(2)
+
+      wallet1_fee = charge_fees.find { |f| f.grouped_by["target_wallet_code"] == "wallet_1" }
+      wallet2_fee = charge_fees.find { |f| f.grouped_by["target_wallet_code"] == "wallet_2" }
+
+      expect(wallet1_fee.units).to eq(15)
+      expect(wallet1_fee.amount_cents).to eq(15_000)
+
+      expect(wallet2_fee.units).to eq(20)
+      expect(wallet2_fee.amount_cents).to eq(20_000)
+    end
+
+    context "with pricing_group_keys and wallet targeting combined" do
+      let(:charge) do
+        create(
+          :standard_charge,
+          plan:,
+          billable_metric:,
+          accepts_target_wallet: true,
+          properties: {
+            amount: "5",
+            pricing_group_keys: ["region"]
+          }
+        )
+      end
+
+      it "groups fees by both pricing_group_keys and target_wallet_code" do
+        jan15 = DateTime.new(2023, 1, 15)
+
+        travel_to(jan15) do
+          wallet1
+          wallet2
+
+          create_subscription({
+            external_customer_id: customer.external_id,
+            external_id: "sub_combined",
+            plan_code: plan.code
+          })
+        end
+
+        subscription = customer.subscriptions.find_by(external_id: "sub_combined")
+
+        # Send events with different combinations of region and target_wallet_code
+        travel_to(jan15 + 1.day) do
+          # wallet_1, region: eu
+          create_event({
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: subscription.external_id,
+            properties: {value: "10", region: "eu", target_wallet_code: "wallet_1"}
+          })
+
+          # wallet_1, region: us
+          create_event({
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: subscription.external_id,
+            properties: {value: "15", region: "us", target_wallet_code: "wallet_1"}
+          })
+
+          # wallet_2, region: eu
+          create_event({
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: subscription.external_id,
+            properties: {value: "20", region: "eu", target_wallet_code: "wallet_2"}
+          })
+        end
+
+        # Bill at end of month
+        travel_to(DateTime.new(2023, 2, 1)) do
+          perform_billing
+        end
+
+        invoice = subscription.invoices.first
+        charge_fees = invoice.fees.charge
+
+        # Should have 3 fees: (wallet_1, eu), (wallet_1, us), (wallet_2, eu)
+        expect(charge_fees.count).to eq(3)
+
+        wallet1_eu_fee = charge_fees.find { |f| f.grouped_by["target_wallet_code"] == "wallet_1" && f.grouped_by["region"] == "eu" }
+        wallet1_us_fee = charge_fees.find { |f| f.grouped_by["target_wallet_code"] == "wallet_1" && f.grouped_by["region"] == "us" }
+        wallet2_eu_fee = charge_fees.find { |f| f.grouped_by["target_wallet_code"] == "wallet_2" && f.grouped_by["region"] == "eu" }
+
+        expect(wallet1_eu_fee.units).to eq(10)
+        expect(wallet1_eu_fee.amount_cents).to eq(5_000)
+
+        expect(wallet1_us_fee.units).to eq(15)
+        expect(wallet1_us_fee.amount_cents).to eq(7_500)
+
+        expect(wallet2_eu_fee.units).to eq(20)
+        expect(wallet2_eu_fee.amount_cents).to eq(10_000)
+      end
+    end
+  end
+
+  describe "pay in advance charges with wallet targeting" do
+    around { |test| lago_premium!(&test) }
+
+    let(:plan) { create(:plan, organization:, amount_cents: 0) }
+    let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "value") }
+
+    let(:charge) do
+      create(
+        :standard_charge,
+        :pay_in_advance,
+        invoiceable: false,
+        plan:,
+        billable_metric:,
+        accepts_target_wallet: true,
+        properties: {amount: "10"}
+      )
+    end
+
+    let(:wallet1) { create(:wallet, customer:, code: "wallet_1", name: "Wallet 1") }
+    let(:wallet2) { create(:wallet, customer:, code: "wallet_2", name: "Wallet 2") }
+
+    before do
+      organization.update!(premium_integrations: ["events_targeting_wallets"])
+      charge
+    end
+
+    it "creates pay_in_advance fees grouped by target_wallet_code" do
+      jan15 = DateTime.new(2023, 1, 15)
+
+      travel_to(jan15) do
+        wallet1
+        wallet2
+
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: "sub_advance",
+          plan_code: plan.code
+        })
+      end
+
+      subscription = customer.subscriptions.find_by(external_id: "sub_advance")
+
+      # Send events - each should create a pay_in_advance fee
+      travel_to(jan15 + 1.day) do
+        expect do
+          create_event({
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: subscription.external_id,
+            properties: {value: "10", target_wallet_code: "wallet_1"}
+          })
+        end.to change { subscription.reload.fees.count }.from(0).to(1)
+
+        fee1 = subscription.fees.order(created_at: :desc).first
+        expect(fee1.pay_in_advance).to eq(true)
+        expect(fee1.units).to eq(10)
+        expect(fee1.amount_cents).to eq(10_000)
+        expect(fee1.grouped_by["target_wallet_code"]).to eq("wallet_1")
+      end
+
+      travel_to(jan15 + 2.days) do
+        expect do
+          create_event({
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: subscription.external_id,
+            properties: {value: "5", target_wallet_code: "wallet_2"}
+          })
+        end.to change { subscription.reload.fees.count }.from(1).to(2)
+
+        fee2 = subscription.fees.order(created_at: :desc).first
+        expect(fee2.pay_in_advance).to eq(true)
+        expect(fee2.units).to eq(5)
+        expect(fee2.amount_cents).to eq(5_000)
+        expect(fee2.grouped_by["target_wallet_code"]).to eq("wallet_2")
+      end
+    end
+  end
+
+  describe "events without target_wallet_code on accepting charge" do
+    around { |test| lago_premium!(&test) }
+
+    let(:plan) { create(:plan, organization:, amount_cents: 0) }
+    let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "value") }
+
+    let(:charge) do
+      create(
+        :standard_charge,
+        plan:,
+        billable_metric:,
+        accepts_target_wallet: true,
+        properties: {amount: "10"}
+      )
+    end
+
+    let(:wallet1) { create(:wallet, customer:, code: "wallet_1", name: "Wallet 1") }
+
+    before do
+      organization.update!(premium_integrations: ["events_targeting_wallets"])
+      charge
+    end
+
+    it "handles mix of events with and without target_wallet_code" do
+      jan15 = DateTime.new(2023, 1, 15)
+
+      travel_to(jan15) do
+        wallet1
+
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: "sub_mixed",
+          plan_code: plan.code
+        })
+      end
+
+      subscription = customer.subscriptions.find_by(external_id: "sub_mixed")
+
+      travel_to(jan15 + 1.day) do
+        # Event with wallet
+        create_event({
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: {value: "10", target_wallet_code: "wallet_1"}
+        })
+
+        # Event without wallet
+        create_event({
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: {value: "5"}
+        })
+      end
+
+      # Bill at end of month
+      travel_to(DateTime.new(2023, 2, 1)) do
+        perform_billing
+      end
+
+      invoice = subscription.invoices.first
+      charge_fees = invoice.fees.charge
+
+      expect(charge_fees.count).to eq(2)
+
+      wallet_fee = charge_fees.find { |f| f.grouped_by["target_wallet_code"] == "wallet_1" }
+      no_wallet_fee = charge_fees.find { |f| f.grouped_by.empty? || f.grouped_by["target_wallet_code"].nil? }
+
+      expect(wallet_fee.units).to eq(10)
+      expect(wallet_fee.amount_cents).to eq(10_000)
+
+      expect(no_wallet_fee.units).to eq(5)
+      expect(no_wallet_fee.amount_cents).to eq(5_000)
+    end
+  end
+end

--- a/spec/services/charge_models/factory_spec.rb
+++ b/spec/services/charge_models/factory_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe ChargeModels::Factory do
 
           it { expect(result).to be_a(ChargeModels::GroupedService) }
         end
+
+        context "when charge accepts target wallet" do
+          let(:charge) { build(:standard_charge, accepts_target_wallet: true) }
+          let(:aggregation_result) { BaseService::Result.new.tap { |r| r.aggregations = [BaseService::Result.new] } }
+
+          it { expect(result).to be_a(ChargeModels::GroupedService) }
+        end
       end
 
       context "with graduated charge model" do

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -672,6 +672,82 @@ RSpec.describe Fees::ChargeService do
         end
       end
 
+      context "with accepts_target_wallet enabled" do
+        let(:charge) do
+          create(
+            :standard_charge,
+            plan: subscription.plan,
+            billable_metric:,
+            accepts_target_wallet: true,
+            properties: {
+              amount: "20"
+            }
+          )
+        end
+
+        let(:billable_metric) do
+          create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "value")
+        end
+
+        let(:event_wallet_1) do
+          create(
+            :event,
+            organization: subscription.organization,
+            subscription:,
+            code: charge.billable_metric.code,
+            timestamp: Time.zone.parse("2022-03-16"),
+            properties: {target_wallet_code: "wallet_1", value: 10}
+          )
+        end
+
+        let(:event_wallet_2) do
+          create(
+            :event,
+            organization: subscription.organization,
+            subscription:,
+            code: charge.billable_metric.code,
+            timestamp: Time.zone.parse("2022-03-16"),
+            properties: {target_wallet_code: "wallet_2", value: 5}
+          )
+        end
+
+        before do
+          organization.update!(premium_integrations: ["events_targeting_wallets"])
+          event_wallet_1
+          event_wallet_2
+        end
+
+        it "creates a fee for each target_wallet_code" do
+          result = charge_subscription_service.call
+          expect(result).to be_success
+          expect(result.fees.count).to eq(2)
+
+          fee1 = result.fees.find { |f| f.grouped_by["target_wallet_code"] == "wallet_1" }
+          expect(fee1).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            charge_id: charge.id,
+            amount_cents: 20_000,
+            precise_amount_cents: 20_000.0,
+            amount_currency: "EUR",
+            units: 10,
+            grouped_by: {"target_wallet_code" => "wallet_1"}
+          )
+
+          fee2 = result.fees.find { |f| f.grouped_by["target_wallet_code"] == "wallet_2" }
+          expect(fee2).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            charge_id: charge.id,
+            amount_cents: 10_000,
+            precise_amount_cents: 10_000.0,
+            amount_currency: "EUR",
+            units: 5,
+            grouped_by: {"target_wallet_code" => "wallet_2"}
+          )
+        end
+      end
+
       context "with graduated charge model" do
         let(:charge) do
           create(


### PR DESCRIPTION
when premium integration is enabled
AND charge has `accepts_target_wallet`

when calculating the fees, we should add grouping by target_wallet_code in the grouping conditions of the fee