### PR TITLE
rake(entitlement): Remove duplicated subscription entitlements

### DIFF
--- a/lib/tasks/entitlements.rake
+++ b/lib/tasks/entitlements.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+namespace :entitlements do
+  desc "Soft-delete duplicate subscription entitlements that have no values and whose feature is already on the parent plan"
+  task cleanup_duplicate_subscription_entitlements: :environment do
+    deleted_at = Time.current.beginning_of_hour
+    batch_size = 5_000
+    total_deleted = 0
+
+    puts "Starting cleanup of duplicate subscription entitlements (deleted_at: #{deleted_at})..."
+
+    loop do
+      result = ActiveRecord::Base.connection.exec_update(<<~SQL.squish, "Cleanup duplicate entitlements", [deleted_at, batch_size])
+        UPDATE entitlement_entitlements
+        SET deleted_at = $1
+        WHERE id IN (
+          SELECT sub_ent.id
+          FROM entitlement_entitlements sub_ent
+          JOIN subscriptions s ON s.id = sub_ent.subscription_id
+          JOIN plans p ON p.id = s.plan_id
+          JOIN entitlement_entitlements plan_ent
+            ON plan_ent.entitlement_feature_id = sub_ent.entitlement_feature_id
+            AND plan_ent.plan_id = COALESCE(p.parent_id, p.id)
+            AND plan_ent.deleted_at IS NULL
+          WHERE sub_ent.subscription_id IS NOT NULL
+            AND sub_ent.deleted_at IS NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM entitlement_entitlement_values v
+              WHERE v.entitlement_entitlement_id = sub_ent.id
+                AND v.deleted_at IS NULL
+            )
+          LIMIT $2
+        )
+      SQL
+
+      total_deleted += result
+      puts "  Progress: #{total_deleted} entitlements deleted..." if (total_deleted % 25_000) < batch_size
+
+      break if result < batch_size
+    end
+
+    puts "Done. Soft-deleted #{total_deleted} entitlements."
+  end
+end

--- a/spec/lib/tasks/entitlements_rake_spec.rb
+++ b/spec/lib/tasks/entitlements_rake_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "entitlements:cleanup_duplicate_subscription_entitlements" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["entitlements:cleanup_duplicate_subscription_entitlements"] }
+
+  let(:organization) { create(:organization) }
+  let(:feature) { create(:feature, organization:) }
+  let(:privilege) { create(:privilege, feature:, organization:) }
+  let(:parent_plan) { create(:plan, organization:) }
+  let(:child_plan) { create(:plan, organization:, parent: parent_plan) }
+  let(:subscription) { create(:subscription, organization:, plan: child_plan) }
+
+  let(:plan_entitlement) do
+    create(:entitlement, feature:, plan: parent_plan, organization:)
+  end
+
+  before do
+    plan_entitlement
+    Rake.application.rake_require("tasks/entitlements")
+    Rake::Task.define_task(:environment)
+    task.reenable
+  end
+
+  context "with a duplicate subscription entitlement (no values, feature on plan)" do
+    let!(:duplicate_entitlement) do
+      create(:entitlement, :subscription, feature:, subscription:, organization:)
+    end
+
+    it "soft-deletes the duplicate entitlement with a rounded timestamp" do
+      freeze_time do
+        expected_deleted_at = Time.current.beginning_of_hour
+
+        expect { task.invoke }.to output(/Done/).to_stdout
+
+        expect(duplicate_entitlement.reload.deleted_at).to eq(expected_deleted_at)
+      end
+    end
+  end
+
+  context "with a subscription entitlement that has values" do
+    let!(:entitlement_with_values) do
+      entitlement = create(:entitlement, :subscription, feature:, subscription:, organization:)
+      create(:entitlement_value, entitlement:, privilege:, organization:)
+      entitlement
+    end
+
+    it "does not soft-delete entitlements that have values" do
+      expect { task.invoke }.to output(/Soft-deleted 0 entitlements/).to_stdout
+
+      expect(entitlement_with_values.reload.deleted_at).to be_nil
+    end
+  end
+
+  context "with a subscription entitlement whose feature is not on the plan" do
+    let(:other_feature) { create(:feature, organization:) }
+
+    let!(:unique_entitlement) do
+      create(:entitlement, :subscription, feature: other_feature, subscription:, organization:)
+    end
+
+    it "does not soft-delete entitlements for features not on the plan" do
+      expect { task.invoke }.to output(/Soft-deleted 0 entitlements/).to_stdout
+
+      expect(unique_entitlement.reload.deleted_at).to be_nil
+    end
+  end
+
+  context "with a subscription on a plan without a parent" do
+    let(:standalone_plan) { create(:plan, organization:) }
+    let(:standalone_subscription) { create(:subscription, organization:, plan: standalone_plan) }
+
+    let!(:duplicate_on_standalone) do
+      create(:entitlement, :subscription, feature:, subscription: standalone_subscription, organization:)
+    end
+
+    before do
+      create(:entitlement, feature:, plan: standalone_plan, organization:)
+    end
+
+    it "soft-deletes duplicates using COALESCE(parent_id, plan_id)" do
+      freeze_time do
+        expect { task.invoke }.to output(/Done/).to_stdout
+
+        expect(duplicate_on_standalone.reload.deleted_at).to eq(Time.current.beginning_of_hour)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Due to a bug recently fixed, we created subscrition entitlements when there was no override.
In this case, the entitlements are inherited from the plan and no entitlement on the sub should exists.

This is not an issue until you delete the entitlement on the plan... and you realize all subs still have the feature.

This take task (soft-)delete the extra entitlement that should not have been created.

[The fix for the bug is here](https://github.com/getlago/lago-api/pull/5002) 🙈 