### PR TITLE
fix(charge): Add advisory lock to avoid updating same charge children…

### DIFF
--- a/app/jobs/charges/update_children_batch_job.rb
+++ b/app/jobs/charges/update_children_batch_job.rb
@@ -3,6 +3,7 @@
 module Charges
   class UpdateChildrenBatchJob < ApplicationJob
     queue_as :low_priority
+    retry_on WithAdvisoryLock::FailedToAcquireLock, wait: :polynomially_longer, attempts: 5
 
     def perform(child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
       Rails.logger.info("Charges::UpdateChildrenBatchJob - Started the execution for parent charge with ID: #{old_parent_attrs["id"]}")

--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -21,20 +21,26 @@ module Charges
     def call
       return result unless charge
 
-      # skip touching to avoid deadlocks and redundant cascading updates
-      Charge.no_touching do
-        Plan.no_touching do
-          charge.children.where(id: child_ids).find_each do |child_charge|
-            Charges::UpdateService.call!(
-              charge: child_charge,
-              params:,
-              cascade_options: {
-                cascade: true,
-                parent_filters:,
-                equal_properties: old_parent.equal_properties?(child_charge),
-                equal_applied_pricing_unit_rate: old_parent.equal_applied_pricing_unit_rate?(child_charge)
-              }
-            )
+      # Acquire an advisory lock on the parent charge to prevent concurrent
+      # cascades from overlapping (e.g. parent updated twice in quick succession).
+      # timeout_seconds: 0 fails immediately if another cascade is running;
+      # the job's retry_on will pick it up later.
+      Charge.with_advisory_lock!("update_children_charge_#{charge.id}", timeout_seconds: 0) do
+        # skip touching to avoid deadlocks and redundant cascading updates
+        Charge.no_touching do
+          Plan.no_touching do
+            charge.children.where(id: child_ids).find_each do |child_charge|
+              Charges::UpdateService.call!(
+                charge: child_charge,
+                params:,
+                cascade_options: {
+                  cascade: true,
+                  parent_filters:,
+                  equal_properties: old_parent.equal_properties?(child_charge),
+                  equal_applied_pricing_unit_rate: old_parent.equal_applied_pricing_unit_rate?(child_charge)
+                }
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
## Summary                                                                                                                                                                                
                                                                                                                                                                                            
  - Add PostgreSQL advisory lock in `Charges::UpdateChildrenService` keyed on the parent charge ID to prevent concurrent cascades from overlapping                                          
  - Add `retry_on WithAdvisoryLock::FailedToAcquireLock` to `Charges::UpdateChildrenBatchJob` so blocked jobs retry later                                                                   
                                                                                                                                                                                            
  ## Context                                                                                                                                                                                
                                                                                                                                                                                            
  When the same parent charge is updated multiple times in quick succession, each update triggers a separate `UpdateChildrenJob`, which spawns overlapping `UpdateChildrenBatchJob`s for the
   same child charges. These concurrent jobs update the same `charge_filters` rows simultaneously, causing prolonged row-level locking (queries lasting over 1 hour) and                    
  `PG::TRDeadlockDetected` errors.                                                                                                                                                          
                                                                                                                                                                                            
  The advisory lock ensures only one cascade runs at a time per parent charge. With `timeout_seconds: 0`, a batch job that can't acquire the lock fails immediately instead of waiting, and 
  the `retry_on` with `polynomially_longer` backoff re-enqueues it for later — avoiding both the lock contention and redundant concurrent work.