### PR TITLE
fix(xero): Use item_code in Xero payloads

### DIFF
--- a/app/services/integrations/aggregator/credit_notes/payloads/xero.rb
+++ b/app/services/integrations/aggregator/credit_notes/payloads/xero.rb
@@ -5,6 +5,20 @@ module Integrations
     module CreditNotes
       module Payloads
         class Xero < BasePayload
+          private
+
+          def item(credit_note_item)
+            item = super
+            item["item_code"] = item.delete("external_id")
+            item
+          end
+
+          def coupons
+            coupons = super
+            coupons.each do |coupon|
+              coupon["item_code"] = coupon.delete("external_id")
+            end
+          end
         end
       end
     end

--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -11,6 +11,7 @@ module Integrations
 
           def item(fee)
             base_item = super
+            base_item["item_code"] = base_item.delete("external_id")
 
             if fee.precise_unit_amount.round(2) != fee.precise_unit_amount
               base_item["units"] = 1
@@ -19,6 +20,14 @@ module Integrations
             end
 
             base_item
+          end
+
+          def discounts
+            discounts = super
+
+            discounts.each do |discount|
+              discount["item_code"] = discount.delete("external_id")
+            end
           end
         end
       end

--- a/spec/services/integrations/aggregator/credit_notes/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/payloads/xero_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::Payloads::Xero do
              {
                "account_code" => mapping_codes.dig(:add_on, :external_account_code),
                "description" => "Add-on Fee",
-               "external_id" => mapping_codes.dig(:add_on, :external_id),
+               "item_code" => mapping_codes.dig(:add_on, :external_id),
                "precise_unit_amount" => 1.9,
                "taxes_amount_cents" => 0.0,
                "units" => 1
@@ -25,7 +25,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::Payloads::Xero do
              {
                "account_code" => mapping_codes.dig(:fixed_charge, :external_account_code),
                "description" => "Fixed Charge Fee",
-               "external_id" => mapping_codes.dig(:fixed_charge, :external_id),
+               "item_code" => mapping_codes.dig(:fixed_charge, :external_id),
                "precise_unit_amount" => 1.4,
                "taxes_amount_cents" => 0.0,
                "units" => 1
@@ -33,7 +33,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::Payloads::Xero do
              {
                "account_code" => mapping_codes.dig(:billable_metric, :external_account_code),
                "description" => "Standard Charge Fee",
-               "external_id" => mapping_codes.dig(:billable_metric, :external_id),
+               "item_code" => mapping_codes.dig(:billable_metric, :external_id),
                "precise_unit_amount" => 1.8,
                "taxes_amount_cents" => 0.0,
                "units" => 1
@@ -41,7 +41,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::Payloads::Xero do
              {
                "account_code" => mapping_codes.dig(:minimum_commitment, :external_account_code),
                "description" => "Minimum Commitment Fee",
-               "external_id" => mapping_codes.dig(:minimum_commitment, :external_id),
+               "item_code" => mapping_codes.dig(:minimum_commitment, :external_id),
                "precise_unit_amount" => 1.7,
                "taxes_amount_cents" => 0.0,
                "units" => 1
@@ -49,7 +49,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::Payloads::Xero do
              {
                "account_code" => mapping_codes.dig(:subscription, :external_account_code),
                "description" => "Subscription",
-               "external_id" => mapping_codes.dig(:subscription, :external_id),
+               "item_code" => mapping_codes.dig(:subscription, :external_id),
                "precise_unit_amount" => 1.6,
                "taxes_amount_cents" => 0.0,
                "units" => 1
@@ -61,6 +61,23 @@ RSpec.describe Integrations::Aggregator::CreditNotes::Payloads::Xero do
             "type" => "ACCRECCREDIT"
           }
         ]
+      end
+
+      context "when there are coupons" do
+        let(:credit_note) { create(:credit_note, customer:, invoice:, issuing_date: DateTime.new(2024, 7, 8), coupons_adjustment_amount_cents: 50) }
+
+        it "returns coupons with item_code instead of external_id" do
+          expect(payload.first["fees"]).to include(
+            {
+              "account_code" => default_mapping_codes.dig(:coupon, :external_account_code),
+              "description" => "Coupons",
+              "item_code" => default_mapping_codes.dig(:coupon, :external_id),
+              "precise_unit_amount" => -0.5,
+              "taxes_amount_cents" => 0,
+              "units" => 1
+            }
+          )
+        end
       end
     end
   end

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -17,12 +17,11 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
             "number" => invoice.number,
             "currency" => "EUR",
             "type" => "ACCREC",
-            "fees" =>
-            [
+            "fees" => [
               {
                 "account_code" => mapping_codes.dig(:add_on, :external_account_code),
                 "description" => "Add-on Fee",
-                "external_id" => mapping_codes.dig(:add_on, :external_id),
+                "item_code" => mapping_codes.dig(:add_on, :external_id),
                 "precise_unit_amount" => 100.0,
                 "taxes_amount_cents" => 2,
                 "units" => 0.2e1
@@ -30,7 +29,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               {
                 "account_code" => mapping_codes.dig(:fixed_charge, :external_account_code),
                 "description" => "Fixed Charge Fee",
-                "external_id" => mapping_codes.dig(:fixed_charge, :external_id),
+                "item_code" => mapping_codes.dig(:fixed_charge, :external_id),
                 "precise_unit_amount" => 25.0,
                 "taxes_amount_cents" => 2,
                 "units" => 0.6e1
@@ -38,7 +37,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               {
                 "account_code" => mapping_codes.dig(:billable_metric, :external_account_code),
                 "description" => "Standard Charge Fee",
-                "external_id" => mapping_codes.dig(:billable_metric, :external_id),
+                "item_code" => mapping_codes.dig(:billable_metric, :external_id),
                 "precise_unit_amount" => 100.0,
                 "taxes_amount_cents" => 2,
                 "units" => 0.3e1
@@ -46,7 +45,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               {
                 "account_code" => mapping_codes.dig(:minimum_commitment, :external_account_code),
                 "description" => "Minimum Commitment Fee",
-                "external_id" => mapping_codes.dig(:minimum_commitment, :external_id),
+                "item_code" => mapping_codes.dig(:minimum_commitment, :external_id),
                 "precise_unit_amount" => 100.0,
                 "taxes_amount_cents" => 2,
                 "units" => 0.4e1
@@ -54,7 +53,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               {
                 "account_code" => mapping_codes.dig(:subscription, :external_account_code),
                 "description" => "Subscription",
-                "external_id" => mapping_codes.dig(:subscription, :external_id),
+                "item_code" => mapping_codes.dig(:subscription, :external_id),
                 "precise_unit_amount" => 100.0,
                 "taxes_amount_cents" => 2,
                 "units" => 0.5e1
@@ -62,7 +61,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               {
                 "account_code" => mapping_codes.dig(:coupon, :external_account_code),
                 "description" => "Coupons",
-                "external_id" => mapping_codes.dig(:coupon, :external_id),
+                "item_code" => mapping_codes.dig(:coupon, :external_id),
                 "precise_unit_amount" => -2.0,
                 "taxes_amount_cents" => -290,
                 "units" => 1
@@ -70,7 +69,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               {
                 "account_code" => mapping_codes.dig(:prepaid_credit, :external_account_code),
                 "description" => "Prepaid credit",
-                "external_id" => mapping_codes.dig(:prepaid_credit, :external_id),
+                "item_code" => mapping_codes.dig(:prepaid_credit, :external_id),
                 "precise_unit_amount" => -3.0,
                 "taxes_amount_cents" => 0,
                 "units" => 1
@@ -78,7 +77,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               {
                 "account_code" => mapping_codes.dig(:prepaid_credit, :external_account_code),
                 "description" => "Usage already billed",
-                "external_id" => mapping_codes.dig(:prepaid_credit, :external_id),
+                "item_code" => mapping_codes.dig(:prepaid_credit, :external_id),
                 "precise_unit_amount" => -1.0,
                 "taxes_amount_cents" => 0,
                 "units" => 1
@@ -86,7 +85,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               {
                 "account_code" => mapping_codes.dig(:credit_note, :external_account_code),
                 "description" => "Credit note",
-                "external_id" => mapping_codes.dig(:credit_note, :external_id),
+                "item_code" => mapping_codes.dig(:credit_note, :external_id),
                 "precise_unit_amount" => -5.0,
                 "taxes_amount_cents" => 0,
                 "units" => 1


### PR DESCRIPTION
## Context

Xero expects `item_code` instead of `external_id` when sending invoice and credit note payloads.

## Description

This overrides `item`, `discounts`, and `coupons` methods in Xero invoice and credit note payloads to rename the `external_id` field to `item_code` before sending to the Xero aggregator.