### PR TITLE
feat(payment-gated-subs): add payment resolution flow for gated subscriptions

### DIFF
--- a/app/jobs/subscriptions/activation_rules/payment/resolve_job.rb
+++ b/app/jobs/subscriptions/activation_rules/payment/resolve_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ActivationRules
+    module Payment
+      class ResolveJob < ApplicationJob
+        queue_as "default"
+
+        def perform(subscription, invoice, payment_status)
+          Payment::ResolveService.call!(subscription:, invoice:, payment_status:)
+        end
+      end
+    end
+  end
+end

--- a/app/models/subscription/activation_rule.rb
+++ b/app/models/subscription/activation_rule.rb
@@ -44,6 +44,17 @@ class Subscription::ActivationRule < ApplicationRecord
   def applicable?
     raise NotImplementedError, "#{self.class}#applicable? must be implemented"
   end
+
+  def evaluate!
+    evaluate_service_class.call!(rule: self)
+  end
+
+  private
+
+  def evaluate_service_class
+    type_module = self.class.name.demodulize
+    "Subscriptions::ActivationRules::#{type_module}::EvaluateService".constantize
+  end
 end
 
 # == Schema Information

--- a/app/models/subscription/activation_rule.rb
+++ b/app/models/subscription/activation_rule.rb
@@ -17,6 +17,9 @@ class Subscription::ActivationRule < ApplicationRecord
     not_applicable: "not_applicable"
   }.freeze
 
+  FULFILLED_STATUSES = STATUSES.values_at(:satisfied, :not_applicable).freeze
+  REJECTED_STATUSES = STATUSES.values_at(:failed, :expired, :declined).freeze
+
   TYPES = {
     payment: "payment"
   }.freeze

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -72,6 +72,7 @@ module Invoices
     def schedule_post_processing_jobs(old_payment_status)
       if params.key?(:payment_status)
         handle_prepaid_credits(params[:payment_status])
+        handle_payment_gated_activation(params[:payment_status])
         update_fees_payment_status
         if old_payment_status != params[:payment_status] && invoice.visible?
           deliver_webhook
@@ -102,6 +103,18 @@ module Invoices
       return unless %i[succeeded failed].include?(payment_status.to_sym)
 
       Invoices::PrepaidCreditJob.perform_after_commit(invoice, payment_status.to_sym)
+    end
+
+    def handle_payment_gated_activation(payment_status)
+      return unless invoice.subscription_gated?
+      return unless %i[succeeded failed].include?(payment_status.to_sym)
+
+      subscription = invoice.subscriptions.find(&:incomplete?)
+      return unless subscription
+
+      Subscriptions::ActivationRules::Payment::ResolveService.call!(
+        subscription:, invoice:, payment_status: payment_status.to_sym
+      )
     end
 
     def valid_metadata_count?(metadata:)

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -112,9 +112,8 @@ module Invoices
       subscription = invoice.subscriptions.find(&:incomplete?)
       return unless subscription
 
-      Subscriptions::ActivationRules::Payment::ResolveService.call!(
-        subscription:, invoice:, payment_status: payment_status.to_sym
-      )
+      Subscriptions::ActivationRules::Payment::ResolveJob
+        .perform_after_commit(subscription, invoice, payment_status.to_sym)
     end
 
     def valid_metadata_count?(metadata:)

--- a/app/services/subscriptions/activation_rules/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/evaluate_service.rb
@@ -3,7 +3,7 @@
 module Subscriptions
   module ActivationRules
     class EvaluateService < BaseService
-      Result = BaseResult[:rules]
+      Result = BaseResult[:subscription, :rules]
 
       def initialize(subscription:)
         @subscription = subscription
@@ -21,12 +21,29 @@ module Subscriptions
           result.rules << rule
         end
 
+        resolve_subscription_status
+
+        result.subscription = subscription
         result
       end
 
       private
 
       attr_reader :subscription
