### PR TITLE
fix(invoices): Prevent duplicate PullTaxesAndApplyJob processing

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -5,6 +5,8 @@ module Invoices
     class PullTaxesAndApplyJob < ApplicationJob
       queue_as "providers"
 
+      unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+
       retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 6
       retry_on OpenSSL::SSL::SSLError, wait: :polynomially_longer, attempts: 6

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -34,6 +34,9 @@ module Invoices
         provider_taxes = taxes_result.fees
 
         ActiveRecord::Base.transaction do
+          invoice.reload
+          return result if invoice.finalized? || invoice.voided? || invoice.closed?
+
           unless invoice.draft?
             invoice.issuing_date = issuing_date
             invoice.payment_due_date = payment_due_date

--- a/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob do
     expect(Invoices::ProviderTaxes::PullTaxesAndApplyService).to have_received(:call)
   end
 
+  describe "unique" do
+    it "has unique :until_executed constraint" do
+      expect(described_class.lock_strategy_class).to eq(ActiveJob::Uniqueness::Strategies::UntilExecuted)
+    end
+  end
+
   describe "retry_on" do
     [
       [Customers::FailedToAcquireLock.new("customer-1-prepaid_credit"), 25],

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -141,6 +141,23 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
       end
     end
 
+    context "when invoice was finalized by a concurrent job" do
+      before do
+        allow(invoice).to receive(:reload).and_wrap_original do |method|
+          method.call
+          invoice.update(status: "finalized")
+          invoice
+        end
+      end
+
+      it "returns early without emitting webhook or activity log" do
+        result = pull_taxes_service.call
+
+        expect(result).to be_success
+        expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
+      end
+    end
+
     context "when taxes are fetched successfully" do
       it "marks the invoice as finalized" do
         expect { pull_taxes_service.call }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Add `unique :until_executed` constraint to `PullTaxesAndApplyJob` to prevent duplicate jobs for the same invoice from being processed concurrently                                                               
  - Add defense-in-depth guard in `PullTaxesAndApplyService`: reload invoice inside the transaction and return early if already finalized/voided/closed by a concurrent job                                          
                                                                                                                                                                                                                     
  ## Root cause                                                                                                                                                                                                      
                                                                                                                                                                                                                     
  During subscription termination, two `PullTaxesAndApplyJob` instances could race on the same invoice:                                                                                                              
                                                                                                                                                                                                                     
  1. Invoice created as draft with grace period, `ComputeTaxesAndTotalsService` enqueues Job A                                                                                                                       
  2. API finalize request resets fees and re-enqueues via `ComputeTaxesAndTotalsService` → Job B
  3. Both jobs pass the `pending? && tax_pending?` guards and finalize the invoice independently                                                                                                                     
  4. This produces duplicate `invoice.created` webhooks, activity logs, and conflicting sequential IDs                                                                                                               
   