### PR TITLE
perf(invoices): Preload offset_amount_cents for invoices collections

### DIFF
--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -59,9 +59,12 @@ module InvoiceIndex
     )
 
     if result.success?
+      invoices = result.invoices.includes(:metadata, :applied_taxes, :billing_entity, :applied_usage_thresholds)
+      Invoice.preload_offset_amounts(invoices)
+
       render(
         json: ::CollectionSerializer.new(
-          result.invoices.includes(:metadata, :applied_taxes, :billing_entity, :applied_usage_thresholds),
+          invoices,
           ::V1::InvoiceSerializer,
           collection_name: "invoices",
           meta: pagination_metadata(

--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -59,8 +59,9 @@ module InvoiceIndex
     )
 
     if result.success?
-      invoices = result.invoices.includes(:metadata, :applied_taxes, :billing_entity, :applied_usage_thresholds)
-      Invoice.preload_offset_amounts(invoices)
+      invoices = Invoice.preload_offset_amounts(
+        result.invoices.includes(:metadata, :applied_taxes, :billing_entity, :applied_usage_thresholds)
+      )
 
       render(
         json: ::CollectionSerializer.new(
@@ -68,7 +69,7 @@ module InvoiceIndex
           ::V1::InvoiceSerializer,
           collection_name: "invoices",
           meta: pagination_metadata(
-            result.invoices,
+            invoices,
             key: "invoices",
             organization_id: current_organization.id,
             params: params.permit(*WHITELIST)

--- a/app/graphql/resolvers/customer_portal/invoices_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/invoices_resolver.rb
@@ -25,6 +25,8 @@ module Resolvers
           }
         )
 
+        return result_error(result) unless result.success?
+
         invoices = result.invoices
         Invoice.preload_offset_amounts(invoices)
         invoices

--- a/app/graphql/resolvers/customer_portal/invoices_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/invoices_resolver.rb
@@ -27,9 +27,7 @@ module Resolvers
 
         return result_error(result) unless result.success?
 
-        invoices = result.invoices
-        Invoice.preload_offset_amounts(invoices)
-        invoices
+        Invoice.preload_offset_amounts(result.invoices)
       rescue ActiveRecord::RecordNotFound
         not_found_error(resource: "customer")
       end

--- a/app/graphql/resolvers/customer_portal/invoices_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/invoices_resolver.rb
@@ -25,7 +25,9 @@ module Resolvers
           }
         )
 
-        result.invoices
+        invoices = result.invoices
+        Invoice.preload_offset_amounts(invoices)
+        invoices
       rescue ActiveRecord::RecordNotFound
         not_found_error(resource: "customer")
       end

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -31,9 +31,7 @@ module Resolvers
 
         return result_error(result) unless result.success?
 
-        invoices = result.invoices
-        Invoice.preload_offset_amounts(invoices)
-        invoices
+        Invoice.preload_offset_amounts(result.invoices)
       rescue ActiveRecord::RecordNotFound
         not_found_error(resource: "customer")
       end

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -29,7 +29,9 @@ module Resolvers
           }
         )
 
-        result.invoices
+        invoices = result.invoices
+        Invoice.preload_offset_amounts(invoices)
+        invoices
       rescue ActiveRecord::RecordNotFound
         not_found_error(resource: "customer")
       end

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -29,6 +29,8 @@ module Resolvers
           }
         )
 
+        return result_error(result) unless result.success?
+
         invoices = result.invoices
         Invoice.preload_offset_amounts(invoices)
         invoices

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -82,7 +82,9 @@ module Resolvers
         }
       )
 
-      result.invoices
+      invoices = result.invoices
+      Invoice.preload_offset_amounts(invoices)
+      invoices
     end
   end
 end

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -82,6 +82,8 @@ module Resolvers
         }
       )
 
+      return result_error(result) unless result.success?
+
       invoices = result.invoices
       Invoice.preload_offset_amounts(invoices)
       invoices

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -84,9 +84,7 @@ module Resolvers
 
       return result_error(result) unless result.success?
 
