### PR TITLE
misc(database): Add pg extension helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Lago/NoDropColumnOrTable:
     - "db/migrate/20251221174251_create_roles.rb"
     - "db/migrate/20251221174733_create_membership_roles.rb"
     - "db/migrate/20251221174938_add_roles_to_invites.rb"
+    - "db/migrate/20260109110146_create_enriched_events.rb"
     - "db/migrate/20260116121015_remove_role_from_memberships.rb"
     - "db/migrate/20260116121019_remove_role_from_invites.rb"
     - "db/migrate/20260119162712_drop_subscription_fixed_charge_units_overrides.rb"

--- a/config/initializers/migration_extensions.rb
+++ b/config/initializers/migration_extensions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ActiveSupport.on_load(:active_record) do
+  require Rails.root.join("lib/migrations/extension_helper")
+
+  ActiveRecord::Migration.include(Migrations::ExtensionHelper)
+end

--- a/db/migrate/20260109092932_setup_partman.rb
+++ b/db/migrate/20260109092932_setup_partman.rb
@@ -3,19 +3,15 @@
 class SetupPartman < ActiveRecord::Migration[8.0]
   def up
     safety_assured do
-      # Check if pg_partman is available on the server
-      result = execute <<~SQL
-        SELECT 1 FROM pg_available_extensions WHERE name = 'pg_partman';
-      SQL
-
-      if result.ntuples.zero?
+      unless pg_extension_present?("pg_partman")
         Rails.logger.debug "pg_partman extension is not available on this PostgreSQL server, skipping..."
-      else
-        execute <<~SQL
-          CREATE SCHEMA IF NOT EXISTS partman;
-          CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;
-        SQL
+        return
       end
+
+      execute <<~SQL
+        CREATE SCHEMA IF NOT EXISTS partman;
+        CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;
+      SQL
     end
   end
 end

--- a/db/migrate/20260109110146_create_enriched_events.rb
+++ b/db/migrate/20260109110146_create_enriched_events.rb
@@ -2,41 +2,36 @@
 
 class CreateEnrichedEvents < ActiveRecord::Migration[8.0]
   def up
-    # Check if pg_partman is available on the server
-    result = safety_assured do
-      execute <<~SQL
-        SELECT 1 FROM pg_available_extensions WHERE name = 'pg_partman';
-      SQL
-    end
+    safety_assured do
+      options = if pg_extension_present?("pg_partman")
+        "PARTITION BY RANGE (timestamp)"
+      else
+        Rails.logger.debug "pg_partman extension is not available on this PostgreSQL server, skipping partitioning"
+        ""
+      end
 
-    options = if result.ntuples.zero?
-      Rails.logger.debug "pg_partman extension is not available on this PostgreSQL server, skipping partitioning"
-      ""
-    else
-      "PARTITION BY RANGE (timestamp)"
-    end
+      create_table :enriched_events, id: false, primary_key: %i[id timestamp], options: do |t|
+        t.uuid :id, null: false, default: -> { "gen_random_uuid()" }
+        t.uuid :organization_id, null: false
+        t.uuid :event_id, null: false, index: true
+        t.string :transaction_id, null: false
+        t.string :external_subscription_id, null: false
+        t.string :code, null: false
+        t.datetime :timestamp, null: false
+        t.uuid :subscription_id, null: false
+        t.uuid :plan_id, null: false
+        t.uuid :charge_id, null: false
+        t.uuid :charge_filter_id
+        t.jsonb :properties, null: false, default: {}
+        t.jsonb :grouped_by, null: false, default: {}
+        t.string :value, null: true
+        t.decimal :decimal_value, precision: 40, scale: 15, null: false, default: 0.0
+        t.datetime :enriched_at, null: false
 
