### PR TITLE
feat(wallet): link re-credited wallet transaction to voided invoice

### DIFF
--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -27,6 +27,7 @@ module Types
       field :remaining_credit_amount, String, null: true
       field :settled_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :voided_invoice, Types::Invoices::Object, null: true
 
       field :selected_invoice_custom_sections, [Types::InvoiceCustomSections::Object], null: true
       field :skip_invoice_custom_sections, Boolean
@@ -42,6 +43,8 @@ module Types
         currency = wallet.currency_for_balance
         object.remaining_amount_cents.fdiv(currency.subunit_to_unit).fdiv(wallet.rate_amount).to_s
       end
+
+      delegate :voided_invoice, to: :object
 
       def wallet_name
         object.wallet.name

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -10,6 +10,9 @@ class WalletTransaction < ApplicationRecord
   belongs_to :invoice, optional: true
   belongs_to :credit_note, optional: true
 
+  # populated for inbound transactions created when an invoice is voided
+  belongs_to :voided_invoice, class_name: "Invoice", optional: true
+
   has_many :consumptions,
     class_name: "WalletTransactionConsumption",
     foreign_key: :inbound_wallet_transaction_id,
@@ -130,6 +133,7 @@ end
 #  invoice_id                          :uuid
 #  organization_id                     :uuid             not null
 #  payment_method_id                   :uuid
+#  voided_invoice_id                   :uuid
 #  wallet_id                           :uuid             not null
 #
 # Indexes
@@ -139,6 +143,7 @@ end
 #  index_wallet_transactions_on_invoice_id         (invoice_id)
 #  index_wallet_transactions_on_organization_id    (organization_id)
 #  index_wallet_transactions_on_payment_method_id  (payment_method_id)
+#  index_wallet_transactions_on_voided_invoice_id  (voided_invoice_id)
 #  index_wallet_transactions_on_wallet_id          (wallet_id)
 #
 # Foreign Keys
@@ -147,5 +152,6 @@ end
 #  fk_rails_...  (invoice_id => invoices.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_method_id => payment_methods.id)
+#  fk_rails_...  (voided_invoice_id => invoices.id)
 #  fk_rails_...  (wallet_id => wallets.id)
 #

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -8,6 +8,7 @@ module V1
         lago_wallet_id: model.wallet_id,
         lago_invoice_id: model.invoice_id,
         lago_credit_note_id: model.credit_note_id,
+        lago_voided_invoice_id: model.voided_invoice_id,
         status: model.status,
         source: model.source,
         transaction_status: model.transaction_status,

--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -46,7 +46,8 @@ module WalletTransactions
           transaction = handle_granted_credits(
             wallet:,
             credits_amount: BigDecimal(params[:granted_credits]).floor(5),
-            reset_consumed_credits: ActiveModel::Type::Boolean.new.cast(params[:reset_consumed_credits])
+            reset_consumed_credits: ActiveModel::Type::Boolean.new.cast(params[:reset_consumed_credits]),
+            voided_invoice_id: params[:voided_invoice_id]
           )
           wallet_transactions << transaction
         end
@@ -129,7 +130,7 @@ module WalletTransactions
       wallet_transaction
     end
 
-    def handle_granted_credits(wallet:, credits_amount:, reset_consumed_credits: false)
+    def handle_granted_credits(wallet:, credits_amount:, reset_consumed_credits: false, voided_invoice_id: nil)
       return if credits_amount.zero?
 
       wallet_credit = WalletCredit.new(wallet:, credit_amount: credits_amount, invoiceable: false)
@@ -144,7 +145,8 @@ module WalletTransactions
           transaction_status: :granted,
           metadata:,
           priority:,
-          name:
+          name:,
+          voided_invoice_id:
         ).wallet_transaction
 
         Wallets::Balance::IncreaseService.new(

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -24,7 +24,8 @@ module WalletTransactions
           :source,
           :status,
           :transaction_type,
-          :transaction_status
+          :transaction_status,
+          :voided_invoice_id
         ),
         organization_id: wallet.organization_id,
         amount:,

--- a/app/services/wallet_transactions/recredit_service.rb
+++ b/app/services/wallet_transactions/recredit_service.rb
@@ -20,7 +20,8 @@ module WalletTransactions
         params: {
           wallet_id: wallet.id,
           granted_credits: wallet_transaction.credit_amount.to_s,
-          reset_consumed_credits: true
+          reset_consumed_credits: true,
+          voided_invoice_id: wallet_transaction.invoice_id
         }
       )
 

