### PR TITLE
refactor(charge-filters): Cascade at filter level instead of charge level

### DIFF
--- a/app/jobs/charge_filters/cascade_job.rb
+++ b/app/jobs/charge_filters/cascade_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  class CascadeJob < ApplicationJob
+    queue_as :default
+
+    def perform(charge_id, action, filter_values, old_properties, new_properties, invoice_display_name)
+      charge = Charge.find_by(id: charge_id)
+      return unless charge
+
+      ChargeFilters::CascadeService.call!(
+        charge:,
+        action:,
+        filter_values:,
+        old_properties:,
+        new_properties:,
+        invoice_display_name:
+      )
+    end
+  end
+end

--- a/app/services/charge_filters/cascade_service.rb
+++ b/app/services/charge_filters/cascade_service.rb
@@ -59,24 +59,26 @@ module ChargeFilters
     def create_child_filter(child_charge)
       return if find_child_filter(child_charge)
 
-      child_filter = child_charge.filters.new(
-        organization_id: child_charge.organization_id,
-        invoice_display_name:,
-        properties: ChargeModels::FilterPropertiesService.call(
-          chargeable: child_charge,
-          properties: new_properties
-        ).properties
-      )
-      child_filter.save!
-
-      filter_values.each do |key, values|
-        billable_metric_filter = child_charge.billable_metric.filters.find_by(key:)
-
-        child_filter.values.create!(
-          billable_metric_filter_id: billable_metric_filter&.id,
+      ActiveRecord::Base.transaction do
+        child_filter = child_charge.filters.new(
           organization_id: child_charge.organization_id,
-          values:
+          invoice_display_name:,
+          properties: ChargeModels::FilterPropertiesService.call(
+            chargeable: child_charge,
+            properties: new_properties
+          ).properties
         )
+        child_filter.save!
+
+        filter_values.each do |key, values|
+          billable_metric_filter = child_charge.billable_metric.filters.find_by(key:)
+
+          child_filter.values.create!(
+            billable_metric_filter_id: billable_metric_filter&.id,
+            organization_id: child_charge.organization_id,
+            values:
+          )
+        end
       end
     end
 
@@ -90,7 +92,7 @@ module ChargeFilters
 
     def find_child_filter(child_charge)
       child_charge.filters.includes(values: :billable_metric_filter).find do |f|
-        f.to_h.sort == filter_values.sort
+        f.to_h == filter_values
       end
     end
 
@@ -100,6 +102,8 @@ module ChargeFilters
       normalize_properties(old_properties) != normalize_properties(child_filter.properties)
     end
 
+    # Cascade group keys even for customized filters — group keys are structural
+    # (they affect how events are bucketed), not pricing overrides.
     def cascade_group_keys(child_filter)
       pricing_group_keys = new_properties&.dig("pricing_group_keys") || new_properties&.dig("grouped_by")
       if pricing_group_keys

--- a/app/services/charge_filters/cascade_service.rb
+++ b/app/services/charge_filters/cascade_service.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  class CascadeService < BaseService
+    Result = BaseResult
+
+    def initialize(charge:, action:, filter_values:, old_properties: nil, new_properties: nil, invoice_display_name: nil)
+      @charge = charge
+      @action = action
+      @filter_values = filter_values
+      @old_properties = old_properties
+      @new_properties = new_properties
+      @invoice_display_name = invoice_display_name
+
+      super
+    end
+
+    def call
+      charge.children
+        .joins(plan: :subscriptions)
+        .where(subscriptions: {status: %w[active pending]})
+        .distinct.find_each do |child_charge|
+          Charge.no_touching do
+            Plan.no_touching do
+              case action
+              when "update" then update_child_filter(child_charge)
+              when "create" then create_child_filter(child_charge)
+              when "destroy" then destroy_child_filter(child_charge)
+              end
+            end
+          end
+        end
+
+      result
+    end
+
+    private
+
+    attr_reader :charge, :action, :filter_values, :old_properties, :new_properties, :invoice_display_name
+
+    def update_child_filter(child_charge)
+      child_filter = find_child_filter(child_charge)
+      return unless child_filter
+
+      if filter_customized?(child_filter)
+        cascade_group_keys(child_filter)
+        child_filter.save! if child_filter.changed?
+        return
+      end
+
+      child_filter.properties = ChargeModels::FilterPropertiesService.call(
+        chargeable: child_charge,
+        properties: new_properties
+      ).properties
+      child_filter.invoice_display_name = invoice_display_name
+      child_filter.save!
+    end
+
+    def create_child_filter(child_charge)
+      return if find_child_filter(child_charge)
+
+      child_filter = child_charge.filters.new(
+        organization_id: child_charge.organization_id,
+        invoice_display_name:,
+        properties: ChargeModels::FilterPropertiesService.call(
+          chargeable: child_charge,
+          properties: new_properties
+        ).properties
+      )
+      child_filter.save!
+
+      filter_values.each do |key, values|
+        billable_metric_filter = child_charge.billable_metric.filters.find_by(key:)
+
+        child_filter.values.create!(
+          billable_metric_filter_id: billable_metric_filter&.id,
+          organization_id: child_charge.organization_id,
+          values:
+        )
+      end
+    end
+
+    def destroy_child_filter(child_charge)
+      child_filter = find_child_filter(child_charge)
+      return unless child_filter
+
+      child_filter.values.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      child_filter.discard!
+    end
+
+    def find_child_filter(child_charge)
+      child_charge.filters.includes(values: :billable_metric_filter).find do |f|
+        f.to_h.sort == filter_values.sort
+      end
+    end
+
+    def filter_customized?(child_filter)
+      return false unless old_properties
+
+      normalize_properties(old_properties) != normalize_properties(child_filter.properties)
+    end
+
+    def cascade_group_keys(child_filter)
+      pricing_group_keys = new_properties&.dig("pricing_group_keys") || new_properties&.dig("grouped_by")
+      if pricing_group_keys
+        child_filter.properties["pricing_group_keys"] = pricing_group_keys
+        child_filter.properties.delete("grouped_by")
+      elsif child_filter.pricing_group_keys.present?
+        child_filter.properties.delete("pricing_group_keys")
+        child_filter.properties.delete("grouped_by")
+      end
+
+      presentation_group_keys = new_properties&.dig("presentation_group_keys")
+      if presentation_group_keys
+        child_filter.properties["presentation_group_keys"] = presentation_group_keys
+      elsif child_filter.presentation_group_keys.present?
+        child_filter.properties.delete("presentation_group_keys")
+      end
+    end
+
+    def normalize_properties(props)
+      return props unless props.is_a?(Hash)
+
+      props.transform_values do |v|
+        (v.is_a?(String) && v.match?(/\A-?\d+(\.\d+)?\z/)) ? v.to_f : v
+      end
+    end
+  end
+end

--- a/app/services/charge_filters/create_service.rb
+++ b/app/services/charge_filters/create_service.rb
@@ -2,7 +2,7 @@
 
 module ChargeFilters
   class CreateService < BaseService
-    include Charges::CascadeUpdatable
+    include ChargeFilters::FilterCascadable
 
     Result = BaseResult[:charge_filter]
 
@@ -18,8 +18,6 @@ module ChargeFilters
       return result.not_found_failure!(resource: "charge") unless charge
       return result.single_validation_failure!(field: :values, error_code: "value_is_mandatory") if params[:values].blank?
 
-      old_filters_attrs = capture_old_filters_attrs
-
       ActiveRecord::Base.transaction do
         charge_filter = charge.filters.create!(
           organization_id: charge.organization_id,
@@ -32,7 +30,12 @@ module ChargeFilters
         result.charge_filter = charge_filter
       end
 
-      trigger_cascade(old_filters_attrs)
+      trigger_filter_cascade(
+        action: "create",
+        filter_values: result.charge_filter.to_h,
+        new_properties: result.charge_filter.properties,
+        invoice_display_name: result.charge_filter.invoice_display_name
+      )
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/charge_filters/destroy_service.rb
+++ b/app/services/charge_filters/destroy_service.rb
@@ -2,7 +2,7 @@
 
 module ChargeFilters
   class DestroyService < BaseService
-    include Charges::CascadeUpdatable
+    include ChargeFilters::FilterCascadable
 
     Result = BaseResult[:charge_filter]
 
@@ -16,7 +16,7 @@ module ChargeFilters
     def call
       return result.not_found_failure!(resource: "charge_filter") unless charge_filter
 
-      old_filters_attrs = capture_old_filters_attrs
+      filter_values = charge_filter.to_h_with_discarded
 
       ActiveRecord::Base.transaction do
         charge_filter.values.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
@@ -25,7 +25,7 @@ module ChargeFilters
         result.charge_filter = charge_filter
       end
 
-      trigger_cascade(old_filters_attrs)
+      trigger_filter_cascade(action: "destroy", filter_values:)
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/charge_filters/destroy_service.rb
+++ b/app/services/charge_filters/destroy_service.rb
@@ -16,6 +16,8 @@ module ChargeFilters
     def call
       return result.not_found_failure!(resource: "charge_filter") unless charge_filter
 
+      # Capture values before the transaction discards them — to_h uses the kept
+      # scope and would return an empty hash after discard.
       filter_values = charge_filter.to_h_with_discarded
 
       ActiveRecord::Base.transaction do

--- a/app/services/charge_filters/filter_cascadable.rb
+++ b/app/services/charge_filters/filter_cascadable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  module FilterCascadable
+    extend ActiveSupport::Concern
+
+    private
+
+    def trigger_filter_cascade(action:, filter_values:, old_properties: nil, new_properties: nil, invoice_display_name: nil)
+      return unless cascade_updates
+      return unless charge.children.exists?
+
+      ChargeFilters::CascadeJob.perform_later(
+        charge.id,
+        action,
+        filter_values.deep_stringify_keys,
+        old_properties&.deep_stringify_keys,
+        new_properties&.deep_stringify_keys,
+        invoice_display_name
+      )
+    end
+  end
+end

--- a/app/services/charge_filters/update_service.rb
+++ b/app/services/charge_filters/update_service.rb
@@ -2,7 +2,7 @@
 
 module ChargeFilters
   class UpdateService < BaseService
-    include Charges::CascadeUpdatable
+    include ChargeFilters::FilterCascadable
 
     Result = BaseResult[:charge_filter]
 
@@ -17,7 +17,7 @@ module ChargeFilters
     def call
       return result.not_found_failure!(resource: "charge_filter") unless charge_filter
 
-      old_filters_attrs = capture_old_filters_attrs
+      old_properties = charge_filter.properties.deep_dup
 
       ActiveRecord::Base.transaction do
         charge_filter.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
@@ -27,7 +27,13 @@ module ChargeFilters
         result.charge_filter = charge_filter
       end
 
-      trigger_cascade(old_filters_attrs)
+      trigger_filter_cascade(
+        action: "update",
+        filter_values: charge_filter.to_h,
+        old_properties:,
+        new_properties: charge_filter.properties,
+        invoice_display_name: charge_filter.invoice_display_name
+      )
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/spec/jobs/charge_filters/cascade_job_spec.rb
+++ b/spec/jobs/charge_filters/cascade_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeFilters::CascadeJob do
+  let(:charge) { create(:standard_charge) }
+  let(:filter_values) { {"region" => ["us"]} }
+  let(:old_properties) { {"amount" => "10"} }
+  let(:new_properties) { {"amount" => "15"} }
+  let(:invoice_display_name) { "US region" }
+
+  before do
+    allow(ChargeFilters::CascadeService).to receive(:call!)
+  end
+
+  it "calls the cascade service" do
+    described_class.perform_now(charge.id, "update", filter_values, old_properties, new_properties, invoice_display_name)
+
+    expect(ChargeFilters::CascadeService).to have_received(:call!).with(
+      charge:,
+      action: "update",
+      filter_values:,
+      old_properties:,
+      new_properties:,
+      invoice_display_name:
+    )
+  end
+
+  context "when charge does not exist" do
+    it "does not call the cascade service" do
+      described_class.perform_now(SecureRandom.uuid, "update", filter_values, old_properties, new_properties, invoice_display_name)
+
+      expect(ChargeFilters::CascadeService).not_to have_received(:call!)
+    end
+  end
+end

--- a/spec/requests/api/v1/plans/charges/filters_controller_spec.rb
+++ b/spec/requests/api/v1/plans/charges/filters_controller_spec.rb
@@ -180,14 +180,14 @@ RSpec.describe Api::V1::Plans::Charges::FiltersController do
       before do
         create(:subscription, plan: child_plan, status: :active)
         child_charge
-        allow(Charges::UpdateChildrenJob).to receive(:perform_later)
+        allow(ChargeFilters::CascadeJob).to receive(:perform_later)
       end
 
       it "triggers cascade to children" do
         subject
 
         expect(response).to have_http_status(:success)
-        expect(Charges::UpdateChildrenJob).to have_received(:perform_later)
+        expect(ChargeFilters::CascadeJob).to have_received(:perform_later)
       end
     end
   end

--- a/spec/scenarios/plans/cascade_filter_updates_spec.rb
+++ b/spec/scenarios/plans/cascade_filter_updates_spec.rb
@@ -2,10 +2,8 @@
 
 require "rails_helper"
 
-# Reproduces the real-world scenario where a customer rapidly updates multiple
-# charge filters via the API (e.g. 160+ PUT requests in quick succession).
-# Each filter update cascades only that specific filter to child charges,
-# so there's no ordering issue — each cascade is independent.
+# Tests filter-level cascade for create, update, and destroy operations.
+# Each filter operation cascades only that specific filter to child charges
 RSpec.describe "Cascade filter updates", :premium do
   include ScenariosHelper
 
@@ -19,7 +17,9 @@ RSpec.describe "Cascade filter updates", :premium do
 
   before { bm_filter }
 
-  it "applies all filter changes when multiple updates are fired in quick succession" do
+  # Sets up a parent plan with a charge and two filters, a subscription with
+  # a charge override, and returns the key objects for assertions.
+  def setup_plan_with_subscription
     create_plan({
       name: "Enterprise",
       code: "enterprise",
@@ -52,10 +52,7 @@ RSpec.describe "Cascade filter updates", :premium do
 
     parent_plan = organization.plans.find_by(code: "enterprise")
     parent_charge = parent_plan.charges.first
-    filter_us = parent_charge.filters.find_by(invoice_display_name: "US region")
-    filter_eu = parent_charge.filters.find_by(invoice_display_name: "EU region")
 
-    # Customer subscribes and overrides a charge → creates child plan + child charge
     create_subscription({
       external_customer_id: customer.external_id,
       external_id: "sub_enterprise",
@@ -71,13 +68,21 @@ RSpec.describe "Cascade filter updates", :premium do
 
     subscription.reload
     child_charge = subscription.plan.charges.find_by(code: "storage_charge")
+
+    {parent_plan:, parent_charge:, child_charge:}
+  end
+
+  it "cascades rapid-fire filter updates independently" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+    filter_us = parent_charge.filters.find_by(invoice_display_name: "US region")
+    filter_eu = parent_charge.filters.find_by(invoice_display_name: "EU region")
     child_filter_us = child_charge.filters.find_by(invoice_display_name: "US region")
     child_filter_eu = child_charge.filters.find_by(invoice_display_name: "EU region")
 
-    expect(child_filter_us.properties).to eq({"amount" => "10"})
-    expect(child_filter_eu.properties).to eq({"amount" => "20"})
-
-    # Rapid-fire filter updates — queue cascade jobs without executing them
+    # Queue multiple filter updates without executing jobs
     update_plan_charge_filter(
       parent_plan, parent_charge.code, filter_us.id,
       {properties: {amount: "15"}, cascade_updates: true},
@@ -94,11 +99,78 @@ RSpec.describe "Cascade filter updates", :premium do
     expect(child_filter_us.reload.properties).to eq({"amount" => "10"})
     expect(child_filter_eu.reload.properties).to eq({"amount" => "20"})
 
-    # Each filter update enqueued its own independent CascadeJob.
-    # No ordering issue — they each update only their own filter on children.
+    # Each filter update enqueued its own independent CascadeJob
     perform_all_enqueued_jobs
 
     expect(child_filter_us.reload.properties).to eq({"amount" => "15"})
     expect(child_filter_eu.reload.properties).to eq({"amount" => "25"})
+  end
+
+  it "cascades filter creation to child charges" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    expect(child_charge.filters.count).to eq(2)
+
+    create_plan_charge_filter(parent_plan, parent_charge.code, {
+      invoice_display_name: "Asia region",
+      properties: {amount: "30"},
+      values: {region: ["asia"]},
+      cascade_updates: true
+    })
+
+    child_charge.reload
+    expect(child_charge.filters.count).to eq(3)
+
+    child_filter_asia = child_charge.filters.find_by(invoice_display_name: "Asia region")
+    expect(child_filter_asia.properties).to eq({"amount" => "30"})
+    expect(child_filter_asia.to_h).to eq({"region" => ["asia"]})
+  end
+
+  it "cascades filter deletion to child charges" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+    filter_eu = parent_charge.filters.find_by(invoice_display_name: "EU region")
+
+    expect(child_charge.filters.count).to eq(2)
+
+    delete_plan_charge_filter(parent_plan, parent_charge.code, filter_eu.id)
+
+    # Destroy via API doesn't pass cascade_updates through the helper,
+    # so cascade manually to test the destroy path
+    ChargeFilters::CascadeService.call!(
+      charge: parent_charge,
+      action: "destroy",
+      filter_values: {"region" => ["eu"]}
+    )
+
+    child_charge.reload
+    expect(child_charge.filters.count).to eq(1)
+    expect(child_charge.filters.first.invoice_display_name).to eq("US region")
+  end
+
+  it "does not overwrite a customer-customized filter" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+    filter_us = parent_charge.filters.find_by(invoice_display_name: "US region")
+    child_filter_us = child_charge.filters.find_by(invoice_display_name: "US region")
+
+    # Customer customizes the US filter on their subscription
+    child_filter_us.update!(properties: {"amount" => "99"})
+
+    # Admin updates the same filter on the parent plan
+    update_plan_charge_filter(
+      parent_plan, parent_charge.code, filter_us.id,
+      {properties: {amount: "15"}, cascade_updates: true}
+    )
+
+    # Customer's override is preserved
+    expect(child_filter_us.reload.properties).to eq({"amount" => "99"})
   end
 end

--- a/spec/scenarios/plans/cascade_filter_updates_spec.rb
+++ b/spec/scenarios/plans/cascade_filter_updates_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Reproduces the real-world scenario where a customer rapidly updates multiple
+# charge filters via the API (e.g. 160+ PUT requests in quick succession).
+# Each filter update cascades only that specific filter to child charges,
+# so there's no ordering issue — each cascade is independent.
+RSpec.describe "Cascade filter updates", :premium do
+  include ScenariosHelper
+
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:billable_metric) { create(:billable_metric, organization:, code: "storage") }
+  let(:bm_filter) do
+    create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu asia])
+  end
+
+  before { bm_filter }
+
+  it "applies all filter changes when multiple updates are fired in quick succession" do
+    create_plan({
+      name: "Enterprise",
+      code: "enterprise",
+      interval: "monthly",
+      amount_cents: 0,
+      amount_currency: "EUR",
+      pay_in_advance: false,
+      charges: [
+        {
+          billable_metric_id: billable_metric.id,
+          charge_model: "standard",
+          code: "storage_charge",
+          pay_in_advance: false,
+          properties: {amount: "0"},
+          filters: [
+            {
+              invoice_display_name: "US region",
+              properties: {amount: "10"},
+              values: {region: ["us"]}
+            },
+            {
+              invoice_display_name: "EU region",
+              properties: {amount: "20"},
+              values: {region: ["eu"]}
+            }
+          ]
+        }
+      ]
+    })
+
+    parent_plan = organization.plans.find_by(code: "enterprise")
+    parent_charge = parent_plan.charges.first
+    filter_us = parent_charge.filters.find_by(invoice_display_name: "US region")
+    filter_eu = parent_charge.filters.find_by(invoice_display_name: "EU region")
+
+    # Customer subscribes and overrides a charge → creates child plan + child charge
+    create_subscription({
+      external_customer_id: customer.external_id,
+      external_id: "sub_enterprise",
+      plan_code: "enterprise"
+    })
+
+    subscription = organization.subscriptions.find_by(external_id: "sub_enterprise")
+
+    update_subscription_charge(subscription, "storage_charge", {
+      invoice_display_name: "My storage",
+      properties: {amount: "0"}
+    })
+
+    subscription.reload
+    child_charge = subscription.plan.charges.find_by(code: "storage_charge")
+    child_filter_us = child_charge.filters.find_by(invoice_display_name: "US region")
+    child_filter_eu = child_charge.filters.find_by(invoice_display_name: "EU region")
+
+    expect(child_filter_us.properties).to eq({"amount" => "10"})
+    expect(child_filter_eu.properties).to eq({"amount" => "20"})
+
+    # Rapid-fire filter updates — queue cascade jobs without executing them
+    update_plan_charge_filter(
+      parent_plan, parent_charge.code, filter_us.id,
+      {properties: {amount: "15"}, cascade_updates: true},
+      perform_jobs: false
+    )
+
+    update_plan_charge_filter(
+      parent_plan, parent_charge.code, filter_eu.id,
+      {properties: {amount: "25"}, cascade_updates: true},
+      perform_jobs: false
+    )
+
+    # Child is unchanged before jobs run
+    expect(child_filter_us.reload.properties).to eq({"amount" => "10"})
+    expect(child_filter_eu.reload.properties).to eq({"amount" => "20"})
+
+    # Each filter update enqueued its own independent CascadeJob.
+    # No ordering issue — they each update only their own filter on children.
+    perform_all_enqueued_jobs
+
+    expect(child_filter_us.reload.properties).to eq({"amount" => "15"})
+    expect(child_filter_eu.reload.properties).to eq({"amount" => "25"})
+  end
+end

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -11,18 +11,20 @@ RSpec.describe ChargeFilters::CascadeService do
 
   let(:child_plan) { create(:plan, organization:, parent: parent_plan) }
   let(:child_charge) { create(:standard_charge, plan: child_plan, billable_metric:, parent: parent_charge, properties: {amount: "0"}) }
-  let!(:subscription) { create(:subscription, plan: child_plan, status: :active) }
 
-  let!(:parent_filter) do
-    filter = create(:charge_filter, charge: parent_charge, invoice_display_name: "US region", properties: {amount: "10"})
+  let(:child_filter) do
+    filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US region", properties: {amount: "10"})
     create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
     filter
   end
 
-  let!(:child_filter) do
-    filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US region", properties: {amount: "10"})
-    create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
-    filter
+  before do
+    create(:subscription, plan: child_plan, status: :active)
+
+    parent_filter = create(:charge_filter, charge: parent_charge, invoice_display_name: "US region", properties: {amount: "10"})
+    create(:charge_filter_value, charge_filter: parent_filter, billable_metric_filter: bm_filter, values: ["us"])
+
+    child_filter
   end
 
   describe "#call" do
@@ -59,10 +61,83 @@ RSpec.describe ChargeFilters::CascadeService do
 
           expect(child_filter.reload.properties).to eq({"amount" => "99"})
         end
+
+        context "when new properties include pricing_group_keys" do
+          subject(:service) do
+            described_class.call(
+              charge: parent_charge,
+              action: "update",
+              filter_values: {"region" => ["us"]},
+              old_properties: {"amount" => "10"},
+              new_properties: {"amount" => "15", "pricing_group_keys" => ["agent_name"]},
+              invoice_display_name: "US region updated"
+            )
+          end
+
+          it "cascades pricing_group_keys even though properties are customized" do
+            service
+
+            expect(child_filter.reload.properties).to eq({"amount" => "99", "pricing_group_keys" => ["agent_name"]})
+          end
+        end
+
+        context "when new properties include presentation_group_keys" do
+          subject(:service) do
+            described_class.call(
+              charge: parent_charge,
+              action: "update",
+              filter_values: {"region" => ["us"]},
+              old_properties: {"amount" => "10"},
+              new_properties: {"amount" => "15", "presentation_group_keys" => [{"value" => "region"}]},
+              invoice_display_name: "US region updated"
+            )
+          end
+
+          it "cascades presentation_group_keys even though properties are customized" do
+            service
+
+            expect(child_filter.reload.properties).to eq({"amount" => "99", "presentation_group_keys" => [{"value" => "region"}]})
+          end
+        end
+
+        context "when new properties remove pricing_group_keys" do
+          subject(:service) do
+            described_class.call(
+              charge: parent_charge,
+              action: "update",
+              filter_values: {"region" => ["us"]},
+              old_properties: {"amount" => "10", "pricing_group_keys" => ["old_key"]},
+              new_properties: {"amount" => "15"},
+              invoice_display_name: "US region updated"
+            )
+          end
+
+          let!(:child_filter) do
+            filter = create(
+              :charge_filter,
+              charge: child_charge,
+              invoice_display_name: "Custom",
+              properties: {"amount" => "99", "pricing_group_keys" => ["old_key"]}
+            )
+            create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
+            filter
+          end
+
+          it "removes pricing_group_keys from the customized filter" do
+            service
+
+            expect(child_filter.reload.properties).to eq({"amount" => "99"})
+          end
+        end
       end
 
       context "when child has no matching filter" do
-        let!(:child_filter) { nil }
+        before do
+          child_charge.filters.each do |f|
+            f.values.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+            f.discard!
+          end
+        end
 
         it "succeeds without error" do
           expect(service).to be_success
@@ -80,8 +155,6 @@ RSpec.describe ChargeFilters::CascadeService do
           invoice_display_name: "EU region"
         )
       end
-
-      let!(:eu_bm_filter) { bm_filter } # reuse — already has "eu" in values
 
       it "creates the filter on the child charge" do
         expect { service }.to change { child_charge.filters.reload.count }.by(1)
@@ -120,7 +193,12 @@ RSpec.describe ChargeFilters::CascadeService do
       end
 
       context "when child has no matching filter" do
-        let!(:child_filter) { nil }
+        before do
+          child_charge.filters.each do |f|
+            f.values.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+            f.discard!
+          end
+        end
 
         it "succeeds without error" do
           expect(service).to be_success
@@ -129,8 +207,6 @@ RSpec.describe ChargeFilters::CascadeService do
     end
 
     context "when child charge has no active subscription" do
-      let!(:subscription) { create(:subscription, plan: child_plan, status: :terminated) }
-
       subject(:service) do
         described_class.call(
           charge: parent_charge,
@@ -140,6 +216,10 @@ RSpec.describe ChargeFilters::CascadeService do
           new_properties: {"amount" => "15"},
           invoice_display_name: "US region"
         )
+      end
+
+      before do
+        Subscription.update_all(status: :terminated) # rubocop:disable Rails/SkipsModelValidations
       end
 
       it "does not update the child filter" do

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeFilters::CascadeService do
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:bm_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
+  let(:parent_plan) { create(:plan, organization:) }
+  let(:parent_charge) { create(:standard_charge, plan: parent_plan, billable_metric:, properties: {amount: "0"}) }
+
+  let(:child_plan) { create(:plan, organization:, parent: parent_plan) }
+  let(:child_charge) { create(:standard_charge, plan: child_plan, billable_metric:, parent: parent_charge, properties: {amount: "0"}) }
+  let!(:subscription) { create(:subscription, plan: child_plan, status: :active) }
+
+  let!(:parent_filter) do
+    filter = create(:charge_filter, charge: parent_charge, invoice_display_name: "US region", properties: {amount: "10"})
+    create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
+    filter
+  end
+
+  let!(:child_filter) do
+    filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US region", properties: {amount: "10"})
+    create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
+    filter
+  end
+
+  describe "#call" do
+    context "with update action" do
+      subject(:service) do
+        described_class.call(
+          charge: parent_charge,
+          action: "update",
+          filter_values: {"region" => ["us"]},
+          old_properties: {"amount" => "10"},
+          new_properties: {"amount" => "15"},
+          invoice_display_name: "US region updated"
+        )
+      end
+
+      it "updates the matching child filter" do
+        service
+
+        expect(child_filter.reload).to have_attributes(
+          properties: {"amount" => "15"},
+          invoice_display_name: "US region updated"
+        )
+      end
+
+      context "when child filter was customized" do
+        let!(:child_filter) do
+          filter = create(:charge_filter, charge: child_charge, invoice_display_name: "Custom", properties: {amount: "99"})
+          create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
+          filter
+        end
+
+        it "does not update the customized filter properties" do
+          service
+
+          expect(child_filter.reload.properties).to eq({"amount" => "99"})
+        end
+      end
+
+      context "when child has no matching filter" do
+        let!(:child_filter) { nil }
+
+        it "succeeds without error" do
+          expect(service).to be_success
+        end
+      end
+    end
+
+    context "with create action" do
+      subject(:service) do
+        described_class.call(
+          charge: parent_charge,
+          action: "create",
+          filter_values: {"region" => ["eu"]},
+          new_properties: {"amount" => "20"},
+          invoice_display_name: "EU region"
+        )
+      end
+
+      let!(:eu_bm_filter) { bm_filter } # reuse — already has "eu" in values
+
+      it "creates the filter on the child charge" do
+        expect { service }.to change { child_charge.filters.reload.count }.by(1)
+
+        new_filter = child_charge.filters.find_by(invoice_display_name: "EU region")
+        expect(new_filter.properties).to eq({"amount" => "20"})
+        expect(new_filter.to_h).to eq({"region" => ["eu"]})
+      end
+
+      context "when child already has the filter" do
+        before do
+          existing = create(:charge_filter, charge: child_charge, properties: {amount: "20"})
+          create(:charge_filter_value, charge_filter: existing, billable_metric_filter: bm_filter, values: ["eu"])
+        end
+
+        it "does not create a duplicate" do
+          expect { service }.not_to change { child_charge.filters.reload.count }
+        end
+      end
+    end
+
+    context "with destroy action" do
+      subject(:service) do
+        described_class.call(
+          charge: parent_charge,
+          action: "destroy",
+          filter_values: {"region" => ["us"]}
+        )
+      end
+
+      it "discards the matching child filter and its values" do
+        service
+
+        expect(child_filter.reload).to be_discarded
+        expect(child_filter.values.kept).to be_empty
+      end
+
+      context "when child has no matching filter" do
+        let!(:child_filter) { nil }
+
+        it "succeeds without error" do
+          expect(service).to be_success
+        end
+      end
+    end
+
+    context "when child charge has no active subscription" do
+      let!(:subscription) { create(:subscription, plan: child_plan, status: :terminated) }
+
+      subject(:service) do
+        described_class.call(
+          charge: parent_charge,
+          action: "update",
+          filter_values: {"region" => ["us"]},
+          old_properties: {"amount" => "10"},
+          new_properties: {"amount" => "15"},
+          invoice_display_name: "US region"
+        )
+      end
+
+      it "does not update the child filter" do
+        service
+
+        expect(child_filter.reload.properties).to eq({"amount" => "10"})
+      end
+    end
+  end
+end

--- a/spec/services/charge_filters/destroy_service_spec.rb
+++ b/spec/services/charge_filters/destroy_service_spec.rb
@@ -62,17 +62,19 @@ RSpec.describe ChargeFilters::DestroyService do
         filter_value
         create(:subscription, plan: child_plan, status: :active)
         child_charge
-        allow(Charges::UpdateChildrenJob).to receive(:perform_later)
+        allow(ChargeFilters::CascadeJob).to receive(:perform_later)
       end
 
-      it "triggers cascade update via Charges::UpdateChildrenJob" do
+      it "triggers filter-level cascade via ChargeFilters::CascadeJob" do
         service
 
-        expect(Charges::UpdateChildrenJob).to have_received(:perform_later).with(
-          params: hash_including("charge_model", "properties", "filters"),
-          old_parent_attrs: hash_including("id" => charge.id),
-          old_parent_filters_attrs: array_including(hash_including("id", "properties")),
-          old_parent_applied_pricing_unit_attrs: nil
+        expect(ChargeFilters::CascadeJob).to have_received(:perform_later).with(
+          charge.id,
+          "destroy",
+          hash_including("card_location"),
+          nil,
+          nil,
+          nil
         )
       end
     end

--- a/spec/services/charge_filters/update_service_spec.rb
+++ b/spec/services/charge_filters/update_service_spec.rb
@@ -83,17 +83,19 @@ RSpec.describe ChargeFilters::UpdateService do
         create(:charge_filter_value, charge_filter:, billable_metric_filter: card_location_filter, values: ["domestic"])
         create(:subscription, plan: child_plan, status: :active)
         child_charge
-        allow(Charges::UpdateChildrenJob).to receive(:perform_later)
+        allow(ChargeFilters::CascadeJob).to receive(:perform_later)
       end
 
-      it "triggers cascade update via Charges::UpdateChildrenJob" do
+      it "triggers filter-level cascade via ChargeFilters::CascadeJob" do
         service
 
-        expect(Charges::UpdateChildrenJob).to have_received(:perform_later).with(
-          params: hash_including("charge_model", "properties", "filters"),
-          old_parent_attrs: hash_including("id" => charge.id),
-          old_parent_filters_attrs: array_including(hash_including("id", "properties")),
-          old_parent_applied_pricing_unit_attrs: nil
+        expect(ChargeFilters::CascadeJob).to have_received(:perform_later).with(
+          charge.id,
+          "update",
+          hash_including("card_location"),
+          hash_including("amount"),
+          hash_including("amount"),
+          anything
         )
       end
     end


### PR DESCRIPTION
## Context

When a customer rapidly updates multiple charge filters via the API (e.g. 160+ PUT requests), each filter update triggered a full charge-level cascade that re-applied the entire charge state to every child. This caused ordering issues, advisory lock contention, and stale `old_parent_filters_attrs` snapshots that broke customization detection.

## Description

Introduce a filter-level cascade for individual filter endpoints (`create`, `update`, `destroy`). Each filter update now enqueues a lightweight `ChargeFilters::CascadeJob` that cascades only that specific filter to child charges — no ordering dependency, no lock contention, no stale snapshots.

The cascade matches child filters by their values hash (same mechanism as `CreateOrUpdateBatchService`) and preserves customer overrides by comparing the child's properties against the old parent properties for that specific filter.