### PR TITLE
Revert "misc(clickhouse): Speedup deduplication (#5334)"

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -98,11 +98,6 @@ module Events
           .and(arel_table[:code].eq(code)))
         ).then { with_timestamp_boundaries(it, from_datetime, to_datetime) }
 
-        # Push property filters BEFORE GROUP BY so ClickHouse filters first,
-        # then deduplicates only relevant rows (significant memory/CPU savings).
-        query = arel_filters_scope(query)
-        query = apply_arel_grouped_by_values(query) if grouped_by_values?
-
         columns = deduplicated_columns.dup
 
         # Grouping and filtering is made based on the properties

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -51,5 +51,91 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
 
   context "with deduplication" do
     it_behaves_like "an event store"
+
+    # Regression test for https://github.com/getlago/lago-api/pull/5359
+    #
+    # Two rows share the same (transaction_id, timestamp) but carry different
+    # filterable properties. Deduplication via argMax(enriched_at) must resolve
+    # to a single row FIRST — otherwise the same logical event could be counted
+    # in multiple filter/group buckets (once per property value it ever had).
+    describe "filters applied after deduplication" do
+      subject(:event_store) do
+        described_class.new(
+          code: billable_metric.code,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by: nil,
+            grouped_by_values: nil,
+            matching_filters: matching_filters,
+            ignored_filters: [],
+            charge_id: charge.id,
+            charge_filter: nil
+          },
+          deduplicate: true
+        )
+      end
+
+      let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
+      let(:organization) { billable_metric.organization }
+      let(:charge) { create(:standard_charge, organization:, billable_metric:) }
+      let(:customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, customer:, started_at: DateTime.parse("2023-03-15")) }
+      let(:subscription_started_at) { subscription.started_at.beginning_of_day }
+      let(:boundaries) do
+        {
+          from_datetime: subscription_started_at,
+          to_datetime: subscription.started_at.end_of_month.end_of_day,
+          charges_duration: 31
+        }
+      end
+
+      let(:transaction_id) { SecureRandom.uuid }
+      let(:timestamp) { subscription_started_at + 1.day }
+
+      before do
+        Clickhouse::EventsEnriched.create!(
+          transaction_id:,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp:,
+          properties: {"value" => 1, "region" => "europe"},
+          value: 1,
+          decimal_value: 1.to_d,
+          precise_total_amount_cents: 1,
+          enriched_at: 1.minute.ago
+        )
+
+        Clickhouse::EventsEnriched.create!(
+          transaction_id:,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp:,
+          properties: {"value" => 1, "region" => "asia"},
+          value: 1,
+          decimal_value: 1.to_d,
+          precise_total_amount_cents: 1,
+          enriched_at: Time.current
+        )
+      end
+
+      context "when the filter matches only the earlier (superseded) property value" do
+        let(:matching_filters) { {"region" => ["europe"]} }
+
+        it "does not count the event (latest enrichment is asia, filter excludes it)" do
+          expect(event_store.count).to eq(0)
+        end
+      end
+
+      context "when the filter matches only the latest property value" do
+        let(:matching_filters) { {"region" => ["asia"]} }
+
+        it "counts the deduplicated event exactly once" do
+          expect(event_store.count).to eq(1)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This reverts commit 8b43396c14aee39ff0ab7c52dd6388c9957054c5.

## Description

The changes introduced with https://github.com/getlago/lago-api/pull/5334 can lead to invalid results when the same `timestamp`/`transaction_id` tuple is used with different filters properties. The same "duplicated event" could be counted multiple times in different buckets.