### PR TITLE
fix: NoMethodError in ProgressiveBillingService for subscription-level thresholds

### DIFF
--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -77,7 +77,7 @@ module Invoices
       invoice_result = CreateGeneratingService.call(
         customer: subscription.customer,
         invoice_type: :progressive_billing,
-        currency: sorted_usage_thresholds.first.plan.amount_currency,
+        currency: sorted_usage_thresholds.first.currency,
         datetime: Time.zone.at(timestamp)
       ) do |invoice|
         CreateInvoiceSubscriptionService

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -133,6 +133,29 @@ RSpec.describe Invoices::ProgressiveBillingService, transaction: false do
       end
     end
 
+    context "when usage threshold belongs to subscription" do
+      let(:sorted_usage_thresholds) { [create(:usage_threshold, :for_subscription, subscription:)] }
+
+      it "creates a progressive billing invoice" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to be_present
+
+        invoice = result.invoice
+        amount_cents = 100
+
+        expect(invoice).to have_attributes(
+          organization: organization,
+          customer: customer,
+          currency: plan.amount_currency,
+          status: "finalized",
+          invoice_type: "progressive_billing",
+          fees_amount_cents: amount_cents
+        )
+      end
+    end
+
     context "when threshold was already billed" do
       before do
         invoice = create(


### PR DESCRIPTION
## Context

We are seeing errors when thresholds are held by the subscription and not the plan.

This PR aims to fix this by getting the currency on the subscription instead of the plan.