### PR TITLE
fix(clickhouse): skip empty filters in OR clauses

### DIFF
--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -50,7 +50,7 @@ module ChargeFilters
         end
 
         res
-      end.compact
+      end.compact.reject { |h| h.empty? || h.values.all?(&:empty?) }
 
       result
     end

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -50,7 +50,7 @@ module ChargeFilters
         end
 
         res
-      end.compact.reject { |h| h.empty? || h.values.all?(&:empty?) }
+      end.compact
 
       result
     end

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -780,12 +780,17 @@ module Events
           )
         end
 
-        conditions = ignored_filters.map do |filters|
-          filters.map do |key, values|
+        conditions = ignored_filters.filter_map do |filters|
+          next if filters.empty?
+
+          clause = filters.filter_map do |key, values|
+            next if values.empty?
+
             ActiveRecord::Base.sanitize_sql_for_conditions(
               ["(coalesce(events_enriched_expanded.sorted_properties[?], '') IN (?))", key.to_s, values.map(&:to_s)]
             )
           end.join(" AND ")
+          clause.presence
         end
         sql = conditions.map { "(#{it})" }.join(" OR ")
         query = query.where(Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new(sql))) if conditions.present?

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -670,12 +670,17 @@ module Events
           scope = scope.where("events_enriched.properties[?] IN (?)", key.to_s, values)
         end
 
-        conditions = ignored_filters.map do |filters|
-          filters.map do |key, values|
+        conditions = ignored_filters.filter_map do |filters|
+          next if filters.empty?
+
+          clause = filters.filter_map do |key, values|
+            next if values.empty?
+
             ActiveRecord::Base.sanitize_sql_for_conditions(
               ["(coalesce(events_enriched.properties[?], '') IN (?))", key.to_s, values.map(&:to_s)]
             )
           end.join(" AND ")
+          clause.presence
         end
         sql = conditions.map { "(#{it})" }.join(" OR ")
         scope = scope.where.not(sql) if sql.present?
@@ -690,12 +695,17 @@ module Events
           )
         end
 
-        conditions = ignored_filters.map do |filters|
-          filters.map do |key, values|
+        conditions = ignored_filters.filter_map do |filters|
+          next if filters.empty?
+
+          clause = filters.filter_map do |key, values|
+            next if values.empty?
+
             ActiveRecord::Base.sanitize_sql_for_conditions(
               ["(coalesce(events_enriched.properties[?], '') IN (?))", key.to_s, values.map(&:to_s)]
             )
           end.join(" AND ")
+          clause.presence
         end
         sql = conditions.map { "(#{it})" }.join(" OR ")
         scope = scope.where(Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new(sql))) if conditions.present?

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -355,14 +355,19 @@ module Events
           )
         end
 
-        conditions = ignored_filters.map do |filters|
-          filters.map do |key, values|
+        conditions = ignored_filters.filter_map do |filters|
+          next if filters.empty?
+
+          clause = filters.filter_map do |key, values|
+            next if values.empty?
+
             sanitize_sql_for_conditions(
               ["(coalesce(events.properties ->> ?, '') IN (?))", key.to_s, values.map(&:to_s)]
             )
           end.join(" AND ")
+          clause.presence
         end
-        sql = conditions.compact_blank.map { "(#{it})" }.join(" OR ")
+        sql = conditions.map { "(#{it})" }.join(" OR ")
         scope = scope.where.not(sql) if sql.present?
 
         scope

