### PR TITLE
feat(payment-gated-subs): guard manual operations on incomplete subscriptions

### DIFF
--- a/app/services/invoices/payments/deliver_error_webhook_service.rb
+++ b/app/services/invoices/payments/deliver_error_webhook_service.rb
@@ -9,6 +9,8 @@ module Invoices
       end
 
       def call_async
+        return result if invoice.subscription? && invoice.open?
+
         if invoice.credit? && (invoice.open? || invoice.visible?)
           wallet_transaction = invoice.fees.credit.first.invoiceable
           SendWebhookJob.perform_later("wallet_transaction.payment_failure", wallet_transaction, params)

--- a/app/services/invoices/payments/deliver_error_webhook_service.rb
+++ b/app/services/invoices/payments/deliver_error_webhook_service.rb
@@ -9,8 +9,6 @@ module Invoices
       end
 
       def call_async
-        return result if invoice.subscription? && invoice.open?
-
         if invoice.credit? && (invoice.open? || invoice.visible?)
           wallet_transaction = invoice.fees.credit.first.invoiceable
           SendWebhookJob.perform_later("wallet_transaction.payment_failure", wallet_transaction, params)

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -16,6 +16,7 @@ module Subscriptions
 
     def call
       return result.not_found_failure!(resource: "subscription") if subscription.blank?
+      return result.not_allowed_failure!(code: "subscription_incomplete") if subscription.incomplete?
 
       ActiveRecord::Base.transaction do
         if subscription.pending?

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -19,6 +19,7 @@ module Subscriptions
 
     def call
       return result.not_found_failure!(resource: "subscription") unless subscription
+      return result.not_allowed_failure!(code: "subscription_incomplete") if subscription.incomplete?
 
       unless valid?(
         customer: subscription.customer,

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -1708,7 +1708,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         let(:subscription) { create(:subscription, :incomplete, customer:, plan:) }
         let(:update_params) { {name: "new name"} }
 
-        it "returns a method not allowed error", pending: "requires update service to reject incomplete subscriptions" do
+        it "returns a method not allowed error" do
           subject
 
           expect(response).to have_http_status(:method_not_allowed)

--- a/spec/services/invoices/payments/deliver_error_webhook_service_spec.rb
+++ b/spec/services/invoices/payments/deliver_error_webhook_service_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe Invoices::Payments::DeliverErrorWebhookService do
       end
     end
 
+    context "when the invoice is a subscription invoice and open" do
+      let(:invoice) { create(:invoice, invoice_type: :subscription, status: :open) }
+
+      it "does not send any webhook" do
+        expect do
+          webhook_service.call_async
+        end.not_to have_enqueued_job(SendWebhookJob)
+      end
+    end
+
     context "when the invoice is credit?" do
       let(:invoiceable) { create(:wallet_transaction) }
       let(:fee) { create(:fee, fee_type: :credit, invoice: invoice, invoiceable:) }

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -94,6 +94,15 @@ RSpec.describe Subscriptions::TerminateService do
       end
     end
 
+    context "when subscription is incomplete" do
+      let(:subscription) { create(:subscription, :incomplete) }
+
+      it "returns a not allowed error" do
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("subscription_incomplete")
+      end
+    end
+
     context "when subscription is not found" do
       let(:subscription) { nil }
 

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Subscriptions::UpdateService do
       subscription
     end
 
+    context "when subscription is incomplete" do
+      let(:subscription) { create(:subscription, :incomplete) }
+
+      it "returns a not allowed error" do
+        result = update_service.call
+
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("subscription_incomplete")
+      end
+    end
+
     context "when both usage_thresholds and plan_overrides.usage_thresholds are present" do
       let(:params) do
         {


### PR DESCRIPTION
## Context

Incomplete subscriptions must only be resolved by the system through payment success, payment failure, or timeout. Manual operations like terminate or update would bypass the activation flow and leave the subscription in an inconsistent state.

## Description

Reject terminate and update requests on incomplete subscriptions with a not_allowed error (code: subscription_incomplete). Silence the invoice.payment_failure webhook for open subscription invoices since payment failures on gated invoices are handled through the subscription.canceled webhook instead.
