### PR TITLE
feat(multi-currency): adjust credit note logic for multi-currency flow

### DIFF
--- a/app/graphql/types/customers/credit_notes_balance.rb
+++ b/app/graphql/types/customers/credit_notes_balance.rb
@@ -5,8 +5,8 @@ module Types
     class CreditNotesBalance < Types::BaseObject
       graphql_name "CustomerCreditNotesBalance"
 
-      field :currency, Types::CurrencyEnum, null: false
       field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :currency, Types::CurrencyEnum, null: false
     end
   end
 end

--- a/app/graphql/types/customers/credit_notes_balance.rb
+++ b/app/graphql/types/customers/credit_notes_balance.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  module Customers
+    class CreditNotesBalance < Types::BaseObject
+      graphql_name "CustomerCreditNotesBalance"
+
+      field :currency, Types::CurrencyEnum, null: false
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+    end
+  end
+end

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -82,6 +82,10 @@ module Types
         GraphQL::Types::BigInt,
         null: false,
         description: "Credit notes credits balance available per customer"
+      field :credit_notes_balances,
+        [Types::Customers::CreditNotesBalance],
+        null: false,
+        description: "Credit notes credits balance available per customer per currency"
       field :credit_notes_credits_available_count,
         Integer,
         null: false,
@@ -151,6 +155,15 @@ module Types
 
       def credit_notes_balance_amount_cents
         object.credit_notes.finalized.sum("credit_notes.balance_amount_cents")
+      end
+
+      def credit_notes_balances
+        object.credit_notes
+          .finalized
+          .where("credit_notes.balance_amount_cents > 0")
+          .group("credit_notes.total_amount_currency")
+          .sum("credit_notes.balance_amount_cents")
+          .map { |currency, amount_cents| {currency:, amount_cents:} }
       end
 
       def billing_configuration

--- a/app/services/credits/credit_note_service.rb
+++ b/app/services/credits/credit_note_service.rb
@@ -73,6 +73,7 @@ module Credits
       customer.credit_notes
         .finalized
         .available
+        .where(total_amount_currency: invoice.currency)
         .where.not(invoice_id: invoice.id)
         .order(created_at: :asc)
         .to_a

--- a/schema.graphql
+++ b/schema.graphql
@@ -4303,6 +4303,11 @@ type Customer {
   creditNotesBalanceAmountCents: BigInt!
 
   """
+  Credit notes credits balance available per customer per currency
+  """
+  creditNotesBalances: [CustomerCreditNotesBalance!]!
+
+  """
   Number of available credits from credit notes per customer
   """
   creditNotesCreditsAvailableCount: Int!
@@ -4437,6 +4442,11 @@ type CustomerCollection {
   Pagination Metadata for navigating the Pagination
   """
   metadata: CollectionMetadata!
+}
+
+type CustomerCreditNotesBalance {
+  amountCents: BigInt!
+  currency: CurrencyEnum!
 }
 
 type CustomerMetadata {

--- a/schema.json
+++ b/schema.json
@@ -19061,6 +19061,30 @@
               "deprecationReason": null
             },
             {
+              "name": "creditNotesBalances",
+              "description": "Credit notes credits balance available per customer per currency",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CustomerCreditNotesBalance",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "creditNotesCreditsAvailableCount",
               "description": "Number of available credits from credit notes per customer",
               "args": [],
@@ -20093,6 +20117,49 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CustomerCreditNotesBalance",
+          "description": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
                   "ofType": null
                 }
               },

--- a/spec/graphql/types/customers/credit_notes_balance_spec.rb
+++ b/spec/graphql/types/customers/credit_notes_balance_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Customers::CreditNotesBalance do
+  subject { described_class }
+
+  it { is_expected.to have_field(:currency).of_type("CurrencyEnum!") }
+  it { is_expected.to have_field(:amount_cents).of_type("BigInt!") }
+end

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Types::Customers::Object do
 
     expect(subject).to have_field(:active_subscriptions_count).of_type("Int!")
     expect(subject).to have_field(:credit_notes_balance_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:credit_notes_balances).of_type("[CustomerCreditNotesBalance!]!")
     expect(subject).to have_field(:credit_notes_credits_available_count).of_type("Int!")
     expect(subject).to have_field(:has_active_wallet).of_type("Boolean!")
     expect(subject).to have_field(:has_credit_notes).of_type("Boolean!")

--- a/spec/services/credits/credit_note_service_spec.rb
+++ b/spec/services/credits/credit_note_service_spec.rb
@@ -139,6 +139,32 @@ RSpec.describe Credits::CreditNoteService do
       end
     end
 
+    context "when credit notes have a different currency than the invoice" do
+      let(:credit_note_usd) do
+        create(
+          :credit_note,
+          total_amount_cents: 30,
+          total_amount_currency: "USD",
+          balance_amount_cents: 30,
+          balance_amount_currency: "USD",
+          credit_amount_cents: 30,
+          credit_amount_currency: "USD",
+          customer:
+        )
+      end
+
+      before { credit_note_usd }
+
+      it "only applies credit notes matching the invoice currency" do
+        result = credit_service.call
+
+        expect(result).to be_success
+        expect(result.credits.count).to eq(2)
+        expect(result.credits.map(&:credit_note)).to match_array([credit_note1, credit_note2])
+        expect(credit_note_usd.reload.balance_amount_cents).to eq(30)
+      end
+    end
+
     context "when credit amount is higher than invoice amount" do
       let(:amount_cents) { 10 }
 


### PR DESCRIPTION
## Context

Lago is working on adding more flexibility into customer relations. The end-goal is to support parent/children associations between customers.

First step is to support multiple currencies per customer.  It will be possible that customer handles billing objects like wallet or subscription in different currencies.

## Description

This PR updates credit note logic. Filtering credit notes per currency is safe and backward-compatible (since currently we support only one currency per customer) and this PR can be merged without any feature flag.