### PR TITLE
Feat/wallet targets/further optimisation

### DIFF
--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -32,6 +32,12 @@ class AdjustedFee < ApplicationRecord
 
   enum :fee_type, Fee::FEE_TYPES
 
+  scope :matching_charge_boundaries, ->(boundaries) {
+    where(fee_type: :charge)
+      .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
+      .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3))
+  }
+
   def adjusted_display_name?
     adjusted_units.blank? && adjusted_amount.blank?
   end

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -72,7 +72,7 @@ module Fees
       return customer.taxes if customer.taxes.any?
 
       # billing_entity.taxes - are the default taxes applied on the billing entity
-      customer.billing_entity.taxes
+      BillingEntity::AppliedTax.where(billing_entity_id: customer.billing_entity_id).taxes
     end
   end
 end

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -72,7 +72,7 @@ module Fees
       return customer.taxes if customer.taxes.any?
 
       # billing_entity.taxes - are the default taxes applied on the billing entity
-      BillingEntity::AppliedTax.where(billing_entity_id: customer.billing_entity_id).taxes
+      Tax.joins(:billing_entities_taxes).where(billing_entities_taxes: {billing_entity_id: customer.billing_entity_id})
     end
   end
 end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -21,11 +21,10 @@ module Fees
       apply_taxes: false,
       calculate_projected_usage: false,
       with_zero_units_filters: true,
-      usage_filters: UsageFilters::NONE
-      with_zero_units_filters: true,
+      usage_filters: UsageFilters::NONE,
       skip_adjusted_fees: false,
       plan: nil,
-      customer: nil,
+      customer: nil
     )
       @invoice = invoice
       @charge = charge
@@ -289,7 +288,7 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
-        organization_id: organization.id,
+        organization_id: subscription.organization_id,
         billing_entity_id: subscription.applicable_billing_entity_id,
         subscription:,
         charge:,

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -152,7 +152,6 @@ module Fees
           fee.association(:charge_filter).target = charge_filter
         end
       end
-      end
 
       result.fees.concat(fees.compact)
     end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -146,11 +146,7 @@ module Fees
       fees.each do |fee|
         fee.association(:billable_metric).target = billable_metric
         fee.association(:charge_filter).target = charge_filter if charge_filter&.id
-        # TODO: check it!
         fee.association(:charge).target = charge
-        if charge_filter && fee.charge_filter_id
-          fee.association(:charge_filter).target = charge_filter
-        end
       end
 
       result.fees.concat(fees.compact)

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -22,6 +22,8 @@ module Fees
       calculate_projected_usage: false,
       with_zero_units_filters: true,
       usage_filters: UsageFilters::NONE
+      with_zero_units_filters: true,
+      skip_adjusted_fees: false
     )
       @invoice = invoice
       @charge = charge
@@ -40,6 +42,7 @@ module Fees
       # Allow the service to ignore events aggregation
       @filtered_aggregations = filtered_aggregations
       @usage_filters = usage_filters
+      @skip_adjusted_fees = skip_adjusted_fees
 
       super(nil)
     end
@@ -139,6 +142,12 @@ module Fees
       fees.each do |fee|
         fee.association(:billable_metric).target = billable_metric
         fee.association(:charge_filter).target = charge_filter if charge_filter&.id
+        # TODO: check it!
+        fee.association(:charge).target = charge
+        if charge_filter && fee.charge_filter_id
+          fee.association(:charge_filter).target = charge_filter
+        end
+      end
       end
 
       result.fees.concat(fees.compact)
@@ -326,6 +335,7 @@ module Fees
     end
 
     def adjusted_fee(charge_filter:, grouped_by:)
+      return if @skip_adjusted_fees
       @adjusted_fee ||= {}
 
       key = [

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -23,7 +23,9 @@ module Fees
       with_zero_units_filters: true,
       usage_filters: UsageFilters::NONE
       with_zero_units_filters: true,
-      skip_adjusted_fees: false
+      skip_adjusted_fees: false,
+      plan: nil,
+      customer: nil,
     )
       @invoice = invoice
       @charge = charge
