### PR TITLE
feat(orders): add Order REST API

### DIFF
--- a/app/contracts/queries/orders_query_filters_contract.rb
+++ b/app/contracts/queries/orders_query_filters_contract.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Queries
+  class OrdersQueryFiltersContract < Dry::Validation::Contract
+    params do
+      optional(:status).maybe do
+        value(:string, included_in?: Order::STATUSES.keys.map(&:to_s)) |
+          array(:string, included_in?: Order::STATUSES.keys.map(&:to_s))
+      end
+      optional(:order_type).maybe do
+        value(:string, included_in?: Order::ORDER_TYPES.keys.map(&:to_s)) |
+          array(:string, included_in?: Order::ORDER_TYPES.keys.map(&:to_s))
+      end
+      optional(:execution_mode).maybe do
+        value(:string, included_in?: Order::EXECUTION_MODES.keys.map(&:to_s)) |
+          array(:string, included_in?: Order::EXECUTION_MODES.keys.map(&:to_s))
+      end
+      optional(:customer_id).maybe { value(:string, format?: Regex::UUID) | array(:string, format?: Regex::UUID) }
+      optional(:number).maybe { value(:string) | array(:string) }
+      optional(:order_form_number).maybe { value(:string) | array(:string) }
+      optional(:quote_number).maybe { value(:string) | array(:string) }
+      optional(:owner_id).maybe { value(:string, format?: Regex::UUID) | array(:string, format?: Regex::UUID) }
+      optional(:executed_at_from).maybe(:time)
+      optional(:executed_at_to).maybe(:time)
+    end
+  end
+end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class OrdersController < Api::BaseController
+      def index
+        result = OrdersQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters: index_filters,
+          search_term: params[:search_term]
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.orders,
+              ::V1::OrderSerializer,
+              collection_name: "orders",
+              meta: pagination_metadata(result.orders)
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        order = current_organization.orders.find_by(id: params[:id])
+        return not_found_error(resource: "order") unless order
+
+        render_order(order)
+      end
+
+      private
+
+      def index_filters
+        {
+          status: params[:status],
+          order_type: params[:order_type],
+          execution_mode: params[:execution_mode],
+          customer_id: params[:customer_id],
+          number: params[:number],
+          order_form_number: params[:order_form_number],
+          quote_number: params[:quote_number],
+          owner_id: params[:owner_id],
+          executed_at_from: params[:executed_at_from],
+          executed_at_to: params[:executed_at_to]
+        }
+      end
+
+      def render_order(order)
+        render(
+          json: ::V1::OrderSerializer.new(order, root_name: "order")
+        )
+      end
+
+      def resource_name
+        "order"
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -4,6 +4,8 @@ module Api
   module V1
     class OrdersController < Api::BaseController
       def index
