### PR TITLE
feat(clickhouse): Add models layer for event store migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,8 @@ Lago/NoDropColumnOrTable:
     - "db/migrate/20260116121019_remove_role_from_invites.rb"
     - "db/migrate/20260119162712_drop_subscription_fixed_charge_units_overrides.rb"
     - "db/migrate/20260129145352_drop_properties_from_enriched_events.rb"
+    - "db/migrate/20260409151451_create_enriched_store_migrations.rb"
+    - "db/migrate/20260409161142_create_enriched_store_subscription_migrations.rb"
 
 # TODO: Fix these services
 Lago/ServiceCall:

--- a/app/models/enriched_store_migration.rb
+++ b/app/models/enriched_store_migration.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class EnrichedStoreMigration < ApplicationRecord
+  include AASM
+
+  belongs_to :organization
+
+  has_many :subscription_migrations,
+    class_name: "EnrichedStoreSubscriptionMigration",
+    dependent: :destroy
+
+  STATUSES = {
+    pending: "pending",
+    checking: "checking",
+    processing: "processing",
+    enabling: "enabling",
+    completed: "completed",
+    failed: "failed"
+  }.freeze
+
+  enum :status, STATUSES, validate: true
+
+  aasm column: "status", timestamps: true do
+    state :pending, initial: true
+    state :checking
+    state :processing
+    state :enabling
+    state :completed
+    state :failed
+
+    event :start_check do
+      transitions from: :pending, to: :checking
+    end
+
+    event :start_processing do
+      transitions from: :checking, to: :processing
+    end
+
+    event :start_enabling do
+      transitions from: :processing, to: :enabling
+    end
+
+    event :complete do
+      transitions from: :enabling, to: :completed
+    end
+
+    event :fail do
+      transitions from: [:pending, :checking, :processing, :enabling], to: :failed
+    end
+
+    event :retry_migration do
+      transitions from: :failed, to: :pending
+    end
+  end
+
+  def all_subscriptions_completed?
+    subscription_migrations.exists? && subscription_migrations.where.not(status: :completed).none?
+  end
+end
+
+# == Schema Information
+#
+# Table name: enriched_store_migrations
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  completed_at    :datetime
+#  error_message   :text
+#  started_at      :datetime
+#  status          :enum             default("pending"), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_enriched_store_migrations_on_organization_id  (organization_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/enriched_store_subscription_migration.rb
+++ b/app/models/enriched_store_subscription_migration.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+class EnrichedStoreSubscriptionMigration < ApplicationRecord
+  include AASM
+
+  belongs_to :enriched_store_migration
+  belongs_to :subscription
+  belongs_to :organization
+
+  STATUSES = {
+    pending: "pending",
+    comparing: "comparing",
+    reprocessing: "reprocessing",
+    waiting_for_enrichment: "waiting_for_enrichment",
+    deduplicating: "deduplicating",
+    dedup_paused: "dedup_paused",
+    validating: "validating",
+    completed: "completed",
+    failed: "failed"
+  }.freeze
+
+  enum :status, STATUSES, validate: true
+
+  aasm column: "status", timestamps: true do
+    state :pending, initial: true
+    state :comparing
+    state :reprocessing
+    state :waiting_for_enrichment
+    state :deduplicating
+    state :dedup_paused
+    state :validating
+    state :completed
+    state :failed
+
+    event :start_comparing do
+      transitions from: :pending, to: :comparing
+    end
+
+    event :start_reprocessing do
+      transitions from: :comparing, to: :reprocessing
+    end
+
+    event :start_waiting do
+      transitions from: :reprocessing, to: :waiting_for_enrichment
+    end
+
+    event :start_deduplicating do
+      transitions from: :waiting_for_enrichment, to: :deduplicating
+    end
+
+    event :pause_dedup do
+      transitions from: :deduplicating, to: :dedup_paused
+    end
+
+    event :start_validating do
+      transitions from: [:deduplicating, :dedup_paused], to: :validating
+    end
+
+    event :complete do
+      transitions from: [:comparing, :validating], to: :completed
+    end
+
+    event :fail do
+      transitions from: [
+        :pending, :comparing, :reprocessing, :waiting_for_enrichment,
+        :deduplicating, :dedup_paused, :validating
+      ], to: :failed
+    end
+
+    event :retry_migration do
+      transitions from: :failed, to: :pending
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: enriched_store_subscription_migrations
+# Database name: primary
+#
+#  id                          :uuid             not null, primary key
+#  attempts                    :integer          default(0)
+#  billable_metric_codes       :jsonb
+#  comparison_results          :jsonb
+#  completed_at                :datetime
+#  dedup_pending_queries       :jsonb
+#  duplicates_removed_count    :integer          default(0)
+#  error_message               :text
+#  events_reprocessed_count    :integer          default(0)
+#  started_at                  :datetime
+#  status                      :enum             default("pending"), not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  enriched_store_migration_id :uuid             not null
+#  organization_id             :uuid             not null
+#  subscription_id             :uuid             not null
+#
+# Indexes
+#
+#  idx_enriched_store_sub_migrations_on_migration_and_subscription  (enriched_store_migration_id,subscription_id) UNIQUE
+#  idx_on_enriched_store_migration_id_e409c5dc43                    (enriched_store_migration_id)
+#  idx_on_organization_id_2be2ef98ea                                (organization_id)
+#  idx_on_subscription_id_b41afd08e0                                (subscription_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (enriched_store_migration_id => enriched_store_migrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (subscription_id => subscriptions.id)
+#

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -97,6 +97,7 @@ class Organization < ApplicationRecord
 
   has_one :applied_dunning_campaign, -> { where(applied_to_organization: true) }, class_name: "DunningCampaign"
   has_one :default_billing_entity, -> { active.order(created_at: :asc) }, class_name: "BillingEntity"
