### PR TITLE
feat(daily-usages): Make `DailyUsage` scheduling interval configurable

### DIFF
--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -31,7 +31,12 @@ module DailyUsages
     end
 
     def scheduling_interval
-      ENV.fetch("LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS", 30.minutes).to_i
+      @scheduling_interval ||= begin
+        raw_value = ENV["LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS"]
+        parsed = Integer(raw_value, exception: false) if raw_value
+        parsed = nil if parsed && parsed <= 0
+        (parsed || 30.minutes).to_i
+      end
     end
 
     def subscriptions


### PR DESCRIPTION
## Context

The daily usage job scheduling interval was hardcoded to 30 minutes. Depending on the load profile of the environment, this hardcoded value may not be appropriate. We may want to have a bigger window on a struggling infrastructure to better spread the load or reduce the window for highly scalable environments to have daily usage available as early as possible.

## Description

This extracts the scheduling interval into a configurable `LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS` env var with a 30-minute default.