### PR TITLE
fix(stuck-invoice): Use the same DB_PRECISION_SCALE to deduct values …

### DIFF
--- a/app/services/credit_notes/create_from_progressive_billing_invoice.rb
+++ b/app/services/credit_notes/create_from_progressive_billing_invoice.rb
@@ -71,8 +71,8 @@ module CreditNotes
 
       (
         amount.truncate(CreditNote::DB_PRECISION_SCALE) -
-        taxes_result.coupons_adjustment_amount_cents +
-        taxes_result.taxes_amount_cents
+        taxes_result.coupons_adjustment_amount_cents.truncate(CreditNote::DB_PRECISION_SCALE) +
+        taxes_result.taxes_amount_cents.truncate(CreditNote::DB_PRECISION_SCALE)
       ).round
     end
   end


### PR DESCRIPTION
## Context
This one is really tricky to test because it envolves really small decimal places; but here's what I found in production while debugging a invoice that got stuck in generating for creating a CreditNote for an ProgressiveBilling invoice.

The amount was [calculated here](https://github.com/getlago/lago-api/blob/main/app/services/credits/progressive_billing_service.rb#L32-L37)

This `coupons_adjustment_amount_cents` was [calculated here ](https://github.com/getlago/lago-api/blob/main/app/services/credit_notes/apply_taxes_service.rb#L73-L80)

it still had taxes variable in the equation, but it was `0.0`.

```
lago-api(prod)> amount.truncate(CreditNote::DB_PRECISION_SCALE)
=> 102
lago-api(prod)> coupons_adjustment_amount_cents = service2.send(:coupons_adjustment_amount_cents)
=> 0.1020000000000000024e3
lago-api(prod)> amount.truncate(CreditNote::DB_PRECISION_SCALE) - coupons_adjustment_amount_cents
=> -0.24e-14
lago-api(prod)> amount.truncate(CreditNote::DB_PRECISION_SCALE) - coupons_adjustment_amount_cents.truncate(CreditNote::DB_PRECISION_SCALE)
=> 0.0
```

## Problem
We get a `102` integer value but when we covert to float [here](https://github.com/getlago/lago-api/blob/main/app/services/credit_notes/create_from_progressive_billing_invoice.rb#L69) it may get a super small decimal place differently.

## Fix
truncate both numbers by the standard precision in the class `CreditNote::DB_PRECISION_SCALE`. 