### PR TITLE
fix(clickhouse): Add `code` to deduplication grouping

### DIFF
--- a/app/services/events/stores/clickhouse/clean_duplicated_service.rb
+++ b/app/services/events/stores/clickhouse/clean_duplicated_service.rb
@@ -50,22 +50,23 @@ module Events
             .where(organization_id: organization.id)
             .where(external_subscription_id: subscription.external_id)
             .where(timestamp: boundaries.charges_from_datetime...boundaries.charges_to_datetime)
-            .group(:transaction_id, :timestamp)
+            .group(:transaction_id, :timestamp, :code)
             .having("count() > 1")
-            .pluck(:transaction_id, :timestamp)
+            .pluck(:transaction_id, :timestamp, :code)
         end
 
         def remove_duplicated_events
           duplicates = duplicated_events.to_a
           return if duplicates.empty?
 
-          duplicates.each do |transaction_id, event_timestamp|
+          duplicates.each do |transaction_id, event_timestamp, code|
             # Fetch all enriched_at timestamps for the duplicated events
             enriched_at = ::Clickhouse::EventsEnriched
               .where(organization_id: organization.id)
               .where(external_subscription_id: subscription.external_id)
               .where(timestamp: event_timestamp)
               .where(transaction_id: transaction_id)
+              .where(code: code)
               .order(enriched_at: :desc)
               .pluck(:enriched_at)
 
@@ -74,6 +75,7 @@ module Events
               .where(external_subscription_id: subscription.external_id)
               .where(timestamp: event_timestamp)
               .where(transaction_id: transaction_id)
+              .where(code: code)
               .where(enriched_at: enriched_at[1..])
               .delete_all
           end

--- a/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse d
           external_subscription_id: subscription.external_id,
           transaction_id: transaction_id,
           timestamp: timestamp,
-          code: "event_code_#{SecureRandom.hex(4)}",
+          code: "event_code",
           enriched_at: base_enriched_at + i.minutes
         )
       end
@@ -43,6 +43,57 @@ RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse d
       expect(event.enriched_at).to match_datetime(base_enriched_at + 2.minutes)
 
       expect(Subscriptions::ChargeCacheService).to have_received(:expire_for_subscription).with(subscription)
+    end
+
+    context "when events share the same transaction_id but have different codes" do
+      let(:other_code) { "other_event_code" }
+
+      before do
+        create(
+          :clickhouse_events_enriched,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          transaction_id: transaction_id,
+          timestamp: timestamp,
+          code: other_code,
+          enriched_at: base_enriched_at
+        )
+      end
+
+      it "does not delete events with a different code" do
+        result = clean_service.call
+
+        expect(result).to be_success
+        expect(::Clickhouse::EventsEnriched.where(transaction_id:, timestamp:, code: "event_code").count).to eq(1)
+        expect(::Clickhouse::EventsEnriched.where(transaction_id:, timestamp:, code: other_code).count).to eq(1)
+      end
+    end
+
+    context "when duplicate events share the same enriched_at timestamp" do
+      before do
+        ::Clickhouse::EventsEnriched.where(transaction_id:, timestamp:).delete_all
+
+        2.times do
+          create(
+            :clickhouse_events_enriched,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            transaction_id: transaction_id,
+            timestamp: timestamp,
+            code: "event_code",
+            enriched_at: base_enriched_at
+          )
+        end
+      end
+
+      it "deletes all copies including the keeper" do
+        expect(::Clickhouse::EventsEnriched.where(transaction_id:, timestamp:).count).to eq(2)
+
+        result = clean_service.call
+
+        expect(result).to be_success
+        expect(::Clickhouse::EventsEnriched.where(transaction_id:, timestamp:).count).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

`CleanDuplicatedService` grouped duplicates by `(transaction_id, timestamp)` only. Events enriched for different metrics (different `code` values) sharing the same `(transaction_id, timestamp)` were incorrectly counted as duplicates. This inflated the number of duplicate groups, caused unnecessary deletions, and triggered per-group queries (N+1).

Additionally, because `code` was not used in the WHERE clause during deletion, the `enriched_at`-based filtering could match the keeper row when multiple records shared the same `enriched_at` value, deleting all copies instead of preserving one.

## Description

`code` was added to the GROUP BY, pluck, and WHERE clauses in both `duplicated_events` and `remove_duplicated_events`. This ensures only true duplicates (same event re-enriched for the same metric) are flagged, and the deletion targets the correct rows.

The existing test setup was also fixed to use a consistent `code` value instead of random ones, since the service now groups by `code`. Two new test contexts were added: one verifying that events with different codes are preserved, and one documenting the pre-existing limitation where all copies get deleted when duplicates share the same `enriched_at` timestamp.

## Test plan

- [x] Existing spec passes with consistent `code` value in factory setup
- [x] New spec: events with same `(transaction_id, timestamp)` but different `code` are not deleted
- [x] New spec: documents behavior when duplicate events share the same `enriched_at` timestamp