### PR TITLE
chore: [MIGRATION] add `search_text` column to `customers`

### DIFF
--- a/app/jobs/database_migrations/backfill_customer_search_text_job.rb
+++ b/app/jobs/database_migrations/backfill_customer_search_text_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillCustomerSearchTextJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1_000
+
+    def perform
+      rows_updated = ActiveRecord::Base.connection.execute(<<~SQL.squish).cmd_tuples
+        UPDATE customers
+        SET search_text = CONCAT_WS(' ', name, firstname, lastname, external_id, email)
+        WHERE id IN (
+          SELECT id FROM customers
+          WHERE search_text = '' OR search_text IS NULL
+          LIMIT #{BATCH_SIZE}
+        )
+      SQL
+
+      if rows_updated.positive?
+        self.class.perform_later
+      else
+        Rails.logger.info("Finished backfilling customer search_text")
+      end
+    end
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -362,6 +362,7 @@ end
 #  payment_provider_code                        :string
 #  payment_receipt_counter                      :bigint           default(0), not null
 #  phone                                        :string
+#  search_text                                  :text
 #  shipping_address_line1                       :string
 #  shipping_address_line2                       :string
 #  shipping_city                                :string

--- a/db/migrate/20260306180434_add_search_text_to_customers.rb
+++ b/db/migrate/20260306180434_add_search_text_to_customers.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AddSearchTextToCustomers < ActiveRecord::Migration[8.0]
+  def up
+    add_column :customers, :search_text, :text
+
+    safety_assured do
+      execute <<-SQL
+        CREATE OR REPLACE FUNCTION restore_invariants_on_customers() RETURNS trigger AS $$
+          BEGIN
+            NEW.search_text := CONCAT_WS(' ', NEW.external_id, NEW.firstname, NEW.lastname, NEW.name, NEW.email);
+            RETURN NEW;
+          END;
+        $$ LANGUAGE plpgsql;
+      SQL
+
+      execute <<-SQL
+        CREATE TRIGGER restore_invariants
+        BEFORE INSERT OR UPDATE ON customers
+        FOR EACH ROW
+        EXECUTE FUNCTION restore_invariants_on_customers();
+      SQL
+    end
+  end
+
+  def down
+    execute <<-SQL
+      DROP TRIGGER IF EXISTS restore_invariants ON customers;
+    SQL
+
+    execute <<-SQL
+      DROP FUNCTION IF EXISTS restore_invariants_on_customers;
+    SQL
+
+    # rubocop: disable Lago/NoDropColumnOrTable
+    remove_column :customers, :search_text
+    # rubocop: enable Lago/NoDropColumnOrTable
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -279,6 +279,7 @@ ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_01a4c0c7db;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS fk_rails_019e2289e5;
 ALTER TABLE IF EXISTS ONLY public.payment_methods DROP CONSTRAINT IF EXISTS fk_rails_00e7a45b0b;
+DROP TRIGGER IF EXISTS restore_invariants ON public.customers;
 DROP TRIGGER IF EXISTS ensure_consistency ON public.roles;
 DROP TRIGGER IF EXISTS before_payment_receipt_insert ON public.payment_receipts;
 CREATE OR REPLACE VIEW public.flat_filters AS
@@ -1047,6 +1048,7 @@ DROP TABLE IF EXISTS public.active_storage_blobs;
 DROP TABLE IF EXISTS public.active_storage_attachments;
 DROP TABLE IF EXISTS partman.template_public_enriched_events;
 DROP FUNCTION IF EXISTS public.set_payment_receipt_number();
+DROP FUNCTION IF EXISTS public.restore_invariants_on_customers();
 DROP FUNCTION IF EXISTS public.ensure_role_consistency();
 DROP TYPE IF EXISTS public.usage_monitoring_alert_types;
 DROP TYPE IF EXISTS public.tax_status;
@@ -1324,6 +1326,20 @@ CREATE TYPE public.usage_monitoring_alert_types AS ENUM (
 CREATE FUNCTION public.ensure_role_consistency() RETURNS trigger
     LANGUAGE plpgsql
     AS $$ BEGIN IF OLD.organization_id IS NULL THEN RAISE EXCEPTION 'Predefined role cannot be modified'; ELSIF OLD.organization_id IS DISTINCT FROM NEW.organization_id THEN RAISE EXCEPTION 'Custom role cannot be moved to another organization'; ELSIF OLD.code IS DISTINCT FROM NEW.code THEN RAISE EXCEPTION 'The code of the role cannot be changed'; ELSIF NEW.permissions != OLD.permissions THEN NEW.permissions := ARRAY(SELECT DISTINCT unnest(NEW.permissions) ORDER BY 1); END IF; RETURN NEW; END; $$;
+
+
+--
+-- Name: restore_invariants_on_customers(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.restore_invariants_on_customers() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+          BEGIN
+            NEW.search_text := CONCAT_WS(' ', NEW.external_id, NEW.firstname, NEW.lastname, NEW.name, NEW.email);
+            RETURN NEW;
+          END;
+        $$;
 
 
 --
@@ -2102,6 +2118,7 @@ CREATE TABLE public.customers (
     subscription_invoice_issuing_date_anchor public.subscription_invoice_issuing_date_anchors,
     subscription_invoice_issuing_date_adjustment public.subscription_invoice_issuing_date_adjustments,
     awaiting_wallet_refresh boolean DEFAULT false NOT NULL,
+    search_text text,
     CONSTRAINT check_customers_on_invoice_grace_period CHECK ((invoice_grace_period >= 0)),
     CONSTRAINT check_customers_on_net_payment_term CHECK ((net_payment_term >= 0))
 );
@@ -9148,6 +9165,13 @@ CREATE TRIGGER ensure_consistency BEFORE UPDATE ON public.roles FOR EACH ROW EXE
 
 
 --
+-- Name: customers restore_invariants; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER restore_invariants BEFORE INSERT OR UPDATE ON public.customers FOR EACH ROW EXECUTE FUNCTION public.restore_invariants_on_customers();
+
+
+--
 -- Name: payment_methods fk_rails_00e7a45b0b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11315,6 +11339,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260311121245'),
+('20260306180434'),
 ('20260306115902'),
 ('20260305165936'),
 ('20260305161303'),

--- a/lib/tasks/migrations/customer_search_text.rake
+++ b/lib/tasks/migrations/customer_search_text.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :migrations do
+  desc "Backfill search_text for existing customers"
+  task backfill_customer_search_text: :environment do
+    DatabaseMigrations::BackfillCustomerSearchTextJob.perform_later
+  end
+end


### PR DESCRIPTION
Add a denormalized `search_text` column to the `customers` table along with a job to asynchronously backfill the data.

The `restore_invariants` trigger will keeps the data up to date by concatenating the `external_id`, `firstname`, `lastname`, `name`, and `email` fields.

This is the first preparation step for the https://github.com/getlago/lago-api/pull/5165 and should be released (including the OS release) before the main PR