### PR TITLE
misc(clickhouse): Speedup deduplication

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -98,6 +98,11 @@ module Events
           .and(arel_table[:code].eq(code)))
         ).then { with_timestamp_boundaries(it, from_datetime, to_datetime) }
 
+        # Push property filters BEFORE GROUP BY so ClickHouse filters first,
+        # then deduplicates only relevant rows (significant memory/CPU savings).
+        query = arel_filters_scope(query)
+        query = apply_arel_grouped_by_values(query) if grouped_by_values?
+
         columns = deduplicated_columns.dup
 
         # Grouping and filtering is made based on the properties


### PR DESCRIPTION
## Context

A performance issue was reported with the deduplication logic implemented in the `Events::Stores::ClickhouseStore`. The memory and CPU usage are very high for subscription with a large number of events.

In some situation (high concurrency) it is leading to the following type of error:
```
ActiveRecord::ActiveRecordError
Response code: 500: (ActiveRecord::ActiveRecordError)
["sum(decimal_value)"]
["Decimal(38, 26)"]
["Code: 241. DB::Exception: (total) memory limit exceeded: would use 10.82 GiB (attempt to allocate chunk of 4.00 MiB), current RSS: 10.81 GiB, maximum: 10.80 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing AggregatingTransform. (MEMORY_LIMIT_EXCEEDED) (version 25.12.1.1497 (official build))"]
```

## Description

This PR improves the performances of the query by applying the `filters` and groups before applying the deduplication via `group by` and `argMax` to reduce the number of records to deduplicate. The previous implementation was indeed applying the logic to all events of the subscription matching the code and timestamp.
