### PR TITLE
Fix(wallet-refresh): do not update customer who does not have wallet refresh false

### DIFF
--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -36,7 +36,7 @@ module Customers
         )
       end
 
-      customer.update!(awaiting_wallet_refresh: false)
+      customer.update!(awaiting_wallet_refresh: false) if customer.awaiting_wallet_refresh?
 
       result.usage_amount_cents = usage_amount_cents
       result.allocation_rules = allocation_rules


### PR DESCRIPTION
when we create a wallet for a customer, 
we create a wallet transaction
then we increase wallet ballance
and then we refresh wallets of the customer
finally, we update customer "awaiting_wallet_refresh" to false

But if it was due to refresh of a newly created wallet, the customer won't have this field as false, so there is no need to update this field on the cusotmer