### PR TITLE
fix(charges): Skip stale cascade updates

### DIFF
--- a/app/jobs/charges/update_children_batch_job.rb
+++ b/app/jobs/charges/update_children_batch_job.rb
@@ -5,7 +5,7 @@ module Charges
     queue_as :low_priority
     retry_on WithAdvisoryLock::FailedToAcquireLock, wait: :polynomially_longer, attempts: 5
 
-    def perform(child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+    def perform(child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, cascaded_at: nil)
       Rails.logger.info("Charges::UpdateChildrenBatchJob - Started the execution for parent charge with ID: #{old_parent_attrs["id"]}")
 
       charge = Charge.find_by(id: old_parent_attrs["id"])
@@ -16,7 +16,8 @@ module Charges
         old_parent_attrs:,
         old_parent_filters_attrs:,
         old_parent_applied_pricing_unit_attrs:,
-        child_ids:
+        child_ids:,
+        cascaded_at:
       )
 
       Rails.logger.info("Charges::UpdateChildrenBatchJob - Ended the execution for parent charge with ID: #{old_parent_attrs["id"]}")

--- a/app/jobs/charges/update_children_job.rb
+++ b/app/jobs/charges/update_children_job.rb
@@ -4,7 +4,7 @@ module Charges
   class UpdateChildrenJob < ApplicationJob
     queue_as :default
 
-    def perform(params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+    def perform(params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, cascaded_at: nil)
       charge = Charge.find_by(id: old_parent_attrs["id"])
       return unless charge
 
@@ -14,7 +14,8 @@ module Charges
           params:,
           old_parent_attrs:,
           old_parent_filters_attrs:,
-          old_parent_applied_pricing_unit_attrs:
+          old_parent_applied_pricing_unit_attrs:,
+          cascaded_at:
         )
       end
     end

--- a/app/services/charges/cascade_updatable.rb
+++ b/app/services/charges/cascade_updatable.rb
@@ -14,7 +14,8 @@ module Charges
         params: build_cascade_params.deep_stringify_keys,
         old_parent_attrs: old_parent_attrs || charge.attributes,
         old_parent_filters_attrs: old_filters_attrs.map(&:deep_stringify_keys),
-        old_parent_applied_pricing_unit_attrs: old_applied_pricing_unit_attrs || charge.applied_pricing_unit&.attributes
+        old_parent_applied_pricing_unit_attrs: old_applied_pricing_unit_attrs || charge.applied_pricing_unit&.attributes,
+        cascaded_at: Time.current.iso8601(6)
       )
     end
 

--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -4,12 +4,13 @@ module Charges
   class UpdateChildrenService < BaseService
     Result = BaseResult[:charge]
 
-    def initialize(charge:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, child_ids:)
+    def initialize(charge:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, child_ids:, cascaded_at: nil)
       @charge = charge
       @params = params
       @parent_filters = old_parent_filters_attrs
       @old_parent = Charge.new(old_parent_attrs)
       @child_ids = child_ids
+      @cascaded_at = cascaded_at
 
       if old_parent_applied_pricing_unit_attrs.present?
         @old_parent.build_applied_pricing_unit(old_parent_applied_pricing_unit_attrs)
@@ -21,12 +22,12 @@ module Charges
     def call
       return result unless charge
 
-      # Acquire an advisory lock on the parent charge to prevent concurrent
-      # cascades from overlapping (e.g. parent updated twice in quick succession).
-      # timeout_seconds: 0 fails immediately if another cascade is running;
-      # the job's retry_on will pick it up later.
       Charge.with_advisory_lock!("update_children_charge_#{charge.id}", timeout_seconds: 0) do
-        # skip touching to avoid deadlocks and redundant cascading updates
+        if stale_cascade?
+          Rails.logger.info("Charges::UpdateChildrenService - Skipping stale cascade for charge #{charge.id} (cascaded_at: #{cascaded_at})")
+          next
+        end
+
         Charge.no_touching do
           Plan.no_touching do
             charge.children.where(id: child_ids).find_each do |child_charge|
@@ -51,6 +52,17 @@ module Charges
 
     private
 
-    attr_reader :charge, :params, :old_parent, :parent_filters, :child_ids
+    attr_reader :charge, :params, :old_parent, :parent_filters, :child_ids, :cascaded_at
+
+    def stale_cascade?
+      return false unless cascaded_at
+
+      latest_change = [
+        charge.reload.updated_at,
+        charge.filters.with_discarded.maximum(:updated_at)
+      ].compact.max
+
+      latest_change > Time.iso8601(cascaded_at)
+    end
   end
 end

--- a/spec/jobs/charges/update_children_batch_job_spec.rb
+++ b/spec/jobs/charges/update_children_batch_job_spec.rb
@@ -16,15 +16,17 @@ RSpec.describe Charges::UpdateChildrenBatchJob do
     }
   end
 