--- a/spec/scenarios/current_usage/with_identical_charge_filters_spec.rb
+++ b/spec/scenarios/current_usage/with_identical_charge_filters_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression test for ISSUE-1799: ClickHouse query fails with empty Tuple()
+# when ignored_filters contains empty hashes or hashes with all-empty-array values.
+#
+# Two patterns produce problematic entries in ignored_filters:
+#
+# 1. Empty hash {} — when a charge filter has no ChargeFilterValue records.
+#    MatchingAndIgnoredService returns {} for that child, which the store
+#    wraps as "()" in SQL.
+#
+# 2. All-empty-values {"key" => []} — when a child filter has the same keys
+#    as the parent AND the child's values are a subset of the parent's.
+#    After subtraction (child_values - parent_values), all arrays become [].
+#    This is the more realistic production case.
+describe "Current Usage - Filters with empty ignored_filters entries", transaction: false do
+  [
+    :postgres,
+    :clickhouse
+  ].each do |store|
+    context "with #{store} store", clickhouse: store == :clickhouse do
+      let(:organization) { create(:organization, webhook_url: nil, clickhouse_events_store: store == :clickhouse) }
+      let(:customer) { create(:customer, organization:) }
+      let(:plan) { create(:plan, organization:, amount_cents: 0, pay_in_advance: false, interval: "monthly") }
+      let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: "value") }
+
+      # Pattern 1: empty hash {} in ignored_filters
+      # Requires filters with no ChargeFilterValue records.
+      context "when charge filters have no values" do
+        before do
+          cloud_filter = create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp])
+
+          charge = create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"})
+
+          create(:charge_filter, charge:, properties: {amount: "5"}, invoice_display_name: "Empty A")
+          create(:charge_filter, charge:, properties: {amount: "8"}, invoice_display_name: "Empty B")
+          create(:charge_filter, charge:, properties: {amount: "3"}, invoice_display_name: "AWS")
+            .tap { |cf| create(:charge_filter_value, charge_filter: cf, billable_metric_filter: cloud_filter, values: ["aws"]) }
+        end
+
+        it "returns current usage without SQL errors" do
+          travel_to(DateTime.new(2024, 3, 5)) do
+            create_subscription(
+              {
+                external_customer_id: customer.external_id,
+                external_id: customer.external_id,
+                plan_code: plan.code
+              }
+            )
+          end
+
+          travel_to(DateTime.new(2024, 3, 6)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_subscription_id: customer.external_id,
+                properties: {cloud: "aws", value: 10}
+              }
+            )
+
+            fetch_current_usage(customer:)
+
+            expect(json[:customer_usage][:charges_usage].first[:filters].count).to eq(4)
+          end
+        end
+      end
+
+      # Pattern 2: all-empty-values {"cloud" => []} in ignored_filters
+      # When a child filter's values are a subset of the parent's values
+      # on all shared keys, the subtraction produces empty arrays.
+      #
+      # Setup:
+      # - Filter "All clouds": cloud=[aws, gcp] (parent — superset)
+      # - Filter "AWS only":   cloud=[aws]       (child — subset)
+      # When processing "All clouds", "AWS only" is a child with the same
+      # key. After subtraction: {"cloud" => ["aws"] - ["aws", "gcp"]} = {"cloud" => []}.
+      context "when a child filter's values are a subset of the parent's" do
+        before do
+          cloud_filter = create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp])
+
+          charge = create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"})
+
+          create(:charge_filter, charge:, properties: {amount: "5"}, invoice_display_name: "All clouds")
+            .tap { |cf| create(:charge_filter_value, charge_filter: cf, billable_metric_filter: cloud_filter, values: %w[aws gcp]) }
+          create(:charge_filter, charge:, properties: {amount: "3"}, invoice_display_name: "AWS only")
+            .tap { |cf| create(:charge_filter_value, charge_filter: cf, billable_metric_filter: cloud_filter, values: ["aws"]) }
+        end
+
+        it "returns current usage without SQL errors" do
+          travel_to(DateTime.new(2024, 3, 5)) do
+            create_subscription(
+              {
+                external_customer_id: customer.external_id,
+                external_id: customer.external_id,
+                plan_code: plan.code
+              }
+            )
+          end
+
+          travel_to(DateTime.new(2024, 3, 6)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_subscription_id: customer.external_id,
+                properties: {cloud: "aws", value: 10}
+              }
+            )
+
+            fetch_current_usage(customer:)
+
+            expect(json[:customer_usage][:charges_usage].first[:filters].count).to eq(3)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/current_usage/with_identical_charge_filters_spec.rb
+++ b/spec/scenarios/current_usage/with_identical_charge_filters_spec.rb
@@ -3,18 +3,10 @@
 require "rails_helper"
 
 # Regression test for ISSUE-1799: ClickHouse query fails with empty Tuple()
