### PR TITLE
feat(multi-currency): split multiple subscriptions invoice per currency

### DIFF
--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -27,6 +27,7 @@ module Subscriptions
         next if billing_subscriptions.empty?
 
         subscription_groups = group_by_payment_method(billing_subscriptions)
+        subscription_groups = group_by_currency(subscription_groups)
 
         subscription_groups.each do |subscriptions|
           BillSubscriptionJob.perform_later(
@@ -519,6 +520,14 @@ module Subscriptions
           ) = DATE(:today#{at_time_zone(customer: "cus", billing_entity: "billing_entities")})
         GROUP BY invoice_subscriptions.subscription_id
       SQL
+    end
+
+    def group_by_currency(subscription_groups)
+      return subscription_groups unless organization.feature_flag_enabled?(:multi_currency)
+
+      subscription_groups.flat_map do |subscriptions|
+        subscriptions.group_by { |sub| sub.plan.amount_currency }.values
+      end
     end
 
     # NOTE: Returns array of subscription groups

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -442,6 +442,176 @@ RSpec.describe Subscriptions::OrganizationBillingService do
       end
     end
 
+    context "when grouping subscriptions by currency" do
+      let(:organization) { create(:organization, feature_flags: ["multi_currency"]) }
+      let(:interval) { :monthly }
+      let(:billing_time) { :anniversary }
+      let(:current_date) { subscription_at.next_month }
+
+      before { subscription.destroy }
+
+      context "when subscriptions have different currencies" do
+        let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }
+        let(:eur_plan) { create(:plan, organization:, interval:, amount_currency: "EUR") }
+
+        let(:usd_subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:eur_subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan: eur_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+
+        before do
+          usd_subscription
+          eur_subscription
+        end
+
+        it "produces separate billing jobs per currency" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([usd_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([eur_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+
+        context "without feature flag" do
+          let(:organization) { create(:organization) }
+
+          it "groups them into a single billing job" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with(
+                contain_exactly(usd_subscription, eur_subscription),
+                current_date.to_i,
+                invoicing_reason: :subscription_periodic
+              )
+          end
+        end
+      end
+
+      context "when subscriptions share the same currency" do
+        let(:plan1) { create(:plan, organization:, interval:, amount_currency: "USD") }
+        let(:plan2) { create(:plan, organization:, interval:, amount_currency: "USD") }
+
+        let(:subscription1) do
+          create(
+            :subscription,
+            customer:,
+            plan: plan1,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:subscription2) do
+          create(
+            :subscription,
+            customer:,
+            plan: plan2,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+
+        before do
+          subscription1
+          subscription2
+        end
+
+        it "groups them into a single billing job" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(
+              contain_exactly(subscription1, subscription2),
+              current_date.to_i,
+              invoicing_reason: :subscription_periodic
+            )
+        end
+      end
+
+      context "when combined with payment method grouping" do
+        let(:organization) { create(:organization, feature_flags: %w[multi_currency multiple_payment_methods]) }
+        let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }
+        let(:eur_plan) { create(:plan, organization:, interval:, amount_currency: "EUR") }
+
+        let(:usd_provider_subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider"
+          )
+        end
+        let(:usd_manual_subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "manual"
+          )
+        end
+        let(:eur_provider_subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan: eur_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider"
+          )
+        end
+
+        before do
+          usd_provider_subscription
+          usd_manual_subscription
+          eur_provider_subscription
+        end
+
+        it "produces separate billing jobs per payment method and currency" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([usd_provider_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([usd_manual_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([eur_provider_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+      end
+    end
+
     context "when grouping subscriptions by payment method" do
       let(:organization) { create(:organization, feature_flags: ["multiple_payment_methods"]) }
       let(:interval) { :monthly }


### PR DESCRIPTION
## Context

Lago is working on adding more flexibility into customer relations. The end-goal is to support parent/children associations between customers.

First step is to support multiple currencies per customer.  It will be possible that customer handles billing objects like wallet or subscription in different currencies.

## Description

This PR updates billing logic. If a customer has multiple subscriptions, we need to group them by currency (in addition to payment method).
