### PR TITLE
misc(clickhouse): Extract enriched_events:compare core logic into a service

### DIFF
--- a/app/services/events/stores/clickhouse/enriched_store_migration/comparison_service.rb
+++ b/app/services/events/stores/clickhouse/enriched_store_migration/comparison_service.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "benchmark"
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        class ComparisonService < BaseService
+          Result = BaseResult[:diff_count, :fee_details, :legacy_elapsed, :enriched_elapsed]
+
+          FieldDiff = Data.define(:legacy, :enriched)
+          FeeValues = Data.define(:units, :amount_cents, :events_count, :total_aggregated_units)
+          FeeDetail = Data.define(
+            :charge_id, :charge_filter_id, :grouped_by,
+            :billable_metric_code, :aggregation_type, :charge_model,
+            :from, :to, :status, :legacy, :enriched, :diffs
+          )
+
+          def initialize(subscription:, deduplicate: false)
+            @subscription = subscription
+            @organization = subscription.organization
+            @deduplicate = deduplicate
+            super
+          end
+
+          def call
+            result.fee_details = []
+
+            legacy_usage_result = nil
+            result.legacy_elapsed = Benchmark.realtime do
+              legacy_usage_result = compute_usage(enriched: false)
+            end
+
+            return result.fail_with_error!(legacy_usage_result.error) if legacy_usage_result.failure?
+
+            enriched_usage_result = nil
+            result.enriched_elapsed = Benchmark.realtime do
+              enriched_usage_result = compute_usage(enriched: true)
+            end
+
+            return result.fail_with_error!(enriched_usage_result.error) if enriched_usage_result.failure?
+
+            compare_fees(legacy_usage_result.usage.fees, enriched_usage_result.usage.fees)
+            result
+          ensure
+            # Ensure the organization state is restored
+            organization.reload
+          end
+
+          private
+
+          attr_reader :subscription, :organization, :deduplicate
+
+          def compute_usage(enriched:)
+            usage_result = nil
+
+            ActiveRecord::Base.transaction do
+              if enriched
+                organization.enable_feature_flag!(:enriched_events_aggregation)
+                organization.update!(clickhouse_deduplication_enabled: deduplicate, pre_filter_events: true)
+              else
+                organization.disable_feature_flag!(:enriched_events_aggregation)
+                organization.update!(clickhouse_deduplication_enabled: deduplicate)
+              end
+              organization.reload
+
+              usage_result = Invoices::CustomerUsageService.call(
+                customer: subscription.customer,
+                subscription: subscription,
+                with_cache: false,
+                apply_taxes: false
+              )
+
+              raise ActiveRecord::Rollback
+            end
+
+            usage_result
+          end
+
+          def compare_fees(legacy_fees, enriched_fees)
+            legacy_by_key = legacy_fees.index_by { |f| fee_key(f) }
+            enriched_by_key = enriched_fees.index_by { |f| fee_key(f) }
+
+            all_keys = (legacy_by_key.keys + enriched_by_key.keys).uniq
+            diff_count = 0
+
+            all_keys.each do |key|
+              legacy_fee = legacy_by_key[key]
+              enriched_fee = enriched_by_key[key]
+
+              if legacy_fee && !enriched_fee
+                diff_count += 1
+                result.fee_details << build_detail(key, "only_in_legacy", legacy_fee, nil)
+              elsif enriched_fee && !legacy_fee
+                diff_count += 1
+                result.fee_details << build_detail(key, "only_in_enriched", nil, enriched_fee)
+              else
+                diffs = compute_field_diffs(legacy_fee, enriched_fee)
+                if diffs.any?
+                  diff_count += 1
+                  result.fee_details << build_detail(key, "diff", legacy_fee, enriched_fee, diffs:)
+                else
+                  result.fee_details << build_detail(key, "match", legacy_fee, enriched_fee)
+                end
+              end
+            end
+
+            result.diff_count = diff_count
+          end
+
+          def fee_key(fee)
+            grouped = fee.grouped_by.presence || {}
+            [fee.charge_id, fee.charge_filter_id, grouped]
+          end
+
+          def compute_field_diffs(legacy_fee, enriched_fee)
+            {
+              units: [legacy_fee.units, enriched_fee.units],
+              amount_cents: [legacy_fee.amount_cents, enriched_fee.amount_cents],
+              events_count: [legacy_fee.events_count, enriched_fee.events_count],
+              total_aggregated_units: [legacy_fee.total_aggregated_units, enriched_fee.total_aggregated_units]
+            }.select { |_, (legacy, enriched)| legacy != enriched }
+          end
+
+          def build_detail(key, status, legacy_fee, enriched_fee, diffs: {})
+            fee = legacy_fee || enriched_fee
+
+            FeeDetail.new(
+              charge_id: key[0],
+              charge_filter_id: key[1],
+              grouped_by: key[2],
+              billable_metric_code: fee.billable_metric.code,
+              aggregation_type: fee.billable_metric.aggregation_type,
+              charge_model: fee.charge.charge_model,
+              from: fee.properties.dig("charges_from_datetime"),
+              to: fee.properties.dig("charges_to_datetime"),
+              status:,
+              legacy: legacy_fee ? fee_values(legacy_fee) : nil,
+              enriched: enriched_fee ? fee_values(enriched_fee) : nil,
+              diffs: diffs.transform_values { |values| FieldDiff.new(legacy: values[0], enriched: values[1]) }
+            )
+          end
+
+          def fee_values(fee)
+            FeeValues.new(
+              units: fee.units.to_s,
+              amount_cents: fee.amount_cents,
+              events_count: fee.events_count,
+              total_aggregated_units: fee.total_aggregated_units.to_s
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/enriched_events_comparison.rake
+++ b/lib/tasks/enriched_events_comparison.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "benchmark"
 require "json"
 
 namespace :enriched_events do
@@ -44,159 +43,60 @@ namespace :enriched_events do
         next
       end
 
-      flag_was_enabled = organization.feature_flag_enabled?(:enriched_events_aggregation)
-      legacy_fees = nil
-      enriched_fees = nil
-      legacy_elapsed = nil
-      enriched_elapsed = nil
+      comparison_result = Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonService.call(
+        subscription:,
+        deduplicate:
+      )
 
-      begin
-        ActiveRecord::Base.transaction do
-          # Run with existing store (feature flag OFF)
-          organization.disable_feature_flag!(:enriched_events_aggregation) if flag_was_enabled
-          organization.update!(clickhouse_deduplication_enabled: deduplicate)
-          organization.reload
-
-          log.call("\nRunning legacy ClickhouseStore...")
-          legacy_elapsed = Benchmark.realtime do
-            legacy_result = Invoices::CustomerUsageService.call(
-              customer: subscription.customer,
-              subscription: subscription,
-              with_cache: false,
-              apply_taxes: false
-            )
-
-            if legacy_result.success?
-              legacy_fees = legacy_result.usage.fees
-            else
-              log.call("[ERROR] Legacy usage computation failed: #{legacy_result.error&.message}")
-            end
-          end
-
-          raise ActiveRecord::Rollback
-        end
-
-        ActiveRecord::Base.transaction do
-          # Run with enriched store (feature flag ON)
-          organization.enable_feature_flag!(:enriched_events_aggregation)
-          organization.update!(clickhouse_deduplication_enabled: deduplicate, pre_filter_events: true)
-          organization.reload
-
-          log.call("Running enriched ClickhouseEnrichedStore...")
-          enriched_elapsed = Benchmark.realtime do
-            enriched_result = Invoices::CustomerUsageService.call(
-              customer: subscription.customer,
-              subscription: subscription,
-              with_cache: false,
-              apply_taxes: false
-            )
-
-            if enriched_result.success?
-              enriched_fees = enriched_result.usage.fees
-            else
-              log.call("[ERROR] Enriched usage computation failed: #{enriched_result.error&.message}")
-            end
-          end
-
-          raise ActiveRecord::Rollback
-        end
-      rescue => e
-        log.call("[ERROR] Unexpected error: #{e.message}")
-        log.call(e.backtrace.first(5).join("\n"))
-        json_results&.push({subscription_id: sub_id, status: "error", reason: e.message})
+      unless comparison_result.success?
+        log.call("[ERROR] Comparison failed: #{comparison_result.error&.message}")
+        json_results&.push({subscription_id: sub_id, status: "error", reason: comparison_result.error&.message})
         next
       end
 
-      if legacy_fees.nil? || enriched_fees.nil?
-        json_results&.push({subscription_id: sub_id, status: "error", reason: "One or both computations failed"})
-        next
-      end
-
+      legacy_elapsed = comparison_result.legacy_elapsed
+      enriched_elapsed = comparison_result.enriched_elapsed
       total_legacy_elapsed += legacy_elapsed
       total_enriched_elapsed += enriched_elapsed
 
-      # Build lookup by composite key
-      fee_key = ->(fee) {
-        grouped = fee.grouped_by.presence || {}
-        [fee.charge_id, fee.charge_filter_id, grouped]
-      }
-
-      legacy_by_key = legacy_fees.index_by { |f| fee_key.call(f) }
-      enriched_by_key = enriched_fees.index_by { |f| fee_key.call(f) }
-
-      all_keys = (legacy_by_key.keys + enriched_by_key.keys).uniq
-      sub_diffs = 0
+      sub_diffs = comparison_result.diff_count
+      total_diffs += sub_diffs
       fee_details = [] if format_json
 
-      all_keys.each do |key|
-        legacy_fee = legacy_by_key[key]
-        enriched_fee = enriched_by_key[key]
+      comparison_result.fee_details.each do |detail|
+        parts = ["charge=#{detail.charge_id}"]
+        parts << "filter=#{detail.charge_filter_id}" if detail.charge_filter_id
+        parts << "metric=#{detail.billable_metric_code}" if detail.billable_metric_code
+        parts << "grouped_by=#{detail.grouped_by}" if detail.grouped_by.present?
+        parts << "agg=#{detail.aggregation_type}" if detail.aggregation_type
+        parts << "model=#{detail.charge_model}" if detail.charge_model
+        parts << "from=#{detail.from}" if detail.from
+        parts << "to=#{detail.to}" if detail.to
+        label = parts.join(" ")
 
-        label = fee_label(legacy_fee || enriched_fee)
-
-        if legacy_fee && !enriched_fee
-          sub_diffs += 1
+        case detail.status
+        when "only_in_legacy"
           log.call("  [ONLY IN LEGACY]  #{label}")
-          if format_json
-            fee_details << {
-              charge_id: key[0], charge_filter_id: key[1], grouped_by: key[2], label: label,
-              status: "only_in_legacy", legacy: fee_values(legacy_fee), enriched: nil, diffs: {}
-            }
-          end
-        elsif enriched_fee && !legacy_fee
-          sub_diffs += 1
+        when "only_in_enriched"
           log.call("  [ONLY IN ENRICHED] #{label}")
-          if format_json
-            fee_details << {
-              charge_id: key[0], charge_filter_id: key[1], grouped_by: key[2], label: label,
-              status: "only_in_enriched", legacy: nil, enriched: fee_values(enriched_fee), diffs: {}
-            }
-          end
-        else
-          compared_fields = {
-            units: [legacy_fee.units, enriched_fee.units],
-            amount_cents: [legacy_fee.amount_cents, enriched_fee.amount_cents],
-            events_count: [legacy_fee.events_count, enriched_fee.events_count],
-            total_aggregated_units: [legacy_fee.total_aggregated_units, enriched_fee.total_aggregated_units]
-          }
-
-          diffs = compared_fields.select { |_, (l, e)| l != e }
-
-          if diffs.empty?
-            log.call("  [MATCH] #{label}") unless quiet
-            if format_json && !quiet
-              fee_details << {
-                charge_id: key[0], charge_filter_id: key[1], grouped_by: key[2], label: label,
-                status: "match", legacy: fee_values(legacy_fee), enriched: fee_values(enriched_fee), diffs: {}
-              }
-            end
-          else
-            sub_diffs += 1
-            log.call("  [DIFF]  #{label}")
-            if format_json
-              diff_details = {}
-              diffs.each do |field, (legacy_val, enriched_val)|
-                delta = compute_delta(legacy_val, enriched_val)
-                diff_details[field] = {legacy: legacy_val.to_s, enriched: enriched_val.to_s, delta: delta}
-              end
-              fee_details << {
-                charge_id: key[0], charge_filter_id: key[1], grouped_by: key[2], label: label,
-                status: "diff", legacy: fee_values(legacy_fee), enriched: fee_values(enriched_fee), diffs: diff_details
-              }
-            else
-              diffs.each do |field, (legacy_val, enriched_val)|
-                delta = compute_delta(legacy_val, enriched_val)
-                log.call("          #{field}: legacy=#{legacy_val.inspect} enriched=#{enriched_val.inspect} (delta: #{delta})")
-              end
+        when "diff"
+          log.call("  [DIFF]  #{label}")
+          unless format_json
+            detail.diffs.each do |field, values|
+              log.call("          #{field}: legacy=#{values.legacy} enriched=#{values.enriched}")
             end
           end
+        when "match"
+          log.call("  [MATCH] #{label}") unless quiet
+        end
+
+        if format_json && (detail.status != "match" || !quiet)
+          fee_details << detail.to_h
         end
       end
 
-      total_diffs += sub_diffs
-
       timing_info = build_timing(legacy_elapsed, enriched_elapsed)
-      log.call("\n  Summary: #{all_keys.size} fee(s), #{sub_diffs} difference(s)")
+      log.call("\n  Summary: #{comparison_result.fee_details.size} fee(s), #{sub_diffs} difference(s)")
       log.call("  Timing: legacy=#{legacy_elapsed.round(3)}s enriched=#{enriched_elapsed.round(3)}s #{timing_info[:comparison]}")
 
       if format_json
@@ -204,7 +104,7 @@ namespace :enriched_events do
           subscription_id: sub_id,
           status: "compared",
           timing: {legacy_seconds: legacy_elapsed.round(3), enriched_seconds: enriched_elapsed.round(3), speedup: timing_info[:speedup]},
-          fee_count: all_keys.size,
+          fee_count: comparison_result.fee_details.size,
           diff_count: sub_diffs,
           fees: fee_details
         }
