### PR TITLE
fix(charges): Remove outer transaction for charge batch update

### DIFF
--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -21,11 +21,6 @@ module Charges
     def call
       return result unless charge
 
-      # NOTE: No outer transaction — each child update is already individually
-      # transactional via Charges::UpdateService. Wrapping all children in a
-      # single transaction causes long lock durations (20 children × 72 filters)
-      # and deadlocks when concurrent batch jobs update the same charge_filters.
-
       # skip touching to avoid deadlocks and redundant cascading updates
       Charge.no_touching do
         Plan.no_touching do

--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -21,22 +21,25 @@ module Charges
     def call
       return result unless charge
 
-      ActiveRecord::Base.transaction do
-        # skip touching to avoid deadlocks and redundant cascading updates
-        Charge.no_touching do
-          Plan.no_touching do
-            charge.children.where(id: child_ids).find_each do |child_charge|
-              Charges::UpdateService.call!(
-                charge: child_charge,
-                params:,
-                cascade_options: {
-                  cascade: true,
-                  parent_filters:,
-                  equal_properties: old_parent.equal_properties?(child_charge),
-                  equal_applied_pricing_unit_rate: old_parent.equal_applied_pricing_unit_rate?(child_charge)
-                }
-              )
-            end
+      # NOTE: No outer transaction — each child update is already individually
+      # transactional via Charges::UpdateService. Wrapping all children in a
+      # single transaction causes long lock durations (20 children × 72 filters)
+      # and deadlocks when concurrent batch jobs update the same charge_filters.
+
+      # skip touching to avoid deadlocks and redundant cascading updates
+      Charge.no_touching do
+        Plan.no_touching do
+          charge.children.where(id: child_ids).find_each do |child_charge|
+            Charges::UpdateService.call!(
+              charge: child_charge,
+              params: params.deep_dup,
+              cascade_options: {
+                cascade: true,
+                parent_filters:,
+                equal_properties: old_parent.equal_properties?(child_charge),
+                equal_applied_pricing_unit_rate: old_parent.equal_applied_pricing_unit_rate?(child_charge)
+              }
+            )
           end
         end
       end

--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -27,7 +27,7 @@ module Charges
           charge.children.where(id: child_ids).find_each do |child_charge|
             Charges::UpdateService.call!(
               charge: child_charge,
-              params: params.deep_dup,
+              params:,
               cascade_options: {
                 cascade: true,
                 parent_filters:,


### PR DESCRIPTION
## Summary                                                                                                                                                                                
                                                                                                                                                                                            
  - Remove the outer `ActiveRecord::Base.transaction` wrapping all childrens in `Charges::UpdateChildrenService` — each child update is already individually transactional via            
  `Charges::UpdateService`                                                                                                                                                                                                                                                                         
                                                                                                                                                                                            
  ## Context
                                                                                                                                                                                            
  `Charges::UpdateChildrenBatchJob` processes batches of 20 child charges. Each child has ~72 charge filters, resulting in ~1,440 individual UPDATE queries on `charge_filters`.            
   
  The outer transaction was holding row locks across all 20 children for the entire batch duration (>1 hour in some cases). When the same parent charge is updated multiple times in rapid  
  succession, concurrent batch jobs would update the same `charge_filters` rows in different order (due to `default_scope { order(updated_at: :asc) }` instability across concurrent
  modifications), causing `PG::TRDeadlockDetected`.                                                                                                                                         
                  
  Removing the outer transaction reduces lock duration from ~1,440 rows held at once to ~72 (one child at a time), making deadlocks far less likely and significantly reducing query        
  execution time.