### PR TITLE
feat(order_forms): Add Quotes

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -29,3 +29,7 @@ payment_gated_subscriptions:
 multi_entity_billing:
   description: "Allow customers to have billing objects across multiple billing entities"
   owners: ["@lovrocolic", "@feliperodrigues", "@mariohd"]
+
+order_forms:
+  description: "Enable quotes, order forms and orders"
+  owners: ["@murparreira", "@toommz", "@rinasergeeva"]

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -7,7 +7,7 @@ class ApiKey < ApplicationRecord
     activity_log add_on analytic api_log billable_metric coupon applied_coupon credit_note customer_usage
     customer event fee invoice organization payment payment_receipt payment_request payment_method plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
-    billing_entity alert feature security_log
+    billing_entity alert feature security_log quote
   ].freeze
 
   MODES = %w[read write].freeze

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -63,6 +63,7 @@ class Customer < ApplicationRecord
   has_many :applied_add_ons
   has_many :add_ons, through: :applied_add_ons
   has_many :daily_usages
+  has_many :quotes
   has_many :wallets
   has_many :wallet_transactions, through: :wallets
   has_many :payment_provider_customers,

--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -44,13 +44,13 @@ end
 # Table name: item_metadata
 # Database name: primary
 #
-#  id                                             :uuid             not null, primary key
-#  owner_type(Polymorphic owner type)             :string           not null
-#  value(item_metadata key-value pairs)           :jsonb            not null
-#  created_at                                     :datetime         not null
-#  updated_at                                     :datetime         not null
-#  organization_id(Reference to the organization) :uuid             not null
-#  owner_id(Polymorphic owner id)                 :uuid             not null
+#  id              :uuid             not null, primary key
+#  owner_type      :string           not null
+#  value           :jsonb            not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  owner_id        :uuid             not null
 #
 # Indexes
 #

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,6 +75,8 @@ class Organization < ApplicationRecord
   has_many :error_details
   has_many :dunning_campaigns
   has_many :roles
+  has_many :quotes
+  has_many :quote_versions
   has_many :activity_logs, class_name: "Clickhouse::ActivityLog"
   has_many :features, class_name: "Entitlement::Feature"
   has_many :privileges, class_name: "Entitlement::Privilege"
@@ -144,6 +146,7 @@ class Organization < ApplicationRecord
     events_targeting_wallets
     security_logs
     granular_lifetime_usage
+    order_forms
   ].freeze
 
   SECURITY_LOGS_RETENTION_DAYS = 90

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -19,7 +19,10 @@ class Quote < ApplicationRecord
   has_many :owners, through: :quote_owners, source: :user, class_name: "User"
 
   has_many :versions, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
-  has_one :current_version, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
+  has_one :current_version,
+    -> { where(status: %w[draft approved]).order(sequential_id: :desc) },
+    class_name: "QuoteVersion"
+  has_one :latest_version, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
 
   enum :order_type, ORDER_TYPES,
     instance_methods: false,

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class Quote < ApplicationRecord
+  include Sequenced
+
+  ORDER_TYPES = {
+    subscription_creation: "subscription_creation",
+    subscription_amendment: "subscription_amendment",
+    one_off: "one_off"
+  }.freeze
+
+  before_save :ensure_number
+
+  belongs_to :organization
+  belongs_to :customer
+  belongs_to :subscription, optional: true
+
+  has_many :quote_owners, dependent: :destroy
+  has_many :owners, through: :quote_owners, source: :user, class_name: "User"
+
+  has_many :versions, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
+  has_one :current_version, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
+
+  enum :order_type, ORDER_TYPES,
+    instance_methods: false,
+    validate: true
+
+  validates :subscription_id,
+    presence: true,
+    if: -> { order_type == "subscription_amendment" }
+
+  sequenced(
+    scope: ->(quote) { quote.organization.quotes },
+    lock_key: ->(quote) { quote.organization_id }
+  )
+
+  private
+
+  def ensure_number
+    return if number.present?
+    return if sequential_id.blank?
+
+    time = created_at || Time.current
+    formatted_sequential_id = format("%04d", sequential_id)
+    self.number = "QT-#{time.strftime("%Y")}-#{formatted_sequential_id}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: quotes
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  number          :string           not null
+#  order_type      :enum             not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  customer_id     :uuid             not null
+#  organization_id :uuid             not null
+#  sequential_id   :integer          not null
+#  subscription_id :uuid
+#
+# Indexes
+#
+#  index_quotes_on_customer_id                        (customer_id)
+#  index_quotes_on_subscription_id                    (subscription_id)
+#  index_unique_quotes_on_organization_number         (organization_id,number) UNIQUE
+#  index_unique_quotes_on_organization_sequential_id  (organization_id,sequential_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (subscription_id => subscriptions.id)
+#

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -19,10 +19,7 @@ class Quote < ApplicationRecord
   has_many :owners, through: :quote_owners, source: :user, class_name: "User"
 
   has_many :versions, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
-  has_one :current_version,
-    -> { where(status: %w[draft approved]).order(sequential_id: :desc) },
-    class_name: "QuoteVersion"
-  has_one :latest_version, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
+  has_one :current_version, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
 
   enum :order_type, ORDER_TYPES,
     instance_methods: false,

--- a/app/models/quote_owner.rb
+++ b/app/models/quote_owner.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class QuoteOwner < ApplicationRecord
+  belongs_to :organization
+  belongs_to :quote
+  belongs_to :user
+end
+
+# == Schema Information
+#
+# Table name: quote_owners
+# Database name: primary
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  quote_id        :uuid             not null
+#  user_id         :uuid             not null
+#
+# Indexes
+#
+#  index_quote_owners_on_organization_id    (organization_id)
+#  index_quote_owners_on_user_id            (user_id)
+#  index_unique_quote_owners_on_quote_user  (quote_id,user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (quote_id => quotes.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -21,9 +21,6 @@ class QuoteVersion < ApplicationRecord
   belongs_to :organization
   belongs_to :quote
 
-  has_one :order_form
-  has_one :order, through: :order_form
-
   enum :status, STATUSES,
     default: :draft,
     validate: true

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+class QuoteVersion < ApplicationRecord
+  include Sequenced
+
+  STATUSES = {
+    draft: "draft",
+    approved: "approved",
+    voided: "voided"
+  }.freeze
+
+  VOID_REASONS = {
+    manual: "manual",
+    superseded: "superseded",
+    cascade_of_expired: "cascade_of_expired",
+    cascade_of_voided: "cascade_of_voided"
+  }.freeze
+
+  before_save :ensure_share_token
+
+  belongs_to :organization
+  belongs_to :quote
+
+  has_one :order_form
+  has_one :order, through: :order_form
+
+  enum :status, STATUSES,
+    default: :draft,
+    validate: true
+  enum :void_reason, VOID_REASONS,
+    instance_methods: false,
+    validate: {allow_nil: true}
+
+  validates :share_token,
+    on: :update,
+    presence: true,
+    if: -> { draft? || approved? }
+
+  validates :void_reason, :voided_at,
+    presence: true,
+    if: -> { voided? }
+
+  validates :approved_at,
+    presence: true,
+    if: -> { approved? }
+
+  sequenced(
+    scope: ->(quote_version) { quote_version.quote.versions },
+    lock_key: ->(quote_version) { quote_version.quote_id }
+  )
+
+  def version = sequential_id
+
+  private
+
+  def ensure_share_token
+    return if voided?
+
+    self.share_token ||= SecureRandom.uuid
+  end
+end
+
+# == Schema Information
+#
+# Table name: quote_versions
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  approved_at     :datetime
+#  billing_items   :jsonb
+#  content         :text
+#  share_token     :string
+#  status          :enum             default("draft"), not null
+#  void_reason     :enum
+#  voided_at       :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  quote_id        :uuid             not null
+#  sequential_id   :integer          not null
+#
+# Indexes
+#
+#  index_quote_versions_on_organization_id             (organization_id)
+#  index_quote_versions_on_quote_id                    (quote_id)
+#  index_unique_quote_versions_on_quote_active_status  (quote_id) UNIQUE WHERE (status = ANY (ARRAY['draft'::quote_status, 'approved'::quote_status]))
+#  index_unique_quote_versions_on_quote_sequential_id  (quote_id,sequential_id) UNIQUE
+#  index_unique_quote_versions_on_share_token          (share_token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (quote_id => quotes.id)
+#

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ApplicationRecord
   has_many :active_memberships, -> { where(status: "active") }, class_name: "Membership"
   has_many :active_organizations, through: :active_memberships, source: :organization
 
+  has_many :quote_owners, dependent: :destroy
+  has_many :quotes, through: :quote_owners
+
   validates :email, presence: true
   validates :password, presence: true
 

--- a/app/services/order_forms/premium.rb
+++ b/app/services/order_forms/premium.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module OrderForms
+  module Premium
+    extend ActiveSupport::Concern
+
+    private
+
+    def order_forms_enabled?(organization)
+      License.premium? && organization.feature_flag_enabled?(:order_forms)
+    end
+  end
+end

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -16,8 +16,6 @@ module QuoteVersions
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
       return result.not_allowed_failure!(code: "inappropriate_state") unless approvable?
-      validation_errors = validate
-      return result.validation_failure!(errors: {quote_version: validation_errors}) if validation_errors.any?
 
       quote_version.update!(
         status: :approved,
@@ -31,19 +29,12 @@ module QuoteVersions
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue ActiveRecord::ActiveRecordError => e
-      result.service_failure!(code: "approval_failed", message: e.message, error: e)
     end
 
     private
 
     def approvable?
       quote_version.draft?
-    end
-
-    def validate
-      []
-      # TODO: payload checks
     end
   end
 end

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class ApproveService < BaseService
+    attr_reader :quote_version
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(quote_version:)
+      @quote_version = quote_version
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless approvable?
+      validation_errors = validate
+      return result.validation_failure!(errors: {quote_version: validation_errors}) if validation_errors.any?
+
+      quote_version.update!(
+        status: :approved,
+        approved_at: Time.current
+      )
+
+      # TODO: OrderForms::CreateService.call
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.approved", quote_version)
+
+      result.quote_version = quote_version
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "approval_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def approvable?
+      quote_version.draft?
+    end
+
+    def validate
+      []
+      # TODO: payload checks
+    end
+  end
+end

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -2,6 +2,8 @@
 
 module QuoteVersions
   class ApproveService < BaseService
+    include OrderForms::Premium
+
     attr_reader :quote_version
 
     Result = BaseResult[:quote_version]
@@ -12,9 +14,8 @@ module QuoteVersions
     end
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "quote_version") unless quote_version
-      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.not_allowed_failure!(code: "inappropriate_state") unless approvable?
 
       quote_version.update!(

--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -25,7 +25,7 @@ module QuoteVersions
     def call
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
-      return result.not_allowed_failure!(code: "inappropriate_state") unless clonable?
+      return result.forbidden_failure!(code: "inappropriate_state") unless clonable?
 
       cloned = QuoteVersion.transaction do
         void!(quote_version:)
@@ -38,6 +38,8 @@ module QuoteVersions
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::RecordNotUnique
+      result.forbidden_failure!(code: "active_version_exists")
     rescue CloneError => e
       result.service_failure!(code: "clone_failed", message: e.message, error: e)
     end
@@ -47,7 +49,8 @@ module QuoteVersions
     def clonable?
       return false if quote_version.quote.versions.where(status: :approved).exists?
 
-      true
+      active_draft = quote_version.quote.versions.where(status: :draft).first
+      active_draft.nil? || active_draft.id == quote_version.id
     end
 
     def create_next_version(quote_version:)

--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class CloneService < BaseService
+    class CloneError < StandardError
+      attr_reader :cause, :error
+
+      def initialize(cause: nil, error: nil)
+        @cause = cause
+        @error = error
+        super("QuoteVersion clone failed due to #{cause.class}")
+      end
+    end
+
+    attr_reader :quote_version
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(quote_version:)
+      @quote_version = quote_version
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless clonable?
+
+      cloned = QuoteVersion.transaction do
+        void!(quote_version:)
+        create_next_version(quote_version:)
+      end
+
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.cloned", cloned)
+
+      result.quote_version = cloned
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue CloneError, ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "clone_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def clonable?
+      return false if quote_version.approved?
+
+      true
+    end
+
+    def create_next_version(quote_version:)
+      quote_version.dup.tap do |cloned|
+        cloned.status = :draft
+        cloned.sequential_id = nil
+        cloned.share_token = nil # will be generated on saving
+        cloned.void_reason = nil
+        cloned.voided_at = nil
+        cloned.approved_at = nil
+        cloned.save!
+      end
+    end
+
+    def void!(quote_version:)
+      return if quote_version.voided?
+
+      void_result = QuoteVersions::VoidService.new(
+        quote_version: quote_version,
+        reason: :superseded
+      ).call
+
+      raise CloneError.new(error: void_result.error, cause: void_result) unless void_result&.success?
+    end
+  end
+end

--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -2,6 +2,8 @@
 
 module QuoteVersions
   class CloneService < BaseService
+    include OrderForms::Premium
+
     class CloneError < StandardError
       attr_reader :source_result
 
@@ -21,9 +23,8 @@ module QuoteVersions
     end
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "quote_version") unless quote_version
-      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.not_allowed_failure!(code: "inappropriate_state") unless clonable?
 
       cloned = QuoteVersion.transaction do

