### PR TITLE
Fix(fixed-charges): date service without fixed_charge boundaries

### DIFF
--- a/app/services/subscriptions/terminated_dates_service.rb
+++ b/app/services/subscriptions/terminated_dates_service.rb
@@ -21,14 +21,14 @@ module Subscriptions
       duplicate = subscription.dup.tap { |s| s.status = :active }
       new_dates_service = Subscriptions::DatesService.new_instance(duplicate, timestamp - 1.day, current_usage: true)
 
-      if new_dates_service.charges_to_datetime
-        return date_service if timestamp < new_dates_service.charges_to_datetime
-        return date_service if (timestamp - new_dates_service.charges_to_datetime) >= 1.day
+      if (new_date_service_charges_to_datetime = new_dates_service.charges_to_datetime)
+        return date_service if timestamp < new_date_service_charges_to_datetime
+        return date_service if (timestamp - new_date_service_charges_to_datetime) >= 1.day
       end
 
-      if new_dates_service.fixed_charges_to_datetime
-        return date_service if timestamp < new_dates_service.fixed_charges_to_datetime
-        return date_service if (timestamp - new_dates_service.fixed_charges_to_datetime) >= 1.day
+      if (new_date_service_fixed_charges_to_datetime = new_dates_service.fixed_charges_to_datetime)
+        return date_service if timestamp < new_date_service_fixed_charges_to_datetime
+        return date_service if (timestamp - new_date_service_fixed_charges_to_datetime) >= 1.day
       end
 
       # We should calculate boundaries as if subscription was not terminated

--- a/spec/services/subscriptions/terminated_dates_service_spec.rb
+++ b/spec/services/subscriptions/terminated_dates_service_spec.rb
@@ -394,13 +394,13 @@ RSpec.describe Subscriptions::TerminatedDatesService do
         end
       end
 
-      context "when pay in advance subscription is yearly with monthly charges in advance and dates_service does not have fixed_charge_boundaries" do
+      context "when pay in advance subscription is yearly with monthly charges in advance and dates_service does not have fixed_charges_boundaries" do
         let(:plan) { create(:plan, organization:, interval: :yearly, bill_charges_monthly: true, pay_in_advance: true) }
         let(:subscription) { create(:subscription, :terminated, plan:, subscription_at:, billing_time: :anniversary, started_at:) }
         let(:subscription_at) { DateTime.parse("02 Feb 2021") }
         let(:started_at) { subscription_at }
         # in the middle of the yearly billing period fixed_charges won't be charged, so the
-        # date service won't return fixed_charge boundaries
+        # date service won't return fixed_charges boundaries
         let(:billing_date) { DateTime.parse("2022-06-02 00:01:46.011") }
 
         it "returns the new date service because subscription is yearly, but the charges were monthly" do


### PR DESCRIPTION
when terminating a subscription, we have a lot of checks for date service to find the correct boundaries. However, if fixed_charges or charges are not billed, date_service won't return them and current check will try to compare timestamp with nil