### PR TITLE
perf(invoices): add index on payment_due_date

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -714,6 +714,7 @@ end
 #  index_invoices_by_cursor                                        (organization_id,issuing_date DESC,created_at DESC,id)
 #  index_invoices_on_customer_id_and_sequential_id                 (customer_id,sequential_id) UNIQUE
 #  index_invoices_on_number                                        (number)
+#  index_invoices_on_payment_due_date                              (payment_due_date) WHERE ((status = 1) AND (payment_status <> 1) AND (payment_overdue = false) AND (payment_dispute_lost_at IS NULL))
 #  index_invoices_on_payment_method_id                             (payment_method_id)
 #  index_invoices_on_ready_to_be_refreshed                         (ready_to_be_refreshed) WHERE (ready_to_be_refreshed = true)
 #  index_invoices_on_voided_invoice_id                             (voided_invoice_id)

--- a/db/migrate/20260415160654_add_index_on_invoices_payment_due_date.rb
+++ b/db/migrate/20260415160654_add_index_on_invoices_payment_due_date.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddIndexOnInvoicesPaymentDueDate < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :invoices, :payment_due_date,
+      where: "status = 1
+              AND payment_status <> 1
+              AND payment_overdue = false
+              AND payment_dispute_lost_at IS NULL",
+      name: :index_invoices_on_payment_due_date,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -480,6 +480,7 @@ DROP INDEX IF EXISTS public.index_invoices_payment_requests_on_invoice_id;
 DROP INDEX IF EXISTS public.index_invoices_on_voided_invoice_id;
 DROP INDEX IF EXISTS public.index_invoices_on_ready_to_be_refreshed;
 DROP INDEX IF EXISTS public.index_invoices_on_payment_method_id;
+DROP INDEX IF EXISTS public.index_invoices_on_payment_due_date;
 DROP INDEX IF EXISTS public.index_invoices_on_number;
 DROP INDEX IF EXISTS public.index_invoices_on_customer_id_and_sequential_id;
 DROP INDEX IF EXISTS public.index_invoices_by_cursor;
@@ -8212,6 +8213,13 @@ CREATE INDEX index_invoices_on_number ON public.invoices USING btree (number);
 
 
 --
+-- Name: index_invoices_on_payment_due_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_invoices_on_payment_due_date ON public.invoices USING btree (payment_due_date) WHERE ((status = 1) AND (payment_status <> 1) AND (payment_overdue = false) AND (payment_dispute_lost_at IS NULL));
+
+
+--
 -- Name: index_invoices_on_payment_method_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11697,6 +11705,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260415160654'),
 ('20260409161142'),
 ('20260409151451'),
 ('20260331122448'),

--- a/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
+++ b/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
@@ -22,4 +22,30 @@ describe Clock::MarkInvoicesAsPaymentOverdueJob, job: true do
         .and have_enqueued_job(Invoices::Payments::MarkOverdueJob).with(invoice: overdue_invoice_2)
     end
   end
+
+  describe "index usage" do
+    # Force PostgreSQL to use indexes even on a tiny test dataset so we can
+    # verify the planner CAN use them for the query patterns the job produces.
+    around do |example|
+      ActiveRecord::Base.connection.execute("SET enable_seqscan = off")
+      example.run
+    ensure
+      ActiveRecord::Base.connection.execute("SET enable_seqscan = on")
+    end
+
+    it "uses the partial index on payment_due_date for the overdue invoice lookup" do
+      create(:invoice, payment_due_date: 1.day.ago)
+
+      plan = Invoice
+        .finalized
+        .not_payment_succeeded
+        .where(payment_overdue: false)
+        .where(payment_dispute_lost_at: nil)
+        .where(payment_due_date: ...Time.current)
+        .explain
+        .inspect
+
+      expect(plan).to include("index_invoices_on_payment_due_date")
+    end
+  end
 end


### PR DESCRIPTION
## Context 

Clock::MarkInvoicesAsPaymentOverdueJob scans invoices by payment_due_date to flag overdue ones, but the column has no supporting index. In production the first find_in_batches page falls back to a PK scan with inline filtering and a LIMIT 1 probe already takes ~25 seconds, making the clock job unusable

## Description
Add a partial index on invoices.payment_due_date restricted to the predicate used by the overdue job: finalized invoices that are not yet paid, not yet flagged overdue, and  not disputed. The partial clause keeps the index minimal and self-maintaining, since rows leave it once they are paid, voided, marked overdue, or lose a dispute. 