--- a/db/migrate/20260203145512_add_voided_invoice_id_to_wallet_transactions.rb
+++ b/db/migrate/20260203145512_add_voided_invoice_id_to_wallet_transactions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddVoidedInvoiceIdToWalletTransactions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :wallet_transactions,
+      :voided_invoice,
+      type: :uuid,
+      index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20260203145801_add_voided_invoice_foreign_key_to_wallet_transactions.rb
+++ b/db/migrate/20260203145801_add_voided_invoice_foreign_key_to_wallet_transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVoidedInvoiceForeignKeyToWalletTransactions < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :wallet_transactions, :invoices, column: :voided_invoice_id, validate: false
+  end
+end

--- a/db/migrate/20260203145809_validate_voided_invoice_foreign_key_on_wallet_transactions.rb
+++ b/db/migrate/20260203145809_validate_voided_invoice_foreign_key_on_wallet_transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateVoidedInvoiceForeignKeyOnWalletTransactions < ActiveRecord::Migration[8.0]
+  def change
+    validate_foreign_key :wallet_transactions, :invoices, column: :voided_invoice_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -21,6 +21,7 @@ ALTER TABLE IF EXISTS ONLY public.payment_receipts DROP CONSTRAINT IF EXISTS fk_
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS fk_rails_f510acb495;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_f435d13904;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_f375d320ad;
+ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_f32b205d44;
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_rails_f228550fda;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRAINT IF EXISTS fk_rails_f18cd04d51;
 ALTER TABLE IF EXISTS ONLY public.customer_snapshots DROP CONSTRAINT IF EXISTS fk_rails_f0bbf2291d;
@@ -327,6 +328,7 @@ DROP INDEX IF EXISTS public.index_wallets_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_wallets_invoice_custom_sections_on_wallet_id;
 DROP INDEX IF EXISTS public.index_wallets_invoice_custom_sections_on_organization_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_wallet_id;
+DROP INDEX IF EXISTS public.index_wallet_transactions_on_voided_invoice_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_organization_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_invoice_id;
@@ -3808,6 +3810,7 @@ CREATE TABLE public.wallet_transactions (
     payment_method_type public.payment_method_types DEFAULT 'provider'::public.payment_method_types NOT NULL,
     skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
     remaining_amount_cents bigint,
+    voided_invoice_id uuid,
     CONSTRAINT remaining_amount_cents_non_negative CHECK (((remaining_amount_cents >= 0) OR (remaining_amount_cents IS NULL)))
 );
 
@@ -9004,6 +9007,13 @@ CREATE INDEX index_wallet_transactions_on_payment_method_id ON public.wallet_tra
 
 
 --
+-- Name: index_wallet_transactions_on_voided_invoice_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_wallet_transactions_on_voided_invoice_id ON public.wallet_transactions USING btree (voided_invoice_id);
+
+
+--
 -- Name: index_wallet_transactions_on_wallet_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11316,6 +11326,14 @@ ALTER TABLE ONLY public.payment_requests
 
 
 --
+-- Name: wallet_transactions fk_rails_f32b205d44; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wallet_transactions
+    ADD CONSTRAINT fk_rails_f32b205d44 FOREIGN KEY (voided_invoice_id) REFERENCES public.invoices(id);
+
+
+--
 -- Name: fees fk_rails_f375d320ad; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11422,6 +11440,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260209103920'),
 ('20260209103526'),
 ('20260204153734'),
