### PR TITLE
refactor(fixed-charges): rename EmitEventsForActiveSubscriptionsService to EmitEventsService

### DIFF
--- a/app/services/fixed_charges/create_service.rb
+++ b/app/services/fixed_charges/create_service.rb
@@ -42,7 +42,7 @@ module FixedCharges
           taxes_result.raise_if_error!
         end
 
-        FixedCharges::EmitEventsForActiveSubscriptionsService.call!(
+        FixedCharges::EmitEventsService.call!(
           fixed_charge:,
           apply_units_immediately: !!params[:apply_units_immediately],
           timestamp:

--- a/app/services/fixed_charges/emit_events_service.rb
+++ b/app/services/fixed_charges/emit_events_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FixedCharges
-  class EmitEventsForActiveSubscriptionsService < BaseService
+  class EmitEventsService < BaseService
     def initialize(fixed_charge:, subscription: nil, apply_units_immediately: false, timestamp: Time.current.to_i)
       @fixed_charge = fixed_charge
       @subscription = subscription

--- a/app/services/fixed_charges/override_service.rb
+++ b/app/services/fixed_charges/override_service.rb
@@ -32,7 +32,7 @@ module FixedCharges
         end
         new_fixed_charge.save!
 
-        FixedCharges::EmitEventsForActiveSubscriptionsService.call!(
+        FixedCharges::EmitEventsService.call!(
           fixed_charge: new_fixed_charge,
           subscription:,
           apply_units_immediately: !!params[:apply_units_immediately]

--- a/app/services/fixed_charges/update_service.rb
+++ b/app/services/fixed_charges/update_service.rb
@@ -42,7 +42,7 @@ module FixedCharges
         result.fixed_charge = fixed_charge
 
         if fixed_charge.units_previously_changed?
-          FixedCharges::EmitEventsForActiveSubscriptionsService.call!(
+          FixedCharges::EmitEventsService.call!(
             fixed_charge:,
             apply_units_immediately: params[:apply_units_immediately],
             timestamp:

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -76,7 +76,7 @@ module Subscriptions
       existing_fixed_charge.units = params[:units] if params.key?(:units)
       existing_fixed_charge.save!
 
-      FixedCharges::EmitEventsForActiveSubscriptionsService.call!(
+      FixedCharges::EmitEventsService.call!(
         fixed_charge: existing_fixed_charge,
         subscription:,
         apply_units_immediately: !!params[:apply_units_immediately]

--- a/spec/services/fixed_charges/create_service_spec.rb
+++ b/spec/services/fixed_charges/create_service_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe FixedCharges::CreateService do
           end
 
           before do
-            allow(FixedCharges::EmitEventsForActiveSubscriptionsService)
+            allow(FixedCharges::EmitEventsService)
               .to receive(:call!)
           end
 
@@ -375,7 +375,7 @@ RSpec.describe FixedCharges::CreateService do
           it "emits fixed charge events for all active subscriptions" do
             result
 
-            expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+            expect(FixedCharges::EmitEventsService)
               .to have_received(:call!)
               .with(
                 fixed_charge: result.fixed_charge,
@@ -397,7 +397,7 @@ RSpec.describe FixedCharges::CreateService do
           end
 
           before do
-            allow(FixedCharges::EmitEventsForActiveSubscriptionsService)
+            allow(FixedCharges::EmitEventsService)
               .to receive(:call!)
           end
 
@@ -410,7 +410,7 @@ RSpec.describe FixedCharges::CreateService do
           it "emits fixed charge events for active subscriptions with apply_units_immediately false" do
             result
 
-            expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+            expect(FixedCharges::EmitEventsService)
               .to have_received(:call!)
               .with(
                 fixed_charge: result.fixed_charge,
@@ -439,15 +439,15 @@ RSpec.describe FixedCharges::CreateService do
       end
 
       before do
-        allow(FixedCharges::EmitEventsForActiveSubscriptionsService)
+        allow(FixedCharges::EmitEventsService)
           .to receive(:call!)
           .and_call_original
       end
 
-      it "passes the custom timestamp to EmitEventsForActiveSubscriptionsService" do
+      it "passes the custom timestamp to EmitEventsService" do
         result
 
-        expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+        expect(FixedCharges::EmitEventsService)
           .to have_received(:call!)
           .with(
             fixed_charge: result.fixed_charge,

--- a/spec/services/fixed_charges/emit_events_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::EmitEventsForActiveSubscriptionsService do
+RSpec.describe FixedCharges::EmitEventsService do
   subject(:service) do
     described_class.new(fixed_charge:, subscription:)
   end

--- a/spec/services/fixed_charges/override_service_spec.rb
+++ b/spec/services/fixed_charges/override_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe FixedCharges::OverrideService do
 
     context "when lago premium", :premium do
       before do
-        allow(FixedCharges::EmitEventsForActiveSubscriptionsService).to receive(:call!)
+        allow(FixedCharges::EmitEventsService).to receive(:call!)
       end
 
       it "creates a fixed charge based on the given fixed charge" do
@@ -72,7 +72,7 @@ RSpec.describe FixedCharges::OverrideService do
       it "emits fixed charge events for all active subscriptions" do
         result = override_service.call
 
-        expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+        expect(FixedCharges::EmitEventsService)
           .to have_received(:call!)
           .with(
             fixed_charge: result.fixed_charge,
@@ -265,7 +265,7 @@ RSpec.describe FixedCharges::OverrideService do
         end
 
         before do
-          allow(FixedCharges::EmitEventsForActiveSubscriptionsService)
+          allow(FixedCharges::EmitEventsService)
             .to receive(:call!)
         end
 
@@ -282,7 +282,7 @@ RSpec.describe FixedCharges::OverrideService do
         it "creates fixed charge events for the specific subscription" do
           result = override_service.call
 
-          expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+          expect(FixedCharges::EmitEventsService)
             .to have_received(:call!)
             .with(
               fixed_charge: result.fixed_charge,
@@ -304,7 +304,7 @@ RSpec.describe FixedCharges::OverrideService do
           it "creates fixed charge events for the specific subscription" do
             result = override_service.call
 
-            expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+            expect(FixedCharges::EmitEventsService)
               .to have_received(:call!)
               .with(
                 fixed_charge: result.fixed_charge,

--- a/spec/services/fixed_charges/update_service_spec.rb
+++ b/spec/services/fixed_charges/update_service_spec.rb
@@ -263,14 +263,14 @@ RSpec.describe FixedCharges::UpdateService do
         end
 
         before do
-          allow(FixedCharges::EmitEventsForActiveSubscriptionsService)
+          allow(FixedCharges::EmitEventsService)
             .to receive(:call!)
         end
 
         it "emits fixed charge events for all active subscriptions" do
           result
 
-          expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+          expect(FixedCharges::EmitEventsService)
             .to have_received(:call!)
             .with(
               fixed_charge: result.fixed_charge,
@@ -309,7 +309,7 @@ RSpec.describe FixedCharges::UpdateService do
           it "emits fixed charge events for all active subscriptions" do
             result
 
-            expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+            expect(FixedCharges::EmitEventsService)
               .to have_received(:call!)
               .with(
                 fixed_charge: result.fixed_charge,
@@ -339,14 +339,14 @@ RSpec.describe FixedCharges::UpdateService do
         end
 
         before do
-          allow(FixedCharges::EmitEventsForActiveSubscriptionsService)
+          allow(FixedCharges::EmitEventsService)
             .to receive(:call!)
         end
 
         it "does not emit any fixed charge events" do
           result
 
-          expect(FixedCharges::EmitEventsForActiveSubscriptionsService)
+          expect(FixedCharges::EmitEventsService)
             .not_to have_received(:call!)
         end
       end

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -129,12 +129,12 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
           expect(result.fixed_charge.units).to eq(10)
         end
 
-        it "calls EmitEventsForActiveSubscriptionsService" do
-          allow(FixedCharges::EmitEventsForActiveSubscriptionsService).to receive(:call!)
+        it "calls EmitEventsService" do
+          allow(FixedCharges::EmitEventsService).to receive(:call!)
 
           service.call
 
-          expect(FixedCharges::EmitEventsForActiveSubscriptionsService).to have_received(:call!).with(
+          expect(FixedCharges::EmitEventsService).to have_received(:call!).with(
             fixed_charge: existing_override,
             subscription:,
             apply_units_immediately: false
@@ -150,12 +150,12 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
             }
           end
 
-          it "calls EmitEventsForActiveSubscriptionsService with apply_units_immediately true" do
-            allow(FixedCharges::EmitEventsForActiveSubscriptionsService).to receive(:call!)
+          it "calls EmitEventsService with apply_units_immediately true" do
+            allow(FixedCharges::EmitEventsService).to receive(:call!)
 
             service.call
 
-            expect(FixedCharges::EmitEventsForActiveSubscriptionsService).to have_received(:call!).with(
+            expect(FixedCharges::EmitEventsService).to have_received(:call!).with(
               fixed_charge: existing_override,
               subscription:,
               apply_units_immediately: true


### PR DESCRIPTION
## Context

The service now handles both active and incomplete subscriptions, making the "ForActiveSubscriptions" suffix inaccurate and unnecessarily verbose.

## Description

Rename FixedCharges::EmitEventsForActiveSubscriptionsService to FixedCharges::EmitEventsService. Update all callers and specs.