### PR TITLE
feat(presentation_group_keys): Add presentation_breakdowns table and its relations and dependencies

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -68,6 +68,16 @@ class Charge < ApplicationRecord
     properties["pricing_group_keys"].presence || properties["grouped_by"]
   end
 
+  def presentation_group_keys
+    properties["presentation_group_keys"].presence
+  end
+
+  def presentation_group_keys_values
+    return [] if presentation_group_keys.blank?
+
+    presentation_group_keys.map { |e| e.fetch("value", nil) }.compact
+  end
+
   def equal_properties?(charge)
     charge_model == charge.charge_model && properties == charge.properties
   end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -54,6 +54,16 @@ class ChargeFilter < ApplicationRecord
     properties["pricing_group_keys"].presence || properties["grouped_by"]
   end
 
+  def presentation_group_keys
+    properties["presentation_group_keys"].presence
+  end
+
+  def presentation_group_keys_values
+    return [] if presentation_group_keys.blank?
+
+    presentation_group_keys.map { |e| e.fetch("value", nil) }.compact
+  end
+
   private
 
   def validate_properties

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -33,6 +33,7 @@ class Fee < ApplicationRecord
 
   has_many :applied_taxes, class_name: "Fee::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
+  has_many :presentation_breakdowns, dependent: :destroy
 
   monetize :amount_cents
   monetize :taxes_amount_cents, with_model_currency: :currency

--- a/app/models/presentation_breakdown.rb
+++ b/app/models/presentation_breakdown.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class PresentationBreakdown < ApplicationRecord
+  belongs_to :organization
+  belongs_to :fee
+end
+
+# == Schema Information
+#
+# Table name: presentation_breakdowns
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  presentation_by :jsonb            not null
+#  units           :decimal(30, 10)  default(0.0), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  fee_id          :uuid             not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_presentation_breakdowns_on_fee_id           (fee_id) UNIQUE
+#  index_presentation_breakdowns_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fee_id => fees.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -45,7 +45,8 @@ module ChargeFilters
             end
 
             if parent_filter.blank? || normalize_properties(parent_filter_properties(parent_filter)) != normalize_properties(filter.properties)
-              # Make sure that pricing group keys are cascaded even if properties are overridden
+              # Make sure that pricing/presentation group keys are cascaded even if properties are overridden
+              cascade_presentation_group_keys(filter, filter_param)
               cascade_pricing_group_keys(filter, filter_param)
               filter.save! if filter.changed?
 
@@ -164,6 +165,16 @@ module ChargeFilters
       elsif filter.pricing_group_keys.present?
         filter.properties.delete("pricing_group_keys")
         filter.properties.delete("grouped_by")
+      end
+    end
+
+    def cascade_presentation_group_keys(filter, params)
+      presentation_group_keys = params.dig(:properties, :presentation_group_keys)
+
+      if presentation_group_keys
+        filter.properties["presentation_group_keys"] = presentation_group_keys
+      elsif filter.presentation_group_keys.present?
+        filter.properties.delete("presentation_group_keys")
       end
     end
 

--- a/app/services/charge_models/filter_properties/base_service.rb
+++ b/app/services/charge_models/filter_properties/base_service.rb
@@ -64,6 +64,7 @@ module ChargeModels
         if charge_model
           attributes << :grouped_by if properties[:grouped_by].present? && properties[:pricing_group_keys].blank?
           attributes << :pricing_group_keys if properties[:pricing_group_keys].present?
+          attributes << :presentation_group_keys if properties[:presentation_group_keys].present?
         end
 
         attributes

--- a/app/services/charges/update_service.rb
+++ b/app/services/charges/update_service.rb
@@ -27,8 +27,11 @@ module Charges
         charge.invoice_display_name = params[:invoice_display_name] unless cascade
         charge.code = params[:code] if cascade && params[:code].present?
 
