### PR TITLE
feat(presentation_group_keys): Add filter_by_presentation in UsageFilters

### DIFF
--- a/app/models/usage_filters.rb
+++ b/app/models/usage_filters.rb
@@ -46,4 +46,5 @@ class UsageFilters
   end
 
   NONE = new.freeze
+  WITHOUT_PRESENTATION_FILTER = new(filter_by_presentation: []).freeze
 end

--- a/app/models/usage_filters.rb
+++ b/app/models/usage_filters.rb
@@ -11,26 +11,32 @@ class UsageFilters
   # skip_grouping    - when set, will ignore grouping by pricing_group_keys
   # full_usage       - when set, will ignore boundaries and will return usage since subscription.started_at
 
-  attr_reader :filter_by_charge_id, :filter_by_charge_code, :filter_by_group, :skip_grouping, :full_usage
+  attr_reader :filter_by_charge_id, :filter_by_charge_code, :filter_by_group, :filter_by_presentation, :skip_grouping, :full_usage
 
   def self.init_from_params(params)
     group = params[:filter_by_group]
     group = JSON.parse(group) if group.is_a?(String)
     group = group.to_unsafe_h if group.respond_to?(:to_unsafe_h)
 
+    presentation = params[:filter_by_presentation]
+    presentation = JSON.parse(presentation) if presentation.is_a?(String)
+    presentation = Array(presentation) if presentation.present?
+
     new(
       filter_by_charge_id: params[:filter_by_charge_id],
       filter_by_charge_code: params[:filter_by_charge_code],
       filter_by_group: group,
+      filter_by_presentation: presentation,
       skip_grouping: ActiveModel::Type::Boolean.new.cast(params[:skip_grouping]),
       full_usage: ActiveModel::Type::Boolean.new.cast(params[:full_usage])
     )
   end
 
-  def initialize(filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_group: nil, skip_grouping: false, full_usage: false)
+  def initialize(filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_group: nil, filter_by_presentation: nil, skip_grouping: false, full_usage: false)
     @filter_by_charge_id = filter_by_charge_id
     @filter_by_charge_code = filter_by_charge_code
     @filter_by_group = filter_by_group&.transform_values { |v| Array(v) }
+    @filter_by_presentation = filter_by_presentation
     @skip_grouping = skip_grouping
     @full_usage = full_usage
   end

--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -14,7 +14,7 @@ module Customers
 
     def call
       usage_amount_cents = customer.active_subscriptions.map do |subscription|
-        invoice = ::Invoices::CustomerUsageService.call!(customer:, subscription:).invoice
+        invoice = ::Invoices::CustomerUsageService.call!(customer:, subscription:, usage_filters: UsageFilters::WITHOUT_PRESENTATION_FILTER).invoice
 
         billed_progressive_invoice_subscriptions = ::Subscriptions::ProgressiveBilledAmount
           .call(subscription:, include_generating_invoices:)

--- a/spec/models/usage_filters_spec.rb
+++ b/spec/models/usage_filters_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe UsageFilters do
       expect(filters.filter_by_charge_id).to be_nil
       expect(filters.filter_by_charge_code).to be_nil
       expect(filters.filter_by_group).to be_nil
+      expect(filters.filter_by_presentation).to be_nil
       expect(filters.skip_grouping).to be(false)
       expect(filters.full_usage).to be(false)
     end
@@ -31,6 +32,7 @@ RSpec.describe UsageFilters do
         filter_by_charge_id: "charge-id",
         filter_by_charge_code: "charge-code",
         filter_by_group: {"cloud" => ["aws"]},
+        filter_by_presentation: ["region"],
         skip_grouping: true,
         full_usage: true
       )
@@ -38,6 +40,7 @@ RSpec.describe UsageFilters do
       expect(filters.filter_by_charge_id).to eq("charge-id")
       expect(filters.filter_by_charge_code).to eq("charge-code")
       expect(filters.filter_by_group).to eq({"cloud" => ["aws"]})
+      expect(filters.filter_by_presentation).to eq(["region"])
       expect(filters.skip_grouping).to be(true)
       expect(filters.full_usage).to be(true)
     end
@@ -49,6 +52,7 @@ RSpec.describe UsageFilters do
         filter_by_charge_id: "charge-id",
         filter_by_charge_code: "charge-code",
         filter_by_group: {cloud: "aws"},
+        filter_by_presentation: ["compact"],
         skip_grouping: "true",
         full_usage: "true"
       }
@@ -58,8 +62,21 @@ RSpec.describe UsageFilters do
       expect(filters.filter_by_charge_id).to eq("charge-id")
       expect(filters.filter_by_charge_code).to eq("charge-code")
       expect(filters.filter_by_group).to eq({cloud: ["aws"]})
+      expect(filters.filter_by_presentation).to eq(["compact"])
       expect(filters.skip_grouping).to be(true)
       expect(filters.full_usage).to be(true)
