### PR TITLE
fix(invoice): reset `payment_overdue` on status change instead of service call

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -522,6 +522,7 @@ class Invoice < ApplicationRecord
   def handle_void_transition!
     update!(
       ready_for_payment_processing: false,
+      payment_overdue: false,
       voided_at: Time.current
     )
   end

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -28,7 +28,6 @@ module Invoices
       end
 
       ActiveRecord::Base.transaction do
-        invoice.payment_overdue = false if invoice.payment_overdue?
         invoice.void!
         flag_lifetime_usage_for_refresh
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1583,11 +1583,12 @@ RSpec.describe Invoice do
     subject(:force_void_call) { invoice.void! }
 
     context "when invoice is finalized" do
-      let(:invoice) { build(:invoice, status: :finalized, ready_for_payment_processing: true) }
+      let(:invoice) { build(:invoice, status: :finalized, ready_for_payment_processing: true, payment_overdue: true) }
 
       it "changes the status to voided and disables payment processing" do
         expect { force_void_call }.to change(invoice, :status).from("finalized").to("voided")
           .and change(invoice, :ready_for_payment_processing).from(true).to(false)
+          .and change(invoice, :payment_overdue).from(true).to(false)
       end
     end
   end


### PR DESCRIPTION
Small refactor but we sometime need to void a bunch of invoices in the console. In this case, we avoid using the full service to ignore the webhook and other stuff.

This PR makes sure the `payment_overdue` is reset on status change, rather than in the service transaction.

I think it's also more consistent with `ready_for_payment_processing`.