### PR TITLE
feat(presentation group keys): POC with 2 requests

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -58,6 +58,7 @@ class Charge < ApplicationRecord
   validate :validate_custom_model
   validate :validate_invoiceable_unless_pay_in_advance
   validate :validate_accepts_target_wallet, if: -> { accepts_target_wallet_changed? }
+  validate :validate_presentation_group_keys
 
   default_scope -> { kept }
 
@@ -66,6 +67,10 @@ class Charge < ApplicationRecord
 
   def pricing_group_keys
     properties["pricing_group_keys"].presence || properties["grouped_by"]
+  end
+
+  def presentation_group_keys_values
+    properties["presentation_group_keys"]&.map { |el| el["value"] }
   end
 
   def equal_properties?(charge)
@@ -172,6 +177,15 @@ class Charge < ApplicationRecord
     return unless accepts_target_wallet
 
     errors.add(:accepts_target_wallet, :feature_unavailable) unless organization.events_targeting_wallets_enabled?
+  end
+
+  def validate_presentation_group_keys
+    raw_keys = properties["presentation_group_keys"]
+    return if raw_keys.blank?
+
+    unless raw_keys.is_a?(Array) && raw_keys.all? { |k| k.is_a?(Hash) && k.key?("value") }
+      errors.add(:properties, "presentation_group_keys must be an array of hashes with a 'value' key")
+    end
   end
 end
 

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -25,6 +25,7 @@ class Fee < ApplicationRecord
   has_one :billable_metric, -> { with_discarded }, through: :charge
   has_one :fixed_charge_add_on, -> { with_discarded }, class_name: "AddOn", through: :fixed_charge, source: :add_on
   has_one :customer, through: :subscription
+  has_one :presentation_breakdown, dependent: :destroy
   has_one :pricing_unit_usage, dependent: :destroy
   has_one :true_up_fee, class_name: "Fee", foreign_key: :true_up_parent_fee_id, dependent: :destroy
 

--- a/app/models/presentation_breakdown.rb
+++ b/app/models/presentation_breakdown.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class PresentationBreakdown < ApplicationRecord
+  belongs_to :organization
+  belongs_to :fee
+end
+
+# == Schema Information
+#
+# Table name: presentation_breakdowns
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  breakdowns      :jsonb            not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  fee_id          :uuid             not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_presentation_breakdowns_on_fee_id           (fee_id) UNIQUE
+#  index_presentation_breakdowns_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fee_id => fees.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/usage_filters.rb
+++ b/app/models/usage_filters.rb
@@ -11,28 +11,35 @@ class UsageFilters
   # skip_grouping    - when set, will ignore grouping by pricing_group_keys
   # full_usage       - when set, will ignore boundaries and will return usage since subscription.started_at
 
-  attr_reader :filter_by_charge_id, :filter_by_charge_code, :filter_by_group, :skip_grouping, :full_usage
+  attr_reader :filter_by_charge_id, :filter_by_charge_code, :filter_by_group,
+    :skip_grouping, :full_usage, :filter_by_presentation
 
   def self.init_from_params(params)
     group = params[:filter_by_group]
     group = JSON.parse(group) if group.is_a?(String)
     group = group.to_unsafe_h if group.respond_to?(:to_unsafe_h)
 
+    presentation = params[:filter_by_presentation]
+    presentation = JSON.parse(presentation) if presentation.is_a?(String)
+    presentation = Array(presentation) if presentation.present?
+
     new(
       filter_by_charge_id: params[:filter_by_charge_id],
       filter_by_charge_code: params[:filter_by_charge_code],
       filter_by_group: group,
       skip_grouping: ActiveModel::Type::Boolean.new.cast(params[:skip_grouping]),
-      full_usage: ActiveModel::Type::Boolean.new.cast(params[:full_usage])
+      full_usage: ActiveModel::Type::Boolean.new.cast(params[:full_usage]),
+      filter_by_presentation: presentation
     )
   end
 
