### PR TITLE
reset cache when refreshing subscription

### DIFF
--- a/app/services/subscriptions/flag_refreshed_service.rb
+++ b/app/services/subscriptions/flag_refreshed_service.rb
@@ -12,6 +12,7 @@ module Subscriptions
     def call
       customer = subscription.customer
       customer.flag_wallets_for_refresh
+      Subscriptions::ChargeCacheService.expire_for_subscription(subscription)
       date = Time.current.in_time_zone(customer.applicable_timezone).to_date
       UsageMonitoring::TrackSubscriptionActivityService.call(subscription:, date:)
 

--- a/spec/services/subscriptions/flag_refreshed_service_spec.rb
+++ b/spec/services/subscriptions/flag_refreshed_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Subscriptions::FlagRefreshedService, :premium do
 
   before do
     allow(UsageMonitoring::TrackSubscriptionActivityService).to receive(:call).and_call_original
+    allow(Subscriptions::ChargeCacheService).to receive(:expire_for_subscription)
     create(:wallet, customer:, organization:)
   end
 
@@ -18,6 +19,11 @@ RSpec.describe Subscriptions::FlagRefreshedService, :premium do
     it "marks customer as awaiting wallet refresh" do
       expect { subject }.to change { customer.reload.awaiting_wallet_refresh }.from(false).to(true)
       expect(result).to be_success
+    end
+
+    it "expires the charge cache for the subscription" do
+      subject
+      expect(Subscriptions::ChargeCacheService).to have_received(:expire_for_subscription).with(subscription)
     end
 
     it "tracks subscription activity" do


### PR DESCRIPTION
  ## Context

  When an event is received, two things happen in parallel:
  1. The event is sent to ClickHouse via Kafka for processing
  2. PostProcessService runs immediately: it expires the charge cache
     and creates a SubscriptionActivity

  The SubscriptionActivity is picked up by a clock job (every 1 min)
  which recalculates current usage and caches the result. The problem
  is that ClickHouse may not have merged the event yet at this point,
  so the cache gets rebuilt with stale data (missing the new event).

  Later, when ClickHouse finishes processing, the events-processor
  signals a subscription refresh via Redis. FlagRefreshedService picks
  this up and creates a new SubscriptionActivity — but it never expired
  the now-stale charge cache. So when the activity is processed, it
  reads the stale cached value instead of querying ClickHouse for
  fresh data.

  ## Description

  Expire the charge cache in FlagRefreshedService so that the stale
  cache built before ClickHouse merged the event gets cleared. This
  ensures the next usage calculation fetches fresh data from ClickHouse.