### PR TITLE
fix(wallet): Add validation to prevent negative balance and credits balance

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -184,7 +184,6 @@ end
 #  charge_model          :integer          default("standard"), not null
 #  code                  :string
 #  deleted_at            :datetime
-#  group_by_wallet       :boolean          default(FALSE), not null
 #  invoice_display_name  :string
 #  invoiceable           :boolean          default(TRUE), not null
 #  min_amount_cents      :bigint           default(0), not null

--- a/app/models/enriched_event.rb
+++ b/app/models/enriched_event.rb
@@ -26,7 +26,6 @@ end
 #  decimal_value            :decimal(40, 15)  default(0.0), not null
 #  enriched_at              :datetime         not null
 #  grouped_by               :jsonb            not null
-#  properties               :jsonb            not null
 #  timestamp                :datetime         not null
 #  value                    :string
 #  charge_filter_id         :uuid

--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -44,13 +44,13 @@ end
 # Table name: item_metadata
 # Database name: primary
 #
-#  id                                             :uuid             not null, primary key
-#  owner_type(Polymorphic owner type)             :string           not null
-#  value(item_metadata key-value pairs)           :jsonb            not null
-#  created_at                                     :datetime         not null
-#  updated_at                                     :datetime         not null
-#  organization_id(Reference to the organization) :uuid             not null
-#  owner_id(Polymorphic owner id)                 :uuid             not null
+#  id              :uuid             not null, primary key
+#  owner_type      :string           not null
+#  value           :jsonb            not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  owner_id        :uuid             not null
 #
 # Indexes
 #

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -43,6 +43,8 @@ class Wallet < ApplicationRecord
   validates :paid_top_up_min_amount_cents, numericality: {greater_than: 0}, allow_nil: true
   validates :paid_top_up_max_amount_cents, numericality: {greater_than: 0}, allow_nil: true
   validates :priority, inclusion: {in: 1..LOWEST_PRIORITY}
+  validates :balance_cents, numericality: {greater_than_or_equal_to: 0}, if: :traceable?
+  validates :credits_balance, numericality: {greater_than_or_equal_to: 0}, if: :traceable?
   validate :paid_top_up_max_greater_than_or_equal_min
   validate :unique_code_per_customer, if: :code_changed?
 

--- a/db/migrate/20260204171946_add_balance_check_constraints_to_wallets.rb
+++ b/db/migrate/20260204171946_add_balance_check_constraints_to_wallets.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddBalanceCheckConstraintsToWallets < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :wallets,
+      "(traceable = false OR balance_cents >= 0)",
+      name: "check_balance_cents_non_negative_when_traceable",
+      validate: false
+
+    add_check_constraint :wallets,
+      "(traceable = false OR credits_balance >= 0)",
+      name: "check_credits_balance_non_negative_when_traceable",
+      validate: false
+  end
+end

--- a/db/migrate/20260204172149_validate_balance_check_constraints_to_wallets.rb
+++ b/db/migrate/20260204172149_validate_balance_check_constraints_to_wallets.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ValidateBalanceCheckConstraintsToWallets < ActiveRecord::Migration[8.0]
+  def change
+    validate_check_constraint :wallets, name: "check_balance_cents_non_negative_when_traceable"
+    validate_check_constraint :wallets, name: "check_credits_balance_non_negative_when_traceable"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3896,7 +3896,9 @@ CREATE TABLE public.wallets (
     payment_method_type public.payment_method_types DEFAULT 'provider'::public.payment_method_types NOT NULL,
     skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
     traceable boolean DEFAULT false NOT NULL,
-    code character varying
+    code character varying,
+    CONSTRAINT check_balance_cents_non_negative_when_traceable CHECK (((traceable = false) OR (balance_cents >= 0))),
+    CONSTRAINT check_credits_balance_non_negative_when_traceable CHECK (((traceable = false) OR (credits_balance >= (0)::numeric)))
 );
 
 
@@ -11404,6 +11406,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260204172149'),
+('20260204171946'),
 ('20260204153734'),
 ('20260202155431'),
 ('20260202134958'),

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -90,6 +90,132 @@ RSpec.describe Wallet do
       expect(subject).to be_valid
       expect(subject.errors).to be_empty
     end
+
+    describe "of balance cents" do
+      let(:wallet) { build(:wallet, balance_cents:, traceable:) }
+      let(:error) { wallet.errors.where(:balance_cents, :greater_than_or_equal_to) }
+
+      before { wallet.valid? }
+
+      context "when wallet is traceable" do
+        let(:traceable) { true }
+
+        context "when balance_cents is negative" do
+          let(:balance_cents) { rand(1..1000) * -1 }
+
+          it "adds an error" do
+            expect(error).to be_present
+          end
+        end
+
+        context "when balance_cents is zero" do
+          let(:balance_cents) { 0 }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when balance_cents is positive" do
+          let(:balance_cents) { rand(1..1000) }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+      end
+
+      context "when wallet is not traceable" do
+        let(:traceable) { false }
+
+        context "when balance_cents is negative" do
+          let(:balance_cents) { rand(1..1000) * -1 }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when balance_cents is zero" do
+          let(:balance_cents) { 0 }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when balance_cents is positive" do
+          let(:balance_cents) { rand(1..1000) }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+      end
+    end
+
+    describe "of credits balance" do
+      let(:wallet) { build(:wallet, credits_balance:, traceable:) }
+      let(:error) { wallet.errors.where(:credits_balance, :greater_than_or_equal_to) }
+
+      before { wallet.valid? }
+
+      context "when wallet is traceable" do
+        let(:traceable) { true }
+
+        context "when credits_balance is negative" do
+          let(:credits_balance) { rand(1..1000) * -1 }
+
+          it "adds an error" do
+            expect(error).to be_present
+          end
+        end
+
+        context "when credits_balance is zero" do
+          let(:credits_balance) { 0 }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when credits_balance is positive" do
+          let(:credits_balance) { rand(1..1000) }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+      end
+
+      context "when wallet is not traceable" do
+        let(:traceable) { false }
+
+        context "when credits_balance is negative" do
+          let(:credits_balance) { rand(1..1000) * -1 }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when credits_balance is zero" do
+          let(:credits_balance) { 0 }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when credits_balance is positive" do
+          let(:credits_balance) { rand(1..1000) }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+      end
+    end
   end
 
   describe "currency=" do


### PR DESCRIPTION
## Context

Surprisingly we didn't had validation on a wallet that ensures that `balance_cents` or `credits_balance` cannot be negative. In certain cases that could lead to consuming amounts bigger than wallet balances.

## Description

Add rails validation and DB constrain to validate that those amounts are bigger or equal to zero but only for traceable wallets.
Linking that validation to traceable wallets will allow us to rollout this checks now and as main topic wallet traceability goes  live all traceable wallets will have it in place. Leaving some non traceable wallet behind but as part of wallet traceability those wallets should be gone.
