### PR TITLE
fix(stripe-error): When Customer does not exist, handle with third_pa…

### DIFF
--- a/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
@@ -13,7 +13,7 @@ module PaymentProviderCustomers
       PaymentProviderCustomers::StripeService.new(stripe_customer)
         .generate_checkout_url
         .raise_if_error!
-    rescue BaseService::UnauthorizedFailure => e
+    rescue BaseService::UnauthorizedFailure, BaseService::ThirdPartyFailure => e
       Rails.logger.warn(e.message)
     end
   end

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -42,7 +42,7 @@ module PaymentProviderCustomers
     rescue ::Stripe::InvalidRequestError, ::Stripe::PermissionError => e
       deliver_error_webhook(e)
 
-      result.service_failure!(code: "stripe_error", message: e.message)
+      result.third_party_failure!(third_party: "Stripe", error_code: e.code, error_message: e.message)
     rescue ::Stripe::AuthenticationError => e
       deliver_error_webhook(e)
 

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -220,9 +220,10 @@ RSpec.describe PaymentProviderCustomers::StripeService do
             result = stripe_service.update
 
             expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::ServiceFailure)
-            expect(result.error.code).to eq("stripe_error")
-            expect(result.error.message).to eq("stripe_error: Invalid request")
+            expect(result.error).to be_a(BaseService::ThirdPartyFailure)
+            expect(result.error.third_party).to eq("Stripe")
+            expect(result.error.error_code).to be_nil
+            expect(result.error.error_message).to eq("Invalid request")
           end
 
           it "delivers an error webhook" do
@@ -245,9 +246,10 @@ RSpec.describe PaymentProviderCustomers::StripeService do
             result = stripe_service.update
 
             expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::ServiceFailure)
-            expect(result.error.code).to eq("stripe_error")
-            expect(result.error.message).to eq("stripe_error: Permission error")
+            expect(result.error).to be_a(BaseService::ThirdPartyFailure)
+            expect(result.error.third_party).to eq("Stripe")
+            expect(result.error.error_code).to be_nil
+            expect(result.error.error_message).to eq("Permission error")
           end
 
           it "delivers an error webhook" do


### PR DESCRIPTION
## Summary                                                                                                                                                                                                          
                                         
  - Change `StripeService#update` to return `third_party_failure!` instead of `service_failure!` when Stripe raises `InvalidRequestError` or `PermissionError`, so the GraphQL layer returns a proper error instead of
   a 500                                                    
  - Rescue `BaseService::ThirdPartyFailure` in `StripeCheckoutUrlJob` so the job doesn't fail when the Stripe customer doesn't exist                                                                                  
                                                                                                                                                                                                                      
  ## Context

  When a `provider_customer_id` references a customer that no longer exists in Stripe:

  1. **GraphQL (`updateCustomer`)**: `StripeService#update` returned `service_failure!`, which is not handled by `ExecutionErrorResponder#result_error` — falls through to the `else` branch returning a 500. Changing
   to `third_party_failure!` matches the existing handler.

  2. **Job (`StripeCheckoutUrlJob`)**: `generate_checkout_url` already returned `third_party_failure!`, but the job only rescued `UnauthorizedFailure`. Adding `ThirdPartyFailure` to the rescue lets the job complete
   gracefully.

  ## Test plan

  - [x] Updated `stripe_service_spec.rb` assertions for `#update` error cases
  - [x] Verify `updateCustomer` mutation returns a proper error when `provider_customer_id` is invalid