--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -3,12 +3,11 @@
 module QuoteVersions
   class CloneService < BaseService
     class CloneError < StandardError
-      attr_reader :cause, :error
+      attr_reader :source_result
 
-      def initialize(cause: nil, error: nil)
-        @cause = cause
-        @error = error
-        super("QuoteVersion clone failed due to #{cause.class}")
+      def initialize(source_result:)
+        @source_result = source_result
+        super("QuoteVersion clone failed: #{source_result&.error&.message}")
       end
     end
 
@@ -38,14 +37,14 @@ module QuoteVersions
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue CloneError, ActiveRecord::ActiveRecordError => e
+    rescue CloneError => e
       result.service_failure!(code: "clone_failed", message: e.message, error: e)
     end
 
     private
 
     def clonable?
-      return false if quote_version.approved?
+      return false if quote_version.quote.versions.where(status: :approved).exists?
 
       true
     end
@@ -54,7 +53,7 @@ module QuoteVersions
       quote_version.dup.tap do |cloned|
         cloned.status = :draft
         cloned.sequential_id = nil
-        cloned.share_token = nil # will be generated on saving
+        cloned.share_token = nil # regenerated on save
         cloned.void_reason = nil
         cloned.voided_at = nil
         cloned.approved_at = nil
@@ -70,7 +69,7 @@ module QuoteVersions
         reason: :superseded
       ).call
 
-      raise CloneError.new(error: void_result.error, cause: void_result) unless void_result&.success?
+      raise CloneError.new(source_result: void_result) unless void_result&.success?
     end
   end
 end

--- a/app/services/quote_versions/create_service.rb
+++ b/app/services/quote_versions/create_service.rb
@@ -2,6 +2,8 @@
 
 module QuoteVersions
   class CreateService < BaseService
+    include OrderForms::Premium
+
     attr_reader :quote, :params
 
     Result = BaseResult[:quote_version]
@@ -13,9 +15,8 @@ module QuoteVersions
     end
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "quote") unless quote
-      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.forbidden_failure! unless order_forms_enabled?(quote.organization)
 
       quote_version = quote.versions.create!(
         organization: quote.organization,

--- a/app/services/quote_versions/create_service.rb
+++ b/app/services/quote_versions/create_service.rb
@@ -2,32 +2,24 @@
 
 module QuoteVersions
   class CreateService < BaseService
-    attr_reader :organization, :quote, :params
+    attr_reader :quote, :params
 
     Result = BaseResult[:quote_version]
 
-    def initialize(organization:, quote:, params: {})
-      @organization = organization
+    def initialize(quote:, params: {})
       @quote = quote
       @params = params
-
       super
     end
 
     def call
       return result.forbidden_failure! unless License.premium?
-      return result.not_found_failure!(resource: "organization") unless organization
       return result.not_found_failure!(resource: "quote") unless quote
-      return result.forbidden_failure! unless organization.feature_flag_enabled?(:order_forms)
-
-      create_params = params.slice(
-        :billing_items,
-        :content
-      )
+      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
 
       quote_version = quote.versions.create!(
-        organization:,
-        **create_params
+        organization: quote.organization,
+        **params.slice(:billing_items, :content)
       )
 
       result.quote_version = quote_version
@@ -37,8 +29,6 @@ module QuoteVersions
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue ActiveRecord::ActiveRecordError => e
-      result.service_failure!(code: "create_failed", message: e.message, error: e)
     end
   end
 end

--- a/app/services/quote_versions/create_service.rb
+++ b/app/services/quote_versions/create_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class CreateService < BaseService
+    attr_reader :organization, :quote, :params
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(organization:, quote:, params: {})
+      @organization = organization
+      @quote = quote
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "organization") unless organization
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless organization.feature_flag_enabled?(:order_forms)
+
+      create_params = params.slice(
+        :billing_items,
+        :content
+      )
+
+      quote_version = quote.versions.create!(
+        organization:,
+        **create_params
+      )
+
+      result.quote_version = quote_version
+
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.created", quote_version)
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "create_failed", message: e.message, error: e)
+    end
+  end
+end

--- a/app/services/quote_versions/create_service.rb
+++ b/app/services/quote_versions/create_service.rb
@@ -17,6 +17,7 @@ module QuoteVersions
     def call
       return result.not_found_failure!(resource: "quote") unless quote
       return result.forbidden_failure! unless order_forms_enabled?(quote.organization)
+      return result.forbidden_failure!(code: "active_version_exists") if active_version_exists?
 
       quote_version = quote.versions.create!(
         organization: quote.organization,
@@ -30,6 +31,14 @@ module QuoteVersions
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::RecordNotUnique
+      result.forbidden_failure!(code: "active_version_exists")
+    end
+
+    private
+
+    def active_version_exists?
+      quote.versions.where(status: %w[draft approved]).exists?
     end
   end
 end

--- a/app/services/quote_versions/update_service.rb
+++ b/app/services/quote_versions/update_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class UpdateService < BaseService
+    attr_reader :quote_version, :params
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(quote_version:, params:)
+      @quote_version = quote_version
+      @params = params
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless editable?
+
+      update_params = params.slice(
+        :billing_items,
+        :content
+      )
+      quote_version.update!(update_params)
+      result.quote_version = quote_version
+
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.updated", quote_version)
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "update_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def editable?
+      quote_version.draft?
+    end
+  end
+end

--- a/app/services/quote_versions/update_service.rb
+++ b/app/services/quote_versions/update_service.rb
@@ -2,6 +2,8 @@
 
 module QuoteVersions
   class UpdateService < BaseService
+    include OrderForms::Premium
+
     attr_reader :quote_version, :params
 
     Result = BaseResult[:quote_version]
@@ -13,9 +15,8 @@ module QuoteVersions
     end
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "quote_version") unless quote_version
-      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.not_allowed_failure!(code: "inappropriate_state") unless editable?
 
       quote_version.update!(params.slice(:billing_items, :content))

--- a/app/services/quote_versions/update_service.rb
+++ b/app/services/quote_versions/update_service.rb
@@ -18,11 +18,7 @@ module QuoteVersions
       return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
       return result.not_allowed_failure!(code: "inappropriate_state") unless editable?
 
-      update_params = params.slice(
-        :billing_items,
-        :content
-      )
-      quote_version.update!(update_params)
+      quote_version.update!(params.slice(:billing_items, :content))
       result.quote_version = quote_version
 
       # TODO: SendWebhookJob.perform_after_commit("quote_version.updated", quote_version)
@@ -30,8 +26,6 @@ module QuoteVersions
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue ActiveRecord::ActiveRecordError => e
-      result.service_failure!(code: "update_failed", message: e.message, error: e)
     end
 
     private

--- a/app/services/quote_versions/void_service.rb
+++ b/app/services/quote_versions/void_service.rb
@@ -2,6 +2,8 @@
 
 module QuoteVersions
   class VoidService < BaseService
+    include OrderForms::Premium
+
     attr_reader :quote_version, :reason
 
     Result = BaseResult[:quote_version]
@@ -13,9 +15,8 @@ module QuoteVersions
     end
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "quote_version") unless quote_version
-      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.single_validation_failure!(field: :void_reason, error_code: "invalid") unless valid_reason?
       return result.not_allowed_failure!(code: "inappropriate_state") unless voidable?
 

--- a/app/services/quote_versions/void_service.rb
+++ b/app/services/quote_versions/void_service.rb
@@ -16,7 +16,7 @@ module QuoteVersions
       return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
-      return result.validation_failure!(errors: {quote_version: ["invalid_void_reason"]}) unless valid_reason?(reason:)
+      return result.single_validation_failure!(field: :void_reason, error_code: "invalid") unless valid_reason?
       return result.not_allowed_failure!(code: "inappropriate_state") unless voidable?
 
       quote_version.update!(
@@ -33,17 +33,15 @@ module QuoteVersions
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue ActiveRecord::ActiveRecordError => e
-      result.service_failure!(code: "void_failed", message: e.message, error: e)
     end
 
     private
 
     def voidable?
-      quote_version.approved? || quote_version.draft?
+      quote_version.draft?
     end
 
-    def valid_reason?(reason:)
+    def valid_reason?
       return false if reason.blank?
 
       QuoteVersion::VOID_REASONS.has_key?(reason.to_s.to_sym)

--- a/app/services/quote_versions/void_service.rb
+++ b/app/services/quote_versions/void_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class VoidService < BaseService
+    attr_reader :quote_version, :reason
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(quote_version:, reason:)
+      @quote_version = quote_version
+      @reason = reason
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.validation_failure!(errors: {quote_version: ["invalid_void_reason"]}) unless valid_reason?(reason:)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless voidable?
+
+      quote_version.update!(
+        status: :voided,
+        void_reason: reason,
+        voided_at: Time.current,
+        share_token: nil,
+        approved_at: nil
+      )
+
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.voided", quote_version)
+
+      result.quote_version = quote_version
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "void_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def voidable?
+      quote_version.approved? || quote_version.draft?
+    end
+
+    def valid_reason?(reason:)
+      return false if reason.blank?
+
+      QuoteVersion::VOID_REASONS.has_key?(reason.to_s.to_sym)
+    end
+  end
+end

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -2,6 +2,8 @@
 
 module Quotes
   class CreateService < BaseService
+    include OrderForms::Premium
+
     attr_reader :organization, :customer, :subscription, :params, :owners
 
     Result = BaseResult[:quote]
@@ -21,7 +23,7 @@ module Quotes
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "subscription") if subscription_required? && subscription.blank?
       return result.not_found_failure!(resource: "subscription") if subscription.present? && !subscription_belongs_to_quote_scope?
-      return result.forbidden_failure! unless organization.feature_flag_enabled?(:order_forms)
+      return result.forbidden_failure! unless order_forms_enabled?(organization)
       return result.single_validation_failure!(field: :owners, error_code: "invalid") unless valid_owners?
 
       Quote.transaction do

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -2,16 +2,6 @@
 
 module Quotes
   class CreateService < BaseService
-    class CreateError < StandardError
-      attr_reader :cause, :error
-
-      def initialize(cause: nil, error: nil)
-        @cause = cause
-        @error = error
-        super("Quote creation failed due to #{cause.class}")
-      end
-    end
-
     attr_reader :organization, :customer, :subscription, :params, :owners
 
     Result = BaseResult[:quote]
@@ -30,28 +20,18 @@ module Quotes
       return result.not_found_failure!(resource: "organization") unless organization
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "subscription") if subscription_required? && subscription.blank?
+      return result.not_found_failure!(resource: "subscription") if subscription.present? && !subscription_belongs_to_quote_scope?
       return result.forbidden_failure! unless organization.feature_flag_enabled?(:order_forms)
-      return result.validation_failure!(errors: {quotes: ["invalid_owner"]}) unless check_owners(owners:)
-
-      quote_create_params = params.slice(
-        :order_type
-      )
-      quote_version_create_params = params.slice(
-        :billing_items,
-        :content
-      )
+      return result.single_validation_failure!(field: :owners, error_code: "invalid") unless valid_owners?
 
       Quote.transaction do
         quote = organization.quotes.create!(
           customer:,
           subscription:,
-          **quote_create_params
+          **params.slice(:order_type)
         )
-        initialize_version!(
-          quote:,
-          version_params: quote_version_create_params
-        )
-        add_owners!(quote:, owners:)
+        initialize_version!(quote:)
+        add_owners!(quote:)
         result.quote = quote
       end
 
@@ -60,8 +40,6 @@ module Quotes
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue CreateError, ActiveRecord::ActiveRecordError => e
-      result.service_failure!(code: "create_failed", message: e.message, error: e)
     end
 
     private
@@ -70,32 +48,31 @@ module Quotes
       params[:order_type].to_s == "subscription_amendment"
     end
 
-    def check_owners(owners:)
+    def subscription_belongs_to_quote_scope?
+      subscription.organization_id == organization.id && subscription.customer_id == customer.id
+    end
+
+    def valid_owners?
       return true if owners.blank?
 
