### PR TITLE
fix(active-job): Prevent calling `ActiveJob.perform_all_later` on unique jobs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,8 @@ require:
   - ./dev/cops/discard_all_cop.rb
   - ./dev/cops/no_drop_column_or_table_cop.rb
   - ./dev/cops/lago_premium_around_cop.rb
+  - ./dev/cops/active_job_perform_all_later_cop.rb
+  - ./dev/cops/stub_perform_all_later_cop.rb
 
 inherit_gem:
   standard: config/base.yml

--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -12,10 +12,9 @@ module Clock
         .where(payment_dispute_lost_at: nil)
         .where(payment_due_date: ...Time.current)
         .in_batches(of: 1000, cursor: [:payment_due_date, :id]) do |batch|
-          jobs = batch.map do |invoice|
-            Invoices::Payments::MarkOverdueJob.new(invoice:)
+          invoices.each do |invoice|
+            Invoices::Payments::MarkOverdueJob.perform_later(invoice:)
           end
-          ActiveJob.perform_all_later(jobs)
         end
     end
   end

--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -12,7 +12,7 @@ module Clock
         .where(payment_dispute_lost_at: nil)
         .where(payment_due_date: ...Time.current)
         .in_batches(of: 1000, cursor: [:payment_due_date, :id]) do |batch|
-          invoices.each do |invoice|
+          batch.each do |invoice|
             Invoices::Payments::MarkOverdueJob.perform_later(invoice:)
           end
         end

--- a/app/jobs/fixed_charges/cascade_plan_update_job.rb
+++ b/app/jobs/fixed_charges/cascade_plan_update_job.rb
@@ -16,7 +16,7 @@ module FixedCharges
             )
           end
 
-          ActiveJob.perform_all_later(jobs)
+          ApplicationJob.perform_all_later(jobs)
       end
     end
   end

--- a/app/services/entitlement/feature_destroy_service.rb
+++ b/app/services/entitlement/feature_destroy_service.rb
@@ -33,7 +33,7 @@ module Entitlement
       end
 
       after_commit do
-        ActiveJob.perform_all_later(jobs)
+        ApplicationJob.perform_all_later(jobs)
         SendWebhookJob.perform_later("feature.deleted", feature)
       end
 

--- a/app/services/entitlement/feature_update_service.rb
+++ b/app/services/entitlement/feature_update_service.rb
@@ -38,7 +38,7 @@ module Entitlement
 
       # NOTE: The webhooks are sent even if there was no actual change
       after_commit do
-        ActiveJob.perform_all_later(jobs)
+        ApplicationJob.perform_all_later(jobs)
         SendWebhookJob.perform_later("feature.updated", feature)
       end
 

--- a/app/services/entitlement/privilege_destroy_service.rb
+++ b/app/services/entitlement/privilege_destroy_service.rb
@@ -28,7 +28,7 @@ module Entitlement
       end
 
       after_commit do
-        ActiveJob.perform_all_later(jobs)
+        ApplicationJob.perform_all_later(jobs)
         SendWebhookJob.perform_later("feature.updated", privilege.feature)
       end
 

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -99,7 +99,7 @@ module Events
 
     def enqueue_post_process_jobs
       jobs = result.events.map { |event| Events::PostProcessJob.new(event:) }
-      ActiveJob.perform_all_later(jobs)
+      ApplicationJob.perform_all_later(jobs)
     end
   end
 end

--- a/app/services/fixed_charges/cascade_child_plan_update_service.rb
+++ b/app/services/fixed_charges/cascade_child_plan_update_service.rb
@@ -46,18 +46,12 @@ module FixedCharges
         end
       end
 
-      jobs = []
       if plan.fixed_charges.pay_in_advance.exists?
-        plan.subscriptions.active.find_each do |subscription|
-          jobs << Invoices::CreatePayInAdvanceFixedChargesJob.new(
-            subscription,
-            timestamp
-          )
+        after_commit do
+          plan.subscriptions.active.find_each do |subscription|
+            Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+          end
         end
-      end
-
-      after_commit do
-        ActiveJob.perform_all_later(jobs)
       end
 
       result.plan = plan

