### PR TITLE
feat(multi-currency): Allow wallet to receive currency param

### DIFF
--- a/app/services/credits/applied_prepaid_credits_service.rb
+++ b/app/services/credits/applied_prepaid_credits_service.rb
@@ -198,7 +198,11 @@ module Credits
     end
 
     def wallets
-      @wallets ||= customer.wallets.active.includes(:wallet_targets).with_positive_balance.in_application_order
+      @wallets ||= begin
+        scope = customer.wallets.active.includes(:wallet_targets).with_positive_balance
+        scope = scope.where(balance_currency: invoice.currency) if invoice.currency.present?
+        scope.in_application_order
+      end
     end
   end
 end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -144,9 +144,8 @@ module Wallets
       params[:currency]
     end
 
-    # TODO: Replace :wallet_traceability with the proper multi_currency feature flag
     def multi_currency_enabled?
-      customer.organization.feature_flag_enabled?(:wallet_traceability)
+      customer.organization.feature_flag_enabled?(:multi_currency)
     end
 
     def valid?

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -61,11 +61,11 @@ module Wallets
       wallet = Wallet.new(attributes)
 
       ActiveRecord::Base.transaction do
-        if params[:currency].present?
-          Customers::UpdateCurrencyService.call!(customer: customer, currency: params[:currency])
+        if currency.present? && (!multi_currency_enabled? || customer.currency.blank?)
+          Customers::UpdateCurrencyService.call!(customer: customer, currency:)
         end
 
-        wallet.currency = wallet.customer.currency
+        wallet.currency = multi_currency_enabled? ? currency : wallet.customer.currency
         wallet.save!
 
         validate_wallet_initial_amount! wallet
@@ -138,6 +138,15 @@ module Wallets
 
     def organization_id
       params[:organization_id]
+    end
+
+    def currency
+      params[:currency]
+    end
+
+    # TODO: Replace :wallet_traceability with the proper multi_currency feature flag
+    def multi_currency_enabled?
+      customer.organization.feature_flag_enabled?(:wallet_traceability)
     end
 
     def valid?

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -65,7 +65,7 @@ module Wallets
           Customers::UpdateCurrencyService.call!(customer: customer, currency:)
         end
 
-        wallet.currency = multi_currency_enabled? ? currency : wallet.customer.currency
+        wallet.currency = multi_currency_enabled? ? (currency || wallet.customer.currency) : wallet.customer.currency
         wallet.save!
 
         validate_wallet_initial_amount! wallet

--- a/spec/services/credits/applied_prepaid_credits_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credits_service_spec.rb
@@ -664,10 +664,10 @@ RSpec.describe Credits::AppliedPrepaidCreditsService do
     context "when wallet currency does not match invoice currency" do
       let(:wallets) { [eur_wallet, usd_wallet] }
       let(:eur_wallet) do
-        create(:wallet, name: "eur wallet", customer:, balance_cents: 1000, currency: "EUR")
+        create(:wallet, :with_inbound_transaction, name: "eur wallet", customer:, balance_cents: 1000, currency: "EUR")
       end
       let(:usd_wallet) do
-        create(:wallet, name: "usd wallet", customer:, balance_cents: 1000, currency: "USD")
+        create(:wallet, :with_inbound_transaction, name: "usd wallet", customer:, balance_cents: 1000, currency: "USD")
       end
 
       it "only applies credits from wallets matching the invoice currency" do

--- a/spec/services/credits/applied_prepaid_credits_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credits_service_spec.rb
@@ -661,6 +661,35 @@ RSpec.describe Credits::AppliedPrepaidCreditsService do
       end
     end
 
+    context "when wallet currency does not match invoice currency" do
+      let(:wallets) { [eur_wallet, usd_wallet] }
+      let(:eur_wallet) do
+        create(:wallet, name: "eur wallet", customer:, balance_cents: 1000, currency: "EUR")
+      end
+      let(:usd_wallet) do
+        create(:wallet, name: "usd wallet", customer:, balance_cents: 1000, currency: "USD")
+      end
+
+      it "only applies credits from wallets matching the invoice currency" do
+        expect(result).to be_success
+        expect(result.wallet_transactions.count).to eq(1)
+        expect(result.wallet_transactions.first.wallet_id).to eq(eur_wallet.id)
+        expect(result.prepaid_credit_amount_cents).to eq(100)
+      end
+    end
+
+    context "when no wallets match the invoice currency" do
+      let(:wallets) do
+        [create(:wallet, name: "usd wallet", customer:, balance_cents: 1000, currency: "USD")]
+      end
+
+      it "returns early with no credits applied" do
+        expect(result).to be_success
+        expect(result.prepaid_credit_amount_cents).to eq(0)
+        expect(result.wallet_transactions).to eq([])
+      end
+    end
+
     context "when there is a concurrent lock" do
       before do
         stub_const("Customers::LockService::ACQUIRE_LOCK_TIMEOUT", 1.second)

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -298,6 +298,11 @@ RSpec.describe Wallets::CreateService do
         expect(customer.reload.currency).to eq("EUR")
       end
 