-# when ignored_filters contains empty hashes or hashes with all-empty-array values.
-#
-# Two patterns produce problematic entries in ignored_filters:
-#
-# 1. Empty hash {} — when a charge filter has no ChargeFilterValue records.
-#    MatchingAndIgnoredService returns {} for that child, which the store
-#    wraps as "()" in SQL.
-#
-# 2. All-empty-values {"key" => []} — when a child filter has the same keys
-#    as the parent AND the child's values are a subset of the parent's.
-#    After subtraction (child_values - parent_values), all arrays become [].
-#    This is the more realistic production case.
+# when ignored_filters contains empty hashes or hashes with all-empty-array
+# values. These states should not occur — charge filters should always have
+# values and duplicates should not exist — but missing validations allow them
+# in production. The store-level defensive guards prevent invalid SQL.
 describe "Current Usage - Filters with empty ignored_filters entries", transaction: false do
   [
     :postgres,
@@ -26,8 +18,8 @@ describe "Current Usage - Filters with empty ignored_filters entries", transacti
       let(:plan) { create(:plan, organization:, amount_cents: 0, pay_in_advance: false, interval: "monthly") }
       let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: "value") }
 
-      # Pattern 1: empty hash {} in ignored_filters
-      # Requires filters with no ChargeFilterValue records.
+      # Filters with no ChargeFilterValue records should not exist but can due
+      # to missing validations. They produce {} in ignored_filters.
       context "when charge filters have no values" do
         before do
           cloud_filter = create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp])
@@ -68,15 +60,9 @@ describe "Current Usage - Filters with empty ignored_filters entries", transacti
         end
       end
 
-      # Pattern 2: all-empty-values {"cloud" => []} in ignored_filters
-      # When a child filter's values are a subset of the parent's values
-      # on all shared keys, the subtraction produces empty arrays.
-      #
-      # Setup:
-      # - Filter "All clouds": cloud=[aws, gcp] (parent — superset)
-      # - Filter "AWS only":   cloud=[aws]       (child — subset)
-      # When processing "All clouds", "AWS only" is a child with the same
-      # key. After subtraction: {"cloud" => ["aws"] - ["aws", "gcp"]} = {"cloud" => []}.
+      # Duplicate filters with identical values should not exist but can due
+      # to missing validations. The child's subtraction zeroes out all arrays,
+      # producing {"cloud" => []} in ignored_filters.
       context "when a child filter's values are a subset of the parent's" do
         before do
           cloud_filter = create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp])

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     ]
   end
 
+  let(:f6) { create(:charge_filter, charge:, invoice_display_name: "f6") }
   before do
     f1
     f1_values
@@ -84,6 +85,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     f4_values
     f5
     f5_values
+    f6
   end
 
   describe "for f1" do
@@ -150,6 +152,23 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
           {"size" => ["512"], "steps" => ["25"]},
           {"size" => %w[512 1024], "steps" => %w[25 50 75 100]},
           {"size" => ["1024"]}
+        ]
+      )
+    end
+  end
+
+  describe "for f6 (filter with no values)" do
+    let(:current_filter) { f6 }
+
+    it "returns a formatted hash" do
+      expect(service_result.matching_filters).to eq({})
+      expect(service_result.ignored_filters).to match_array(
+        [
+          {"size" => ["512"], "steps" => ["25"], "model" => ["llama-2"]},
+          {"size" => ["512"], "steps" => ["25"]},
+          {"size" => ["512", "1024"], "steps" => ["25", "50", "75", "100"]},
+          {"size" => ["512", "1024"]},
+          {"size" => ["512"]}
         ]
       )
     end

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -173,4 +173,59 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
       )
     end
   end