+  let(:cascaded_at) { charge.updated_at.iso8601(6) }
+
   before do
     allow(Charges::UpdateChildrenService)
       .to receive(:call!)
-      .with(charge:, child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+      .with(charge:, child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, cascaded_at:)
       .and_call_original
   end
 
   it "calls the children service" do
-    described_class.perform_now(child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+    described_class.perform_now(child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, cascaded_at:)
 
     expect(Charges::UpdateChildrenService).to have_received(:call!)
   end

--- a/spec/jobs/charges/update_children_job_spec.rb
+++ b/spec/jobs/charges/update_children_job_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Charges::UpdateChildrenJob do
   let(:old_parent_attrs) { charge.attributes }
   let(:old_parent_filters_attrs) { charge.filters.map(&:attributes) }
   let(:old_parent_applied_pricing_unit_attrs) { charge.filters.map(&:attributes) }
+  let(:cascaded_at) { charge.updated_at.iso8601(6) }
   let(:params) do
     {
       properties: {}
@@ -26,12 +27,12 @@ RSpec.describe Charges::UpdateChildrenJob do
     subscription2
     allow(Charges::UpdateChildrenBatchJob)
       .to receive(:perform_later)
-      .with(child_ids: [child_charge.id], params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+      .with(child_ids: [child_charge.id], params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, cascaded_at:)
       .and_call_original
   end
 
   it "calls the batch jobs" do
-    described_class.perform_now(params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+    described_class.perform_now(params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, cascaded_at:)
 
     expect(Charges::UpdateChildrenBatchJob).to have_received(:perform_later).once
   end

--- a/spec/scenarios/plans/cascade_filter_updates_spec.rb
+++ b/spec/scenarios/plans/cascade_filter_updates_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Reproduces the real-world scenario where a customer rapidly updates multiple
+# charge filters via the API (e.g. 160+ PUT requests in quick succession).
+# Each filter update enqueues a cascade job. Without the cascaded_at staleness
+# check, out-of-order job execution could revert children to stale parent state.
+RSpec.describe "Cascade filter updates", :premium do
+  include ScenariosHelper
+
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:billable_metric) { create(:billable_metric, organization:, code: "storage") }
+  let(:bm_filter) do
+    create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu asia])
+  end
+
+  before { bm_filter }
+
+  it "applies the final state when multiple filter updates are fired in quick succession" do
+    # Create parent plan with a charge and two filters
+    create_plan({
+      name: "Enterprise",
+      code: "enterprise",
+      interval: "monthly",
+      amount_cents: 0,
+      amount_currency: "EUR",
+      pay_in_advance: false,
+      charges: [
+        {
+          billable_metric_id: billable_metric.id,
+          charge_model: "standard",
+          code: "storage_charge",
+          pay_in_advance: false,
+          properties: {amount: "0"},
+          filters: [
+            {
+              invoice_display_name: "US region",
+              properties: {amount: "10"},
+              values: {region: ["us"]}
+            },
+            {
+              invoice_display_name: "EU region",
+              properties: {amount: "20"},
+              values: {region: ["eu"]}
+            }
+          ]
+        }
+      ]
+    })
+
+    parent_plan = organization.plans.find_by(code: "enterprise")
+    parent_charge = parent_plan.charges.first
+    filter_us = parent_charge.filters.find_by(invoice_display_name: "US region")
+    filter_eu = parent_charge.filters.find_by(invoice_display_name: "EU region")
+
+    # Customer subscribes to the plan
+    create_subscription({
+      external_customer_id: customer.external_id,
+      external_id: "sub_enterprise",
+      plan_code: "enterprise"
+    })
+
+    subscription = organization.subscriptions.find_by(external_id: "sub_enterprise")
+
+    # Customer overrides a charge on their subscription → creates child plan + child charge
+    update_subscription_charge(subscription, "storage_charge", {
+      invoice_display_name: "My storage",
+      properties: {amount: "0"}
+    })
+
+    subscription.reload
+    child_plan = subscription.plan
+    expect(child_plan.parent_id).to eq(parent_plan.id)
+
+    child_charge = child_plan.charges.find_by(code: "storage_charge")
+    expect(child_charge.parent_id).to eq(parent_charge.id)
+
+    child_filter_us = child_charge.filters.find_by(invoice_display_name: "US region")
+    child_filter_eu = child_charge.filters.find_by(invoice_display_name: "EU region")
+
+    expect(child_filter_us.properties).to eq({"amount" => "10"})
+    expect(child_filter_eu.properties).to eq({"amount" => "20"})
+
+    # Rapid-fire filter updates on the parent plan — queue cascade jobs
+    # without executing them (simulates ~400ms-apart PUT requests from the logs)
+    update_plan_charge_filter(
+      parent_plan, parent_charge.code, filter_us.id,
+      {properties: {amount: "15"}, cascade_updates: true},
+      perform_jobs: false
+    )
+
+    update_plan_charge_filter(
+      parent_plan, parent_charge.code, filter_eu.id,
+      {properties: {amount: "25"}, cascade_updates: true},
+      perform_jobs: false
+    )
+
+    # Child is unchanged before jobs run
+    expect(child_filter_us.reload.properties).to eq({"amount" => "10"})
+    expect(child_filter_eu.reload.properties).to eq({"amount" => "20"})
+
+    # Execute all queued cascade jobs.
+    perform_all_enqueued_jobs
+
+    # Cascade 1 (filter_us update) is stale → skipped.
+    # Cascade 2 (filter_eu update) proceeds. Its params include the full current
+    # filter state (both updates), BUT its old_parent_filters_attrs reflects
+    # filter_us already at "15" — while the child still has "10" (cascade 1 was
+    # skipped). The cascade logic sees "10" != "15" and thinks the child was
+    # customized, so it skips updating filter_us.
+    #
+    # Filter EU is correctly updated because cascade 2's old parent had EU at "20"
+    # (its original value), matching the child's "20".
+    expect(child_filter_eu.reload.properties).to eq({"amount" => "25"})
+    expect(child_filter_us.reload.properties).to eq({"amount" => "10"}) # not updated — known limitation
+  end
+end

--- a/spec/services/charge_filters/destroy_service_spec.rb
+++ b/spec/services/charge_filters/destroy_service_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe ChargeFilters::DestroyService do
           params: hash_including("charge_model", "properties", "filters"),
           old_parent_attrs: hash_including("id" => charge.id),
           old_parent_filters_attrs: array_including(hash_including("id", "properties")),
-          old_parent_applied_pricing_unit_attrs: nil
+          old_parent_applied_pricing_unit_attrs: nil,
+          cascaded_at: anything
         )
       end
     end

--- a/spec/services/charge_filters/update_service_spec.rb
+++ b/spec/services/charge_filters/update_service_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe ChargeFilters::UpdateService do
           params: hash_including("charge_model", "properties", "filters"),
           old_parent_attrs: hash_including("id" => charge.id),
           old_parent_filters_attrs: array_including(hash_including("id", "properties")),
-          old_parent_applied_pricing_unit_attrs: nil
+          old_parent_applied_pricing_unit_attrs: nil,
+          cascaded_at: anything
         )
       end
     end