-        # Make sure that pricing group keys are cascaded even if properties are overridden
-        cascade_pricing_group_keys if cascade
+        # Make sure that pricing group keys and presentation group keys are cascaded even if properties are overridden
+        if cascade
+          cascade_pricing_group_keys
+          cascade_presentation_group_keys
+        end
 
         if !cascade || cascade_options[:equal_properties]
           properties = params.delete(:properties).presence || ChargeModels::BuildDefaultPropertiesService.call(
@@ -100,6 +103,16 @@ module Charges
     attr_reader :charge, :params, :cascade_options, :cascade, :cascade_updates
 
     delegate :plan, to: :charge
+
+    def cascade_presentation_group_keys
+      presentation_group_keys = params.dig(:properties, :presentation_group_keys)
+
+      if presentation_group_keys
+        charge.properties["presentation_group_keys"] = presentation_group_keys
+      elsif charge.properties["presentation_group_keys"].present?
+        charge.properties.delete("presentation_group_keys")
+      end
+    end
 
     def cascade_pricing_group_keys
       pricing_group_keys = params.dig(:properties, :pricing_group_keys) || params.dig(:properties, :grouped_by)

--- a/app/services/charges/validators/base_service.rb
+++ b/app/services/charges/validators/base_service.rb
@@ -3,6 +3,9 @@
 module Charges
   module Validators
     class BaseService < BaseValidator
+      ALLOWED_PRESENTATION_GROUP_KEYS_OPTIONS_KEYS = %i[display_in_invoice].freeze
+      ALLOWED_PRESENTATION_GROUP_KEYS_KEYS = %i[value options].freeze
+
       def initialize(charge:, properties: nil)
         @charge = charge
         @properties = properties || charge.properties
@@ -15,6 +18,7 @@ module Charges
         # NOTE: override and add validation rules
 
         validate_pricing_group_keys
+        validate_presentation_group_keys
 
         if errors?
           result.validation_failure!(errors:)
@@ -49,6 +53,46 @@ module Charges
         end
 
         add_error(field: grouped_key, error_code: "invalid_type")
+      end
+
+      def validate_presentation_group_keys
+        raw_keys = properties["presentation_group_keys"]
+        return if raw_keys.blank?
+
+        valid_presentation_group_keys = raw_keys.is_a?(Array) && raw_keys.all? do |key|
+          next false unless key.is_a?(Hash)
+
+          key = key.deep_symbolize_keys
+          keys_valid = (key.keys - ALLOWED_PRESENTATION_GROUP_KEYS_KEYS).empty?
+          value_key_present = key.key?(:value)
+
+          value_valid = key[:value].is_a?(String) && key[:value].present?
+
+          options_key_valid = true
+
+          if key.key?(:options)
+            options = key[:options]
+
+            options_key_valid = if options.is_a?(Hash)
+              options.keys == ALLOWED_PRESENTATION_GROUP_KEYS_OPTIONS_KEYS && [true, false].include?(options[:display_in_invoice])
+            else
+              false
+            end
+          end
+
+          keys_valid && value_key_present && value_valid && options_key_valid
+        end
+
+        unless valid_presentation_group_keys
+          add_error(
+            field: "presentation_group_keys",
+            error_code: "invalid_type"
+          )
+        end
+
+        if raw_keys.size > 2
+          add_error(field: "presentation_group_keys", error_code: "too_many_keys")
+        end
       end
     end
   end

--- a/db/migrate/20260407091845_add_presentation_breakdowns.rb
+++ b/db/migrate/20260407091845_add_presentation_breakdowns.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddPresentationBreakdowns < ActiveRecord::Migration[8.0]
+  def change
+    create_table :presentation_breakdowns, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :fee, null: false, foreign_key: true, type: :uuid, index: {unique: true}
+
+      t.jsonb :presentation_by, null: false, default: []
+      t.decimal :units, precision: 30, scale: 10, null: false, default: 0.0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1430,11 +1430,11 @@ CREATE TYPE public.usage_monitoring_alert_types AS ENUM (
     'billable_metric_current_usage_amount',
     'billable_metric_current_usage_units',
     'lifetime_usage_amount',
-    'billable_metric_lifetime_usage_units',
     'wallet_balance_amount',
     'wallet_credits_balance',
     'wallet_ongoing_balance_amount',
-    'wallet_credits_ongoing_balance'
+    'wallet_credits_ongoing_balance',
+    'billable_metric_lifetime_usage_units'
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11,6 +11,7 @@ SET row_security = off;
 
 ALTER TABLE IF EXISTS ONLY public.membership_roles DROP CONSTRAINT IF EXISTS membership_role_membership_fk;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_ff75b29299;
+ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_ff548a9f4c;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_fea16bf2e7;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaign_thresholds DROP CONSTRAINT IF EXISTS fk_rails_fd84cdb7c6;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS fk_rails_fd60209637;
@@ -82,6 +83,7 @@ ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails
 ALTER TABLE IF EXISTS ONLY public.applied_coupons DROP CONSTRAINT IF EXISTS fk_rails_bacb46d2a3;
 ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_rails_ba128983c2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_b974dac270;
+ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_b8f3cabc8e;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS fk_rails_b749d2045d;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_b61aa73940;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_b50dc82c1e;
@@ -407,6 +409,8 @@ DROP INDEX IF EXISTS public.index_pricing_units_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_pricing_unit_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_fee_id;
+DROP INDEX IF EXISTS public.index_presentation_breakdowns_on_organization_id;
+DROP INDEX IF EXISTS public.index_presentation_breakdowns_on_fee_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id;
@@ -830,6 +834,7 @@ ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sec
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
+ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS presentation_breakdowns_pkey;
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS plans_taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS plans_pkey;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS pending_vies_checks_pkey;
@@ -946,6 +951,7 @@ DROP TABLE IF EXISTS public.recurring_transaction_rules;
 DROP TABLE IF EXISTS public.quantified_events;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
+DROP TABLE IF EXISTS public.presentation_breakdowns;
 DROP TABLE IF EXISTS public.pending_vies_checks;
 DROP TABLE IF EXISTS public.payment_receipts;
 DROP TABLE IF EXISTS public.payment_providers;
@@ -1424,11 +1430,11 @@ CREATE TYPE public.usage_monitoring_alert_types AS ENUM (
     'billable_metric_current_usage_amount',
     'billable_metric_current_usage_units',
     'lifetime_usage_amount',
+    'billable_metric_lifetime_usage_units',
     'wallet_balance_amount',
     'wallet_credits_balance',
     'wallet_ongoing_balance_amount',
-    'wallet_credits_ongoing_balance',
-    'billable_metric_lifetime_usage_units'
+    'wallet_credits_ongoing_balance'
 );
 
 
@@ -4534,6 +4540,21 @@ CREATE TABLE public.pending_vies_checks (
 
 
 --
+-- Name: presentation_breakdowns; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.presentation_breakdowns (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    fee_id uuid NOT NULL,
+    presentation_by jsonb DEFAULT '[]'::jsonb NOT NULL,
+    units numeric(30,10) DEFAULT 0.0 NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: pricing_unit_usages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5699,6 +5720,14 @@ ALTER TABLE ONLY public.plans
 
 ALTER TABLE ONLY public.plans_taxes
     ADD CONSTRAINT plans_taxes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: presentation_breakdowns presentation_breakdowns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.presentation_breakdowns
+    ADD CONSTRAINT presentation_breakdowns_pkey PRIMARY KEY (id);
 
 
 --
@@ -8723,6 +8752,20 @@ CREATE INDEX index_plans_taxes_on_tax_id ON public.plans_taxes USING btree (tax_
 
 
 --
+-- Name: index_presentation_breakdowns_on_fee_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_presentation_breakdowns_on_fee_id ON public.presentation_breakdowns USING btree (fee_id);
+
+
+--
+-- Name: index_presentation_breakdowns_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_presentation_breakdowns_on_organization_id ON public.presentation_breakdowns USING btree (organization_id);
+
+
+--
 -- Name: index_pricing_unit_usages_on_fee_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11107,6 +11150,14 @@ ALTER TABLE ONLY public.subscription_activation_rules
 
 
 --
+-- Name: presentation_breakdowns fk_rails_b8f3cabc8e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.presentation_breakdowns
+    ADD CONSTRAINT fk_rails_b8f3cabc8e FOREIGN KEY (fee_id) REFERENCES public.fees(id);
+
+
+--
 -- Name: wallet_transactions_invoice_custom_sections fk_rails_b974dac270; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11675,6 +11726,14 @@ ALTER TABLE ONLY public.fixed_charges_taxes
 
 
 --
+-- Name: presentation_breakdowns fk_rails_ff548a9f4c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.presentation_breakdowns
+    ADD CONSTRAINT fk_rails_ff548a9f4c FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: wallet_transactions_invoice_custom_sections fk_rails_ff75b29299; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11699,6 +11758,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260409161142'),
 ('20260409151451'),
+('20260407091845'),
 ('20260331122448'),
 ('20260331103301'),
 ('20260327140626'),

--- a/spec/factories/presentation_breakdowns.rb
+++ b/spec/factories/presentation_breakdowns.rb
@@ -6,17 +6,12 @@ FactoryBot.define do
     fee factory: :charge_fee
     units { 60.0 }
     presentation_by do
-      [
-        {department: "engineering"}
-      ]
+      {department: "engineering"}
     end
 
     trait :with_composite_presentation_by do
       presentation_by do
-        [
-          {department: "engineering"},
-          {region: "eu"}
-        ]
+        {department: "engineering", region: "eu"}
       end
     end
   end

--- a/spec/factories/presentation_breakdowns.rb
+++ b/spec/factories/presentation_breakdowns.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :presentation_breakdown do
+    organization { fee&.organization || association(:organization) }
+    fee factory: :charge_fee
+    units { 60.0 }
+    presentation_by do
+      [
+        {department: "engineering"}
+      ]
+    end
+
+    trait :with_composite_presentation_by do
+      presentation_by do
+        [
+          {department: "engineering"},
+          {region: "eu"}
+        ]
+      end
+    end
+  end
+end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -456,4 +456,116 @@ RSpec.describe ChargeFilter do
       end
     end
   end
+
+  describe "#presentation_group_keys" do
+    subject(:charge_filter) { build(:charge_filter, properties:) }
+
+    context "when presentation_group_keys is present" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => [{"value" => "region"}]} }
+
+      it "returns the presentation group keys" do
+        expect(charge_filter.presentation_group_keys).to eq([{"value" => "region"}])
+      end
+    end
+
+    context "when presentation_group_keys is blank" do
+      let(:properties) { {"amount_cents" => "1000"} }
+
+      it "returns nil" do
+        expect(charge_filter.presentation_group_keys).to be_nil
+      end
+    end
+
+    context "when presentation_group_keys is an empty array" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => []} }
+
+      it "returns nil" do
+        expect(charge_filter.presentation_group_keys).to be_nil
+      end
+    end
+  end
+
+  describe "#presentation_group_keys_values" do
+    subject(:charge_filter) { build(:charge_filter, properties:) }
+
+    context "when presentation_group_keys is blank" do
+      let(:properties) { {"amount_cents" => "1000"} }
+
+      it "returns an empty array" do
+        expect(charge_filter.presentation_group_keys_values).to eq([])
+      end
+    end
+
+    context "when presentation_group_keys is nil" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => nil} }
+
+      it "returns an empty array" do
+        expect(charge_filter.presentation_group_keys_values).to eq([])
+      end
+    end
+
+    context "when presentation_group_keys is an empty array" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => []} }
+
+      it "returns an empty array" do
+        expect(charge_filter.presentation_group_keys_values).to eq([])
+      end
+    end
+
+    context "when presentation_group_keys has one element with value" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => [{"value" => "region"}]} }
+
+      it "returns array with the value" do
+        expect(charge_filter.presentation_group_keys_values).to eq(["region"])
+      end
+    end
+
+    context "when presentation_group_keys has multiple elements with values" do
+      let(:properties) do
+        {
+          "amount_cents" => "1000",
+          "presentation_group_keys" => [
+            {"value" => "region"},
+            {"value" => "country"}
+          ]
+        }
+      end
+
+      it "returns array with all values" do
+        expect(charge_filter.presentation_group_keys_values).to eq(["region", "country"])
+      end
+    end
+
+    context "when presentation_group_keys has elements with options" do
+      let(:properties) do
+        {
+          "amount_cents" => "1000",
+          "presentation_group_keys" => [
+            {"value" => "region", "options" => {"display_in_invoice" => true}},
+            {"value" => "country"}
+          ]
+        }
+      end
+
+      it "returns array with all values" do
+        expect(charge_filter.presentation_group_keys_values).to eq(["region", "country"])
+      end
+    end
+
+    context "when presentation_group_keys has elements with nil values" do
+      let(:properties) do
+        {
+          "amount_cents" => "1000",
+          "presentation_group_keys" => [
+            {"value" => "region"},
+            {"value" => nil}
+          ]
+        }
+      end
+
+      it "returns array with only non-nil values" do
+        expect(charge_filter.presentation_group_keys_values).to eq(["region"])
+      end
+    end
+  end
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -538,6 +538,102 @@ RSpec.describe Charge do
     end
   end
 
