### PR TITLE
feat(orders): add Order GraphQL API

### DIFF
--- a/app/graphql/resolvers/order_resolver.rb
+++ b/app/graphql/resolvers/order_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class OrderResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "orders:view"
+
+    description "Query a single order"
+
+    argument :id, ID, required: true, description: "Uniq ID of the order"
+
+    type Types::Orders::Object, null: true
+
+    def resolve(id:)
+      current_organization.orders.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: "order")
+    end
+  end
+end

--- a/app/graphql/resolvers/orders_resolver.rb
+++ b/app/graphql/resolvers/orders_resolver.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class OrdersResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "orders:view"
+
+    description "Query orders"
+
+    argument :customer_id, [ID], required: false
+    argument :executed_at_from, GraphQL::Types::ISO8601DateTime, required: false
+    argument :executed_at_to, GraphQL::Types::ISO8601DateTime, required: false
+    argument :execution_mode, [Types::Orders::ExecutionModeEnum], required: false
+    argument :limit, Integer, required: false
+    argument :number, [String], required: false
+    argument :order_form_number, [String], required: false
+    argument :order_type, [Types::Orders::OrderTypeEnum], required: false
+    argument :owner_id, [ID], required: false
+    argument :page, Integer, required: false
+    argument :quote_number, [String], required: false
+    argument :search_term, String, required: false
+    argument :status, [Types::Orders::StatusEnum], required: false
+
+    type Types::Orders::Object.collection_type, null: false
+
+    def resolve( # rubocop:disable Metrics/ParameterLists
+      customer_id: nil,
+      executed_at_from: nil,
+      executed_at_to: nil,
+      execution_mode: nil,
+      limit: nil,
+      number: nil,
+      order_form_number: nil,
+      order_type: nil,
+      owner_id: nil,
+      page: nil,
+      quote_number: nil,
+      search_term: nil,
+      status: nil
+    )
+      result = OrdersQuery.call(
+        organization: current_organization,
+        pagination: {page:, limit:},
+        filters: {
+          status:,
+          order_type:,
+          execution_mode:,
+          customer_id:,
+          number:,
+          order_form_number:,
+          quote_number:,
+          owner_id:,
+          executed_at_from:,
+          executed_at_to:
+        },
+        search_term:
+      )
+
+      result.orders
+    end
+  end
+end

--- a/app/graphql/types/orders/backdated_billing_enum.rb
+++ b/app/graphql/types/orders/backdated_billing_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class BackdatedBillingEnum < Types::BaseEnum
+      graphql_name "OrderBackdatedBillingEnum"
+
+      Order::BACKDATED_BILLING_OPTIONS.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/orders/execution_mode_enum.rb
+++ b/app/graphql/types/orders/execution_mode_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class ExecutionModeEnum < Types::BaseEnum
+      graphql_name "OrderExecutionModeEnum"
+
+      Order::EXECUTION_MODES.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class Object < Types::BaseObject
+      graphql_name "Order"
+
+      field :backdated_billing, Types::Orders::BackdatedBillingEnum, null: true
+      field :execution_mode, Types::Orders::ExecutionModeEnum, null: true
+      field :id, ID, null: false
+      field :number, String, null: false
+      field :order_type, Types::Orders::OrderTypeEnum, null: false
+      field :status, Types::Orders::StatusEnum, null: false
+
+      field :billing_snapshot, GraphQL::Types::JSON, null: false
+      field :currency, String, null: true
+      field :executed_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :execution_record, GraphQL::Types::JSON, null: true
+
+      field :customer, Types::Customers::Object, null: false
+      field :order_form, Types::OrderForms::Object, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/app/graphql/types/orders/order_type_enum.rb
+++ b/app/graphql/types/orders/order_type_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class OrderTypeEnum < Types::BaseEnum
+      Order::ORDER_TYPES.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/orders/status_enum.rb
+++ b/app/graphql/types/orders/status_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class StatusEnum < Types::BaseEnum
+      graphql_name "OrderStatusEnum"
+
+      Order::STATUSES.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -74,8 +74,10 @@ module Types
     field :invoices, resolver: Resolvers::InvoicesResolver
     field :memberships, resolver: Resolvers::MembershipsResolver
     field :mrrs, resolver: Resolvers::Analytics::MrrsResolver
+    field :order, resolver: Resolvers::OrderResolver
     field :order_form, resolver: Resolvers::OrderFormResolver
     field :order_forms, resolver: Resolvers::OrderFormsResolver
+    field :orders, resolver: Resolvers::OrdersResolver
     field :organization, resolver: Resolvers::OrganizationResolver
     field :overdue_balances, resolver: Resolvers::Analytics::OverdueBalancesResolver
     field :password_reset, resolver: Resolvers::PasswordResetResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -8882,9 +8882,51 @@ enum OnTerminationInvoiceEnum {
   skip
 }
 