-      valid_owners = organization.memberships.active.pluck(:user_id)
-      invalid_owners = owners - valid_owners
-      return false if invalid_owners.any?
-
-      true
+      known = organization.memberships.active.where(user_id: owners).pluck(:user_id)
+      (owners - known).empty?
     end
 
-    def initialize_version!(quote:, version_params: {})
-      create_result = QuoteVersions::CreateService.new(
-        organization: quote.organization,
+    def initialize_version!(quote:)
+      QuoteVersions::CreateService.call!(
         quote: quote,
-        params: version_params
-      ).call
-
-      raise CreateError.new(error: create_result.error, cause: create_result) unless create_result&.success?
+        params: params.slice(:billing_items, :content)
+      )
     end
 
-    def add_owners!(quote:, owners:)
+    def add_owners!(quote:)
       return if owners.blank?
 
-      owners.each do |user_id|
-        quote.quote_owners.create!(organization:, user_id:)
-      end
+      now = Time.current
+      quote.quote_owners.insert_all(
+        owners.map { |user_id| {organization_id: organization.id, user_id: user_id, created_at: now, updated_at: now} }
+      )
     end
 
     def normalize_owners(owners:)

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Quotes
+  class CreateService < BaseService
+    class CreateError < StandardError
+      attr_reader :cause, :error
+
+      def initialize(cause: nil, error: nil)
+        @cause = cause
+        @error = error
+        super("Quote creation failed due to #{cause.class}")
+      end
+    end
+
+    attr_reader :organization, :customer, :subscription, :params, :owners
+
+    Result = BaseResult[:quote]
+
+    def initialize(organization:, customer:, subscription: nil, params: {})
+      @organization = organization
+      @customer = customer
+      @subscription = subscription
+      @params = params
+      @owners = normalize_owners(owners: params[:owners])
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "organization") unless organization
+      return result.not_found_failure!(resource: "customer") unless customer
+      return result.not_found_failure!(resource: "subscription") if subscription_required? && subscription.blank?
+      return result.forbidden_failure! unless organization.feature_flag_enabled?(:order_forms)
+      return result.validation_failure!(errors: {quotes: ["invalid_owner"]}) unless check_owners(owners:)
+
+      quote_create_params = params.slice(
+        :order_type
+      )
+      quote_version_create_params = params.slice(
+        :billing_items,
+        :content
+      )
+
+      Quote.transaction do
+        quote = organization.quotes.create!(
+          customer:,
+          subscription:,
+          **quote_create_params
+        )
+        initialize_version!(
+          quote:,
+          version_params: quote_version_create_params
+        )
+        add_owners!(quote:, owners:)
+        result.quote = quote
+      end
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.created", quote)
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue CreateError, ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "create_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def subscription_required?
+      params[:order_type].to_s == "subscription_amendment"
+    end
+
+    def check_owners(owners:)
+      return true if owners.blank?
+
+      valid_owners = organization.memberships.active.pluck(:user_id)
+      invalid_owners = owners - valid_owners
+      return false if invalid_owners.any?
+
+      true
+    end
+
+    def initialize_version!(quote:, version_params: {})
+      create_result = QuoteVersions::CreateService.new(
+        organization: quote.organization,
+        quote: quote,
+        params: version_params
+      ).call
+
+      raise CreateError.new(error: create_result.error, cause: create_result) unless create_result&.success?
+    end
+
+    def add_owners!(quote:, owners:)
+      return if owners.blank?
+
+      owners.each do |user_id|
+        quote.quote_owners.create!(organization:, user_id:)
+      end
+    end
+
+    def normalize_owners(owners:)
+      return [] if owners.blank?
+      return owners.map(&:to_s).uniq if owners.is_a?(Array)
+
+      [owners.to_s]
+    end
+  end
+end

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -71,10 +71,9 @@ module Quotes
     def add_owners!(quote:)
       return if owners.blank?
 
-      now = Time.current
-      quote.quote_owners.insert_all(
-        owners.map { |user_id| {organization_id: organization.id, user_id: user_id, created_at: now, updated_at: now} }
-      )
+      owners.each do |user_id|
+        quote.quote_owners.create!(organization:, user_id:)
+      end
     end
 
     def normalize_owners(owners:)

--- a/app/services/quotes/update_service.rb
+++ b/app/services/quotes/update_service.rb
@@ -2,6 +2,8 @@
 
 module Quotes
   class UpdateService < BaseService
+    include OrderForms::Premium
+
     attr_reader :quote, :params, :owners
 
     Result = BaseResult[:quote]
@@ -14,9 +16,8 @@ module Quotes
     end
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "quote") unless quote
-      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.forbidden_failure! unless order_forms_enabled?(quote.organization)
       return result.single_validation_failure!(field: :owners, error_code: "invalid") unless valid_owners?
 
       sync_owners!(quote:) if params.has_key?(:owners)

