### PR TITLE
fix(taxes): detect EU special territories before VIES validation

### DIFF
--- a/app/services/customers/eu_auto_taxes_service.rb
+++ b/app/services/customers/eu_auto_taxes_service.rb
@@ -86,7 +86,8 @@ module Customers
       tax_exceptions = LagoEuVat::Rate.country_rates(country_code:)[:exceptions]
       return if tax_exceptions.blank?
 
-      tax_exceptions.find { |tax_exception| customer.zipcode.match?(tax_exception["postcode"]) }
+      normalized_zip = customer.zipcode.gsub(/\s/, "")
+      tax_exceptions.find { |tax_exception| normalized_zip.match?(tax_exception["postcode"]) }
     end
 
     def territory_tax_code(country_code, tax_exception)


### PR DESCRIPTION
## Context
B2C customers in special territories (e.g., Canary Islands) were charged the standard country rate instead of the exception rate. Also, B2B customers in territories like France DOM-TOM were routed through VIES and got reverse charge instead of territory-specific rates.

EU special territory detection relies on regex matching against customer zipcodes. Zipcodes with whitespace (e.g., " 35 001 ") would fail to match territory patterns, silently falling through to standard rates.

## Description
This pull request short-circuits by post-code matching before VIES for 17 territories across 7 countries. It still relies on the current [eu_vat_rates.json](https://github.com/getlago/lago-api/blob/main/lib/lago_eu_vat/lago_eu_vat/eu_vat_rates.json#L107-L118) as the source of truth for the tax details.

Strip whitespace from zipcode before regex matching in territory detection. Add tests for zipcode normalization and customer relocation from mainland to special territory.

| Scenario | Zipcode | Before (bug) | After (fix) |
|----------|---------|-------------|-------------|
| **Spain** | | | |
| B2B ES — Canary Islands | 35001 | ❌ 21% standard | ✅ 0% exception |
| B2C ES — Canary Islands | 35001 | ❌ 21% standard | ✅ 0% exception |
| B2B ES — Canary Islands | 38314 | ❌ 21% standard | ✅ 0% exception |
| B2B ES — Ceuta | 51001 | ❌ 21% standard | ✅ 0% exception |
| B2B ES — Melilla | 52001 | ❌ 21% standard | ✅ 0% exception |
| **France B2B** | | | |
| B2B FR — Martinique | 97200 | ❌ reverse charge | ✅ 8.5% exception |
| B2B FR — Guadeloupe | 97100 | ❌ reverse charge | ✅ 8.5% exception |
| B2B FR — Réunion | 97412 | ❌ reverse charge | ✅ 8.5% exception |
| B2B FR — Guyane | 97300 | ❌ reverse charge | ✅ 0% exception |
| B2B FR — Mayotte | 97600 | ❌ reverse charge | ✅ 0% exception |
| **France B2C** | | | |
| B2C FR — Martinique | 97200 | ✅ 20% standard | ✅ 20% standard |
| B2C FR — Guadeloupe | 97100 | ✅ 20% standard | ✅ 20% standard |
| B2C FR — Réunion | 97412 | ✅ 20% standard | ✅ 20% standard |
| B2C FR — Guyane | 97300 | ✅ 20% standard | ✅ 20% standard |
| B2C FR — Mayotte | 97600 | ✅ 20% standard | ✅ 20% standard |
| **Germany** | | | |
| B2B DE — Büsingen am Hochrhein | 78266 | ❌ reverse charge | ✅ 0% exception |
| B2C DE — Büsingen am Hochrhein | 78266 | ❌ 19% standard | ✅ 0% exception |
| B2B DE — Heligoland | 27498 | ❌ reverse charge | ✅ 0% exception |
| **Italy** | | | |
| B2B IT — Livigno | 23041 | ❌ reverse charge | ✅ 0% exception |
| B2C IT — Livigno | 23041 | ❌ 22% standard | ✅ 0% exception |
| B2B IT — Campione d'Italia | 22061 | ❌ reverse charge | ✅ 0% exception |
| **Portugal** | | | |
| B2B PT — Azores | 9500 | ❌ reverse charge | ✅ 18% exception |
| B2C PT — Azores | 9500 | ❌ 23% standard | ✅ 18% exception |
| B2B PT — Madeira | 9000 | ❌ reverse charge | ✅ 22% exception |
| **Austria** | | | |
| B2B AT — Jungholz | 6691 | ❌ reverse charge | ✅ 19% exception |
| B2C AT — Jungholz | 6691 | ❌ 20% standard | ✅ 19% exception |
| B2B AT — Mittelberg | 6992 | ❌ reverse charge | ✅ 19% exception |
| B2B AT — Mittelberg | 6991 | ❌ reverse charge | ✅ 19% exception |
| **Greece** | | | |
| B2B GR — Mount Athos | 63086 | ❌ reverse charge | ✅ 0% exception |
| B2C GR — Mount Athos | 63086 | ❌ 24% standard | ✅ 0% exception |