-    create_table :enriched_events, id: false, primary_key: %i[id timestamp], options: do |t|
-      t.uuid :id, null: false, default: -> { "gen_random_uuid()" }
-      t.uuid :organization_id, null: false
-      t.uuid :event_id, null: false, index: true
-      t.string :transaction_id, null: false
-      t.string :external_subscription_id, null: false
-      t.string :code, null: false
-      t.datetime :timestamp, null: false
-      t.uuid :subscription_id, null: false
-      t.uuid :plan_id, null: false
-      t.uuid :charge_id, null: false
-      t.uuid :charge_filter_id
-      t.jsonb :properties, null: false, default: {}
-      t.jsonb :grouped_by, null: false, default: {}
-      t.string :value, null: true
-      t.decimal :decimal_value, precision: 40, scale: 15, null: false, default: 0.0
-      t.datetime :enriched_at, null: false
-
-      t.index %i[organization_id subscription_id charge_id charge_filter_id timestamp], name: "idx_billing_on_enriched_events"
-      t.index %i[organization_id external_subscription_id code timestamp], name: "idx_lookup_on_enriched_events"
-      t.index %i[organization_id external_subscription_id transaction_id timestamp charge_id], unique: true, name: "idx_unique_on_enriched_events"
+        t.index %i[organization_id subscription_id charge_id charge_filter_id timestamp], name: "idx_billing_on_enriched_events"
+        t.index %i[organization_id external_subscription_id code timestamp], name: "idx_lookup_on_enriched_events"
+        t.index %i[organization_id external_subscription_id transaction_id timestamp charge_id], unique: true, name: "idx_unique_on_enriched_events"
+      end
     end
   end
 

--- a/db/migrate/20260109132143_partition_enriched_events.rb
+++ b/db/migrate/20260109132143_partition_enriched_events.rb
@@ -3,33 +3,29 @@
 class PartitionEnrichedEvents < ActiveRecord::Migration[8.0]
   def up
     safety_assured do
-      # Check if pg_partman is available on the server
-      result = execute <<~SQL
-        SELECT 1 FROM pg_available_extensions WHERE name = 'pg_partman';
+      unless pg_extension_present?("pg_partman")
+        Rails.logger.debug "pg_partman extension is not available on this PostgreSQL server, skipping..."
+        return
+      end
+
+      execute <<~SQL
+        SELECT partman.create_parent(
+          p_parent_table := 'public.enriched_events',
+          p_control := 'timestamp',
+          p_interval := '1 month',
+          p_type := 'range',
+          p_premake := 3,                    -- Create 3 months ahead
+          p_start_partition := '2024-12-01'
+        )
       SQL
 
-      if result.ntuples.zero?
-        Rails.logger.debug "pg_partman extension is not available on this PostgreSQL server, skipping..."
-      else
-        execute <<~SQL
-          SELECT partman.create_parent(
-            p_parent_table := 'public.enriched_events',
-            p_control := 'timestamp',
-            p_interval := '1 month',
-            p_type := 'range',
-            p_premake := 3,                    -- Create 3 months ahead
-            p_start_partition := '2024-12-01'
-          )
-        SQL
-
-        execute <<~SQL
-          UPDATE partman.part_config
-          SET infinite_time_partitions = true,
-              retention = '14 months', -- Handle yearly plan with large grace periods
-              retention_keep_table = true
-          WHERE parent_table = 'public.enriched_events';
-        SQL
-      end
+      execute <<~SQL
+        UPDATE partman.part_config
+        SET infinite_time_partitions = true,
+            retention = '14 months', -- Handle yearly plan with large grace periods
+            retention_keep_table = true
+        WHERE parent_table = 'public.enriched_events';
+      SQL
     end
   end
 end

--- a/lib/migrations/extension_helper.rb
+++ b/lib/migrations/extension_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Migrations
+  module ExtensionHelper
+    def pg_extension_present?(extension)
+      result = execute <<~SQL
+        SELECT 1 FROM pg_available_extensions WHERE name = '#{extension}'
+      SQL
+
+      result.ntuples.positive?
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR is related to https://github.com/getlago/lago-api/pull/5025#discussion_r2798059134

## Description

It adds a new helper for migrations with postgres to check the presence on an extension library.

Usage:
```ruby
require Rails.root.join("lib/migrations/extension_helper")

class SomeMigration < ActiveRecord::Migration[8.0]
  include Migrations::ExtensionHelper

  def up
    return unless pg_extension_present?("some_pg_extension")
    
    # ... some migration logic
  end
end
```