### PR TITLE
fix(kafka): Fix Kafka error management

### DIFF
--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -85,7 +85,7 @@ module Utils
       return unless self.class.available?
 
       current_time = Time.current.iso8601[...-1]
-      Karafka.producer.produce_async(
+      KafkaProducer.produce_async(
         topic: ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"],
         key: "#{organization_id}--#{activity_id}",
         payload: {
@@ -105,11 +105,6 @@ module Utils
           external_subscription_id: external_subscription_id
         }.to_json
       )
-    rescue WaterDrop::Errors::MessageInvalidError => e
-      raise if ENV["SENTRY_DSN"].blank?
-
-      # Avoid raising error up to the end-user
-      Sentry.capture_exception(e)
     end
 
     def activity_source

--- a/app/services/utils/api_log.rb
+++ b/app/services/utils/api_log.rb
@@ -24,7 +24,7 @@ module Utils
       return unless self.class.available?
 
       current_time = Time.current.iso8601[...-1]
-      Karafka.producer.produce_async(
+      KafkaProducer.produce_async(
         topic: ENV["LAGO_KAFKA_API_LOGS_TOPIC"],
         key:,
         payload: {

--- a/app/services/utils/email_activity_log.rb
+++ b/app/services/utils/email_activity_log.rb
@@ -27,9 +27,6 @@ module Utils
 
     def produce
       enqueue_task if AVAILABLE && message.present? && organization_id.present?
-    rescue => e
-      Rails.logger.error("Failed to produce email activity log: #{e.message}")
-      nil
     end
 
     private
@@ -63,7 +60,7 @@ module Utils
         external_customer_id:,
         external_subscription_id: nil
       }
-      Karafka.producer.produce_async(
+      KafkaProducer.produce_async(
         topic: TOPIC,
         key: "#{organization_id}--#{activity_id}",
         payload: payload.to_json

--- a/app/services/utils/kafka_producer.rb
+++ b/app/services/utils/kafka_producer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Utils
+  class KafkaProducer
+    def self.produce_async(topic:, key:, payload:)
+      Karafka.producer.produce_async(topic:, key:, payload:)
+      true
+    rescue WaterDrop::Errors::MessageInvalidError,
+      WaterDrop::Errors::ProduceError => e
+      # The library will raise an error in two cases:
+      # 1. Message is invalid (e.g., too large, or missing required fields)
+      # 2. When the topic doesn't exist and the rdkafka producer has acknowledged it.
+      #    See https://github.com/confluentinc/librdkafka/blob/f21766ffb663e1a54ef2f014b02b51509c834c31/CONFIGURATION.md?plain=1#L22
+      # For all other cases, it will not raise as the message is produced async.
+      raise if ENV["SENTRY_DSN"].blank?
+
+      # Avoid raising error up to the end-user
+      Sentry.capture_exception(e)
+      false
+    end
+  end
+end

--- a/app/services/utils/security_log.rb
+++ b/app/services/utils/security_log.rb
@@ -66,7 +66,7 @@ module Utils
       return false unless self.class.available?
       return false unless @skip_organization_check || @organization.security_logs_enabled?
 
-      Karafka.producer.produce_async(
+      KafkaProducer.produce_async(
         topic: self.class.topic,
         key: @key,
         payload: {
@@ -82,8 +82,6 @@ module Utils
           created_at: @current_time
         }.to_json
       )
-
-      true
     end
 
     private

--- a/karafka.rb
+++ b/karafka.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# You can enable debug logging for Karafka by adding `debug: "topic"` to the `config.kafka` configuration. This will log
+# debug information about topics (unknown topics, topic metadata, etc.) which can be helpful for troubleshooting Kafka
+# connectivity issues locally.
+#
 class KarafkaApp < Karafka::App
   setup do |config|
     config.kafka = {

--- a/karafka.rb
+++ b/karafka.rb
@@ -36,6 +36,12 @@ class KarafkaApp < Karafka::App
     Sentry.capture_exception(event[:error])
   end
 
+  # Logs producer errors to Sentry.
+  Karafka.producer.monitor.subscribe "error.occurred" do |event|
+    Sentry.capture_exception(event[:error])
+    Rails.logger.error("Karafka producer error: #{event[:error].message}")
+  end
+
   if ENV["LAGO_KAFKA_EVENTS_CHARGED_IN_ADVANCE_TOPIC"].present?
     routes.draw do
       consumer_group :lago_events_charged_in_advance_consumer do

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -237,6 +237,37 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
           )
         end
       end
+
+      [
+        {exception: WaterDrop::Errors::ProduceError, message: "#<Rdkafka::RdkafkaError: Local: Unknown topic (unknown_topic)>"},
+        {exception: WaterDrop::Errors::MessageInvalidError, message: "Message is too large"}
+      ].each do |error_context|
+        exception = error_context[:exception]
+        message = error_context[:message]
+        context "when producer raises #{exception}" do
+          subject(:produce) { activity_log.produce(coupon, "coupon.created", activity_id: "activity-id") { result } }
+
+          let(:result) { BaseService::Result.new }
+
+          before do
+            allow(karafka_producer).to receive(:produce_async).and_raise(exception.new(message))
+          end
+
+          context "when sentry is configured", :sentry do
+            it "captures the exception and returns false" do
+              expect(produce).to be result
+              expect(sentry_events).to include_sentry_event(exception: exception, message: message)
+            end
+          end
+
+          context "when sentry is not configured" do
+            it "re-raises the error" do
+              expect { produce }.to raise_error(exception, message)
+              expect(sentry_events).to be_empty
+            end
+          end
+        end
+      end
     end
 
     context "when kafka is not configured" do
@@ -250,35 +281,35 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
         expect(karafka_producer).not_to have_received(:produce_async)
       end
     end
+  end
 
-    describe ".available?" do
-      subject { activity_log.available? }
+  describe ".available?" do
+    subject { activity_log.available? }
 
-      context "without clickhouse" do
-        before do
-          ENV["LAGO_CLICKHOUSE_ENABLED"] = nil
-        end
-
-        it { is_expected.to be_falsey }
+    context "without clickhouse" do
+      before do
+        ENV["LAGO_CLICKHOUSE_ENABLED"] = nil
       end
 
-      context "without kafka vars" do
-        before do
-          ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
-          ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = nil
-          ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
-        end
+      it { is_expected.to be_falsey }
+    end
 
-        it { is_expected.to be_falsey }
+    context "without kafka vars" do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
+        ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = nil
+        ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
       end
 
-      context "with everything configured", :kafka_configured do
-        before do
-          ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
-        end
+      it { is_expected.to be_falsey }
+    end
 
-        it { is_expected.to be_truthy }
+    context "with everything configured", :kafka_configured do
+      before do
+        ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
       end
+
+      it { is_expected.to be_truthy }
     end
   end
 

--- a/spec/services/utils/api_log_spec.rb
+++ b/spec/services/utils/api_log_spec.rb
@@ -101,41 +101,70 @@ RSpec.describe Utils::ApiLog do
       end
     end
 
-    describe ".available?" do
-      subject { api_log.available? }
+    [
+      {exception: WaterDrop::Errors::ProduceError, message: "#<Rdkafka::RdkafkaError: Local: Unknown topic (unknown_topic)>"},
+      {exception: WaterDrop::Errors::MessageInvalidError, message: "Message is too large"}
+    ].each do |error_context|
+      exception = error_context[:exception]
+      message = error_context[:message]
+      context "when producer raises #{exception}" do
+        subject(:produce) { api_log.produce(fake_request, fake_response, organization:) }
 
-      context "without clickhouse" do
         before do
-          ENV["LAGO_CLICKHOUSE_ENABLED"] = nil
+          allow(karafka_producer).to receive(:produce_async).and_raise(exception.new(message))
         end
 
-        it { is_expected.to be_falsey }
+        context "when sentry is configured", :sentry do
+          it "captures the exception and returns false" do
+            expect { produce }.not_to raise_error
+            expect(sentry_events).to include_sentry_event(exception: exception, message: message)
+          end
+        end
+
+        context "when sentry is not configured" do
+          it "re-raises the error" do
+            expect { produce }.to raise_error(exception, message)
+            expect(sentry_events).to be_empty
+          end
+        end
+      end
+    end
+  end
+
+  describe ".available?" do
+    subject { api_log.available? }
+
+    context "without clickhouse" do
+      before do
+        ENV["LAGO_CLICKHOUSE_ENABLED"] = nil
       end
 
-      context "without kafka vars" do
-        before do
-          ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
-          ENV["LAGO_KAFKA_API_LOGS_TOPIC"] = nil
-          ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
-        end
+      it { is_expected.to be_falsey }
+    end
 
-        it { is_expected.to be_falsey }
+    context "without kafka vars" do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
+        ENV["LAGO_KAFKA_API_LOGS_TOPIC"] = nil
+        ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
       end
 
-      context "with everything configured" do
-        before do
-          ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = "kafka"
-          ENV["LAGO_KAFKA_API_LOGS_TOPIC"] = "api_logs"
-          ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
-        end
+      it { is_expected.to be_falsey }
+    end
 
-        after do
-          ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
-          ENV["LAGO_KAFKA_API_LOGS_TOPIC"] = nil
-        end
-
-        it { is_expected.to be_truthy }
+    context "with everything configured" do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = "kafka"
+        ENV["LAGO_KAFKA_API_LOGS_TOPIC"] = "api_logs"
+        ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
       end
+
+      after do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
+        ENV["LAGO_KAFKA_API_LOGS_TOPIC"] = nil
+      end
+
+      it { is_expected.to be_truthy }
     end
   end
 end

--- a/spec/services/utils/email_activity_log_spec.rb
+++ b/spec/services/utils/email_activity_log_spec.rb
@@ -103,14 +103,35 @@ RSpec.describe Utils::EmailActivityLog, :capture_kafka_messages do
       expect(kafka_messages).to be_empty
     end
 
-    it "logs error and returns nil when kafka raises" do
-      allow(karafka_producer).to receive(:produce_async).and_raise(StandardError, "Kafka down")
-      allow(Rails.logger).to receive(:error)
+    [
+      {exception: WaterDrop::Errors::ProduceError, message: "#<Rdkafka::RdkafkaError: Local: Unknown topic (unknown_topic)>"},
+      {exception: WaterDrop::Errors::MessageInvalidError, message: "Message is too large"}
+    ].each do |error_context|
+      exception = error_context[:exception]
+      exception_message = error_context[:message]
+      context "when producer raises #{exception}" do
+        subject(:produce) { described_class.produce(document: invoice, message:) }
 
-      result = described_class.produce(document: invoice, message:)
+        let(:result) { BaseService::Result.new }
 
-      expect(result).to be_nil
-      expect(Rails.logger).to have_received(:error).with("Failed to produce email activity log: Kafka down")
+        before do
+          allow(karafka_producer).to receive(:produce_async).and_raise(exception.new(exception_message))
+        end
+
+        context "when sentry is configured", :sentry do
+          it "captures the exception and returns false" do
+            expect(produce).to eq false
+            expect(sentry_events).to include_sentry_event(exception: exception, message: exception_message)
+          end
+        end
+
+        context "when sentry is not configured" do
+          it "re-raises the error" do
+            expect { produce }.to raise_error(exception, exception_message)
+            expect(sentry_events).to be_empty
+          end
+        end
+      end
     end
 
     context "with credit_note document" do

--- a/spec/services/utils/kafka_producer_spec.rb
+++ b/spec/services/utils/kafka_producer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe Utils::KafkaProducer do
+  describe ".produce_async" do
+    subject(:produce_async) { described_class.produce_async(topic: "test_topic", key: "test_key", payload: "test_payload") }
+
+    it "produces the message on kafka and returns true" do
+      expect(produce_async).to be(true)
+      expect(karafka.produced_messages).to eq([
+        {
+          topic: "test_topic",
+          key: "test_key",
+          payload: "test_payload"
+        }
+      ])
+    end
+
+    [
+      {exception: WaterDrop::Errors::ProduceError, message: "#<Rdkafka::RdkafkaError: Local: Unknown topic (unknown_topic)>"},
+      {exception: WaterDrop::Errors::MessageInvalidError, message: "Message is too large"}
+    ].each do |error_context|
+      exception = error_context[:exception]
+      message = error_context[:message]
+
+      context "when producer raises #{exception}" do
+        before do
+          allow(Karafka.producer).to receive(:produce_async).and_raise(exception.new(message))
+        end
+
+        context "when sentry is configured", :sentry do
+          it "captures the exception and returns false" do
+            expect(produce_async).to be(false)
+            expect(sentry_events).to include_sentry_event(exception: exception, message: message)
+          end
+        end
+
+        context "when sentry is not configured" do
+          it "re-raises the error" do
+            expect { produce_async }.to raise_error(exception, message)
+            expect(sentry_events).to be_empty
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/utils/security_log_spec.rb
+++ b/spec/services/utils/security_log_spec.rb
@@ -271,5 +271,32 @@ RSpec.describe Utils::SecurityLog do
         end
       end
     end
+
+    [
+      {exception: WaterDrop::Errors::ProduceError, message: "#<Rdkafka::RdkafkaError: Local: Unknown topic (unknown_topic)>"},
+      {exception: WaterDrop::Errors::MessageInvalidError, message: "Message is too large"}
+    ].each do |error_context|
+      exception = error_context[:exception]
+      message = error_context[:message]
+      context "when producer raises #{exception}" do
+        before do
+          allow(karafka_producer).to receive(:produce_async).and_raise(exception.new(message))
+        end
+
+        context "when sentry is configured", :sentry do
+          it "captures the exception and returns false" do
+            expect(produce).to be false
+            expect(sentry_events).to include_sentry_event(exception: exception, message: message)
+          end
+        end
+
+        context "when sentry is not configured" do
+          it "re-raises the error" do
+            expect { produce }.to raise_error(exception, message)
+            expect(sentry_events).to be_empty
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,8 @@ else
   require "debug"
 end
 
+require "sentry/test_helper"
+require "sentry/rspec"
 require "webmock/rspec"
 require "simplecov"
 require "money-rails/test_helpers"
@@ -60,6 +62,13 @@ end
 
 ENV["STRIPE_API_VERSION"] ||= "2020-08-27"
 
+Sentry.init do |config|
+  config.dsn = "https://fake@sentry.io/123"
+  config.enabled_environments = ["production"]
+  config.environment = :test
+  config.transport.transport_class = Sentry::DummyTransport
+end
+
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods
@@ -77,6 +86,7 @@ RSpec.configure do |config|
   config.include ActiveStorageValidations::Matchers
   config.include Karafka::Testing::RSpec::Helpers
   config.include GraphQL::Testing::Helpers.for(LagoApiSchema)
+  config.include Sentry::TestHelper
 
   # NOTE: these files make real API calls and should be excluded from build
   #       run them manually when needed
@@ -200,6 +210,22 @@ RSpec.configure do |config|
 
   config.around(:example, :premium) do |example|
     lago_premium!(&example)
+  end
+
+  config.around(:each, :sentry) do |example|
+    present = ENV.key?("SENTRY_DSN")
+    value = ENV["SENTRY_DSN"]
+    ENV["SENTRY_DSN"] = "https://fake@sentry.io/123"
+
+    setup_sentry_test
+    example.run
+  ensure
+    teardown_sentry_test
+    if !present
+      ENV.delete("SENTRY_DSN")
+    else
+      ENV["SENTRY_DSN"] = value
+    end
   end
 
   config.around(:example, :bullet) do |example|


### PR DESCRIPTION
## Context

There's currently two issues with our Kafka message production implementation:

1. We currently do not log any Kafka async produce errors to Sentry.
2. Events are sent asynchronously so connection errors are not raised. However, `rdkafka's` [`topic.metadata.propagation.max.ms`](https://github.com/confluentinc/librdkafka/blob/f21766ffb663e1a54ef2f014b02b51509c834c31/CONFIGURATION.md?plain=1#L22) setting causes the producer to throw errors synchronously once a topic is confirmed non-existent after the propagation timeout.

## Description

This solves **1** by subscribing to the producer `error.occurred` events in `karafka.rb` to capture async producer errors in Sentry.

**2** is solved by cacthing the `WaterDrop::Errors::ProduceError` in the `Utils::*Log` classes and logging it to Sentry. Note that we now also rescue `WaterDrop::Errors::MessageInvalidError` for the `SecurityLog` to have a common behaviour with the other `*Log` classes.

A `:sentry` metadata was added to simplify the setup.