### PR TITLE
remove not needed join

### DIFF
--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -74,7 +74,7 @@ class SubscriptionsQuery < BaseQuery
 
   def with_external_customer(scope)
     customers = Customer.where(external_id: filters.external_customer_id)
-    scope.where(customer_id: customers.ids)
+    scope.where(customer_id: customers.select(:id))
   end
 
   def with_plan_code(scope)

--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -39,11 +39,14 @@ class SubscriptionsQuery < BaseQuery
   end
 
   def base_scope
-    if organization.present?
+    scope = if organization.present?
       Subscription.where(organization:)
     else
       Subscription.where(customer: filters.customer)
-    end.joins(:customer, :plan).ransack(search_params)
+    end.includes(:customer, :plan)
+
+    scope = scope.joins(:customer, :plan) if search_term.present?
+    scope.ransack(search_params)
   end
 
   def search_params

--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -73,7 +73,8 @@ class SubscriptionsQuery < BaseQuery
   end
 
   def with_external_customer(scope)
-    scope.joins(:customer).where(customers: {external_id: filters.external_customer_id})
+    customers = Customer.where(external_id: filters.external_customer_id)
+    scope.where(customer_id: customers.ids)
   end
 
   def with_plan_code(scope)


### PR DESCRIPTION
## Context

we can get rid of joining customers when searching by customer_external_id, because joining whole table of subscriptions with whole table of customers is a heavy operation. Having one separate request for it would make more sense
