### PR TITLE
feat(presentation_group_keys): Update ChargeCacheMiddleware to also serialize presentation_breakdowns

### DIFF
--- a/app/services/subscriptions/charge_cache_middleware.rb
+++ b/app/services/subscriptions/charge_cache_middleware.rb
@@ -2,6 +2,8 @@
 
 module Subscriptions
   class ChargeCacheMiddleware
+    EMPTY_ARRAY = [].freeze
+
     def initialize(subscription:, charge:, to_datetime:, cache: true)
       @subscription = subscription
       @charge = charge
@@ -14,7 +16,12 @@ module Subscriptions
 
       json = Subscriptions::ChargeCacheService.call(subscription:, charge:, charge_filter:, expires_in: cache_expiration) do
         yield
-          .map { |fee| fee.attributes.merge("pricing_unit_usage" => fee.pricing_unit_usage&.attributes) }
+          .map do |fee|
+            fee.attributes.merge(
+              "pricing_unit_usage" => fee.pricing_unit_usage&.attributes,
+              "presentation_breakdowns" => fee.presentation_breakdowns.map(&:attributes)
+            )
+          end
           .to_json
       end
 
@@ -23,10 +30,18 @@ module Subscriptions
           PricingUnitUsage.new(j["pricing_unit_usage"].slice(*PricingUnitUsage.column_names))
         end
 
-        Fee.new(
+        fee = Fee.new(
           **j.slice(*Fee.column_names),
           pricing_unit_usage:
         )
+
+        j.fetch("presentation_breakdowns", EMPTY_ARRAY).each do |breakdown|
+          fee.presentation_breakdowns.build(
+            breakdown.slice(*PresentationBreakdown.column_names)
+          )
+        end
+
+        fee
       end
     end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -3550,6 +3550,68 @@ RSpec.describe Fees::ChargeService, :premium do
               expect(parsed.first["events_count"]).to eq(1)
             end
 
+            context "when charge uses presentation_group_keys" do
+              let(:billable_metric) do
+                create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "value")
+              end
+
+              let(:charge) do
+                create(
+                  :standard_charge,
+                  plan: subscription.plan,
+                  billable_metric:,
+                  properties: {
+                    amount: "20",
+                    presentation_group_keys: [{value: "region"}]
+                  }
+                )
+              end
+
+              before do
+                create(
+                  :event,
+                  organization:,
+                  subscription:,
+                  code: billable_metric.code,
+                  timestamp: Time.zone.parse("2022-03-16"),
+                  properties: {region: "eu", value: 10}
+                )
+                create(
+                  :event,
+                  organization:,
+                  subscription:,
+                  code: billable_metric.code,
+                  timestamp: Time.zone.parse("2022-03-16"),
+                  properties: {region: "us", value: 5}
+                )
+              end
+
+              it "keeps presentation_breakdowns on subsequent calls from cache" do
+                first_result = charge_subscription_service.call
+                cached_value = Rails.cache.read(cache_key)
+                second_result = charge_subscription_service.call
+
+                expect(first_result).to be_success
+                expect(first_result.fees.count).to eq(1)
+                expect(first_result.fees.first.presentation_breakdowns.map(&:presentation_by)).to match_array(
+                  [{"region" => "eu"}, {"region" => "us"}]
+                )
+
+                expect(JSON.parse(cached_value).first["presentation_breakdowns"]).to match_array(
+                  [
+                    hash_including({"presentation_by" => {"region" => "eu"}, "units" => "10.0", "organization_id" => organization.id}),
+                    hash_including({"presentation_by" => {"region" => "us"}, "units" => "5.0", "organization_id" => organization.id})
+                  ]
+                )
+
+                expect(second_result).to be_success
+                expect(second_result.fees.count).to eq(1)
+                expect(second_result.fees.first.presentation_breakdowns.map(&:presentation_by)).to match_array(
+                  [{"region" => "eu"}, {"region" => "us"}]
+                )
+              end
+            end
+
             it "returns fees from cache on subsequent calls" do
               first_result = charge_subscription_service.call
               second_result = charge_subscription_service.call


### PR DESCRIPTION
This commit updates the Subscriptions::ChargeCacheMiddleware to support presentation breakdowns

Currently, the service doesn't know about the new presentation_breakdowns in Fee and we're
changing the class to parse correctly the presentation_breakdowns into JSON and also 
updates the code to deserialize from the cache when is enabled.

This commit is part of these other commits and part of presentation group keys functionality:
- https://github.com/getlago/lago-api/pull/5332
- https://github.com/getlago/lago-api/pull/5335
- https://github.com/getlago/lago-api/pull/5351
