### PR TITLE
feat(payment-gated-subs): allow fee creation for incomplete subscriptions

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -278,7 +278,7 @@ module Invoices
       # NOTE: When a subscription is terminated we still need to charge the subscription
       #       fee if the plan is in pay in arrears, otherwise this fee will never
       #       be created.
-      subscription.active? ||
+      subscription.active? || subscription.incomplete? ||
         (subscription.terminated? && subscription.plan.pay_in_arrears?) ||
         (subscription.terminated? && subscription.terminated_at > invoice.created_at)
     end
@@ -346,7 +346,7 @@ module Invoices
       # NOTE: When a subscription is terminated we still need to charge the fixed_charges
       #       fee if the fixed_charge is pay in arrears, otherwise this fee will never
       #       be created.
-      subscription.active? ||
+      subscription.active? || subscription.incomplete? ||
         (subscription.terminated? && subscription.plan.fixed_charges.pay_in_arrears.any?) ||
         (subscription.terminated? && subscription.terminated_at > invoice.created_at)
     end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -2362,6 +2362,25 @@ RSpec.describe Invoices::CalculateFeesService do
     end
   end
 
+  context "when subscription is incomplete" do
+    let(:status) { :incomplete }
+    let(:timestamp) { Time.zone.parse("07 Mar 2022") }
+    let(:started_at) { Time.zone.parse("07 Mar 2022") }
+    let(:billing_time) { :anniversary }
+    let(:pay_in_advance) { true }
+    let(:fixed_charge) do
+      create(:fixed_charge, plan: subscription.plan, charge_model: "standard", properties: {amount: "10"}, units: 10, pay_in_advance: true)
+    end
+
+    it "creates subscription and fixed charge fees" do
+      result = invoice_service.call
+
+      expect(result).to be_success
+      expect(invoice.fees.subscription.count).to eq(1)
+      expect(invoice.fees.fixed_charge.count).to eq(1)
+    end
+  end
+
   describe "#should_create_yearly_subscription_fee?" do
     subject(:method_call) { invoice_service.send(:should_create_yearly_subscription_fee?, subscription) }
 


### PR DESCRIPTION
## Context

When a subscription enters the incomplete state for payment gating, the billing flow still needs to create subscription and fixed charge fees to produce the activation invoice that will be sent to the PSP.

## Description

Add incomplete status to the conditions in should_create_subscription_fee and should_create_fixed_charge_fees in CalculateFeesService so fees are generated for incomplete subscriptions alongside active ones.