### PR TITLE
fix(ActivityLog): Add limit on number of charge filters

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -18,6 +18,7 @@ class Plan < ApplicationRecord
   has_many :commitments
   has_many :charges, dependent: :destroy
   has_many :billable_metrics, through: :charges
+  has_many :charge_filters, through: :charges, source: :filters
   has_many :fixed_charges, dependent: :destroy
   has_many :add_ons, through: :fixed_charges
   has_many :subscriptions

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -6,6 +6,7 @@ module Utils
     IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES = %w[BillableMetric Coupon Plan BillingEntity Entitlement::Feature].freeze
     MAX_SERIALIZED_FEES = 25
     MAX_SERIALIZED_CHARGES = 50
+    MAX_SERIALIZED_CHARGE_FILTERS = 100
 
     SERIALIZED_INCLUDED_OBJECTS = {
       billing_entity: %i[taxes],
@@ -140,13 +141,13 @@ module Utils
           SERIALIZED_INCLUDED_OBJECTS[:invoice]
         end
       when :plan
-        if object.charges.count > MAX_SERIALIZED_CHARGES
+        if has_many_charges_or_filters?(object)
           SERIALIZED_INCLUDED_OBJECTS[:plan] - [:charges]
         else
           SERIALIZED_INCLUDED_OBJECTS[:plan]
         end
       when :subscription
-        if object.plan.charges.count > MAX_SERIALIZED_CHARGES
+        if has_many_charges_or_filters?(object.plan)
           [{plan: SERIALIZED_INCLUDED_OBJECTS[:plan] - [:charges]}]
         else
           SERIALIZED_INCLUDED_OBJECTS[:subscription]
@@ -195,6 +196,10 @@ module Utils
       return nil unless object.is_a?(Subscription)
 
       object.external_id
+    end
+
+    def has_many_charges_or_filters?(plan)
+      plan.charges.count > MAX_SERIALIZED_CHARGES || plan.charge_filters.count > MAX_SERIALIZED_CHARGE_FILTERS
     end
   end
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Plan do
     expect(subject).to have_many(:usage_thresholds)
     expect(subject).to have_many(:commitments)
     expect(subject).to have_many(:charges).dependent(:destroy)
+    expect(subject).to have_many(:charge_filters).through(:charges).source(:filters)
     expect(subject).to have_many(:billable_metrics).through(:charges)
     expect(subject).to have_many(:fixed_charges).dependent(:destroy)
     expect(subject).to have_many(:add_ons).through(:fixed_charges)


### PR DESCRIPTION
## Description

This PR follows https://github.com/getlago/lago-api/pull/4994

It applies the limit logic to the number of filters and not only to the number of charges to mitigate the risk of raising a `WaterDrop::Errors::MessageInvalidError` and keep logging the changes that were made by the user