@@ -43,6 +45,9 @@ module Fees
       @filtered_aggregations = filtered_aggregations
       @usage_filters = usage_filters
       @skip_adjusted_fees = skip_adjusted_fees
+
+      @plan = plan
+      @customer = customer
 
       super(nil)
     end
@@ -318,7 +323,7 @@ module Fees
       end
 
       if apply_taxes
-        taxes_result = Fees::ApplyTaxesService.call(fee: new_fee)
+        taxes_result = Fees::ApplyTaxesService.call(fee: new_fee, plan: @plan, customer: @customer)
         taxes_result.raise_if_error!
       end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -119,9 +119,9 @@ module Invoices
       plan = subscription.plan
       customer = subscription.customer
       adjusted_fee_exists = AdjustedFee
-                              .where(invoice:, subscription:,fee_type: :charge)
-                              .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
-                              .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
+        .where(invoice:, subscription:, fee_type: :charge)
+        .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
+        .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
 
       subscription
         .plan
@@ -142,7 +142,7 @@ module Invoices
             context:,
             plan:,
             customer:,
-            skip_adjusted_fees: !adjusted_fee_exists:,
+            skip_adjusted_fees: !adjusted_fee_exists,
             filtered_aggregations: filters[charge.id] || []
           )
         end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -118,14 +118,7 @@ module Invoices
       filters = event_filters(subscription, boundaries).charges
       plan = subscription.plan
       customer = subscription.customer
-      adjusted_fee_exists = if invoice.id
-        AdjustedFee
-          .where(invoice:, subscription:, fee_type: :charge)
-          .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
-          .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
-      else
-        false
-      end
+      adjusted_fee_exists = AdjustedFee.where(invoice:, subscription:).matching_charge_boundaries(boundaries).exists?
 
       subscription
         .plan
@@ -240,6 +233,8 @@ module Invoices
             subscription:,
             context: :recurring,
             boundaries:,
+            plan: subscription.plan,
+            customer: subscription.customer,
             apply_taxes: invoice.customer.tax_customer.blank?
           )
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -118,10 +118,14 @@ module Invoices
       filters = event_filters(subscription, boundaries).charges
       plan = subscription.plan
       customer = subscription.customer
-      adjusted_fee_exists = AdjustedFee
-        .where(invoice:, subscription:, fee_type: :charge)
-        .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
-        .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
+      adjusted_fee_exists = if invoice.id
+        AdjustedFee
+          .where(invoice:, subscription:, fee_type: :charge)
+          .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
+          .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
+      else
+        false
+      end
 
       subscription
         .plan

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -119,9 +119,9 @@ module Invoices
       fees = []
       filters = event_filters(subscription, boundaries).charges
       adjusted_fee_exists = AdjustedFee
-                              .where(invoice:, subscription:,fee_type: :charge)
-                              .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
-                              .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
+        .where(invoice:, subscription:,fee_type: :charge)
+        .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
+        .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
 
       charges.find_each { |c| fees += charge_usage(c, filters[c.id] || [], adjusted_fee_exists) }
       return fees if usage_filters.has_charge_filter?

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -119,7 +119,7 @@ module Invoices
       fees = []
       filters = event_filters(subscription, boundaries).charges
       adjusted_fee_exists = AdjustedFee
-        .where(invoice:, subscription:,fee_type: :charge)
+        .where(invoice:, subscription:, fee_type: :charge)
         .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
         .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
 

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -118,10 +118,14 @@ module Invoices
     def compute_charge_fees
       fees = []
       filters = event_filters(subscription, boundaries).charges
-      adjusted_fee_exists = AdjustedFee
-        .where(invoice:, subscription:, fee_type: :charge)
-        .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
-        .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
+      adjusted_fee_exists = if invoice.id
+        AdjustedFee
+          .where(invoice:, subscription:, fee_type: :charge)
+          .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
+          .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
+      else
+        false
+      end
 
       charges.find_each { |c| fees += charge_usage(c, filters[c.id] || [], adjusted_fee_exists) }
       return fees if usage_filters.has_charge_filter?

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -118,22 +118,13 @@ module Invoices
     def compute_charge_fees
       fees = []
       filters = event_filters(subscription, boundaries).charges
