### PR TITLE
fix(billing): add provider tax support to pay-in-advance fixed charges

### DIFF
--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -428,10 +428,10 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
           File.read(p)
         end
 
-        it "marks invoice as failed and creates error detail" do
+        it "returns a tax error, marks invoice as failed and creates error detail" do
           result = invoice_service.call
 
-          expect(result).to be_failure
+          expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages[:tax_error]).to eq(["taxDateTooFarInFuture"])
 


### PR DESCRIPTION
## Context

The CreatePayInAdvanceFixedChargesService was missing support for tax provider integrations (Anrok/Avalara). When a customer had a tax provider configured, the service would incorrectly apply local taxes instead of fetching taxes from the provider, resulting in inconsistent tax calculations.

## Description

Add provider tax support following the same pattern used in CreatePayInAdvanceChargeService:
- Check if customer has a tax provider integration
- Fetch taxes from the provider before computing invoice amounts
- Apply provider taxes to fees and pass them to ComputeAmountsFromFees
- Handle tax errors by marking invoice as failed and creating error details
- Add comprehensive tests for both success and error scenarios