+
+  describe "when a child filter has all values subsumed by the current filter" do
+    subject(:service_result) { described_class.call(charge: charge_2, filter: current_filter) }
+
+    let(:billable_metric_2) { create(:billable_metric) }
+    let(:charge_2) { create(:standard_charge, billable_metric: billable_metric_2) }
+
+    let(:bm_filter_region) { create(:billable_metric_filter, billable_metric: billable_metric_2, key: "region", values: %w[eu us]) }
+    let(:bm_filter_cloud) { create(:billable_metric_filter, billable_metric: billable_metric_2, key: "cloud", values: %w[aws gcp]) }
+
+    # parent_filter has region=eu and cloud=aws (fewer values)
+    let(:parent_filter) { create(:charge_filter, charge: charge_2, invoice_display_name: "parent") }
+    let(:parent_filter_values) do
+      [
+        create(:charge_filter_value, values: %w[eu], billable_metric_filter: bm_filter_region, charge_filter: parent_filter),
+        create(:charge_filter_value, values: %w[aws], billable_metric_filter: bm_filter_cloud, charge_filter: parent_filter)
+      ]
+    end
+
+    # superset_child has region=eu,us and cloud=aws,gcp (superset of parent).
+    # After subtraction (child_values - parent_values): {"region" => ["us"], "cloud" => ["gcp"]} (non-empty, kept).
+    let(:superset_child) { create(:charge_filter, charge: charge_2, invoice_display_name: "superset") }
+    let(:superset_child_values) do
+      [
+        create(:charge_filter_value, values: %w[eu us], billable_metric_filter: bm_filter_region, charge_filter: superset_child),
+        create(:charge_filter_value, values: %w[aws gcp], billable_metric_filter: bm_filter_cloud, charge_filter: superset_child)
+      ]
+    end
+
+    # identical_child has the exact same keys and values as parent_filter.
+    # After subtraction: {"region" => [], "cloud" => []} (all empty, must be rejected).
+    let(:identical_child) { create(:charge_filter, charge: charge_2, invoice_display_name: "identical") }
+    let(:identical_child_values) do
+      [
+        create(:charge_filter_value, values: %w[eu], billable_metric_filter: bm_filter_region, charge_filter: identical_child),
+        create(:charge_filter_value, values: %w[aws], billable_metric_filter: bm_filter_cloud, charge_filter: identical_child)
+      ]
+    end
+
+    let(:current_filter) { parent_filter }
+
+    before do
+      parent_filter_values
+      superset_child_values
+      identical_child_values
+    end
+
+    it "rejects ignored filters where all values are empty arrays after subtraction" do
+      # superset_child: {"region" => ["eu", "us"], "cloud" => ["aws", "gcp"]} - parent → {"region" => ["us"], "cloud" => ["gcp"]} (kept)
+      # identical_child: {"region" => ["eu"], "cloud" => ["aws"]} - parent → {"region" => [], "cloud" => []} (rejected)
+      expect(service_result.ignored_filters).to eq(
+        [{"region" => %w[us], "cloud" => %w[gcp]}]
+      )
+    end
+  end
 end

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     ]
   end
 
-  let(:f6) { create(:charge_filter, charge:, invoice_display_name: "f6") }
   before do
     f1
     f1_values
@@ -85,7 +84,6 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     f4_values
     f5
     f5_values
-    f6
   end
 
   describe "for f1" do
@@ -157,75 +155,4 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     end
   end
 
