### PR TITLE
feat(payment-gated-subs): add webhooks for incomplete and canceled subscriptions

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -60,6 +60,8 @@ class SendWebhookJob < ApplicationJob
     "feature.created" => Webhooks::Features::CreatedService,
     "feature.updated" => Webhooks::Features::UpdatedService,
     "feature.deleted" => Webhooks::Features::DeletedService,
+    "subscription.canceled" => Webhooks::Subscriptions::CanceledService,
+    "subscription.incomplete" => Webhooks::Subscriptions::IncompleteService,
     "subscription.terminated" => Webhooks::Subscriptions::TerminatedService,
     "subscription.started" => Webhooks::Subscriptions::StartedService,
     "subscription.termination_alert" => Webhooks::Subscriptions::TerminationAlertService,

--- a/app/services/webhooks/subscriptions/canceled_service.rb
+++ b/app/services/webhooks/subscriptions/canceled_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Subscriptions
+    class CanceledService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::SubscriptionSerializer.new(
+          object,
+          root_name: "subscription",
+          includes: %i[plan customer]
+        )
+      end
+
+      def webhook_type
+        "subscription.canceled"
+      end
+
+      def object_type
+        "subscription"
+      end
+    end
+  end
+end

--- a/app/services/webhooks/subscriptions/incomplete_service.rb
+++ b/app/services/webhooks/subscriptions/incomplete_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Subscriptions
+    class IncompleteService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::SubscriptionSerializer.new(
+          object,
+          root_name: "subscription",
+          includes: %i[plan customer]
+        )
+      end
+
+      def webhook_type
+        "subscription.incomplete"
+      end
+
+      def object_type
+        "subscription"
+      end
+    end
+  end
+end

--- a/config/webhook_event_types.yml
+++ b/config/webhook_event_types.yml
@@ -228,6 +228,16 @@ plan_deleted:
   description: A plan has been deleted
   category: Plans
   deprecated: false
+subscription_canceled:
+  name: subscription.canceled
+  description: A subscription has been canceled
+  category: Subscriptions and Fees
+  deprecated: false
+subscription_incomplete:
+  name: subscription.incomplete
+  description: A subscription is awaiting activation rule resolution before becoming active
+  category: Subscriptions and Fees
+  deprecated: false
 subscription_terminated:
   name: subscription.terminated
   description: A subscription has been terminated

--- a/schema.graphql
+++ b/schema.graphql
@@ -5685,6 +5685,8 @@ enum EventTypeEnum {
   plan_created
   plan_deleted
   plan_updated
+  subscription_canceled
+  subscription_incomplete
   subscription_started
   subscription_terminated
   subscription_termination_alert

--- a/schema.json
+++ b/schema.json
@@ -27538,6 +27538,18 @@
               "deprecationReason": null
             },
             {
+              "name": "subscription_canceled",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscription_incomplete",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "subscription_terminated",
               "description": null,
               "isDeprecated": false,

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -501,6 +501,14 @@ RSpec.describe SendWebhookJob do
       let(:options) { {usage_threshold: create(:usage_threshold)} }
 
       it_behaves_like "a webhook service",
+        "subscription.canceled",
+        Webhooks::Subscriptions::CanceledService
+
+      it_behaves_like "a webhook service",
+        "subscription.incomplete",
+        Webhooks::Subscriptions::IncompleteService
+
+      it_behaves_like "a webhook service",
         "subscription.started",
         Webhooks::Subscriptions::StartedService
 

--- a/spec/services/webhooks/subscriptions/canceled_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/canceled_service_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::Subscriptions::CanceledService do
+  subject(:webhook_service) { described_class.new(object: subscription) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, :canceled, customer:, plan:, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "subscription.canceled", "subscription", {
+      "lago_id" => String,
+      "external_id" => String,
+      "lago_customer_id" => String,
+      "external_customer_id" => String,
+      "plan_code" => String,
+      "status" => "canceled",
+      "billing_time" => String,
+      "created_at" => String,
+      "customer" => Hash,
+      "payment_method" => Hash
+    }
+  end
+end

--- a/spec/services/webhooks/subscriptions/incomplete_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/incomplete_service_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::Subscriptions::IncompleteService do
+  subject(:webhook_service) { described_class.new(object: subscription) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, :incomplete, customer:, plan:, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "subscription.incomplete", "subscription", {
+      "lago_id" => String,
+      "external_id" => String,
+      "lago_customer_id" => String,
+      "external_customer_id" => String,
+      "plan_code" => String,
+      "status" => "incomplete",
+      "billing_time" => String,
+      "started_at" => String,
+      "created_at" => String,
+      "customer" => Hash,
+      "payment_method" => Hash
+    }
+  end
+end


### PR DESCRIPTION
## Context

Payment-gated subscription activation requires notifying API consumers when a subscription enters the `incomplete` state (waiting for payment confirmation) and when it transitions to `canceled` (payment failed or timed out).

## Description

Add two new outbound webhook services following the existing subscription webhook pattern: `subscription.incomplete` and `subscription.canceled`. Both serialize the subscription with plan and customer includes via `V1::SubscriptionSerializer`. Register the new webhook types in the `SendWebhookJob::WEBHOOK_SERVICES` mapping so they can be dispatched via `SendWebhookJob.perform_later`.