### PR TITLE
feat(payment-gated-subs): skip grace period for gated invoices

### DIFF
--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -2,7 +2,7 @@
 
 module Invoices
   class CreateGeneratingService < BaseService
-    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false, skip_charges: false, invoice_id: nil, invoicing_reason: nil) # rubocop:disable Metrics/ParameterLists
+    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false, skip_charges: false, invoice_id: nil, invoicing_reason: nil, subscription_gated: false) # rubocop:disable Metrics/ParameterLists
       @customer = customer
       @invoice_type = invoice_type
       @currency = currency
@@ -11,6 +11,7 @@ module Invoices
       @skip_charges = skip_charges
       @invoice_id = invoice_id
       @recurring = invoicing_reason&.to_sym == :subscription_periodic
+      @subscription_gated = subscription_gated
 
       super
     end
@@ -45,7 +46,7 @@ module Invoices
 
     private
 
-    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance, :skip_charges, :invoice_id, :recurring
+    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance, :skip_charges, :invoice_id, :recurring, :subscription_gated
 
     delegate :organization, to: :customer
 
@@ -66,6 +67,8 @@ module Invoices
     end
 
     def grace_period?
+      return false if subscription_gated
+
       invoice_type.to_sym == :subscription
     end
 

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -124,6 +124,19 @@ RSpec.describe Invoices::CreateGeneratingService do
           expect(result.invoice.expected_finalization_date.to_s).to eq("2022-11-27")
         end
       end
+
+      context "when subscription_gated is true" do
+        subject(:create_service) do
+          described_class.new(customer:, invoice_type:, currency:, datetime:, charge_in_advance:, invoicing_reason:, subscription_gated: true)
+        end
+
+        it "skips grace period and uses current date as issuing date" do
+          result = create_service.call
+
+          expect(result.invoice.issuing_date.to_s).to eq(datetime.to_date.to_s)
+          expect(result.invoice.expected_finalization_date.to_s).to eq(datetime.to_date.to_s)
+        end
+      end
     end
 
     context "when customer is a partner account", :premium do


### PR DESCRIPTION
## Context

Payment-gated invoices must attempt payment immediately rather than waiting for the grace period to expire. The invoice should go directly to open status, not draft.

## Description

Add a subscription_gated parameter to CreateGeneratingService. When true the grace period is skipped, setting the issuing date and expected finalization date to the current date regardless of customer grace period configuration.