### PR TITLE
feat(db): Avoid RDS Proxy connection pinning

### DIFF
--- a/config/initializers/rds_proxy.rb
+++ b/config/initializers/rds_proxy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Activates the RDS Proxy connection patch. See lib/lago/rds_proxy/connection_patch.rb
+# for what the patch does and why.
+
+if ENV["DATABASE_VIA_RDS_PROXY"].present?
+  require "lago/rds_proxy/connection_patch"
+
+  # The pg gem auto-sends SET client_encoding when default_internal is set,
+  # bypassing configure_connection. Reset to nil to suppress.
+  Encoding.default_internal = nil
+
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(
+      Lago::RdsProxy::ConnectionPatch
+    )
+  end
+end

--- a/lib/lago/rds_proxy/connection_patch.rb
+++ b/lib/lago/rds_proxy/connection_patch.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Patches PostgreSQLAdapter#configure_connection to skip session-level SET
+# commands that cause RDS Proxy to pin the connection. The skipped settings
+# must be configured via the proxy's initQuery instead:
+#
+#   SET client_encoding = 'UTF8';
+#   SET client_min_messages TO 'warning';
+#   SET search_path TO 'public';
+#   SET standard_conforming_strings = on;
+#   SET intervalstyle = iso_8601;
+#   SET timezone TO 'UTC'
+#
+# `@schema_search_path` is cached locally to avoid an extra `SHOW search_path`
+# query on first access. This assumes the proxy's initQuery sets a `search_path`
+# matching `@config[:schema_search_path]` (both default to 'public').
+#
+# `reconfigure_connection_timezone` is overridden to a no-op because it is
+# invoked by `add_pg_decoders` during type map setup and would otherwise emit
+# `SET SESSION timezone TO 'UTC'`.
+#
+# See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-pinning.html
+module Lago
+  module RdsProxy
+    module ConnectionPatch
+      def configure_connection
+        check_version
+
+        @schema_search_path = @config[:schema_search_path] || @config[:schema_order]
+
+        unless ActiveRecord.db_warnings_action.nil?
+          @raw_connection.set_notice_receiver do |result|
+            message = result.error_field(PG::Result::PG_DIAG_MESSAGE_PRIMARY)
+            code = result.error_field(PG::Result::PG_DIAG_SQLSTATE)
+            level = result.error_field(PG::Result::PG_DIAG_SEVERITY)
+            @notice_receiver_sql_warnings << SQLWarning.new(message, code, level, nil, @pool)
+          end
+        end
+
+        # User-defined variables from database.yml will still pin the connection.
+        variables = @config.fetch(:variables, {}).stringify_keys
+        variables.each do |k, v|
+          if v == ":default" || v == :default
+            internal_execute("SET SESSION #{k} TO DEFAULT", "SCHEMA")
+          elsif !v.nil?
+            internal_execute("SET SESSION #{k} TO #{quote(v)}", "SCHEMA")
+          end
+        end
+
+        add_pg_encoders
+        add_pg_decoders
+        reload_type_map
+      end
+
+      private
+
+      def reconfigure_connection_timezone
+        # no-op: proxy's initQuery sets the timezone
+      end
+    end
+  end
+end