-  describe "for f6 (filter with no values)" do
-    let(:current_filter) { f6 }
-
-    it "returns a formatted hash" do
-      expect(service_result.matching_filters).to eq({})
-      expect(service_result.ignored_filters).to match_array(
-        [
-          {"size" => ["512"], "steps" => ["25"], "model" => ["llama-2"]},
-          {"size" => ["512"], "steps" => ["25"]},
-          {"size" => ["512", "1024"], "steps" => ["25", "50", "75", "100"]},
-          {"size" => ["512", "1024"]},
-          {"size" => ["512"]}
-        ]
-      )
-    end
-  end
-
-  describe "when a child filter has all values subsumed by the current filter" do
-    subject(:service_result) { described_class.call(charge: charge_2, filter: current_filter) }
-
-    let(:billable_metric_2) { create(:billable_metric) }
-    let(:charge_2) { create(:standard_charge, billable_metric: billable_metric_2) }
-
-    let(:bm_filter_region) { create(:billable_metric_filter, billable_metric: billable_metric_2, key: "region", values: %w[eu us]) }
-    let(:bm_filter_cloud) { create(:billable_metric_filter, billable_metric: billable_metric_2, key: "cloud", values: %w[aws gcp]) }
-
-    # parent_filter has region=eu and cloud=aws (fewer values)
-    let(:parent_filter) { create(:charge_filter, charge: charge_2, invoice_display_name: "parent") }
-    let(:parent_filter_values) do
-      [
-        create(:charge_filter_value, values: %w[eu], billable_metric_filter: bm_filter_region, charge_filter: parent_filter),
-        create(:charge_filter_value, values: %w[aws], billable_metric_filter: bm_filter_cloud, charge_filter: parent_filter)
-      ]
-    end
-
-    # superset_child has region=eu,us and cloud=aws,gcp (superset of parent).
-    # After subtraction (child_values - parent_values): {"region" => ["us"], "cloud" => ["gcp"]} (non-empty, kept).
-    let(:superset_child) { create(:charge_filter, charge: charge_2, invoice_display_name: "superset") }
-    let(:superset_child_values) do
-      [
-        create(:charge_filter_value, values: %w[eu us], billable_metric_filter: bm_filter_region, charge_filter: superset_child),
-        create(:charge_filter_value, values: %w[aws gcp], billable_metric_filter: bm_filter_cloud, charge_filter: superset_child)
-      ]
-    end
-
-    # identical_child has the exact same keys and values as parent_filter.
-    # After subtraction: {"region" => [], "cloud" => []} (all empty, must be rejected).
-    let(:identical_child) { create(:charge_filter, charge: charge_2, invoice_display_name: "identical") }
-    let(:identical_child_values) do
-      [
-        create(:charge_filter_value, values: %w[eu], billable_metric_filter: bm_filter_region, charge_filter: identical_child),
-        create(:charge_filter_value, values: %w[aws], billable_metric_filter: bm_filter_cloud, charge_filter: identical_child)
-      ]
-    end
-
-    let(:current_filter) { parent_filter }
-
-    before do
-      parent_filter_values
-      superset_child_values
-      identical_child_values
-    end
-
-    it "rejects ignored filters where all values are empty arrays after subtraction" do
-      # superset_child: {"region" => ["eu", "us"], "cloud" => ["aws", "gcp"]} - parent → {"region" => ["us"], "cloud" => ["gcp"]} (kept)
-      # identical_child: {"region" => ["eu"], "cloud" => ["aws"]} - parent → {"region" => [], "cloud" => []} (rejected)
-      expect(service_result.ignored_filters).to eq(
-        [{"region" => %w[us], "cloud" => %w[gcp]}]
-      )
-    end
-  end
 end

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -155,7 +155,13 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     end
   end
 
-  # Isolated setups for edge cases discovered via fuzz testing (ISSUE-1799)
+  # The following contexts cover edge cases where ignored_filters contains
+  # empty hashes or hashes with all-empty-array values. These states should
+  # not occur in normal usage — charge filters should always have values,
+  # and duplicate filters should not exist — but missing validations allow
+  # them in production. The store-level defensive guards (ISSUE-1799) prevent
+  # these from producing invalid SQL.
+
   context "when a filter has no values" do
     subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
 
