### PR TITLE
fix(vies): Handle HTTP 307 redirect error

### DIFF
--- a/app/models/pending_vies_check.rb
+++ b/app/models/pending_vies_check.rb
@@ -7,6 +7,7 @@ class PendingViesCheck < ApplicationRecord
     Valvat::BlockedError => "blocked",
     Valvat::InvalidRequester => "invalid_requester",
     Valvat::ServiceUnavailable => "service_unavailable",
+    Valvat::HTTPError => "service_unavailable",
     Valvat::MemberStateUnavailable => "member_state_unavailable"
   }.freeze
 

--- a/spec/models/pending_vies_check_spec.rb
+++ b/spec/models/pending_vies_check_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe PendingViesCheck, type: :model do
       expect(described_class.error_type_for(Valvat::BlockedError.new("error", :vies))).to eq("blocked")
       expect(described_class.error_type_for(Valvat::InvalidRequester.new("error", :vies))).to eq("invalid_requester")
       expect(described_class.error_type_for(Valvat::ServiceUnavailable.new("error", :vies))).to eq("service_unavailable")
+      expect(described_class.error_type_for(Valvat::HTTPError.new("The VIES web service returned the error: 307 ", :vies))).to eq("service_unavailable")
       expect(described_class.error_type_for(Valvat::MemberStateUnavailable.new("error", :vies))).to eq("member_state_unavailable")
     end
 


### PR DESCRIPTION
## Context

The VIES service can return a 307 redirect to an error page when unavailable. This was causing unhandled `Valvat::HTTPError` exceptions.

## Description

This catches `Valvat::HTTPError` in `EuAutoTaxesService` and treat 307 redirects as service unavailability, creating a pending VIES check and scheduling a retry. Other HTTP errors are re-raised. Add `Valvat::HTTPError` to `PendingViesCheck::ERROR_TYPE_MAP` as `service_unavailable`.