--- a/spec/lib/lago/rds_proxy/connection_patch_spec.rb
+++ b/spec/lib/lago/rds_proxy/connection_patch_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "lago/rds_proxy/connection_patch"
+
+RSpec.describe Lago::RdsProxy::ConnectionPatch do
+  # Stub class mimicking PostgreSQLAdapter's interface for the methods our
+  # patch interacts with. We assert on call ordering and absence of SETs.
+  let(:adapter_class) do
+    Class.new do
+      attr_accessor :schema_search_path, :calls
+
+      def initialize(config)
+        @config = config
+        @raw_connection = Object.new
+        @notice_receiver_sql_warnings = []
+        @pool = Object.new
+        @calls = []
+      end
+
+      def check_version
+        @calls << :check_version
+      end
+
+      def add_pg_encoders
+        @calls << :add_pg_encoders
+      end
+
+      def add_pg_decoders
+        @calls << :add_pg_decoders
+      end
+
+      def reload_type_map
+        @calls << :reload_type_map
+      end
+
+      def internal_execute(sql, _name = nil)
+        @calls << [:internal_execute, sql]
+      end
+
+      def quote(value)
+        "'#{value}'"
+      end
+
+      def reconfigure_connection_timezone
+        @calls << :original_reconfigure_connection_timezone
+      end
+
+      prepend Lago::RdsProxy::ConnectionPatch
+    end
+  end
+
+  let(:adapter) { adapter_class.new(config) }
+
+  before { allow(ActiveRecord).to receive(:db_warnings_action).and_return(nil) }
+
+  describe "#configure_connection" do
+    context "with a basic config" do
+      let(:config) { {schema_search_path: "public"} }
+
+      before { adapter.configure_connection }
+
+      it "calls check_version" do
+        expect(adapter.calls).to include(:check_version)
+      end
+
+      it "caches the schema_search_path from config" do
+        expect(adapter.schema_search_path).to eq("public")
+      end
+
+      it "calls add_pg_encoders, add_pg_decoders and reload_type_map" do
+        expect(adapter.calls).to include(:add_pg_encoders, :add_pg_decoders, :reload_type_map)
+      end
+
+      it "does not send any SET commands" do
+        sets = adapter.calls.select { |c| c.is_a?(Array) && c[0] == :internal_execute }
+        expect(sets).to be_empty
+      end
+    end
+
+    context "with no schema_search_path in config" do
+      let(:config) { {} }
+
+      it "leaves @schema_search_path nil for the lazy getter to populate" do
+        adapter.configure_connection
+        expect(adapter.schema_search_path).to be_nil
+      end
+    end
+
+    context "with schema_order fallback" do
+      let(:config) { {schema_order: "tenant_a,public"} }
+
+      it "uses schema_order when schema_search_path is absent" do
+        adapter.configure_connection
+        expect(adapter.schema_search_path).to eq("tenant_a,public")
+      end
+    end
+
+    context "with user-defined variables" do
+      let(:config) { {variables: {statement_timeout: "30s", lock_timeout: :default}} }
+
+      before { adapter.configure_connection }
+
+      it "still applies SET SESSION for explicit variables (and accepts the pinning cost)" do
+        expect(adapter.calls).to include([:internal_execute, "SET SESSION statement_timeout TO '30s'"])
+        expect(adapter.calls).to include([:internal_execute, "SET SESSION lock_timeout TO DEFAULT"])
+      end
+    end
+
+    context "with nil values in variables" do
+      let(:config) { {variables: {statement_timeout: nil}} }
+
+      it "skips nil values" do
+        adapter.configure_connection
+        sets = adapter.calls.select { |c| c.is_a?(Array) && c[0] == :internal_execute }
+        expect(sets).to be_empty
+      end
+    end
+  end
+
+  describe "#reconfigure_connection_timezone" do
+    let(:config) { {} }
+
+    it "is a no-op so add_pg_decoders does not emit SET SESSION timezone" do
+      adapter.send(:reconfigure_connection_timezone)
+      expect(adapter.calls).not_to include(:original_reconfigure_connection_timezone)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an opt-in patch to ActiveRecord's PostgreSQL adapter so that new connections no longer emit session-level `SET` commands, which is a prerequisite for AWS RDS Proxy to multiplex connections rather than pin them 1:1.

## Context

Lago is rolling out AWS RDS Proxy in front of PostgreSQL on the EU staging environment, with the aim of enabling connection multiplexing and seamless blue/green upgrade cutovers.

Out of the box though, the proxy wasn't actually multiplexing anything. Any time a client sends a session-level `SET` command, RDS Proxy pins the client to a specific database connection for the rest of that session because it can't guarantee session state is safe to share. Rails' PostgreSQL adapter sends five `SET` commands on every new connection via `configure_connection`, plus a sixth `SET SESSION timezone` that's emitted indirectly through `add_pg_decoders → update_typemap_for_default_timezone → reconfigure_connection_timezone`. With those pins in place, the proxy degraded to a pure passthrough: just an extra network hop, no connection count reduction.

AWS does not offer a session-pinning filter for PostgreSQL. The one filter that exists (`EXCLUDE_VARIABLE_SETS`) is MySQL-only, [confirmed in the AWS docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-pinning.html). For PostgreSQL, the only path to unpinned connections is to stop sending session `SET`s from the client and configure the equivalent state via the proxy's `initQuery` parameter instead.

## What changed

Three new files:

- `lib/lago/rds_proxy/connection_patch.rb`: the `Lago::RdsProxy::ConnectionPatch` module, defining a replacement `configure_connection` (keeps `check_version`, the notice receiver, user-defined `variables:`, and the type map setup; drops the SETs) plus a no-op override for `reconfigure_connection_timezone` so `add_pg_decoders` doesn't re-introduce `SET SESSION timezone`.
- `config/initializers/rds_proxy.rb`: gated on `DATABASE_VIA_RDS_PROXY`; when set, it `require`s the patch module and prepends it onto `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter`. Also resets `Encoding.default_internal = nil` to stop the `pg` gem from calling `set_client_encoding` independently of `configure_connection`.
- `spec/lib/lago/rds_proxy/connection_patch_spec.rb`: nine specs covering the `configure_connection` override (check_version called, `@schema_search_path` cached, no SETs emitted, user-defined variables still applied, nil values skipped, `schema_order` fallback) and the `reconfigure_connection_timezone` no-op.

Without `DATABASE_VIA_RDS_PROXY` set, nothing loads and the adapter behaves exactly as before. Local development, CI, and non-proxy deployments are unaffected.

## Infra-side prerequisite

The proxy's `initQuery` must set the six equivalent values on the database side, otherwise sessions will start with PostgreSQL defaults rather than what Rails expects:

```sql
SET client_encoding = 'UTF8';
SET client_min_messages TO 'warning';
SET search_path TO 'public';
SET standard_conforming_strings = on;
SET intervalstyle = iso_8601;
SET timezone TO 'UTC'
```

## Local verification

Tested locally with PostgreSQL query logging enabled (`ALTER SYSTEM SET log_statement = 'all'`).

Baseline run (env var unset), one new connection:
```
SET client_min_messages TO 'warning'
SET standard_conforming_strings = on
SET intervalstyle = iso_8601
SET SESSION timezone TO 'UTC'
SHOW search_path
SELECT 1 AS baseline_test
```
Five pre-query statements (4 SETs + 1 SHOW). Every one of the SETs would pin the connection on RDS Proxy.

Patched run (`DATABASE_VIA_RDS_PROXY=true`), one new connection:
```
SELECT 99 AS fresh_verify_test
```
Zero pre-query statements. Just the application query.

## How to try locally

You won't have an RDS Proxy locally, but you can reproduce the before/after connection behavior against plain PostgreSQL to confirm the patch is working as designed:

1. Enable query logging on the dev database:
   ```bash
   docker exec lago_db_dev psql -U lago -d lago -c "ALTER SYSTEM SET log_statement = 'all';"
   docker exec lago_db_dev psql -U lago -d lago -c "SELECT pg_reload_conf();"
   ```
2. Run a baseline query without the patch:
   ```bash
   lago exec api bin/rails runner 'ActiveRecord::Base.connection.execute("SELECT 1 AS baseline")'
   ```
3. Run the same query with the patch active:
   ```bash
   lago exec api env DATABASE_VIA_RDS_PROXY=true bin/rails runner 'ActiveRecord::Base.connection.execute("SELECT 2 AS patched")'
   ```
4. Compare what was sent to PostgreSQL:
   ```bash
   docker logs --since 30s lago_db_dev 2>&1 | grep -E "(SET|SHOW|baseline|patched)"
   ```
5. Restore the logging setting afterwards:
   ```bash
   docker exec lago_db_dev psql -U lago -d lago -c "ALTER SYSTEM RESET log_statement;"
   docker exec lago_db_dev psql -U lago -d lago -c "SELECT pg_reload_conf();"
   ```

You should see the baseline process emit 4 SETs + 1 SHOW before the query, and the patched process emit only the query itself.

## Test plan

- [x] `spec/lib/lago/rds_proxy/connection_patch_spec.rb` passes (9 examples, 0 failures)
- [x] Locally verified zero session-level SETs on new connections when `DATABASE_VIA_RDS_PROXY=true`
- [x] Locally verified default behavior unchanged when the env var is unset
- [ ] Stage on `eu-west-1` alongside the proxy's updated `initQuery` and confirm `DatabaseConnectionsCurrentlySessionPinned` drops to ~0 in CloudWatch
- [ ] Stage with `DATABASE_PREPARED_STATEMENTS=false` to also eliminate extended-query-protocol pinning
- [ ] Measure p99 query latency on billing/event-ingestion paths before/after to confirm no regression from the added proxy hop