### PR TITLE
fix(clickhouse): events_enriched cloud migration

### DIFF
--- a/db/clickhouse_migrate/cloud/02_events_enriched.sql
+++ b/db/clickhouse_migrate/cloud/02_events_enriched.sql
@@ -9,7 +9,7 @@ CREATE TABLE default.events_enriched
     `sorted_properties` Map(String, String) DEFAULT mapSort(properties),
     `enriched_at` DateTime64(3) DEFAULT now(),
     `value` Nullable(String),
-    `decimal_value` Nullable(Decimal(38, 26) DEFAULT toDecimal128OrZero(value, 26)),
+    `decimal_value` Nullable(Decimal(38, 26)) DEFAULT toDecimal128OrZero(value, 26),
     `precise_total_amount_cents` Nullable(Decimal(40, 15))
 )
 ENGINE = SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}', timestamp)


### PR DESCRIPTION
## Description

This PR fixes the cloud migration for the `events_enriched` table.

NOTE: this migration is executed **manually** when creating a new cluster, so it is safe to update it directly.