### PR TITLE
fix(integrations): prevent duplicate customer creation in external providers

### DIFF
--- a/spec/jobs/integration_customers/create_job_spec.rb
+++ b/spec/jobs/integration_customers/create_job_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe IntegrationCustomers::CreateJob do
         customer: customer
       )
 
-      expect(job.lock_key_arguments).to eq([integration_customer_params: integration_customer_params,
-                                            integration: integration,
-                                            customer: customer])
+      expect(job.lock_key_arguments).to eq([integration, customer])
     end
   end
 end


### PR DESCRIPTION
## Summary
When a Lago customer is created with a NetSuite integration, we enqueue an `IntegrationCustomers::CreateJob` to create the corresponding record in NetSuite via Nango. The job has a `unique :until_executed` lock to prevent duplicates. The problem is that if the customer is updated shortly after creation (before the first job completes), the batch service sees no integration customer in the DB yet and enqueues a second CreateJob. The uniqueness lock *should* prevent this, but it was using all job arguments as the lock key; including `integration_customer_params`. 

Since the create and update requests often carry slightly different params (even just an extra or missing optional field), the lock keys diverge and both jobs run. Both jobs then check for an existing integration customer, both find nothing, and both call the Nango API; creating two customer records in NetSuite. The DB unique constraint on `(customer_id, type)` prevents a duplicate in Lago, but the external provider already has the orphaned duplicate.

The fix adds a `lock_key_arguments` override to scope the lock to only `(integration, customer)`, which is what actually defines the identity of the operation. The params describe *how* to create, not *what* to create, so they shouldn't be part of the lock key. This matches the pattern used by other jobs in the codebase like `CreatePayInAdvanceChargeJob`.

This affects all providers that call an external API before saving to the DB: NetSuite, Xero, HubSpot, and Avalara.