+        return forbidden_error(code: "feature_not_available") unless current_organization.feature_flag_enabled?(:order_forms)
+
         result = OrdersQuery.call(
           organization: current_organization,
           pagination: {
@@ -29,6 +31,8 @@ module Api
       end
 
       def show
+        return forbidden_error(code: "feature_not_available") unless current_organization.feature_flag_enabled?(:order_forms)
+
         order = current_organization.orders.find_by(id: params[:id])
         return not_found_error(resource: "order") unless order
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -5,7 +5,7 @@ class ApiKey < ApplicationRecord
 
   RESOURCES = %w[
     activity_log add_on analytic api_log billable_metric coupon applied_coupon credit_note customer_usage
-    customer event fee invoice organization order_form payment payment_receipt payment_request payment_method plan subscription lifetime_usage
+    customer event fee invoice organization order order_form payment payment_receipt payment_request payment_method plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
     billing_entity alert feature security_log quote
   ].freeze

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -46,6 +46,10 @@ class Order < ApplicationRecord
 
   validates :billing_snapshot, presence: true
 
+  def self.ransackable_attributes(_ = nil)
+    %w[number]
+  end
+
   sequenced(
     scope: ->(order) { order.organization.orders },
     lock_key: ->(order) { order.organization_id }

--- a/app/queries/orders_query.rb
+++ b/app/queries/orders_query.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+class OrdersQuery < BaseQuery
+  Result = BaseResult[:orders]
+  Filters = BaseFilters[
+    :status,
+    :order_type,
+    :execution_mode,
+    :customer_id,
+    :number,
+    :order_form_number,
+    :quote_number,
+    :owner_id,
+    :executed_at_from,
+    :executed_at_to
+  ]
+
+  def call
+    return result unless validate_filters.success?
+
+    orders = base_scope.result
+    orders = with_status(orders) if filters.status.present?
+    orders = with_order_type(orders) if filters.order_type.present?
+    orders = with_execution_mode(orders) if filters.execution_mode.present?
+    orders = with_customer_id(orders) if filters.customer_id.present?
+    orders = with_number(orders) if filters.number.present?
+    orders = with_order_form_number(orders) if filters.order_form_number.present?
+    orders = with_quote_number(orders) if filters.quote_number.present?
+    orders = with_owner_id(orders) if filters.owner_id.present?
+    orders = with_executed_at_range(orders) if executed_at_range?
+    orders = paginate(orders)
+    orders = apply_consistent_ordering(orders)
+
+    result.orders = orders
+    result
+  end
+
+  private
+
+  def filters_contract
+    @filters_contract ||= Queries::OrdersQueryFiltersContract.new
+  end
+
+  def base_scope
+    organization.orders.ransack(search_params)
+  end
+
+  def search_params
+    return if search_term.blank?
+
+    {
+      m: "or",
+      number_cont: search_term
+    }
+  end
+
+  def with_status(scope)
+    scope.where(status: filters.status)
+  end
+
+  def with_order_type(scope)
+    scope.where(order_type: filters.order_type)
+  end
+
+  def with_execution_mode(scope)
+    scope.where(execution_mode: filters.execution_mode)
+  end
+
+  def with_customer_id(scope)
+    scope.where(customer_id: filters.customer_id)
+  end
+
+  def with_number(scope)
+    scope.where(number: filters.number)
+  end
+
+  def with_order_form_number(scope)
+    scope.joins(:order_form).where(order_forms: {number: filters.order_form_number})
+  end
+
+  def with_quote_number(scope)
+    scope.joins(order_form: :quote).where(quotes: {number: filters.quote_number})
+  end
+
+  def with_owner_id(scope)
+    scope.where(
+      order_form_id: OrderForm.where(
+        quote_id: QuoteOwner.where(user_id: filters.owner_id).select(:quote_id)
+      ).select(:id)
+    )
+  end
+
+  def with_executed_at_range(scope)
+    scope = scope.where(executed_at: executed_at_from..) if filters.executed_at_from
+    scope = scope.where(executed_at: ..executed_at_to) if filters.executed_at_to
+    scope
+  end
+
+  def executed_at_range?
+    filters.executed_at_from.present? || filters.executed_at_to.present?
+  end
+
+  def executed_at_from
+    @executed_at_from ||= parse_datetime_filter(:executed_at_from)
+  end
+
+  def executed_at_to
+    @executed_at_to ||= parse_datetime_filter(:executed_at_to)
+  end
+end

--- a/app/serializers/v1/order_serializer.rb
+++ b/app/serializers/v1/order_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module V1
+  class OrderSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        number: model.number,
+        status: model.status,
+        order_type: model.order_type,
+        execution_mode: model.execution_mode,
+        backdated_billing: model.backdated_billing,
+        billing_snapshot: model.billing_snapshot,
+        currency: model.currency,
+        execution_record: model.execution_record,
+        executed_at: model.executed_at&.iso8601,
+        lago_organization_id: model.organization_id,
+        lago_customer_id: model.customer_id,
+        lago_order_form_id: model.order_form_id,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
       end
       resources :payment_requests, only: %i[create index show]
       resources :order_forms, only: %i[show index]
+      resources :orders, only: %i[show index]
       resources :payments, only: %i[create index show]
       resources :plans, param: :code, code: /.*/ do
         resources :charges, only: %i[index show create update destroy], param: :code, code: /.*/, controller: "plans/charges" do

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :order do
+    customer
+    organization { customer&.organization || association(:organization) }
+    order_form { association(:order_form, customer:, organization:) }
+    billing_snapshot { {items: []} }
+    order_type { :subscription_creation }
+    currency { "EUR" }
+    status { :created }
+  end
+end

--- a/spec/queries/orders_query_spec.rb
+++ b/spec/queries/orders_query_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrdersQuery do
+  subject(:result) do
+    described_class.call(organization:, pagination:, filters:, search_term:)
+  end
+
+  let(:returned_ids) { result.orders.pluck(:id) }
+  let(:pagination) { nil }
+  let(:filters) { nil }
+  let(:search_term) { nil }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let(:order_one) { create(:order, organization:, customer:, order_form:) }
+  let(:order_form_two) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, order_type: :one_off) }
+
+  before do
+    order_one
+    order_two
+  end
+
+  it "returns all orders for the organization" do
+    expect(result).to be_success
+    expect(returned_ids).to match_array([order_one.id, order_two.id])
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 1} }
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.orders.count).to eq(1)
+      expect(result.orders.current_page).to eq(2)
+      expect(result.orders.total_pages).to eq(2)
+      expect(result.orders.total_count).to eq(2)
+    end
+  end
+
+  context "when filtering by status" do
+    let(:filters) { {status: "created"} }
+
+    it "returns only orders with the specified status" do
+      expect(result).to be_success
+      expect(returned_ids).to match_array([order_one.id, order_two.id])
+    end
+  end
+
+  context "when filtering by order_type" do
+    let(:filters) { {order_type: "one_off"} }
+
+    it "returns only orders with the specified order type" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_two.id])
+    end
+  end
+
+  context "when filtering by customer_id" do
+    let(:other_customer) { create(:customer, organization:) }
+    let(:other_quote) { create(:quote, organization:, customer: other_customer) }
+    let(:other_order_form) { create(:order_form, :signed, organization:, customer: other_customer, quote: other_quote) }
+    let(:order_two) { create(:order, organization:, customer: other_customer, order_form: other_order_form) }
+    let(:filters) { {customer_id: [customer.id]} }
+
+    it "returns only orders for the specified customer" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_one.id])
+    end
+  end
+
+  context "when filtering by execution_mode" do
+    let(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, execution_mode: :order_only) }
+    let(:filters) { {execution_mode: "order_only"} }
+
+    it "returns only orders with the specified execution mode" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_two.id])
+    end
+  end
+
+  context "when filtering by number" do
+    let(:filters) { {number: [order_one.number]} }
+
+    it "returns only orders with the specified numbers" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_one.id])
+    end
+  end
+
+  context "when filtering by order_form_number" do
+    let(:filters) { {order_form_number: [order_form.number]} }
+
+    it "returns only orders linked to the specified order form" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_one.id])
+    end
+  end
+
+  context "when filtering by quote_number" do
+    let(:other_customer) { create(:customer, organization:) }
+    let(:other_quote) { create(:quote, organization:, customer: other_customer) }
+    let(:other_order_form) { create(:order_form, :signed, organization:, customer: other_customer, quote: other_quote) }
+    let(:order_two) { create(:order, organization:, customer: other_customer, order_form: other_order_form) }
+    let(:filters) { {quote_number: [quote.number]} }
+
+    it "returns only orders linked to the specified quote" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_one.id])
+    end
+  end
+
+  context "when filtering by owner_id" do
+    let(:user) { membership.user }
+    let(:other_customer) { create(:customer, organization:) }
+    let(:other_quote) { create(:quote, organization:, customer: other_customer) }
+    let(:other_order_form) { create(:order_form, :signed, organization:, customer: other_customer, quote: other_quote) }
+    let(:order_two) { create(:order, organization:, customer: other_customer, order_form: other_order_form) }
+    let(:filters) { {owner_id: [user.id]} }
+
+    before { QuoteOwner.create!(organization:, quote:, user:) }
+
+    it "returns only orders whose quote has the specified owner" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_one.id])
+    end
+  end
+
+  context "when filtering by executed_at range" do
+    let(:order_one) { create(:order, organization:, customer:, order_form:, executed_at: 3.days.ago) }
+    let(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, executed_at: 1.day.ago) }
+    let(:filters) { {executed_at_from: 2.days.ago.iso8601, executed_at_to: Time.current.iso8601} }
+
+    it "returns only orders within the date range" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_two.id])
+    end
+  end
+
+  context "with search_term on number" do
+    let(:search_term) { order_one.number }
+
+    it "returns matching orders" do
+      expect(result).to be_success
+      expect(returned_ids).to eq([order_one.id])
+    end
+  end
+
+  context "when no orders exist" do
+    before { Order.delete_all }
+
+    it "returns an empty result set" do
+      expect(result).to be_success
+      expect(returned_ids).to be_empty
+    end
+  end
+end

