### PR TITLE
feat(charge): Add backfill jobs for charges and fixed charges code

### DIFF
--- a/app/jobs/database_migrations/backfill_charges_code_job.rb
+++ b/app/jobs/database_migrations/backfill_charges_code_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillChargesCodeJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1_000
+
+    def perform(batch_number = 1)
+      return Rails.logger.info("Finished populating charge codes") unless Charge.unscoped.where(code: nil).exists?
+
+      result = ActiveRecord::Base.connection.execute(<<-SQL.squish)
+        WITH plan_batch AS (
+          SELECT DISTINCT plan_id
+          FROM charges
+          WHERE code IS NULL
+          LIMIT #{BATCH_SIZE}
+        ),
+        ranked_codes AS (
+          SELECT
+            c.id,
+            bm.code AS base_code,
+            ROW_NUMBER() OVER (PARTITION BY c.plan_id, bm.code ORDER BY c.created_at, c.id) AS rn
+          FROM charges c
+          INNER JOIN plan_batch pb ON pb.plan_id = c.plan_id
+          INNER JOIN billable_metrics bm ON bm.id = c.billable_metric_id
+          WHERE c.code IS NULL
+        )
+        UPDATE charges
+        SET code = CASE
+          WHEN ranked_codes.rn = 1 THEN ranked_codes.base_code
+          ELSE ranked_codes.base_code || '_' || ranked_codes.rn
+        END
+        FROM ranked_codes
+        WHERE charges.id = ranked_codes.id
+      SQL
+
+      if result.cmd_tuples.positive?
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished populating charge codes")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/jobs/database_migrations/backfill_fixed_charges_code_job.rb
+++ b/app/jobs/database_migrations/backfill_fixed_charges_code_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillFixedChargesCodeJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1_000
+
+    def perform(batch_number = 1)
+      return Rails.logger.info("Finished populating fixed charge codes") unless FixedCharge.unscoped.where(code: nil).exists?
+
+      result = ActiveRecord::Base.connection.execute(<<-SQL.squish)
+        WITH plan_batch AS (
+          SELECT DISTINCT plan_id
+          FROM fixed_charges
+          WHERE code IS NULL
+          LIMIT #{BATCH_SIZE}
+        ),
+        ranked_codes AS (
+          SELECT
+            fc.id,
+            ao.code AS base_code,
+            ROW_NUMBER() OVER (PARTITION BY fc.plan_id, ao.code ORDER BY fc.created_at, fc.id) AS rn
+          FROM fixed_charges fc
+          INNER JOIN plan_batch pb ON pb.plan_id = fc.plan_id
+          INNER JOIN add_ons ao ON ao.id = fc.add_on_id
+          WHERE fc.code IS NULL
+        )
+        UPDATE fixed_charges
+        SET code = CASE
+          WHEN ranked_codes.rn = 1 THEN ranked_codes.base_code
+          ELSE ranked_codes.base_code || '_' || ranked_codes.rn
+        END
+        FROM ranked_codes
+        WHERE fixed_charges.id = ranked_codes.id
+      SQL
+
+      if result.cmd_tuples.positive?
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished populating fixed charge codes")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/lib/tasks/upgrade_verification.rake
+++ b/lib/tasks/upgrade_verification.rake
@@ -11,7 +11,10 @@ namespace :upgrade do
     Rails.logger.level = Logger::Severity::ERROR
 
     resources_to_fill = [
-      {model: Wallet, job: DatabaseMigrations::PopulateWalletsWithCodeJob},
+      # TODO: Uncomment when code is required for wallets
+      # {model: Wallet, job: DatabaseMigrations::PopulateWalletsWithCodeJob},
+      {model: Charge, job: DatabaseMigrations::BackfillChargesCodeJob},
+      {model: FixedCharge, job: DatabaseMigrations::BackfillFixedChargesCodeJob}
     ]
 
     puts "##################################\nStarting required jobs"


### PR DESCRIPTION
The `code` column on `charges` and `fixed_charges` tables needs to become NOT NULL, but existing rows may have NULL values. This is the first phase of a two-phase rollout.

Add batch backfill jobs that populate the `code` column from the associated billable metric or add-on code, with deduplication via row numbering. Register both jobs in the upgrade verification rake task so they run automatically before the next release.