+
+      def resolve_subscription_status
+        return unless subscription.incomplete?
+
+        if subscription.activation_rules.any?(&:failed?)
+          subscription.mark_as_canceled!
+
+          after_commit do
+            SendWebhookJob.perform_later("subscription.canceled", subscription)
+          end
+        elsif !subscription.pending_rules?
+          Subscriptions::ActivateService.call!(subscription:)
+        end
+      end
     end
   end
 end

--- a/app/services/subscriptions/activation_rules/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/evaluate_service.rb
@@ -34,14 +34,11 @@ module Subscriptions
       def resolve_subscription_status
         return unless subscription.incomplete?
 
-        if any_rule_failed?
-          subscription.mark_as_canceled!
-
-          after_commit do
-            SendWebhookJob.perform_later("subscription.canceled", subscription)
-          end
-        elsif all_rules_satisfied?
+        if all_rules_satisfied?
           Subscriptions::ActivateService.call!(subscription:)
+        elsif any_rule_failed?
+          subscription.mark_as_canceled!
+          SendWebhookJob.perform_after_commit("subscription.canceled", subscription)
         end
       end
 

--- a/app/services/subscriptions/activation_rules/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/evaluate_service.rb
@@ -18,7 +18,7 @@ module Subscriptions
           result.rules << rule
         end
 
-        resolve_subscription_status
+        ResolveSubscriptionStatusService.call!(subscription:)
 
         result.subscription = subscription
         result
@@ -27,25 +27,6 @@ module Subscriptions
       private
 
       attr_reader :subscription
-
-      def resolve_subscription_status
-        return unless subscription.incomplete?
-
-        if all_rules_satisfied?
-          Subscriptions::ActivateService.call!(subscription:)
-        elsif any_rule_failed?
-          subscription.mark_as_canceled!
-          SendWebhookJob.perform_after_commit("subscription.canceled", subscription)
-        end
-      end
-
-      def all_rules_satisfied?
-        subscription.activation_rules.all? { |rule| rule.satisfied? || rule.not_applicable? }
-      end
-
-      def any_rule_failed?
-        subscription.activation_rules.any? { |rule| rule.failed? || rule.expired? || rule.declined? }
-      end
     end
   end
 end

--- a/app/services/subscriptions/activation_rules/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/evaluate_service.rb
@@ -14,10 +14,7 @@ module Subscriptions
         result.rules = []
 
         subscription.activation_rules.each do |rule|
-          case rule
-          when Subscription::ActivationRule::Payment
-            Payment::EvaluateService.call!(rule:)
-          end
+          rule.evaluate!
           result.rules << rule
         end
 

--- a/app/services/subscriptions/activation_rules/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/evaluate_service.rb
@@ -34,15 +34,23 @@ module Subscriptions
       def resolve_subscription_status
         return unless subscription.incomplete?
 
-        if subscription.activation_rules.any?(&:failed?)
+        if any_rule_failed?
           subscription.mark_as_canceled!
 
           after_commit do
             SendWebhookJob.perform_later("subscription.canceled", subscription)
           end
-        elsif !subscription.pending_rules?
+        elsif all_rules_satisfied?
           Subscriptions::ActivateService.call!(subscription:)
         end
+      end
+
+      def all_rules_satisfied?
+        subscription.activation_rules.all? { |rule| rule.satisfied? || rule.not_applicable? }
+      end
+
+      def any_rule_failed?
+        subscription.activation_rules.any? { |rule| rule.failed? || rule.expired? || rule.declined? }
       end
     end
   end

--- a/app/services/subscriptions/activation_rules/payment/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/evaluate_service.rb
@@ -38,7 +38,7 @@ module Subscriptions
         end
 
         def transition_pending_rule
-          raise ArgumentError, "status required to transition a pending rule" unless status.present?
+          raise ArgumentError, "status required to transition a pending rule" if status.blank?
 
           rule.public_send(:"#{status}!")
         end

