### PR TITLE
feat(payment-gated-subs): add event guards for incomplete subscriptions

### DIFF
--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -41,7 +41,9 @@ module Events
     def subscriptions
       return @subscriptions if defined? @subscriptions
 
-      subscriptions = organization.subscriptions.where(external_id: event.external_subscription_id)
+      subscriptions = organization.subscriptions
+        .where(external_id: event.external_subscription_id)
+        .where.not(status: :incomplete)
       return unless subscriptions
 
       @subscriptions = subscriptions

--- a/app/services/fixed_charges/emit_events_for_active_subscriptions_service.rb
+++ b/app/services/fixed_charges/emit_events_for_active_subscriptions_service.rb
@@ -31,11 +31,11 @@ module FixedCharges
       # This handles cases like plan overrides where the subscription hasn't been updated yet
       # otherwise, emit events for all active subscriptions on the plan
       if subscription
-        # Only emit events for active subscriptions, even when explicitly provided
+        # Emit events for active and incomplete subscriptions
         # Pending subscriptions will have events created when they activate
-        subscription.active? ? [subscription] : []
+        (subscription.active? || subscription.incomplete?) ? [subscription] : []
       else
-        fixed_charge.plan.subscriptions.active
+        fixed_charge.plan.subscriptions.where(status: %i[active incomplete])
       end
     end
 

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -63,6 +63,24 @@ RSpec.describe Events::PostProcessService do
       end
     end
 
+    context "when subscription is incomplete" do
+      let(:subscription) do
+        create(:subscription, :incomplete, organization:, customer:, plan:, started_at:)
+      end
+
+      it "does not enqueue a pay in advance job" do
+        expect { process_service.call }.not_to have_enqueued_job(Events::PayInAdvanceJob)
+      end
+
+      it "does not track subscription activity" do
+        allow(UsageMonitoring::TrackSubscriptionActivityService).to receive(:call)
+
+        process_service.call
+
+        expect(UsageMonitoring::TrackSubscriptionActivityService).not_to have_received(:call)
+      end
+    end
+
     context "when event matches an pay_in_advance charge" do
       let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, invoiceable: false) }
       let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "item_id") }

--- a/spec/services/fixed_charges/emit_events_for_active_subscriptions_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_for_active_subscriptions_service_spec.rb
@@ -77,6 +77,43 @@ RSpec.describe FixedCharges::EmitEventsForActiveSubscriptionsService do
       expect(FixedChargeEvent.where(subscription: terminated_subscription, fixed_charge:)).not_to exist
     end
 
+    context "when there are incomplete subscriptions" do
+      let(:incomplete_subscription) do
+        create(
+          :subscription,
+          :incomplete,
+          :anniversary,
+          plan:,
+          customer: customer_1,
+          started_at: 1.day.ago,
+          subscription_at: 1.day.ago
+        )
+      end
+
+      before { incomplete_subscription }
+
+      it "creates fixed charge events for incomplete subscriptions" do
+        expect(FixedChargeEvent.where(subscription: incomplete_subscription, fixed_charge:)).not_to exist
+
+        result
+
+        expect(FixedChargeEvent.where(subscription: incomplete_subscription, fixed_charge:)).to exist
+      end
+    end
+
+    context "when a provided subscription is incomplete" do
+      let(:subscription) do
+        create(:subscription, :incomplete, :anniversary, plan:, started_at: 1.day.ago, subscription_at: 1.day.ago)
+      end
+
+      it "creates fixed charge event for the incomplete subscription" do
+        expect { result }.to change(FixedChargeEvent, :count).by(1)
+
+        event = FixedChargeEvent.find_by(subscription:, fixed_charge:)
+        expect(event).to be_present
+      end
+    end
+
     context "when there are no active subscriptions" do
       let(:active_subscription_1) { nil }
       let(:active_subscription_2) { nil }


### PR DESCRIPTION
## Context

Incomplete subscriptions have a `started_at` in the past, so they pass time-boundary queries unlike pending subscriptions. Without explicit guards, customer usage events would be processed for billing and pay-in-advance charges during the incomplete window.

Conversely, internal fixed charge events must still be emitted for incomplete subscriptions to produce correct activation invoices.

## Description

Exclude incomplete subscriptions from `Events::PostProcessService` query so usage events are ignored for billing, fee generation, and activity tracking while a subscription awaits payment confirmation.

Include incomplete subscriptions in
`FixedCharges::EmitEventsForActiveSubscriptionsService` so internal billing events needed for gated invoice creation are emitted correctly.