+  describe "#presentation_group_keys" do
+    subject(:charge) { build(:standard_charge, properties:) }
+
+    context "when presentation_group_keys is present" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => [{"value" => "region"}]} }
+
+      it "returns the presentation group keys" do
+        expect(charge.presentation_group_keys).to eq([{"value" => "region"}])
+      end
+    end
+
+    context "when presentation_group_keys is blank" do
+      let(:properties) { {"amount_cents" => "1000"} }
+
+      it "returns nil" do
+        expect(charge.presentation_group_keys).to be_nil
+      end
+    end
+
+    context "when presentation_group_keys is an empty array" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => []} }
+
+      it "returns nil" do
+        expect(charge.presentation_group_keys).to be_nil
+      end
+    end
+  end
+
+  describe "#presentation_group_keys_values" do
+    subject(:charge) { build(:standard_charge, properties:) }
+
+    context "when presentation_group_keys is blank" do
+      let(:properties) { {"amount_cents" => "1000"} }
+
+      it "returns an empty array" do
+        expect(charge.presentation_group_keys_values).to eq([])
+      end
+    end
+
+    context "when presentation_group_keys is nil" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => nil} }
+
+      it "returns an empty array" do
+        expect(charge.presentation_group_keys_values).to eq([])
+      end
+    end
+
+    context "when presentation_group_keys is an empty array" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => []} }
+
+      it "returns an empty array" do
+        expect(charge.presentation_group_keys_values).to eq([])
+      end
+    end
+
+    context "when presentation_group_keys has one element with value" do
+      let(:properties) { {"amount_cents" => "1000", "presentation_group_keys" => [{"value" => "region"}]} }
+
+      it "returns array with the value" do
+        expect(charge.presentation_group_keys_values).to eq(["region"])
+      end
+    end
+
+    context "when presentation_group_keys has multiple elements with values" do
+      let(:properties) do
+        {
+          "amount_cents" => "1000",
+          "presentation_group_keys" => [
+            {"value" => "region"},
+            {"value" => "country"}
+          ]
+        }
+      end
+
+      it "returns array with all values" do
+        expect(charge.presentation_group_keys_values).to eq(["region", "country"])
+      end
+    end
+
+    context "when presentation_group_keys has elements with nil values" do
+      let(:properties) do
+        {
+          "amount_cents" => "1000",
+          "presentation_group_keys" => [
+            {"value" => "region"},
+            {"value" => nil}
+          ]
+        }
+      end
+
+      it "returns array with only non-nil values" do
+        expect(charge.presentation_group_keys_values).to eq(["region"])
+      end
+    end
+  end
+
   describe "#equal_properties?" do
     let(:charge1) { build(:standard_charge, properties: {amount: 100}) }
 

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Fee do
   it { is_expected.to belong_to(:add_on).optional }
   it { is_expected.to belong_to(:charge).optional }
   it { is_expected.to belong_to(:fixed_charge).optional }
