### PR TITLE
misc(clickhouse): Add re-enrich subscription orchestrator

### DIFF
--- a/app/jobs/events/stores/clickhouse/enriched_store_migration/orchestrator_job.rb
+++ b/app/jobs/events/stores/clickhouse/enriched_store_migration/orchestrator_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        class OrchestratorJob < ApplicationJob
+          queue_as "low_priority"
+
+          def perform(enriched_store_migration)
+            # TODO: Implement in step 4 — calls OrchestratorService
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_job.rb
+++ b/app/jobs/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        class SubscriptionOrchestratorJob < ApplicationJob
+          queue_as "low_priority"
+
+          def perform(subscription_migration)
+            SubscriptionOrchestratorService.call!(subscription_migration:)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_job.rb
+++ b/app/jobs/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        class WaitForEnrichmentJob < ApplicationJob
+          queue_as "low_priority"
+
+          BACKOFF_SCHEDULE = [5, 10].freeze
+          DEFAULT_BACKOFF = 15
+
+          def perform(subscription_migration, attempt = 1)
+            check_result = WaitForEnrichmentService.call!(
+              subscription_migration:,
+              attempt:,
+              max_attempts: WaitForEnrichmentService::MAX_ATTEMPTS
+            )
+
+            if check_result.status == :not_ready
+              wait_minutes = BACKOFF_SCHEDULE[attempt - 1] || DEFAULT_BACKOFF
+              self.class.set(wait: wait_minutes.minutes).perform_later(subscription_migration, attempt + 1)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_service.rb
+++ b/app/services/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_service.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        # Drives a single subscription through the enriched store migration pipeline.
+        # Called repeatedly — it reads the current state and executes the next step:
+        #
+        #   pending     → run initial comparison
+        #   comparing   → if no diffs: completed (fast path)
+        #                 if diffs + codes: reprocess events via Kafka, then wait for enrichment
+        #                 if diffs + no codes: failed (unexpected mismatch)
+        #   deduplicating → clean duplicate enriched_expanded rows
+        #                   if ClickHouse times out: pause (queries saved for manual run)
+        #                   otherwise: move to validation
+        #   validating  → final comparison after reprocessing + dedup
+        #                 if clean: completed; if diffs remain: failed
+        #
+        # On completion, enqueues the org-level OrchestratorJob to check overall progress.
+        class SubscriptionOrchestratorService < BaseService
+          CLEANUP_TIMEOUT = 5.minutes
+
+          Result = BaseResult[:subscription_migration]
+
+          def initialize(subscription_migration:)
+            @subscription_migration = subscription_migration
+            super
+          end
+
+          def call
+            case subscription_migration.status
+            when "pending"
+              handle_pending
+            when "comparing"
+              handle_comparing
+            when "deduplicating"
+              handle_deduplicating
+            when "validating"
+              handle_validating
+            else
+              result.service_failure!(code: :invalid_status, message: "Unprocessable status: #{subscription_migration.status}")
+            end
+
+            result.subscription_migration = subscription_migration
+            result
+          end
+
+          private
+
+          attr_reader :subscription_migration
+
+          delegate :subscription, to: :subscription_migration
+
+          def handle_pending
+            subscription_migration.start_comparing!
+            handle_comparing
+          end
+
+          def handle_comparing
+            comparison = run_comparison
+            return unless comparison
+
+            if comparison.diff_count.zero?
+              subscription_migration.complete!
+              enqueue_orchestrator
+            elsif subscription_migration.billable_metric_codes.present?
+              subscription_migration.start_reprocessing!
+              reprocess_events
+            else
+              fail_migration!("Diffs found but no billable metric codes to reprocess")
+            end
+          end
+
+          def handle_deduplicating
+            dedup_result = ::Events::Stores::Clickhouse::CleanDuplicatedEnrichedExpandedService.call(
+              subscription:,
+              codes: subscription_migration.billable_metric_codes,
+              timeout: CLEANUP_TIMEOUT
+            )
+
+            if dedup_result.failure?
+              fail_migration!(dedup_result.error&.message || "Deduplication failed")
+              return
+            end
+
+            if dedup_result.queries.present?
+              subscription_migration.dedup_pending_queries = dedup_result.queries
+              subscription_migration.pause_dedup!
+            else
+              subscription_migration.duplicates_removed_count = dedup_result.duplicated_count
+              subscription_migration.start_validating!
+              handle_validating
+            end
+          end
+
+          def handle_validating
+            comparison = run_comparison
+            return unless comparison
+
+            if comparison.diff_count.zero?
+              subscription_migration.complete!
+              enqueue_orchestrator
+            else
+              fail_migration!("Validation failed: #{comparison.diff_count} diff(s) remain after reprocessing")
+            end
+          end
+
+          def run_comparison
+            comparison = ::Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonService.call(subscription:)
+
+            unless comparison.success?
+              fail_migration!(comparison.error&.message || "Comparison failed")
+              return
+            end
+
+            codes = comparison.fee_details
+              .reject { |detail| detail.status == "match" }
+              .filter_map(&:billable_metric_code)
+              .uniq
+
+            subscription_migration.update!(
+              comparison_results: comparison.fee_details,
+              billable_metric_codes: codes
+            )
+
+            comparison
+          end
+
+          def reprocess_events
+            reprocess_result = ::Events::Stores::Clickhouse::ReEnrichSubscriptionEventsService.call(
+              subscription:,
+              codes: subscription_migration.billable_metric_codes
+            )
+
+            unless reprocess_result.success?
+              fail_migration!(reprocess_result.error&.message || "Reprocessing failed")
+              return
+            end
+
+            subscription_migration.events_reprocessed_count = reprocess_result.events_count
+            subscription_migration.start_waiting!
+
+            WaitForEnrichmentJob.perform_later(subscription_migration)
+          rescue => e
+            fail_migration!(e.message)
+          end
+
+          def fail_migration!(message)
+            subscription_migration.update!(error_message: message)
+            subscription_migration.fail!
+          end
+
+          def enqueue_orchestrator
+            OrchestratorJob.perform_later(subscription_migration.enriched_store_migration)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_service.rb
+++ b/app/services/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_service.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        # After events are reprocessed and republished to Kafka, the enrichment pipeline
+        # asynchronously produces rows in events_enriched_expanded. This service polls
+        # ClickHouse to check whether all reprocessed events have been enriched.
+        #
+        # A single event can produce multiple enriched_expanded rows (one per charge on the
+        # billable metric), so we count distinct transaction_ids rather than total rows.
+        #
+        # Returns :ready (advances to deduplicating), :not_ready (caller re-enqueues with
+        # backoff), or :max_attempts_reached (marks the subscription migration as failed).
+        class WaitForEnrichmentService < BaseService
+          STATUSES = %i[ready not_ready max_attempts_reached].freeze
+          MAX_ATTEMPTS = 10
+
+          Result = BaseResult[:status, :enriched_count]
+
+          def initialize(subscription_migration:, attempt:, max_attempts: MAX_ATTEMPTS)
+            @subscription_migration = subscription_migration
+            @attempt = attempt
+            @max_attempts = max_attempts
+            super
+          end
+
+          def call
+            return result unless subscription_migration.waiting_for_enrichment?
+
+            enriched_count = count_enriched_events
+            result.enriched_count = enriched_count
+
+            if enriched_count >= subscription_migration.events_reprocessed_count
+              subscription_migration.update!(attempts: attempt)
+              subscription_migration.start_deduplicating!
+              SubscriptionOrchestratorJob.perform_later(subscription_migration)
+              result.status = :ready
+            elsif attempt >= max_attempts
+              subscription_migration.update!(
+                attempts: attempt,
+                error_message: "Enrichment not ready after #{max_attempts} attempts " \
+                               "(enriched: #{enriched_count}, expected: #{subscription_migration.events_reprocessed_count})"
+              )
+              subscription_migration.fail!
+              result.status = :max_attempts_reached
+            else
+              subscription_migration.update!(attempts: attempt)
+              result.status = :not_ready
+            end
+
+            result
+          end
+
+          private
+
+          attr_reader :subscription_migration, :attempt, :max_attempts
+
+          def count_enriched_events
+            subscription = subscription_migration.subscription
+
+            scope = ::Clickhouse::EventsEnrichedExpanded
+              .where(organization_id: subscription.organization_id)
+              .where(external_subscription_id: subscription.external_id)
+              .where("timestamp >= ?", subscription.started_at)
+
+            scope = scope.where("timestamp <= ?", subscription.terminated_at) if subscription.terminated?
+            scope = scope.where(code: subscription_migration.billable_metric_codes) if subscription_migration.billable_metric_codes.present?
+
+            scope.pick(Arel.sql("uniqExact(transaction_id)"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_job_spec.rb
+++ b/spec/jobs/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::SubscriptionOrchestratorJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:migration) { create(:enriched_store_migration, :processing, organization:) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:subscription_migration) do
+    create(:enriched_store_subscription_migration,
+      enriched_store_migration: migration,
+      organization:,
+      subscription:)
+  end
+
+  before do
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::SubscriptionOrchestratorService)
+      .to receive(:call!)
+  end
+
+  describe "#perform" do
+    it "calls the SubscriptionOrchestratorService" do
+      described_class.perform_now(subscription_migration)
+
+      expect(Events::Stores::Clickhouse::EnrichedStoreMigration::SubscriptionOrchestratorService)
+        .to have_received(:call!).with(subscription_migration:)
+    end
+  end
+end