-  def initialize(filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_group: nil, skip_grouping: false, full_usage: false)
+  def initialize(filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_group: nil, skip_grouping: false, full_usage: false, filter_by_presentation: nil)
     @filter_by_charge_id = filter_by_charge_id
     @filter_by_charge_code = filter_by_charge_code
     @filter_by_group = filter_by_group&.transform_values { |v| Array(v) }
     @skip_grouping = skip_grouping
     @full_usage = full_usage
+    @filter_by_presentation = filter_by_presentation
   end
 
   def has_charge_filter?

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -13,7 +13,8 @@ module V1
             charge: charge_data(fee),
             billable_metric: billable_metric_data(fee),
             filters: filters(fees),
-            grouped_usage: grouped_usage(fees)
+            grouped_usage: grouped_usage(fees),
+            presentation_breakdown: presentation_breakdown(fees)
           }
         end
       end
@@ -110,8 +111,13 @@ module V1
         {
           **usage_data.except(:amount_currency),
           grouped_by: grouped_fees.first.grouped_by,
-          filters: filters(grouped_fees)
+          filters: filters(grouped_fees),
+          presentation_breakdown: presentation_breakdown(grouped_fees)
         }
+      end
+
+      def presentation_breakdown(fees)
+        fees.flat_map { |f| f.presentation_breakdown&.breakdowns || [] }
       end
     end
   end

--- a/app/services/charge_models/filter_properties/base_service.rb
+++ b/app/services/charge_models/filter_properties/base_service.rb
@@ -64,6 +64,7 @@ module ChargeModels
         if charge_model
           attributes << :grouped_by if properties[:grouped_by].present? && properties[:pricing_group_keys].blank?
           attributes << :pricing_group_keys if properties[:pricing_group_keys].present?
+          attributes << :presentation_group_keys if properties[:presentation_group_keys].present?
         end
 
         attributes

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -366,7 +366,15 @@ module Fees
     end
 
     def compute_presentation_breakdowns(fees, charge_filter:)
-      presentation_keys = charge.presentation_group_keys_values
+      all_presentation_keys = charge.presentation_group_keys_values
+
+      presentation_keys = if usage_filters.filter_by_presentation.present?
+        all_presentation_keys & usage_filters.filter_by_presentation
+      else
+        all_presentation_keys
+      end
+
+      return if presentation_keys.blank?
 
       combined_filters = aggregation_filters(charge_filter:)
       combined_keys = ((combined_filters[:grouped_by] || []) + presentation_keys).uniq

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -119,6 +119,10 @@ module Fees
       # Preserve preloaded billable_metric on all fees (including cached ones) to avoid N+1 queries
       fees.each { |fee| fee.association(:billable_metric).target = billable_metric }
 
+      if charge.presentation_group_keys_values.present?
+        compute_presentation_breakdowns(fees.compact, charge_filter:)
+      end
+
       result.fees.concat(fees.compact)
     end
 
@@ -358,6 +362,45 @@ module Fees
           aggregation.current_amount = aggregation_result.custom_aggregation&.[](:amount)
           aggregation.save!
         end
+      end
+    end
+
+    def compute_presentation_breakdowns(fees, charge_filter:)
+      presentation_keys = charge.presentation_group_keys_values
+
+      combined_filters = aggregation_filters(charge_filter:)
+      combined_keys = ((combined_filters[:grouped_by] || []) + presentation_keys).uniq
+      combined_filters[:grouped_by] = combined_keys
+
+      combined_aggregator = BillableMetrics::AggregationFactory.new_instance(
+        charge:,
+        current_usage:,
+        subscription:,
+        boundaries: {
+          from_datetime: boundaries.charges_from_datetime,
+          to_datetime: boundaries.charges_to_datetime,
+          charges_duration: boundaries.charges_duration,
+          max_timestamp: boundaries.max_timestamp
+        },
+        filters: combined_filters
+      )
+      combined_result = combined_aggregator.aggregate(options: {})
+      return unless combined_result.success?
+
+      fees.each do |fee|
+        matching = (combined_result.aggregations || []).select do |agg|
+          fee.grouped_by.blank? || fee.grouped_by.all? { |k, v| agg.grouped_by[k] == v }
+        end
+
+        breakdowns = matching.map do |agg|
+          presentation_by = presentation_keys.index_with { |k| agg.grouped_by[k] }
+          {presentation_by:, units: agg.aggregation.to_s}
+        end
+
+        fee.build_presentation_breakdown(
+          organization_id: fee.organization_id,
+          breakdowns:
+        )
       end
     end
 

