### PR TITLE
perf(invoices): align overdue job with new index

### DIFF
--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -11,8 +11,8 @@ module Clock
         .where(payment_overdue: false)
         .where(payment_dispute_lost_at: nil)
         .where(payment_due_date: ...Time.current)
-        .find_in_batches do |invoices|
-          jobs = invoices.map do |invoice|
+        .in_batches(of: 1000, cursor: [:payment_due_date, :id]) do |batch|
+          jobs = batch.map do |invoice|
             Invoices::Payments::MarkOverdueJob.new(invoice:)
           end
           ActiveJob.perform_all_later(jobs)

--- a/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
+++ b/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
@@ -42,6 +42,8 @@ describe Clock::MarkInvoicesAsPaymentOverdueJob, job: true do
         .where(payment_overdue: false)
         .where(payment_dispute_lost_at: nil)
         .where(payment_due_date: ...Time.current)
+        .order(:payment_due_date, :id)
+        .limit(1000)
         .explain
         .inspect
 


### PR DESCRIPTION
## Context

Follow-up to #5345 (closes [ISSUE-1812](https://linear.app/getlago/issue/ISSUE-1812/add-index-for-invoice-payment-due-date)).

The partial index on `invoices.payment_due_date` shipped in #5345 was
not being picked by the planner for `Clock::MarkInvoicesAsPaymentOverdueJob`.
`find_in_batches` forces `ORDER BY id LIMIT`, and combined with stale
multi-column selectivity estimates the planner preferred a PK scan
over the new index.

## Description

Replace `find_in_batches` with `in_batches(of: 1000, cursor: [:payment_due_date, :id])`.
The generated query orders by `(payment_due_date, id)`, whose prefix
matches the partial index, so the planner picks it consistently.

The index-usage spec is updated to assert the plan for the new query
order.