--- a/app/services/subscriptions/activation_rules/payment/evaluate_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/evaluate_service.rb
@@ -38,6 +38,8 @@ module Subscriptions
         end
 
         def transition_pending_rule
+          raise ArgumentError, "status required to transition a pending rule" unless status.present?
+
           rule.public_send(:"#{status}!")
         end
 

--- a/app/services/subscriptions/activation_rules/payment/resolve_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/resolve_service.rb
@@ -44,7 +44,7 @@ module Subscriptions
           EvaluateService.call!(rule: payment_rule, status: :failed)
           invoice.closed!
           ActivationRules::ResolveSubscriptionStatusService.call!(subscription:)
-          subscription.update!(cancelation_reason: :payment_failed) if subscription.canceled?
+          subscription.update!(cancelation_reason: :payment_failed)
         end
 
         def payment_rule

--- a/app/services/subscriptions/activation_rules/payment/resolve_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/resolve_service.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ActivationRules
+    module Payment
+      class ResolveService < BaseService
+        Result = BaseResult
+
+        def initialize(subscription:, invoice:, payment_status:)
+          @subscription = subscription
+          @invoice = invoice
+          @payment_status = payment_status.to_sym
+          super
+        end
+
+        def call
+          subscription.with_lock do
+            case payment_status
+            when :succeeded
+              handle_success
+            when :failed
+              handle_failure
+            end
+          end
+
+          result
+        end
+
+        private
+
+        attr_reader :subscription, :invoice, :payment_status
+
+        def handle_success
+          # TODO: implement in next TDD cycle
+        end
+
+        def handle_failure
+          return unless subscription.incomplete? && invoice.open? && invoice.subscription?
+
+          payment_rule.failed!
+          invoice.closed!
+          subscription.cancelation_reason = :payment_failed
+          subscription.mark_as_canceled!
+
+          SendWebhookJob.perform_later("subscription.canceled", subscription)
+        end
+
+        def payment_rule
+          @payment_rule ||= subscription.activation_rules.find_by(type: "payment")
+        end
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/activation_rules/payment/resolve_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/resolve_service.rb
@@ -35,7 +35,7 @@ module Subscriptions
 
           EvaluateService.call!(rule: payment_rule, status: :satisfied)
           Invoices::FinalizeService.call!(invoice:)
-          ActivationRules::EvaluateService.call!(subscription:)
+          ActivationRules::ResolveSubscriptionStatusService.call!(subscription:)
         end
 
         def handle_failure
@@ -43,8 +43,8 @@ module Subscriptions
 
           EvaluateService.call!(rule: payment_rule, status: :failed)
           invoice.closed!
-          subscription.cancelation_reason = :payment_failed
-          ActivationRules::EvaluateService.call!(subscription:)
+          ActivationRules::ResolveSubscriptionStatusService.call!(subscription:)
+          subscription.update!(cancelation_reason: :payment_failed) if subscription.canceled?
         end
 
         def payment_rule

--- a/app/services/subscriptions/activation_rules/payment/resolve_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/resolve_service.rb
@@ -31,22 +31,24 @@ module Subscriptions
         attr_reader :subscription, :invoice, :payment_status
 
         def handle_success
-          # TODO: implement in next TDD cycle
+          return unless subscription.incomplete? && invoice.open? && invoice.subscription?
+
+          EvaluateService.call!(rule: payment_rule, status: :satisfied)
+          Invoices::FinalizeService.call!(invoice:)
+          ActivationRules::EvaluateService.call!(subscription:)
         end
 
         def handle_failure
           return unless subscription.incomplete? && invoice.open? && invoice.subscription?
 
-          payment_rule.failed!
+          EvaluateService.call!(rule: payment_rule, status: :failed)
           invoice.closed!
           subscription.cancelation_reason = :payment_failed
