### PR TITLE
feat(events): Reusable UniqueCount and WeightedSum queries

### DIFF
--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -284,7 +284,13 @@ module Events
 
         attr_reader :store
 
-        delegate :arel_table, :with_ctes, :charges_duration, :events_cte_queries, :grouped_arel_columns, to: :store
+        delegate :arel_table,
+          :with_ctes,
+          :charges_duration,
+          :events_cte_queries,
+          :grouped_arel_columns,
+          :operation_type_sql,
+          to: :store
 
         def events_cte_sql
           # NOTE: Common table expression returning event's timestamp, property name and operation type.
@@ -297,7 +303,7 @@ module Events
                 "coalesce",
                 [
                   Arel::Nodes::NamedFunction.new("NULLIF", [
-                    Arel::Nodes::SqlLiteral.new("events_enriched.sorted_properties['operation_type']"),
+                    Arel::Nodes::SqlLiteral.new(operation_type_sql),
                     Arel::Nodes::SqlLiteral.new("''")
                   ]),
                   Arel::Nodes::SqlLiteral.new("'add'")
@@ -320,7 +326,7 @@ module Events
                 "coalesce",
                 [
                   Arel::Nodes::NamedFunction.new("NULLIF", [
-                    Arel::Nodes::SqlLiteral.new("events_enriched.sorted_properties['operation_type']"),
+                    Arel::Nodes::SqlLiteral.new(operation_type_sql),
                     Arel::Nodes::SqlLiteral.new("''")
                   ]),
                   Arel::Nodes::SqlLiteral.new("'add'")

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -778,6 +778,10 @@ module Events
           grouped_by.map.with_index { |_, index| "g_#{index}" }.join(", ")
         ]
       end
+
+      def operation_type_sql
+        "events_enriched.sorted_properties['operation_type']"
+      end
     end
   end
 end

--- a/app/services/events/stores/postgres/unique_count_query.rb
+++ b/app/services/events/stores/postgres/unique_count_query.rb
@@ -239,7 +239,7 @@ module Events
 
         attr_reader :store
 
-        delegate :events, :charges_duration, :sanitized_property_name, to: :store
+        delegate :events, :charges_duration, :sanitized_property_name, :operation_type_sql, to: :store
 
         def events_cte_sql
           # NOTE: Common table expression returning event's timestamp, property name and operation type.
@@ -249,7 +249,7 @@ module Events
                 .select(
                   "timestamp, \
                   #{sanitized_property_name} AS property, \
-                  COALESCE(events.properties->>'operation_type', 'add') AS operation_type"
+                  #{operation_type_sql} AS operation_type"
                 ).to_sql
             })
           SQL
@@ -267,7 +267,7 @@ module Events
                   "#{groups.join(", ")}, \
                   timestamp, \
                   #{sanitized_property_name} AS property, \
-                  COALESCE(events.properties->>'operation_type', 'add') AS operation_type"
+                  #{operation_type_sql} AS operation_type"
                 ).to_sql
             })
           SQL

--- a/app/services/events/stores/postgres/weighted_sum_query.rb
+++ b/app/services/events/stores/postgres/weighted_sum_query.rb
@@ -57,7 +57,7 @@ module Events
 
         attr_reader :store
 
-        delegate :events, :charges_duration, :sanitized_property_name, to: :store
+        delegate :events, :charges_duration, :sanitized_property_name, :created_at_ordering_column, to: :store
 
         def events_cte_sql
           <<-SQL
@@ -66,7 +66,7 @@ module Events
               UNION
               (#{
                 events(ordered: true)
-                  .select("timestamp, (#{sanitized_property_name})::numeric AS difference, events.created_at")
+                  .select("timestamp, (#{sanitized_property_name})::numeric AS difference, #{created_at_ordering_column}")
                   .to_sql
               })
               UNION
@@ -123,7 +123,7 @@ module Events
               UNION
               (#{
                 events(ordered: true)
-                  .select("#{groups.join(", ")}, timestamp, (#{sanitized_property_name})::numeric AS difference, events.created_at")
+                  .select("#{groups.join(", ")}, timestamp, (#{sanitized_property_name})::numeric AS difference, #{created_at_ordering_column}")
                   .to_sql
               })
               UNION

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -435,6 +435,14 @@ module Events
           result
         end
       end
+
+      def operation_type_sql
+        "COALESCE(events.properties->>'operation_type', 'add')"
+      end
+
+      def created_at_ordering_column
+        "events.created_at"
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

This PR is a preparatory work related to the introduction of two new event stores:
- `Events::Stores::PostgresEnrichedStore`
- `Events::Stores::ClickhouseEnrichedStore`

The goal is to allow these new stores to re-use the existing `Events::Stores::*::UniqueCountQuery` and `Events::Stores::*::WeightedSumQuery`, by extracting all direct reference to the events table as re-usable SQL fragment in the parent store classes.