### PR TITLE
refactor(fixed-charges): return created events from EmitEventsForActiveSubscriptionsService

### DIFF
--- a/app/services/fixed_charges/emit_events_service.rb
+++ b/app/services/fixed_charges/emit_events_service.rb
@@ -2,6 +2,8 @@
 
 module FixedCharges
   class EmitEventsService < BaseService
+    Result = BaseResult[:fixed_charge_events]
+
     def initialize(fixed_charge:, subscription: nil, apply_units_immediately: false, timestamp: Time.current.to_i)
       @fixed_charge = fixed_charge
       @subscription = subscription
@@ -11,12 +13,12 @@ module FixedCharges
     end
 
     def call
-      subscriptions.each do |subscription|
+      result.fixed_charge_events = subscriptions.map do |subscription|
         ::FixedChargeEvents::CreateService.call!(
           subscription:,
           fixed_charge:,
           timestamp: apply_units_immediately ? timestamp : next_billing_period(subscription)
-        )
+        ).fixed_charge_event
       end
 
       result

--- a/spec/services/fixed_charges/emit_events_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_service_spec.rb
@@ -57,15 +57,16 @@ RSpec.describe FixedCharges::EmitEventsService do
     it "creates fixed charge events for all active subscriptions" do
       expect { result }.to change(FixedChargeEvent, :count).by(2)
 
-      event_1 = FixedChargeEvent.find_by(subscription: active_subscription_1, fixed_charge:)
-      event_2 = FixedChargeEvent.find_by(subscription: active_subscription_2, fixed_charge:)
+      events = result.fixed_charge_events
+      expect(events.size).to eq(2)
 
-      expect(event_1).to be_present
+      event_1 = events.find { |e| e.subscription_id == active_subscription_1.id }
+      event_2 = events.find { |e| e.subscription_id == active_subscription_2.id }
+
       expect(event_1.organization).to eq(active_subscription_1.organization)
       expect(event_1.units).to eq(fixed_charge.units)
       expect(event_1.timestamp).to be_within(1.second).of(active_subscription_1.started_at.beginning_of_day + 1.month)
 
-      expect(event_2).to be_present
       expect(event_2.organization).to eq(active_subscription_2.organization)
       expect(event_2.units).to eq(fixed_charge.units)
       expect(event_2.timestamp).to be_within(1.second).of(1.month.from_now.beginning_of_month)
@@ -93,11 +94,9 @@ RSpec.describe FixedCharges::EmitEventsService do
       before { incomplete_subscription }
 
       it "creates fixed charge events for incomplete subscriptions" do
-        expect(FixedChargeEvent.where(subscription: incomplete_subscription, fixed_charge:)).not_to exist
+        expect { result }.to change(FixedChargeEvent, :count)
 
-        result
-
-        expect(FixedChargeEvent.where(subscription: incomplete_subscription, fixed_charge:)).to exist
+        expect(result.fixed_charge_events.map(&:subscription_id)).to include(incomplete_subscription.id)
       end
     end
 
@@ -109,8 +108,8 @@ RSpec.describe FixedCharges::EmitEventsService do
       it "creates fixed charge event for the incomplete subscription" do
         expect { result }.to change(FixedChargeEvent, :count).by(1)
 
-        event = FixedChargeEvent.find_by(subscription:, fixed_charge:)
-        expect(event).to be_present
+        expect(result.fixed_charge_events.size).to eq(1)
+        expect(result.fixed_charge_events.first.subscription_id).to eq(subscription.id)
       end
     end
 


### PR DESCRIPTION
## Context

The service creates fixed charge events but does not expose them in the result, forcing callers and tests to query the database to access them.

## Description

Collect the fixed charge events created by FixedChargeEvents::CreateService and return them as result.fixed_charge_events. Update tests to assert on the result instead of querying FixedChargeEvent directly.