-      invoices = result.invoices
-      Invoice.preload_offset_amounts(invoices)
-      invoices
+      Invoice.preload_offset_amounts(result.invoices)
     end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -164,6 +164,26 @@ class Invoice < ApplicationRecord
     %w[customer]
   end
 
+  # Batch-loads offset_amount_cents for a collection of invoices in a single query,
+  # caching the result on each instance to avoid N+1 queries during serialization.
+  def self.preload_offset_amounts(invoices)
+    return unless invoices
+
+    invoice_ids = invoices.map(&:id).compact
+
+    offset_amounts = CreditNote
+      .where(invoice_id: invoice_ids)
+      .finalized
+      .group(:invoice_id)
+      .sum(:offset_amount_cents)
+
+    invoices.each do |invoice|
+      invoice.precalculated_offset_amount_cents = (offset_amounts[invoice.id] || 0)
+    end
+
+    invoices
+  end
+
   def payment_invoices
     Invoice.where(id: id)
   end
@@ -294,24 +314,6 @@ class Invoice < ApplicationRecord
       number_of_days:,
       period_duration: date_service.charges_duration_in_days
     }
-  end
-
-  # Batch-loads offset_amount_cents for a collection of invoices in a single query,
-  # caching the result on each instance to avoid N+1 queries during serialization.
-  def self.preload_offset_amounts(invoices)
-    return unless invoices
-
-    invoice_ids = invoices.map(&:id).compact
-
-    offset_amounts = CreditNote
-      .where(invoice_id: invoice_ids)
-      .finalized
-      .group(:invoice_id)
-      .sum(:offset_amount_cents)
-
-    invoices.each do |invoice|
-      invoice.precalculated_offset_amount_cents = (offset_amounts[invoice.id] || 0)
-    end
   end
 
   def offset_amount_cents

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -154,6 +154,8 @@ class Invoice < ApplicationRecord
   validates :total_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :payment_dispute_lost_at, absence: true, unless: :payment_dispute_losable?
 
+  attr_writer :precalculated_offset_amount_cents
+
   def self.ransackable_attributes(_ = nil)
     %w[id number]
   end
@@ -294,10 +296,18 @@ class Invoice < ApplicationRecord
     }
   end
 
-  # Caches offset_amount_cents in the invoice instance to avoid N+1 queries when exporting invoices.
-  # Allows batch calculation of offset amounts for many invoices in a single aggregated query.
-  def save_precalculated_offset_amount_cents(offset_amount_cents)
-    @precalculated_offset_amount_cents = offset_amount_cents
+  # Batch-loads offset_amount_cents for a collection of invoices in a single query,
+  # caching the result on each instance to avoid N+1 queries during serialization.
+  def self.preload_offset_amounts(invoices)
+    offset_amounts = CreditNote
+      .where(invoice_id: invoices.map(&:id))
+      .finalized
+      .group(:invoice_id)
+      .sum(:offset_amount_cents)
+
+    invoices.each do |invoice|
+      invoice.precalculated_offset_amount_cents = (offset_amounts[invoice.id] || 0)
+    end
   end
 
   def offset_amount_cents

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -299,7 +299,7 @@ class Invoice < ApplicationRecord
   # Batch-loads offset_amount_cents for a collection of invoices in a single query,
   # caching the result on each instance to avoid N+1 queries during serialization.
   def self.preload_offset_amounts(invoices)
-    return if invoices.blank?
+    return unless invoices
 
     invoice_ids = invoices.map(&:id).compact
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -299,8 +299,12 @@ class Invoice < ApplicationRecord
   # Batch-loads offset_amount_cents for a collection of invoices in a single query,
   # caching the result on each instance to avoid N+1 queries during serialization.
   def self.preload_offset_amounts(invoices)
+    return if invoices.blank?
+
+    invoice_ids = invoices.map(&:id).compact
+
     offset_amounts = CreditNote
