### PR TITLE
feat(payment-gated-subs): add activation rule evaluate services

### DIFF
--- a/app/services/subscriptions/activation_rules/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/evaluate_service.rb
@@ -3,17 +3,22 @@
 module Subscriptions
   module ActivationRules
     class EvaluateService < BaseService
+      Result = BaseResult[:rules]
+
       def initialize(subscription:)
         @subscription = subscription
         super
       end
 
       def call
+        result.rules = []
+
         subscription.activation_rules.each do |rule|
           case rule
           when Subscription::ActivationRule::Payment
             Payment::EvaluateService.call!(rule:)
           end
+          result.rules << rule
         end
 
         result

--- a/app/services/subscriptions/activation_rules/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/evaluate_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ActivationRules
+    class EvaluateService < BaseService
+      def initialize(subscription:)
+        @subscription = subscription
+        super
+      end
+
+      def call
+        subscription.activation_rules.each do |rule|
+          case rule
+          when Subscription::ActivationRule::Payment
+            Payment::EvaluateService.call!(rule:)
+          end
+        end
+
+        result
+      end
+
+      private
+
+      attr_reader :subscription
+    end
+  end
+end

--- a/app/services/subscriptions/activation_rules/payment/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/evaluate_service.rb
@@ -4,6 +4,8 @@ module Subscriptions
   module ActivationRules
     module Payment
       class EvaluateService < BaseService
+        Result = BaseResult[:rule]
+
         def initialize(rule:, status: nil)
           @rule = rule
           @status = status
@@ -18,6 +20,7 @@ module Subscriptions
             transition_pending_rule
           end
 
+          result.rule = rule
           result
         end
 

--- a/app/services/subscriptions/activation_rules/payment/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/evaluate_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ActivationRules
+    module Payment
+      class EvaluateService < BaseService
+        def initialize(rule:, status: nil)
+          @rule = rule
+          @status = status
+          super
+        end
+
+        def call
+          case rule.status.to_sym
+          when :inactive
+            evaluate_inactive_rule
+          when :pending
+            transition_pending_rule
+          end
+
+          result
+        end
+
+        private
+
+        attr_reader :rule, :status
+
+        def evaluate_inactive_rule
+          if rule.applicable?
+            rule.expires_at = compute_expires_at
+            rule.pending!
+          else
+            rule.not_applicable!
+          end
+        end
+
+        def transition_pending_rule
+          rule.public_send(:"#{status}!")
+        end
+
+        def compute_expires_at
+          return nil if rule.timeout_hours.zero?
+
+          Time.current + rule.timeout_hours.hours
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/subscription/activation_rules.rb
+++ b/spec/factories/subscription/activation_rules.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :subscription_activation_rule, class: "Subscription::ActivationRule::Payment" do
+  factory :subscription_activation_rule, class: "Subscription::ActivationRule::Payment", aliases: [:payment_subscription_activation_rule] do
     subscription
     organization { subscription&.organization || association(:organization) }
     type { "payment" }

--- a/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe Subscriptions::ActivationRules::EvaluateService do
 
     it "delegates to Payment::EvaluateService" do
       expect(result).to be_success
-      expect(rule.reload.status).to eq("pending")
+      expect(result.rules.first).to be_pending
     end
   end
 
   context "when subscription has no activation rules" do
     it "returns success without changes" do
       expect(result).to be_success
+      expect(result.rules).to be_empty
     end
   end
 end

--- a/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ActivationRules::EvaluateService do
+  subject(:result) { described_class.call(subscription:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
+
+  context "when subscription has a payment activation rule" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:) }
+
+    before { rule }
+
+    it "delegates to Payment::EvaluateService" do
+      expect(result).to be_success
+      expect(rule.reload.status).to eq("pending")
+    end
+  end
+
+  context "when subscription has no activation rules" do
+    it "returns success without changes" do
+      expect(result).to be_success
+    end
+  end
+end

--- a/spec/services/subscriptions/activation_rules/payment/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/evaluate_service_spec.rb
@@ -20,14 +20,12 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
     context "when rule is applicable (pay-in-advance plan, no trial)" do
       it "transitions rule to pending" do
         expect(result).to be_success
-        expect(rule.reload.status).to eq("pending")
+        expect(result.rule).to be_pending
       end
 
       it "sets expires_at based on timeout_hours" do
         freeze_time do
-          result
-
-          expect(rule.reload.expires_at).to eq(Time.current + 48.hours)
+          expect(result.rule.expires_at).to eq(Time.current + 48.hours)
         end
       end
 
@@ -35,9 +33,8 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
         let(:timeout_hours) { 0 }
 
         it "transitions rule to pending without expires_at" do
-          result
-
-          expect(rule.reload).to have_attributes(status: "pending", expires_at: nil)
+          expect(result.rule).to be_pending
+          expect(result.rule.expires_at).to be_nil
         end
       end
     end
@@ -49,9 +46,7 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
       before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
 
       it "transitions rule to pending" do
-        result
-
-        expect(rule.reload.status).to eq("pending")
+        expect(result.rule).to be_pending
       end
     end
 
@@ -59,9 +54,8 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
       let(:plan) { create(:plan, organization:, pay_in_advance: false) }
 
       it "transitions rule to not_applicable" do