-          subscription.mark_as_canceled!
-
-          SendWebhookJob.perform_later("subscription.canceled", subscription)
+          ActivationRules::EvaluateService.call!(subscription:)
         end
 
         def payment_rule
-          @payment_rule ||= subscription.activation_rules.find_by(type: "payment")
+          @payment_rule ||= subscription.activation_rules.payment.sole
         end
       end
     end

--- a/app/services/subscriptions/activation_rules/resolve_subscription_status_service.rb
+++ b/app/services/subscriptions/activation_rules/resolve_subscription_status_service.rb
@@ -29,11 +29,11 @@ module Subscriptions
       attr_reader :subscription
 
       def all_rules_satisfied?
-        subscription.activation_rules.all? { |rule| rule.satisfied? || rule.not_applicable? }
+        subscription.activation_rules.where.not(status: Subscription::ActivationRule::FULFILLED_STATUSES).none?
       end
 
       def any_rule_failed?
-        subscription.activation_rules.any? { |rule| rule.failed? || rule.expired? || rule.declined? }
+        subscription.activation_rules.where(status: Subscription::ActivationRule::REJECTED_STATUSES).exists?
       end
     end
   end

--- a/app/services/subscriptions/activation_rules/resolve_subscription_status_service.rb
+++ b/app/services/subscriptions/activation_rules/resolve_subscription_status_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ActivationRules
+    class ResolveSubscriptionStatusService < BaseService
+      Result = BaseResult[:subscription]
+
+      def initialize(subscription:)
+        @subscription = subscription
+        super
+      end
+
+      def call
+        return result.tap { result.subscription = subscription } unless subscription.incomplete?
+
+        if all_rules_satisfied?
+          Subscriptions::ActivateService.call!(subscription:)
+        elsif any_rule_failed?
+          subscription.mark_as_canceled!
+          SendWebhookJob.perform_after_commit("subscription.canceled", subscription)
+        end
+
+        result.subscription = subscription
+        result
+      end
+
+      private
+
+      attr_reader :subscription
+
+      def all_rules_satisfied?
+        subscription.activation_rules.all? { |rule| rule.satisfied? || rule.not_applicable? }
+      end
+
+      def any_rule_failed?
+        subscription.activation_rules.any? { |rule| rule.failed? || rule.expired? || rule.declined? }
+      end
+    end
+  end
+end

--- a/spec/jobs/subscriptions/activation_rules/payment/resolve_job_spec.rb
+++ b/spec/jobs/subscriptions/activation_rules/payment/resolve_job_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ActivationRules::Payment::ResolveJob do
+  subject(:job) { described_class.perform_now(subscription, invoice, payment_status) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, :incomplete, organization:, customer:) }
+  let(:invoice) { create(:invoice, organization:, customer:, status: :open, invoice_type: :subscription) }
+  let(:payment_status) { "failed" }
+
+  before do
+    allow(Subscriptions::ActivationRules::Payment::ResolveService).to receive(:call!)
+  end
+
+  it "calls ResolveService with the correct arguments" do
+    job
+
+    expect(Subscriptions::ActivationRules::Payment::ResolveService).to have_received(:call!)
+      .with(subscription:, invoice:, payment_status:)
+  end
+end

--- a/spec/models/subscription/activation_rule_spec.rb
+++ b/spec/models/subscription/activation_rule_spec.rb
@@ -104,4 +104,15 @@ RSpec.describe Subscription::ActivationRule do
       expect { rule.applicable? }.to raise_error(NotImplementedError)
     end
   end
+
+  describe "#evaluate!" do
+    it "calls the type-specific EvaluateService" do
+      allow(Subscriptions::ActivationRules::Payment::EvaluateService).to receive(:call!)
+
+      activation_rule.evaluate!
+
+      expect(Subscriptions::ActivationRules::Payment::EvaluateService)
+        .to have_received(:call!).with(rule: activation_rule)
+    end
+  end
 end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -244,6 +244,44 @@ RSpec.describe Invoices::UpdateService do
       end
     end
 