+    end
+
+    it "parses filter_by_presentation from JSON" do
+      filters = described_class.init_from_params(filter_by_presentation: '["department","region"]')
+
+      expect(filters.filter_by_presentation).to eq(["department", "region"])
+    end
+
+    it "keeps an empty filter_by_presentation array" do
+      filters = described_class.init_from_params(filter_by_presentation: [])
+
+      expect(filters.filter_by_presentation).to eq([])
     end
 
     it "handles missing params with defaults" do
@@ -70,6 +87,7 @@ RSpec.describe UsageFilters do
       expect(filters.filter_by_charge_id).to be_nil
       expect(filters.filter_by_charge_code).to be_nil
       expect(filters.filter_by_group).to be_nil
+      expect(filters.filter_by_presentation).to be_nil
       expect(filters.skip_grouping).to be_nil
       expect(filters.full_usage).to be_nil
     end
@@ -81,6 +99,7 @@ RSpec.describe UsageFilters do
       expect(described_class::NONE.filter_by_charge_id).to be_nil
       expect(described_class::NONE.filter_by_charge_code).to be_nil
       expect(described_class::NONE.filter_by_group).to be_nil
+      expect(described_class::NONE.filter_by_presentation).to be_nil
       expect(described_class::NONE.skip_grouping).to be(false)
       expect(described_class::NONE.full_usage).to be(false)
     end

--- a/spec/models/usage_filters_spec.rb
+++ b/spec/models/usage_filters_spec.rb
@@ -104,4 +104,16 @@ RSpec.describe UsageFilters do
       expect(described_class::NONE.full_usage).to be(false)
     end
   end
+
+  describe "WITHOUT_PRESENTATION" do
+    it "is a frozen instance with default values but without presentation" do
+      expect(described_class::WITHOUT_PRESENTATION_FILTER).to be_frozen
+      expect(described_class::WITHOUT_PRESENTATION_FILTER.filter_by_charge_id).to be_nil
+      expect(described_class::WITHOUT_PRESENTATION_FILTER.filter_by_charge_code).to be_nil
+      expect(described_class::WITHOUT_PRESENTATION_FILTER.filter_by_group).to be_nil
+      expect(described_class::WITHOUT_PRESENTATION_FILTER.filter_by_presentation).to eq([])
+      expect(described_class::WITHOUT_PRESENTATION_FILTER.skip_grouping).to be(false)
+      expect(described_class::WITHOUT_PRESENTATION_FILTER.full_usage).to be(false)
+    end
+  end
 end

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe Customers::RefreshWalletsService do
           :standard_charge,
           plan: subscription.plan,
           billable_metric:,
-          properties: {amount: "3"}
+          properties: {amount: "3", presentation_group_keys: [{value: "cloud"}]}
         )
 
         create(
           :standard_charge,
           plan: subscription.plan,
           billable_metric: pay_in_advance_billable_metric,
-          properties: {amount: "1"},
+          properties: {amount: "1", presentation_group_keys: [{value: "region"}]},
           pay_in_advance: true,
           invoiceable: true
         )
@@ -97,6 +97,35 @@ RSpec.describe Customers::RefreshWalletsService do
 
     it "marks customer as not awaiting wallet refresh" do
       expect { subject }.to change(customer, :awaiting_wallet_refresh).from(true).to(false)
+    end
+
+    context "when charges have presentation_group_keys" do
+      before do
+        allow(Invoices::CustomerUsageService).to receive(:call!).and_call_original
+        allow(BillableMetrics::AggregationFactory).to receive(:new_instance).and_call_original
+      end
+
+      it "calls CustomerUsageService with UsageFilters::WITHOUT_PRESENTATION_FILTER" do
+        subject
+
+        customer.active_subscriptions.each do |subscription|
+          expect(Invoices::CustomerUsageService).to have_received(:call!).with(
+            customer:,
+            subscription:,
+            usage_filters: UsageFilters::WITHOUT_PRESENTATION_FILTER
+          )
+        end
+      end
+
+      it "calls AggregationFactory with presentation_by as empty array" do
+        subject
+
+        expect(BillableMetrics::AggregationFactory).to have_received(:new_instance).at_least(:once) do |args|
+          next unless args[:filters].key?(:presentation_by)
+
+          expect(args[:filters][:presentation_by]).to eq([])
+        end
+      end
     end
 
     describe "current usage calculation" do


### PR DESCRIPTION
This commit introduces the filter_by_presentation option in UsageFilters

This filter will be used to generate presentation breakdowns based on the options
provided via API. 
For now, we're introducing the `filter_by_presentation` option and also an option to completely disable the
breakdowns in `Invoices::CustomerUsageService`, this is useful for refresh wallet services 
where is not necessary to compute presentation breakdowns.

This commit is part of these other commits and part of presentation group keys functionality:
- https://github.com/getlago/lago-api/pull/5332
- https://github.com/getlago/lago-api/pull/5335