--- a/db/migrate/20260325150204_create_presentation_breakdowns.rb
+++ b/db/migrate/20260325150204_create_presentation_breakdowns.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreatePresentationBreakdowns < ActiveRecord::Migration[8.0]
+  def change
+    create_table :presentation_breakdowns, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :fee, null: false, foreign_key: true, type: :uuid, index: {unique: true}
+
+      t.jsonb :breakdowns, null: false, default: []
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11,6 +11,7 @@ SET row_security = off;
 
 ALTER TABLE IF EXISTS ONLY public.membership_roles DROP CONSTRAINT IF EXISTS membership_role_membership_fk;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_ff75b29299;
+ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_ff548a9f4c;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_fea16bf2e7;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaign_thresholds DROP CONSTRAINT IF EXISTS fk_rails_fd84cdb7c6;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_fd399a23d3;
@@ -78,6 +79,7 @@ ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails
 ALTER TABLE IF EXISTS ONLY public.applied_coupons DROP CONSTRAINT IF EXISTS fk_rails_bacb46d2a3;
 ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_rails_ba128983c2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_b974dac270;
+ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_b8f3cabc8e;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_b61aa73940;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_b50dc82c1e;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_b3864df641;
@@ -118,6 +120,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_8c18828b53;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_8c09ee2428;
 ALTER TABLE IF EXISTS ONLY public.invoice_metadata DROP CONSTRAINT IF EXISTS fk_rails_8bb5b094c4;
+ALTER TABLE IF EXISTS ONLY public.group_keys DROP CONSTRAINT IF EXISTS fk_rails_8b1b2a29a0;
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_89e1020aca;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT IF EXISTS fk_rails_8887954ec7;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_885dc100ef;
@@ -398,6 +401,8 @@ DROP INDEX IF EXISTS public.index_pricing_units_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_pricing_unit_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_fee_id;
+DROP INDEX IF EXISTS public.index_presentation_breakdowns_on_organization_id;
+DROP INDEX IF EXISTS public.index_presentation_breakdowns_on_fee_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id;
@@ -811,6 +816,7 @@ ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sec
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
+ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS presentation_breakdowns_pkey;
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS plans_taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS plans_pkey;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS pending_vies_checks_pkey;
@@ -924,6 +930,7 @@ DROP TABLE IF EXISTS public.recurring_transaction_rules;
 DROP TABLE IF EXISTS public.quantified_events;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
+DROP TABLE IF EXISTS public.presentation_breakdowns;
 DROP TABLE IF EXISTS public.pending_vies_checks;
 DROP TABLE IF EXISTS public.payment_receipts;
 DROP TABLE IF EXISTS public.payment_providers;