+    context "when invoice is subscription_gated and payment_status changes" do
+      let(:plan) { create(:plan, organization: invoice.organization, pay_in_advance: true) }
+      let(:subscription) { create(:subscription, :incomplete, organization: invoice.organization, customer: invoice.customer, plan:) }
+      let(:rule) { create(:subscription_activation_rule, subscription:, status: "pending") }
+      let(:invoice) { create(:invoice, status: :open, invoice_type: :subscription, payment_overdue: false) }
+
+      before do
+        rule
+        create(:invoice_subscription, invoice:, subscription:)
+      end
+
+      context "when payment_status is succeeded" do
+        let(:update_args) { {payment_status: "succeeded"} }
+
+        it "calls ResolveService" do
+          allow(Subscriptions::ActivationRules::Payment::ResolveService).to receive(:call!)
+
+          invoice_service.call
+
+          expect(Subscriptions::ActivationRules::Payment::ResolveService).to have_received(:call!)
+            .with(subscription:, invoice:, payment_status: :succeeded)
+        end
+      end
+
+      context "when payment_status is failed" do
+        let(:update_args) { {payment_status: "failed"} }
+
+        it "calls ResolveService" do
+          allow(Subscriptions::ActivationRules::Payment::ResolveService).to receive(:call!)
+
+          invoice_service.call
+
+          expect(Subscriptions::ActivationRules::Payment::ResolveService).to have_received(:call!)
+            .with(subscription:, invoice:, payment_status: :failed)
+        end
+      end
+    end
+
     context "with payment_status update and notification is turned on" do
       let(:webhook_notification) { true }
 

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -245,15 +245,15 @@ RSpec.describe Invoices::UpdateService do
     end
 
     context "when invoice is subscription_gated and payment_status changes" do
+      let(:subscription) do
+        create(:subscription, :incomplete, :with_activation_rules,
+          organization: invoice.organization, customer: invoice.customer, plan:,
+          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}])
+      end
       let(:plan) { create(:plan, organization: invoice.organization, pay_in_advance: true) }
-      let(:subscription) { create(:subscription, :incomplete, organization: invoice.organization, customer: invoice.customer, plan:) }
-      let(:rule) { create(:subscription_activation_rule, subscription:, status: "pending") }
       let(:invoice) { create(:invoice, status: :open, invoice_type: :subscription, payment_overdue: false) }
 
-      before do
-        rule
-        create(:invoice_subscription, invoice:, subscription:)
-      end
+      before { create(:invoice_subscription, invoice:, subscription:) }
 
       context "when payment_status is succeeded" do
         let(:update_args) { {payment_status: "succeeded"} }

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -258,26 +258,20 @@ RSpec.describe Invoices::UpdateService do
       context "when payment_status is succeeded" do
         let(:update_args) { {payment_status: "succeeded"} }
 
-        it "calls ResolveService" do
-          allow(Subscriptions::ActivationRules::Payment::ResolveService).to receive(:call!)
-
-          invoice_service.call
-
-          expect(Subscriptions::ActivationRules::Payment::ResolveService).to have_received(:call!)
-            .with(subscription:, invoice:, payment_status: :succeeded)
+        it "enqueues ResolveJob" do
+          expect { invoice_service.call }
+            .to have_enqueued_job_after_commit(Subscriptions::ActivationRules::Payment::ResolveJob)
+            .with(subscription, invoice, :succeeded)
         end
       end
 
       context "when payment_status is failed" do
         let(:update_args) { {payment_status: "failed"} }
 
-        it "calls ResolveService" do
-          allow(Subscriptions::ActivationRules::Payment::ResolveService).to receive(:call!)
-
-          invoice_service.call
-
-          expect(Subscriptions::ActivationRules::Payment::ResolveService).to have_received(:call!)
-            .with(subscription:, invoice:, payment_status: :failed)
+        it "enqueues ResolveJob" do
+          expect { invoice_service.call }
+            .to have_enqueued_job_after_commit(Subscriptions::ActivationRules::Payment::ResolveJob)
+            .with(subscription, invoice, :failed)
         end
       end
     end

