### PR TITLE
feat(events-processor): Add accepts_target_wallet to flat_filters view

### DIFF
--- a/db/migrate/20260219083335_update_flat_filters_to_version_4.rb
+++ b/db/migrate/20260219083335_update_flat_filters_to_version_4.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateFlatFiltersToVersion4 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :flat_filters, version: 4, revert_to_version: 3
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -297,7 +297,8 @@ SELECT
     NULL::jsonb AS filters,
     NULL::jsonb AS properties,
     NULL::jsonb AS pricing_group_keys,
-    NULL::boolean AS pay_in_advance;
+    NULL::boolean AS pay_in_advance,
+    NULL::boolean AS accepts_target_wallet;
 CREATE OR REPLACE VIEW public.billable_metrics_grouped_charges AS
 SELECT
     NULL::uuid AS organization_id,
@@ -4006,7 +4007,8 @@ SELECT
     NULL::jsonb AS filters,
     NULL::jsonb AS properties,
     NULL::jsonb AS pricing_group_keys,
-    NULL::boolean AS pay_in_advance;
+    NULL::boolean AS pay_in_advance,
+    NULL::boolean AS accepts_target_wallet;
 
 
 --
@@ -9221,7 +9223,8 @@ CREATE OR REPLACE VIEW public.flat_filters AS
         END AS filters,
     COALESCE(charge_filters.properties, charges.properties) AS properties,
     (COALESCE(charge_filters.properties, charges.properties) -> 'pricing_group_keys'::text) AS pricing_group_keys,
-    charges.pay_in_advance
+    charges.pay_in_advance,
+    charges.accepts_target_wallet
    FROM ((((public.billable_metrics
      JOIN public.charges ON ((charges.billable_metric_id = billable_metrics.id)))
      LEFT JOIN public.charge_filters ON ((charge_filters.charge_id = charges.id)))
@@ -11444,6 +11447,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260219083335'),
 ('20260216115709'),
 ('20260209103920'),
 ('20260209103526'),

--- a/db/views/flat_filters_v04.sql
+++ b/db/views/flat_filters_v04.sql
@@ -1,0 +1,45 @@
+-- This view is used on events_processor side to check filters matching on events received for organization using the Clickhouse store
+-- It then allows us to expire the usage chage directly within the events events_processor service
+SELECT
+  billable_metrics.organization_id AS organization_id,
+  billable_metrics.code AS billable_metric_code,
+  charges.plan_id AS plan_id,
+  charges.id AS charge_id,
+  charges.updated_at AS charge_updated_at,
+  charge_filters.id AS charge_filter_id,
+  charge_filters.updated_at AS charge_filter_updated_at,
+  CASE WHEN charge_filters.id IS NOT NULL
+  THEN
+	  jsonb_object_agg(
+	    COALESCE(billable_metric_filters.key, ''),
+	    CASE
+	      WHEN charge_filter_values.values::text[] && ARRAY['__ALL_FILTER_VALUES__']
+	      THEN billable_metric_filters.values
+	      ELSE charge_filter_values.values
+	    end
+	  )
+	  ELSE NULL
+  END AS filters,
+  COALESCE(charge_filters.properties, charges.properties) AS properties,
+  COALESCE(charge_filters.properties, charges.properties)->'pricing_group_keys' AS pricing_group_keys,
+  charges.pay_in_advance AS pay_in_advance,
+  charges.accepts_target_wallet AS accepts_target_wallet
+FROM billable_metrics
+  INNER JOIN charges ON charges.billable_metric_id = billable_metrics.id
+  LEFT JOIN charge_filters ON charge_filters.charge_id = charges.id
+  LEFT JOIN charge_filter_values ON charge_filter_values.charge_filter_id = charge_filters.id
+  LEFT JOIN billable_metric_filters ON billable_metric_filters.id = charge_filter_values.billable_metric_filter_id
+WHERE
+  billable_metrics.deleted_at IS NULL
+  AND charges.deleted_at IS NULL
+  AND charge_filters.deleted_at IS NULL
+  AND charge_filter_values.deleted_at IS NULL
+  AND billable_metric_filters.deleted_at IS NULL
+GROUP BY
+  billable_metrics.organization_id,
+  billable_metrics.code,
+  charges.plan_id,
+  charges.id,
+  charges.updated_at,
+  charge_filters.id,
+  charge_filters.updated_at


### PR DESCRIPTION
## Description

A new `charges.accepts_target_wallet` was recently added to group events by wallet, using the `target_wallet_code` sent in `events#properties`.

As we need to include this value in the `grouped_by` and `sorted_grouped_by` attributes of the `events_enriched_expanded`, the `flat_filters` view need to be updated to include this new attribute. 
