### PR TITLE
feat(order-forms): add OrderForm GraphQL API

### DIFF
--- a/app/graphql/resolvers/order_form_resolver.rb
+++ b/app/graphql/resolvers/order_form_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class OrderFormResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "order_forms:view"
+
+    description "Query a single order form"
+
+    argument :id, ID, required: true, description: "Uniq ID of the order form"
+
+    type Types::OrderForms::Object, null: true
+
+    def resolve(id:)
+      current_organization.order_forms.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: "order_form")
+    end
+  end
+end

--- a/app/graphql/resolvers/order_forms_resolver.rb
+++ b/app/graphql/resolvers/order_forms_resolver.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class OrderFormsResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "order_forms:view"
+
+    description "Query order forms"
+
+    argument :created_at_from, GraphQL::Types::ISO8601DateTime, required: false
+    argument :created_at_to, GraphQL::Types::ISO8601DateTime, required: false
+    argument :customer_id, [ID], required: false
+    argument :expires_at_from, GraphQL::Types::ISO8601DateTime, required: false
+    argument :expires_at_to, GraphQL::Types::ISO8601DateTime, required: false
+    argument :limit, Integer, required: false
+    argument :number, [String], required: false
+    argument :owner_id, [ID], required: false
+    argument :page, Integer, required: false
+    argument :quote_number, [String], required: false
+    argument :search_term, String, required: false
+    argument :status, [Types::OrderForms::StatusEnum], required: false
+
+    type Types::OrderForms::Object.collection_type, null: false
+
+    def resolve( # rubocop:disable Metrics/ParameterLists
+      created_at_from: nil,
+      created_at_to: nil,
+      expires_at_from: nil,
+      expires_at_to: nil,
+      customer_id: nil,
+      limit: nil,
+      number: nil,
+      owner_id: nil,
+      page: nil,
+      quote_number: nil,
+      search_term: nil,
+      status: nil
+    )
+      result = OrderFormsQuery.call(
+        organization: current_organization,
+        pagination: {page:, limit:},
+        filters: {
+          status:,
+          customer_id:,
+          number:,
+          quote_number:,
+          owner_id:,
+          created_at_from:,
+          created_at_to:,
+          expires_at_from:,
+          expires_at_to:
+        },
+        search_term:
+      )
+
+      return result_error(result) unless result.success?
+
+      result.order_forms
+    end
+  end
+end

--- a/app/graphql/types/order_forms/object.rb
+++ b/app/graphql/types/order_forms/object.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  module OrderForms
+    class Object < Types::BaseObject
+      graphql_name "OrderForm"
+
+      field :id, ID, null: false
+      field :number, String, null: false
+      field :status, Types::OrderForms::StatusEnum, null: false
+      field :void_reason, Types::OrderForms::VoidReasonEnum, null: true
+
+      field :billing_snapshot, GraphQL::Types::JSON, null: false
+      field :expires_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :signed_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :signed_by_user_id, ID, null: true
+      field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
+
+      field :customer, Types::Customers::Object, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/app/graphql/types/order_forms/object.rb
+++ b/app/graphql/types/order_forms/object.rb
@@ -22,6 +22,7 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      dataload_association :customer
       dataload_association :quote
     end
   end

--- a/app/graphql/types/order_forms/object.rb
+++ b/app/graphql/types/order_forms/object.rb
@@ -17,9 +17,12 @@ module Types
       field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :customer, Types::Customers::Object, null: false
+      field :quote, Types::Quotes::Object, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      dataload_association :quote
     end
   end
 end

--- a/app/graphql/types/order_forms/status_enum.rb
+++ b/app/graphql/types/order_forms/status_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module OrderForms
+    class StatusEnum < Types::BaseEnum
+      graphql_name "OrderFormStatusEnum"
+
+      OrderForm::STATUSES.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/order_forms/void_reason_enum.rb
+++ b/app/graphql/types/order_forms/void_reason_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module OrderForms
+    class VoidReasonEnum < Types::BaseEnum
+      graphql_name "OrderFormVoidReasonEnum"
+
+      OrderForm::VOID_REASONS.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -75,6 +75,8 @@ module Types
     field :invoices, resolver: Resolvers::InvoicesResolver
     field :memberships, resolver: Resolvers::MembershipsResolver
     field :mrrs, resolver: Resolvers::Analytics::MrrsResolver
+    field :order_form, resolver: Resolvers::OrderFormResolver
+    field :order_forms, resolver: Resolvers::OrderFormsResolver
     field :organization, resolver: Resolvers::OrganizationResolver
     field :overdue_balances, resolver: Resolvers::Analytics::OverdueBalancesResolver
     field :password_reset, resolver: Resolvers::PasswordResetResolver

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -142,6 +142,10 @@ quotes:
     - manager
   void:
     - manager