--- a/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
@@ -27,4 +27,55 @@ RSpec.describe Subscriptions::ActivationRules::EvaluateService do
       expect(result.rules).to be_empty
     end
   end
+
+  context "when all rules are satisfied" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "satisfied") }
+
+    before { rule }
+
+    it "activates the subscription" do
+      freeze_time do
+        expect(result.subscription).to be_active
+        expect(result.subscription.activated_at).to eq(Time.current)
+      end
+    end
+
+    it "sends a subscription.started webhook" do
+      result
+
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", subscription)
+    end
+
+    it "produces a subscription.started activity log" do
+      result
+
+      expect(Utils::ActivityLog).to have_produced("subscription.started").with(subscription)
+    end
+  end
+
+  context "when a rule has failed" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "failed") }
+
+    before { rule }
+
+    it "cancels the subscription" do
+      expect(result.subscription).to be_canceled
+    end
+
+    it "sends a subscription.canceled webhook" do
+      result
+
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
+    end
+  end
+
+  context "when rules are still pending" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "pending") }
+
+    before { rule }
+
+    it "does not change subscription status" do
+      expect(result.subscription).to be_incomplete
+    end
+  end
 end

--- a/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Subscriptions::ActivationRules::EvaluateService do
 
     before { rule }
 
-    it "delegates to Payment::EvaluateService" do
+    it "evaluates the rule and delegates to ResolveSubscriptionStatusService" do
       expect(result).to be_success
       expect(result.rules.first).to be_pending
     end
@@ -28,90 +28,16 @@ RSpec.describe Subscriptions::ActivationRules::EvaluateService do
     end
   end
 
-  context "when all rules are satisfied" do
+  context "when all rules are already satisfied" do
     let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "satisfied") }
 
     before { rule }
 
-    it "activates the subscription" do
-      freeze_time do
-        expect(result.subscription).to be_active
-        expect(result.subscription.activated_at).to eq(Time.current)
-      end
-    end
+    it "activates the subscription via ResolveSubscriptionStatusService" do
+      allow(Subscriptions::ActivationRules::ResolveSubscriptionStatusService).to receive(:call).and_call_original
 
-    it "sends a subscription.started webhook" do
-      result
-
-      expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", subscription)
-    end
-
-    it "produces a subscription.started activity log" do
-      result
-
-      expect(Utils::ActivityLog).to have_produced("subscription.started").with(subscription)
-    end
-  end
-
-  context "when a rule has failed" do
-    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "failed") }
-
-    before { rule }
-
-    it "cancels the subscription" do
-      expect(result.subscription).to be_canceled
-    end
-
-    it "sends a subscription.canceled webhook" do
-      result
-
-      expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
-    end
-  end
-
-  context "when all rules are not_applicable" do
-    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "not_applicable") }
-
-    before { rule }
-
-    it "activates the subscription" do
       expect(result.subscription).to be_active
-    end
-  end
-
-  context "when a rule has expired" do
-    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "expired") }
-
-    before { rule }
-
-    it "cancels the subscription" do
-      expect(result.subscription).to be_canceled
-    end
-
-    it "sends a subscription.canceled webhook" do
-      result
-
-      expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
-    end
-  end
-
-  context "when a rule is still inactive" do
-    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "inactive") }
-
-    before { rule }
-
-    it "does not change subscription status" do
-      expect(result.subscription).to be_incomplete
-    end
-  end
-
-  context "when rules are still pending" do
-    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "pending") }
-
-    before { rule }
-
-    it "does not change subscription status" do
-      expect(result.subscription).to be_incomplete
+      expect(Subscriptions::ActivationRules::ResolveSubscriptionStatusService).to have_received(:call).with(subscription:)
     end
   end
 end

