### PR TITLE
feat(payment-gated-subs): reject subscription creation when external_id is incomplete

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -51,13 +51,14 @@ module Subscriptions
           .raise_if_error!
 
         customer.with_lock do
-          @current_subscription = editable_subscriptions
-            .find_by("id = ? OR external_id = ?", params[:subscription_id], external_id)
-
-          if current_subscription&.next_subscription&.incomplete?
-            result.validation_failure!(errors: {subscription: ["pending_plan_change"]})
+          if customer.subscriptions.incomplete
+              .exists?(["id = ? OR external_id = ?", params[:subscription_id], external_id])
+            result.validation_failure!(errors: {subscription: ["subscription_incomplete"]})
             result.raise_if_error!
           end
+
+          @current_subscription = editable_subscriptions
+            .find_by("id = ? OR external_id = ?", params[:subscription_id], external_id)
 
           subscription = handle_subscription
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1134,12 +1134,12 @@ RSpec.describe Subscriptions::CreateService do
               )
             end
 
-            it "returns pending_plan_change error" do
+            it "returns subscription_incomplete error" do
               result = create_service.call
 
               expect(result).not_to be_success
               expect(result.error).to be_a(BaseService::ValidationFailure)
-              expect(result.error.messages[:subscription]).to eq(["pending_plan_change"])
+              expect(result.error.messages[:subscription]).to eq(["subscription_incomplete"])
             end
           end
         end
@@ -1348,15 +1348,31 @@ RSpec.describe Subscriptions::CreateService do
               )
             end
 
-            it "returns pending_plan_change error" do
+            it "returns subscription_incomplete error" do
               result = create_service.call
 
               expect(result).not_to be_success
               expect(result.error).to be_a(BaseService::ValidationFailure)
-              expect(result.error.messages[:subscription]).to eq(["pending_plan_change"])
+              expect(result.error.messages[:subscription]).to eq(["subscription_incomplete"])
             end
           end
         end
+      end
+    end
+
+    context "when existing subscription with same external_id is incomplete" do
+      let(:incomplete_subscription) do
+        create(:subscription, :incomplete, customer:, plan:, organization:, external_id:)
+      end
+
+      before { incomplete_subscription }
+
+      it "returns a subscription_incomplete error" do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:subscription]).to eq(["subscription_incomplete"])
       end
     end
 


### PR DESCRIPTION
## Context

When a subscription is incomplete (awaiting payment confirmation), no new subscription should be created with the same external_id. This prevents upgrades, downgrades, or duplicate subscriptions while an activation is in flight.

## Description

Add an early guard in CreateService that checks for incomplete subscriptions matching the requested external_id before looking up editable subscriptions. Returns a subscription_incomplete validation error. This replaces the previous next_subscription.incomplete? guard which is now subsumed by the broader check since next subscriptions share the same external_id.