### PR TITLE
feat(payment-gated-subs): keep gated invoices open in TransitionToFinalStatusService

### DIFF
--- a/app/services/invoices/transition_to_final_status_service.rb
+++ b/app/services/invoices/transition_to_final_status_service.rb
@@ -10,7 +10,9 @@ module Invoices
     end
 
     def call
-      if should_finalize_invoice?
+      if invoice.subscription_gated? && invoice.total_amount_cents.positive?
+        # Keep open for payment-gated invoices awaiting payment resolution
+      elsif should_finalize_invoice?
         Invoices::FinalizeService.call!(invoice: invoice)
       else
         invoice.status = :closed

--- a/app/services/invoices/transition_to_final_status_service.rb
+++ b/app/services/invoices/transition_to_final_status_service.rb
@@ -10,14 +10,17 @@ module Invoices
     end
 
     def call
-      if invoice.subscription_gated? && invoice.total_amount_cents.positive?
-        # Keep open for payment-gated invoices awaiting payment resolution
-      elsif should_finalize_invoice?
+      result.invoice = invoice
+
+      # Keep open for payment-gated invoices awaiting payment resolution
+      return result if invoice.subscription_gated? && invoice.total_amount_cents.positive?
+
+      if should_finalize_invoice?
         Invoices::FinalizeService.call!(invoice: invoice)
       else
         invoice.status = :closed
       end
-      result.invoice = invoice
+
       result
     end
 

--- a/spec/services/invoices/transition_to_final_status_service_spec.rb
+++ b/spec/services/invoices/transition_to_final_status_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Invoices::TransitionToFinalStatusService do
-  subject { described_class.new(invoice: invoice) }
+  subject(:result) { described_class.call(invoice:) }
 
   let(:organization) { create(:organization) }
   let(:billing_entity) { create(:billing_entity, organization:, finalize_zero_amount_invoice: billing_entity_setting) }
@@ -18,66 +18,103 @@ RSpec.describe Invoices::TransitionToFinalStatusService do
       currency: "EUR",
       fees_amount_cents:,
       issuing_date: Time.zone.now.beginning_of_month,
-      customer: customer
+      customer:
     )
   end
 
-  describe "#call" do
-    before { subject.call }
+  context "when invoice fees_amount_cents is not zero" do
+    it "finalizes the invoice" do
+      result
 
-    context "when invoice fees_amount_cents is not zero" do
+      expect(invoice.status).to eq("finalized")
+    end
+
+    context "with billing entity and customer settings defined to not finalize" do
+      let(:organization_setting) { "false" }
+      let(:customer_setting) { "skip" }
+
       it "finalizes the invoice" do
+        result
+
         expect(invoice.status).to eq("finalized")
       end
+    end
+  end
 
-      context "with billing entity and customer settings defined to not finalize" do
-        let(:organization_setting) { "false" }
-        let(:customer_setting) { "skip" }
+  context "when invoice is subscription_gated with positive amount" do
+    let(:fees_amount_cents) { 100 }
+    let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+    let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
+    let(:invoice) do
+      create(
+        :invoice,
+        organization:,
+        currency: "EUR",
+        fees_amount_cents:,
+        total_amount_cents: fees_amount_cents,
+        issuing_date: Time.zone.now.beginning_of_month,
+        customer:,
+        status: :open
+      )
+    end
 
-        it "finalizes the invoice" do
-          expect(invoice.status).to eq("finalized")
-        end
+    before do
+      create(:subscription_activation_rule, subscription:, status: "pending")
+      create(:invoice_subscription, invoice:, subscription:)
+    end
+
+    it "keeps the invoice as open" do
+      result
+
+      expect(invoice.status).to eq("open")
+    end
+  end
+
+  context "when invoice fees_amount_cents is zero" do
+    let(:fees_amount_cents) { 0 }
+
+    context "with customer setting defined to finalize" do
+      let(:customer_setting) { "finalize" }
+      let(:organization_setting) { "false" }
+
+      it "finalizes the invoice" do
+        result
+
+        expect(invoice.status).to eq("finalized")
       end
     end
 
