### PR TITLE
feat(payment-gated-subs): extract ActivateService

### DIFF
--- a/app/services/subscriptions/activate_all_pending_service.rb
+++ b/app/services/subscriptions/activate_all_pending_service.rb
@@ -21,26 +21,7 @@ module Subscriptions
           Time.zone.at(timestamp)
         )
         .find_each do |subscription|
-          subscription.mark_as_active!(Time.zone.at(timestamp))
-          fixed_charge_timestamp = subscription.started_at + 1.second
-
-          EmitFixedChargeEventsService.call!(
-            subscriptions: [subscription],
-            timestamp: fixed_charge_timestamp
-          )
-
-          if subscription.should_sync_hubspot_subscription?
-            Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription:)
-          end
-
-          SendWebhookJob.perform_later("subscription.started", subscription)
-          Utils::ActivityLog.produce(subscription, "subscription.started")
-
-          if subscription.plan.pay_in_advance? && !subscription.in_trial_period?
-            BillSubscriptionJob.perform_later([subscription], timestamp, invoicing_reason: :subscription_starting)
-          elsif subscription.fixed_charges.pay_in_advance.any?
-            Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, fixed_charge_timestamp)
-          end
+          ActivateService.call!(subscription:, timestamp: Time.zone.at(timestamp))
         end
 
       result

--- a/app/services/subscriptions/activate_all_pending_service.rb
+++ b/app/services/subscriptions/activate_all_pending_service.rb
@@ -5,7 +5,7 @@ module Subscriptions
     Result = BaseResult
 
     def initialize(timestamp:)
-      @timestamp = timestamp
+      @timestamp = Time.zone.at(timestamp)
 
       super
     end
@@ -18,10 +18,10 @@ module Subscriptions
         .where(
           "DATE(subscriptions.subscription_at#{at_time_zone}) <= " \
           "DATE(?#{at_time_zone})",
-          Time.zone.at(timestamp)
+          timestamp
         )
         .find_each do |subscription|
-          ActivateService.call!(subscription:, timestamp: Time.zone.at(timestamp))
+          ActivateService.call!(subscription:, timestamp:)
         end
 
       result

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -21,13 +21,15 @@ module Subscriptions
         timestamp: subscription.started_at + 1.second
       )
 
-      bill_subscription
+      after_commit do
+        bill_subscription
 
-      SendWebhookJob.perform_later("subscription.started", subscription)
-      Utils::ActivityLog.produce(subscription, "subscription.started")
+        SendWebhookJob.perform_later("subscription.started", subscription)
+        Utils::ActivityLog.produce(subscription, "subscription.started")
 
-      if subscription.should_sync_hubspot_subscription?
-        Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription:)
+        if subscription.should_sync_hubspot_subscription?
+          Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription:)
+        end
       end
 
       result

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -44,8 +44,7 @@ module Subscriptions
         BillSubscriptionJob.perform_later(
           [subscription],
           timestamp.to_i,
-          invoicing_reason: :subscription_starting,
-          skip_charges: true
+          invoicing_reason: :subscription_starting
         )
       elsif subscription.fixed_charges.pay_in_advance.any?
         Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class ActivateService < BaseService
+    Result = BaseResult[:subscription]
+
+    def initialize(subscription:, timestamp: Time.current)
+      @subscription = subscription
+      @timestamp = timestamp
+      super
+    end
+
+    def call
+      result.subscription = subscription
+      return result if subscription.active?
+
+      subscription.mark_as_active!(timestamp)
+
+      EmitFixedChargeEventsService.call!(
+        subscriptions: [subscription],
+        timestamp: subscription.started_at + 1.second
+      )
+
+      bill_subscription
+
+      SendWebhookJob.perform_later("subscription.started", subscription)
+      Utils::ActivityLog.produce(subscription, "subscription.started")
+
+      if subscription.should_sync_hubspot_subscription?
+        Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription:)
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :subscription, :timestamp
+
+    def bill_subscription
+      if subscription.plan.pay_in_advance? && !subscription.in_trial_period?
+        BillSubscriptionJob.perform_later(
+          [subscription],
+          timestamp.to_i,
+          invoicing_reason: :subscription_starting,
+          skip_charges: true
+        )
+      elsif subscription.fixed_charges.pay_in_advance.any?
+        Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(
+          subscription,
+          subscription.started_at + 1.second
+        )
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ActivateService do
+  subject(:result) { described_class.call(subscription:, timestamp:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, :pending, organization:, customer:, plan:, subscription_at: Time.current) }
+  let(:timestamp) { Time.current }
+
+  it "activates the subscription" do
+    freeze_time do
+      expect(result.subscription).to be_active
+      expect(result.subscription.started_at).to eq(Time.current)
+      expect(result.subscription.activated_at).to eq(Time.current)
+    end
+  end
+
+  it "sends a subscription.started webhook" do
+    result
+
+    expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", subscription)
+  end
+
+  it "produces a subscription.started activity log" do
+    result
+
+    expect(Utils::ActivityLog).to have_produced("subscription.started").with(subscription)
+  end
+
+  context "when subscription has fixed charges" do
+    let(:add_on) { create(:add_on, organization:) }
+    let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
+
+    before { fixed_charge }
+
+    it "emits fixed charge events" do
+      expect { result }.to change(FixedChargeEvent, :count).by(1)
+    end
+  end
+
+  context "when subscription should sync with hubspot" do
+    let(:customer) { create(:customer, :with_hubspot_integration, organization:) }
+
+    it "enqueues hubspot sync job" do
+      result
+
+      expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob)
+        .to have_been_enqueued.with(subscription:)
+    end
+  end
+
+  context "when plan is pay in advance and not in trial" do
+    let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+
+    it "enqueues BillSubscriptionJob" do
+      result
+
+      expect(BillSubscriptionJob).to have_been_enqueued
+        .with([subscription], anything, invoicing_reason: :subscription_starting, skip_charges: true)
+    end
+  end
+
+  context "when plan is pay in arrears with pay-in-advance fixed charges" do
+    let(:plan) { create(:plan, organization:, pay_in_advance: false) }
+    let(:add_on) { create(:add_on, organization:) }
+
+    before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+    it "enqueues CreatePayInAdvanceFixedChargesJob" do
+      result
+
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob).to have_been_enqueued
+    end
+  end
+
+  context "when plan is pay in advance with trial period" do
+    let(:plan) { create(:plan, organization:, pay_in_advance: true, trial_period: 30) }
+
+    it "does not enqueue BillSubscriptionJob" do
+      result
+
+      expect(BillSubscriptionJob).not_to have_been_enqueued
+    end
+  end
+
+  context "when subscription is already active" do
+    let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+    it "returns the subscription without changes" do
+      expect(result.subscription).to be_active
+      expect(SendWebhookJob).not_to have_been_enqueued
+    end
+  end
+end

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Subscriptions::ActivateService do
     expect(Utils::ActivityLog).to have_produced("subscription.started").with(subscription)
   end
 