+  has_one :enriched_store_migration
 
   has_many :invoice_custom_sections
   has_many :manual_invoice_custom_sections, -> { where(section_type: "manual") }, class_name: "InvoiceCustomSection"

--- a/db/migrate/20260409151451_create_enriched_store_migrations.rb
+++ b/db/migrate/20260409151451_create_enriched_store_migrations.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateEnrichedStoreMigrations < ActiveRecord::Migration[8.0]
+  def up
+    create_enum :enriched_store_migration_status, %w[pending checking processing enabling completed failed]
+
+    create_table :enriched_store_migrations, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: {unique: true}
+      t.enum :status, enum_type: "enriched_store_migration_status", null: false, default: "pending"
+      t.datetime :started_at
+      t.datetime :completed_at
+      t.text :error_message
+
+      t.timestamps
+    end
+  end
+
+  def down
+    safety_assured do
+      drop_table :enriched_store_migrations
+      drop_enum :enriched_store_migration_status
+    end
+  end
+end

--- a/db/migrate/20260409161142_create_enriched_store_subscription_migrations.rb
+++ b/db/migrate/20260409161142_create_enriched_store_subscription_migrations.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreateEnrichedStoreSubscriptionMigrations < ActiveRecord::Migration[8.0]
+  def up
+    create_enum :enriched_store_sub_migration_status, %w[
+      pending comparing reprocessing waiting_for_enrichment
+      deduplicating dedup_paused validating completed failed
+    ]
+
+    create_table :enriched_store_subscription_migrations, id: :uuid do |t|
+      t.references :enriched_store_migration, type: :uuid, null: false, foreign_key: true
+      t.references :subscription, type: :uuid, null: false, foreign_key: true
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: true
+      t.enum :status, enum_type: "enriched_store_sub_migration_status", null: false, default: "pending"
+      t.jsonb :billable_metric_codes, default: []
+      t.integer :events_reprocessed_count, default: 0
+      t.integer :duplicates_removed_count, default: 0
+      t.jsonb :dedup_pending_queries, default: []
+      t.jsonb :comparison_results, default: {}
+      t.text :error_message
+      t.datetime :started_at
+      t.datetime :completed_at
+      t.integer :attempts, default: 0
+
+      t.timestamps
+    end
+
+    add_index :enriched_store_subscription_migrations,
+      [:enriched_store_migration_id, :subscription_id],
+      unique: true,
+      name: "idx_enriched_store_sub_migrations_on_migration_and_subscription"
+  end
+
+  def down
+    drop_table :enriched_store_subscription_migrations
+    drop_enum :enriched_store_sub_migration_status
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23,6 +23,7 @@ ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS fk
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_f435d13904;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_f375d320ad;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_f32b205d44;
+ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_f232478e56;
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_rails_f228550fda;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRAINT IF EXISTS fk_rails_f18cd04d51;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_eeb6a32be1;
@@ -45,6 +46,7 @@ ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
 ALTER TABLE IF EXISTS ONLY public.invites DROP CONSTRAINT IF EXISTS fk_rails_dd342449a6;
+ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_dc444f5f29;
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_db9140d0fd;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8b4a1;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_d9ea200904;
@@ -71,6 +73,7 @@ ALTER TABLE IF EXISTS ONLY public.payment_methods DROP CONSTRAINT IF EXISTS fk_r
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS fk_rails_c545103d57;
 ALTER TABLE IF EXISTS ONLY public.active_storage_attachments DROP CONSTRAINT IF EXISTS fk_rails_c3b3935057;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_c29bf4ff0f;
+ALTER TABLE IF EXISTS ONLY public.enriched_store_migrations DROP CONSTRAINT IF EXISTS fk_rails_c04bd1a196;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_bff25bb1bb;
 ALTER TABLE IF EXISTS ONLY public.charge_filter_values DROP CONSTRAINT IF EXISTS fk_rails_bf661ef73d;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaign_thresholds DROP CONSTRAINT IF EXISTS fk_rails_bf1f386f75;
@@ -277,6 +280,7 @@ ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_ra
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_0baa7bd751;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_0934890b24;
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_08dfe87131;
+ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_08d9dce6d1;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_085d1cc97b;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXISTS fk_rails_07b21049f2;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_06b7046ec3;
@@ -585,6 +589,7 @@ DROP INDEX IF EXISTS public.index_entitlement_entitlements_on_plan_id;
 DROP INDEX IF EXISTS public.index_entitlement_entitlements_on_organization_id;
 DROP INDEX IF EXISTS public.index_entitlement_entitlements_on_entitlement_feature_id;
 DROP INDEX IF EXISTS public.index_entitlement_entitlement_values_on_organization_id;
+DROP INDEX IF EXISTS public.index_enriched_store_migrations_on_organization_id;
 DROP INDEX IF EXISTS public.index_dunning_campaigns_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_dunning_campaigns_on_organization_id;
 DROP INDEX IF EXISTS public.index_dunning_campaigns_on_deleted_at;
@@ -747,6 +752,7 @@ DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_recurring_756a2a370
 DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_78eb24d06c;
 DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_4290c95dec;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_type_8feb7b9623;
+DROP INDEX IF EXISTS public.idx_on_subscription_id_b41afd08e0;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_295edd8bb3;
 DROP INDEX IF EXISTS public.idx_on_recurring_transaction_rule_id_fba3d39cca;
 DROP INDEX IF EXISTS public.idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb;
@@ -759,6 +765,7 @@ DROP INDEX IF EXISTS public.idx_on_organization_id_ccdf05cbfe;
 DROP INDEX IF EXISTS public.idx_on_organization_id_83703a45f4;
 DROP INDEX IF EXISTS public.idx_on_organization_id_7020c3c43a;
 DROP INDEX IF EXISTS public.idx_on_organization_id_376a587b04;
+DROP INDEX IF EXISTS public.idx_on_organization_id_2be2ef98ea;
 DROP INDEX IF EXISTS public.idx_on_invoice_id_payment_request_id_aa550779a4;
 DROP INDEX IF EXISTS public.idx_on_invoice_custom_section_id_d8b9068730;
 DROP INDEX IF EXISTS public.idx_on_invoice_custom_section_id_ccb39e9622;
