### PR TITLE
refacto(queries): Avoid overriding Query constructor and use filter instead

### DIFF
--- a/app/contracts/queries/wallet_transaction_consumptions_query_filters_contract.rb
+++ b/app/contracts/queries/wallet_transaction_consumptions_query_filters_contract.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Queries
+  class WalletTransactionConsumptionsQueryFiltersContract < Dry::Validation::Contract
+    params do
+      required(:wallet_transaction_id).filled(:string)
+      required(:direction).filled(:string, included_in?: %w[consumptions fundings])
+    end
+  end
+end

--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -94,9 +94,11 @@ module Api
       def wallet_transaction_consumptions(direction:)
         result = WalletTransactionConsumptionsQuery.call(
           organization: current_organization,
-          wallet_transaction_id: params[:id],
-          direction:,
-          pagination: {page: params[:page], limit: params[:per_page] || PER_PAGE}
+          pagination: {page: params[:page], limit: params[:per_page] || PER_PAGE},
+          filters: {
+            wallet_transaction_id: params[:id],
+            direction: direction.to_s
+          }
         )
 
         return render_error_response(result) unless result.success?

--- a/app/queries/wallet_transaction_consumptions_query.rb
+++ b/app/queries/wallet_transaction_consumptions_query.rb
@@ -2,24 +2,15 @@
 
 class WalletTransactionConsumptionsQuery < BaseQuery
   Result = BaseResult[:wallet_transaction_consumptions]
-
-  DIRECTIONS = %i[consumptions fundings].freeze
-
-  def initialize(organization:, wallet_transaction_id:, direction:, pagination: DEFAULT_PAGINATION_PARAMS)
-    @wallet_transaction = organization.wallet_transactions.find_by(id: wallet_transaction_id)
-    @direction = direction.to_sym
-
-    raise ArgumentError, "Invalid direction: #{@direction}" unless DIRECTIONS.include?(@direction)
-
-    super(organization:, pagination:)
-  end
+  Filters = BaseFilters[:wallet_transaction_id, :direction]
 
   def call
+    return result unless validate_filters.success?
     return result.not_found_failure!(resource: "wallet_transaction") unless wallet_transaction
     return result.single_validation_failure!(field: :wallet, error_code: "not_traceable") unless wallet_transaction.wallet.traceable?
     return result.single_validation_failure!(field: :transaction_type, error_code: "invalid_transaction_type") unless valid_transaction_type?
 
-    consumptions = wallet_transaction.public_send(direction)
+    consumptions = wallet_transaction.public_send(filters.direction)
     consumptions = paginate(consumptions)
     consumptions = apply_consistent_ordering(consumptions)
 
@@ -29,10 +20,16 @@ class WalletTransactionConsumptionsQuery < BaseQuery
 
   private
 
-  attr_reader :wallet_transaction, :direction
+  def wallet_transaction
+    @wallet_transaction ||= organization.wallet_transactions.find_by(id: filters.wallet_transaction_id)
+  end
+
+  def filters_contract
+    @filters_contract ||= Queries::WalletTransactionConsumptionsQueryFiltersContract.new
+  end
 
   def valid_transaction_type?
-    case direction
+    case filters.direction.to_sym
     when :consumptions
       wallet_transaction.inbound?
     when :fundings

--- a/spec/queries/wallet_transaction_consumptions_query_spec.rb
+++ b/spec/queries/wallet_transaction_consumptions_query_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe WalletTransactionConsumptionsQuery do
   subject(:result) do
     described_class.call(
       organization:,
-      wallet_transaction_id:,
-      direction:,
-      pagination:
+      pagination:,
+      filters: {
+        wallet_transaction_id:,
+        direction:
+      }
     )
   end
 
@@ -19,16 +21,18 @@ RSpec.describe WalletTransactionConsumptionsQuery do
   let(:pagination) { nil }
 
   describe "with invalid direction" do
-    let(:direction) { :invalid }
+    let(:direction) { "invalid" }
     let(:wallet_transaction_id) { SecureRandom.uuid }
 
-    it "raises ArgumentError" do
-      expect { result }.to raise_error(ArgumentError, "Invalid direction: invalid")
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+      expect(result.error.messages).to include(:direction)
     end
   end
 
   describe "consumptions direction" do
-    let(:direction) { :consumptions }
+    let(:direction) { "consumptions" }
     let(:wallet_transaction_id) { inbound_transaction.id }
     let(:inbound_transaction) { create(:wallet_transaction, wallet:, transaction_type: "inbound", remaining_amount_cents: 10000) }
 
@@ -106,7 +110,7 @@ RSpec.describe WalletTransactionConsumptionsQuery do
   end
 
   describe "fundings direction" do
-    let(:direction) { :fundings }
+    let(:direction) { "fundings" }
     let(:wallet_transaction_id) { outbound_transaction.id }
     let(:outbound_transaction) { create(:wallet_transaction, wallet:, transaction_type: "outbound") }
 


### PR DESCRIPTION
I think we should strive to avoid overriding constructor of query object. The param added should usually be done via filter.
The end goal is to refacto the pagination too and avoid so much repetition.

See https://github.com/getlago/lago-api/pull/4588 for the rest (it's coming)