+  it { is_expected.to have_many(:presentation_breakdowns) }
   it { is_expected.to have_one(:fixed_charge_add_on).through(:fixed_charge) }
   it { is_expected.to have_one(:adjusted_fee).dependent(:nullify) }
   it { is_expected.to have_one(:billable_metric).through(:charge) }

--- a/spec/models/presentation_breakdown_spec.rb
+++ b/spec/models/presentation_breakdown_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PresentationBreakdown do
+  subject { build(:presentation_breakdown) }
+
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:fee)
+    end
+  end
+end

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -241,12 +241,13 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
             scheme_filter.key => ["visa"]
           },
           invoice_display_name: "New display name",
-          properties: {amount: "20"}.merge(pricing_group_keys)
+          properties: {amount: "20"}.merge(pricing_group_keys).merge(presentation_group_keys)
         }
       ]
     end
 
     let(:pricing_group_keys) { {pricing_group_keys: ["region"]} }
+    let(:presentation_group_keys) { {} }
 
     before { filter_values }
 
@@ -456,6 +457,47 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
               invoice_display_name: nil,
               properties: {"amount" => "0.00115740741"}
             )
+          end
+        end
+
+        context "when properties contains a presentation_group_keys attribute" do
+          let(:presentation_group_keys) { {presentation_group_keys: [{"value" => "region", "options" => {"display_in_invoice" => true}}]} }
+
+          it "updates the filter" do
+            expect { service }.not_to change(ChargeFilter, :count)
+
+            expect(filter.reload.presentation_group_keys).to eq([{"value" => "region", "options" => {"display_in_invoice" => true}}])
+            expect(filter.values.count).to eq(2)
+            expect(filter.values.pluck(:values).flatten).to match_array(%w[domestic visa])
+          end
+
+          context "when filters already have a presentation_group_keys value" do
+            let(:filter) do
+              create(:charge_filter, charge:, properties: {amount: "755", presentation_group_keys: [{"value" => "cloud"}]})
+            end
+
+            it "updates the filter" do
+              expect { service }.not_to change(ChargeFilter, :count)
+
+              expect(filter.reload.presentation_group_keys).to eq([{"value" => "region", "options" => {"display_in_invoice" => true}}])
+              expect(filter.values.count).to eq(2)
+              expect(filter.values.pluck(:values).flatten).to match_array(%w[domestic visa])
+            end
+          end
+        end
+
+        context "when filters already has a presentation_group_keys value" do
+          let(:filter) do
+            create(:charge_filter, charge:, properties: {amount: "755", presentation_group_keys: [{"value" => "cloud"}]})
+          end
+          let(:presentation_group_keys) { {} }
+
+          it "clears the presentation_group_keys" do
+            expect { service }.not_to change(ChargeFilter, :count)
+
+            expect(filter.reload.presentation_group_keys).to be_nil
+            expect(filter.values.count).to eq(2)
+            expect(filter.values.pluck(:values).flatten).to match_array(%w[domestic visa])
           end
         end
       end