@@ -772,6 +779,7 @@ DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_9946ccf514;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_6a228dc433;
 DROP INDEX IF EXISTS public.idx_on_entitlement_feature_id_821ae72311;
 DROP INDEX IF EXISTS public.idx_on_entitlement_entitlement_id_48c0b3356a;
+DROP INDEX IF EXISTS public.idx_on_enriched_store_migration_id_e409c5dc43;
 DROP INDEX IF EXISTS public.idx_on_dunning_campaign_id_currency_fbf233b2ae;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_invoice_custom_section_id_bd78c547d3;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_customer_id_invoice_custom_e7aada65cb;
@@ -782,6 +790,7 @@ DROP INDEX IF EXISTS public.idx_invoice_subscriptions_on_subscription_with_times
 DROP INDEX IF EXISTS public.idx_features_code_unique_per_organization;
 DROP INDEX IF EXISTS public.idx_events_for_distinct_codes;
 DROP INDEX IF EXISTS public.idx_events_billing_lookup;
+DROP INDEX IF EXISTS public.idx_enriched_store_sub_migrations_on_migration_and_subscription;
 DROP INDEX IF EXISTS public.idx_enqueued_per_organization;
 DROP INDEX IF EXISTS public.idx_cached_aggregation_filtered_lookup;
 DROP INDEX IF EXISTS public.idx_alerts_unique_per_type_per_wallet;
@@ -868,6 +877,8 @@ ALTER TABLE IF EXISTS ONLY public.entitlement_privileges DROP CONSTRAINT IF EXIS
 ALTER TABLE IF EXISTS ONLY public.entitlement_features DROP CONSTRAINT IF EXISTS entitlement_features_pkey;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS entitlement_entitlements_pkey;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT IF EXISTS entitlement_entitlement_values_pkey;
+ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS enriched_store_subscription_migrations_pkey;
+ALTER TABLE IF EXISTS ONLY public.enriched_store_migrations DROP CONSTRAINT IF EXISTS enriched_store_migrations_pkey;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaigns DROP CONSTRAINT IF EXISTS dunning_campaigns_pkey;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaign_thresholds DROP CONSTRAINT IF EXISTS dunning_campaign_thresholds_pkey;
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS data_exports_pkey;
@@ -1018,6 +1029,8 @@ DROP TABLE IF EXISTS public.entitlement_privileges;
 DROP TABLE IF EXISTS public.entitlement_features;
 DROP TABLE IF EXISTS public.entitlement_entitlements;
 DROP TABLE IF EXISTS public.entitlement_entitlement_values;
+DROP TABLE IF EXISTS public.enriched_store_subscription_migrations;
+DROP TABLE IF EXISTS public.enriched_store_migrations;
 DROP TABLE IF EXISTS public.enriched_events_default;
 DROP TABLE IF EXISTS public.enriched_events;
 DROP TABLE IF EXISTS public.dunning_campaigns;
@@ -1085,6 +1098,8 @@ DROP TYPE IF EXISTS public.inbound_webhook_status;
 DROP TYPE IF EXISTS public.fixed_charge_charge_model;
 DROP TYPE IF EXISTS public.entity_document_numbering;
 DROP TYPE IF EXISTS public.entitlement_privilege_value_types;
+DROP TYPE IF EXISTS public.enriched_store_sub_migration_status;
+DROP TYPE IF EXISTS public.enriched_store_migration_status;
 DROP TYPE IF EXISTS public.customer_type;
 DROP TYPE IF EXISTS public.customer_account_type;
 DROP TYPE IF EXISTS public.billable_metric_weighted_interval;
