### PR TITLE
fix(alerts): handle alert with only recurring thresholds

### DIFF
--- a/app/models/usage_monitoring/alert.rb
+++ b/app/models/usage_monitoring/alert.rb
@@ -76,10 +76,13 @@ module UsageMonitoring
     def find_thresholds_crossed_increasing(current)
       crossed = []
       return crossed if current <= previous_value
-      return crossed if current < one_time_thresholds_values.first
 
-      if previous_value < one_time_thresholds_values.last
-        crossed += one_time_thresholds_values.filter { it > previous_value && it <= current }
+      if one_time_thresholds_values.present?
+        return crossed if current < one_time_thresholds_values.first
+
+        if previous_value < one_time_thresholds_values.last
+          crossed += one_time_thresholds_values.filter { it > previous_value && it <= current }
+        end
       end
 
       crossed += find_recurring_thresholds_crossed_increasing(
@@ -92,10 +95,13 @@ module UsageMonitoring
     def find_thresholds_crossed_decreasing(current)
       crossed = []
       return crossed if current >= previous_value
-      return crossed if current > one_time_thresholds_values.last
 
-      if previous_value > one_time_thresholds_values.first
-        crossed += one_time_thresholds_values.filter { it < previous_value && it >= current }
+      if one_time_thresholds_values.present?
+        return crossed if current > one_time_thresholds_values.last
+
+        if previous_value > one_time_thresholds_values.first
+          crossed += one_time_thresholds_values.filter { it < previous_value && it >= current }
+        end
       end
 
       crossed += find_recurring_thresholds_crossed_decreasing(
@@ -148,6 +154,7 @@ module UsageMonitoring
     end
 
     def find_recurring_thresholds_crossed_increasing(previous, current, step, initial)
+      initial ||= 0
       return [] unless step
 
       previous_steps = ((previous - initial) / step).ceil
@@ -162,6 +169,7 @@ module UsageMonitoring
     end
 
     def find_recurring_thresholds_crossed_decreasing(previous, current, step, initial)
+      initial ||= 0
       return [] unless step
 
       previous_steps = ((initial - previous) / step).ceil

--- a/spec/models/usage_monitoring/alert_spec.rb
+++ b/spec/models/usage_monitoring/alert_spec.rb
@@ -112,6 +112,12 @@ RSpec.describe UsageMonitoring::Alert do
         alert.previous_value = 33
         expect(alert.find_thresholds_crossed(351)).to eq([50, 150, 250, 350])
       end
+
+      it "returns recurring threshold if crossed and no one-time thresholds are set" do
+        alert = create(:alert, code: "my-code", thresholds: [], recurring_threshold: 100)
+        alert.previous_value = 33
+        expect(alert.find_thresholds_crossed(351)).to eq([100, 200, 300])
+      end
     end
 
     context "when direction is decreasing" do
@@ -138,6 +144,12 @@ RSpec.describe UsageMonitoring::Alert do
       it "returns recurring thresholds if crossed" do
         alert.previous_value = 600
         expect(alert.find_thresholds_crossed(-100)).to eq([-100, 0, 100, 200, 500])
+      end
+
+      it "returns recurring threshold if crossed and no one-time thresholds are set" do
+        alert = create(:alert, code: "my-code", thresholds: [], recurring_threshold: 100, direction: "decreasing")
+        alert.previous_value = 350
+        expect(alert.find_thresholds_crossed(33)).to eq([100, 200, 300])
       end
     end
   end

--- a/spec/scenarios/usage_monitoring/subscription_alerts_spec.rb
+++ b/spec/scenarios/usage_monitoring/subscription_alerts_spec.rb
@@ -146,6 +146,46 @@ describe "Subscriptions Alerting Scenario", :premium, cache: :redis do
     end
   end
 
+  context "with only a recurring thresholds" do
+    it "sends alert forever" do
+      create_subscription({
+        external_customer_id: customer.external_id,
+        external_id: subscription_external_id,
+        plan_code: plan.code
+      })
+      subscription = customer.subscriptions.sole
+      create_alert(subscription_external_id, {alert_type: :current_usage_amount, code: :simple, thresholds: [
+        {value: 10_00, code: :info, recurring: true}
+      ]})
+      alert = UsageMonitoring::Alert.find(json[:alert][:lago_id])
+
+      send_event!(code: billable_metric.code, properties: {ops_count: 7}, external_subscription_id: subscription_external_id)
+
+      perform_usage_update
+      expect(UsageMonitoring::TriggeredAlert.where(alert:).count).to eq(1)
+      expect(UsageMonitoring::SubscriptionActivity.where(subscription:).count).to eq 0
+
+      ta = alert.triggered_alerts.sole
+      expect(ta.current_value).to eq(3500)
+      expect(ta.crossed_thresholds.map(&:symbolize_keys)).to eq([
+        {code: "info", value: "1000.0", recurring: true},
+        {code: "info", value: "2000.0", recurring: true},
+        {code: "info", value: "3000.0", recurring: true}
+      ])
+
+      send_event!(code: billable_metric.code, properties: {ops_count: 4}, external_subscription_id: subscription_external_id)
+
+      perform_usage_update
+      expect(UsageMonitoring::TriggeredAlert.where(alert:).count).to eq(2)
+      ta = alert.triggered_alerts.order(:created_at).last
+      expect(ta.current_value).to eq(5500)
+      expect(ta.crossed_thresholds.map(&:symbolize_keys)).to eq([
+        {code: "info", value: "4000.0", recurring: true},
+        {code: "info", value: "5000.0", recurring: true}
+      ])
+    end
+  end
+
   context "with billable_metric_current_usage_units alert" do
     it do
       create_subscription({


### PR DESCRIPTION
## Context

Alerts can have one time thresholds and recurring thresholds.
Currently, **the UI won't let you set only a recurring** thresholds. This is not handled by the alerting system so it breaks when processing alerts with only a recurring thresholds.

Unfortunately, it's possible to set an alert with no thresholds via the API.

## Description

This PR allows alert to have only recurring thresholds.
Alternatively, we could add validation to disallow alert to have only a reucrring threshold. I'm can't find any reason to prevent it tho.

Note that there are currently 0 alerts in production without only recurring thresholds.


## Screesnhots


<img width="1558" height="2242" alt="CleanShot 2026-02-20 at 08 42 08@2x" src="https://github.com/user-attachments/assets/ccf74855-344d-4818-b792-1c3cf20129e1" />
<img width="3044" height="2566" alt="CleanShot 2026-02-20 at 08 44 42@2x" src="https://github.com/user-attachments/assets/e8e20ce9-6984-4a5b-9906-4b872d5b4ff1" />