--- a/spec/services/charges/create_service_spec.rb
+++ b/spec/services/charges/create_service_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe Charges::CreateService do
             values: %w[card physical]
           )
         end
+        let(:properties) { {} }
 
         let(:params) do
           {
@@ -122,7 +123,8 @@ RSpec.describe Charges::CreateService do
                 properties: {amount: "90"},
                 values: {billable_metric_filter.key => ["card"]}
               }
-            ]
+            ],
+            properties: properties
           }
         end
 
@@ -161,6 +163,21 @@ RSpec.describe Charges::CreateService do
             billable_metric_filter_id: billable_metric_filter.id,
             values: ["card"]
           )
+        end
+
+        context "when presentation_group_keys are present in properties" do
+          let(:properties) do
+            {amount: "0", presentation_group_keys: [{"value" => "department"}, {"value" => "region"}]}
+          end
+
+          it "sets correctly attributes" do
+            subject
+
+            created_charge = plan.reload.charges.first
+            expect(created_charge).to have_attributes(
+              properties: {"amount" => "0", "presentation_group_keys" => [{"value" => "department"}, {"value" => "region"}]}
+            )
+          end
         end
 
         context "when premium", :premium do

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Charges::UpdateService do
           accepts_target_wallet: true,
           properties: {
             amount: "400"
-          }.merge(pricing_group_keys),
+          }.merge(pricing_group_keys).merge(presentation_group_keys),
           applied_pricing_unit: applied_pricing_unit_params,
           filters: [
             {
@@ -105,6 +105,7 @@ RSpec.describe Charges::UpdateService do
         }
       end
 
+      let(:presentation_group_keys) { {} }
       let(:pricing_group_keys) { {} }
 
       before { create(:applied_pricing_unit, pricing_unitable: charge, conversion_rate: 1.1) }
@@ -259,6 +260,17 @@ RSpec.describe Charges::UpdateService do
           end
         end
 
+        context "with presentation_group_keys in the properties" do
+          let(:presentation_group_keys) do
+            {presentation_group_keys: [{"value" => "region", "options" => {"display_in_invoice" => true}}]}
+          end
+
+          it "apply the value to the charge" do
+            expect { subject }.to change { charge.reload.properties["presentation_group_keys"] }
+              .from(nil).to([{"value" => "region", "options" => {"display_in_invoice" => true}}])
+          end
+        end
+
         context "with pricing_group_keys in the properties" do
           let(:pricing_group_keys) { {pricing_group_keys: ["cloud"]} }
 
@@ -279,6 +291,38 @@ RSpec.describe Charges::UpdateService do
 
           it "does not update charge properties" do
             expect { subject }.not_to change { charge.reload.properties }
+          end
+
+          context "with presentation_group_keys in the properties" do
+            let(:presentation_group_keys) do
+              {presentation_group_keys: [{"value" => "region", "options" => {"display_in_invoice" => true}}]}
+            end
+
+            it "apply the value to the charge" do
+              expect { subject }.to change { charge.reload.properties["presentation_group_keys"] }
+                .from(nil).to([{"value" => "region", "options" => {"display_in_invoice" => true}}])
+            end
+
+            context "when charge has a presentation_group_keys" do
+              let(:charge) do
+                create(
+                  :standard_charge,
+                  plan:,
+                  billable_metric_id: sum_billable_metric.id,
+                  amount_currency: "USD",
+                  properties: {
+                    amount: "300",
+                    presentation_group_keys: [{value: "department"}]
+                  }
+                )
+              end
+
+              it "overrides the keys" do
+                expect { subject }.to change { charge.reload.properties["presentation_group_keys"] }
+                  .from([{"value" => "department"}])
+                  .to([{"value" => "region", "options" => {"display_in_invoice" => true}}])
+              end
+            end
           end
 
           context "with pricing_group_keys in the properties" do

--- a/spec/services/charges/validators/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/validators/graduated_percentage_service_spec.rb
@@ -199,5 +199,11 @@ RSpec.describe Charges::Validators::GraduatedPercentageService do
         {"graduated_percentage_ranges" => ranges}.merge(grouping_properties)
       end
     end
+
+    it_behaves_like "presentation_group_keys property validation" do
+      let(:properties) do
+        {"graduated_percentage_ranges" => ranges}.merge(grouping_properties)
+      end
+    end
   end
 end

--- a/spec/services/charges/validators/graduated_service_spec.rb
+++ b/spec/services/charges/validators/graduated_service_spec.rb
@@ -221,5 +221,9 @@ RSpec.describe Charges::Validators::GraduatedService do
     it_behaves_like "pricing_group_keys property validation" do
       let(:properties) { {"graduated_ranges" => ranges}.merge(grouping_properties) }
     end
+
+    it_behaves_like "presentation_group_keys property validation" do
+      let(:properties) { {"graduated_ranges" => ranges}.merge(grouping_properties) }
+    end
   end
 end

--- a/spec/services/charges/validators/package_service_spec.rb
+++ b/spec/services/charges/validators/package_service_spec.rb
@@ -194,5 +194,15 @@ RSpec.describe Charges::Validators::PackageService do
         }.merge(grouping_properties)
       end
     end