@@ -4395,6 +4402,20 @@ CREATE TABLE public.pending_vies_checks (
 
 
 --
+-- Name: presentation_breakdowns; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.presentation_breakdowns (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    fee_id uuid NOT NULL,
+    breakdowns jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: pricing_unit_usages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5527,6 +5548,14 @@ ALTER TABLE ONLY public.plans
 
 ALTER TABLE ONLY public.plans_taxes
     ADD CONSTRAINT plans_taxes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: presentation_breakdowns presentation_breakdowns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.presentation_breakdowns
+    ADD CONSTRAINT presentation_breakdowns_pkey PRIMARY KEY (id);
 
 
 --
@@ -8480,6 +8509,20 @@ CREATE INDEX index_plans_taxes_on_tax_id ON public.plans_taxes USING btree (tax_
 
 
 --
+-- Name: index_presentation_breakdowns_on_fee_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_presentation_breakdowns_on_fee_id ON public.presentation_breakdowns USING btree (fee_id);
+
+
+--
+-- Name: index_presentation_breakdowns_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_presentation_breakdowns_on_organization_id ON public.presentation_breakdowns USING btree (organization_id);
+
+
+--
 -- Name: index_pricing_unit_usages_on_fee_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10826,6 +10869,14 @@ ALTER TABLE ONLY public.entitlement_entitlements
 
 
 --
+-- Name: presentation_breakdowns fk_rails_b8f3cabc8e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.presentation_breakdowns
+    ADD CONSTRAINT fk_rails_b8f3cabc8e FOREIGN KEY (fee_id) REFERENCES public.fees(id);
+
+
+--
 -- Name: wallet_transactions_invoice_custom_sections fk_rails_b974dac270; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11359,6 +11410,14 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 
 ALTER TABLE ONLY public.fixed_charges_taxes
     ADD CONSTRAINT fk_rails_fea16bf2e7 FOREIGN KEY (fixed_charge_id) REFERENCES public.fixed_charges(id);
+
+
+--
+-- Name: presentation_breakdowns fk_rails_ff548a9f4c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.presentation_breakdowns
+    ADD CONSTRAINT fk_rails_ff548a9f4c FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --

--- a/spec/factories/presentation_breakdowns.rb
+++ b/spec/factories/presentation_breakdowns.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :presentation_breakdown do
+    organization { fee&.organization || association(:organization) }
+    fee factory: :charge_fee
+
+    breakdowns do
+      [
+        {presentation_by: {department: "engineering"}, units: "60.0"},
+        {presentation_by: {department: "sales"}, units: "40.0"}
+      ]
+    end
+  end
+end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Fee do
   it { is_expected.to have_one(:adjusted_fee).dependent(:nullify) }
   it { is_expected.to have_one(:billable_metric).through(:charge) }
   it { is_expected.to have_one(:customer).through(:subscription) }
+  it { is_expected.to have_one(:presentation_breakdown).dependent(:destroy) }
   it { is_expected.to have_one(:pricing_unit_usage).dependent(:destroy) }
   it { is_expected.to have_one(:true_up_fee).with_foreign_key(:true_up_parent_fee_id).class_name("Fee").dependent(:destroy) }
 

--- a/spec/models/presentation_breakdown_spec.rb
+++ b/spec/models/presentation_breakdown_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PresentationBreakdown do
+  subject { build(:presentation_breakdown) }
+
+  describe "associations" do
+    it do
+      is_expected.to belong_to(:organization)
+      is_expected.to belong_to(:fee)
+    end
+  end
+end

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
         aggregation_type: billable_metric.aggregation_type,
         grouped_by: {"card_type" => "visa"},
         charge_filter: nil,
-        pricing_unit_usage:
+        pricing_unit_usage:,
+        presentation_breakdown: nil
       )
     ]
   end
@@ -81,9 +82,11 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           "units" => "10.0",
           "total_aggregated_units" => "10.0",
           "grouped_by" => {"card_type" => "visa"},
-          "filters" => []
+          "filters" => [],
+          "presentation_breakdown" => []
         }
-      ]
+      ],
+      "presentation_breakdown" => []
     )
   end
 
@@ -128,9 +131,11 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
             "units" => "10.0",
             "total_aggregated_units" => "10.0",
             "grouped_by" => {"card_type" => "visa"},
-            "filters" => []
+            "filters" => [],
+            "presentation_breakdown" => []
           }
-        ]
+        ],
+        "presentation_breakdown" => []
       )
     end
   end
@@ -157,7 +162,8 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           grouped_by: {"card_type" => "visa"},
           charge_filter:,
           charge_filter_id: charge_filter.id,
-          pricing_unit_usage:
+          pricing_unit_usage:,
+          presentation_breakdown: nil
         )
       end
     end


### PR DESCRIPTION
the goal of this POC is to be able to compare approaches of having a separate request to get the presentation_breakdown (but having 2 requests per each charge filter), or have everything in one request and then retransform the data
current POC implements 2 requests approach

Note:
20k fees (20k events) were generated in 1.5min - test that was done 2 months ago
with this POC I had 5 charges with 10 pricing group keys in each (50 fees) with 200 presentation breakdowns inside - response was received in 6s