--- a/app/services/quotes/update_service.rb
+++ b/app/services/quotes/update_service.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Quotes
+  class UpdateService < BaseService
+    attr_reader :quote, :params, :owners
+
+    Result = BaseResult[:quote]
+
+    def initialize(quote:, params:)
+      @quote = quote
+      @params = params
+      @owners = normalize_owners(owners: params[:owners])
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.validation_failure!(errors: {quotes: ["invalid_owner"]}) unless check_owners(owners:)
+
+      sync_owners!(quote:, owners:) if params.has_key?(:owners)
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.updated", quote)
+
+      result.quote = quote.reload
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "update_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def check_owners(owners:)
+      return true if owners.blank?
+
+      valid_owners = quote.organization.memberships.active.pluck(:user_id)
+      invalid_owners = owners - valid_owners
+      return false if invalid_owners.any?
+
+      true
+    end
+
+    def normalize_owners(owners:)
+      return [] if owners.blank?
+      return owners.map(&:to_s).uniq if owners.is_a?(Array)
+
+      [owners.to_s]
+    end
+
+    def sync_owners!(quote:, owners:)
+      QuoteOwner.transaction do
+        current_owners = quote.owner_ids
+
+        owners_to_remove = current_owners - owners
+        quote.quote_owners.where(user_id: owners_to_remove).delete_all if owners_to_remove.any?
+
+        owners_to_add = owners - current_owners
+        owners_to_add.each do |user_id|
+          quote.quote_owners.create!(
+            organization_id: quote.organization_id,
+            user_id: user_id
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/quotes/update_service.rb
+++ b/app/services/quotes/update_service.rb
@@ -54,10 +54,10 @@ module Quotes
         quote.quote_owners.where(user_id: owners_to_remove).delete_all if owners_to_remove.any?
 
         owners_to_add = owners - current_owners
-        if owners_to_add.any?
-          now = Time.current
-          quote.quote_owners.insert_all(
-            owners_to_add.map { |user_id| {organization_id: quote.organization_id, user_id: user_id, created_at: now, updated_at: now} }
+        owners_to_add.each do |user_id|
+          quote.quote_owners.create!(
+            organization_id: quote.organization_id,
+            user_id: user_id
           )
         end
       end

--- a/app/services/quotes/update_service.rb
+++ b/app/services/quotes/update_service.rb
@@ -17,9 +17,9 @@ module Quotes
       return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "quote") unless quote
       return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
-      return result.validation_failure!(errors: {quotes: ["invalid_owner"]}) unless check_owners(owners:)
+      return result.single_validation_failure!(field: :owners, error_code: "invalid") unless valid_owners?
 
-      sync_owners!(quote:, owners:) if params.has_key?(:owners)
+      sync_owners!(quote:) if params.has_key?(:owners)
 
       # TODO: SendWebhookJob.perform_after_commit("quote.updated", quote)
 
@@ -27,20 +27,15 @@ module Quotes
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue ActiveRecord::ActiveRecordError => e
-      result.service_failure!(code: "update_failed", message: e.message, error: e)
     end
 
     private
 
-    def check_owners(owners:)
+    def valid_owners?
       return true if owners.blank?
 
-      valid_owners = quote.organization.memberships.active.pluck(:user_id)
-      invalid_owners = owners - valid_owners
-      return false if invalid_owners.any?
-
-      true
+      known = quote.organization.memberships.active.where(user_id: owners).pluck(:user_id)
+      (owners - known).empty?
     end
 
     def normalize_owners(owners:)
@@ -50,7 +45,7 @@ module Quotes
       [owners.to_s]
     end
 
-    def sync_owners!(quote:, owners:)
+    def sync_owners!(quote:)
       QuoteOwner.transaction do
         current_owners = quote.owner_ids
 
@@ -58,10 +53,10 @@ module Quotes
         quote.quote_owners.where(user_id: owners_to_remove).delete_all if owners_to_remove.any?
 
         owners_to_add = owners - current_owners
-        owners_to_add.each do |user_id|
-          quote.quote_owners.create!(
-            organization_id: quote.organization_id,
-            user_id: user_id
+        if owners_to_add.any?
+          now = Time.current
+          quote.quote_owners.insert_all(
+            owners_to_add.map { |user_id| {organization_id: quote.organization_id, user_id: user_id, created_at: now, updated_at: now} }
           )
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,11 +32,13 @@ en:
         invalid_free_units_per_total_aggregation: invalid_free_units_per_total_aggregation
         invalid_graduated_ranges: invalid_graduated_ranges
         invalid_organization: invalid_organization
+        invalid_owner: invalid_owner
         invalid_package_size: invalid_package_size
         invalid_per_unit_amount: invalid_per_unit_amount
         invalid_rate: invalid_rate
         invalid_size: invalid_size
         invalid_timezone: invalid_timezone
+        invalid_void_reason: invalid_void_reason
         invalid_volume_ranges: invalid_volume_ranges
         language_code_invalid: not_a_valid_language_code
         less_than_or_equal_to: value_is_out_of_range

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -128,6 +128,20 @@ invoice_custom_sections:
     - finance
   delete:
     - finance
+quotes:
+  view:
+    - finance
+    - manager
+  create:
+    - manager
+  update:
+    - manager
+  approve:
+    - manager
+  clone:
+    - manager
+  void:
+    - manager
 organization:
   view:
     - finance

--- a/db/migrate/20260304074158_add_quotes.rb
+++ b/db/migrate/20260304074158_add_quotes.rb
@@ -4,7 +4,7 @@ class AddQuotes < ActiveRecord::Migration[8.0]
   def change
     create_enum :quote_status, %w[draft approved voided]
     create_enum :quote_void_reason, %w[manual superseded cascade_of_expired cascade_of_voided]
-    create_enum :order_type, %w[subscription_creation subscription_amendment one_off]
+    create_enum :quote_order_type, %w[subscription_creation subscription_amendment one_off]
 
     create_table :quotes, id: :uuid do |t|
       t.references :organization,
@@ -22,7 +22,7 @@ class AddQuotes < ActiveRecord::Migration[8.0]
       t.string :number, null: false
       t.integer :sequential_id, null: false
       t.enum :order_type,
-        enum_type: :order_type,
+        enum_type: :quote_order_type,
         null: false
       t.timestamps
 

--- a/db/migrate/20260304074158_add_quotes.rb
+++ b/db/migrate/20260304074158_add_quotes.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+class AddQuotes < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :quote_status, %w[draft approved voided]
+    create_enum :quote_void_reason, %w[manual superseded cascade_of_expired cascade_of_voided]
+    create_enum :order_type, %w[subscription_creation subscription_amendment one_off]
+
+    create_table :quotes, id: :uuid do |t|
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique index below
+        type: :uuid
+      t.references :customer,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :subscription,
+        foreign_key: true,
+        type: :uuid
+      t.string :number, null: false
+      t.integer :sequential_id, null: false
+      t.enum :order_type,
+        enum_type: :order_type,
+        null: false
+      t.timestamps
+
+      # constraints and indices
+      t.check_constraint "sequential_id > 0",
+        name: "quotes_constraint_sequential_id_positive"
+      t.index [:organization_id, :sequential_id],
+        unique: true,
+        name: "index_unique_quotes_on_organization_sequential_id"
+      t.index [:organization_id, :number],
+        unique: true,
+        name: "index_unique_quotes_on_organization_number"
+    end
+
+    create_table :quote_versions, id: :uuid do |t|
+      # identity
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :quote,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.integer :sequential_id, null: false # acts as version number
+      # lifecycle
+      t.enum :status,
+        enum_type: :quote_status,
+        null: false,
+        default: "draft"
+      t.datetime :approved_at
+      t.datetime :voided_at
+      t.enum :void_reason, enum_type: :quote_void_reason
+      # content
+      t.jsonb :billing_items
+      t.text :content
+      t.string :share_token
+      t.timestamps
+
+      # constraints and indices
+      t.check_constraint "sequential_id > 0",
+        name: "quote_versions_constraint_sequential_id_positive"
+      t.check_constraint "(status = 'voided') = (void_reason IS NOT NULL AND voided_at IS NOT NULL)",
+        name: "quote_versions_constraint_void_fields_match_status"
+      t.check_constraint "(status = 'approved') = (approved_at IS NOT NULL)",
+        name: "quote_versions_constraint_approved_at_matches_status"
+      t.index [:quote_id, :sequential_id],
+        unique: true,
+        name: "index_unique_quote_versions_on_quote_sequential_id"
+      t.index :quote_id,
+        unique: true,
+        where: "status IN ('draft', 'approved')",
+        name: "index_unique_quote_versions_on_quote_active_status"
+      t.index :share_token,
+        unique: true,
+        name: "index_unique_quote_versions_on_share_token"
+    end
+
+    create_table :quote_owners do |t|
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :quote,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique index below
+        type: :uuid
+      t.references :user,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.timestamps
+
+      t.index [:quote_id, :user_id],
+        unique: true,
+        name: "index_unique_quote_owners_on_quote_user"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1139,10 +1139,10 @@ DROP TYPE IF EXISTS public.subscription_activation_rule_types;
 DROP TYPE IF EXISTS public.subscription_activation_rule_statuses;
 DROP TYPE IF EXISTS public.quote_void_reason;
 DROP TYPE IF EXISTS public.quote_status;
+DROP TYPE IF EXISTS public.quote_order_type;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
 DROP TYPE IF EXISTS public.payment_method_types;
-DROP TYPE IF EXISTS public.order_type;
 DROP TYPE IF EXISTS public.invoice_settlement_settlement_type;
 DROP TYPE IF EXISTS public.invoice_custom_section_type;
 DROP TYPE IF EXISTS public.inbound_webhook_status;
@@ -1324,17 +1324,6 @@ CREATE TYPE public.invoice_settlement_settlement_type AS ENUM (
 
 
 --
--- Name: order_type; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.order_type AS ENUM (
-    'subscription_creation',
-    'subscription_amendment',
-    'one_off'
-);
-
-
---
 -- Name: payment_method_types; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -1363,6 +1352,17 @@ CREATE TYPE public.payment_payable_payment_status AS ENUM (
 CREATE TYPE public.payment_type AS ENUM (
     'provider',
     'manual'
+);
+
+
+--
+-- Name: quote_order_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.quote_order_type AS ENUM (
+    'subscription_creation',
+    'subscription_amendment',
+    'one_off'
 );
 
 
@@ -4834,7 +4834,7 @@ CREATE TABLE public.quotes (
     subscription_id uuid,
     number character varying NOT NULL,
     sequential_id integer NOT NULL,
-    order_type public.order_type NOT NULL,
+    order_type public.quote_order_type NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT quotes_constraint_sequential_id_positive CHECK ((sequential_id > 0))

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -45,6 +45,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_de7694c307;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
 ALTER TABLE IF EXISTS ONLY public.invites DROP CONSTRAINT IF EXISTS fk_rails_dd342449a6;
 ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_dc444f5f29;
@@ -58,6 +59,7 @@ ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EX
 ALTER TABLE IF EXISTS ONLY public.idempotency_records DROP CONSTRAINT IF EXISTS fk_rails_d4f02c82b2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transaction_consumptions DROP CONSTRAINT IF EXISTS fk_rails_d4abfdb375;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_d384ec1ebf;
+ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS fk_rails_d2d917b73a;
 ALTER TABLE IF EXISTS ONLY public.item_metadata DROP CONSTRAINT IF EXISTS fk_rails_d0b1714507;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_d07bc24ce3;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ce2c63d69f;
@@ -100,6 +102,7 @@ ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_a7f20c73bb;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_a710519346;
 ALTER TABLE IF EXISTS ONLY public.group_properties DROP CONSTRAINT IF EXISTS fk_rails_a2d2cb3819;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_a1ab65f1f7;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_9f22076477;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_9ea6759859;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_9e3f99b7a2;
@@ -152,6 +155,7 @@ ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_7886
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_77f2d4440d;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_778360c382;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_775eb0ecd8;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_7734750af9;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_76ceb88c74;
 ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rails_755d734f25;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
@@ -186,6 +190,7 @@ ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_5cb2f24c3d;
 ALTER TABLE IF EXISTS ONLY public.payment_receipts DROP CONSTRAINT IF EXISTS fk_rails_5c2e0b6d34;
 ALTER TABLE IF EXISTS ONLY public.error_details DROP CONSTRAINT IF EXISTS fk_rails_5c21eece29;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_5bb40a7bae;
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_5ade8984b1;
 ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS fk_rails_5a4b906a16;
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS fk_rails_5a43da571b;
@@ -207,6 +212,7 @@ ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sec
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_49212d501e;
 ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk_rails_47d8081062;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_45230f8485;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_4117574b51;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_41088c7d45;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_3ff27d7624;
@@ -266,12 +272,14 @@ ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EX
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_19c47827ba;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_189f2a3949;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_1811b32fcd;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_173327f0dc;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_150139409e;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_142809fee1;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_12d29bc654;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_123667657c;
+ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS fk_rails_10ee148d0d;
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_10428ecad2;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_103e187859;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_0f807322b1;
@@ -368,6 +376,12 @@ DROP INDEX IF EXISTS public.index_usage_monitoring_alert_thresholds_on_organizat
 DROP INDEX IF EXISTS public.index_unique_transaction_id;
 DROP INDEX IF EXISTS public.index_unique_terminating_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_starting_invoice_subscription;
+DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_sequential_id;
+DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_number;
+DROP INDEX IF EXISTS public.index_unique_quote_versions_on_share_token;
+DROP INDEX IF EXISTS public.index_unique_quote_versions_on_quote_sequential_id;
+DROP INDEX IF EXISTS public.index_unique_quote_versions_on_quote_active_status;
+DROP INDEX IF EXISTS public.index_unique_quote_owners_on_quote_user;
 DROP INDEX IF EXISTS public.index_unique_applied_to_organization_per_organization;
 DROP INDEX IF EXISTS public.index_uniq_wallet_code_per_customer;
 DROP INDEX IF EXISTS public.index_uniq_invoice_subscriptions_on_fixed_charges_boundaries;
@@ -405,6 +419,12 @@ DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_started_at;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_expiration_at;
+DROP INDEX IF EXISTS public.index_quotes_on_subscription_id;
+DROP INDEX IF EXISTS public.index_quotes_on_customer_id;
+DROP INDEX IF EXISTS public.index_quote_versions_on_quote_id;
+DROP INDEX IF EXISTS public.index_quote_versions_on_organization_id;
+DROP INDEX IF EXISTS public.index_quote_owners_on_user_id;
+DROP INDEX IF EXISTS public.index_quote_owners_on_organization_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_organization_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_group_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_external_id;
@@ -843,6 +863,9 @@ ALTER TABLE IF EXISTS ONLY public.roles DROP CONSTRAINT IF EXISTS roles_pkey;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS refunds_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS recurring_transaction_rules_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS recurring_transaction_rules_invoice_custom_sections_pkey;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS quotes_pkey;
+ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS quote_versions_pkey;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS quote_owners_pkey;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
@@ -939,6 +962,7 @@ ALTER TABLE IF EXISTS ONLY public.active_storage_blobs DROP CONSTRAINT IF EXISTS
 ALTER TABLE IF EXISTS ONLY public.active_storage_attachments DROP CONSTRAINT IF EXISTS active_storage_attachments_pkey;
 ALTER TABLE IF EXISTS public.versions ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.usage_monitoring_subscription_activities ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE IF EXISTS public.quote_owners ALTER COLUMN id DROP DEFAULT;
 DROP TABLE IF EXISTS public.webhooks;
 DROP TABLE IF EXISTS public.webhook_endpoints;
 DROP TABLE IF EXISTS public.wallets_invoice_custom_sections;
@@ -958,6 +982,10 @@ DROP TABLE IF EXISTS public.roles;
 DROP TABLE IF EXISTS public.refunds;
 DROP TABLE IF EXISTS public.recurring_transaction_rules_invoice_custom_sections;
 DROP TABLE IF EXISTS public.recurring_transaction_rules;
+DROP TABLE IF EXISTS public.quotes;
+DROP TABLE IF EXISTS public.quote_versions;
+DROP SEQUENCE IF EXISTS public.quote_owners_id_seq;
+DROP TABLE IF EXISTS public.quote_owners;
 DROP TABLE IF EXISTS public.quantified_events;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
@@ -1109,9 +1137,12 @@ DROP TYPE IF EXISTS public.subscription_invoice_issuing_date_adjustments;
 DROP TYPE IF EXISTS public.subscription_cancelation_reasons;
 DROP TYPE IF EXISTS public.subscription_activation_rule_types;
 DROP TYPE IF EXISTS public.subscription_activation_rule_statuses;
+DROP TYPE IF EXISTS public.quote_void_reason;
+DROP TYPE IF EXISTS public.quote_status;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
 DROP TYPE IF EXISTS public.payment_method_types;
+DROP TYPE IF EXISTS public.order_type;
 DROP TYPE IF EXISTS public.invoice_settlement_settlement_type;
 DROP TYPE IF EXISTS public.invoice_custom_section_type;
 DROP TYPE IF EXISTS public.inbound_webhook_status;
@@ -1293,6 +1324,17 @@ CREATE TYPE public.invoice_settlement_settlement_type AS ENUM (
 
 
 --
+-- Name: order_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.order_type AS ENUM (
+    'subscription_creation',
+    'subscription_amendment',
+    'one_off'
+);
+
+
+--
 -- Name: payment_method_types; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -1321,6 +1363,29 @@ CREATE TYPE public.payment_payable_payment_status AS ENUM (
 CREATE TYPE public.payment_type AS ENUM (
     'provider',
     'manual'
+);
+
+
+--
+-- Name: quote_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.quote_status AS ENUM (
+    'draft',
+    'approved',
+    'voided'
+);
+
+
+--
+-- Name: quote_void_reason; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.quote_void_reason AS ENUM (
+    'manual',
+    'superseded',
+    'cascade_of_expired',
+    'cascade_of_voided'
 );
 
 
@@ -4702,6 +4767,81 @@ CREATE TABLE public.quantified_events (
 
 
 --
+-- Name: quote_owners; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quote_owners (
+    id bigint NOT NULL,
+    organization_id uuid NOT NULL,
+    quote_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: quote_owners_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.quote_owners_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: quote_owners_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.quote_owners_id_seq OWNED BY public.quote_owners.id;
+
+
+--
+-- Name: quote_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quote_versions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    quote_id uuid NOT NULL,
+    sequential_id integer NOT NULL,
+    status public.quote_status DEFAULT 'draft'::public.quote_status NOT NULL,
+    approved_at timestamp(6) without time zone,
+    voided_at timestamp(6) without time zone,
+    void_reason public.quote_void_reason,
+    billing_items jsonb,
+    content text,
+    share_token character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT quote_versions_constraint_approved_at_matches_status CHECK (((status = 'approved'::public.quote_status) = (approved_at IS NOT NULL))),
+    CONSTRAINT quote_versions_constraint_sequential_id_positive CHECK ((sequential_id > 0)),
+    CONSTRAINT quote_versions_constraint_void_fields_match_status CHECK (((status = 'voided'::public.quote_status) = ((void_reason IS NOT NULL) AND (voided_at IS NOT NULL))))
+);
+
+
+--
+-- Name: quotes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quotes (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    customer_id uuid NOT NULL,
+    subscription_id uuid,
+    number character varying NOT NULL,
+    sequential_id integer NOT NULL,
+    order_type public.order_type NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT quotes_constraint_sequential_id_positive CHECK ((sequential_id > 0))
+);
+
+
+--
 -- Name: recurring_transaction_rules; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5039,6 +5179,13 @@ CREATE TABLE public.webhooks (
 --
 
 ALTER TABLE ONLY public.enriched_events ATTACH PARTITION public.enriched_events_default DEFAULT;
+
+
+--
+-- Name: quote_owners id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners ALTER COLUMN id SET DEFAULT nextval('public.quote_owners_id_seq'::regclass);
 
 
 --
@@ -5805,6 +5952,30 @@ ALTER TABLE ONLY public.pricing_units
 
 ALTER TABLE ONLY public.quantified_events
     ADD CONSTRAINT quantified_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quote_owners quote_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT quote_owners_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quote_versions quote_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_versions
+    ADD CONSTRAINT quote_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quotes quotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT quotes_pkey PRIMARY KEY (id);
 
 
 --
@@ -8931,6 +9102,48 @@ CREATE INDEX index_quantified_events_on_organization_id ON public.quantified_eve
 
 
 --
+-- Name: index_quote_owners_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_owners_on_organization_id ON public.quote_owners USING btree (organization_id);
+
+
+--
+-- Name: index_quote_owners_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_owners_on_user_id ON public.quote_owners USING btree (user_id);
+
+
+--
+-- Name: index_quote_versions_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_versions_on_organization_id ON public.quote_versions USING btree (organization_id);
+
+
+--
+-- Name: index_quote_versions_on_quote_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_versions_on_quote_id ON public.quote_versions USING btree (quote_id);
+
+
+--
+-- Name: index_quotes_on_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quotes_on_customer_id ON public.quotes USING btree (customer_id);
+
+
+--
+-- Name: index_quotes_on_subscription_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quotes_on_subscription_id ON public.quotes USING btree (subscription_id);
+
+
+--
 -- Name: index_recurring_transaction_rules_on_expiration_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9187,6 +9400,48 @@ CREATE UNIQUE INDEX index_uniq_wallet_code_per_customer ON public.wallets USING 
 --
 
 CREATE UNIQUE INDEX index_unique_applied_to_organization_per_organization ON public.dunning_campaigns USING btree (organization_id) WHERE ((applied_to_organization = true) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_unique_quote_owners_on_quote_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_owners_on_quote_user ON public.quote_owners USING btree (quote_id, user_id);
+
+
+--
+-- Name: index_unique_quote_versions_on_quote_active_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_versions_on_quote_active_status ON public.quote_versions USING btree (quote_id) WHERE (status = ANY (ARRAY['draft'::public.quote_status, 'approved'::public.quote_status]));
+
+
+--
+-- Name: index_unique_quote_versions_on_quote_sequential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_versions_on_quote_sequential_id ON public.quote_versions USING btree (quote_id, sequential_id);
+
+
+--
+-- Name: index_unique_quote_versions_on_share_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_versions_on_share_token ON public.quote_versions USING btree (share_token);
+
+
+--
+-- Name: index_unique_quotes_on_organization_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quotes_on_organization_number ON public.quotes USING btree (organization_id, number);
+
+
+--
+-- Name: index_unique_quotes_on_organization_sequential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quotes_on_organization_sequential_id ON public.quotes USING btree (organization_id, sequential_id);
 
 
 --
@@ -9786,6 +10041,14 @@ ALTER TABLE ONLY public.applied_invoice_custom_sections
 
 
 --
+-- Name: quote_versions fk_rails_10ee148d0d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_versions
+    ADD CONSTRAINT fk_rails_10ee148d0d FOREIGN KEY (quote_id) REFERENCES public.quotes(id);
+
+
+--
 -- Name: entitlement_subscription_feature_removals fk_rails_123667657c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9831,6 +10094,14 @@ ALTER TABLE ONLY public.invoice_subscriptions
 
 ALTER TABLE ONLY public.entitlement_entitlements
     ADD CONSTRAINT fk_rails_173327f0dc FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
+
+
+--
+-- Name: quote_owners fk_rails_1811b32fcd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_1811b32fcd FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -10306,6 +10577,14 @@ ALTER TABLE ONLY public.credit_notes
 
 
 --
+-- Name: quote_owners fk_rails_45230f8485; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_45230f8485 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: integration_items fk_rails_47d8081062; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10471,6 +10750,14 @@ ALTER TABLE ONLY public.invoice_settlements
 
 ALTER TABLE ONLY public.add_ons_taxes
     ADD CONSTRAINT fk_rails_5ade8984b1 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: quotes fk_rails_5bb40a7bae; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT fk_rails_5bb40a7bae FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
 
 
 --
@@ -10743,6 +11030,14 @@ ALTER TABLE ONLY public.integrations
 
 ALTER TABLE ONLY public.commitments
     ADD CONSTRAINT fk_rails_76ceb88c74 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: quote_owners fk_rails_7734750af9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_7734750af9 FOREIGN KEY (quote_id) REFERENCES public.quotes(id);
 
 
 --
@@ -11162,6 +11457,14 @@ ALTER TABLE ONLY public.credit_note_items
 
 
 --
+-- Name: quotes fk_rails_a1ab65f1f7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT fk_rails_a1ab65f1f7 FOREIGN KEY (customer_id) REFERENCES public.customers(id);
+
+
+--
 -- Name: group_properties fk_rails_a2d2cb3819; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11498,6 +11801,14 @@ ALTER TABLE ONLY public.item_metadata
 
 
 --
+-- Name: quote_versions fk_rails_d2d917b73a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_versions
+    ADD CONSTRAINT fk_rails_d2d917b73a FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: payments fk_rails_d384ec1ebf; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11599,6 +11910,14 @@ ALTER TABLE ONLY public.invites
 
 ALTER TABLE ONLY public.coupon_targets
     ADD CONSTRAINT fk_rails_de6b3c3138 FOREIGN KEY (plan_id) REFERENCES public.plans(id);
+
+
+--
+-- Name: quotes fk_rails_de7694c307; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT fk_rails_de7694c307 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -11936,6 +12255,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260305161303'),
 ('20260305161302'),
 ('20260305100007'),
+('20260304074158'),
 ('20260227184913'),
 ('20260224134805'),
 ('20260220131101'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -5753,6 +5753,7 @@ enum FeatureFlagEnum {
   multi_entity_billing
   multiple_payment_methods
   non_persistable_charge_cache_optimization
+  order_forms
   payment_gated_subscriptions
   postgres_enriched_events
   wallet_traceability
@@ -6410,6 +6411,7 @@ enum IntegrationTypeEnum {
   multi_entities_pro
   netsuite
   okta
+  order_forms
   preview
   progressive_billing
   projected_usage
@@ -9220,6 +9222,12 @@ enum PermissionEnum {
   pricing_units_create
   pricing_units_update
   pricing_units_view
+  quotes_approve
+  quotes_clone
+  quotes_create
+  quotes_update
+  quotes_view
+  quotes_void
   roles_create
   roles_delete
   roles_update
@@ -9327,6 +9335,12 @@ type Permissions {
   pricingUnitsCreate: Boolean!
   pricingUnitsUpdate: Boolean!
   pricingUnitsView: Boolean!
+  quotesApprove: Boolean!
+  quotesClone: Boolean!
+  quotesCreate: Boolean!
+  quotesUpdate: Boolean!
+  quotesView: Boolean!
+  quotesVoid: Boolean!
   rolesCreate: Boolean!
   rolesDelete: Boolean!
   rolesUpdate: Boolean!
@@ -9466,6 +9480,7 @@ enum PremiumIntegrationTypeEnum {
   multi_entities_pro
   netsuite
   okta
+  order_forms
   preview
   progressive_billing
   projected_usage

--- a/schema.json
+++ b/schema.json
@@ -27919,6 +27919,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -32896,6 +32902,12 @@
             },
             {
               "name": "granular_lifetime_usage",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -44663,6 +44675,42 @@
               "deprecationReason": null
             },
             {
+              "name": "quotes_view",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_create",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_update",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_approve",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_clone",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_void",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -46353,6 +46401,102 @@
               "deprecationReason": null
             },
             {
+              "name": "quotesApprove",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesClone",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesCreate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesUpdate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesView",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesVoid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rolesCreate",
               "description": null,
               "args": [],
@@ -47772,6 +47916,12 @@
             },
             {
               "name": "granular_lifetime_usage",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/quote_owners.rb
+++ b/spec/factories/quote_owners.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :quote_owner do
+    quote
+    organization { quote.organization }
+    user { create(:membership, organization: quote.organization).user }
+  end
+end

--- a/spec/factories/quote_versions.rb
+++ b/spec/factories/quote_versions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :quote_version do
+    quote
+    organization { quote.organization }
+    status { :draft }
+    sequence(:sequential_id) { |n| n }
+
+    trait :approved do
+      status { :approved }
+      approved_at { Time.current }
+    end
+
+    trait :voided do
+      status { :voided }
+      voided_at { Time.current }
+      void_reason { :manual }
+    end
+  end
+end

--- a/spec/factories/quotes.rb
+++ b/spec/factories/quotes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :quote do
+    organization
+    customer
+    order_type { :subscription_creation }
+    sequence(:sequential_id) { |n| n }
+
+    trait :with_version do
+      transient do
+        version_trait { nil }
+      end
+
+      after(:create) do |quote, evaluator|
+        traits = Array(evaluator.version_trait)
+        create(
+          :quote_version,
+          *traits,
+          quote: quote,
+          organization: quote.organization
+        )
+      end
+    end
+  end
+end

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
       events_targeting_wallets
       security_logs
       granular_lifetime_usage
+      order_forms
     ]
   end
 

--- a/spec/models/quote_owner_spec.rb
+++ b/spec/models/quote_owner_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteOwner do
+  subject(:quote_owner) { create(:quote_owner) }
+
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:quote)
+      expect(subject).to belong_to(:user)
+    end
+  end
+end

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quote do
+  subject(:quote) { create(:quote) }
+
+  describe "enums" do
+    it "defines enums" do
+      expect(subject).to define_enum_for(:order_type)
+        .backed_by_column_of_type(:enum)
+        .with_values(
+          {
+            subscription_creation: "subscription_creation",
+            subscription_amendment: "subscription_amendment",
+            one_off: "one_off"
+          }
+        )
+        .without_instance_methods
+        .validating(allowing_nil: false)
+    end
+  end
+
+  describe "associations" do
+    it "has the expected associations" do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:customer)
+      expect(subject).to belong_to(:subscription).optional
+      expect(subject).to have_many(:quote_owners).dependent(:destroy)
+      expect(subject).to have_many(:owners).through(:quote_owners)
+      expect(subject).to have_many(:versions).class_name("QuoteVersion").order(sequential_id: :desc)
+      expect(subject).to have_one(:current_version).class_name("QuoteVersion").order(sequential_id: :desc)
+    end
+  end
+
+  describe "validations" do
+    it "requires subscription_id when order_type is subscription_amendment" do
+      subscription = create(:subscription)
+      quote = build(:quote, order_type: :subscription_amendment, subscription: nil, organization: subscription.organization, customer: create(:customer, organization: subscription.organization))
+      expect(quote).not_to be_valid
+      quote.subscription = subscription
+      expect(quote).to be_valid
+    end
+  end
+
+  describe "callbacks" do
+    describe "ensure_number" do
+      it "assigns a formatted number when sequential_id and created_at are present" do
+        quote = create(:quote, sequential_id: 123, number: nil, created_at: Time.zone.local(2020, 1, 2))
+        expect(quote.number).to eq("QT-2020-0123")
+      end
+    end
+  end
+end

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -6,15 +6,13 @@ RSpec.describe Quote do
   subject(:quote) { create(:quote) }
 
   describe "enums" do
-    it "defines enums" do
+    it do
       expect(subject).to define_enum_for(:order_type)
         .backed_by_column_of_type(:enum)
         .with_values(
-          {
-            subscription_creation: "subscription_creation",
-            subscription_amendment: "subscription_amendment",
-            one_off: "one_off"
-          }
+          subscription_creation: "subscription_creation",
+          subscription_amendment: "subscription_amendment",
+          one_off: "one_off"
         )
         .without_instance_methods
         .validating(allowing_nil: false)
@@ -22,33 +20,78 @@ RSpec.describe Quote do
   end
 
   describe "associations" do
-    it "has the expected associations" do
+    it do
       expect(subject).to belong_to(:organization)
       expect(subject).to belong_to(:customer)
       expect(subject).to belong_to(:subscription).optional
       expect(subject).to have_many(:quote_owners).dependent(:destroy)
       expect(subject).to have_many(:owners).through(:quote_owners)
       expect(subject).to have_many(:versions).class_name("QuoteVersion").order(sequential_id: :desc)
-      expect(subject).to have_one(:current_version).class_name("QuoteVersion").order(sequential_id: :desc)
+      expect(subject).to have_one(:current_version).class_name("QuoteVersion")
+      expect(subject).to have_one(:latest_version).class_name("QuoteVersion").order(sequential_id: :desc)
     end
   end
 
   describe "validations" do
-    it "requires subscription_id when order_type is subscription_amendment" do
-      subscription = create(:subscription)
-      quote = build(:quote, order_type: :subscription_amendment, subscription: nil, organization: subscription.organization, customer: create(:customer, organization: subscription.organization))
-      expect(quote).not_to be_valid
-      quote.subscription = subscription
-      expect(quote).to be_valid
+    describe "subscription_id" do
+      it "requires subscription_id when order_type is subscription_amendment" do
+        organization = create(:organization)
+        customer = create(:customer, organization:)
+        quote = build(:quote, organization:, customer:, order_type: :subscription_amendment, subscription: nil)
+        expect(quote).not_to be_valid
+        quote.subscription = create(:subscription, organization:, customer:)
+        expect(quote).to be_valid
+      end
+
+      it "does not require subscription_id when order_type is subscription_creation" do
+        quote = build(:quote, order_type: :subscription_creation, subscription: nil)
+        expect(quote).to be_valid
+      end
+
+      it "does not require subscription_id when order_type is one_off" do
+        quote = build(:quote, order_type: :one_off, subscription: nil)
+        expect(quote).to be_valid
+      end
     end
   end
 
-  describe "callbacks" do
-    describe "ensure_number" do
-      it "assigns a formatted number when sequential_id and created_at are present" do
-        quote = create(:quote, sequential_id: 123, number: nil, created_at: Time.zone.local(2020, 1, 2))
-        expect(quote.number).to eq("QT-2020-0123")
+  describe "sequencing" do
+    it "assigns sequential ids per organization" do
+      organization = create(:organization)
+      customer = create(:customer, organization:)
+      first = create(:quote, organization:, customer:, sequential_id: nil)
+      second = create(:quote, organization:, customer:, sequential_id: nil)
+      expect([first.sequential_id, second.sequential_id]).to eq([1, 2])
+    end
+
+    it "scopes the sequence per organization" do
+      org_a = create(:organization)
+      org_b = create(:organization)
+      a1 = create(:quote, organization: org_a, customer: create(:customer, organization: org_a), sequential_id: nil)
+      b1 = create(:quote, organization: org_b, customer: create(:customer, organization: org_b), sequential_id: nil)
+      expect([a1.sequential_id, b1.sequential_id]).to eq([1, 1])
+    end
+  end
+
+  describe "ensure_number callback" do
+    it "assigns a formatted number when sequential_id and created_at are present" do
+      quote = create(:quote, sequential_id: 123, number: nil, created_at: Time.zone.local(2020, 1, 2))
+      expect(quote.number).to eq("QT-2020-0123")
+    end
+
+    it "uses the current year when created_at is blank on save" do
+      organization = create(:organization)
+      customer = create(:customer, organization:)
+      travel_to(Time.zone.local(2026, 6, 1)) do
+        quote = build(:quote, organization:, customer:, sequential_id: 7, number: nil, created_at: nil, order_type: :one_off)
+        quote.save!
+        expect(quote.number).to eq("QT-2026-0007")
       end
+    end
+
+    it "preserves an explicitly assigned number" do
+      quote = create(:quote, sequential_id: 1, number: "QT-CUSTOM-0001")
+      expect(quote.number).to eq("QT-CUSTOM-0001")
     end
   end
 end

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe Quote do
       expect(subject).to have_many(:quote_owners).dependent(:destroy)
       expect(subject).to have_many(:owners).through(:quote_owners)
       expect(subject).to have_many(:versions).class_name("QuoteVersion").order(sequential_id: :desc)
-      expect(subject).to have_one(:current_version).class_name("QuoteVersion")
-      expect(subject).to have_one(:latest_version).class_name("QuoteVersion").order(sequential_id: :desc)
+      expect(subject).to have_one(:current_version).class_name("QuoteVersion").order(sequential_id: :desc)
     end
   end
 

--- a/spec/models/quote_version_spec.rb
+++ b/spec/models/quote_version_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersion do
+  subject(:quote_version) { create(:quote_version) }
+
+  describe "enums" do
+    it "defines enums" do
+      expect(subject).to define_enum_for(:status)
+        .backed_by_column_of_type(:enum)
+        .with_values(
+          {
+            draft: "draft",
+            approved: "approved",
+            voided: "voided"
+          }
+        )
+        .with_default(:draft)
+        .validating(allowing_nil: false)
+
+      expect(subject).to define_enum_for(:void_reason)
+        .backed_by_column_of_type(:enum)
+        .with_values(
+          {
+            manual: "manual",
+            superseded: "superseded",
+            cascade_of_expired: "cascade_of_expired",
+            cascade_of_voided: "cascade_of_voided"
+          }
+        )
+        .without_instance_methods
+        .validating(allowing_nil: true)
+    end
+  end
+
+  describe "associations" do
+    it "has the expected associations" do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:quote)
+
+      # TODO: Uncomment when the order form and order associations are implemented
+      # expect(subject).to have_one(:order_form)
+      # expect(subject).to have_one(:order).through(:order_form)
+    end
+  end
+
+  describe "validations" do
+    it "requires share_token for draft and approved statuses on update" do
+      draft = build(:quote_version, status: :draft, share_token: nil)
+      expect(draft.valid?(:update)).to be false
+
+      approved = build(:quote_version, status: :approved, share_token: nil, approved_at: Time.current)
+      expect(approved.valid?(:update)).to be false
+    end
+
+    it "requires void_reason and voided_at when voided" do
+      quote_version = build(:quote_version, status: :voided, void_reason: nil, voided_at: nil)
+      expect(quote_version).not_to be_valid
+
+      quote_version.void_reason = :manual
+      quote_version.voided_at = Time.current
+      expect(quote_version).to be_valid
+    end
+
+    it "requires approved_at when approved" do
+      quote_version = build(:quote_version, status: :approved, approved_at: nil)
+      expect(quote_version).not_to be_valid
+    end
+  end
+
+  describe "callbacks" do
+    describe "ensure_share_token" do
+      it "generates a share_token for draft versions" do
+        quote_version = create(:quote_version, status: :draft, share_token: nil)
+        expect(quote_version.share_token).to be_present
+      end
+
+      it "does not generate a share_token for voided versions" do
+        quote_version = create(:quote_version, :voided)
+        expect(quote_version.share_token).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/quote_version_spec.rb
+++ b/spec/models/quote_version_spec.rb
@@ -6,28 +6,20 @@ RSpec.describe QuoteVersion do
   subject(:quote_version) { create(:quote_version) }
 
   describe "enums" do
-    it "defines enums" do
+    it do
       expect(subject).to define_enum_for(:status)
         .backed_by_column_of_type(:enum)
-        .with_values(
-          {
-            draft: "draft",
-            approved: "approved",
-            voided: "voided"
-          }
-        )
+        .with_values(draft: "draft", approved: "approved", voided: "voided")
         .with_default(:draft)
         .validating(allowing_nil: false)
 
       expect(subject).to define_enum_for(:void_reason)
         .backed_by_column_of_type(:enum)
         .with_values(
-          {
-            manual: "manual",
-            superseded: "superseded",
-            cascade_of_expired: "cascade_of_expired",
-            cascade_of_voided: "cascade_of_voided"
-          }
+          manual: "manual",
+          superseded: "superseded",
+          cascade_of_expired: "cascade_of_expired",
+          cascade_of_voided: "cascade_of_voided"
         )
         .without_instance_methods
         .validating(allowing_nil: true)
@@ -35,51 +27,82 @@ RSpec.describe QuoteVersion do
   end
 
   describe "associations" do
-    it "has the expected associations" do
+    it do
       expect(subject).to belong_to(:organization)
       expect(subject).to belong_to(:quote)
-
-      # TODO: Uncomment when the order form and order associations are implemented
-      # expect(subject).to have_one(:order_form)
-      # expect(subject).to have_one(:order).through(:order_form)
     end
   end
 
   describe "validations" do
-    it "requires share_token for draft and approved statuses on update" do
-      draft = build(:quote_version, status: :draft, share_token: nil)
-      expect(draft.valid?(:update)).to be false
-
-      approved = build(:quote_version, status: :approved, share_token: nil, approved_at: Time.current)
-      expect(approved.valid?(:update)).to be false
+    it "is valid by default" do
+      expect(build(:quote_version)).to be_valid
     end
 
-    it "requires void_reason and voided_at when voided" do
-      quote_version = build(:quote_version, status: :voided, void_reason: nil, voided_at: nil)
-      expect(quote_version).not_to be_valid
+    describe "share_token" do
+      it "is required for draft and approved statuses on update" do
+        draft = build(:quote_version, status: :draft, share_token: nil)
+        expect(draft.valid?(:update)).to be false
 
-      quote_version.void_reason = :manual
-      quote_version.voided_at = Time.current
-      expect(quote_version).to be_valid
+        approved = build(:quote_version, status: :approved, share_token: nil, approved_at: Time.current)
+        expect(approved.valid?(:update)).to be false
+      end
     end
 
-    it "requires approved_at when approved" do
-      quote_version = build(:quote_version, status: :approved, approved_at: nil)
-      expect(quote_version).not_to be_valid
+    describe "void_reason and voided_at" do
+      it "are required when status is voided" do
+        quote_version = build(:quote_version, status: :voided, void_reason: nil, voided_at: nil)
+        expect(quote_version).not_to be_valid
+
+        quote_version.void_reason = :manual
+        quote_version.voided_at = Time.current
+        expect(quote_version).to be_valid
+      end
+    end
+
+    describe "approved_at" do
+      it "is required when status is approved" do
+        quote_version = build(:quote_version, status: :approved, approved_at: nil)
+        expect(quote_version).not_to be_valid
+      end
+
+      it "is allowed to be nil when status is draft" do
+        quote_version = build(:quote_version, status: :draft, approved_at: nil)
+        expect(quote_version).to be_valid
+      end
     end
   end
 
-  describe "callbacks" do
-    describe "ensure_share_token" do
-      it "generates a share_token for draft versions" do
-        quote_version = create(:quote_version, status: :draft, share_token: nil)
-        expect(quote_version.share_token).to be_present
-      end
+  describe "sequencing" do
+    it "assigns sequential ids per quote" do
+      quote = create(:quote)
+      v1 = create(:quote_version, :voided, quote:, organization: quote.organization, sequential_id: nil)
+      v2 = create(:quote_version, quote:, organization: quote.organization, sequential_id: nil)
+      expect([v1.sequential_id, v2.sequential_id]).to eq([1, 2])
+    end
+  end
 
-      it "does not generate a share_token for voided versions" do
-        quote_version = create(:quote_version, :voided)
-        expect(quote_version.share_token).to be_nil
-      end
+  describe "ensure_share_token callback" do
+    it "generates a share_token for draft versions" do
+      quote_version = create(:quote_version, status: :draft, share_token: nil)
+      expect(quote_version.share_token).to be_present
+    end
+
+    it "does not generate a share_token for voided versions" do
+      quote_version = create(:quote_version, :voided)
+      expect(quote_version.share_token).to be_nil
+    end
+
+    it "preserves an explicitly assigned share_token" do
+      token = SecureRandom.uuid
+      quote_version = create(:quote_version, status: :draft, share_token: token)
+      expect(quote_version.share_token).to eq(token)
+    end
+  end
+
+  describe "#version" do
+    it "is an alias for sequential_id" do
+      quote_version = build(:quote_version, sequential_id: 42)
+      expect(quote_version.version).to eq(42)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,19 @@ RSpec.describe User do
 
   it_behaves_like "paper_trail traceable"
 
+  describe "associations" do
+    it do
+      expect(subject).to have_many(:password_resets)
+      expect(subject).to have_many(:user_devices)
+      expect(subject).to have_many(:memberships)
+      expect(subject).to have_many(:organizations).through(:memberships).class_name("Organization")
+      expect(subject).to have_many(:active_memberships).class_name("Membership")
+      expect(subject).to have_many(:active_organizations).through(:active_memberships).source(:organization)
+      expect(subject).to have_many(:quote_owners).dependent(:destroy)
+      expect(subject).to have_many(:quotes).through(:quote_owners)
+    end
+  end
+
   describe "normalizations" do
     it "sanitizes email on assignment" do
       user = described_class.new(email: " hello@some\u200Bthing\u2013other.com ", password: "password")

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::ApproveService do
+  subject(:approve_service) { described_class.new(quote_version:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, organization:) }
+  let(:quote_version) { create(:quote_version, quote:, organization:) }
+
+  describe ".call" do
+    let(:result) { approve_service.call }
+
+    context "when the quote version is approvable", :premium do
+      it "approves the quote version" do
+        freeze_time do
+          expect(result).to be_success
+          expect(result.quote_version.approved?).to eq(true)
+          expect(result.quote_version.approved_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context "when the quote version is voided", :premium do
+      let(:quote_version) { create(:quote_version, :voided, quote:, organization:) }
+
+      it "does not approve the quote version" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+
+        quote_version.reload
+        expect(quote_version.approved?).to eq(false)
+        expect(quote_version.approved_at).to eq(nil)
+      end
+    end
+
+    context "when the quote version is already approved", :premium do
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+      it "does not approve the quote version" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when quote version does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::CloneService do
+  subject(:clone_service) { described_class.new(quote_version:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let!(:quote) { create(:quote, organization:) }
+  let!(:versions) do
+    QuoteVersion.transaction do
+      v1 = create(:quote_version, :voided, quote:, organization:)
+      v2 = create(:quote_version, :voided, quote:, organization:)
+      [v1, v2]
+    end
+  end
+  let(:quote_version) { versions.last }
+
+  describe ".call" do
+    let(:result) { clone_service.call }
+
+    context "when the quote version is clonable", :premium do
+      context "when the quote version is already voided" do
+        it "creates a clone and doesn't override the original quote version" do
+          expect(result).to be_success
+          cloned = result.quote_version
+          expect(cloned.id).not_to eq(quote_version.id)
+          expect(cloned.organization_id).to eq(quote_version.organization_id)
+          expect(cloned.quote_id).to eq(quote_version.quote_id)
+          expect(cloned.version).to eq(quote_version.version + 1)
+          expect(cloned.draft?).to eq(true)
+          expect(cloned.void_reason).to eq(nil)
+          expect(cloned.voided_at).to eq(nil)
+          expect(cloned.approved_at).to eq(nil)
+
+          expect(quote.reload.current_version).to eq(cloned)
+
+          quote_version.reload
+          expect(quote_version.voided?).to eq(true)
+          expect(quote_version.void_reason).to eq("manual")
+          expect(quote_version.voided_at).not_to eq(nil)
+        end
+      end
+
+      context "when the quote version is draft" do
+        let!(:versions) do
+          QuoteVersion.transaction do
+            v1 = create(:quote_version, :voided, quote:, organization:)
+            v2 = create(:quote_version, :draft, quote:, organization:)
+            [v1, v2]
+          end
+        end
+        let(:quote_version) { versions.last }
+
+        it "creates an clone and voids the original quote version" do
+          expect(result).to be_success
+          cloned = result.quote_version
+          expect(cloned.id).not_to eq(quote_version.id)
+          expect(cloned.organization_id).to eq(quote_version.organization_id)
+          expect(cloned.quote_id).to eq(quote_version.quote_id)
+          expect(cloned.version).to eq(quote_version.version + 1)
+          expect(cloned.draft?).to eq(true)
+          expect(cloned.void_reason).to eq(nil)
+          expect(cloned.voided_at).to eq(nil)
+          expect(cloned.approved_at).to eq(nil)
+
+          expect(quote.reload.current_version).to eq(cloned)
+
+          quote_version.reload
+          expect(quote_version.voided?).to eq(true)
+          expect(quote_version.void_reason).to eq("superseded")
+          expect(quote_version.voided_at).not_to eq(nil)
+        end
+      end
+    end
+
+    context "when the quote version is not clonable", :premium do
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+      it "does not create a clone" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+
+        quote_version.reload
+        expect(quote_version.approved?).to eq(true)
+        expect(quote_version.void_reason).to eq(nil)
+        expect(quote_version.voided_at).to eq(nil)
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe QuoteVersions::CloneService do
 
       it "rejects the clone" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
         expect(result.error.code).to eq("inappropriate_state")
       end
     end
@@ -93,8 +93,30 @@ RSpec.describe QuoteVersions::CloneService do
 
       it "rejects the clone because the quote is locked by an approved version" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
         expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+
+    context "when an unrelated draft is the active version on the quote", :premium do
+      let!(:versions) do
+        QuoteVersion.transaction do
+          v_voided = create(:quote_version, :voided, quote:, organization:)
+          v_active = create(:quote_version, quote:, organization:)
+          [v_voided, v_active]
+        end
+      end
+      let(:quote_version) { versions.first } # cloning the older voided one
+
+      it "rejects the clone because the active version is not the source" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+
+        versions.last.reload
+        expect(versions.last.draft?).to eq(true)
+        expect(versions.last.voided_at).to eq(nil)
       end
     end
 

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe QuoteVersions::CloneService do
     let(:result) { clone_service.call }
 
     context "when the quote version is clonable", :premium do
-      context "when the quote version is already voided" do
-        it "creates a clone and doesn't override the original quote version" do
+      context "when the source version is voided" do
+        it "creates a clone and leaves the source untouched" do
           expect(result).to be_success
           cloned = result.quote_version
           expect(cloned.id).not_to eq(quote_version.id)
@@ -42,27 +42,21 @@ RSpec.describe QuoteVersions::CloneService do
         end
       end
 
-      context "when the quote version is draft" do
+      context "when the source version is draft" do
         let!(:versions) do
           QuoteVersion.transaction do
             v1 = create(:quote_version, :voided, quote:, organization:)
-            v2 = create(:quote_version, :draft, quote:, organization:)
+            v2 = create(:quote_version, quote:, organization:)
             [v1, v2]
           end
         end
-        let(:quote_version) { versions.last }
 
-        it "creates an clone and voids the original quote version" do
+        it "creates a clone and voids the source" do
           expect(result).to be_success
           cloned = result.quote_version
           expect(cloned.id).not_to eq(quote_version.id)
-          expect(cloned.organization_id).to eq(quote_version.organization_id)
-          expect(cloned.quote_id).to eq(quote_version.quote_id)
           expect(cloned.version).to eq(quote_version.version + 1)
           expect(cloned.draft?).to eq(true)
-          expect(cloned.void_reason).to eq(nil)
-          expect(cloned.voided_at).to eq(nil)
-          expect(cloned.approved_at).to eq(nil)
 
           expect(quote.reload.current_version).to eq(cloned)
 
@@ -74,22 +68,37 @@ RSpec.describe QuoteVersions::CloneService do
       end
     end
 
-    context "when the quote version is not clonable", :premium do
-      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+    context "when any quote version is already approved", :premium do
+      let!(:versions) do
+        [create(:quote_version, :approved, quote:, organization:)]
+      end
+      let(:quote_version) { versions.first }
 
-      it "does not create a clone" do
+      it "rejects the clone" do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
         expect(result.error.code).to eq("inappropriate_state")
-
-        quote_version.reload
-        expect(quote_version.approved?).to eq(true)
-        expect(quote_version.void_reason).to eq(nil)
-        expect(quote_version.voided_at).to eq(nil)
       end
     end
 
-    context "when quote does not exist", :premium do
+    context "when an older voided version is cloned but the latest is approved", :premium do
+      let!(:versions) do
+        QuoteVersion.transaction do
+          v1 = create(:quote_version, :voided, quote:, organization:)
+          v2 = create(:quote_version, :approved, quote:, organization:)
+          [v1, v2]
+        end
+      end
+      let(:quote_version) { versions.first }
+
+      it "rejects the clone because the quote is locked by an approved version" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when quote_version does not exist", :premium do
       let(:quote_version) { nil }
 
       it "returns a not found error" do

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -98,7 +98,6 @@ RSpec.describe QuoteVersions::CloneService do
       end
     end
 
-
     context "when an unrelated draft is the active version on the quote", :premium do
       let!(:versions) do
         QuoteVersion.transaction do

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -3,23 +3,16 @@
 require "rails_helper"
 
 RSpec.describe QuoteVersions::CreateService do
-  subject(:create_service) {
-    described_class.new(
-      organization:,
-      quote:,
-      params: create_params
-    )
-  }
+  subject(:create_service) do
+    described_class.new(quote:, params: create_params)
+  end
 
   let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
   let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
-  let(:create_params) {
-    {
-      billing_items: {},
-      content: "Test content"
-    }
-  }
+  let(:create_params) do
+    {billing_items: {}, content: "Test content"}
+  end
 
   describe ".call" do
     let(:result) { create_service.call }
@@ -37,18 +30,6 @@ RSpec.describe QuoteVersions::CreateService do
       end
     end
 
-    context "when organization does not exist", :premium do
-      let(:organization) { nil }
-      let(:customer) { create(:customer) }
-      let(:quote) { create(:quote) }
-
-      it "returns a not found error" do
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::NotFoundFailure)
-        expect(result.error.message).to eq("organization_not_found")
-      end
-    end
-
     context "when quote does not exist", :premium do
       let(:quote) { nil }
 
@@ -60,6 +41,16 @@ RSpec.describe QuoteVersions::CreateService do
     end
 
     context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "when feature flag is disabled", :premium do
+      let(:organization) { create(:organization) }
+
       it "returns forbidden status" do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ForbiddenFailure)

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::CreateService do
+  subject(:create_service) {
+    described_class.new(
+      organization:,
+      quote:,
+      params: create_params
+    )
+  }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:create_params) {
+    {
+      billing_items: {},
+      content: "Test content"
+    }
+  }
+
+  describe ".call" do
+    let(:result) { create_service.call }
+
+    context "when license is premium", :premium do
+      it "creates draft quote version" do
+        expect(result).to be_success
+        expect(result.quote_version.quote_id).to eq(quote.id)
+        expect(result.quote_version.organization_id).to eq(quote.organization_id)
+        expect(result.quote_version.version).to eq(1)
+        expect(result.quote_version.draft?).to eq(true)
+        expect(result.quote_version.content).to eq("Test content")
+        expect(result.quote_version.share_token).not_to be_nil
+        expect(result.quote_version.billing_items).to eq({})
+      end
+    end
+
+    context "when organization does not exist", :premium do
+      let(:organization) { nil }
+      let(:customer) { create(:customer) }
+      let(:quote) { create(:quote) }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("organization_not_found")
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -40,6 +40,40 @@ RSpec.describe QuoteVersions::CreateService do
       end
     end
 
+
+    context "when an active draft version already exists for the quote", :premium do
+      before { create(:quote_version, quote:, organization:) }
+
+      it "rejects with active_version_exists" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("active_version_exists")
+      end
+    end
+
+    context "when an approved version already exists for the quote", :premium do
+      before { create(:quote_version, :approved, quote:, organization:) }
+
+      it "rejects with active_version_exists" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("active_version_exists")
+      end
+    end
+
+    context "when a concurrent insert wins the unique-index race", :premium do
+      it "translates the RecordNotUnique into active_version_exists" do
+        allow(quote.versions).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+        allow(create_service).to receive(:active_version_exists?).and_return(false)
+        # The service holds its own reference to `quote`, so stub it via the instance.
+        allow(create_service).to receive(:quote).and_return(quote)
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("active_version_exists")
+      end
+    end
+
     context "when license is not premium" do
       it "returns forbidden status" do
         expect(result).not_to be_success

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe QuoteVersions::CreateService do
       end
     end
 
-
     context "when an active draft version already exists for the quote", :premium do
       before { create(:quote_version, quote:, organization:) }
 
@@ -64,9 +63,6 @@ RSpec.describe QuoteVersions::CreateService do
     context "when a concurrent insert wins the unique-index race", :premium do
       it "translates the RecordNotUnique into active_version_exists" do
         allow(quote.versions).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
-        allow(create_service).to receive(:active_version_exists?).and_return(false)
-        # The service holds its own reference to `quote`, so stub it via the instance.
-        allow(create_service).to receive(:quote).and_return(quote)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ForbiddenFailure)

--- a/spec/services/quote_versions/update_service_spec.rb
+++ b/spec/services/quote_versions/update_service_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::UpdateService do
+  subject(:update_service) { described_class.new(quote_version:, params: update_params) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, organization:) }
+  let(:quote_version) { create(:quote_version, quote:, organization:) }
+  let(:update_params) {
+    {
+      billing_items: {},
+      content: "Test content"
+    }
+  }
+
+  describe ".call" do
+    let(:result) { update_service.call }
+
+    context "when draft quote version", :premium do
+      it "updates the quote version" do
+        expect(result).to be_success
+        expect(result.quote_version.id).to eq(quote_version.id)
+        expect(result.quote_version.quote_id).to eq(quote_version.quote_id)
+        expect(result.quote_version.organization_id).to eq(quote_version.organization_id)
+        expect(result.quote_version.version).to eq(quote_version.version)
+        expect(result.quote_version.draft?).to eq(true)
+        expect(result.quote_version.billing_items).to eq({})
+        expect(result.quote_version.content).to eq("Test content")
+      end
+    end
+
+    context "when approved quote version", :premium do
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when voided quote version", :premium do
+      let(:quote_version) { create(:quote_version, :voided, quote:, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when quote version does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::VoidService do
+  subject(:void_service) { described_class.new(quote_version:, reason:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote_version) { create(:quote_version, organization:) }
+  let(:reason) { "manual" }
+
+  describe ".call" do
+    let(:result) { void_service.call }
+
+    context "when quote is voidable", :premium do
+      it "voides the quote" do
+        freeze_time do
+          expect(result).to be_success
+          expect(result.quote_version.voided?).to eq(true)
+          expect(result.quote_version.void_reason).to eq(reason)
+          expect(result.quote_version.voided_at).to eq(Time.current)
+          expect(result.quote_version.share_token).to eq(nil)
+          expect(result.quote_version.approved_at).to eq(nil)
+        end
+      end
+    end
+
+    context "when quote isn't voidable", :premium do
+      let(:quote_version) { create(:quote_version, :voided, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when reason is invalid", :premium do
+      context "when reason is blank" do
+        let(:reason) { nil }
+
+        it "returns validation failure" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:quote_version]).to eq(["invalid_void_reason"])
+        end
+      end
+
+      context "when reason is undefined" do
+        let(:reason) { "invalid_reason" }
+
+        it "returns validation failure" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:quote_version]).to eq(["invalid_void_reason"])
+        end
+      end
+    end
+
+    context "when quote_version does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe QuoteVersions::VoidService do
     let(:result) { void_service.call }
 
     context "when quote is voidable", :premium do
-      it "voides the quote" do
+      it "voids the quote version" do
         freeze_time do
           expect(result).to be_success
           expect(result.quote_version.voided?).to eq(true)
@@ -25,10 +25,20 @@ RSpec.describe QuoteVersions::VoidService do
       end
     end
 
+    context "when quote version is approved", :premium do
+      let(:quote_version) { create(:quote_version, :approved, organization:) }
+
+      it "is not voidable" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
     context "when quote isn't voidable", :premium do
       let(:quote_version) { create(:quote_version, :voided, organization:) }
 
-      it "returns validation failure" do
+      it "returns method not allowed" do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
         expect(result.error.code).to eq("inappropriate_state")
@@ -42,7 +52,7 @@ RSpec.describe QuoteVersions::VoidService do
         it "returns validation failure" do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:quote_version]).to eq(["invalid_void_reason"])
+          expect(result.error.messages[:void_reason]).to eq(["invalid"])
         end
       end
 
@@ -52,7 +62,7 @@ RSpec.describe QuoteVersions::VoidService do
         it "returns validation failure" do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:quote_version]).to eq(["invalid_void_reason"])
+          expect(result.error.messages[:void_reason]).to eq(["invalid"])
         end
       end
     end

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::CreateService do
+  subject(:create_service) {
+    described_class.new(
+      organization:,
+      customer:,
+      subscription:,
+      params: create_params
+    )
+  }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:membership) { create(:membership, organization:) }
+  let(:owner) { membership.user }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { nil }
+  let(:create_params) {
+    {
+      billing_items: {},
+      content: "Test content",
+      order_type: :subscription_creation,
+      owners: [owner.id]
+    }
+  }
+
+  describe ".call" do
+    let(:result) { create_service.call }
+
+    context "when license is premium", :premium do
+      it "creates an empty draft quote" do
+        travel_to(DateTime.new(2025, 3, 11, 20, 0, 0)) do
+          expect(result).to be_success
+          expect(result.quote.organization_id).to eq(organization.id)
+          expect(result.quote.customer_id).to eq(customer.id)
+          expect(result.quote.sequential_id).to eq(1)
+          expect(result.quote.number).to eq("QT-2025-0001")
+          expect(result.quote.order_type).to eq("subscription_creation")
+          expect(result.quote.owner_ids).to eq([owner.id])
+
+          expect(result.quote.versions.size).to eq(1)
+          expect(result.quote.current_version.version).to eq(1)
+          expect(result.quote.current_version.draft?).to eq(true)
+          expect(result.quote.current_version.content).to eq("Test content")
+        end
+      end
+    end
+
+    context "when owners include invalid user ids", :premium do
+      let(:create_params) {
+        {
+          order_type: :subscription_creation,
+          owners: ["invalid_user_id"]
+        }
+      }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:quotes]).to eq(["invalid_owner"])
+      end
+    end
+
+    context "when organization does not exist", :premium do
+      let(:organization) { nil }
+      let(:customer) { create(:customer) }
+      let(:membership) { create(:membership) }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("organization_not_found")
+      end
+    end
+
+    context "when customer does not exist", :premium do
+      let(:customer) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("customer_not_found")
+      end
+    end
+
+    context "when subscription is required but not provided", :premium do
+      let(:create_params) { {order_type: "subscription_amendment"} }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("subscription_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -3,28 +3,28 @@
 require "rails_helper"
 
 RSpec.describe Quotes::CreateService do
-  subject(:create_service) {
+  subject(:create_service) do
     described_class.new(
       organization:,
       customer:,
       subscription:,
       params: create_params
     )
-  }
+  end
 
   let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
   let(:membership) { create(:membership, organization:) }
   let(:owner) { membership.user }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { nil }
-  let(:create_params) {
+  let(:create_params) do
     {
       billing_items: {},
       content: "Test content",
       order_type: :subscription_creation,
       owners: [owner.id]
     }
-  }
+  end
 
   describe ".call" do
     let(:result) { create_service.call }
@@ -48,18 +48,62 @@ RSpec.describe Quotes::CreateService do
       end
     end
 
-    context "when owners include invalid user ids", :premium do
-      let(:create_params) {
+    context "when subscription is required and provided correctly", :premium do
+      let(:subscription) { create(:subscription, organization:, customer:) }
+      let(:create_params) do
         {
-          order_type: :subscription_creation,
-          owners: ["invalid_user_id"]
+          billing_items: {},
+          content: "Amendment",
+          order_type: :subscription_amendment,
+          owners: [owner.id]
         }
-      }
+      end
+
+      it "creates the quote linked to the subscription" do
+        expect(result).to be_success
+        expect(result.quote.subscription_id).to eq(subscription.id)
+        expect(result.quote.order_type).to eq("subscription_amendment")
+      end
+    end
+
+    context "when subscription belongs to another customer", :premium do
+      let(:other_customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, organization:, customer: other_customer) }
+      let(:create_params) do
+        {order_type: :subscription_amendment, owners: [owner.id]}
+      end
+
+      it "returns subscription_not_found" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("subscription_not_found")
+      end
+    end
+
+    context "when subscription belongs to another organization", :premium do
+      let(:other_organization) { create(:organization, feature_flags: ["order_forms"]) }
+      let(:other_customer) { create(:customer, organization: other_organization) }
+      let(:subscription) { create(:subscription, organization: other_organization, customer: other_customer) }
+      let(:create_params) do
+        {order_type: :subscription_amendment, owners: [owner.id]}
+      end
+
+      it "returns subscription_not_found" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("subscription_not_found")
+      end
+    end
+
+    context "when owners include invalid user ids", :premium do
+      let(:create_params) do
+        {order_type: :subscription_creation, owners: ["invalid_user_id"]}
+      end
 
       it "returns validation failure" do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:quotes]).to eq(["invalid_owner"])
+        expect(result.error.messages[:owners]).to eq(["invalid"])
       end
     end
 
@@ -96,6 +140,16 @@ RSpec.describe Quotes::CreateService do
     end
 
     context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "when feature flag is disabled", :premium do
+      let(:organization) { create(:organization) }
+
       it "returns forbidden status" do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ForbiddenFailure)

--- a/spec/services/quotes/update_service_spec.rb
+++ b/spec/services/quotes/update_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::UpdateService do
+  subject(:update_service) { described_class.new(quote:, params: update_params) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:membership) { create(:membership, organization:) }
+  let(:owner) { membership.user }
+  let(:quote) { create(:quote, organization:) }
+  let(:update_params) {
+    {
+      owners: [owner.id]
+    }
+  }
+
+  describe ".call" do
+    let(:result) { update_service.call }
+
+    it "updates the quote", :premium do
+      expect(result).to be_success
+      expect(result.quote.id).to eq(quote.id)
+      expect(result.quote.organization_id).to eq(quote.organization_id)
+      expect(result.quote.customer_id).to eq(quote.customer_id)
+      expect(result.quote.sequential_id).to eq(quote.sequential_id)
+      expect(result.quote.number).to eq(quote.number)
+      expect(result.quote.owner_ids).to eq([owner.id])
+    end
+
+    context "when owners include invalid user ids", :premium do
+      let(:update_params) { {owners: ["invalid_user_id"]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:quotes]).to eq(["invalid_owner"])
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/update_service_spec.rb
+++ b/spec/services/quotes/update_service_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Quotes::UpdateService do
   let(:membership) { create(:membership, organization:) }
   let(:owner) { membership.user }
   let(:quote) { create(:quote, organization:) }
-  let(:update_params) {
-    {
-      owners: [owner.id]
-    }
-  }
+  let(:update_params) { {owners: [owner.id]} }
 
   describe ".call" do
     let(:result) { update_service.call }
@@ -34,7 +30,7 @@ RSpec.describe Quotes::UpdateService do
       it "returns validation failure" do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:quotes]).to eq(["invalid_owner"])
