### PR TITLE
misc(cable): Use dedicated LAGO_REDIS_CABLE_URL for Action Cable

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,6 @@
 development:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
+  url: <%= ENV.fetch("LAGO_REDIS_CABLE_URL", ENV.fetch("REDIS_URL", "redis://localhost:6379/1")) %>
   channel_prefix: lago_development
 
 test:
@@ -8,10 +8,10 @@ test:
 
 staging:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
+  url: <%= ENV.fetch("LAGO_REDIS_CABLE_URL", ENV.fetch("REDIS_URL", "redis://localhost:6379/1")) %>
   channel_prefix: lago_staging
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
+  url: <%= ENV.fetch("LAGO_REDIS_CABLE_URL", ENV.fetch("REDIS_URL", "redis://localhost:6379/1")) %>
   channel_prefix: lago_production


### PR DESCRIPTION
Action Cable was using the shared `REDIS_URL`, making it impossible to route Action Cable traffic to a separate Redis instance.