--- a/spec/requests/api/v1/orders_controller_spec.rb
+++ b/spec/requests/api/v1/orders_controller_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::OrdersController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let(:order) { create(:order, organization:, customer:, order_form:) }
+
+  describe "GET /api/v1/orders" do
+    subject { get_with_token(organization, "/api/v1/orders") }
+
+    let(:order_form_two) { create(:order_form, :signed, organization:, customer:, quote:) }
+    let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, order_type: :one_off) }
+
+    before { create(:order, organization:, customer:, order_form:) }
+
+    include_examples "requires API permission", "order", "read"
+
+    it "returns a list of orders" do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:orders].count).to eq(2)
+    end
+
+    context "when filtering by status" do
+      subject { get_with_token(organization, "/api/v1/orders", {status: "created"}) }
+
+      it "returns only matching orders" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:orders].count).to eq(2)
+      end
+    end
+
+    context "when filtering by order_type" do
+      subject { get_with_token(organization, "/api/v1/orders", {order_type: "one_off"}) }
+
+      it "returns only matching orders" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:orders].count).to eq(1)
+        expect(json[:orders].first[:lago_id]).to eq(order_two.id)
+      end
+    end
+  end
+
+  describe "GET /api/v1/orders/:id" do
+    subject { get_with_token(organization, "/api/v1/orders/#{order.id}") }
+
+    before { order }
+
+    include_examples "requires API permission", "order", "read"
+
+    it "returns the order" do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:order][:lago_id]).to eq(order.id)
+      expect(json[:order][:number]).to eq(order.number)
+      expect(json[:order][:status]).to eq("created")
+      expect(json[:order]).to have_key(:execution_record)
+    end
+
+    context "when order does not exist" do
+      subject { get_with_token(organization, "/api/v1/orders/#{SecureRandom.uuid}") }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("order")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/orders_controller_spec.rb
+++ b/spec/requests/api/v1/orders_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::OrdersController do
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
   let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