+order_forms:
+  view:
+    - finance
+    - manager
 organization:
   view:
     - finance

--- a/schema.graphql
+++ b/schema.graphql
@@ -9077,6 +9077,7 @@ type OrderForm {
   expiresAt: ISO8601DateTime
   id: ID!
   number: String!
+  quote: Quote!
   signedAt: ISO8601DateTime
   signedByUserId: ID
   status: OrderFormStatusEnum!

--- a/schema.graphql
+++ b/schema.graphql
@@ -9070,6 +9070,49 @@ enum OrderByEnum {
   net_revenue_amount_cents
 }
 
+type OrderForm {
+  billingSnapshot: JSON!
+  createdAt: ISO8601DateTime!
+  customer: Customer!
+  expiresAt: ISO8601DateTime
+  id: ID!
+  number: String!
+  signedAt: ISO8601DateTime
+  signedByUserId: ID
+  status: OrderFormStatusEnum!
+  updatedAt: ISO8601DateTime!
+  voidReason: OrderFormVoidReasonEnum
+  voidedAt: ISO8601DateTime
+}
+
+"""
+OrderFormCollection type
+"""
+type OrderFormCollection {
+  """
+  A collection of paginated OrderFormCollection
+  """
+  collection: [OrderForm!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+enum OrderFormStatusEnum {
+  expired
+  generated
+  signed
+  voided
+}
+
+enum OrderFormVoidReasonEnum {
+  expired
+  invalid
+  manual
+}
+
 enum OrderTypeEnum {
   one_off
   subscription_amendment
@@ -9356,6 +9399,7 @@ enum PermissionEnum {
   invoices_update
   invoices_view
   invoices_void
+  order_forms_view
   organization_emails_update
   organization_emails_view
   organization_integrations_create
@@ -9469,6 +9513,7 @@ type Permissions {
   invoicesUpdate: Boolean!
   invoicesView: Boolean!
   invoicesVoid: Boolean!
+  orderFormsView: Boolean!
   organizationEmailsUpdate: Boolean!
   organizationEmailsView: Boolean!
   organizationIntegrationsCreate: Boolean!
@@ -10458,6 +10503,21 @@ type Query {
   Query MRR of an organization
   """
   mrrs(billingEntityId: ID, currency: CurrencyEnum): MrrCollection!
+
+  """
+  Query a single order form
+  """
+  orderForm(
+    """
+    Uniq ID of the order form
+    """
+    id: ID!
+  ): OrderForm
+
+  """
+  Query order forms
+  """
+  orderForms(createdAtFrom: ISO8601DateTime, createdAtTo: ISO8601DateTime, customerId: [ID!], expiresAtFrom: ISO8601DateTime, expiresAtTo: ISO8601DateTime, limit: Int, number: [String!], ownerId: [ID!], page: Int, quoteNumber: [String!], searchTerm: String, status: [OrderFormStatusEnum!]): OrderFormCollection!
 
   """
   Query the current organization

--- a/schema.json
+++ b/schema.json
@@ -43511,6 +43511,304 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "OrderForm",
+          "description": null,
+          "fields": [
+            {
+              "name": "billingSnapshot",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Customer",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expiresAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "number",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "signedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "signedByUserId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrderFormStatusEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "voidReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderFormVoidReasonEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "voidedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OrderFormCollection",
+          "description": "OrderFormCollection type",
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated OrderFormCollection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "OrderForm",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderFormStatusEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "generated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "signed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expired",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "voided",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderFormVoidReasonEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "manual",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expired",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invalid",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "OrderTypeEnum",
           "description": null,
@@ -45559,6 +45857,12 @@
               "deprecationReason": null
             },
             {
+              "name": "order_forms_view",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -46738,6 +47042,22 @@
             },
             {
               "name": "invoicesVoid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderFormsView",
               "description": null,
               "args": [],
               "type": {
@@ -56164,6 +56484,236 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "MrrCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderForm",
+              "description": "Query a single order form",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the order form",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "OrderForm",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderForms",
+              "description": "Query order forms",
+              "args": [
+                {
+                  "name": "createdAtFrom",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "createdAtTo",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "customerId",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "expiresAtFrom",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "expiresAtTo",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "number",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "ownerId",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "quoteNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "OrderFormStatusEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderFormCollection",
                   "ofType": null
                 }
               },

--- a/schema.json
+++ b/schema.json
@@ -43608,6 +43608,22 @@
               "deprecationReason": null
             },
             {
+              "name": "quote",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Quote",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "signedAt",
               "description": null,
               "args": [],

--- a/spec/graphql/resolvers/order_form_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_form_resolver_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Resolvers::OrderFormResolver do
           status
           createdAt
           updatedAt
+          quote {
+            id
+            number
+            currentVersion { id }
+          }
         }
       }
     GQL
@@ -44,6 +49,9 @@ RSpec.describe Resolvers::OrderFormResolver do
     expect(data["id"]).to eq(order_form.id)
     expect(data["number"]).to eq(order_form.number)
     expect(data["status"]).to eq("generated")
+    expect(data["quote"]["id"]).to eq(order_form.quote.id)
+    expect(data["quote"]["number"]).to eq(order_form.quote.number)
+    expect(data["quote"]["currentVersion"]["id"]).to eq(order_form.quote_version.id)
   end
 
   context "when order form is not found" do

--- a/spec/graphql/resolvers/order_form_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_form_resolver_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::OrderFormResolver do
+  let(:required_permission) { "order_forms:view" }
+
+  let(:query) do
+    <<~GQL
+      query($id: ID!) {
+        orderForm(id: $id) {
+          id
+          number
+          status
+          createdAt
+          updatedAt
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:order_form) { create(:order_form, organization:, customer:) }
+
+  before { order_form }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "order_forms:view"
+
+  it "returns a single order form" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables: {id: order_form.id}
+    )
+
+    data = result["data"]["orderForm"]
+
+    expect(data["id"]).to eq(order_form.id)
+    expect(data["number"]).to eq(order_form.number)
+    expect(data["status"]).to eq("generated")
+  end
+
+  context "when order form is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {id: SecureRandom.uuid}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/resolvers/order_forms_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_forms_resolver_spec.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::OrderFormsResolver do
+  let(:required_permission) { "order_forms:view" }
+  let(:query) {}
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let!(:order_form) { create(:order_form, organization:, customer:) }
+
+  before { create(:order_form, :signed, organization:, customer:) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "order_forms:view"
+
+  context "when listing all order forms" do
+    let(:query) do
+      <<~GQL
+        query {
+          orderForms(limit: 5) {
+            collection {
+              id
+              number
+              status
+            }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns a list of order forms" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by status" do
+    let(:query) do
+      <<~GQL
+        query($status: [OrderFormStatusEnum!]) {
+          orderForms(status: $status, limit: 5) {
+            collection { id status }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching order forms" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {status: ["generated"]}
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_form.id)
+    end
+  end
+
+  context "when filtering by number" do
+    let(:query) do
+      <<~GQL
+        query($number: [String!]) {
+          orderForms(number: $number, limit: 5) {
+            collection { id number }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching order forms" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {number: [order_form.number]}
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_form.id)
+    end
+  end
+
+  context "when filtering by customer_id" do
+    let(:other_customer) { create(:customer, organization:) }
+
+    let(:query) do
+      <<~GQL
+        query($customerId: [ID!]) {
+          orderForms(customerId: $customerId, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before { create(:order_form, organization:, customer: other_customer) }
+
+    it "returns only matching order forms" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customerId: [customer.id]}
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by quote_number" do
+    let(:query) do
+      <<~GQL
+        query($quoteNumber: [String!]) {
+          orderForms(quoteNumber: $quoteNumber, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only order forms linked to the specified quote" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {quoteNumber: [order_form.quote_version.quote.number]}
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_form.id)
+    end
+  end
+
+  context "when filtering by owner_id" do
+    let(:query) do
+      <<~GQL
+        query($ownerId: [ID!]) {
+          orderForms(ownerId: $ownerId, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      QuoteOwner.create!(organization:, quote: order_form.quote_version.quote, user: membership.user)
+    end
+
+    it "returns only order forms whose quote has the specified owner" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {ownerId: [membership.user.id]}
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_form.id)
+    end
+  end
+
+  context "when filtering by created_at range" do
+    let!(:order_form) { create(:order_form, organization:, customer:, created_at: 5.days.ago) }
+
+    let(:query) do
+      <<~GQL
+        query($createdAtFrom: ISO8601DateTime, $createdAtTo: ISO8601DateTime) {
+          orderForms(createdAtFrom: $createdAtFrom, createdAtTo: $createdAtTo, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only order forms within the date range" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {createdAtFrom: 2.days.ago.iso8601, createdAtTo: 1.day.from_now.iso8601}
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["metadata"]["totalCount"]).to eq(1)
+    end
+  end
+
+  context "when filtering by expires_at range" do
+    let!(:order_form) { create(:order_form, organization:, customer:, expires_at: 5.days.from_now) }
+
+    let(:query) do
+      <<~GQL
+        query($expiresAtFrom: ISO8601DateTime, $expiresAtTo: ISO8601DateTime) {
+          orderForms(expiresAtFrom: $expiresAtFrom, expiresAtTo: $expiresAtTo, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before { create(:order_form, :signed, organization:, customer:, expires_at: 15.days.from_now) }
+
+    it "returns only order forms expiring within the date range" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {expiresAtFrom: 3.days.from_now.iso8601, expiresAtTo: 10.days.from_now.iso8601}
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_form.id)
+    end
+  end
+end

--- a/spec/graphql/resolvers/order_forms_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_forms_resolver_spec.rb
@@ -237,6 +237,34 @@ RSpec.describe Resolvers::OrderFormsResolver do
     end
   end
 
+  context "when searching by search_term" do
+    let(:query) do
+      <<~GQL
+        query($searchTerm: String) {
+          orderForms(searchTerm: $searchTerm, limit: 5) {
+            collection { id number }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only order forms whose number matches the search term" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {searchTerm: order_form.number}
+      )
+
+      response = result["data"]["orderForms"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_form.id)
+    end
+  end
+
   context "when filtering by expires_at range" do
     let!(:order_form) { create(:order_form, organization:, customer:, expires_at: 5.days.from_now) }
 
@@ -266,6 +294,35 @@ RSpec.describe Resolvers::OrderFormsResolver do
 
       expect(response["collection"].count).to eq(1)
       expect(response["collection"].first["id"]).to eq(order_form.id)
+    end
+  end
+
+  context "with N+1 query detection", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+    let(:query) do
+      <<~GQL
+        query {
+          orderForms(limit: 10) {
+            collection {
+              id
+              customer { id }
+              quote { id }
+            }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "does not trigger N+1 queries" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      expect(result["errors"]).to be_nil
+      expect(result.dig("data", "orderForms", "collection").length).to eq(2)
     end
   end
 end

--- a/spec/graphql/resolvers/order_forms_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_forms_resolver_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Resolvers::OrderFormsResolver do
               id
               number
               status
+              quote {
+                id
+                number
+                currentVersion { id }
+              }
             }
             metadata { currentPage, totalCount }
           }
@@ -33,7 +38,7 @@ RSpec.describe Resolvers::OrderFormsResolver do
       GQL
     end
 
-    it "returns a list of order forms" do
+    it "returns a list of order forms with their quotes" do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
@@ -45,6 +50,12 @@ RSpec.describe Resolvers::OrderFormsResolver do
 
       expect(response["collection"].count).to eq(2)
       expect(response["metadata"]["totalCount"]).to eq(2)
+
+      collection = response["collection"]
+      expect(collection.map { |row| row["quote"]["id"] }).to match_array(
+        OrderForm.where(id: collection.map { |row| row["id"] }).map { |of| of.quote.id }
+      )
+      expect(collection).to all(satisfy { |row| row.dig("quote", "currentVersion", "id").present? })
     end
   end
 

--- a/spec/graphql/types/order_forms/object_spec.rb
+++ b/spec/graphql/types/order_forms/object_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::OrderForms::Object do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:number).of_type("String!")
+    expect(subject).to have_field(:status).of_type("OrderFormStatusEnum!")
+    expect(subject).to have_field(:void_reason).of_type("OrderFormVoidReasonEnum")
+    expect(subject).to have_field(:billing_snapshot).of_type("JSON!")
+    expect(subject).to have_field(:expires_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:signed_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:signed_by_user_id).of_type("ID")
+    expect(subject).to have_field(:voided_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:customer).of_type("Customer!")
+    expect(subject).to have_field(:quote).of_type("Quote!")
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+  end
+end

--- a/spec/graphql/types/order_forms/status_enum_spec.rb
+++ b/spec/graphql/types/order_forms/status_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::OrderForms::StatusEnum do
+  it "exposes all enum values" do
+    expect(described_class.values.keys).to match_array(OrderForm::STATUSES.keys.map(&:to_s))
+  end
+end

--- a/spec/graphql/types/order_forms/void_reason_enum_spec.rb
+++ b/spec/graphql/types/order_forms/void_reason_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::OrderForms::VoidReasonEnum do
+  it "exposes all enum values" do
+    expect(described_class.values.keys).to match_array(OrderForm::VOID_REASONS.keys.map(&:to_s))
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 Order Forms lifecycle

## Context

This is PR 2 of 2 in a stacked split. Stacked on the REST PR so the shared model, query, and factories are available. Requires a frontend dev to QA via the UI.

Stack:
- OrderForm REST (#5360)
- **#this** — OrderForm GraphQL

## Description

Add OrderForm read-only GraphQL API:

- `Types::OrderForms::Object` with customer, quote, and lifecycle fields
- `Types::OrderForms::StatusEnum`, `Types::OrderForms::VoidReasonEnum`
- `Resolvers::OrderFormResolver` (single) and `Resolvers::OrderFormsResolver` (collection with filters)
- Register `order_form` and `order_forms` on `QueryType`
- Regenerated `schema.graphql` and `schema.json`
- Resolver specs covering single lookup and each filter