### PR TITLE
fix(charges): Do not touch charges when updating charge children in b…

### DIFF
--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -22,19 +22,21 @@ module Charges
       return result unless charge
 
       ActiveRecord::Base.transaction do
-        # skip touching to avoid deadlocks
-        Plan.no_touching do
-          charge.children.where(id: child_ids).find_each do |child_charge|
-            Charges::UpdateService.call!(
-              charge: child_charge,
-              params:,
-              cascade_options: {
-                cascade: true,
-                parent_filters:,
-                equal_properties: old_parent.equal_properties?(child_charge),
-                equal_applied_pricing_unit_rate: old_parent.equal_applied_pricing_unit_rate?(child_charge)
-              }
-            )
+        # skip touching to avoid deadlocks and redundant cascading updates
+        Charge.no_touching do
+          Plan.no_touching do
+            charge.children.where(id: child_ids).find_each do |child_charge|
+              Charges::UpdateService.call!(
+                charge: child_charge,
+                params:,
+                cascade_options: {
+                  cascade: true,
+                  parent_filters:,
+                  equal_properties: old_parent.equal_properties?(child_charge),
+                  equal_applied_pricing_unit_rate: old_parent.equal_applied_pricing_unit_rate?(child_charge)
+                }
+              )
+            end
           end
         end
       end

--- a/spec/services/charges/update_children_service_spec.rb
+++ b/spec/services/charges/update_children_service_spec.rb
@@ -117,6 +117,14 @@ RSpec.describe Charges::UpdateChildrenService do
           expect { update_service.call }.not_to change { child_plan.reload.updated_at }
         end
       end
+
+      it "does not touch child charge from filter saves" do
+        allow(Charge).to receive(:no_touching).and_call_original
+
+        update_service.call
+
+        expect(Charge).to have_received(:no_touching).once
+      end
     end
 
     context "when charge has children that has been modified" do

--- a/spec/services/charges/update_children_service_spec.rb
+++ b/spec/services/charges/update_children_service_spec.rb
@@ -118,12 +118,24 @@ RSpec.describe Charges::UpdateChildrenService do
         end
       end
 
-      it "does not touch child charge from filter saves" do
-        allow(Charge).to receive(:no_touching).and_call_original
+      it "does not issue an extra child charge update from filter saves" do
+        child_charge_updates = []
 
-        update_service.call
+        callback = lambda do |_name, _start, _finish, _id, payload|
+          sql = payload[:sql]
+          next unless sql.match?(/\AUPDATE\s+"charges"/i)
 
-        expect(Charge).to have_received(:no_touching).once
+          binds = payload[:type_casted_binds] || payload[:binds]
+          next unless Array(binds).include?(child_charge.id)
+
+          child_charge_updates << sql
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          update_service.call
+        end
+
+        expect(child_charge_updates.size).to eq(1)
       end
     end
 


### PR DESCRIPTION
Summary                                                                                                                               
                                                                                                                                          
  - Add Charge.no_touching to Charges::UpdateChildrenService to prevent cascading touch: true writes from ChargeFilter → Charge during    
  batch cascade updates                                                                                                                   
                                                                                                                                          
  Context                                                                                                                                 
                                                                                                                                          
  ChargeFilter has belongs_to :charge, touch: true, meaning every filter save/touch triggers an UPDATE on the parent charge row. During a 
  batch cascade update of 20 children, each with N filters, this causes ~2N redundant UPDATEs per child charge (one from filter.save!, one
   from the explicit filter.touch), plus PaperTrail version inserts for each touched charge.                                              
                                                                                                                                          
  This write amplification inside a single transaction causes long-held row locks. When two UpdateChildrenJob runs overlap (e.g., rapid   
  successive edits to the parent charge), the second batch waits for the first's transaction lock — we observed individual UPDATE 
  charge_filters queries waiting over 1h30.                                                                                               
                                                                                                                                        
  Plan.no_touching was already in place for the same reason. This adds Charge.no_touching following the same pattern. Normal charge.save! 
  still works (it's not a touch), so all attribute changes are persisted — only the redundant cascading touches are skipped.
                                                                                                                                          
  Test plan                                                                                                                             

  - Existing Charges::UpdateChildrenService specs pass (6 examples, 0 failures)  