-      .where(invoice_id: invoices.map(&:id))
+      .where(invoice_id: invoice_ids)
       .finalized
       .group(:invoice_id)
       .sum(:offset_amount_cents)

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -101,9 +101,7 @@ module DataExports
       end
 
       def collection
-        invoices = Invoice.find(data_export_part.object_ids)
-        Invoice.preload_offset_amounts(invoices)
-        invoices
+        Invoice.preload_offset_amounts(Invoice.find(data_export_part.object_ids))
       end
 
       def organization

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -102,20 +102,7 @@ module DataExports
 
       def collection
         invoices = Invoice.find(data_export_part.object_ids)
-        preload_offset_amounts(invoices)
-      end
-
-      def preload_offset_amounts(invoices)
-        offset_amounts = CreditNote
-          .where(invoice_id: data_export_part.object_ids)
-          .finalized
-          .group(:invoice_id)
-          .sum(:offset_amount_cents)
-
-        invoices.each do |invoice|
-          invoice.save_precalculated_offset_amount_cents(offset_amounts[invoice.id] || 0)
-        end
-
+        Invoice.preload_offset_amounts(invoices)
         invoices
       end
 

--- a/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
@@ -68,6 +68,29 @@ RSpec.describe Resolvers::CustomerPortal::InvoicesResolver do
     end
   end
 