+        expect(result.error.messages[:owners]).to eq(["invalid"])
       end
     end
 


### PR DESCRIPTION
## Context

This PR lays the foundation for the upcoming _Quote_ feature, a premium offering that lets sales and finance teams formalize commercial intent with their customers before it becomes actual billing.

A quote represents one of three commercial moves:

- creating a new subscription
- amending an existing one
- selling a one-off

It goes through a review/approval workflow before any subscription or invoice is created on the customer's account.

The feature is hidden behind `License.premium?` and a new `order_forms` organization feature flag, and there is no public surface (API, GraphQL, webhooks) in this PR. Follow-up PRs will expose it.

## Description

### Domain model

```mermaid
classDiagram
    class Quote {
      +uuid id
      +uuid customer
      +uuid subscription
      +string number
      +enum order_type
    }
    class QuoteVersion {
      +uuid id
      +uuid quote_id
      +bigint version
      +enum status
      +jsonb billing_items
      +jsonb content
    }
    class QuoteOwner {
      +bigint id
      +uuid quote_id
      +uuid user_id
    }
    class User {
      +uuid id
      +string email
    }

    Quote "1" -- "0..*" QuoteVersion : has_many (versions)
    QuoteVersion --> Quote : belongs_to (quote_id)
    Quote "1" o-- "0..*" QuoteOwner : quote_owners
    User "1" o-- "0..*" QuoteOwner : quote_owners
    QuoteOwner --> User : belongs_to (user_id)
    QuoteOwner --> Quote : belongs_to (quote_id)
    Quote "1" -- "1" QuoteVersion : has_one (current_version)
    User "0..*" -- "0..*" Quote : owners (through QuoteOwner)
```

