### PR TITLE
misc: Rename `LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS` for clarity

### DIFF
--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -32,7 +32,7 @@ module DailyUsages
 
     def scheduling_interval
       @scheduling_interval ||= begin
-        raw_value = ENV["LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS"]
+        raw_value = ENV["LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS"]
         parsed = Integer(raw_value, exception: false) if raw_value
         parsed = nil if parsed && parsed <= 0
         (parsed || 30.minutes).to_i

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
     end
 
-    context "when LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS is set" do
-      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS" => "60")) }
+    context "when LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS is set" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS" => "60")) }
 
       it "uses the configured interval" do
         expect(compute_service.call).to be_success
@@ -36,8 +36,8 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
     end
 
-    context "when LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS is negative" do
-      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS" => "-100")) }
+    context "when LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS is negative" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS" => "-100")) }
 
       it "falls back to the default interval" do
         expect(compute_service.call).to be_success
@@ -47,8 +47,8 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
     end
 
-    context "when LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS is zero" do
-      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS" => "0")) }
+    context "when LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS is zero" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS" => "0")) }
 
       it "falls back to the default interval" do
         expect(compute_service.call).to be_success
@@ -58,8 +58,8 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
     end
 
-    context "when LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS is non-numeric" do
-      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS" => "invalid")) }
+    context "when LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS is non-numeric" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS" => "invalid")) }
 
       it "falls back to the default interval" do
         expect(compute_service.call).to be_success
@@ -69,8 +69,8 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
     end
 
-    context "when LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS is blank" do
-      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS" => "")) }
+    context "when LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS is blank" do
+      before { stub_const("ENV", ENV.to_h.merge("LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS" => "")) }
 
       it "falls back to the default interval" do
         expect(compute_service.call).to be_success


### PR DESCRIPTION
## Context

`LAGO_DAILY_USAGES_SCHEDULING_INTERVAL_SECONDS` could be confusing as it could mean the interval at which we schedule the CRON job.

## Description

This updates it to `LAGO_DAILY_USAGE_SCHEDULING_JITTER_SECONDS` for more explicitness and use singular name to keep consistency with existing variables.