+  context "when preloading offset amounts" do
+    subject do
+      execute_graphql(
+        customer_portal_user: customer,
+        query:
+      )
+    end
+
+    let(:query) do
+      <<~GQL
+        query {
+          customerPortalInvoices(limit: 5) {
+            collection { id totalDueAmountCents totalSettledAmountCents }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+    let(:preloadable_invoices) { [draft_invoice, finalized_invoice] }
+
+    include_examples "preloads offset amounts"
+  end
+
   context "when query fails" do
     it "returns an error" do
       allow(InvoicesQuery).to receive(:call).and_return(

--- a/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
@@ -68,6 +68,21 @@ RSpec.describe Resolvers::CustomerPortal::InvoicesResolver do
     end
   end
 
+  context "when query fails" do
+    it "returns an error" do
+      allow(InvoicesQuery).to receive(:call).and_return(
+        BaseService::Result.new.tap { |r| r.validation_failure!(errors: {base: ["test_error"]}) }
+      )
+
+      result = execute_graphql(
+        customer_portal_user: customer,
+        query:
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity")
+    end
+  end
+
   context "without customer portal user" do
     it "returns an error" do
       result = execute_graphql(

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -94,6 +94,24 @@ RSpec.describe Resolvers::Customers::InvoicesResolver do
     end
   end
 
+  context "when query fails" do
+    it "returns an error" do
+      allow(InvoicesQuery).to receive(:call).and_return(
+        BaseService::Result.new.tap { |r| r.validation_failure!(errors: {base: ["test_error"]}) }
+      )
+
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customerId: customer.id}
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity")
+    end
+  end
+
   context "when customer does not exists" do
     it "returns no results" do
       result = execute_graphql(

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -94,6 +94,32 @@ RSpec.describe Resolvers::Customers::InvoicesResolver do
     end
   end
 
+  context "when preloading offset amounts" do
+    subject do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customerId: customer.id}
+      )
+    end
+
+    let(:query) do
+      <<~GQL
+        query($customerId: ID!) {
+          customerInvoices(customerId: $customerId) {
+            collection { id totalDueAmountCents totalSettledAmountCents }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+    let(:preloadable_invoices) { [draft_invoice, finalized_invoice] }
+
+    include_examples "preloads offset amounts"
+  end
+
   context "when query fails" do
     it "returns an error" do
       allow(InvoicesQuery).to receive(:call).and_return(

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -551,6 +551,30 @@ RSpec.describe Resolvers::InvoicesResolver do
     end
   end
 
+  context "when filters are invalid" do
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(limit: 5, billingEntityIds: ["random"]) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity")
+    end
+  end
+
   context "when filtering by billing_entity_id" do
     let(:billing_entity2) { create(:billing_entity, organization:) }
     let(:invoice_third) do

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -551,6 +551,31 @@ RSpec.describe Resolvers::InvoicesResolver do
     end
   end
 
+  context "when preloading offset amounts" do
+    subject do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+    end
+
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(limit: 5) {
+            collection { id totalDueAmountCents totalSettledAmountCents }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+    let(:preloadable_invoices) { [invoice_first, invoice_second] }
+
+    include_examples "preloads offset amounts"
+  end
+
   context "when filters are invalid" do
     let(:query) do
       <<~GQL

--- a/spec/support/shared_examples/invoice_index.rb
+++ b/spec/support/shared_examples/invoice_index.rb
@@ -61,6 +61,15 @@ RSpec.shared_examples "an invoice index endpoint" do
     end
   end
 
+  context "when preloading offset amounts" do
+    let(:params) { {} }
+    let(:preloadable_invoices) { create_list(:invoice, 2, customer:, organization:) }
+
+    before { preloadable_invoices }
+
+    include_examples "preloads offset amounts"
+  end
+
   context "with issuing_date params" do
     let(:params) do
       {issuing_date_from: 2.days.ago.to_date, issuing_date_to: Date.tomorrow.to_date}

--- a/spec/support/shared_examples/preload_offset_amounts.rb
+++ b/spec/support/shared_examples/preload_offset_amounts.rb
@@ -9,7 +9,7 @@
 RSpec.shared_examples "preloads offset amounts" do
   before do
     preloadable_invoices.each do |invoice|
-      create(:credit_note, :finalized, invoice:, offset_amount_cents: 100)
+      create(:credit_note, status: :finalized, invoice:, offset_amount_cents: 100)
     end
   end
 

--- a/spec/support/shared_examples/preload_offset_amounts.rb
+++ b/spec/support/shared_examples/preload_offset_amounts.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Verifies that offset_amount_cents is batch-loaded in a single aggregated query
+# instead of N+1 individual queries per invoice.
+#
+# The caller must define:
+# - `preloadable_invoices`: an array of at least 2 invoices to attach credit notes to
+# - `subject`: the action that triggers loading and serializing invoices
+RSpec.shared_examples "preloads offset amounts" do
+  before do
+    preloadable_invoices.each do |invoice|
+      create(:credit_note, :finalized, invoice:, offset_amount_cents: 100)
+    end
+  end
+
+  it "uses a single aggregated query instead of N+1" do
+    query_count = 0
+    counter = ->(_name, _start, _finish, _id, payload) {
+      query_count += 1 if /SELECT SUM.*offset_amount_cents.*FROM.*credit_notes/i.match?(payload[:sql])
+    }
+
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+      subject
+    end
+
+    expect(query_count).to eq(1), "Expected single query to credit_notes table, but got #{query_count}"
+  end
+end


### PR DESCRIPTION
## Context

The /api/v1/invoices endpoint and GraphQL invoice list queries produce N+1 queries on the credit_notes table. For each invoice in the response, offset_amount_cents executes `SELECT SUM(offset_amount_cents) FROM credit_notes WHERE invoice_id = ? AND status = ?` individually.

A batch preloading pattern already existed in the CSV data export service but was never applied to the API or GraphQL layers.

## Description

Add Invoice.preload_offset_amounts class method that loads all offset amounts for a collection of invoices in a single `SUM ... GROUP BY invoice_id` query, caching the result on each instance via an instance variable. This replaces 2N queries with 1.

  Apply preloading to all invoice collection endpoints:
  - REST API: InvoiceIndex concern (serves /api/v1/invoices and /api/v1/customers/:id/invoices)
  - GraphQL: InvoicesResolver, Customers::InvoicesResolver, CustomerPortal::InvoicesResolver