+      it "sets the wallet currency from customer" do
+        wallet = service_result.wallet
+        expect(wallet.currency).to eq(customer.reload.currency)
+      end
+
       context "when no currency is provided" do
         let(:params) do
           {
@@ -315,6 +320,80 @@ RSpec.describe Wallets::CreateService do
         it "returns an error" do
           expect(service_result).not_to be_success
           expect(service_result.error.messages[:currency]).to eq(["value_is_invalid"])
+        end
+      end
+    end
+
+    context "when customer already has a different currency" do
+      let(:customer_currency) { "USD" }
+
+      it "returns a currency mismatch error" do
+        expect(service_result).not_to be_success
+        expect(service_result.error.messages[:currency]).to eq(["currencies_does_not_match"])
+      end
+
+      it "does not update the customer currency" do
+        service_result
+        expect(customer.reload.currency).to eq("USD")
+      end
+    end
+
+    context "when customer already has the same currency" do
+      let(:customer_currency) { "EUR" }
+
+      it "creates the wallet successfully" do
+        expect(service_result).to be_success
+
+        wallet = service_result.wallet
+        expect(wallet.currency).to eq("EUR")
+      end
+
+      it "does not change the customer currency" do
+        service_result
+        expect(customer.reload.currency).to eq("EUR")
+      end
+    end
+
+    # TODO: Replace :wallet_traceability with the proper multi_currency feature flag
+    context "when multi currency is enabled" do
+      before { organization.update!(feature_flags: ["wallet_traceability"]) }
+
+      context "when customer does not have a currency" do
+        let(:customer_currency) { nil }
+
+        it "applies the currency to the customer" do
+          service_result
+          expect(customer.reload.currency).to eq("EUR")
+        end
+
+        it "sets the wallet currency from params" do
+          wallet = service_result.wallet
+          expect(wallet.currency).to eq("EUR")
+        end
+      end
+
+      context "when customer already has a different currency" do
+        let(:customer_currency) { "USD" }
+
+        it "does not update the customer currency" do
+          service_result
+          expect(customer.reload.currency).to eq("USD")
+        end
+
+        it "sets the wallet currency from params" do
+          wallet = service_result.wallet
+          expect(wallet.currency).to eq("EUR")
+        end
+      end
+
+      context "when customer already has the same currency" do
+        let(:customer_currency) { "EUR" }
+
+        it "creates the wallet successfully" do
+          expect(service_result).to be_success
+
+          wallet = service_result.wallet
+          expect(wallet.currency).to eq("EUR")
         end
       end
     end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -395,6 +395,29 @@ RSpec.describe Wallets::CreateService do
           expect(wallet.currency).to eq("EUR")
         end
       end
+
+      context "when currency param is nil and customer has a currency" do
+        let(:customer_currency) { "USD" }
+        let(:params) do
+          {
+            name: "New Wallet",
+            customer:,
+            organization_id: organization.id,
+            currency: nil,
+            rate_amount: "1.00",
+            expiration_at:,
+            paid_credits: "0.00",
+            granted_credits: "0.00"
+          }
+        end
+
+        it "falls back to the customer currency" do
+          expect(service_result).to be_success
+
+          wallet = service_result.wallet
+          expect(wallet.currency).to eq("USD")
+        end
+      end
     end
 
     context "when wallet have transaction metadata" do

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -354,9 +354,8 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
-    # TODO: Replace :wallet_traceability with the proper multi_currency feature flag
     context "when multi currency is enabled" do
-      before { organization.update!(feature_flags: ["wallet_traceability"]) }
+      before { organization.update!(feature_flags: ["multi_currency"]) }
 
       context "when customer does not have a currency" do
         let(:customer_currency) { nil }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                            
  - Refactor `Wallets::CreateService` to support multi-currency wallets behind the `multi-currency` feature flag                                  
    - When flag is **off**: existing behavior preserved — wallet inherits currency from customer                                                                                                                     
    - When flag is **on**: wallet uses currency from params directly, skips `UpdateCurrencyService` when customer already has a currency                                                                             
  - Add currency filter to `Credits::AppliedPrepaidCreditsService` — only wallets matching `invoice.currency` are used when applying prepaid credits                                                                 
  - Add tests for both changes covering flag on/off, currency mismatches, and no-match scenarios                                                                                                                     
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  - [ ] Verify wallet creation without feature flag assigns customer currency                                                                                                                                        
  - [ ] Verify wallet creation with feature flag assigns param currency regardless of customer currency
  - [ ] Verify prepaid credits are only applied from wallets matching invoice currency                                                                                                                               
  - [ ] Verify no credits are applied when no wallets match invoice currency                                                                                                                                         
  - [ ] Run full `spec/services/wallets/create_service_spec.rb`                                                                                                                                                      
  - [ ] Run full `spec/services/credits/applied_prepaid_credits_service_spec.rb` 