--- a/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/evaluate_service_spec.rb
@@ -69,6 +69,42 @@ RSpec.describe Subscriptions::ActivationRules::EvaluateService do
     end
   end
 
+  context "when all rules are not_applicable" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "not_applicable") }
+
+    before { rule }
+
+    it "activates the subscription" do
+      expect(result.subscription).to be_active
+    end
+  end
+
+  context "when a rule has expired" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "expired") }
+
+    before { rule }
+
+    it "cancels the subscription" do
+      expect(result.subscription).to be_canceled
+    end
+
+    it "sends a subscription.canceled webhook" do
+      result
+
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
+    end
+  end
+
+  context "when a rule is still inactive" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "inactive") }
+
+    before { rule }
+
+    it "does not change subscription status" do
+      expect(result.subscription).to be_incomplete
+    end
+  end
+
   context "when rules are still pending" do
     let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "pending") }
 

--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
+  subject(:result) { described_class.call(subscription:, invoice:, payment_status:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
+  let(:rule) { create(:subscription_activation_rule, subscription:, status: "pending") }
+  let(:invoice) do
+    create(:invoice, organization:, customer:, status: :open, invoice_type: :subscription,
+      total_amount_cents: 100, fees_amount_cents: 100)
+  end
+  let(:payment_status) { :failed }
+
+  before do
+    rule
+    create(:invoice_subscription, invoice:, subscription:)
+  end
+
+  context "when subscription is not incomplete" do
+    let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+    it "returns early without changes" do
+      result
+
+      expect(rule.reload.status).to eq("pending")
+      expect(invoice.reload.status).to eq("open")
+    end
+  end
+
+  context "when invoice is not open" do
+    before { invoice.update!(status: :finalized) }
+
+    it "returns early without changes" do
+      result
+
+      expect(rule.reload.status).to eq("pending")
+      expect(subscription.reload).to be_incomplete
+    end
+  end
+
+  context "when invoice is not a subscription invoice" do
+    let(:invoice) do
+      create(:invoice, :credit, organization:, customer:, status: :open,
+        total_amount_cents: 100, fees_amount_cents: 100)
+    end
+
+    it "returns early without changes" do
+      result
+
+      expect(rule.reload.status).to eq("pending")
+      expect(subscription.reload).to be_incomplete
+    end
+  end
+
+  context "when payment_status is failed" do
+    let(:payment_status) { :failed }
+
+    it "marks the activation rule as failed" do
+      result
+
+      expect(rule.reload.status).to eq("failed")
+    end
+
+    it "closes the invoice" do
+      result
+
+      expect(invoice.reload.status).to eq("closed")
+    end
+
+    it "cancels the subscription with payment_failed reason" do
+      result
+
+      expect(subscription.reload).to be_canceled
+      expect(subscription.cancelation_reason).to eq("payment_failed")
+    end
+
+    it "sends a subscription.canceled webhook" do
+      result
+
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
+    end
+  end
+end

--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -57,6 +57,48 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
     end
   end
 
+  context "when payment_status is succeeded" do
+    let(:payment_status) { :succeeded }
+
+    it "marks the activation rule as satisfied" do
+      result
+
+      expect(rule.reload.status).to eq("satisfied")
+    end
+
+    it "finalizes the invoice" do
+      result
+
+      expect(invoice.reload.status).to eq("finalized")
+    end
+
+    it "activates the subscription" do
+      freeze_time do
+        result
+
+        expect(subscription.reload).to be_active
+        expect(subscription.activated_at).to eq(Time.current)
+      end
+    end
+
+    it "sends a subscription.started webhook" do
+      result
+
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", subscription)
+    end
+
+    context "when subscription is already active (idempotency)" do
+      let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+      it "returns early without changes" do
+        result
+
+        expect(rule.reload.status).to eq("pending")
+        expect(invoice.reload.status).to eq("open")
+      end
+    end
+  end
+
   context "when payment_status is failed" do
     let(:payment_status) { :failed }
 

--- a/spec/services/subscriptions/activation_rules/resolve_subscription_status_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/resolve_subscription_status_service_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ActivationRules::ResolveSubscriptionStatusService do
+  subject(:result) { described_class.call(subscription:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let(:subscription) { create(:subscription, :incomplete, organization:, customer:, plan:) }
+
+  context "when all rules are satisfied" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "satisfied") }
+
+    before { rule }
+
+    it "activates the subscription" do
+      freeze_time do
+        expect(result.subscription).to be_active
+        expect(result.subscription.activated_at).to eq(Time.current)
+      end
+    end
+
+    it "sends a subscription.started webhook" do
+      result
+
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", subscription)
+    end
+
+    it "produces a subscription.started activity log" do
+      result
+
+      expect(Utils::ActivityLog).to have_produced("subscription.started").with(subscription)
+    end
+  end
+
+  context "when all rules are not_applicable" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "not_applicable") }
+
+    before { rule }
+
+    it "activates the subscription" do
+      expect(result.subscription).to be_active
+    end
+  end
+
+  context "when a rule has failed" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "failed") }
+
+    before { rule }
+
+    it "cancels the subscription" do
+      expect(result.subscription).to be_canceled
+    end
+
+    it "sends a subscription.canceled webhook" do
+      result
+
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
+    end
+  end
+
+  context "when a rule has expired" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "expired") }
+
+    before { rule }
+
+    it "cancels the subscription" do
+      expect(result.subscription).to be_canceled
+    end
+  end
+
+  context "when a rule has been declined" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "declined") }
+
+    before { rule }
+
+    it "cancels the subscription" do
+      expect(result.subscription).to be_canceled
+    end
+  end
+
+  context "when rules are still pending" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "pending") }
+
+    before { rule }
+
+    it "does not change subscription status" do
+      expect(result.subscription).to be_incomplete
+    end
+  end
+
+  context "when a rule is still inactive" do
+    let(:rule) { create(:payment_subscription_activation_rule, subscription:, status: "inactive") }
+
+    before { rule }
+
+    it "does not change subscription status" do
+      expect(result.subscription).to be_incomplete
+    end
+  end
+
+  context "when subscription is not incomplete" do
+    let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+    it "returns the subscription without changes" do
+      expect(result.subscription).to be_active
+    end
+  end
+
+  context "when there are no activation rules" do
+    it "activates the subscription" do
+      expect(result.subscription).to be_active
+    end
+  end
+end