@@ -232,15 +132,6 @@ namespace :enriched_events do
 
   private
 
-  def fee_values(fee)
-    {
-      units: fee.units.to_s,
-      amount_cents: fee.amount_cents,
-      events_count: fee.events_count,
-      total_aggregated_units: fee.total_aggregated_units.to_s
-    }
-  end
-
   def build_timing(legacy_elapsed, enriched_elapsed)
     if enriched_elapsed.zero?
       {speedup: nil, comparison: "enriched=0s"}
@@ -255,34 +146,5 @@ namespace :enriched_events do
       end
       {speedup: speedup, comparison: comparison}
     end
-  end
-
-  def fee_label(fee)
-    parts = ["charge=#{fee.charge_id}"]
-    if fee.billable_metric
-      parts << "metric=#{fee.billable_metric.code}"
-      parts << "agg=#{fee.billable_metric.aggregation_type}"
-    end
-    parts << "model=#{fee.charge&.charge_model}" if fee.charge
-    parts << "filter=#{fee.charge_filter.to_h} filter_id=#{fee.charge_filter_id}" if fee.charge_filter_id
-    grouped = fee.grouped_by.presence
-    parts << "grouped_by=#{grouped}" if grouped
-    parts << "from=#{fee.properties["charges_from_datetime"]}" if fee.properties["charges_from_datetime"]
-    parts << "to=#{fee.properties["charges_to_datetime"]}" if fee.properties["charges_to_datetime"]
-    parts.join(" ")
-  end
-
-  def compute_delta(legacy_val, enriched_val)
-    return "N/A" if legacy_val.nil? || enriched_val.nil?
-
-    diff = enriched_val.to_d - legacy_val.to_d
-    if legacy_val.to_d.zero?
-      diff.zero? ? "0" : "#{diff} (from zero)"
-    else
-      pct = (diff / legacy_val.to_d * 100).round(4)
-      "#{diff} (#{pct}%)"
-    end
-  rescue
-    "N/A"
   end
 end

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/comparison_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/comparison_service_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonService do
+  subject(:service) { described_class.new(subscription:, deduplicate:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let(:deduplicate) { false }
+
+  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls", aggregation_type: "count_agg") }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:, organization:) }
+
+  let(:fee_attributes) do
+    {
+      charge:,
+      charge_filter_id: nil,
+      grouped_by: {},
+      properties: {"charges_from_datetime" => "2026-04-01T00:00:00Z", "charges_to_datetime" => "2026-04-30T23:59:59Z"}
+    }
+  end
+
+  describe "#call" do
+    let(:legacy_fee) do
+      Fee.new(
+        fee_attributes.merge(
+          units: 10,
+          amount_cents: 1000,
+          events_count: 5,
+          total_aggregated_units: 10
+        )
+      )
+    end
+
+    let(:enriched_fee) do
+      Fee.new(
+        fee_attributes.merge(
+          units: 10,
+          amount_cents: 1000,
+          events_count: 5,
+          total_aggregated_units: 10
+        )
+      )
+    end
+
+    let(:legacy_usage) { SubscriptionUsage.new(fees: [legacy_fee]) }
+    let(:enriched_usage) { SubscriptionUsage.new(fees: [enriched_fee]) }
+    let(:legacy_result) { BaseService::LegacyResult.new.tap { |r| r.usage = legacy_usage } }
+    let(:enriched_result) { BaseService::LegacyResult.new.tap { |r| r.usage = enriched_usage } }
+
+    before do
+      allow(Invoices::CustomerUsageService).to receive(:call)
+        .and_return(legacy_result, enriched_result)
+    end
+
+    context "when fees match" do
+      it "returns zero diffs with timing and fee metadata" do
+        result = service.call
+
+        expect(result).to be_success
+        expect(result.diff_count).to eq(0)
+        expect(result.legacy_elapsed).to be_a(Float)
+        expect(result.enriched_elapsed).to be_a(Float)
+
+        detail = result.fee_details.first
+        expect(detail).to be_a(described_class::FeeDetail)
+        expect(detail.status).to eq("match")
+        expect(detail.billable_metric_code).to eq("api_calls")
+        expect(detail.aggregation_type).to eq("count_agg")
+        expect(detail.charge_model).to eq("standard")
+        expect(detail.from).to eq("2026-04-01T00:00:00Z")
+        expect(detail.to).to eq("2026-04-30T23:59:59Z")
+      end
+    end
+
+    context "when fees have differences" do
+      let(:enriched_fee) do
+        Fee.new(
+          fee_attributes.merge(
+            units: 12,
+            amount_cents: 1200,
+            events_count: 6,
+            total_aggregated_units: 12
+          )
+        )
+      end
+
+      it "returns the diffs" do
+        result = service.call
+
+        expect(result).to be_success
+        expect(result.diff_count).to eq(1)
+
+        detail = result.fee_details.first
+        expect(detail.status).to eq("diff")
+        expect(detail.diffs).to match(
+          units: described_class::FieldDiff.new(legacy: 10.0, enriched: 12.0),
+          amount_cents: described_class::FieldDiff.new(legacy: 1000, enriched: 1200),
+          events_count: described_class::FieldDiff.new(legacy: 5, enriched: 6),
+          total_aggregated_units: described_class::FieldDiff.new(legacy: 10.0, enriched: 12.0)
+        )
+      end
+    end
+
+    context "when a fee exists only in legacy" do
+      let(:enriched_usage) { SubscriptionUsage.new(fees: []) }
+
+      it "reports the fee as only_in_legacy" do
+        result = service.call
+
+        expect(result).to be_success
+        expect(result.diff_count).to eq(1)
+        expect(result.fee_details.first.status).to eq("only_in_legacy")
+      end
+    end
+
+    context "when a fee exists only in enriched" do
+      let(:legacy_usage) { SubscriptionUsage.new(fees: []) }
+
+      it "reports the fee as only_in_enriched" do
+        result = service.call
+
+        expect(result).to be_success
+        expect(result.diff_count).to eq(1)
+        expect(result.fee_details.first.status).to eq("only_in_enriched")
+      end
+    end
+
+    context "when the service completes successfully" do
+      it "does not alter the organization state" do
+        original_flags = organization.feature_flags.dup
+        original_dedup = organization.clickhouse_deduplication_enabled
+        original_pre_filter = organization.pre_filter_events
+
+        service.call
+        organization.reload
+
+        expect(organization.feature_flags).to eq(original_flags)
+        expect(organization.clickhouse_deduplication_enabled).to eq(original_dedup)
+        expect(organization.pre_filter_events).to eq(original_pre_filter)
+      end
+    end
+
+    context "when legacy computation fails" do
+      let(:legacy_result) do
+        BaseService::LegacyResult.new.tap { |r| r.service_failure!(code: "legacy_error", message: "legacy computation broke") }
+      end
+
+      it "returns the original error" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq("legacy_error")
+        expect(result.error.message).to include("legacy computation broke")
+      end
+
+      it "does not alter the organization state" do
+        original_flags = organization.feature_flags.dup
+        original_dedup = organization.clickhouse_deduplication_enabled
+        original_pre_filter = organization.pre_filter_events
+
+        service.call
+        organization.reload
+
+        expect(organization.feature_flags).to eq(original_flags)
+        expect(organization.clickhouse_deduplication_enabled).to eq(original_dedup)
+        expect(organization.pre_filter_events).to eq(original_pre_filter)
+      end
+    end
+
+    context "when enriched computation fails" do
+      let(:enriched_result) do
+        BaseService::LegacyResult.new.tap { |r| r.service_failure!(code: "enriched_error", message: "enriched computation broke") }
+      end
+
+      it "returns the original error" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq("enriched_error")
+        expect(result.error.message).to include("enriched computation broke")
+      end
+
+      it "does not alter the organization state" do
+        original_flags = organization.feature_flags.dup
+        original_dedup = organization.clickhouse_deduplication_enabled
+        original_pre_filter = organization.pre_filter_events
+
+        service.call
+        organization.reload
+
+        expect(organization.feature_flags).to eq(original_flags)
+        expect(organization.clickhouse_deduplication_enabled).to eq(original_dedup)
+        expect(organization.pre_filter_events).to eq(original_pre_filter)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5309

Migrating an organization from `Events::Stores::ClickhouseStore` to `Events::Stores::ClickhouseEnrichedStore` today requires running 4+ rake tasks manually in sequence, with manual verification between steps. 

A full migration process with a two-level tracking system (on organizations and subscriptions), relying on resumable state machines, asynchronous and per-subscription independent processes will be added to automate these tasks

## Description

This PR extract the core logic of `enriched_events:compare` into a new `Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonService` with testing coverage.