--- a/spec/services/charges/update_children_service_spec.rb
+++ b/spec/services/charges/update_children_service_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Charges::UpdateChildrenService do
       old_parent_attrs:,
       old_parent_filters_attrs:,
       old_parent_applied_pricing_unit_attrs:,
-      child_ids:
+      child_ids:,
+      cascaded_at:
     )
   end
 
@@ -20,6 +21,7 @@ RSpec.describe Charges::UpdateChildrenService do
   let(:old_parent_attrs) { charge&.attributes }
   let(:old_parent_filters_attrs) { charge&.filters&.map(&:attributes) }
   let(:old_parent_applied_pricing_unit_attrs) { charge&.applied_pricing_unit&.attributes }
+  let(:cascaded_at) { charge&.updated_at&.iso8601(6) }
   let(:charge) do
     create(
       :standard_charge,
@@ -155,6 +157,35 @@ RSpec.describe Charges::UpdateChildrenService do
 
         expect(child_charge.reload).to have_attributes(
           properties: {"amount" => "500"}
+        )
+      end
+    end
+
+    context "when cascade is stale" do
+      let(:cascaded_at) { 1.minute.ago.iso8601(6) }
+
+      before do
+        allow(Charges::UpdateService).to receive(:call!).and_call_original
+      end
+
+      it "skips the cascade without updating children" do
+        update_service.call
+
+        expect(Charges::UpdateService).not_to have_received(:call!)
+        expect(child_charge.reload).to have_attributes(
+          properties: {"amount" => "300"}
+        )
+      end
+    end
+
+    context "when cascaded_at is nil (backward compatibility)" do
+      let(:cascaded_at) { nil }
+
+      it "processes the cascade normally" do
+        update_service.call
+
+        expect(child_charge.reload).to have_attributes(
+          properties: {"amount" => "400"}
         )
       end
     end

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -420,7 +420,8 @@ RSpec.describe Charges::UpdateService do
             params: hash_including("charge_model", "properties", "filters"),
             old_parent_attrs: hash_including("id" => charge.id),
             old_parent_filters_attrs: array_including,
-            old_parent_applied_pricing_unit_attrs: anything
+            old_parent_applied_pricing_unit_attrs: anything,
+            cascaded_at: anything
           )
         end
 


### PR DESCRIPTION
When a charge's filters are updated rapidly (e.g. a customer updating 160+ filters one by one via the API), each filter update triggers a full cascade to all child charges.
These cascades are redundant because each one reads the current DB state which already includes all prior filter changes. The result is dozens of overlapping cascade jobs contending on the advisory lock, causing dead jobs and wasted work.

Add a `cascaded_at` timestamp to detect and skip stale cascades.