### PR TITLE
feat(payment-gated-subs): use empty payment reference for gated invoices

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -54,7 +54,7 @@ module Invoices
         payment_result = ::PaymentProviders::CreatePaymentFactory.new_instance(
           provider:,
           payment:,
-          reference: "#{invoice.billing_entity.name} - Invoice #{invoice.number}",
+          reference: payment_reference,
           metadata: {
             lago_invoice_id: invoice.id,
             lago_customer_id: invoice.customer_id,
@@ -167,6 +167,12 @@ module Invoices
           },
           error_details: e.original_error ? V1::Errors::ErrorSerializerFactory.new_instance(e.original_error).serialize : {}
         })
+      end
+
+      def payment_reference
+        return "" if invoice.subscription_gated?
+
+        "#{invoice.billing_entity.name} - Invoice #{invoice.number}"
       end
 
       def processing_payment

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -170,9 +170,11 @@ module Invoices
       end
 
       def payment_reference
-        return "" if invoice.subscription_gated?
-
-        "#{invoice.billing_entity.name} - Invoice #{invoice.number}"
+        if invoice.subscription_gated?
+          "#{invoice.billing_entity.name} - Invoice #{invoice.id}"
+        else
+          "#{invoice.billing_entity.name} - Invoice #{invoice.number}"
+        end
       end
 
       def processing_payment

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -72,6 +72,35 @@ RSpec.describe Invoices::Payments::CreateService do
       expect(invoice.payments.count).to eq(1)
     end
 
+    context "when invoice is subscription_gated (payment-gated)" do
+      let(:subscription) { create(:subscription, :incomplete, customer:, organization:) }
+      let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 100, status: :open) }
+
+      before do
+        create(:subscription_activation_rule, subscription:, status: "pending")
+        create(:invoice_subscription, invoice:, subscription:)
+
+        allow(provider_class)
+          .to receive(:new)
+          .with(
+            payment: an_instance_of(Payment),
+            reference: "",
+            metadata: {
+              lago_invoice_id: invoice.id,
+              lago_customer_id: customer.id,
+              invoice_issuing_date: invoice.issuing_date.iso8601,
+              invoice_type: invoice.invoice_type
+            }
+          ).and_return(provider_service)
+      end
+
+      it "passes an empty reference to the payment provider" do
+        create_service.call
+
+        expect(provider_class).to have_received(:new).with(hash_including(reference: ""))
+      end
+    end
+
     context "with gocardless payment provider" do
       let(:provider) { "gocardless" }
       let(:provider_class) { PaymentProviders::Gocardless::Payments::CreateService }

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -73,18 +73,22 @@ RSpec.describe Invoices::Payments::CreateService do
     end
 
     context "when invoice is subscription_gated (payment-gated)" do
-      let(:subscription) { create(:subscription, :incomplete, customer:, organization:) }
+      let(:subscription) do
+        create(:subscription, :incomplete, :with_activation_rules,
+          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+          customer:, organization:)
+      end
       let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 100, status: :open) }
+      let(:expected_reference) { "#{invoice.billing_entity.name} - Invoice #{invoice.id}" }
 
       before do
-        create(:subscription_activation_rule, subscription:, status: "pending")
         create(:invoice_subscription, invoice:, subscription:)
 
         allow(provider_class)
           .to receive(:new)
           .with(
             payment: an_instance_of(Payment),
-            reference: "",
+            reference: expected_reference,
             metadata: {
               lago_invoice_id: invoice.id,
               lago_customer_id: customer.id,
@@ -94,10 +98,10 @@ RSpec.describe Invoices::Payments::CreateService do
           ).and_return(provider_service)
       end
 
-      it "passes an empty reference to the payment provider" do
+      it "uses invoice ID instead of number in the reference" do
         create_service.call
 
-        expect(provider_class).to have_received(:new).with(hash_including(reference: ""))
+        expect(provider_class).to have_received(:new).with(hash_including(reference: expected_reference))
       end
     end
 


### PR DESCRIPTION
## Context

Open invoices for payment-gated subscriptions do not have a real invoice number assigned yet. The number is only set when the invoice transitions from open to finalized on payment success.

## Description

Extract payment reference into a method and return an empty string when the invoice is subscription_gated. This prevents sending a DRAFT placeholder number to the payment provider.