-    context "when invoice fees_amount_cents is zero" do
-      let(:fees_amount_cents) { 0 }
+    context "with customer setting defined to skip" do
+      let(:customer_setting) { "skip" }
+      let(:organization_setting) { "true" }
 
-      context "with customer setting defined to finalize" do
-        let(:customer_setting) { "finalize" }
-        let(:organization_setting) { "false" }
+      it "closes the invoice" do
+        result
+
+        expect(invoice.status).to eq("closed")
+      end
+    end
+
+    context "with customer setting defined to inherit" do
+      let(:customer_setting) { "inherit" }
+
+      context "with billing_entity setting to finalize" do
+        let(:billing_entity_setting) { "true" }
 
         it "finalizes the invoice" do
+          result
+
           expect(invoice.status).to eq("finalized")
         end
       end
 
-      context "with customer setting defined to skip" do
-        let(:customer_setting) { "skip" }
-        let(:organization_setting) { "true" }
+      context "with billing_entity setting to skip" do
+        let(:billing_entity_setting) { "false" }
 
         it "closes the invoice" do
+          result
+
           expect(invoice.status).to eq("closed")
-        end
-      end
-
-      context "with customer setting defined to inherit" do
-        let(:customer_setting) { "inherit" }
-
-        context "with billing_entity setting to finalize" do
-          let(:billing_entity_setting) { "true" }
-
-          it "finalizes the invoice" do
-            expect(invoice.status).to eq("finalized")
-          end
-        end
-
-        context "with billing_entity setting to skip" do
-          let(:billing_entity_setting) { "false" }
-
-          it "closes the invoice" do
-            expect(invoice.status).to eq("closed")
-          end
         end
       end
     end

--- a/spec/services/invoices/transition_to_final_status_service_spec.rb
+++ b/spec/services/invoices/transition_to_final_status_service_spec.rb
@@ -44,7 +44,11 @@ RSpec.describe Invoices::TransitionToFinalStatusService do
   context "when invoice is subscription_gated with positive amount" do
     let(:fees_amount_cents) { 100 }
     let(:plan) { create(:plan, organization:, pay_in_advance: true) }
-    let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
+    let(:subscription) do
+      create(:subscription, :incomplete, :with_activation_rules,
+        activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+        organization:, customer:, plan:)
+    end
     let(:invoice) do
       create(
         :invoice,
@@ -58,15 +62,42 @@ RSpec.describe Invoices::TransitionToFinalStatusService do
       )
     end
 
-    before do
-      create(:subscription_activation_rule, subscription:, status: "pending")
-      create(:invoice_subscription, invoice:, subscription:)
-    end
+    before { create(:invoice_subscription, invoice:, subscription:) }
 
     it "keeps the invoice as open" do
       result
 
       expect(invoice.status).to eq("open")
+    end
+  end
+
+  context "when invoice is subscription_gated with zero amount" do
+    let(:fees_amount_cents) { 0 }
+    let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+    let(:subscription) do
+      create(:subscription, :incomplete, :with_activation_rules,
+        activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+        organization:, customer:, plan:)
+    end
+    let(:invoice) do
+      create(
+        :invoice,
+        organization:,
+        currency: "EUR",
+        fees_amount_cents:,
+        total_amount_cents: 0,
+        issuing_date: Time.zone.now.beginning_of_month,
+        customer:,
+        status: :open
+      )
+    end
+
+    before { create(:invoice_subscription, invoice:, subscription:) }
+
+    it "follows the normal finalize/close logic" do
+      result
+
+      expect(invoice.status).to eq("finalized")
     end
   end
 


### PR DESCRIPTION
## Context

Payment-gated invoices must remain in open status until payment is resolved. The transition service should not finalize or close them.

## Description

Add a guard in TransitionToFinalStatusService that preserves the open status for subscription-gated invoices with a positive total amount. Zero-amount gated invoices continue through the existing finalize/close logic unchanged.

Refactor the spec to use subject(:result) pattern.