--- a/spec/jobs/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_job_spec.rb
+++ b/spec/jobs/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_job_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrichmentJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:migration) { create(:enriched_store_migration, :processing, organization:) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:subscription_migration) do
+    create(:enriched_store_subscription_migration, :waiting_for_enrichment,
+      enriched_store_migration: migration,
+      organization:,
+      subscription:,
+      events_reprocessed_count: 100,
+      billable_metric_codes: ["code1"])
+  end
+
+  let(:service_result) do
+    result = Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrichmentService::Result.new
+    result.status = status
+    result.enriched_count = 50
+    result
+  end
+
+  before do
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrichmentService)
+      .to receive(:call!).and_return(service_result)
+  end
+
+  describe "#perform" do
+    context "when service returns ready" do
+      let(:status) { :ready }
+
+      it "does not re-enqueue" do
+        described_class.perform_now(subscription_migration, 1)
+
+        expect(described_class).not_to have_been_enqueued
+      end
+    end
+
+    context "when service returns not_ready" do
+      let(:status) { :not_ready }
+
+      it "re-enqueues with backoff" do
+        freeze_time do
+          expect { described_class.perform_now(subscription_migration, 1) }.to have_enqueued_job(described_class)
+            .with(subscription_migration, 2)
+            .at(5.minutes.from_now)
+        end
+      end
+    end
+
+    context "when service returns not_ready on later attempt" do
+      let(:status) { :not_ready }
+
+      it "uses the correct backoff schedule" do
+        freeze_time do
+          expect { described_class.perform_now(subscription_migration, 2) }.to have_enqueued_job(described_class)
+            .with(subscription_migration, 3)
+            .at(10.minutes.from_now)
+        end
+      end
+    end
+
+    context "when service returns max_attempts_reached" do
+      let(:status) { :max_attempts_reached }
+
+      it "does not re-enqueue" do
+        expect { described_class.perform_now(subscription_migration, 10) }.not_to have_enqueued_job(described_class)
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/subscription_orchestrator_service_spec.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::SubscriptionOrchestratorService do
+  subject(:service) { described_class.new(subscription_migration:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let(:migration) { create(:enriched_store_migration, :processing, organization:) }
+
+  let(:comparison_service) { Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonService }
+
+  let(:comparison_result) do
+    result = comparison_service::Result.new
+    result.diff_count = diff_count
+    result.fee_details = fee_details
+    result
+  end
+
+  let(:diff_count) { 0 }
+  let(:fee_details) { [] }
+
+  before do
+    allow(comparison_service).to receive(:call).and_return(comparison_result)
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::OrchestratorJob)
+      .to receive(:perform_later)
+  end
+
+  describe "#call" do
+    context "when pending with no diffs" do
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      it "transitions to completed via fast path" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_completed
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::OrchestratorJob)
+          .to have_received(:perform_later).with(migration)
+      end
+    end
+
+    context "when pending with diffs and codes to reprocess" do
+      let(:diff_count) { 1 }
+      let(:fee_details) do
+        [
+          comparison_service::FeeDetail.new(
+            charge_id: "c1", charge_filter_id: nil, grouped_by: {},
+            billable_metric_code: "api_calls", aggregation_type: "count_agg",
+            charge_model: "standard", from: nil, to: nil,
+            status: "diff", legacy: nil, enriched: nil, diffs: {}
+          )
+        ]
+      end
+
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      let(:reprocess_result) do
+        result = Events::Stores::Clickhouse::ReEnrichSubscriptionEventsService::Result.new
+        result.events_count = 42
+        result.batch_count = 1
+        result
+      end
+
+      before do
+        allow(Events::Stores::Clickhouse::ReEnrichSubscriptionEventsService)
+          .to receive(:call).and_return(reprocess_result)
+        allow(Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrichmentJob)
+          .to receive(:perform_later)
+      end
+
+      it "assigns billable_metric_codes and transitions to waiting_for_enrichment" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_waiting_for_enrichment
+        expect(subscription_migration.billable_metric_codes).to eq(["api_calls"])
+        expect(subscription_migration.events_reprocessed_count).to eq(42)
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrichmentJob)
+          .to have_received(:perform_later).with(subscription_migration)
+      end
+    end
+
+    context "when pending with diffs but no codes" do
+      let(:diff_count) { 1 }
+      let(:fee_details) do
+        [
+          comparison_service::FeeDetail.new(
+            charge_id: "c1", charge_filter_id: nil, grouped_by: {},
+            billable_metric_code: nil, aggregation_type: nil,
+            charge_model: "standard", from: nil, to: nil,
+            status: "diff", legacy: nil, enriched: nil, diffs: {}
+          )
+        ]
+      end
+
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      it "transitions to failed" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_failed
+        expect(subscription_migration.error_message).to include("no billable metric codes")
+      end
+    end
+
+    context "when deduplicating successfully" do
+      let(:billable_metric_codes) { ["code1"] }
+
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration, :deduplicating,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:,
+          billable_metric_codes:)
+      end
+
+      let(:dedup_result) do
+        result = Events::Stores::Clickhouse::CleanDuplicatedEnrichedExpandedService::Result.new
+        result.duplicated_count = 5
+        result.queries = []
+        result
+      end
+
+      before do
+        allow(Events::Stores::Clickhouse::CleanDuplicatedEnrichedExpandedService)
+          .to receive(:call).and_return(dedup_result)
+      end
+
+      it "transitions to completed after validating" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_completed
+        expect(subscription_migration.duplicates_removed_count).to eq(5)
+      end
+    end
+
+    context "when deduplicating with timeout" do
+      let(:billable_metric_codes) { ["code1"] }
+
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration, :deduplicating,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:,
+          billable_metric_codes:)
+      end
+
+      let(:dedup_result) do
+        result = Events::Stores::Clickhouse::CleanDuplicatedEnrichedExpandedService::Result.new
+        result.duplicated_count = 100
+        result.queries = ["DELETE FROM events_enriched_expanded WHERE ..."]
+        result
+      end
+
+      before do
+        allow(Events::Stores::Clickhouse::CleanDuplicatedEnrichedExpandedService)
+          .to receive(:call).and_return(dedup_result)
+      end
+
+      it "transitions to dedup_paused with pending queries" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_dedup_paused
+        expect(subscription_migration.dedup_pending_queries).to eq(["DELETE FROM events_enriched_expanded WHERE ..."])
+      end
+    end
+
+    context "when deduplicating with failure" do
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration, :deduplicating,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      before do
+        failed_result = Events::Stores::Clickhouse::CleanDuplicatedEnrichedExpandedService::Result.new
+        failed_result.service_failure!(code: :dedup_failure, message: "Deduplication failed")
+        allow(Events::Stores::Clickhouse::CleanDuplicatedEnrichedExpandedService).to receive(:call).and_return(failed_result)
+      end
+
+      it "transitions to failed" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_failed
+        expect(subscription_migration.error_message).to eq("dedup_failure: Deduplication failed")
+      end
+    end
+
+    context "when validating with no diffs" do
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration, :validating,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      it "transitions to completed" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_completed
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::OrchestratorJob)
+          .to have_received(:perform_later).with(migration)
+      end
+    end
+
+    context "when validating with diffs" do
+      let(:diff_count) { 2 }
+      let(:fee_details) do
+        [
+          comparison_service::FeeDetail.new(
+            charge_id: "c1", charge_filter_id: nil, grouped_by: {},
+            billable_metric_code: "api_calls", aggregation_type: "count_agg",
+            charge_model: "standard", from: nil, to: nil,
+            status: "diff", legacy: nil, enriched: nil, diffs: {}
+          ),
+          comparison_service::FeeDetail.new(
+            charge_id: "c2", charge_filter_id: nil, grouped_by: {},
+            billable_metric_code: "storage", aggregation_type: "sum_agg",
+            charge_model: "standard", from: nil, to: nil,
+            status: "diff", legacy: nil, enriched: nil, diffs: {}
+          )
+        ]
+      end
+
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration, :validating,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      it "transitions to failed" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_failed
+        expect(subscription_migration.error_message).to include("2 diff(s) remain")
+      end
+    end
+
+    context "when comparison service fails" do
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      before do
+        failed_result = comparison_service::Result.new
+        failed_result.service_failure!(code: "error", message: "something broke")
+        allow(comparison_service).to receive(:call).and_return(failed_result)
+      end
+
+      it "transitions to failed" do
+        service.call
+        subscription_migration.reload
+        expect(subscription_migration).to be_failed
+        expect(subscription_migration.error_message).to include("something broke")
+      end
+    end
+
+    context "when in an unactionable state" do
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration, :waiting_for_enrichment,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      it "returns a failed result" do
+        result = service.call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code.to_s).to eq("invalid_status")
+        expect(result.error.error_message).to eq("Unprocessable status: waiting_for_enrichment")
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/wait_for_enrichment_service_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::WaitForEnrichmentService, clickhouse: {clean_before: true} do
+  subject(:service) { described_class.new(subscription_migration:, attempt:, max_attempts:) }
+
+  let(:organization) { create(:organization) }
+  let(:migration) { create(:enriched_store_migration, :processing, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:, code: "code1") }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+  let(:subscription) { create(:subscription, organization:, plan:) }
+  let(:subscription_migration) do
+    create(:enriched_store_subscription_migration, :waiting_for_enrichment,
+      enriched_store_migration: migration,
+      organization:,
+      subscription:,
+      events_reprocessed_count:,
+      billable_metric_codes: ["code1"])
+  end
+
+  let(:attempt) { 1 }
+  let(:max_attempts) { 10 }
+  let(:events_reprocessed_count) { 3 }
+
+  def create_enriched_expanded_event(transaction_id: SecureRandom.uuid, event_charge: charge)
+    Clickhouse::EventsEnrichedExpanded.create!(
+      transaction_id:,
+      organization_id: organization.id,
+      external_subscription_id: subscription.external_id,
+      subscription_id: subscription.id,
+      plan_id: plan.id,
+      code: billable_metric.code,
+      aggregation_type: billable_metric.aggregation_type,
+      charge_id: event_charge.id,
+      charge_version: event_charge.updated_at,
+      charge_filter_id: "",
+      timestamp: Time.current,
+      properties: {},
+      grouped_by: {},
+      value: "1",
+      decimal_value: 1.to_d,
+      precise_total_amount_cents: nil,
+      enriched_at: Time.current
+    )
+  end
+
+  describe "#call" do
+    context "when enriched events are ready" do
+      before do
+        3.times { create_enriched_expanded_event }
+      end
+
+      it "transitions to deduplicating and returns ready status" do
+        result = service.call
+
+        subscription_migration.reload
+        expect(result.status).to eq(:ready)
+        expect(result.enriched_count).to eq(3)
+        expect(subscription_migration).to be_deduplicating
+        expect(subscription_migration.attempts).to eq(1)
+
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::SubscriptionOrchestratorJob)
+          .to have_been_enqueued.with(subscription_migration)
+      end
+    end
+
+    context "when a single event produces multiple enriched_expanded rows" do
+      let(:charge_2) { create(:standard_charge, plan:, billable_metric:) }
+      let(:events_reprocessed_count) { 1 }
+
+      before do
+        transaction_id = SecureRandom.uuid
+        create_enriched_expanded_event(transaction_id:, event_charge: charge)
+        create_enriched_expanded_event(transaction_id:, event_charge: charge_2)
+      end
+
+      it "counts distinct events, not total rows" do
+        result = service.call
+
+        expect(result.status).to eq(:ready)
+        expect(result.enriched_count).to eq(1)
+      end
+    end
+
+    context "when enriched events are not ready" do
+      before do
+        create_enriched_expanded_event
+      end
+
+      it "returns not_ready status without state transition" do
+        result = service.call
+
+        subscription_migration.reload
+        expect(result.status).to eq(:not_ready)
+        expect(result.enriched_count).to eq(1)
+        expect(subscription_migration).to be_waiting_for_enrichment
+        expect(subscription_migration.attempts).to eq(1)
+      end
+    end
+
+    context "when max attempts reached" do
+      let(:attempt) { 10 }
+
+      before do
+        create_enriched_expanded_event
+      end
+
+      it "transitions to failed" do
+        result = service.call
+
+        subscription_migration.reload
+        expect(result.status).to eq(:max_attempts_reached)
+        expect(subscription_migration).to be_failed
+        expect(subscription_migration.attempts).to eq(10)
+        expect(subscription_migration.error_message).to include("10 attempts")
+      end
+    end
+
+    context "when subscription migration is not in waiting_for_enrichment state" do
+      let(:subscription_migration) do
+        create(:enriched_store_subscription_migration, :comparing,
+          enriched_store_migration: migration,
+          organization:,
+          subscription:)
+      end
+
+      it "returns without action" do
+        result = service.call
+        expect(result).to be_success
+        expect(result.status).to be_nil
+        expect(subscription_migration.reload).to be_comparing
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5311

Migrating an organization from `Events::Stores::ClickhouseStore` to `Events::Stores::ClickhouseEnrichedStore` today requires running 4+ rake tasks manually in sequence, with manual verification between steps. 

A full migration process with a two-level tracking system (on organizations and subscriptions), relying on resumable state machines, asynchronous and per-subscription independent processes will be added to automate these tasks

## Description

This PR adds the subscription state machine to monitor the full migration process at subscription level