+
+    it_behaves_like "presentation_group_keys property validation" do
+      let(:package_properties) do
+        {
+          package_size: 10,
+          free_units: 10,
+          amount: "100"
+        }.merge(grouping_properties)
+      end
+    end
   end
 end

--- a/spec/services/charges/validators/percentage_service_spec.rb
+++ b/spec/services/charges/validators/percentage_service_spec.rb
@@ -340,5 +340,14 @@ RSpec.describe Charges::Validators::PercentageService do
         }.merge(grouping_properties)
       end
     end
+
+    it_behaves_like "presentation_group_keys property validation" do
+      let(:percentage_properties) do
+        {
+          rate: "0.25",
+          fixed_amount: "2"
+        }.merge(grouping_properties)
+      end
+    end
   end
 end

--- a/spec/services/charges/validators/standard_service_spec.rb
+++ b/spec/services/charges/validators/standard_service_spec.rb
@@ -47,5 +47,9 @@ RSpec.describe Charges::Validators::StandardService do
     it_behaves_like "pricing_group_keys property validation" do
       let(:properties) { {"amount" => "12"}.merge(grouping_properties) }
     end
+
+    it_behaves_like "presentation_group_keys property validation" do
+      let(:properties) { {"amount" => "12"}.merge(grouping_properties) }
+    end
   end
 end