### PR DESCRIPTION
## Context

When a payment succeeds or fails for a gated subscription, the system needs to resolve the activation rule, transition the invoice and subscription to their final states, and fire the appropriate side effects. This is the core payment outcome handling for Milestone 1.

## Description

Add Payment::ResolveService that handles payment outcomes for incomplete subscriptions within a row-level lock for idempotency.

* On success: marks the payment rule as satisfied via Payment::EvaluateService, finalizes the invoice, and delegates to ResolveSubscriptionStatusService for subscription activation.

* On failure: marks the rule as failed, closes the invoice, delegates to ResolveSubscriptionStatusService for subscription cancellation, and explicitly saves the cancelation_reason.

Extract ResolveSubscriptionStatusService from EvaluateService to separate rule evaluation (inactive → pending/not_applicable) from subscription status resolution (activate when all rules satisfied, cancel when any rule failed/expired/declined). EvaluateService now calls both in sequence. ResolveService calls only the status resolution after transitioning the rule, avoiding redundant re-evaluation.

Add polymorphic evaluate! method to ActivationRule for type-specific dispatch without case statements. Add guard in Payment::EvaluateService#transition_pending_rule against nil status.

Add Payment::ResolveJob as an async wrapper, wired into Invoices::UpdateService via perform_after_commit following the same pattern as PrepaidCreditJob.