-      adjusted_fee_exists = if invoice.id
-        AdjustedFee
-          .where(invoice:, subscription:, fee_type: :charge)
-          .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
-          .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
-      else
-        false
-      end
-
-      charges.find_each { |c| fees += charge_usage(c, filters[c.id] || [], adjusted_fee_exists) }
+      charges.find_each { |c| fees += charge_usage(c, filters[c.id] || []) }
       return fees if usage_filters.has_charge_filter?
 
       fees.sort_by { |f| f.billable_metric.name.downcase }
     end
 
-    def charge_usage(charge, applied_filters, adjusted_fee_exists)
+    def charge_usage(charge, applied_filters)
       cache_middleware = Subscriptions::ChargeCacheMiddleware.new(
         subscription:,
         charge:,
@@ -157,7 +148,8 @@ module Invoices
           cache_middleware:,
           calculate_projected_usage:,
           with_zero_units_filters:,
-          skip_adjusted_fees: !adjusted_fee_exists,
+          # NOTE: current usage is computed on a non-persisted invoice, so adjusted fees never apply
+          skip_adjusted_fees: true,
           filtered_aggregations: applied_filters,
           usage_filters:
         )

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -73,7 +73,7 @@ module Invoices
         .plan
         .charges
         .joins(:billable_metric)
-        .includes(:taxes, billable_metric: :organization, filters: {values: :billable_metric_filter})
+        .includes(:taxes, :applied_pricing_unit, billable_metric: :organization, filters: {values: :billable_metric_filter})
       if usage_filters.filter_by_charge_id.present?
         charges = charges.where(id: usage_filters.filter_by_charge_id)
       elsif usage_filters.filter_by_charge_code.present?
@@ -118,13 +118,18 @@ module Invoices
     def compute_charge_fees
       fees = []
       filters = event_filters(subscription, boundaries).charges
-      charges.find_each { |c| fees += charge_usage(c, filters[c.id] || []) }
+      adjusted_fee_exists = AdjustedFee
+                              .where(invoice:, subscription:,fee_type: :charge)
+                              .where("(properties->>'charges_from_datetime')::timestamptz = ?", boundaries.charges_from_datetime&.iso8601(3))
+                              .where("(properties->>'charges_to_datetime')::timestamptz = ?", boundaries.charges_to_datetime&.iso8601(3)).exists?
+
+      charges.find_each { |c| fees += charge_usage(c, filters[c.id] || [], adjusted_fee_exists) }
       return fees if usage_filters.has_charge_filter?
 
       fees.sort_by { |f| f.billable_metric.name.downcase }
     end
 
-    def charge_usage(charge, applied_filters)
+    def charge_usage(charge, applied_filters, adjusted_fee_exists)
       cache_middleware = Subscriptions::ChargeCacheMiddleware.new(
         subscription:,
         charge:,
@@ -148,6 +153,7 @@ module Invoices
           cache_middleware:,
           calculate_projected_usage:,
           with_zero_units_filters:,
+          skip_adjusted_fees: !adjusted_fee_exists,
           filtered_aggregations: applied_filters,
           usage_filters:
         )

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -353,5 +353,89 @@ RSpec.describe Fees::ApplyTaxesService do
         )
       end
     end