### Quotes

A quote is the commercial container shared with the customer. It is identified by a human-readable number of the form `QT-YYYY-####`, sequenced per organization so each tenant gets its own clean numbering. The same quote can be co-owned by multiple internal users (the sales reps, AEs, finance contacts working the deal), so collaboration on a single deal does not require duplicate records.

When a quote is created, the originating commercial intent (`subscription_creation`, `subscription_amendment`, `one_off`) is captured up front. Amendments must point at an existing subscription on the same customer; the service layer enforces that the customer/subscription actually belong to the organization driving the quote.

### Versions and lifecycle

Customers iterate. A quote therefore has a stack of versions, each carrying its own `billing_items` payload and free-form `content`, and only one of them can be _active_ (`draft` or `approved`) at any time. That invariant is enforced at the database level so two parallel edits cannot both end up active.

A version moves through a small lifecycle:

- `draft` - the working copy, freely editable, shareable with the customer via a unique `share_token`.
- `approved` - the customer has accepted the offer; the version becomes immutable and timestamped.
- `voided` - the version is no longer in play, with an explicit reason (`manual`, `superseded`, `cascade_of_expired`, `cascade_of_voided`) so the team always knows _why_ a quote went away.

Cloning is the supersession path: starting from the current draft, the service voids it with reason `superseded` and produces a fresh draft pre-filled with its content, so reps can iterate on a proposal without losing history. Cloning is refused once a version has been approved, to prevent accidentally overwriting a deal the customer already accepted.

### Premium gating and access control

Every quote-related action runs through a shared `OrderForms::Premium` gate, so the feature only lights up when both the premium license and the per-organization `order_forms` flag are on. A new `quotes` permission group covers `view`, `create`, `update`, `approve`, `clone`, and `void`, scoped to the appropriate roles (managers can act, finance can view).

### Out of scope

This PR is foundation only. No controllers, GraphQL, serializers, or webhooks. `SendWebhookJob` calls and the materialization step (`OrderForms::CreateService`, which will turn an approved version into a real subscription/invoice) are stubbed as `TODO`s and will land in follow-up PRs.