+('20260203145809'),
+('20260203145801'),
+('20260203145512'),
 ('20260202155431'),
 ('20260202134958'),
 ('20260129145352'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -12543,6 +12543,7 @@ type WalletTransaction {
   transactionStatus: WalletTransactionTransactionStatusEnum!
   transactionType: WalletTransactionTransactionTypeEnum!
   updatedAt: ISO8601DateTime!
+  voidedInvoice: Invoice
   wallet: Wallet
   walletName: String
 }

--- a/schema.json
+++ b/schema.json
@@ -67327,6 +67327,18 @@
               "deprecationReason": null
             },
             {
+              "name": "voidedInvoice",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Invoice",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "wallet",
               "description": null,
               "args": [],

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Types::WalletTransactions::Object do
     expect(subject).to have_field(:remaining_amount_cents).of_type("BigInt")
     expect(subject).to have_field(:remaining_credit_amount).of_type("String")
     expect(subject).to have_field(:invoice).of_type("Invoice")
+    expect(subject).to have_field(:voided_invoice).of_type("Invoice")
     expect(subject).to have_field(:metadata).of_type("[WalletTransactionMetadataObject!]")
     expect(subject).to have_field(:settled_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
@@ -55,6 +56,27 @@ RSpec.describe Types::WalletTransactions::Object do
 
       it "returns the remaining credit amount as string" do
         expect(subject).to eq("20.0")
+      end
+    end
+  end
+
+  describe "#voided_invoice" do
+    subject { run_graphql_field("WalletTransaction.voidedInvoice", wallet_transaction) }
+
+    let(:wallet_transaction) { create(:wallet_transaction, voided_invoice:) }
+    let(:voided_invoice) { nil }
+
+    context "when voided_invoice is nil" do
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when voided_invoice is present" do
+      let(:voided_invoice) { create(:invoice, :voided) }
+
+      it "returns the invoice" do
+        expect(subject).to eq(voided_invoice)
       end
     end
   end

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe WalletTransaction do
     it { is_expected.to belong_to(:wallet) }
     it { is_expected.to belong_to(:invoice).optional }
     it { is_expected.to belong_to(:credit_note).optional }
+    it { is_expected.to belong_to(:voided_invoice).class_name("Invoice").optional }
     it { is_expected.to belong_to(:organization) }
     it { is_expected.to have_many(:consumptions).class_name("WalletTransactionConsumption").with_foreign_key(:inbound_wallet_transaction_id).inverse_of(:inbound_wallet_transaction).dependent(:destroy) }
     it { is_expected.to have_many(:fundings).class_name("WalletTransactionConsumption").with_foreign_key(:outbound_wallet_transaction_id).inverse_of(:outbound_wallet_transaction).dependent(:destroy) }

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         "lago_wallet_id" => wallet_transaction.wallet_id,
         "lago_invoice_id" => nil,
         "lago_credit_note_id" => nil,
+        "lago_voided_invoice_id" => nil,
         "status" => wallet_transaction.status,
         "source" => wallet_transaction.source,
         "transaction_status" => wallet_transaction.transaction_status,
@@ -48,6 +49,19 @@ RSpec.describe ::V1::WalletTransactionSerializer do
       expect(result["wallet_transaction"]).to include(
         "lago_invoice_id" => wallet_transaction.invoice.id,
         "lago_credit_note_id" => wallet_transaction.credit_note.id
+      )
+    end
+  end
+
+  context "when transaction has a voided_invoice" do
+    let(:voided_invoice) { create(:invoice) }
+    let(:wallet_transaction) { create(:wallet_transaction, voided_invoice:) }
+
+    it "serializes the voided_invoice_id" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["wallet_transaction"]).to include(
+        "lago_voided_invoice_id" => voided_invoice.id
       )
     end
   end

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -163,6 +163,21 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
       end
     end
 
+    context "with voided_invoice_id parameter" do
+      let(:voided_invoice) { create(:invoice, :voided, organization:) }
+      let(:params) do
+        {
+          wallet_id: wallet.id,
+          granted_credits: "10",
+          voided_invoice_id: voided_invoice.id
+        }
+      end
+
+      it "creates granted transaction with voided_invoice_id" do
+        expect(result.wallet_transactions.first.voided_invoice_id).to eq(voided_invoice.id)
+      end
+    end
+
     context "with name parameter" do
       let(:name) { "Custom Top-up Name" }
 


### PR DESCRIPTION
## Context

Customers can't distinguish when free credits (granted) or prepaid credits (purchased) are used. The wallet traceability feature enables tracking which inbound wallet transactions (purchased/granted credits) are consumed by outbound transactions (invoice applications). This provides visibility into whether free or prepaid credits were used.

Here's the list of all the high-level implementation steps:

| #   | Work Breakdown                                 | Description                                                               |
| --- | ---------------------------------------------- | ------------------------------------------------------------------------- |
| 1   | Track consumption when applying prepaid credit | Core traceability infrastructure: join table, models, consumption service |
| 2   | Voiding wallet credits                         | Handle voiding inbound transactions and reverse consumption records       |
| 3   | Voiding invoice                                | Handle voiding invoices that consumed wallet credits                      |
| 4   | Credit Notes on Prepaid Credit invoices        | Handle credit notes for invoices paid with wallet credits                 |
| 5   | API: Retrieving Consumptions and Fundings      | REST API endpoints for consumption/funding data                           |
| 6   | GraphQL: Retrieving Consumptions and Fundings  | GraphQL API for consumption/funding data                                  |
| 7   | Invoice PDF Template Changes                   | Display free vs prepaid credits breakdown on invoice PDFs                 |
| 8   | Migrating wallets to be traceable              | Rake task to backfill existing wallets with consumption records           |

## Description

This implements step #3 of the above breakdown: Voiding invoice.

This adds a `voided_invoice_id` column to `wallet_transactions` to explicitly link inbound transactions created when an invoice is voided. When an invoice is voided, the `RecreditService` creates a new inbound wallet transaction to restore credits. This field links back to the voided invoice for full traceability.

This approach avoids breaking API changes while providing explicit semantics. The field is exposed in both REST API (`lago_voided_invoice_id`) and GraphQL (`voidedInvoice`).