### PR TITLE
fix: BigDecimal nil comparison in UsageMonitoring::Alert

### DIFF
--- a/app/models/usage_monitoring/alert.rb
+++ b/app/models/usage_monitoring/alert.rb
@@ -76,14 +76,17 @@ module UsageMonitoring
     def find_thresholds_crossed_increasing(current)
       crossed = []
       return crossed if current <= previous_value
-      return crossed if current < one_time_thresholds_values.first
 
-      if previous_value < one_time_thresholds_values.last
-        crossed += one_time_thresholds_values.filter { it > previous_value && it <= current }
+      if one_time_thresholds_values.present?
+        return crossed if current < one_time_thresholds_values.first
+
+        if previous_value < one_time_thresholds_values.last
+          crossed += one_time_thresholds_values.filter { it > previous_value && it <= current }
+        end
       end
 
       crossed += find_recurring_thresholds_crossed_increasing(
-        previous_value, current, recurring_threshold&.value, one_time_thresholds_values.last
+        previous_value, current, recurring_threshold&.value, one_time_thresholds_values.last || 0
       )
 
       crossed.uniq.sort
@@ -92,14 +95,17 @@ module UsageMonitoring
     def find_thresholds_crossed_decreasing(current)
       crossed = []
       return crossed if current >= previous_value
-      return crossed if current > one_time_thresholds_values.last
 
-      if previous_value > one_time_thresholds_values.first
-        crossed += one_time_thresholds_values.filter { it < previous_value && it >= current }
+      if one_time_thresholds_values.present?
+        return crossed if current > one_time_thresholds_values.last
+
+        if previous_value > one_time_thresholds_values.first
+          crossed += one_time_thresholds_values.filter { it < previous_value && it >= current }
+        end
       end
 
       crossed += find_recurring_thresholds_crossed_decreasing(
-        previous_value, current, recurring_threshold&.value, one_time_thresholds_values.first
+        previous_value, current, recurring_threshold&.value, one_time_thresholds_values.first || 0
       )
 
       crossed.uniq.sort

--- a/spec/models/usage_monitoring/alert_spec.rb
+++ b/spec/models/usage_monitoring/alert_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe UsageMonitoring::Alert do
   end
 
   describe "#find_thresholds_crossed" do
+    context "when alert has only recurring thresholds (no one-time thresholds)" do
+      let(:alert) { create(:alert, code: "only-recurring", thresholds: nil, recurring_threshold: 100) }
+
+      it "does not raise ArgumentError for increasing direction" do
+        alert.previous_value = 0
+        expect(alert.find_thresholds_crossed(150)).to eq([100])
+      end
+
+      it "does not raise ArgumentError for decreasing direction" do
+        alert.direction = "decreasing"
+        alert.previous_value = 50
+        expect(alert.find_thresholds_crossed(-150)).to eq([-100])
+      end
+    end
+
     context "when direction is increasing" do
       it "returns threshold values between previous_value and current (inclusive)" do
         alert.previous_value = 8

--- a/spec/scenarios/usage_monitoring/subscription_alerts_spec.rb
+++ b/spec/scenarios/usage_monitoring/subscription_alerts_spec.rb
@@ -146,6 +146,59 @@ describe "Subscriptions Alerting Scenario", :premium, cache: :redis do
     end
   end
 
+  context "with only a recurring threshold (no one-time thresholds)" do
+    it "triggers alerts at each recurring step without raising" do
+      create_subscription({
+        external_customer_id: customer.external_id,
+        external_id: subscription_external_id,
+        plan_code: plan.code
+      })
+      create_alert(subscription_external_id, {
+        alert_type: :current_usage_amount,
+        code: :recurring_only,
+        thresholds: [
+          {value: 10_00, code: :alert, recurring: true}
+        ]
+      })
+      alert = UsageMonitoring::Alert.find(json[:alert][:lago_id])
+
+      send_event!(code: billable_metric.code, properties: {ops_count: 7}, external_subscription_id: subscription_external_id)
+      perform_usage_update
+
+      expect(alert.triggered_alerts.count).to eq(1)
+      ta = alert.triggered_alerts.sole
+      expect(ta.current_value).to eq(3_500)
+      expect(ta.previous_value).to eq(0)
+      expect(ta.crossed_thresholds.map(&:symbolize_keys)).to eq([
+        {code: "alert", value: "1000.0", recurring: true},
+        {code: "alert", value: "2000.0", recurring: true},
+        {code: "alert", value: "3000.0", recurring: true}
+      ])
+
+      webhooks_sent.find { |w| w[:webhook_type] == "alert.triggered" }.tap do |webhook|
+        expect(webhook[:object_type]).to eq("triggered_alert")
+        expect(webhook[:triggered_alert]).to include({
+          lago_id: ta.id,
+          current_value: "3500.0",
+          previous_value: "0.0",
+          triggered_at: String
+        })
+      end
+
+      send_event!(code: billable_metric.code, properties: {ops_count: 4}, external_subscription_id: subscription_external_id)
+      perform_usage_update
+
+      expect(alert.triggered_alerts.count).to eq(2)
+      ta = alert.triggered_alerts.order(:created_at).last
+      expect(ta.current_value).to eq(5500)
+      expect(ta.previous_value).to eq(3500)
+      expect(ta.crossed_thresholds.map(&:symbolize_keys)).to eq([
+        {code: "alert", value: "4000.0", recurring: true},
+        {code: "alert", value: "5000.0", recurring: true}
+      ])
+    end
+  end
+
   context "with billable_metric_current_usage_units alert" do
     it do
       create_subscription({


### PR DESCRIPTION
## Context

We are seeing errors in `UsageMonitoring::Alert#find_thresholds_crossed_increasing` when processing subscription activity alerts that only have recurring thresholds.

This PR handles this edge case by checking for existing one-time thresholds before passing them to `find_recurring_thresholds_crossed_increasing`