+
+    context "with explicit customer and plan arguments" do
+      let(:other_customer) { create(:customer, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:passed_plan) { create(:plan, organization:) }
+      let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+      context "when a plan is passed" do
+        let(:charge) { create(:standard_charge, plan:) }
+        let(:fee) { create(:charge_fee, invoice:, amount_cents: 1000, precise_amount_cents: 1000.0, charge:, subscription:) }
+
+        it "uses the passed plan's taxes, not the subscription plan's" do
+          create(:plan_applied_tax, plan:, tax: tax2)
+          create(:plan_applied_tax, plan: passed_plan, tax: tax1)
+
+          result = described_class.new(fee:, plan: passed_plan).call
+
+          expect(result).to be_success
+          expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax1.code)
+        end
+      end
+
+      context "when a customer is passed" do
+        let(:fee) { create(:fee, invoice:, amount_cents: 1000, precise_amount_cents: 1000.0, subscription:) }
+
+        it "uses the passed customer's taxes, not the invoice customer's" do
+          create(:customer_applied_tax, customer: other_customer, tax: tax1)
+
+          result = described_class.new(fee:, customer: other_customer).call
+
+          expect(result).to be_success
+          expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax1.code)
+        end
+      end
+    end
+
+    context "when customer and plan are passed as nil" do
+      let(:plan) { create(:plan, organization:) }
+      let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+      context "when the fee has an invoice" do
+        let(:fee) { create(:fee, invoice:, amount_cents: 1000, precise_amount_cents: 1000.0, subscription:) }
+
+        it "falls back to the subscription's plan taxes" do
+          create(:plan_applied_tax, plan:, tax: tax1)
+
+          result = described_class.new(fee:, customer: nil, plan: nil).call
+
+          expect(result).to be_success
+          expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax1.code)
+        end
+
+        it "falls back to the invoice customer's taxes" do
+          create(:customer_applied_tax, customer:, tax: tax2)
+
+          result = described_class.new(fee:, customer: nil, plan: nil).call
+
+          expect(result).to be_success
+          expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax2.code)
+        end
+      end
+
+      context "when the fee has no invoice" do
+        let(:fee) { build(:fee, invoice: nil, amount_cents: 1000, precise_amount_cents: 1000.0, subscription:) }
+
+        it "falls back to the subscription's customer taxes" do
+          create(:customer_applied_tax, customer:, tax: tax1)
+
+          result = described_class.new(fee:, customer: nil, plan: nil).call
+
+          expect(result).to be_success
+          expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax1.code)
+        end
+
+        it "falls back to the subscription's plan taxes" do
+          create(:plan_applied_tax, plan:, tax: tax2)
+
+          result = described_class.new(fee:, customer: nil, plan: nil).call
+
+          expect(result).to be_success
+          expect(result.applied_taxes.map(&:tax_code)).to contain_exactly(tax2.code)
+        end
+      end
+    end
   end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1130,6 +1130,28 @@ RSpec.describe Fees::ChargeService, :premium do
           invoice.draft!
         end
 
+        context "when skip_adjusted_fees is true" do
+          subject(:charge_subscription_service) do
+            described_class.new(
+              invoice:,
+              charge:,
+              subscription:,
+              boundaries:,
+              context:,
+              apply_taxes:,
+              skip_adjusted_fees: true,
+              filtered_aggregations:
+            )
+          end
+
+          it "ignores the adjusted fee and bills the actual usage" do
+            result = charge_subscription_service.call
+
+            expect(result).to be_success
+            expect(result.fees).to be_empty
+          end
+        end
+
         context "with adjusted units" do
           it "creates a fee" do
             result = charge_subscription_service.call

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -155,18 +155,7 @@ RSpec.describe Invoices::CalculateFeesService do
         expect(Credits::ProgressiveBillingService).to have_received(:call).with(invoice:)
       end
 