@@ -48,6 +48,17 @@ RSpec.describe Api::V1::OrdersController do
         expect(json[:orders].first[:lago_id]).to eq(order_two.id)
       end
     end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_not_available")
+      end
+    end
   end
 
   describe "GET /api/v1/orders/:id" do
@@ -74,6 +85,17 @@ RSpec.describe Api::V1::OrdersController do
         subject
 
         expect(response).to be_not_found_error("order")
+      end
+    end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_not_available")
       end
     end
   end

--- a/spec/serializers/v1/order_serializer_spec.rb
+++ b/spec/serializers/v1/order_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::OrderSerializer do
+  subject(:serializer) { described_class.new(order, root_name: "order") }
+
+  let(:order) { create(:order) }
+
+  it "serializes the object" do
+    result = JSON.parse(serializer.to_json)
+
+    expect(result["order"]).to include(
+      "lago_id" => order.id,
+      "number" => order.number,
+      "status" => "created",
+      "order_type" => "subscription_creation",
+      "execution_mode" => nil,
+      "backdated_billing" => nil,
+      "billing_snapshot" => order.billing_snapshot,
+      "currency" => "EUR",
+      "execution_record" => nil,
+      "executed_at" => nil,
+      "lago_organization_id" => order.organization_id,
+      "lago_customer_id" => order.customer_id,
+      "lago_order_form_id" => order.order_form_id,
+      "created_at" => order.created_at.iso8601,
+      "updated_at" => order.updated_at.iso8601
+    )
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 Order Forms lifecycle

## Context

This is PR 3 of 4 in a stacked split. Stacked on the OrderForm GraphQL PR so all OrderForm code (REST + GraphQL + shared) is available.

Stack:
- OrderForm REST (#5360)
- OrderForm GraphQL (#5361)
- **#this** — Order REST
- Order GraphQL (stacked)

## Description

Add Order read-only REST API plus the shared infrastructure for Order:

- `OrdersController` with inlined `index` and `show` actions
- `V1::OrderSerializer` for REST API serialization
- `OrdersQuery` with filters: status, order_type, execution_mode, customer_id, number, order_form_number, quote_number, owner_id, executed_at range
- `Queries::OrdersQueryFiltersContract` for filter validation
- `Order` factory
- Route `resources :orders, only: %i[show index]`
- `ApiKey::RESOURCES` updated with `order`
- Full specs for serializer, query, controller