### PR TITLE
fix(integrations): split credit note into pre-tax and tax portions for NetSuite

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -260,7 +260,7 @@ module Integrations
               if subtotal.zero?
                 0
               else
-                credit.amount_cents * cn.taxes_amount_cents / subtotal
+                (credit.amount_cents * cn.taxes_amount_cents).fdiv(subtotal).round
               end
             end
           end


### PR DESCRIPTION
## Context

When an invoice has a credit note that fully covers the amount (fees + taxes), the NetSuite sync fails with "The total can not be negative". This happens because the credit note discount was sent as a single post-tax line item, while fees are sent pre-tax with taxes in a separate taxdetails section.

## Description

Split the credit note discount into its pre-tax (line item) and tax (tax detail) portions. A new `credit_notes_taxes_amount_cents` method computes the proportional tax from each applied credit note. The line item now subtracts only the pre-tax amount, and the corresponding tax detail carries the negative tax amount instead of zero.