@@ -1158,6 +1173,37 @@ CREATE TYPE public.customer_account_type AS ENUM (
 CREATE TYPE public.customer_type AS ENUM (
     'company',
     'individual'
+);
+
+
+--
+-- Name: enriched_store_migration_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.enriched_store_migration_status AS ENUM (
+    'pending',
+    'checking',
+    'processing',
+    'enabling',
+    'completed',
+    'failed'
+);
+
+
+--
+-- Name: enriched_store_sub_migration_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.enriched_store_sub_migration_status AS ENUM (
+    'pending',
+    'comparing',
+    'reprocessing',
+    'waiting_for_enrichment',
+    'deduplicating',
+    'dedup_paused',
+    'validating',
+    'completed',
+    'failed'
 );
 
 
@@ -2349,6 +2395,46 @@ CREATE TABLE public.enriched_events_default (
     operation_type character varying,
     precise_total_amount_cents numeric(40,15),
     target_wallet_code character varying
+);
+
+
+--
+-- Name: enriched_store_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.enriched_store_migrations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    status public.enriched_store_migration_status DEFAULT 'pending'::public.enriched_store_migration_status NOT NULL,
+    started_at timestamp(6) without time zone,
+    completed_at timestamp(6) without time zone,
+    error_message text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: enriched_store_subscription_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.enriched_store_subscription_migrations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    enriched_store_migration_id uuid NOT NULL,
+    subscription_id uuid NOT NULL,
+    organization_id uuid NOT NULL,
+    status public.enriched_store_sub_migration_status DEFAULT 'pending'::public.enriched_store_sub_migration_status NOT NULL,
+    billable_metric_codes jsonb DEFAULT '[]'::jsonb,
+    events_reprocessed_count integer DEFAULT 0,
+    duplicates_removed_count integer DEFAULT 0,
+    dedup_pending_queries jsonb DEFAULT '[]'::jsonb,
+    comparison_results jsonb DEFAULT '{}'::jsonb,
+    error_message text,
+    started_at timestamp(6) without time zone,
+    completed_at timestamp(6) without time zone,
+    attempts integer DEFAULT 0,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -5224,6 +5310,22 @@ ALTER TABLE ONLY public.dunning_campaigns
 
 
 --
+-- Name: enriched_store_migrations enriched_store_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.enriched_store_migrations
+    ADD CONSTRAINT enriched_store_migrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: enriched_store_subscription_migrations enriched_store_subscription_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.enriched_store_subscription_migrations
+    ADD CONSTRAINT enriched_store_subscription_migrations_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: entitlement_entitlement_values entitlement_entitlement_values_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5929,6 +6031,13 @@ CREATE INDEX idx_enqueued_per_organization ON public.usage_monitoring_subscripti
 
 
 --
+-- Name: idx_enriched_store_sub_migrations_on_migration_and_subscription; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_enriched_store_sub_migrations_on_migration_and_subscription ON public.enriched_store_subscription_migrations USING btree (enriched_store_migration_id, subscription_id);
+
+
+--
 -- Name: idx_events_billing_lookup; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5996,6 +6105,13 @@ CREATE UNIQUE INDEX idx_on_billing_entity_id_invoice_custom_section_id_bd78c547d
 --
 
 CREATE UNIQUE INDEX idx_on_dunning_campaign_id_currency_fbf233b2ae ON public.dunning_campaign_thresholds USING btree (dunning_campaign_id, currency) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: idx_on_enriched_store_migration_id_e409c5dc43; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_enriched_store_migration_id_e409c5dc43 ON public.enriched_store_subscription_migrations USING btree (enriched_store_migration_id);
 
 
 --
@@ -6090,6 +6206,13 @@ CREATE UNIQUE INDEX idx_on_invoice_id_payment_request_id_aa550779a4 ON public.in
 
 
 --
+-- Name: idx_on_organization_id_2be2ef98ea; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_organization_id_2be2ef98ea ON public.enriched_store_subscription_migrations USING btree (organization_id);
+
+
+--
 -- Name: idx_on_organization_id_376a587b04; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6171,6 +6294,13 @@ CREATE INDEX idx_on_recurring_transaction_rule_id_fba3d39cca ON public.recurring
 --
 
 CREATE INDEX idx_on_subscription_id_295edd8bb3 ON public.entitlement_subscription_feature_removals USING btree (subscription_id);
+
+
+--
+-- Name: idx_on_subscription_id_b41afd08e0; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_subscription_id_b41afd08e0 ON public.enriched_store_subscription_migrations USING btree (subscription_id);
 
 
 --
@@ -7309,6 +7439,13 @@ CREATE INDEX index_dunning_campaigns_on_organization_id ON public.dunning_campai
 --
 
 CREATE UNIQUE INDEX index_dunning_campaigns_on_organization_id_and_code ON public.dunning_campaigns USING btree (organization_id, code) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_enriched_store_migrations_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_enriched_store_migrations_on_organization_id ON public.enriched_store_migrations USING btree (organization_id);
 
 
 --
@@ -9378,6 +9515,14 @@ ALTER TABLE ONLY public.fees
 
 
 --
+-- Name: enriched_store_subscription_migrations fk_rails_08d9dce6d1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.enriched_store_subscription_migrations
+    ADD CONSTRAINT fk_rails_08d9dce6d1 FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
+
+
+--
 -- Name: add_ons_taxes fk_rails_08dfe87131; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11026,6 +11171,14 @@ ALTER TABLE ONLY public.customers
 
 
 --
+-- Name: enriched_store_migrations fk_rails_c04bd1a196; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.enriched_store_migrations
+    ADD CONSTRAINT fk_rails_c04bd1a196 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: wallet_transactions fk_rails_c29bf4ff0f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11234,6 +11387,14 @@ ALTER TABLE ONLY public.customers_invoice_custom_sections
 
 
 --
+-- Name: enriched_store_subscription_migrations fk_rails_dc444f5f29; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.enriched_store_subscription_migrations
+    ADD CONSTRAINT fk_rails_dc444f5f29 FOREIGN KEY (enriched_store_migration_id) REFERENCES public.enriched_store_migrations(id);
+
+
+--
 -- Name: invites fk_rails_dd342449a6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11410,6 +11571,14 @@ ALTER TABLE ONLY public.payment_requests
 
 
 --
+-- Name: enriched_store_subscription_migrations fk_rails_f232478e56; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.enriched_store_subscription_migrations
+    ADD CONSTRAINT fk_rails_f232478e56 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: wallet_transactions fk_rails_f32b205d44; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11528,6 +11697,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260409161142'),
+('20260409151451'),
 ('20260331122448'),
 ('20260331103301'),
 ('20260327140626'),

--- a/spec/factories/enriched_store_migrations.rb
+++ b/spec/factories/enriched_store_migrations.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :enriched_store_migration do
+    organization
+
+    trait :checking do
+      status { :checking }
+      started_at { Time.current }
+    end
+
+    trait :processing do
+      status { :processing }
+      started_at { Time.current }
+    end
+
+    trait :enabling do
+      status { :enabling }
+      started_at { Time.current }
+    end
+
+    trait :completed do
+      status { :completed }
+      started_at { 1.hour.ago }
+      completed_at { Time.current }
+    end
+
+    trait :failed do
+      status { :failed }
+      started_at { Time.current }
+      error_message { "Something went wrong" }
+    end
+  end
+end

--- a/spec/factories/enriched_store_subscription_migrations.rb
+++ b/spec/factories/enriched_store_subscription_migrations.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :enriched_store_subscription_migration do
+    enriched_store_migration
+    organization { enriched_store_migration&.organization || association(:organization) }
+    subscription { association(:subscription, organization: organization) }
+
+    trait :comparing do
+      status { :comparing }
+      started_at { Time.current }
+    end
+
+    trait :reprocessing do
+      status { :reprocessing }
+      started_at { Time.current }
+    end
+
+    trait :waiting_for_enrichment do
+      status { :waiting_for_enrichment }
+      started_at { Time.current }
+    end
+
+    trait :deduplicating do
+      status { :deduplicating }
+      started_at { Time.current }
+    end
+
+    trait :dedup_paused do
+      status { :dedup_paused }
+      started_at { Time.current }
+      dedup_pending_queries { ["DELETE FROM events_enriched_expanded..."] }
+    end
+
+    trait :validating do
+      status { :validating }
+      started_at { Time.current }
+    end
+
+    trait :completed do
+      status { :completed }
+      started_at { 1.hour.ago }
+      completed_at { Time.current }
+    end
+
+    trait :failed do
+      status { :failed }
+      started_at { Time.current }
+      error_message { "Something went wrong" }
+    end
+  end
+end

--- a/spec/models/enriched_store_migration_spec.rb
+++ b/spec/models/enriched_store_migration_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EnrichedStoreMigration do
+  subject(:migration) { create(:enriched_store_migration) }
+
+  describe "enums" do
+    it do
+      expect(subject).to define_enum_for(:status)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_values(
+          pending: "pending",
+          checking: "checking",
+          processing: "processing",
+          enabling: "enabling",
+          completed: "completed",
+          failed: "failed"
+        )
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to have_many(:subscription_migrations)
+        .class_name("EnrichedStoreSubscriptionMigration")
+        .dependent(:destroy)
+    end
+  end
+
+  describe "AASM transitions" do
+    describe "#start_check" do
+      it "transitions from pending to checking" do
+        expect(migration).to be_pending
+        migration.start_check!
+        expect(migration).to be_checking
+      end
+    end
+
+    describe "#start_processing" do
+      subject(:migration) { create(:enriched_store_migration, :checking) }
+
+      it "transitions from checking to processing" do
+        migration.start_processing!
+        expect(migration).to be_processing
+      end
+    end
+
+    describe "#start_enabling" do
+      subject(:migration) { create(:enriched_store_migration, :processing) }
+
+      it "transitions from processing to enabling" do
+        migration.start_enabling!
+        expect(migration).to be_enabling
+      end
+    end
+
+    describe "#complete" do
+      subject(:migration) { create(:enriched_store_migration, :enabling) }
+
+      it "transitions from enabling to completed" do
+        migration.complete!
+        expect(migration).to be_completed
+      end
+    end
+
+    describe "#fail" do
+      %i[pending checking processing enabling].each do |state|
+        it "transitions from #{state} to failed" do
+          record = if state == :pending
+            create(:enriched_store_migration)
+          else
+            create(:enriched_store_migration, state)
+          end
+
+          record.fail!
+          expect(record).to be_failed
+        end
+      end
+    end
+
+    describe "#retry_migration" do
+      subject(:migration) { create(:enriched_store_migration, :failed) }
+
+      it "transitions from failed to pending" do
+        migration.retry_migration!
+        expect(migration).to be_pending
+      end
+    end
+  end
+
+  describe "#all_subscriptions_completed?" do
+    it "returns false when there are no subscription migrations" do
+      expect(migration).not_to be_all_subscriptions_completed
+    end
+
+    it "returns true when all subscription migrations are completed" do
+      create(:enriched_store_subscription_migration, :completed, enriched_store_migration: migration)
+      create(:enriched_store_subscription_migration, :completed, enriched_store_migration: migration)
+
+      expect(migration).to be_all_subscriptions_completed
+    end
+
+    it "returns false when some subscription migrations are not completed" do
+      create(:enriched_store_subscription_migration, :completed, enriched_store_migration: migration)
+      create(:enriched_store_subscription_migration, enriched_store_migration: migration)
+
+      expect(migration).not_to be_all_subscriptions_completed
+    end
+  end
+end

--- a/spec/models/enriched_store_subscription_migration_spec.rb
+++ b/spec/models/enriched_store_subscription_migration_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EnrichedStoreSubscriptionMigration do
+  subject(:subscription_migration) { create(:enriched_store_subscription_migration) }
+
+  describe "enums" do
+    it do
+      expect(subject).to define_enum_for(:status)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_values(
+          pending: "pending",
+          comparing: "comparing",
+          reprocessing: "reprocessing",
+          waiting_for_enrichment: "waiting_for_enrichment",
+          deduplicating: "deduplicating",
+          dedup_paused: "dedup_paused",
+          validating: "validating",
+          completed: "completed",
+          failed: "failed"
+        )
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:enriched_store_migration)
+      expect(subject).to belong_to(:subscription)
+      expect(subject).to belong_to(:organization)
+    end
+  end
+
+  describe "AASM transitions" do
+    describe "#start_comparing" do
+      it "transitions from pending to comparing" do
+        expect(subscription_migration).to be_pending
+        subscription_migration.start_comparing!
+        expect(subscription_migration).to be_comparing
+      end
+    end
+
+    describe "#start_reprocessing" do
+      subject(:subscription_migration) { create(:enriched_store_subscription_migration, :comparing) }
+
+      it "transitions from comparing to reprocessing" do
+        subscription_migration.start_reprocessing!
+        expect(subscription_migration).to be_reprocessing
+      end
+    end
+
+    describe "#start_waiting" do
+      subject(:subscription_migration) { create(:enriched_store_subscription_migration, :reprocessing) }
+
+      it "transitions from reprocessing to waiting_for_enrichment" do
+        subscription_migration.start_waiting!
+        expect(subscription_migration).to be_waiting_for_enrichment
+      end
+    end
+
+    describe "#start_deduplicating" do
+      subject(:subscription_migration) { create(:enriched_store_subscription_migration, :waiting_for_enrichment) }
+
+      it "transitions from waiting_for_enrichment to deduplicating" do
+        subscription_migration.start_deduplicating!
+        expect(subscription_migration).to be_deduplicating
+      end
+    end
+
+    describe "#pause_dedup" do
+      subject(:subscription_migration) { create(:enriched_store_subscription_migration, :deduplicating) }
+
+      it "transitions from deduplicating to dedup_paused" do
+        subscription_migration.pause_dedup!
+        expect(subscription_migration).to be_dedup_paused
+      end
+    end
+
+    describe "#start_validating" do
+      %i[deduplicating dedup_paused].each do |state|
+        it "transitions from #{state} to validating" do
+          record = create(:enriched_store_subscription_migration, state)
+          record.start_validating!
+          expect(record).to be_validating
+        end
+      end
+    end
+
+    describe "#complete" do
+      %i[comparing validating].each do |state|
+        it "transitions from #{state} to completed" do
+          record = create(:enriched_store_subscription_migration, state)
+          record.complete!
+          expect(record).to be_completed
+        end
+      end
+    end
+
+    describe "#fail" do
+      %i[pending comparing reprocessing waiting_for_enrichment deduplicating dedup_paused validating].each do |state|
+        it "transitions from #{state} to failed" do
+          record = if state == :pending
+            create(:enriched_store_subscription_migration)
+          else
+            create(:enriched_store_subscription_migration, state)
+          end
+
+          record.fail!
+          expect(record).to be_failed
+        end
+      end
+    end
+
+    describe "#retry_migration" do
+      subject(:subscription_migration) { create(:enriched_store_subscription_migration, :failed) }
+
+      it "transitions from failed to pending" do
+        subscription_migration.retry_migration!
+        expect(subscription_migration).to be_pending
+      end
+    end
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Organization do
       expect(subject).to have_many(:subscription_feature_removals).class_name("Entitlement::SubscriptionFeatureRemoval")
 
       expect(subject).to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true)
+      expect(subject).to have_one(:enriched_store_migration)
       expect(subject).to have_many(:pending_vies_checks)
     end
   end


### PR DESCRIPTION
## Context

Migrating an organization from `Events::Stores::ClickhouseStore` to `Events::Stores::ClickhouseEnrichedStore` today requires running 4+ rake tasks manually in sequence, with manual verification between steps. 

A full migration process with a two-level tracking system (on organizations and subscriptions), relying on resumable state machines, asynchronous and per-subscription independent processes will be added to automate these tasks

## Description

This PR adds the model layer for monitoring the event store migration process.
- `EnrichedStoreMigration`: Handle the migration at organization level
- `EnrichedStoreSubscriptionMigration`: Handle to migration at subscription level