--- a/spec/services/charges/validators/volume_service_spec.rb
+++ b/spec/services/charges/validators/volume_service_spec.rb
@@ -184,5 +184,9 @@ RSpec.describe Charges::Validators::VolumeService do
     it_behaves_like "pricing_group_keys property validation" do
       let(:properties) { {"volume_ranges" => ranges}.merge(grouping_properties) }
     end
+
+    it_behaves_like "presentation_group_keys property validation" do
+      let(:properties) { {"volume_ranges" => ranges}.merge(grouping_properties) }
+    end
   end
 end

--- a/spec/support/shared_examples/charges/presentation_group_keys_validation.rb
+++ b/spec/support/shared_examples/charges/presentation_group_keys_validation.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "presentation_group_keys property validation" do
+  let(:grouping_properties) { {"presentation_group_keys" => presentation_group_keys} }
+  let(:presentation_group_keys) { nil }
+
+  it { expect(validation_service).to be_valid }
+
+  context "when presentation_group_keys is an empty array" do
+    let(:presentation_group_keys) { [] }
+
+    it "is valid" do
+      expect(validation_service).to be_valid
+    end
+  end
+
+  context "when presentation_group_keys is valid with 1 element" do
+    let(:presentation_group_keys) { [{"value" => "region"}] }
+
+    it "is valid" do
+      expect(validation_service).to be_valid
+    end
+  end
+
+  context "when presentation_group_keys is valid with 2 elements" do
+    let(:presentation_group_keys) { [{"value" => "region"}, {"value" => "country"}] }
+
+    it "is valid" do
+      expect(validation_service).to be_valid
+    end
+  end
+
+  context "when presentation_group_keys has options" do
+    let(:presentation_group_keys) do
+      [
+        {"value" => "region", "options" => {"display_in_invoice" => true}},
+        {"value" => "country", "options" => {"display_in_invoice" => false}}
+      ]
+    end
+
+    it "is valid" do
+      expect(validation_service).to be_valid
+    end
+  end
+
+  context "when presentation_group_keys has options with non-hash value" do
+    let(:presentation_group_keys) { [{"value" => "region", "options" => "invalid"}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys has options with unknown key" do
+    let(:presentation_group_keys) { [{"value" => "region", "options" => {"unknown" => true}}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys has options with extra keys" do
+    let(:presentation_group_keys) do
+      [{"value" => "region", "options" => {"display_in_invoice" => true, "extra" => false}}]
+    end
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys has options with non-boolean display_in_invoice" do
+    let(:presentation_group_keys) { [{"value" => "region", "options" => {"display_in_invoice" => "true"}}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys has more than 2 elements" do
+    let(:presentation_group_keys) do
+      [
+        {"value" => "region"},
+        {"value" => "country"},
+        {"value" => "city"}
+      ]
+    end
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("too_many_keys")
+    end
+  end
+
+  context "when presentation_group_keys is not an array" do
+    let(:presentation_group_keys) { "not_an_array" }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys contains non-hash elements" do
+    let(:presentation_group_keys) { ["region", "country"] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys contains hashes without 'value' key" do
+    let(:presentation_group_keys) { [{"key" => "region"}, {"value" => "country"}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys contains hashes with nil value" do
+    let(:presentation_group_keys) { [{"value" => nil}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys contains hashes with empty string value" do
+    let(:presentation_group_keys) { [{"value" => ""}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys contains hashes with numeric value" do
+    let(:presentation_group_keys) { [{"value" => 123}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when presentation_group_keys contains hashes with extra keys" do
+    let(:presentation_group_keys) { [{"value" => "region", "extra" => "nope"}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("invalid_type")
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a new `PresentationBreakdown` model to the application, along with its database table, associations, and tests. The changes allow each Fee to have a set of presentation breakdowns, explaining the units based on each presentation key defined and the aggregation choosen.

example defining two presentation keys, `"region"` and `"city"`.

```
Storage
  Instance A                  28 units    $28.00
    └ EU + Barcelona          10
    └ EU + Paris              3         
    └ US + Miami              15          
  Instance B                   7 units     $7.00
    └ EU + Barcelona           4         
    └ US + New York            3  
``` 

These changes are the initial step for generating and tracking the fees units breakdowns