### PR TITLE
fix(event-processor): incompatible log events

### DIFF
--- a/karafka.rb
+++ b/karafka.rb
@@ -30,12 +30,7 @@ class KarafkaApp < Karafka::App
     config.monitor = Karafka::LagoMonitor.new
   end
 
-  Karafka.monitor.subscribe(
-    WaterDrop::Instrumentation::LoggerListener.new(
-      Karafka.logger,
-      log_messages: true
-    )
-  )
+  Karafka.monitor.subscribe(Karafka::Instrumentation::LoggerListener.new)
 
   Karafka.monitor.subscribe "error.occurred" do |event|
     Sentry.capture_exception(event[:error])


### PR DESCRIPTION
## Context

Karafka error messages are not compatible with WaterDrop's expected payload. All errors are swallowed, as a second exception is raised:

```
/usr/local/bundle/gems/karafka-core-2.5.10/lib/karafka/core/monitoring/event.rb:21:in 'Hash#fetch': key not found: :producer_id (KeyError)
	from /usr/local/bundle/gems/karafka-core-2.5.10/lib/karafka/core/monitoring/event.rb:21:in 'Karafka::Core::Monitoring::Event#[]'
	from /usr/local/bundle/gems/waterdrop-2.8.16/lib/waterdrop/instrumentation/logger_listener.rb:220:in 'WaterDrop::Instrumentation::LoggerListener#error'
	from /usr/local/bundle/gems/waterdrop-2.8.16/lib/waterdrop/instrumentation/logger_listener.rb:157:in 'WaterDrop::Instrumentation::LoggerListener#on_error_occurred'
	from /usr/local/bundle/gems/karafka-core-2.5.10/lib/karafka/core/monitoring/notifications.rb:171:in 'block in Karafka::Core::Monitoring::Notifications#notify_listeners'
	from /usr/local/bundle/gems/karafka-core-2.5.10/lib/karafka/core/monitoring/notifications.rb:167:in 'Array#each'
	from /usr/local/bundle/gems/karafka-core-2.5.10/lib/karafka/core/monitoring/notifications.rb:167:in 'Karafka::Core::Monitoring::Notifications#notify_listeners'
	from /usr/local/bundle/gems/karafka-core-2.5.10/lib/karafka/core/monitoring/notifications.rb:145:in 'Karafka::Core::Monitoring::Notifications#instrument'
	from /usr/local/bundle/gems/karafka-core-2.5.10/lib/karafka/core/monitoring/monitor.rb:33:in 'Karafka::Core::Monitoring::Monitor#instrument'
	from /app/lib/karafka/lago_monitor.rb:9:in 'Karafka::LagoMonitor#instrument'
	from /usr/local/bundle/gems/karafka-2.5.7/lib/karafka/connection/listener.rb:262:in 'Karafka::Connection::Listener#fetch_loop'
	from /usr/local/bundle/gems/karafka-2.5.7/lib/karafka/connection/listener.rb:84:in 'Karafka::Connection::Listener#call'
	from /usr/local/bundle/gems/karafka-2.5.7/lib/karafka/helpers/async.rb:51:in 'block (2 levels) in Karafka::Helpers::Async#async_call'
	from /usr/local/bundle/gems/newrelic_rpm-10.0.0/lib/new_relic/agent/tracer.rb:434:in 'block (2 levels) in NewRelic::Agent::Tracer.thread_block_with_current_transaction'
	from /usr/local/bundle/gems/newrelic_rpm-10.0.0/lib/new_relic/agent/tracer.rb:357:in 'NewRelic::Agent::Tracer.capture_segment_error'
	from /usr/local/bundle/gems/newrelic_rpm-10.0.0/lib/new_relic/agent/tracer.rb:433:in 'block in NewRelic::Agent::Tracer.thread_block_with_current_transaction'
/usr/local/bundle/gems/karafka-core-2.5.10/lib/karafka/core/monitoring/event.rb:21:in 'Hash#fetch': key not found: :producer_id (KeyError)
```