### PR TITLE
fix(timeout): Add retry for Net::ReadTimeout

### DIFF
--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -14,6 +14,7 @@ module Integrations
         retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
         retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
+        retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 25
 
         def perform(payment:)
           result = Integrations::Aggregator::Payments::CreateService.call(payment:)


### PR DESCRIPTION
## Description
This PR adds auto-retry in case of `Net::ReadTimeout` for two jobs:
- `Invoices::GenerateDocumentJob`
- `Integrations::Aggregator::Payment::CreateJob`