### PR TITLE
fix(subscriptions): Return unauthorized if 3DS required for Stripe

### DIFF
--- a/app/services/payment_providers/stripe/payments/authorize_service.rb
+++ b/app/services/payment_providers/stripe/payments/authorize_service.rb
@@ -29,6 +29,10 @@ module PaymentProviders
 
           payment_intent = create_payment_intent
 
+          # TODO: Skip pre-auth for Indian customers — RBI mandates 3DS on every transaction,
+          #       which cannot be completed in a synchronous server-side flow.
+          #       The card will be validated on the first actual invoice charge instead.
+
           if payment_intent.status == "requires_action"
             return result.single_validation_failure!(
               field: :payment_intent,
@@ -67,6 +71,7 @@ module PaymentProviders
               amount:,
               currency: currency.downcase,
               confirm: true,
+              off_session: true,
               payment_method_options: {
                 card: {
                   capture_method: "manual"

--- a/app/services/payment_providers/stripe/payments/authorize_service.rb
+++ b/app/services/payment_providers/stripe/payments/authorize_service.rb
@@ -29,6 +29,13 @@ module PaymentProviders
 
           payment_intent = create_payment_intent
 
+          if payment_intent.status == "requires_action"
+            return result.single_validation_failure!(
+              field: :payment_intent,
+              error_code: "authorization_requires_action"
+            )
+          end
+
           result.stripe_payment_intent = payment_intent
 
           result

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -476,6 +476,25 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
             })
           end
         end
+
+        context "when the authorization requires 3D Secure" do
+          let(:stripe_pi) do
+            {
+              id: "pi_12345",
+              amount: "100",
+              amount_capturable: "0",
+              status: "requires_action"
+            }
+          end
+
+          it "returns an error and does not create the subscription" do
+            subject
+
+            expect(response).to have_http_status(:unprocessable_content)
+            expect(json[:error_details]).to include(payment_intent: ["authorization_requires_action"])
+            expect(Subscription.count).to eq(0)
+          end
+        end
       end
     end
 

--- a/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe PaymentProviders::Stripe::Payments::AuthorizeService do
     context "with provider_method_id" do
       let(:payment_intent) do
         Stripe::PaymentIntent.construct_from(
-          id: "pi_#{SecureRandom.hex(6)}"
+          id: "pi_#{SecureRandom.hex(6)}",
+          status: "requires_capture"
         )
       end
 
@@ -62,6 +63,30 @@ RSpec.describe PaymentProviders::Stripe::Payments::AuthorizeService do
         subject.call
 
         expect(PaymentProviders::CancelPaymentAuthorizationJob).to have_been_enqueued
+      end
+
+      context "when payment intent requires 3D Secure authentication" do
+        let(:payment_intent) do
+          Stripe::PaymentIntent.construct_from(
+            id: "pi_#{SecureRandom.hex(6)}",
+            status: "requires_action",
+            amount_capturable: 0
+          )
+        end
+
+        it "returns a failure" do
+          result = subject.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to include(payment_intent: ["authorization_requires_action"])
+        end
+
+        it "cancels the payment intent" do
+          subject.call
+
+          expect(PaymentProviders::CancelPaymentAuthorizationJob).to have_been_enqueued
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

When Stripe can't complete a pre-auth due to 3DS, it does not raise a StripeError. Instead, it returns a PaymentIntent with status: "requires_action". The AuthorizeService only catches Stripe::StripeError exceptions, so this case is treated as a success.

## Description

This PR adds a validation error if PaymentIntent status is "requires_action"