### PR TITLE
perf(subscription): Optimize subscription termination alert job 

### DIFF
--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -4,18 +4,21 @@ module Clock
   class SubscriptionsToBeTerminatedJob < ClockJob
     def perform
       Subscription
-        .joins(customer: :organization)
-        .joins("left join webhooks on subscriptions.id = webhooks.object_id and " \
-               "webhooks.webhook_type = 'subscription.termination_alert'")
         .active
-        .where(
-          "DATE(subscriptions.ending_at::timestamptz) IN (?)",
-          sent_at_dates
-        )
-        .where("webhooks.id IS NULL OR webhooks.created_at::date != ?", Time.current.to_date)
-        .distinct
-        .find_each do |subscription|
-          SendWebhookJob.perform_later("subscription.termination_alert", subscription)
+        .where("DATE(ending_at::timestamptz) IN (?)", sent_at_dates)
+        .in_batches do |subscriptions|
+          subscriptions = subscriptions.to_a
+          subscription_ids_already_alerted = Webhook.where(
+            webhook_type: "subscription.termination_alert",
+            object_type: "Subscription",
+            object_id: subscriptions.map(&:id)
+          )
+            .where("created_at::date = ?", Time.current.to_date)
+            .pluck(:object_id)
+          subscriptions.filter { |subscription| subscription_ids_already_alerted.exclude?(subscription.id) }
+            .each do |subscription|
+              SendWebhookJob.perform_later("subscription.termination_alert", subscription)
+            end
         end
     end
 

--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -3,9 +3,12 @@
 module Clock
   class SubscriptionsToBeTerminatedJob < ClockJob
     def perform
+      now = Time.current
+      today = now.to_date
+
       Subscription
         .active
-        .where("DATE(ending_at::timestamptz) IN (?)", sent_at_dates)
+        .where("DATE(ending_at::timestamptz) IN (?)", sent_at_dates(now))
         .in_batches do |subscriptions|
           subscriptions = subscriptions.to_a
           subscription_ids_already_alerted = Webhook.where(
@@ -13,8 +16,9 @@ module Clock
             object_type: "Subscription",
             object_id: subscriptions.map(&:id)
           )
-            .where("created_at::date = ?", Time.current.to_date)
+            .where("created_at::date = ?", today)
             .pluck(:object_id)
+            .to_set
           subscriptions.filter { |subscription| subscription_ids_already_alerted.exclude?(subscription.id) }
             .each do |subscription|
               SendWebhookJob.perform_later("subscription.termination_alert", subscription)
@@ -24,13 +28,13 @@ module Clock
 
     private
 
-    def sent_at_dates
+    def sent_at_dates(now)
       # NOTE: The alert will be sent 15 and 45 days before the subscription is terminated by default.
       #       You can override the default by setting below env var.
       #       E.g. LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS=1,15,45 will cause it
       #       to be sent at 1, 15, 45 days before subscription terminates, respectively.
       sent_at_days_config = ENV.fetch("LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS", "15,45")
-      sent_at_days_config.split(",").map { |day_string| Time.current + day_string.to_i.days }.map(&:to_date)
+      sent_at_days_config.split(",").map { |day_string| (now + day_string.to_i.days).to_date }
     end
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -331,6 +331,7 @@ end
 # Indexes
 #
 #  index_subscriptions_on_customer_id                          (customer_id)
+#  index_subscriptions_on_ending_at_active                     (ending_at) WHERE ((status = 1) AND (ending_at IS NOT NULL))
 #  index_subscriptions_on_external_id                          (external_id)
 #  index_subscriptions_on_last_received_event_on               (last_received_event_on)
 #  index_subscriptions_on_last_received_event_on_null          (id) WHERE (last_received_event_on IS NULL)

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -87,12 +87,13 @@ end
 #
 # Indexes
 #
