### PR TITLE
fix(superset): handle service failure in dashboards resolver

### DIFF
--- a/app/graphql/resolvers/superset/dashboards_resolver.rb
+++ b/app/graphql/resolvers/superset/dashboards_resolver.rb
@@ -19,6 +19,8 @@ module Resolvers
           user: nil
         )
 
+        return result_error(result) unless result.success?
+
         result.dashboards
       end
     end

--- a/spec/graphql/resolvers/superset/dashboards_resolver_spec.rb
+++ b/spec/graphql/resolvers/superset/dashboards_resolver_spec.rb
@@ -96,4 +96,24 @@ RSpec.describe Resolvers::Superset::DashboardsResolver do
       expect(dashboards_response).to eq([])
     end
   end
+
+  context "when the superset service fails" do
+    let(:result) do
+      BaseService::Result.new.tap do |r|
+        r.service_failure!(code: "superset_auth_failed", message: "Failed to authenticate with Superset")
+      end
+    end
+
+    it "returns an error" do
+      graphql_result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      expect(graphql_result["errors"]).to be_present
+      expect(graphql_result["errors"].first["extensions"]["code"]).to eq("superset_auth_failed")
+    end
+  end
 end


### PR DESCRIPTION
## Context

A customer hits an error page when accessing the Superset dashboard.
The GraphQL query returns "Cannot return null for non-nullable field
Query.supersetDashboards".

## Description

The resolver was missing the standard `result.success?` check after
calling `Auth::SupersetService`. When the service fails (missing config,
auth error, timeout, etc.), `result.dashboards` is never set, so `nil`
is returned on a non-nullable field, crashing the query.

Add the error guard and a test for the failure path.