### PR TITLE
chore(redis): Allow to specify Redis password for cache in dev env

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   config.server_timing = true
 
   cache_store_config = {url: ENV["LAGO_REDIS_CACHE_URL"], db: ENV.fetch("LAGO_REDIS_CACHE_DB", 0)}
-  if ENV["LAGO_REDIS_CACHE_PASSWORD"].present? && !ENV["LAGO_REDIS_CACHE_PASSWORD"].empty?
+  if ENV["LAGO_REDIS_CACHE_PASSWORD"].present?
     cache_store_config = cache_store_config.merge({password: ENV["LAGO_REDIS_CACHE_PASSWORD"]})
   end
   config.cache_store = :redis_cache_store, cache_store_config


### PR DESCRIPTION
## Context

We allow to specify the cache Redis password on production but there's no way to test this in development environment

## Description

This adds the possibility to specify the cache Redis password.