### PR TITLE
feat: Use EXISTS subquery for settlements

### DIFF
--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -199,9 +199,10 @@ class InvoicesQuery < BaseQuery
 
   def with_settlements(scope)
     scope.where(
-      id: scope.joins(:invoice_settlements)
-        .where(invoice_settlements: {settlement_type: valid_settlements})
-        .select(:id)
+      "EXISTS (
+          SELECT 1 FROM invoice_settlements
+          WHERE invoice_settlements.target_invoice_id = invoices.id
+          AND invoice_settlements.settlement_type IN (?))", valid_settlements
     )
   end
 


### PR DESCRIPTION
## Context

The settlements filter in the invoices query was using a subquery with joins to filter invoices by settlement type. This approach required an unnecessary intermediate join and subselect.

## Description

Refactor to use EXISTS subquery instead of a join-based approach. This is more efficient as EXISTS short-circuits on the first match and directly leverages the index on `target_invoice_id`.