+type Order {
+  backdatedBilling: OrderBackdatedBillingEnum
+  billingSnapshot: JSON!
+  createdAt: ISO8601DateTime!
+  currency: String
+  customer: Customer!
+  executedAt: ISO8601DateTime
+  executionMode: OrderExecutionModeEnum
+  executionRecord: JSON
+  id: ID!
+  number: String!
+  orderForm: OrderForm!
+  orderType: OrderTypeEnum!
+  status: OrderStatusEnum!
+  updatedAt: ISO8601DateTime!
+}
+
+enum OrderBackdatedBillingEnum {
+  generate_past_invoices
+  start_without_invoices
+}
+
 enum OrderByEnum {
   gross_revenue_amount_cents
   net_revenue_amount_cents
+}
+
+"""
+OrderCollection type
+"""
+type OrderCollection {
+  """
+  A collection of paginated OrderCollection
+  """
+  collection: [Order!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+enum OrderExecutionModeEnum {
+  execute_in_lago
+  order_only
 }
 
 type OrderForm {
@@ -8928,6 +8970,17 @@ enum OrderFormVoidReasonEnum {
   expired
   invalid
   manual
+}
+
+enum OrderStatusEnum {
+  created
+  executed
+}
+
+enum OrderTypeEnum {
+  one_off
+  subscription_amendment
+  subscription_creation
 }
 
 """
@@ -10287,6 +10340,16 @@ type Query {
   mrrs(billingEntityId: ID, currency: CurrencyEnum): MrrCollection!
 
   """
+  Query a single order
+  """
+  order(
+    """
+    Uniq ID of the order
+    """
+    id: ID!
+  ): Order
+
+  """
   Query a single order form
   """
   orderForm(
@@ -10300,6 +10363,11 @@ type Query {
   Query order forms
   """
   orderForms(createdAtFrom: ISO8601DateTime, createdAtTo: ISO8601DateTime, customerId: [ID!], expiresAtFrom: ISO8601DateTime, expiresAtTo: ISO8601DateTime, limit: Int, number: [String!], ownerId: [ID!], page: Int, quoteNumber: [String!], searchTerm: String, status: [OrderFormStatusEnum!]): OrderFormCollection!
+
+  """
+  Query orders
+  """
+  orders(customerId: [ID!], executedAtFrom: ISO8601DateTime, executedAtTo: ISO8601DateTime, executionMode: [OrderExecutionModeEnum!], limit: Int, number: [String!], orderFormNumber: [String!], orderType: [OrderTypeEnum!], ownerId: [ID!], page: Int, quoteNumber: [String!], searchTerm: String, status: [OrderStatusEnum!]): OrderCollection!
 
   """
   Query the current organization

--- a/schema.json
+++ b/schema.json
@@ -42520,6 +42520,244 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Order",
+          "description": null,
+          "fields": [
+            {
+              "name": "backdatedBilling",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderBackdatedBillingEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingSnapshot",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Customer",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executionMode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderExecutionModeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executionRecord",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "number",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderForm",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderForm",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrderTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrderStatusEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderBackdatedBillingEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "generate_past_invoices",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "start_without_invoices",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "OrderByEnum",
           "description": null,
@@ -42535,6 +42773,80 @@
             },
             {
               "name": "net_revenue_amount_cents",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OrderCollection",
+          "description": "OrderCollection type",
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated OrderCollection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Order",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderExecutionModeEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "execute_in_lago",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_only",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -42833,6 +43145,58 @@
             },
             {
               "name": "invalid",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderStatusEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderTypeEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "subscription_creation",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscription_amendment",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "one_off",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -55220,6 +55584,35 @@
               "deprecationReason": null
             },
             {
+              "name": "order",
+              "description": "Query a single order",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the order",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "orderForm",
               "description": "Query a single order form",
               "args": [
@@ -55443,6 +55836,243 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "OrderFormCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders",
+              "description": "Query orders",
+              "args": [
+                {
+                  "name": "customerId",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "executedAtFrom",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "executedAtTo",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "executionMode",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "OrderExecutionModeEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "number",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderFormNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderType",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "OrderTypeEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "ownerId",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "quoteNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "OrderStatusEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderCollection",
                   "ofType": null
                 }
               },

--- a/spec/graphql/resolvers/order_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_resolver_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::OrderResolver do
+  let(:required_permission) { "orders:view" }
+
+  let(:query) do
+    <<~GQL
+      query($id: ID!) {
+        order(id: $id) {
+          id
+          number
+          status
+          orderType
+          executionRecord
+          createdAt
+          updatedAt
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let(:order) { create(:order, organization:, customer:, order_form:) }
+
+  before { order }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "orders:view"
+
+  it "returns a single order" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables: {id: order.id}
+    )
+
+    data = result["data"]["order"]
+
+    expect(data["id"]).to eq(order.id)
+    expect(data["number"]).to eq(order.number)
+    expect(data["status"]).to eq("created")
+    expect(data["orderType"]).to eq("subscription_creation")
+  end
+
+  context "when order is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {id: SecureRandom.uuid}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/resolvers/orders_resolver_spec.rb
+++ b/spec/graphql/resolvers/orders_resolver_spec.rb
@@ -1,0 +1,324 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::OrdersResolver do
+  let(:required_permission) { "orders:view" }
+  let(:query) {}
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let(:order_form_two) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, order_type: :one_off) }
+
+  before { create(:order, organization:, customer:, order_form:) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "orders:view"
+
+  context "when listing all orders" do
+    let(:query) do
+      <<~GQL
+        query {
+          orders(limit: 5) {
+            collection {
+              id
+              number
+              status
+              orderType
+            }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns a list of orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by order type" do
+    let(:query) do
+      <<~GQL
+        query($orderType: [OrderTypeEnum!]) {
+          orders(orderType: $orderType, limit: 5) {
+            collection { id orderType }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {orderType: ["one_off"]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+
+  context "when filtering by status" do
+    let(:query) do
+      <<~GQL
+        query($status: [OrderStatusEnum!]) {
+          orders(status: $status, limit: 5) {
+            collection { id status }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {status: ["created"]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by execution_mode" do
+    let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, execution_mode: :order_only) }
+
+    let(:query) do
+      <<~GQL
+        query($executionMode: [OrderExecutionModeEnum!]) {
+          orders(executionMode: $executionMode, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {executionMode: ["order_only"]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+
+  context "when filtering by number" do
+    let(:query) do
+      <<~GQL
+        query($number: [String!]) {
+          orders(number: $number, limit: 5) {
+            collection { id number }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {number: [order_two.number]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+
+  context "when filtering by customer_id" do
+    let(:other_customer) { create(:customer, organization:) }
+    let(:other_quote) { create(:quote, organization:, customer: other_customer) }
+    let(:other_order_form) { create(:order_form, :signed, organization:, customer: other_customer, quote: other_quote) }
+
+    let(:query) do
+      <<~GQL
+        query($customerId: [ID!]) {
+          orders(customerId: $customerId, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before { create(:order, organization:, customer: other_customer, order_form: other_order_form) }
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customerId: [customer.id]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by order_form_number" do
+    let(:query) do
+      <<~GQL
+        query($orderFormNumber: [String!]) {
+          orders(orderFormNumber: $orderFormNumber, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {orderFormNumber: [order_form_two.number]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+
+  context "when filtering by quote_number" do
+    let(:other_customer) { create(:customer, organization:) }
+    let(:other_quote) { create(:quote, organization:, customer: other_customer) }
+    let(:other_order_form) { create(:order_form, :signed, organization:, customer: other_customer, quote: other_quote) }
+
+    let(:query) do
+      <<~GQL
+        query($quoteNumber: [String!]) {
+          orders(quoteNumber: $quoteNumber, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before { create(:order, organization:, customer: other_customer, order_form: other_order_form) }
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {quoteNumber: [quote.number]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by owner_id" do
+    let(:query) do
+      <<~GQL
+        query($ownerId: [ID!]) {
+          orders(ownerId: $ownerId, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before { QuoteOwner.create!(organization:, quote:, user: membership.user) }
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {ownerId: [membership.user.id]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by executed_at range" do
+    let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, executed_at: 1.day.ago) }
+
+    let(:query) do
+      <<~GQL
+        query($executedAtFrom: ISO8601DateTime, $executedAtTo: ISO8601DateTime) {
+          orders(executedAtFrom: $executedAtFrom, executedAtTo: $executedAtTo, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only orders within the date range" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {executedAtFrom: 2.days.ago.iso8601, executedAtTo: 1.day.from_now.iso8601}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 Order Forms lifecycle

## Context

This is PR 4 of 4 in a stacked split. Stacked on the Order REST PR so the shared model, query, and factories are available.

Stack:
- OrderForm REST (#5360)
- OrderForm GraphQL (#5361)
- Order REST (#5720)
- **#this** — Order GraphQL (merges last)

## Description

Add Order read-only GraphQL API:

- `Types::Orders::Object` with customer, order_form, status/type/execution fields
- `Types::Orders::StatusEnum`, `OrderTypeEnum`, `ExecutionModeEnum`, `BackdatedBillingEnum`
- `Resolvers::OrderResolver` (single) and `Resolvers::OrdersResolver` (collection with filters)
- Register `order` and `orders` on `QueryType`
- Regenerated `schema.graphql` and `schema.json`
- Resolver specs covering single lookup and each filter