--- a/app/services/usage_monitoring/process_organization_subscription_activities_service.rb
+++ b/app/services/usage_monitoring/process_organization_subscription_activities_service.rb
@@ -29,7 +29,7 @@ module UsageMonitoring
 
         ActiveRecord::Base.transaction do
           batch.update_all(enqueued: true, enqueued_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-          after_commit { ActiveJob.perform_all_later(jobs) }
+          after_commit { ApplicationJob.perform_all_later(jobs) }
         end
 
         nb_jobs_enqueued += jobs.size

--- a/dev/cops/active_job_perform_all_later_cop.rb
+++ b/dev/cops/active_job_perform_all_later_cop.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module Cops
+  # `ActiveJob.perform_all_later` bypasses the `before_enqueue` callbacks used by
+  # `activejob-uniqueness` to acquire uniqueness locks. This means unique jobs scheduled
+  # via `perform_all_later` silently skip uniqueness checks, potentially causing duplicate
+  # job execution.
+  #
+  # Use `ApplicationJob.perform_all_later` instead, which includes a runtime guard that
+  # raises an `ArgumentError` if any of the jobs have uniqueness enabled.
+  class ActiveJobPerformAllLaterCop < ::RuboCop::Cop::Base
+    MSG = "Avoid using `ActiveJob.perform_all_later`. Use `ApplicationJob.perform_all_later` instead."
+
+    def_node_matcher :active_job_perform_all_later?, <<~PATTERN
+      (send (const nil? :ActiveJob) :perform_all_later ...)
+    PATTERN
+
+    def self.badge
+      @badge ||= ::RuboCop::Cop::Badge.for("Lago/ActiveJobPerformAllLater") # rubocop:disable ThreadSafety/ClassInstanceVariable
+    end
+
+    def on_send(node)
+      return unless active_job_perform_all_later?(node)
+
+      add_offense(node)
+    end
+  end
+end

--- a/dev/cops/stub_perform_all_later_cop.rb
+++ b/dev/cops/stub_perform_all_later_cop.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module Cops
+  # `ApplicationJob.perform_all_later` includes a runtime guard that raises an `ArgumentError`
+  # when any of the jobs have uniqueness enabled. Stubbing this method in specs silences that
+  # guard, defeating its purpose. Stub `ActiveJob.perform_all_later` directly or use
+  # `have_enqueued_job` matchers instead.
+  class StubPerformAllLaterCop < ::RuboCop::Cop::Base
+    MSG = "Avoid stubbing `perform_all_later` on `ApplicationJob` as it silences the runtime uniqueness guard."
+
+    # Matches:
+    #   allow(ApplicationJob).to receive(:perform_all_later)
+    #   expect(ApplicationJob).to have_received(:perform_all_later)
+    #   expect(ApplicationJob).not_to have_received(:perform_all_later)
+    def_node_matcher :stub_perform_all_later?, <<~PATTERN
+      (send
+        (send nil? {:allow :expect} (const nil? :ApplicationJob))
+        {:to :not_to :to_not}
+        (send nil? {:receive :have_received} (sym :perform_all_later))
+        ...)
+    PATTERN
+
+    def self.badge
+      @badge ||= ::RuboCop::Cop::Badge.for("Lago/StubPerformAllLater") # rubocop:disable ThreadSafety/ClassInstanceVariable
+    end
+
+    def on_send(node)
+      return unless stub_perform_all_later?(node)
+
+      add_offense(node)
+    end
+  end
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -10,6 +10,42 @@ RSpec.describe ApplicationJob do
     end
   end
 
+  describe ".perform_all_later" do
+    let(:non_unique_job_class) do
+      Class.new(ApplicationJob) do
+        self.queue_adapter = :test
+
+        def perform
+        end
+      end
+    end
+
+    let(:unique_job_class) do
+      Class.new(ApplicationJob) do
+        self.queue_adapter = :test
+        unique :until_executed
+
+        def perform
+        end
+      end
+    end
+
+    it "delegates to ActiveJob.perform_all_later for non-unique jobs" do
+      jobs = [non_unique_job_class.new]
+      allow(ActiveJob).to receive(:perform_all_later)
+
+      described_class.perform_all_later(jobs)
+
+      expect(ActiveJob).to have_received(:perform_all_later).with(jobs)
+    end
+
+    it "raises ArgumentError when any job has uniqueness enabled" do
+      jobs = [non_unique_job_class.new, unique_job_class.new]
+
+      expect { described_class.perform_all_later(jobs) }.to raise_error(ArgumentError, /perform_all_later is not compatible with unique jobs/)
+    end
+  end
+
   describe "#perform_after_commit" do
     it "performs the job after the commit" do
       ApplicationRecord.transaction do

--- a/spec/lib/cops/active_job_perform_all_later_cop_spec.rb
+++ b/spec/lib/cops/active_job_perform_all_later_cop_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "cop_helper"
+
+RSpec.describe Cops::ActiveJobPerformAllLaterCop, :config do
+  it "registers an offense when using ActiveJob.perform_all_later" do
+    expect_offense(<<~RUBY)
+      ActiveJob.perform_all_later(jobs)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using `ActiveJob.perform_all_later`. Use `ApplicationJob.perform_all_later` instead.
+    RUBY
+  end
+
+  it "does not register an offense when using ApplicationJob.perform_all_later" do
+    expect_no_offenses(<<~RUBY)
+      ApplicationJob.perform_all_later(jobs)
+    RUBY
+  end
+end

--- a/spec/lib/cops/stub_perform_all_later_cop_spec.rb
+++ b/spec/lib/cops/stub_perform_all_later_cop_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "cop_helper"
+
+RSpec.describe Cops::StubPerformAllLaterCop, :config do
+  it "registers an offense when stubbing perform_all_later on ApplicationJob" do
+    expect_offense(<<~RUBY)
+      allow(ApplicationJob).to receive(:perform_all_later)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing `perform_all_later` on `ApplicationJob` as it silences the runtime uniqueness guard.
+    RUBY
+  end
+
+  it "registers an offense when expecting perform_all_later on ApplicationJob" do
+    expect_offense(<<~RUBY)
+      expect(ApplicationJob).to have_received(:perform_all_later)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing `perform_all_later` on `ApplicationJob` as it silences the runtime uniqueness guard.
+    RUBY
+  end
+
+  it "registers an offense when negatively expecting perform_all_later on ApplicationJob" do
+    expect_offense(<<~RUBY)
+      expect(ApplicationJob).not_to have_received(:perform_all_later)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing `perform_all_later` on `ApplicationJob` as it silences the runtime uniqueness guard.
+    RUBY
+  end
+
+  it "does not register an offense when stubbing perform_all_later on ActiveJob" do
+    expect_no_offenses(<<~RUBY)
+      allow(ActiveJob).to receive(:perform_all_later)
+    RUBY
+  end
+
+  it "does not register an offense when stubbing other methods on ApplicationJob" do
+    expect_no_offenses(<<~RUBY)
+      allow(ApplicationJob).to receive(:perform_later)
+    RUBY
+  end
+end

--- a/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
+++ b/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService
       create_list(:subscription_activity, 3, organization:, enqueued: false)
       create_list(:subscription_activity, 2, organization:, enqueued: true)
 
-      expect { service.call }
+      result = nil
+      expect { result = service.call }
         .to have_enqueued_job(UsageMonitoring::ProcessSubscriptionActivityJob).exactly(3).times
 
-      expect(service.call).to be_success
+      expect(result).to be_success
+      expect(result.nb_jobs_enqueued).to eq(3)
       expect(organization.subscription_activities.where(enqueued: true).count).to eq(5)
       expect(organization.subscription_activities.where(enqueued: false).count).to eq(0)
     end

--- a/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
+++ b/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
@@ -7,23 +7,14 @@ RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService
     let(:organization) { create(:organization) }
     let(:service) { described_class.new(organization:) }
 
-    before do
-      allow(ActiveJob).to receive(:perform_all_later)
-    end
-
     it "enqueues jobs for subscription activities that are not yet enqueued" do
       create_list(:subscription_activity, 3, organization:, enqueued: false)
       create_list(:subscription_activity, 2, organization:, enqueued: true)
 
-      result = service.call
+      expect { service.call }
+        .to have_enqueued_job(UsageMonitoring::ProcessSubscriptionActivityJob).exactly(3).times
 
-      expect(ActiveJob).to have_received(:perform_all_later).once do |jobs|
-        expect(jobs).to all(be_a(UsageMonitoring::ProcessSubscriptionActivityJob))
-      end
-
-      expect(result).to be_success
-      expect(result.nb_jobs_enqueued).to eq(3)
-
+      expect(service.call).to be_success
       expect(organization.subscription_activities.where(enqueued: true).count).to eq(5)
       expect(organization.subscription_activities.where(enqueued: false).count).to eq(0)
     end
@@ -32,7 +23,8 @@ RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService
       it "returns 0 for number of jobs enqueued and does not enqueue any job" do
         create_list(:subscription_activity, 2, organization:, enqueued: true)
 
-        expect(ActiveJob).not_to have_received(:perform_all_later)
+        expect { service.call }
+          .not_to have_enqueued_job(UsageMonitoring::ProcessSubscriptionActivityJob)
 
         result = service.call
 
@@ -51,10 +43,8 @@ RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService
       it "processes activities in batches" do
         create_list(:subscription_activity, batch_size + 1, organization:, enqueued: false)
 
-        result = service.call
-
-        expect(ActiveJob).to have_received(:perform_all_later).twice
-        expect(result.nb_jobs_enqueued).to eq(batch_size + 1)
+        expect { service.call }
+          .to have_enqueued_job(UsageMonitoring::ProcessSubscriptionActivityJob).exactly(batch_size + 1).times
       end
     end
 

--- a/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
+++ b/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
@@ -54,11 +54,9 @@ RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService
       it "enqueues ProcessSubscriptionActivityJob instances on the dedicated queue" do
         create_list(:subscription_activity, 2, organization:, enqueued: false)
 
-        service.call
-
-        expect(ActiveJob).to have_received(:perform_all_later).once do |jobs|
-          expect(jobs.map(&:queue_name)).to all(eq("dedicated_alerts"))
-        end
+        expect { service.call }
+          .to have_enqueued_job(UsageMonitoring::ProcessSubscriptionActivityJob)
+          .on_queue("dedicated_alerts").exactly(2).times
       end
     end
 
@@ -68,11 +66,9 @@ RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService
       it "enqueues ProcessSubscriptionActivityJob instances on the default queue" do
         create_list(:subscription_activity, 2, organization:, enqueued: false)
 
-        service.call
-
-        expect(ActiveJob).to have_received(:perform_all_later).once do |jobs|
-          expect(jobs.map(&:queue_name)).to all(eq("default"))
-        end
+        expect { service.call }
+          .to have_enqueued_job(UsageMonitoring::ProcessSubscriptionActivityJob)
+          .on_queue("default").exactly(2).times
       end
     end
   end


### PR DESCRIPTION
## Context

`ActiveJob.perform_all_later` bypasses the `before_enqueue` callbacks used by `activejob-uniqueness` to acquire uniqueness locks. As a result, unique jobs scheduled through `perform_all_later` silently skip their uniqueness checks, which can lead to duplicate job execution.

Nothing in the codebase prevented this footgun: a developer could either call `ActiveJob.perform_all_later` directly or stub the wrapper in specs and the uniqueness guarantee would silently disappear.

## Description

This adds a runtime guard and two RuboCop cops to make bulk-enqueueing safe for unique jobs.

A new `ApplicationJob.perform_all_later` wraps `ActiveJob.perform_all_later` and raises `ArgumentError` when any job in the batch has uniqueness enabled (i.e. defines a `lock_strategy_class`). All existing call sites were updated to go through `ApplicationJob.perform_all_later`.

Two custom cops back the runtime check:
- `Lago/ActiveJobPerformAllLater` flags direct calls to `ActiveJob.perform_all_later` and points to `ApplicationJob.perform_all_later`.
- `Lago/StubPerformAllLater` flags stubbing `ApplicationJob.perform_all_later` in specs, since stubbing would silence the runtime guard. Specs should stub `ActiveJob.perform_all_later` or use `have_enqueued_job` matchers instead.

## Test plan

- [x] `spec/jobs/application_job_spec.rb` covers the runtime guard for unique and non-unique jobs.
- [x] `spec/lib/cops/active_job_perform_all_later_cop_spec.rb` covers the cop flagging direct `ActiveJob.perform_all_later` calls.
- [x] `spec/lib/cops/stub_perform_all_later_cop_spec.rb` covers the cop flagging `ApplicationJob.perform_all_later` stubs.
- [x] Existing specs for updated call sites still pass.