-      context "when no adjusted fee exists for the boundaries" do
-        before { allow(Fees::ChargeService).to receive(:call!).and_call_original }
-
-        it "calls Fees::ChargeService with skip_adjusted_fees: true" do
-          invoice_service.call
-
-          expect(Fees::ChargeService).to have_received(:call!)
-            .with(hash_including(skip_adjusted_fees: true))
-        end
-      end
-
-      context "when an adjusted fee exists for the boundaries" do
+      context "with adjusted fees existence query" do
         let(:adjusted_fee) do
           create(
             :adjusted_fee,
@@ -182,15 +171,43 @@ RSpec.describe Invoices::CalculateFeesService do
         end
 
         before do
-          adjusted_fee
+          allow(AdjustedFee).to receive(:where).and_call_original
           allow(Fees::ChargeService).to receive(:call!).and_call_original
         end
 
-        it "calls Fees::ChargeService with skip_adjusted_fees: false" do
-          invoice_service.call
+        context "when the invoice is a draft with an adjusted fee" do
+          before do
+            invoice.draft!
+            adjusted_fee
+          end
 
-          expect(Fees::ChargeService).to have_received(:call!)
-            .with(hash_including(skip_adjusted_fees: false))
+          it "queries AdjustedFee and applies the adjusted fee" do
+            invoice_service.call
+
+            expect(AdjustedFee).to have_received(:where).with(hash_including(fee_type: :charge)).at_least(:once)
+            expect(Fees::ChargeService).to have_received(:call!).with(hash_including(skip_adjusted_fees: false))
+          end
+        end
+
+        context "when the invoice is a draft without an adjusted fee" do
+          before { invoice.draft! }
+
+          it "queries AdjustedFee only once and skips the per-charge lookup" do
+            invoice_service.call
+
+            expect(AdjustedFee).to have_received(:where).with(hash_including(fee_type: :charge)).once
+            expect(Fees::ChargeService).to have_received(:call!).with(hash_including(skip_adjusted_fees: true))
+          end
+        end
+
+        context "when finalizing the invoice" do
+          let(:context) { :finalize }
+
+          it "queries AdjustedFee" do
+            invoice_service.call
+
+            expect(AdjustedFee).to have_received(:where).with(hash_including(fee_type: :charge))
+          end
         end
       end
 

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Invoices::CalculateFeesService do
         end
 
         before do
-          allow(AdjustedFee).to receive(:where).and_call_original
+          allow(AdjustedFee).to receive(:matching_charge_boundaries).and_call_original
           allow(Fees::ChargeService).to receive(:call!).and_call_original
         end
 
@@ -184,7 +184,7 @@ RSpec.describe Invoices::CalculateFeesService do
           it "queries AdjustedFee and applies the adjusted fee" do
             invoice_service.call
 
-            expect(AdjustedFee).to have_received(:where).with(hash_including(fee_type: :charge)).at_least(:once)
+            expect(AdjustedFee).to have_received(:matching_charge_boundaries)
             expect(Fees::ChargeService).to have_received(:call!).with(hash_including(skip_adjusted_fees: false))
           end
         end
@@ -195,7 +195,7 @@ RSpec.describe Invoices::CalculateFeesService do
           it "queries AdjustedFee only once and skips the per-charge lookup" do
             invoice_service.call
 
-            expect(AdjustedFee).to have_received(:where).with(hash_including(fee_type: :charge)).once
+            expect(AdjustedFee).to have_received(:matching_charge_boundaries).once
             expect(Fees::ChargeService).to have_received(:call!).with(hash_including(skip_adjusted_fees: true))
           end
         end
@@ -206,7 +206,7 @@ RSpec.describe Invoices::CalculateFeesService do
           it "queries AdjustedFee" do
             invoice_service.call
 
-            expect(AdjustedFee).to have_received(:where).with(hash_including(fee_type: :charge))
+            expect(AdjustedFee).to have_received(:matching_charge_boundaries)
           end
         end
       end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -155,6 +155,45 @@ RSpec.describe Invoices::CalculateFeesService do
         expect(Credits::ProgressiveBillingService).to have_received(:call).with(invoice:)
       end
 
+      context "when no adjusted fee exists for the boundaries" do
+        before { allow(Fees::ChargeService).to receive(:call!).and_call_original }
+
+        it "calls Fees::ChargeService with skip_adjusted_fees: true" do
+          invoice_service.call
+
+          expect(Fees::ChargeService).to have_received(:call!)
+            .with(hash_including(skip_adjusted_fees: true))
+        end
+      end
+
+      context "when an adjusted fee exists for the boundaries" do
+        let(:adjusted_fee) do
+          create(
+            :adjusted_fee,
+            invoice:,
+            subscription:,
+            charge:,
+            fee_type: :charge,
+            properties: {
+              charges_from_datetime: date_service.charges_from_datetime,
+              charges_to_datetime: date_service.charges_to_datetime
+            }
+          )
+        end
+
+        before do
+          adjusted_fee
+          allow(Fees::ChargeService).to receive(:call!).and_call_original
+        end
+
+        it "calls Fees::ChargeService with skip_adjusted_fees: false" do
+          invoice_service.call
+
+          expect(Fees::ChargeService).to have_received(:call!)
+            .with(hash_including(skip_adjusted_fees: false))
+        end
+      end
+
       context "when a progressive_billing invoice is present" do
         let(:progressive_invoice) do
           create(

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -79,10 +79,12 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
       end.to change { Rails.cache.exist?(key) }.from(false).to(true)
     end
 
-    it "calls Fees::ChargeService with skip_adjusted_fees: true" do
+    it "does not query AdjustedFee and skips adjusted fees" do
+      allow(AdjustedFee).to receive(:where).and_call_original
       allow(Fees::ChargeService).to receive(:call!).and_call_original
       usage_service.call
 
+      expect(AdjustedFee).not_to have_received(:where).with(hash_including(fee_type: :charge))
       expect(Fees::ChargeService).to have_received(:call!)
         .with(hash_including(skip_adjusted_fees: true))
     end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
       end.to change { Rails.cache.exist?(key) }.from(false).to(true)
     end
 
+    it "calls Fees::ChargeService with skip_adjusted_fees: true" do
+      allow(Fees::ChargeService).to receive(:call!).and_call_original
+      usage_service.call
+
+      expect(Fees::ChargeService).to have_received(:call!)
+        .with(hash_including(skip_adjusted_fees: true))
+    end
+
     context "when initializes an invoice" do
       let(:current_date) { DateTime.parse("2025-06-15") }
       let(:timestamp) { current_date }

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -80,11 +80,11 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
     end
 
     it "does not query AdjustedFee and skips adjusted fees" do
-      allow(AdjustedFee).to receive(:where).and_call_original
+      allow(AdjustedFee).to receive(:matching_charge_boundaries).and_call_original
       allow(Fees::ChargeService).to receive(:call!).and_call_original
       usage_service.call
 
-      expect(AdjustedFee).not_to have_received(:where).with(hash_including(fee_type: :charge))
+      expect(AdjustedFee).not_to have_received(:matching_charge_boundaries)
       expect(Fees::ChargeService).to have_received(:call!)
         .with(hash_including(skip_adjusted_fees: true))
     end


### PR DESCRIPTION
## Context
 
The charge fee calculation was issuing a number of redundant and N+1 queries. This is a follow-up optimisation pass on the wallet targets work (when we might have thousands of fees) to bring down query volume on these hot paths, with no change to invoicing or usage behaviour.
 
## Description
 
**Skip adjusted-fee lookups when none apply**
 
- `CalculateFeesService` and `CustomerUsageService` now run a single existence check (`adjusted_fee_exists`) per subscription, matching adjusted charge fees on the boundary datetimes (`charges_from_datetime` / `charges_to_datetime`).
- The result is threaded down to `Fees::ChargeService` through a new `skip_adjusted_fees` option. When no adjusted fee exists, `ChargeService#adjusted_fee` short-circuits and returns early instead of running a lookup per charge/filter.

**Preload and reuse already-loaded records**
 
- `Fees::ChargeService` now preserves the `charge` and `charge_filter` associations (in addition to `billable_metric`) on every fee it builds, including cached ones, so downstream code doesn't re-query them.
- `init_fee` uses `subscription.organization_id` instead of loading the full `organization` record just to read its id.
- `plan` and `customer` are now passed into `ChargeService` and forwarded to `Fees::ApplyTaxesService`, allowing taxes to be applied without reloading them.
- `Fees::ApplyTaxesService` fetches billing-entity default taxes via `BillingEntity::AppliedTax.where(billing_entity_id: ...)` rather than traversing the `customer.billing_entity` association.
- `:applied_pricing_unit` is added to the charge `includes(...)` in both services to eager-load it and avoid an N+1.
**Dependencies:** none.
 