### PR TITLE
refactor(queries): convert WebhookQuery to required filter

### DIFF
--- a/app/contracts/queries/webhooks_query_filters_contract.rb
+++ b/app/contracts/queries/webhooks_query_filters_contract.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Queries
+  class WebhooksQueryFiltersContract < Dry::Validation::Contract
+    params do
+      required(:webhook_endpoint_id).filled(:string)
+
+      optional(:status).maybe do
+        value(:string, included_in?: Webhook::STATUS.map(&:to_s)) |
+          array(:string, included_in?: Webhook::STATUS.map(&:to_s))
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/webhooks_resolver.rb
+++ b/app/graphql/resolvers/webhooks_resolver.rb
@@ -18,12 +18,11 @@ module Resolvers
     type Types::Webhooks::Object.collection_type, null: false
 
     def resolve(webhook_endpoint_id:, page: nil, limit: nil, status: nil, search_term: nil)
-      webhook_endpoint = current_organization.webhook_endpoints.find(webhook_endpoint_id)
-
       result = WebhooksQuery.call(
-        webhook_endpoint:,
+        organization: current_organization,
         search_term:,
         filters: {
+          webhook_endpoint_id:,
           status:
         },
         pagination: {

--- a/spec/contracts/queries/webhooks_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/webhooks_query_filters_contract_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Queries::WebhooksQueryFiltersContract do
+  subject(:result) { described_class.new.call(filters.to_h) }
+
+  let(:filters) { {} }
+
+  context "when filtering by webhook_endpoint_id" do
+    let(:filters) { {webhook_endpoint_id: "webhook-123"} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+
+    context "when filter is blank" do
+      let(:filters) { {webhook_endpoint_id: nil} }
+
+      it "is invalid" do
+        expect(result.success?).to be(false)
+      end
+    end
+  end
+
+  context "when filtering by status" do
+    let(:filters) { {webhook_endpoint_id: "webhook-123", status: "pending"} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+
+    context "when filter is an array" do
+      let(:filters) { {webhook_endpoint_id: "webhook-123", status: ["pending", "succeeded"]} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+  end
+
+  context "when filters are invalid" do
+    it_behaves_like "an invalid filter", :status, "random", ["must be one of: pending, succeeded, failed or must be an array"]
+    it_behaves_like "an invalid filter", :status, ["pending", "random"], {1 => ["must be one of: pending, succeeded, failed"]}
+  end
+end


### PR DESCRIPTION
Extracted from https://github.com/getlago/lago-api/pull/4588

This PR focuses just on WebhookQuery.
The goal is to always use filter instead of constructor override, to remove duplication and one day, refactor pagination.

This is necessary as @rinasergeeva is going to add more filters!