@@ -200,18 +206,13 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
 
     let(:isolated_charge) { create(:standard_charge, billable_metric:) }
 
-    # Parent: size=[512, 1024] (superset)
     let(:parent_filter) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "parent") }
-    # Child: size=[512] (strict subset — subtraction produces [])
     let(:subset_child) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "subset_child") }
-    # Sibling: size=[1024] (not a subset — subtraction produces ["1024"] - ["512","1024"] = [])
-    # Actually this IS a subset too. Let's add a non-subset for contrast.
     let(:partial_overlap) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "partial") }
 
     before do
       create(:charge_filter_value, values: %w[512 1024], billable_metric_filter: filter_size, charge_filter: parent_filter)
       create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: subset_child)
-      # partial_overlap uses size + steps — different key set, so no subtraction
       create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: partial_overlap)
       create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: partial_overlap)
     end
@@ -219,7 +220,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     describe "for parent_filter" do
       let(:current_filter) { parent_filter }
 
-      it "produces all-empty-values entry from subset child and keeps non-subset children intact" do
+      it "produces all-empty-values entry from subset child and keeps different-key children intact" do
         expect(service_result.matching_filters).to eq({"size" => %w[512 1024]})
         expect(service_result.ignored_filters).to eq(
           [

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -155,4 +155,106 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     end
   end
 
+  # Isolated setups for edge cases discovered via fuzz testing (ISSUE-1799)
+  context "when a filter has no values" do
+    subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
+
+    let(:isolated_charge) { create(:standard_charge, billable_metric:) }
+
+    let(:empty_a) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "empty_a") }
+    let(:empty_b) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "empty_b") }
+    let(:with_values) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "with_values") }
+
+    before do
+      empty_a
+      empty_b
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: with_values)
+    end
+
+    describe "for empty_a" do
+      let(:current_filter) { empty_a }
+
+      it "produces empty hashes in ignored_filters from other empty filters" do
+        expect(service_result.matching_filters).to eq({})
+        expect(service_result.ignored_filters).to eq(
+          [
+            {},
+            {"size" => ["512"]}
+          ]
+        )
+      end
+    end
+
+    describe "for with_values" do
+      let(:current_filter) { with_values }
+
+      it "does not include empty filters as children" do
+        expect(service_result.matching_filters).to eq({"size" => ["512"]})
+        expect(service_result.ignored_filters).to eq([])
+      end
+    end
+  end
+
+  context "when a child's values are a subset of the parent's" do
+    subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
+
+    let(:isolated_charge) { create(:standard_charge, billable_metric:) }
+
+    # Parent: size=[512, 1024] (superset)
+    let(:parent_filter) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "parent") }
+    # Child: size=[512] (strict subset — subtraction produces [])
+    let(:subset_child) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "subset_child") }
+    # Sibling: size=[1024] (not a subset — subtraction produces ["1024"] - ["512","1024"] = [])
+    # Actually this IS a subset too. Let's add a non-subset for contrast.
+    let(:partial_overlap) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "partial") }
+
+    before do
+      create(:charge_filter_value, values: %w[512 1024], billable_metric_filter: filter_size, charge_filter: parent_filter)
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: subset_child)
+      # partial_overlap uses size + steps — different key set, so no subtraction
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: partial_overlap)
+      create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: partial_overlap)
+    end
+
+    describe "for parent_filter" do
+      let(:current_filter) { parent_filter }
+
+      it "produces all-empty-values entry from subset child and keeps non-subset children intact" do
+        expect(service_result.matching_filters).to eq({"size" => %w[512 1024]})
+        expect(service_result.ignored_filters).to eq(
+          [
+            {"size" => []},
+            {"size" => ["512"], "steps" => ["25"]}
+          ]
+        )
+      end
+    end
+  end
+
+  context "when two filters have identical keys and values" do
+    subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
+
+    let(:isolated_charge) { create(:standard_charge, billable_metric:) }
+
+    let(:filter_a) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_a") }
+    let(:filter_b) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_b") }
+
+    before do
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: filter_a)
+      create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: filter_a)
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: filter_b)
+      create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: filter_b)
+    end
+
+    describe "for filter_a" do
+      let(:current_filter) { filter_a }
+
+      it "produces all-empty-values entry from the identical sibling" do
+        expect(service_result.matching_filters).to eq({"size" => ["512"], "steps" => ["25"]})
+        expect(service_result.ignored_filters).to eq(
+          [{"size" => [], "steps" => []}]
+        )
+      end
+    end
+  end
 end

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -346,6 +346,24 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
             end
           end
         end