-#  index_webhooks_for_query                          (organization_id,webhook_endpoint_id,webhook_type,updated_at)
-#  index_webhooks_on_endpoint_and_timestamps         (webhook_endpoint_id,updated_at,created_at)
-#  index_webhooks_on_endpoint_status_and_timestamps  (webhook_endpoint_id,status,updated_at)
-#  index_webhooks_on_organization_id                 (organization_id)
-#  index_webhooks_on_updated_at_for_cleanup          (updated_at)
-#  index_webhooks_on_webhook_endpoint_id             (webhook_endpoint_id)
+#  index_webhooks_for_query                                      (organization_id,webhook_endpoint_id,webhook_type,updated_at)
+#  index_webhooks_on_endpoint_and_timestamps                     (webhook_endpoint_id,updated_at,created_at)
+#  index_webhooks_on_endpoint_status_and_timestamps              (webhook_endpoint_id,status,updated_at)
+#  index_webhooks_on_object_type_and_object_id_and_webhook_type  (object_type,object_id,webhook_type)
+#  index_webhooks_on_organization_id                             (organization_id)
+#  index_webhooks_on_updated_at_for_cleanup                      (updated_at)
+#  index_webhooks_on_webhook_endpoint_id                         (webhook_endpoint_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20260403184747_add_index_on_webhooks_object_type_object_id_webhook_type.rb
+++ b/db/migrate/20260403184747_add_index_on_webhooks_object_type_object_id_webhook_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIndexOnWebhooksObjectTypeObjectIdWebhookType < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :webhooks, [:object_type, :object_id, :webhook_type],
+      name: "index_webhooks_on_object_type_and_object_id_and_webhook_type",
+      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260403184747_add_index_on_webhooks_object_type_object_id_webhook_type.rb
+++ b/db/migrate/20260403184747_add_index_on_webhooks_object_type_object_id_webhook_type.rb
@@ -6,6 +6,7 @@ class AddIndexOnWebhooksObjectTypeObjectIdWebhookType < ActiveRecord::Migration[
   def change
     add_index :webhooks, [:object_type, :object_id, :webhook_type],
       name: "index_webhooks_on_object_type_and_object_id_and_webhook_type",
-      algorithm: :concurrently
+      algorithm: :concurrently,
+      if_not_exists: true
   end
 end

--- a/db/migrate/20260403184752_add_index_on_subscriptions_ending_at_active.rb
+++ b/db/migrate/20260403184752_add_index_on_subscriptions_ending_at_active.rb
@@ -7,6 +7,7 @@ class AddIndexOnSubscriptionsEndingAtActive < ActiveRecord::Migration[8.0]
     add_index :subscriptions, :ending_at,
       where: "status = 1 AND ending_at IS NOT NULL",
       name: "index_subscriptions_on_ending_at_active",
-      algorithm: :concurrently
+      algorithm: :concurrently,
+      if_not_exists: true
   end
 end

--- a/db/migrate/20260403184752_add_index_on_subscriptions_ending_at_active.rb
+++ b/db/migrate/20260403184752_add_index_on_subscriptions_ending_at_active.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexOnSubscriptionsEndingAtActive < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscriptions, :ending_at,
+      where: "status = 1 AND ending_at IS NOT NULL",
+      name: "index_subscriptions_on_ending_at_active",
+      algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -324,6 +324,7 @@ DROP INDEX IF EXISTS public.index_wt_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_webhooks_on_webhook_endpoint_id;
 DROP INDEX IF EXISTS public.index_webhooks_on_updated_at_for_cleanup;
 DROP INDEX IF EXISTS public.index_webhooks_on_organization_id;
+DROP INDEX IF EXISTS public.index_webhooks_on_object_type_and_object_id_and_webhook_type;
 DROP INDEX IF EXISTS public.index_webhooks_on_endpoint_status_and_timestamps;
 DROP INDEX IF EXISTS public.index_webhooks_on_endpoint_and_timestamps;
 DROP INDEX IF EXISTS public.index_webhooks_for_query;
@@ -378,6 +379,7 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_organization_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_last_received_event_on_null;
 DROP INDEX IF EXISTS public.index_subscriptions_on_last_received_event_on;
 DROP INDEX IF EXISTS public.index_subscriptions_on_external_id;
+DROP INDEX IF EXISTS public.index_subscriptions_on_ending_at_active;
 DROP INDEX IF EXISTS public.index_subscriptions_on_customer_id;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_on_subscription_id;
@@ -8991,6 +8993,13 @@ CREATE INDEX index_subscriptions_on_customer_id ON public.subscriptions USING bt
 
 
 --
+-- Name: index_subscriptions_on_ending_at_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscriptions_on_ending_at_active ON public.subscriptions USING btree (ending_at) WHERE ((status = 1) AND (ending_at IS NOT NULL));
+
+
+--
 -- Name: index_subscriptions_on_external_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9366,6 +9375,13 @@ CREATE INDEX index_webhooks_on_endpoint_and_timestamps ON public.webhooks USING 
 --
 
 CREATE INDEX index_webhooks_on_endpoint_status_and_timestamps ON public.webhooks USING btree (webhook_endpoint_id, status, updated_at);
+
+
+--
+-- Name: index_webhooks_on_object_type_and_object_id_and_webhook_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_webhooks_on_object_type_and_object_id_and_webhook_type ON public.webhooks USING btree (object_type, object_id, webhook_type);
 
 
 --
@@ -11768,6 +11784,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260409161142'),
 ('20260409151451'),
 ('20260407091845'),
+('20260403184752'),
+('20260403184747'),
 ('20260331122448'),
 ('20260331103301'),
 ('20260327140626'),

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -306,6 +306,106 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
       end
     end
 
+    context "when ending_at is at end of day" do
+      it "still enqueues the alert" do
+        subscription = create(:subscription, customer:, organization:, ending_at: ending_at_15_days.end_of_day)
+
+        travel_to(current_date) do
+          described_class.perform_now
+
+          expect(SendWebhookJob).to have_been_enqueued
+            .with("subscription.termination_alert", subscription)
+            .exactly(:once)
+        end
+      end
+    end
+
+    context "with subscriptions from different organizations" do
+      it "enqueues for matching subscriptions across organizations" do
+        other_org = create(:organization)
+        other_customer = create(:customer, organization: other_org)
+        create(:webhook_endpoint, organization: other_org)
+        other_sub = create(:subscription, customer: other_customer, organization: other_org, ending_at: ending_at_15_days)
+        sub = create(:subscription, customer:, organization:, ending_at: ending_at_15_days)
+
+        travel_to(current_date) do
+          described_class.perform_now
+
+          expect(SendWebhookJob).to have_been_enqueued
+            .with("subscription.termination_alert", sub)
+          expect(SendWebhookJob).to have_been_enqueued
+            .with("subscription.termination_alert", other_sub)
+        end
+      end
+    end
+
+    context "when a termination_alert webhook exists with a different object_type" do
+      it "does not block the alert" do
+        subscription = create(:subscription, customer:, organization:, ending_at: ending_at_15_days)
+
+        travel_to(current_date) do
+          webhook = create(
+            :webhook,
+            :succeeded,
+            webhook_endpoint:,
+            object: subscription,
+            webhook_type: "subscription.termination_alert",
+            created_at: current_date
+          )
+          webhook.update_column(:object_type, "Invoice") # rubocop:disable Rails/SkipsModelValidations
+
+          described_class.perform_now
+
+          expect(SendWebhookJob).to have_been_enqueued
+            .with("subscription.termination_alert", subscription)
+            .exactly(:once)
+        end
+      end
+    end
+
+    describe "index usage" do
+      # Force PostgreSQL to use indexes even on a tiny test dataset so we can
+      # verify the planner CAN use them for the query patterns the job produces.
+      around do |example|
+        ActiveRecord::Base.connection.execute("SET enable_seqscan = off")
+        example.run
+      ensure
+        ActiveRecord::Base.connection.execute("SET enable_seqscan = on")
+      end
+
+      it "uses the partial index on ending_at for the subscription lookup" do
+        create(:subscription, customer:, organization:, ending_at: ending_at_15_days)
+
+        plan = travel_to(current_date) do
+          Subscription
+            .active
+            .where("DATE(ending_at::timestamptz) IN (?)", [ending_at_15_days.to_date])
+            .explain
+            .inspect
+        end
+
+        expect(plan).to include("index_subscriptions_on_ending_at_active")
+      end
+
+      it "uses the composite index on (object_type, object_id, webhook_type) for the webhook dedup" do
+        subscription = create(:subscription, customer:, organization:, ending_at: ending_at_15_days)
+
+        plan = travel_to(current_date) do
+          Webhook
+            .where(
+              webhook_type: "subscription.termination_alert",
+              object_type: "Subscription",
+              object_id: [subscription.id]
+            )
+            .where("created_at::date = ?", current_date.to_date)
+            .explain
+            .inspect
+        end
+
+        expect(plan).to include("index_webhooks_on_object_type_and_object_id_and_webhook_type")
+      end
+    end
+
     context "with custom LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS" do
       around do |test|
         old_value = ENV["LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS"]


### PR DESCRIPTION
## Context

The `Clock::SubscriptionsToBeTerminatedJob` uses a `LEFT JOIN` on the `webhooks` table to deduplicate alerts already sent today. This join is expensive because:

1. The `webhooks` table is large and there is no index on `(object_type, object_id, webhook_type)`, forcing a sequential scan.
2. The `subscriptions` query also lacks a partial index on `ending_at` for active subscriptions, leading to a full table scan.
3. The `LEFT JOIN` + `DISTINCT` pattern produces a single heavy query instead of leveraging batching.

## Description

The query strategy was replaced with a batch-based approach: subscriptions matching the date criteria are loaded with `in_batches`, and a separate `Webhook` query checks which ones were already alerted today. This avoids the costly `LEFT JOIN` + `DISTINCT` and lets each batch produce a small, indexed lookup.

Two indexes were added to support the new query patterns:

- **`index_webhooks_on_object_type_and_object_id_and_webhook_type`** — composite index on `(object_type, object_id, webhook_type)` for the webhook dedup lookup.
- **`index_subscriptions_on_ending_at_active`** — partial index on `ending_at` filtered to active subscriptions with a non-null `ending_at`, for the subscription date lookup.

Both migrations use `algorithm: :concurrently` with `disable_ddl_transaction!` for zero-downtime deployment.

New test cases cover cross-organization subscriptions, end-of-day `ending_at` timestamps, mismatched `object_type` on existing webhooks, and EXPLAIN-based assertions verifying that both indexes are used by the planner.