-        result
-
-        expect(rule.reload.status).to eq("not_applicable")
+        expect(result).to be_success
+        expect(result.rule).to be_not_applicable
       end
     end
 
@@ -69,9 +63,8 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
       let(:plan) { create(:plan, organization:, pay_in_advance: true, trial_period: 30) }
 
       it "transitions rule to not_applicable" do
-        result
-
-        expect(rule.reload.status).to eq("not_applicable")
+        expect(result).to be_success
+        expect(result.rule).to be_not_applicable
       end
     end
 
@@ -82,9 +75,8 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
       before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
 
       it "transitions rule to pending" do
-        result
-
-        expect(rule.reload.status).to eq("pending")
+        expect(result).to be_success
+        expect(result.rule).to be_pending
       end
     end
   end
@@ -96,9 +88,8 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
       let(:status) { :satisfied }
 
       it "transitions rule to satisfied" do
-        result
-
-        expect(rule.reload.status).to eq("satisfied")
+        expect(result).to be_success
+        expect(result.rule).to be_satisfied
       end
     end
 
@@ -106,9 +97,8 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
       let(:status) { :failed }
 
       it "transitions rule to failed" do
-        result
-
-        expect(rule.reload.status).to eq("failed")
+        expect(result).to be_success
+        expect(result.rule).to be_failed
       end
     end
 
@@ -116,9 +106,8 @@ RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
       let(:status) { :expired }
 
       it "transitions rule to expired" do
-        result
-
-        expect(rule.reload.status).to eq("expired")
+        expect(result).to be_success
+        expect(result.rule).to be_expired
       end
     end
   end

--- a/spec/services/subscriptions/activation_rules/payment/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/evaluate_service_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ActivationRules::Payment::EvaluateService do
+  subject(:result) { described_class.call(rule:, status:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
+  let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: rule_status, timeout_hours:) }
+  let(:rule_status) { "inactive" }
+  let(:timeout_hours) { 48 }
+  let(:status) { nil }
+
+  context "when rule is inactive" do
+    let(:rule_status) { "inactive" }
+
+    context "when rule is applicable (pay-in-advance plan, no trial)" do
+      it "transitions rule to pending" do
+        expect(result).to be_success
+        expect(rule.reload.status).to eq("pending")
+      end
+
+      it "sets expires_at based on timeout_hours" do
+        freeze_time do
+          result
+
+          expect(rule.reload.expires_at).to eq(Time.current + 48.hours)
+        end
+      end
+
+      context "when timeout_hours is zero" do
+        let(:timeout_hours) { 0 }
+
+        it "transitions rule to pending without expires_at" do
+          result
+
+          expect(rule.reload).to have_attributes(status: "pending", expires_at: nil)
+        end
+      end
+    end
+
+    context "when rule is applicable (pay-in-arrears plan with pay-in-advance fixed charges)" do
+      let(:plan) { create(:plan, organization:, pay_in_advance: false) }
+      let(:add_on) { create(:add_on, organization:) }
+
+      before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+      it "transitions rule to pending" do
+        result
+
+        expect(rule.reload.status).to eq("pending")
+      end
+    end
+
+    context "when rule is not applicable (pay-in-arrears plan, no fixed charges)" do
+      let(:plan) { create(:plan, organization:, pay_in_advance: false) }
+
+      it "transitions rule to not_applicable" do
+        result
+
+        expect(rule.reload.status).to eq("not_applicable")
+      end
+    end
+
+    context "when rule is not applicable (pay-in-advance plan with trial period)" do
+      let(:plan) { create(:plan, organization:, pay_in_advance: true, trial_period: 30) }
+
+      it "transitions rule to not_applicable" do
+        result
+
+        expect(rule.reload.status).to eq("not_applicable")
+      end
+    end
+
+    context "when plan has trial but has pay-in-advance fixed charges" do
+      let(:plan) { create(:plan, organization:, pay_in_advance: true, trial_period: 30) }
+      let(:add_on) { create(:add_on, organization:) }
+
+      before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+      it "transitions rule to pending" do
+        result
+
+        expect(rule.reload.status).to eq("pending")
+      end
+    end
+  end
+
+  context "when rule is pending" do
+    let(:rule_status) { "pending" }
+
+    context "when status is satisfied" do
+      let(:status) { :satisfied }
+
+      it "transitions rule to satisfied" do
+        result
+
+        expect(rule.reload.status).to eq("satisfied")
+      end
+    end
+
+    context "when status is failed" do
+      let(:status) { :failed }
+
+      it "transitions rule to failed" do
+        result
+
+        expect(rule.reload.status).to eq("failed")
+      end
+    end
+
+    context "when status is expired" do
+      let(:status) { :expired }
+
+      it "transitions rule to expired" do
+        result
+
+        expect(rule.reload.status).to eq("expired")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Payment-gated subscriptions need a mechanism to evaluate activation rules and transition them through their lifecycle. Rules start as inactive and must be evaluated to determine if they apply, then resolved when the payment outcome is known.

## Description

Add EvaluateService as a delegator that iterates a subscription's activation rules and dispatches to the type-specific evaluate service. Add Payment::EvaluateService that handles the payment rule state machine: inactive rules transition to pending (applicable) or not_applicable based on plan billing configuration; pending rules transition to satisfied, failed, or expired based on payment outcome. Add factory alias payment_subscription_activation_rule for clarity.