+
+        # Empty hashes or hashes with all-empty-array values in ignored_filters
+        # could produce invalid SQL (e.g., empty Tuple() in ClickHouse) if not
+        # filtered out. This verifies the defensive guards in filters_scope.
+        context "when ignored_filters contains empty and all-empty-values entries" do
+          let(:ignored_filters) do
+            [
+              {},
+              {"city" => [], "country" => []},
+              {"city" => ["caen"]},
+              {"city" => ["cambridge", "london"], "country" => ["united kingdom"]}
+            ]
+          end
+
+          it "returns the number of unique events ignoring empty entries" do
+            expect(event_store.count).to eq(4)
+          end
+        end
       end
 
       context "with max timestamp" do

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -347,9 +347,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           end
         end
 
-        # Empty hashes or hashes with all-empty-array values in ignored_filters
-        # could produce invalid SQL (e.g., empty Tuple() in ClickHouse) if not
-        # filtered out. This verifies the defensive guards in filters_scope.
+        # Charge filters with no values or duplicate values should not exist but
+        # can due to missing validations. They produce empty hashes or hashes with
+        # all-empty-array values in ignored_filters, which would generate invalid
+        # SQL (e.g., empty Tuple() in ClickHouse) without the defensive guards.
         context "when ignored_filters contains empty and all-empty-values entries" do
           let(:ignored_filters) do
             [


### PR DESCRIPTION
## Context

The events store fails with `Code: 43. DB::Exception: Illegal type (Tuple()) of 1 argument of function or` on ClickHouse orgs for customers whose charges have **orphan `ChargeFilter` rows** — rows with no associated `ChargeFilterValue`. The crash originates in `ChargeFilters::MatchingAndIgnoredService`: every orphan sibling pushes `{}` into `ignored_filters`. The store renders this to an empty string, and the outer `conditions.map { "(#{it})" }.join(" OR ")` wraps it as `()`. ClickHouse interprets `()` as an empty `Tuple()` literal inside `NOT (tuple() OR ...)` and raises `ILLEGAL_TYPE_OF_ARGUMENT`. This should no longer occur but happened due to previously missing validations.

A related shape — `{"key" => []}` — is produced when a child filter's values are a subset of the parent's, or when two filters carry identical values; `MatchingAndIgnoredService`'s subtraction zeroes out the array. ActiveRecord renders this as `IN (NULL)` rather than `()`, so it does not crash, but the outer OR clause still subtracts the matching event from the default-remainder bucket — which silently double-counts the event. That semantic issue is tracked separately and is **out of scope** here (see below); this PR only prevents the invalid-SQL crash.


## Description

Defensive guards were added to all store filter methods (ClickHouse `filters_scope`, ClickHouse `arel_filters_scope`, ClickHouse enriched `arel_filters_scope`, and Postgres `filters_scope`). The `compact_blank` call in the Postgres store was removed since the new filtering makes it redundant.

A test was added for the edge case where a charge filter has no values, verifying that the resulting empty hashes are excluded from `ignored_filters`.