### PR TITLE
fix(roles): Fix signup:seed_organization task with new roles system

### DIFF
--- a/lib/tasks/signup.rake
+++ b/lib/tasks/signup.rake
@@ -19,7 +19,9 @@ namespace :signup do
         id: organization.id, organization:, name: organization.name, code: organization.name.parameterize
       )
 
-      Membership.find_or_create_by!(user:, organization:, role: :admin)
+      admin_role = Role.find_or_create_by!(admin: true)
+      membership = Membership.find_or_create_by!(user:, organization:)
+      MembershipRole.find_or_create_by!(membership:, organization:, role: admin_role)
 
       if ENV["LAGO_ORG_API_KEY"].present?
         api_key = ApiKey.find_or_create_by!(organization:, value: ENV["LAGO_ORG_API_KEY"])


### PR DESCRIPTION
## Context

After introducing the custom roles feature (PR https://github.com/getlago/lago-api/pull/4741), the `signup:seed_organization` rake task still uses the old approach, which causes integration tests in the [lago-ruby-client ](https://github.com/getlago/lago-ruby-client)to fail:
```
lago-ruby-client-api  |bin/rails aborted!
lago-ruby-client-api  | ActiveRecord::StatementInvalid: PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type integer: "admin" (ActiveRecord::StatementInvalid)
lago-ruby-client-api  | CONTEXT:  unnamed portal parameter $3 = '...'
lago-ruby-client-api  | /app/api/lib/tasks/signup.rake:22:in 'block (2 levels) in <main>'
```

## Description

Fixed the rake task to use the new roles approach