### PR TITLE
perf(cursor pagination)

### DIFF
--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -9,6 +9,7 @@ module InvoiceIndex
     :amount_to,
     :billing_entity_codes,
     :currency,
+    :cursor,
     :invoice_type,
     :issuing_date_from,
     :issuing_date_to,
@@ -35,7 +36,8 @@ module InvoiceIndex
       organization: current_organization,
       pagination: {
         page: params[:page],
-        limit: params[:per_page] || PER_PAGE
+        limit: params[:per_page] || PER_PAGE,
+        cursor: params[:cursor]
       },
       search_term: params[:search_term],
       filters: {
@@ -66,6 +68,7 @@ module InvoiceIndex
           collection_name: "invoices",
           meta: pagination_metadata(
             result.invoices,
+            cursor: result.cursor,
             key: "invoices",
             organization_id: current_organization.id,
             params: params.permit(*WHITELIST)

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -8,7 +8,7 @@ module Pagination
   # The TTL for caching the number of records
   DEFAULT_TTL = 30.minutes.freeze
 
-  def pagination_metadata(records, **count_params)
+  def pagination_metadata(records, cursor: nil, **count_params)
     current_page = prev_page = next_page = total_pages = nil
     total_count = _count_total(**count_params) { records.total_count }
 
@@ -24,7 +24,8 @@ module Pagination
       "next_page" => next_page,
       "prev_page" => prev_page,
       "total_pages" => total_pages.to_i,
-      "total_count" => total_count
+      "total_count" => total_count,
+      "cursor" => cursor
     }
   end
 

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -13,6 +13,7 @@ module Resolvers
     argument :amount_to, Integer, required: false
     argument :billing_entity_ids, [ID], required: false
     argument :currency, Types::CurrencyEnum, required: false
+    argument :cursor, String, required: false
     argument :customer_external_id, String, required: false
     argument :customer_id, ID, required: false, description: "Uniq ID of the customer"
     argument :invoice_type, [Types::Invoices::InvoiceTypeEnum], required: false
@@ -38,6 +39,7 @@ module Resolvers
       amount_to: nil,
       billing_entity_ids: nil,
       currency: nil,
+      cursor: nil,
       customer_external_id: nil,
       customer_id: nil,
       invoice_type: nil,
@@ -58,7 +60,7 @@ module Resolvers
     )
       result = InvoicesQuery.call(
         organization: current_organization,
-        pagination: {page:, limit:},
+        pagination: {page:, limit:, cursor:},
         search_term:,
         filters: {
           amount_from:,

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -5,7 +5,7 @@ class BaseQuery < BaseService
   DEFAULT_PAGINATION_PARAMS = {page: nil, limit: nil}
   DEFAULT_ORDER = {created_at: :desc}
 
-  Pagination = Struct.new(:page, :limit, keyword_init: true)
+  Pagination = Struct.new(:page, :limit, :cursor, keyword_init: true)
   Filters = BaseFilters
 
   def initialize(organization:, pagination: DEFAULT_PAGINATION_PARAMS, filters: {}, search_term: nil, order: nil)
@@ -38,7 +38,8 @@ class BaseQuery < BaseService
 
     @pagination ||= Pagination.new(
       page: pagination_params[:page],
-      limit: pagination_params[:limit]
+      limit: pagination_params[:limit],
+      cursor: pagination_params[:cursor]
     )
   end
 
@@ -56,6 +57,25 @@ class BaseQuery < BaseService
   rescue Date::Error
     result.single_validation_failure!(field: field_name.to_sym, error_code: "invalid_date")
       .raise_if_error!
+  end
+
+  # Narrows the scope to records after the cursor position.
+  # Subclasses override this to apply a row-value comparison.
+  def apply_cursor(scope)
+    scope
+  end
+
+  # Builds a cursor hash from the last record of the result set.
+  # Subclasses override this to return the relevant sort-key values.
+  def build_cursor(_record)
+  end
+
+  def decode_cursor(encoded)
+    JSON.parse(Base64.decode64(encoded)).symbolize_keys
+  end
+
+  def encode_cursor(hash)
+    Base64.strict_encode64(hash.to_json)
   end
 
   # Apply consistent ordering across query objects

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -29,6 +29,7 @@ class InvoicesQuery < BaseQuery
 
     invoices = base_scope.result.includes(:customer).includes(file_attachment: :blob)
     invoices = with_customers_filter(invoices)
+    invoices = apply_cursor(invoices)
     invoices = paginate(invoices)
     invoices = apply_consistent_ordering(
       invoices,
@@ -54,12 +55,37 @@ class InvoicesQuery < BaseQuery
     invoices = with_settlements(invoices) if valid_settlements.present?
 
     result.invoices = invoices
+    last_record = invoices.last
+    result.cursor = encode_cursor(build_cursor(last_record)) if last_record
     result
   rescue BaseService::FailedResult
     result
   end
 
   private
+
+  # Sort order is (issuing_date DESC, created_at DESC, id ASC).
+  # DESC columns use a tuple comparison; the ASC tiebreaker (id) is handled separately
+  # because UUID does not support arithmetic negation.
+  def apply_cursor(scope)
+    return scope if pagination&.cursor.blank?
+
+    decoded = decode_cursor(pagination.cursor)
+    scope.where(
+      "(invoices.issuing_date, invoices.created_at) < (?, ?) " \
+      "OR ((invoices.issuing_date, invoices.created_at) = (?, ?) AND invoices.id > ?)",
+      decoded[:issuing_date], decoded[:created_at],
+      decoded[:issuing_date], decoded[:created_at], decoded[:id]
+    )
+  end
+
+  def build_cursor(record)
+    {
+      issuing_date: record.issuing_date.iso8601,
+      created_at: record.created_at.iso8601(6),
+      id: record.id
+    }
+  end
 
   def filters_contract
     @filters_contract ||= Queries::InvoicesQueryFiltersContract.new

--- a/app/services/base_result.rb
+++ b/app/services/base_result.rb
@@ -3,6 +3,8 @@
 class BaseResult
   include Result
 
+  attr_accessor :cursor
+
   class_attribute :attributes, default: [] # rubocop:disable ThreadSafety/ClassAndModuleAttributes
 
   def self.[](*attributes)

--- a/config/initializers/graphql_pagination.rb
+++ b/config/initializers/graphql_pagination.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Extend CollectionMetadataType with a cursor field
+# to support cursor-based pagination across all collection types.
+GraphqlPagination::CollectionMetadataType.field(
+  :cursor,
+  String,
+  null: true,
+  description: "Cursor for the last record on the current page"
+)
+
+GraphqlPagination::CollectionMetadataType.define_method(:cursor) do
+  object.try(:cursor)
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1171,6 +1171,11 @@ type CollectionMetadata {
   currentPage: Int!
 
   """
+  Cursor for the last record on the current page
+  """
+  cursor: String
+
+  """
   The number of items per page
   """
   limitValue: Int!
@@ -6874,6 +6879,11 @@ type Metadata {
   currentPage: Int!
 
   """
+  Cursor for the last record on the current page
+  """
+  cursor: String
+
+  """
   The number of items per page
   """
   limitValue: Int!
@@ -10052,6 +10062,7 @@ type Query {
     amountTo: Int
     billingEntityIds: [ID!]
     currency: CurrencyEnum
+    cursor: String
     customerExternalId: String
 
     """
@@ -12935,6 +12946,11 @@ type WalletCollectionMetadata {
   Current Page of loaded data
   """
   currentPage: Int!
+
+  """
+  Cursor for the last record on the current page
+  """
+  cursor: String
   customerActiveWalletsCount: Int!
 
   """

--- a/schema.json
+++ b/schema.json
@@ -7519,6 +7519,18 @@
               "deprecationReason": null
             },
             {
+              "name": "cursor",
+              "description": "Cursor for the last record on the current page",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "limitValue",
               "description": "The number of items per page",
               "args": [],
@@ -35771,6 +35783,18 @@
               "deprecationReason": null
             },
             {
+              "name": "cursor",
+              "description": "Cursor for the last record on the current page",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "limitValue",
               "description": "The number of items per page",
               "args": [],
@@ -53543,6 +53567,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "cursor",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "customerExternalId",
                   "description": null,
                   "type": {
@@ -68620,6 +68656,18 @@
                   "name": "Int",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "Cursor for the last record on the current page",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/controllers/concerns/pagination_spec.rb
+++ b/spec/controllers/concerns/pagination_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Pagination do
         "next_page" => 3,
         "prev_page" => 1,
         "total_pages" => 3,
-        "total_count" => 25
+        "total_count" => 25,
+        "cursor" => nil
       )
     end
   end
@@ -58,7 +59,8 @@ RSpec.describe Pagination do
         "next_page" => nil,
         "prev_page" => nil,
         "total_pages" => 0,
-        "total_count" => 0
+        "total_count" => 0,
+        "cursor" => nil
       )
     end
   end
@@ -102,7 +104,8 @@ RSpec.describe Pagination do
         "next_page" => 3,
         "prev_page" => 1,
         "total_pages" => 3,
-        "total_count" => 25
+        "total_count" => 25,
+        "cursor" => nil
       )
     end
   end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -147,6 +147,86 @@ RSpec.describe InvoicesQuery do
     end
   end
 
+  context "with cursor" do
+    let(:pagination) { {page: 1, limit: 10, cursor: cursor_value} }
+
+    let(:cursor_value) do
+      Base64.strict_encode64({
+        issuing_date: invoice_first.issuing_date.iso8601,
+        created_at: invoice_first.created_at.iso8601(6),
+        id: invoice_first.id
+      }.to_json)
+    end
+
+    it "excludes the cursor record and all records before it" do
+      expect(result).to be_success
+      # invoice_first is the cursor — excluded
+      expect(returned_ids).not_to include(invoice_first.id)
+      # invoice_fourth/fifth/sixth have issuing_date = today (before cursor in DESC) — excluded
+      expect(returned_ids).not_to include(invoice_fourth.id)
+      expect(returned_ids).not_to include(invoice_fifth.id)
+      expect(returned_ids).not_to include(invoice_sixth.id)
+      # invoice_second/third have older issuing_date (after cursor in DESC) — included
+      expect(returned_ids).to match_array([invoice_second.id, invoice_third.id])
+    end
+
+    it "returns a cursor for the result set" do
+      expect(result.cursor).to be_present
+      decoded = JSON.parse(Base64.decode64(result.cursor))
+      expect(decoded.keys).to match_array(%w[issuing_date created_at id])
+    end
+
+    context "when combined with page > 1" do
+      let(:pagination) { {page: 1, limit: 1, cursor: cursor_value} }
+
+      it "paginates within the cursor-scoped set" do
+        expect(result).to be_success
+        expect(result.invoices.count).to eq(1)
+        expect(result.invoices.total_count).to eq(2)
+      end
+    end
+
+    context "when cursor records share the same issuing_date and created_at" do
+      let(:invoice_second) do
+        create(
+          :invoice,
+          organization:,
+          id: "00000000-0000-0000-0000-000000000000",
+          status: "finalized",
+          payment_status: "pending",
+          customer: customer_second,
+          number: "2222222222",
+          issuing_date: invoice_first.issuing_date,
+          created_at: invoice_first.created_at
+        )
+      end
+
+      it "uses id as a tiebreaker" do
+        expect(result).to be_success
+        # invoice_second has a smaller UUID than invoice_first,
+        # so in ASC id order it comes before the cursor — excluded
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+      end
+    end
+  end
+
+  context "when result set is not empty" do
+    it "returns a cursor" do
+      expect(result).to be_success
+      expect(result.cursor).to be_present
+    end
+  end
+
+  context "when result set is empty" do
+    let(:filters) { {customer_id: SecureRandom.uuid} }
+
+    it "returns nil cursor" do
+      expect(result).to be_success
+      expect(result.cursor).to be_nil
+    end
+  end
+
   context "when filtering by draft status" do
     let(:filters) { {status: "draft"} }
 

--- a/spec/requests/api/v1/subscriptions/alerts_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/alerts_controller_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Api::V1::Subscriptions::AlertsController do
           next_page: nil,
           prev_page: nil,
           total_pages: 1,
-          total_count: 1
+          total_count: 1,
+          cursor: nil
         })
       end
     end

--- a/spec/support/shared_examples/invoice_index.rb
+++ b/spec/support/shared_examples/invoice_index.rb
@@ -56,7 +56,8 @@ RSpec.shared_examples "an invoice index endpoint" do
         next_page: 2,
         prev_page: nil,
         total_pages: 2,
-        total_count: 2
+        total_count: 2,
+        cursor: nil
       )
     end
   end

--- a/spec/support/shared_examples/invoice_index.rb
+++ b/spec/support/shared_examples/invoice_index.rb
@@ -57,7 +57,7 @@ RSpec.shared_examples "an invoice index endpoint" do
         prev_page: nil,
         total_pages: 2,
         total_count: 2,
-        cursor: nil
+        cursor: be_a(String)
       )
     end
   end


### PR DESCRIPTION
> The interesting point here is that we use ordering by `id:uuid` which for `uuid v4` is meaningless. We could/should use v7 uuid across the application to support that kinf kind of queries.

# Context

The `InvoicesQuery` sorts by `(issuing_date DESC, created_at DESC, id ASC)` and uses Kaminari's `page(N).per(M)` for offset-based pagination. The API response includes `current_page`, `next_page`, `prev_page`, `total_pages`, and `total_count`.

Two problems:

1. No composite index matches the sort order. PostgreSQL must perform a full sort on every request.
2. With `OFFSET N`, PostgreSQL must sort and discard N rows before returning results. For deep pages this cost grows linearly.

Adding a composite index solves problem 1 and enables cursor-based pagination that solves problem 2.

The cursor does **not replace** offset pagination but **supplements** it. Every response returns an encoded cursor. If the client passes a cursor, the query narrows the working set to records after that position, then applies the regular `page`/`per_page` logic within the narrowed set. Clients that ignore the cursor see no change.

# Solution

## Sort/Cursor index

Add a composite B-tree index on `invoices` that matches the default sort order and is scoped to the tenant:

```sql
CREATE INDEX CONCURRENTLY index_invoices_on_org_issuing_date_created_at_id
  ON invoices (organization_id, issuing_date DESC, created_at DESC, id ASC)
```

This index serves two purposes:
- Eliminates the sort step for the default `ORDER BY`
- Enables efficient index seek for cursor-based pagination via row-value comparison

## Cursor encoding

The cursor is a Base64-encoded JSON object containing the three sort-key values of the last record on the current page:

```json
{"issuing_date": "2025-01-15", "created_at": "2025-01-15T10:30:00Z", "id": "uuid"}
```

Encoded as a single opaque string.

## Request flow

1. Client sends `GET /invoices` (no cursor) — standard offset query (the `1`-st page of `100` records by default).
2. Response includes `meta.cursor` with the encoded position of the last returned record.
3. On the next request the client sends `GET /invoices?cursor=<value>&per_page=20` — the query adds a `WHERE` clause to exclude all records at or before the cursor, then applies the regular `page`/`per_page` pagination within the remaining set.
4. The client can still use `page` > 1 with a cursor — this means "page N within the set starting after cursor".

# QA (regression)

> Ensure backward-compatibility to the existing UI

The search behavior must remain identical across all surfaces that use `search_term`. No UI changes are expected — only the underlying query execution changes.

## Invoices list page (app)

- [x] Search by invoice number (full and partial) — verify correct results
- [x] Search by customer name — verify invoices of matching customers appear
- [x] Search by customer email — same
- [x] Search by customer external ID — same
- [x] Search by customer firstname / lastname — same
- [x] Search by partial UUID (invoice id) — verify the matching invoice appears
- [x] Empty search field — verify all invoices are returned (no filtering)
- [x] Search combined with filters (status, payment status, date range, currency, amount, billing entity) — verify both search and filters apply correctly
- [x] Search with pagination — verify results remain consistent across pages
- [x] Export invoices with active search term — verify the exported data matches the filtered list

## Customer invoices tab (app)

- [x] Search by invoice number within a specific customer's invoices tab — verify results
- [x] Verify that customer-field search is not applied (only invoice fields: `id`, `number`)