+  it "does not enqueue billing jobs" do
+    result
+
+    expect(BillSubscriptionJob).not_to have_been_enqueued
+    expect(Invoices::CreatePayInAdvanceFixedChargesJob).not_to have_been_enqueued
+  end
+
   context "when subscription has fixed charges" do
     let(:add_on) { create(:add_on, organization:) }
     let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
@@ -60,7 +67,27 @@ RSpec.describe Subscriptions::ActivateService do
       result
 
       expect(BillSubscriptionJob).to have_been_enqueued
-        .with([subscription], anything, invoicing_reason: :subscription_starting, skip_charges: true)
+        .with([subscription], anything, invoicing_reason: :subscription_starting)
+    end
+
+    it "does not enqueue CreatePayInAdvanceFixedChargesJob" do
+      result
+
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob).not_to have_been_enqueued
+    end
+  end
+
+  context "when plan is pay in advance with pay-in-advance fixed charges" do
+    let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+    let(:add_on) { create(:add_on, organization:) }
+
+    before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+    it "enqueues BillSubscriptionJob but not CreatePayInAdvanceFixedChargesJob" do
+      result
+
+      expect(BillSubscriptionJob).to have_been_enqueued
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob).not_to have_been_enqueued
     end
   end
 
@@ -75,6 +102,26 @@ RSpec.describe Subscriptions::ActivateService do
 
       expect(Invoices::CreatePayInAdvanceFixedChargesJob).to have_been_enqueued
     end
+
+    it "does not enqueue BillSubscriptionJob" do
+      result
+
+      expect(BillSubscriptionJob).not_to have_been_enqueued
+    end
+  end
+
+  context "when plan is pay in arrears with non-pay-in-advance fixed charges" do
+    let(:plan) { create(:plan, organization:, pay_in_advance: false) }
+    let(:add_on) { create(:add_on, organization:) }
+
+    before { create(:fixed_charge, plan:, add_on:, pay_in_advance: false) }
+
+    it "does not enqueue any billing job" do
+      result
+
+      expect(BillSubscriptionJob).not_to have_been_enqueued
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob).not_to have_been_enqueued
+    end
   end
 
   context "when plan is pay in advance with trial period" do
@@ -85,6 +132,24 @@ RSpec.describe Subscriptions::ActivateService do
 
       expect(BillSubscriptionJob).not_to have_been_enqueued
     end
+
+    context "when plan has pay-in-advance fixed charges" do
+      let(:add_on) { create(:add_on, organization:) }
+
+      before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+      it "enqueues CreatePayInAdvanceFixedChargesJob" do
+        result
+
+        expect(Invoices::CreatePayInAdvanceFixedChargesJob).to have_been_enqueued
+      end
+
+      it "does not enqueue BillSubscriptionJob" do
+        result
+
+        expect(BillSubscriptionJob).not_to have_been_enqueued
+      end
+    end
   end
 
   context "when subscription is already active" do
@@ -93,6 +158,8 @@ RSpec.describe Subscriptions::ActivateService do
     it "returns the subscription without changes" do
       expect(result.subscription).to be_active
       expect(SendWebhookJob).not_to have_been_enqueued
+      expect(BillSubscriptionJob).not_to have_been_enqueued
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob).not_to have_been_enqueued
     end
   end
 end


### PR DESCRIPTION
## Context

Subscription activation logic is duplicated across `CreateService`, `ActivateAllPendingService`, and `TerminateService` with slightly different side effects. A single entry point makes activation consistent and provides a reusable service for gated activation flows.

## Description

Extract `ActivateService` that handles the common activation concerns: `mark_as_active`, emit fixed charge events, bill subscription or pay-in-advance fixed charges, send subscription.started webhook and activity log, and trigger HubSpot sync. Accepts a Time object as timestamp parameter. Returns early if subscription is already active.

Refactor `ActivateAllPendingService` to delegate to the new service, removing inline activation logic.