### PR TITLE
[Quotes & Order Forms] Quote billing item sub-resource services, mutations and API

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -25,3 +25,7 @@ multi_currency:
 payment_gated_subscriptions:
   description: "Enable payment-gated subscription activation rules"
   owners: ["@osmarluz", "@ancorcruz"]
+
+order_forms:
+  description: "Enable quotes, order forms and orders"
+  owners: ["@murparreira", "@toommz", "@rinasergeeva"]

--- a/app/controllers/api/v1/quotes/billing_items/add_ons_controller.rb
+++ b/app/controllers/api/v1/quotes/billing_items/add_ons_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Quotes
+      module BillingItems
+        class AddOnsController < Api::BaseController
+          def create
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::AddOns::AddService.call(quote:, params: create_params.to_h)
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          def update
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::AddOns::UpdateService.call(quote:, id: params[:id], params: update_params.to_h)
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          def destroy
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::AddOns::RemoveService.call(quote:, id: params[:id])
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          private
+
+          def create_params
+            extract_add_on_params(params.require(:add_on))
+          end
+
+          def update_params
+            extract_add_on_params(params.require(:add_on))
+          end
+
+          def extract_add_on_params(add_on_params)
+            permitted = add_on_params.permit(
+              :add_on_id,
+              :name,
+              :description,
+              :units,
+              :amount_cents,
+              :invoice_display_name,
+              :service_from_date,
+              :service_to_date,
+              :position
+            )
+            permitted[:add_on_overrides] = add_on_params[:add_on_overrides]&.to_unsafe_h
+            permitted
+          end
+
+          def render_quote(quote)
+            render(json: ::V1::QuoteSerializer.new(quote, root_name: "quote").serialize)
+          end
+
+          def resource_name
+            "quote"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/quotes/billing_items/coupons_controller.rb
+++ b/app/controllers/api/v1/quotes/billing_items/coupons_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Quotes
+      module BillingItems
+        class CouponsController < Api::BaseController
+          def create
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::Coupons::AddService.call(quote:, params: create_params.to_h)
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          def update
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::Coupons::UpdateService.call(quote:, id: params[:id], params: update_params.to_h)
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          def destroy
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::Coupons::RemoveService.call(quote:, id: params[:id])
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          private
+
+          def create_params
+            params.require(:coupon).permit(
+              :coupon_id,
+              :coupon_type,
+              :amount_cents,
+              :percentage_rate,
+              :currency,
+              :frequency,
+              :frequency_duration,
+              :expiration_at,
+              :position
+            )
+          end
+
+          def update_params
+            params.require(:coupon).permit(
+              :coupon_id,
+              :coupon_type,
+              :amount_cents,
+              :percentage_rate,
+              :currency,
+              :frequency,
+              :frequency_duration,
+              :expiration_at,
+              :position
+            )
+          end
+
+          def render_quote(quote)
+            render(json: ::V1::QuoteSerializer.new(quote, root_name: "quote").serialize)
+          end
+
+          def resource_name
+            "quote"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/quotes/billing_items/plans_controller.rb
+++ b/app/controllers/api/v1/quotes/billing_items/plans_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Quotes
+      module BillingItems
+        class PlansController < Api::BaseController
+          def create
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::Plans::AddService.call(quote:, params: create_params.to_h)
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          def update
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::Plans::UpdateService.call(quote:, id: params[:id], params: update_params.to_h)
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          def destroy
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::Plans::RemoveService.call(quote:, id: params[:id])
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          private
+
+          def create_params
+            extract_plan_params(params.require(:plan))
+          end
+
+          def update_params
+            extract_plan_params(params.require(:plan))
+          end
+
+          def extract_plan_params(plan_params)
+            permitted = plan_params.permit(
+              :plan_id,
+              :plan_name,
+              :plan_code,
+              :plan_description,
+              :position,
+              :subscription_external_id
+            )
+            permitted[:plan_overrides] = plan_params[:plan_overrides]&.to_unsafe_h
+            permitted[:entitlements_overrides] = plan_params[:entitlements_overrides]&.to_unsafe_h
+            permitted
+          end
+
+          def render_quote(quote)
+            render(json: ::V1::QuoteSerializer.new(quote, root_name: "quote").serialize)
+          end
+
+          def resource_name
+            "quote"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/quotes/billing_items/wallet_credits_controller.rb
+++ b/app/controllers/api/v1/quotes/billing_items/wallet_credits_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Quotes
+      module BillingItems
+        class WalletCreditsController < Api::BaseController
+          def create
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::WalletCredits::AddService.call(quote:, params: create_params.to_h)
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          def update
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::WalletCredits::UpdateService.call(quote:, id: params[:id], params: update_params.to_h)
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          def destroy
+            quote = current_organization.quotes.find_by(id: params[:quote_id])
+            result = ::Quotes::BillingItems::WalletCredits::RemoveService.call(quote:, id: params[:id])
+            result.success? ? render_quote(result.quote) : render_error_response(result)
+          end
+
+          private
+
+          def create_params
+            params.require(:wallet_credit).permit(
+              :name,
+              :currency,
+              :rate_amount,
+              :paid_credits,
+              :granted_credits,
+              :expiration_at,
+              :priority,
+              :position,
+              recurring_transaction_rules: [{}]
+            )
+          end
+
+          def update_params
+            params.require(:wallet_credit).permit(
+              :name,
+              :currency,
+              :rate_amount,
+              :paid_credits,
+              :granted_credits,
+              :expiration_at,
+              :priority,
+              :position,
+              recurring_transaction_rules: [{}]
+            )
+          end
+
+          def render_quote(quote)
+            render(json: ::V1::QuoteSerializer.new(quote, root_name: "quote").serialize)
+          end
+
+          def resource_name
+            "quote"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/add_ons/add.rb
+++ b/app/graphql/mutations/quotes/billing_items/add_ons/add.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module AddOns
+        class Add < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "AddQuoteAddOn"
+          description "Adds an add-on billing item to a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :name, String, required: true
+          argument :add_on_id, ID, required: false
+          argument :description, String, required: false
+          argument :units, Integer, required: false
+          argument :amount_cents, GraphQL::Types::BigInt, required: false
+          argument :invoice_display_name, String, required: false
+          argument :service_from_date, String, required: false
+          argument :service_to_date, String, required: false
+          argument :add_on_overrides, GraphQL::Types::JSON, required: false
+          argument :position, Integer, required: false
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, **args)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::AddOns::AddService.call(quote:, params: args)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/add_ons/remove.rb
+++ b/app/graphql/mutations/quotes/billing_items/add_ons/remove.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module AddOns
+        class Remove < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "RemoveQuoteAddOn"
+          description "Removes an add-on billing item from a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :id, ID, required: true
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, id:)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::AddOns::RemoveService.call(quote:, id:)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/add_ons/update.rb
+++ b/app/graphql/mutations/quotes/billing_items/add_ons/update.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module AddOns
+        class Update < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "UpdateQuoteAddOn"
+          description "Updates an add-on billing item on a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :id, ID, required: true
+          argument :name, String, required: false
+          argument :add_on_id, ID, required: false
+          argument :description, String, required: false
+          argument :units, Integer, required: false
+          argument :amount_cents, GraphQL::Types::BigInt, required: false
+          argument :invoice_display_name, String, required: false
+          argument :service_from_date, String, required: false
+          argument :service_to_date, String, required: false
+          argument :add_on_overrides, GraphQL::Types::JSON, required: false
+          argument :position, Integer, required: false
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, id:, **args)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::AddOns::UpdateService.call(quote:, id:, params: args)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/coupons/add.rb
+++ b/app/graphql/mutations/quotes/billing_items/coupons/add.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Coupons
+        class Add < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "AddQuoteCoupon"
+          description "Adds a coupon billing item to a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :coupon_id, ID, required: true
+          argument :coupon_type, String, required: true
+          argument :amount_cents, GraphQL::Types::BigInt, required: false
+          argument :percentage_rate, Float, required: false
+          argument :currency, String, required: false
+          argument :frequency, String, required: false
+          argument :frequency_duration, Integer, required: false
+          argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
+          argument :position, Integer, required: false
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, **args)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::Coupons::AddService.call(quote:, params: args)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/coupons/remove.rb
+++ b/app/graphql/mutations/quotes/billing_items/coupons/remove.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Coupons
+        class Remove < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "RemoveQuoteCoupon"
+          description "Removes a coupon billing item from a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :id, ID, required: true
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, id:)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::Coupons::RemoveService.call(quote:, id:)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/coupons/update.rb
+++ b/app/graphql/mutations/quotes/billing_items/coupons/update.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Coupons
+        class Update < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "UpdateQuoteCoupon"
+          description "Updates a coupon billing item on a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :id, ID, required: true
+          argument :coupon_id, ID, required: false
+          argument :coupon_type, String, required: false
+          argument :amount_cents, GraphQL::Types::BigInt, required: false
+          argument :percentage_rate, Float, required: false
+          argument :currency, String, required: false
+          argument :frequency, String, required: false
+          argument :frequency_duration, Integer, required: false
+          argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
+          argument :position, Integer, required: false
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, id:, **args)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::Coupons::UpdateService.call(quote:, id:, params: args)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/plans/add.rb
+++ b/app/graphql/mutations/quotes/billing_items/plans/add.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Plans
+        class Add < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "AddQuotePlan"
+          description "Adds a plan billing item to a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :plan_id, ID, required: true
+          argument :plan_name, String, required: false
+          argument :plan_code, String, required: false
+          argument :plan_description, String, required: false
+          argument :position, Integer, required: false
+          argument :subscription_external_id, String, required: false
+          argument :plan_overrides, GraphQL::Types::JSON, required: false
+          argument :entitlements_overrides, GraphQL::Types::JSON, required: false
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, **args)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::Plans::AddService.call(quote:, params: args)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/plans/remove.rb
+++ b/app/graphql/mutations/quotes/billing_items/plans/remove.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Plans
+        class Remove < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "RemoveQuotePlan"
+          description "Removes a plan billing item from a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :id, ID, required: true
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, id:)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::Plans::RemoveService.call(quote:, id:)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/plans/update.rb
+++ b/app/graphql/mutations/quotes/billing_items/plans/update.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Plans
+        class Update < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "UpdateQuotePlan"
+          description "Updates a plan billing item on a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :id, ID, required: true
+          argument :plan_id, ID, required: false
+          argument :plan_name, String, required: false
+          argument :plan_code, String, required: false
+          argument :plan_description, String, required: false
+          argument :position, Integer, required: false
+          argument :subscription_external_id, String, required: false
+          argument :plan_overrides, GraphQL::Types::JSON, required: false
+          argument :entitlements_overrides, GraphQL::Types::JSON, required: false
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, id:, **args)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::Plans::UpdateService.call(quote:, id:, params: args)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/wallet_credits/add.rb
+++ b/app/graphql/mutations/quotes/billing_items/wallet_credits/add.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module WalletCredits
+        class Add < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "AddQuoteWalletCredit"
+          description "Adds a wallet credit billing item to a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :name, String, required: false
+          argument :currency, String, required: false
+          argument :rate_amount, String, required: false
+          argument :paid_credits, String, required: false
+          argument :granted_credits, String, required: false
+          argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
+          argument :priority, Integer, required: false
+          argument :recurring_transaction_rules, GraphQL::Types::JSON, required: false
+          argument :position, Integer, required: false
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, **args)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::WalletCredits::AddService.call(quote:, params: args)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/wallet_credits/remove.rb
+++ b/app/graphql/mutations/quotes/billing_items/wallet_credits/remove.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module WalletCredits
+        class Remove < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "RemoveQuoteWalletCredit"
+          description "Removes a wallet credit billing item from a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :id, ID, required: true
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, id:)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::WalletCredits::RemoveService.call(quote:, id:)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/wallet_credits/update.rb
+++ b/app/graphql/mutations/quotes/billing_items/wallet_credits/update.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module WalletCredits
+        class Update < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+          graphql_name "UpdateQuoteWalletCredit"
+          description "Updates a wallet credit billing item on a draft quote"
+
+          argument :quote_id, ID, required: true
+          argument :id, ID, required: true
+          argument :name, String, required: false
+          argument :currency, String, required: false
+          argument :rate_amount, String, required: false
+          argument :paid_credits, String, required: false
+          argument :granted_credits, String, required: false
+          argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
+          argument :priority, Integer, required: false
+          argument :recurring_transaction_rules, GraphQL::Types::JSON, required: false
+          argument :position, Integer, required: false
+
+          type Types::Quotes::Object
+
+          def resolve(quote_id:, id:, **args)
+            quote = current_organization.quotes.find_by(id: quote_id)
+            result = ::Quotes::BillingItems::WalletCredits::UpdateService.call(quote:, id:, params: args)
+            result.success? ? result.quote : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -238,5 +238,21 @@ module Types
     field :remove_subscription_entitlement, mutation: Mutations::Entitlement::RemoveSubscriptionEntitlement
 
     field :create_ai_conversation, mutation: Mutations::AiConversations::Create
+
+    field :add_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Add
+    field :update_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Update
+    field :remove_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Remove
+
+    field :add_quote_add_on, mutation: Mutations::Quotes::BillingItems::AddOns::Add
+    field :update_quote_add_on, mutation: Mutations::Quotes::BillingItems::AddOns::Update
+    field :remove_quote_add_on, mutation: Mutations::Quotes::BillingItems::AddOns::Remove
+
+    field :add_quote_coupon, mutation: Mutations::Quotes::BillingItems::Coupons::Add
+    field :update_quote_coupon, mutation: Mutations::Quotes::BillingItems::Coupons::Update
+    field :remove_quote_coupon, mutation: Mutations::Quotes::BillingItems::Coupons::Remove
+
+    field :add_quote_wallet_credit, mutation: Mutations::Quotes::BillingItems::WalletCredits::Add
+    field :update_quote_wallet_credit, mutation: Mutations::Quotes::BillingItems::WalletCredits::Update
+    field :remove_quote_wallet_credit, mutation: Mutations::Quotes::BillingItems::WalletCredits::Remove
   end
 end

--- a/app/graphql/types/quotes/object.rb
+++ b/app/graphql/types/quotes/object.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Types
+  module Quotes
+    class Object < Types::BaseObject
+      graphql_name "Quote"
+
+      field :id, ID, null: false
+      field :status, String, null: false
+      field :order_type, String, null: false
+      field :number, String, null: false
+      field :version, Integer, null: false
+      field :currency, String, null: true
+      field :description, String, null: true
+      field :content, String, null: true
+      field :legal_text, String, null: true
+      field :internal_notes, String, null: true
+      field :auto_execute, Boolean, null: false
+      field :billing_items, GraphQL::Types::JSON, null: true
+      field :commercial_terms, GraphQL::Types::JSON, null: true
+      field :contacts, GraphQL::Types::JSON, null: true
+      field :metadata, GraphQL::Types::JSON, null: true
+      field :approved_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -7,7 +7,7 @@ class ApiKey < ApplicationRecord
     activity_log add_on analytic api_log billable_metric coupon applied_coupon credit_note customer_usage
     customer event fee invoice organization payment payment_receipt payment_request payment_method plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
-    billing_entity alert feature security_log
+    billing_entity alert feature security_log quote
   ].freeze
 
   MODES = %w[read write].freeze

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -63,6 +63,9 @@ class Customer < ApplicationRecord
   has_many :applied_add_ons
   has_many :add_ons, through: :applied_add_ons
   has_many :daily_usages
+  has_many :quotes
+  has_many :order_forms
+  has_many :orders
   has_many :wallets
   has_many :wallet_transactions, through: :wallets
   has_many :payment_provider_customers,

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+class Order < ApplicationRecord
+  include Sequenced
+
+  STATUSES = {
+    created: "created",
+    executed: "executed"
+  }.freeze
+
+  BACKDATED_BILLING_OPTIONS = {
+    generate_past_invoices: 0,
+    start_without_invoices: 1
+  }.freeze
+
+  ORDER_TYPES = {
+    subscription_creation: 0,
+    subscription_amendment: 1,
+    one_off: 2
+  }.freeze
+
+  EXECUTION_MODES = {
+    execute_in_lago: 0,
+    order_only: 1
+  }.freeze
+
+  before_save :ensure_number
+
+  belongs_to :organization
+  belongs_to :customer
+  belongs_to :order_form
+  has_one :quote, through: :order_form
+
+  enum :status, STATUSES,
+    default: :created,
+    validate: true
+  enum :order_type, ORDER_TYPES,
+    instance_methods: false,
+    validate: true
+  enum :execution_mode, EXECUTION_MODES,
+    instance_methods: false,
+    validate: {allow_nil: true}
+  enum :backdated_billing, BACKDATED_BILLING_OPTIONS,
+    instance_methods: false,
+    validate: {allow_nil: true}
+
+  validates :billing_snapshot, presence: true
+
+  sequenced(
+    scope: ->(order) { order.organization.orders },
+    lock_key: ->(order) { order.organization_id }
+  )
+
+  private
+
+  def ensure_number
+    return if number.present?
+    return if sequential_id.blank?
+
+    time = created_at || Time.current
+    formatted_sequential_id = format("%04d", sequential_id)
+    self.number = "ORD-#{time.strftime("%Y")}-#{formatted_sequential_id}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: orders
+# Database name: primary
+#
+#  id                            :uuid             not null, primary key
+#  backdated_billing(Rails enum) :integer
+#  billing_snapshot              :jsonb            not null
+#  currency                      :string
+#  executed_at                   :datetime
+#  execution_mode(Rails enum)    :integer
+#  execution_record              :json
+#  number                        :string           not null
+#  order_type(Rails enum)        :integer          not null
+#  status                        :enum             default("created"), not null
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  customer_id                   :uuid             not null
+#  order_form_id                 :uuid             not null
+#  organization_id               :uuid             not null
+#  sequential_id                 :integer          not null
+#
+# Indexes
+#
+#  index_orders_on_customer_id                       (customer_id)
+#  index_orders_on_order_form_id                     (order_form_id)
+#  index_unique_orders_on_organization_number        (organization_id,number) UNIQUE
+#  index_unique_orders_on_organization_sequentialid  (organization_id,sequential_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (order_form_id => order_forms.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class OrderForm < ApplicationRecord
+  include Sequenced
+
+  STATUSES = {
+    generated: "generated",
+    signed: "signed",
+    expired: "expired",
+    voided: "voided"
+  }.freeze
+
+  VOID_REASONS = {
+    manual: 0,
+    expired: 1,
+    invalid: 2
+  }.freeze
+
+  before_save :ensure_number
+
+  belongs_to :organization
+  belongs_to :customer
+  belongs_to :quote
+  has_one :order
+
+  enum :status, STATUSES,
+    default: :generated,
+    validate: true
+  enum :void_reason, VOID_REASONS,
+    instance_methods: false,
+    validate: {allow_nil: true}
+
+  validates :billing_snapshot, presence: true
+
+  sequenced(
+    scope: ->(order_form) { order_form.organization.order_forms },
+    lock_key: ->(order_form) { order_form.organization_id }
+  )
+
+  private
+
+  def ensure_number
+    return if number.present?
+    return if sequential_id.blank?
+
+    time = created_at || Time.current
+    formatted_sequential_id = format("%04d", sequential_id)
+    self.number = "OF-#{time.strftime("%Y")}-#{formatted_sequential_id}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: order_forms
+# Database name: primary
+#
+#  id                          :uuid             not null, primary key
+#  billing_snapshot            :jsonb            not null
+#  content                     :text
+#  contract_uploaded_at        :datetime
+#  contract_uploaded_by_user   :uuid
+#  expires_at                  :datetime
+#  legal_text                  :text
+#  number                      :string           not null
+#  signed_at                   :datetime
+#  status                      :enum             default("generated"), not null
+#  void_reason(Rails enum)     :integer
+#  voided_at                   :datetime
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  customer_id                 :uuid             not null
+#  organization_id             :uuid             not null
+#  quote_id                    :uuid             not null
+#  sequential_id               :integer          not null
+#  signed_by_user_id           :uuid
+#
+# Indexes
+#
+#  index_order_forms_on_customer_id                       (customer_id)
+#  index_order_forms_on_quote_id                          (quote_id)
+#  index_unique_order_forms_on_organization_number        (organization_id,number) UNIQUE
+#  index_unique_order_forms_on_organization_sequentialid  (organization_id,sequential_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (quote_id => quotes.id)
+#  fk_rails_...  (signed_by_user_id => users.id)
+#

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -74,6 +74,9 @@ class Organization < ApplicationRecord
   has_many :error_details
   has_many :dunning_campaigns
   has_many :roles
+  has_many :quotes
+  has_many :order_forms
+  has_many :orders
   has_many :activity_logs, class_name: "Clickhouse::ActivityLog"
   has_many :features, class_name: "Entitlement::Feature"
   has_many :privileges, class_name: "Entitlement::Privilege"
@@ -143,6 +146,7 @@ class Organization < ApplicationRecord
     events_targeting_wallets
     security_logs
     granular_lifetime_usage
+    order_forms
   ].freeze
 
   SECURITY_LOGS_RETENTION_DAYS = 90

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class Quote < ApplicationRecord
+  include Sequenced
+
+  STATUSES = {
+    draft: "draft",
+    approved: "approved",
+    voided: "voided"
+  }.freeze
+
+  VOID_REASONS = {
+    manual: 0,
+    superseded: 1,
+    cascade_of_expired: 2,
+    cascade_of_voided: 3
+  }.freeze
+
+  before_save :ensure_number
+
+  belongs_to :organization
+  belongs_to :customer
+  has_one :order_form
+  has_one :order, through: :order_form
+  has_many :quote_owners, dependent: :destroy
+  has_many :owners, through: :quote_owners, source: :user, class_name: "User"
+
+  enum :status, STATUSES,
+    default: :draft,
+    validate: true
+  enum :void_reason, VOID_REASONS,
+    instance_methods: false,
+    validate: {allow_nil: true}
+  enum :order_type, Order::ORDER_TYPES,
+    instance_methods: false,
+    validate: true
+  enum :execution_mode, Order::EXECUTION_MODES,
+    instance_methods: false,
+    validate: {allow_nil: true}
+  enum :backdated_billing, Order::BACKDATED_BILLING_OPTIONS,
+    instance_methods: false,
+    validate: {allow_nil: true}
+
+  sequenced(
+    scope: ->(quote) { quote.organization.quotes },
+    lock_key: ->(quote) { quote.organization_id }
+  )
+
+  private
+
+  def ensure_number
+    return if number.present?
+    return if sequential_id.blank?
+
+    time = created_at || Time.current
+    formatted_sequential_id = format("%04d", sequential_id)
+    self.number = "QT-#{time.strftime("%Y")}-#{formatted_sequential_id}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: quotes
+# Database name: primary
+#
+#  id                            :uuid             not null, primary key
+#  approved_at                   :datetime
+#  auto_execute                  :boolean          default(FALSE), not null
+#  backdated_billing(Rails enum) :integer
+#  billing_items                 :jsonb
+#  commercial_terms              :jsonb
+#  contacts                      :jsonb
+#  content                       :text
+#  currency                      :string
+#  description                   :text
+#  execution_mode(Rails enum)    :integer
+#  internal_notes                :text
+#  legal_text                    :text
+#  metadata                      :jsonb
+#  number                        :string           not null
+#  order_type(Rails enum)        :integer          not null
+#  share_token                   :string
+#  status                        :enum             default("draft"), not null
+#  version                       :integer          default(1), not null
+#  void_reason(Rails enum)       :integer
+#  voided_at                     :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  customer_id                   :uuid             not null
+#  organization_id               :uuid             not null
+#  sequential_id                 :integer          not null
+#
+# Indexes
+#
+#  index_quotes_on_customer_id                               (customer_id)
+#  index_quotes_on_organization_number                       (organization_id,number)
+#  index_unique_quotes_on_organization_sequentialid_version  (organization_id,sequential_id,version DESC) UNIQUE
+#  index_unique_quotes_on_share_token                        (share_token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -17,6 +17,7 @@ class Quote < ApplicationRecord
   }.freeze
 
   before_save :ensure_number
+  before_save :ensure_share_token
 
   belongs_to :organization
   belongs_to :customer
@@ -41,6 +42,21 @@ class Quote < ApplicationRecord
     instance_methods: false,
     validate: {allow_nil: true}
 
+  validates :share_token,
+    on: :update,
+    presence: true,
+    if: -> { draft? || approved? }
+
+  validates :void_reason, :voided_at,
+    on: :update,
+    presence: true,
+    if: -> { voided? }
+
+  validates :approved_at,
+    on: :update,
+    presence: true,
+    if: -> { approved? }
+
   sequenced(
     scope: ->(quote) { quote.organization.quotes },
     lock_key: ->(quote) { quote.organization_id }
@@ -55,6 +71,12 @@ class Quote < ApplicationRecord
     time = created_at || Time.current
     formatted_sequential_id = format("%04d", sequential_id)
     self.number = "QT-#{time.strftime("%Y")}-#{formatted_sequential_id}"
+  end
+
+  def ensure_share_token
+    return if voided?
+
+    self.share_token ||= SecureRandom.uuid
   end
 end
 

--- a/app/models/quote_owner.rb
+++ b/app/models/quote_owner.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class QuoteOwner < ApplicationRecord
+  belongs_to :quote
+  belongs_to :user
+end
+
+# == Schema Information
+#
+# Table name: quote_owners
+# Database name: primary
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  quote_id        :uuid             not null
+#  user_id         :uuid             not null
+#
+# Indexes
+#
+#  index_quote_owners_on_organization_id    (organization_id)
+#  index_quote_owners_on_user_id            (user_id)
+#  index_unique_quote_owners_on_quote_user  (quote_id,user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (quote_id => quotes.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/quote_owner.rb
+++ b/app/models/quote_owner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class QuoteOwner < ApplicationRecord
+  belongs_to :organization
   belongs_to :quote
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ApplicationRecord
   has_many :active_memberships, -> { where(status: "active") }, class_name: "Membership"
   has_many :active_organizations, through: :active_memberships, source: :organization
 
+  has_many :quote_owners, dependent: :destroy
+  has_many :quotes, through: :quote_owners
+
   validates :email, presence: true
   validates :password, presence: true
 

--- a/app/serializers/v1/quote_serializer.rb
+++ b/app/serializers/v1/quote_serializer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module V1
+  class QuoteSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        status: model.status,
+        order_type: model.order_type,
+        number: model.number,
+        version: model.version,
+        currency: model.currency,
+        description: model.description,
+        content: model.content,
+        legal_text: model.legal_text,
+        internal_notes: model.internal_notes,
+        auto_execute: model.auto_execute,
+        billing_items: model.billing_items,
+        commercial_terms: model.commercial_terms,
+        contacts: model.contacts,
+        metadata: model.metadata,
+        approved_at: model.approved_at&.iso8601,
+        voided_at: model.voided_at&.iso8601,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+    end
+  end
+end

--- a/app/services/quotes/approve_service.rb
+++ b/app/services/quotes/approve_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Quotes
+  class ApproveService < BaseService
+    attr_reader :quote
+
+    Result = BaseResult[:quote]
+
+    def initialize(quote:)
+      @quote = quote
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless approvable?
+      validation_errors = validate
+      return result.validation_failure!(errors: {quote: validation_errors}) if validation_errors.any?
+
+      quote.update!(
+        status: :approved,
+        approved_at: Time.current
+      )
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.approved", quote)
+
+      result.quote = quote
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    def approvable?
+      quote.draft?
+    end
+
+    def validate
+      []
+      # TODO: payload checks
+    end
+  end
+end

--- a/app/services/quotes/billing_items/add_ons/add_service.rb
+++ b/app/services/quotes/billing_items/add_ons/add_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module AddOns
+      class AddService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote:, params:)
+          @quote = quote
+          @params = params
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          unless quote.order_type == "one_off"
+            return result.validation_failure!(
+              errors: {billing_item: ["add_ons not allowed for subscription order type"]}
+            )
+          end
+
+          name = params[:name] || params["name"]
+          add_on_id = params[:add_on_id] || params["add_on_id"]
+          amount_cents = params[:amount_cents] || params["amount_cents"]
+
+          if name.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["name is required"]}
+            )
+          end
+
+          if add_on_id.present?
+            unless quote.organization.add_ons.exists?(id: add_on_id)
+              return result.validation_failure!(
+                errors: {billing_item: ["add_on not found in organization"]}
+              )
+            end
+          elsif amount_cents.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["amount_cents is required when add_on_id is not provided"]}
+            )
+          end
+
+          item = params.transform_keys(&:to_s)
+          item["id"] ||= "qta_#{SecureRandom.uuid}"
+
+          persist_items("add_ons", current_items("add_ons") + [item])
+        end
+
+        private
+
+        attr_reader :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/add_ons/add_service.rb
+++ b/app/services/quotes/billing_items/add_ons/add_service.rb
@@ -11,6 +11,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           unless quote.order_type == "one_off"

--- a/app/services/quotes/billing_items/add_ons/remove_service.rb
+++ b/app/services/quotes/billing_items/add_ons/remove_service.rb
@@ -11,6 +11,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           items = current_items("add_ons")

--- a/app/services/quotes/billing_items/add_ons/remove_service.rb
+++ b/app/services/quotes/billing_items/add_ons/remove_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module AddOns
+      class RemoveService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote:, id:)
+          @quote = quote
+          @id = id
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          items = current_items("add_ons")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          items.delete_at(item_index)
+          persist_items("add_ons", items)
+        end
+
+        private
+
+        attr_reader :id
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/add_ons/update_service.rb
+++ b/app/services/quotes/billing_items/add_ons/update_service.rb
@@ -12,6 +12,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           items = current_items("add_ons")

--- a/app/services/quotes/billing_items/add_ons/update_service.rb
+++ b/app/services/quotes/billing_items/add_ons/update_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module AddOns
+      class UpdateService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote:, id:, params:)
+          @quote = quote
+          @id = id
+          @params = params
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          items = current_items("add_ons")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          updated_item = items[item_index].merge(params.transform_keys(&:to_s))
+
+          name = updated_item["name"]
+          add_on_id = updated_item["add_on_id"]
+          amount_cents = updated_item["amount_cents"]
+
+          if name.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["name is required"]}
+            )
+          end
+
+          if add_on_id.present?
+            unless quote.organization.add_ons.exists?(id: add_on_id)
+              return result.validation_failure!(
+                errors: {billing_item: ["add_on not found in organization"]}
+              )
+            end
+          elsif amount_cents.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["amount_cents is required when add_on_id is not provided"]}
+            )
+          end
+
+          items[item_index] = updated_item
+          persist_items("add_ons", items)
+        end
+
+        private
+
+        attr_reader :id, :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/base_mutation_service.rb
+++ b/app/services/quotes/billing_items/base_mutation_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    class BaseMutationService < BaseService
+      Result = BaseResult[:quote]
+
+      private
+
+      attr_reader :quote
+
+      def current_items(type)
+        billing_items = (quote.billing_items || {}).transform_keys(&:to_s)
+        billing_items.fetch(type.to_s, []).map { |item| item.transform_keys(&:to_s) }
+      end
+
+      def persist_items(type, items)
+        existing = (quote.billing_items || {}).transform_keys(&:to_s)
+        quote.update!(billing_items: existing.merge(type.to_s => items))
+        result.quote = quote.reload
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/coupons/add_service.rb
+++ b/app/services/quotes/billing_items/coupons/add_service.rb
@@ -14,6 +14,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           unless ALLOWED_ORDER_TYPES.include?(quote.order_type)

--- a/app/services/quotes/billing_items/coupons/add_service.rb
+++ b/app/services/quotes/billing_items/coupons/add_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Coupons
+      class AddService < Quotes::BillingItems::BaseMutationService
+        ALLOWED_ORDER_TYPES = %w[subscription_creation subscription_amendment].freeze
+        COUPON_TYPES = %w[fixed_amount percentage].freeze
+
+        def initialize(quote:, params:)
+          @quote = quote
+          @params = params
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          unless ALLOWED_ORDER_TYPES.include?(quote.order_type)
+            return result.validation_failure!(
+              errors: {billing_item: ["coupons not allowed for one_off order type"]}
+            )
+          end
+
+          coupon_id = params[:coupon_id] || params["coupon_id"]
+          coupon_type = params[:coupon_type] || params["coupon_type"]
+
+          if coupon_id.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["coupon_id is required"]}
+            )
+          end
+
+          unless quote.organization.coupons.exists?(id: coupon_id)
+            return result.validation_failure!(
+              errors: {billing_item: ["coupon not found in organization"]}
+            )
+          end
+
+          unless COUPON_TYPES.include?(coupon_type.to_s)
+            return result.validation_failure!(
+              errors: {billing_item: ["coupon_type is invalid"]}
+            )
+          end
+
+          item = params.transform_keys(&:to_s)
+          item["id"] ||= "qtc_#{SecureRandom.uuid}"
+
+          persist_items("coupons", current_items("coupons") + [item])
+        end
+
+        private
+
+        attr_reader :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/coupons/remove_service.rb
+++ b/app/services/quotes/billing_items/coupons/remove_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Coupons
+      class RemoveService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote:, id:)
+          @quote = quote
+          @id = id
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          items = current_items("coupons")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          items.delete_at(item_index)
+          persist_items("coupons", items)
+        end
+
+        private
+
+        attr_reader :id
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/coupons/remove_service.rb
+++ b/app/services/quotes/billing_items/coupons/remove_service.rb
@@ -11,6 +11,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           items = current_items("coupons")

--- a/app/services/quotes/billing_items/coupons/update_service.rb
+++ b/app/services/quotes/billing_items/coupons/update_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Coupons
+      class UpdateService < Quotes::BillingItems::BaseMutationService
+        COUPON_TYPES = %w[fixed_amount percentage].freeze
+
+        def initialize(quote:, id:, params:)
+          @quote = quote
+          @id = id
+          @params = params
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          items = current_items("coupons")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          updated_item = items[item_index].merge(params.transform_keys(&:to_s))
+
+          coupon_id = updated_item["coupon_id"]
+          coupon_type = updated_item["coupon_type"]
+
+          if coupon_id.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["coupon_id is required"]}
+            )
+          end
+
+          unless quote.organization.coupons.exists?(id: coupon_id)
+            return result.validation_failure!(
+              errors: {billing_item: ["coupon not found in organization"]}
+            )
+          end
+
+          unless COUPON_TYPES.include?(coupon_type.to_s)
+            return result.validation_failure!(
+              errors: {billing_item: ["coupon_type is invalid"]}
+            )
+          end
+
+          items[item_index] = updated_item
+          persist_items("coupons", items)
+        end
+
+        private
+
+        attr_reader :id, :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/coupons/update_service.rb
+++ b/app/services/quotes/billing_items/coupons/update_service.rb
@@ -14,6 +14,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           items = current_items("coupons")

--- a/app/services/quotes/billing_items/plans/add_service.rb
+++ b/app/services/quotes/billing_items/plans/add_service.rb
@@ -13,6 +13,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           unless ALLOWED_ORDER_TYPES.include?(quote.order_type)

--- a/app/services/quotes/billing_items/plans/add_service.rb
+++ b/app/services/quotes/billing_items/plans/add_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Plans
+      class AddService < Quotes::BillingItems::BaseMutationService
+        ALLOWED_ORDER_TYPES = %w[subscription_creation subscription_amendment].freeze
+
+        def initialize(quote:, params:)
+          @quote = quote
+          @params = params
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          unless ALLOWED_ORDER_TYPES.include?(quote.order_type)
+            return result.validation_failure!(
+              errors: {billing_item: ["plans not allowed for one_off order type"]}
+            )
+          end
+
+          plan_id = params[:plan_id] || params["plan_id"]
+
+          if plan_id.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["plan_id is required"]}
+            )
+          end
+
+          unless quote.organization.plans.exists?(id: plan_id)
+            return result.validation_failure!(
+              errors: {billing_item: ["plan not found in organization"]}
+            )
+          end
+
+          item = params.transform_keys(&:to_s)
+          item["id"] ||= "qtp_#{SecureRandom.uuid}"
+
+          persist_items("plans", current_items("plans") + [item])
+        end
+
+        private
+
+        attr_reader :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/plans/remove_service.rb
+++ b/app/services/quotes/billing_items/plans/remove_service.rb
@@ -11,6 +11,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           items = current_items("plans")

--- a/app/services/quotes/billing_items/plans/remove_service.rb
+++ b/app/services/quotes/billing_items/plans/remove_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Plans
+      class RemoveService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote:, id:)
+          @quote = quote
+          @id = id
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          items = current_items("plans")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          items.delete_at(item_index)
+          persist_items("plans", items)
+        end
+
+        private
+
+        attr_reader :id
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/plans/update_service.rb
+++ b/app/services/quotes/billing_items/plans/update_service.rb
@@ -12,6 +12,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           items = current_items("plans")

--- a/app/services/quotes/billing_items/plans/update_service.rb
+++ b/app/services/quotes/billing_items/plans/update_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Plans
+      class UpdateService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote:, id:, params:)
+          @quote = quote
+          @id = id
+          @params = params
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          items = current_items("plans")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          updated_item = items[item_index].merge(params.transform_keys(&:to_s))
+
+          plan_id = updated_item["plan_id"]
+
+          if plan_id.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["plan_id is required"]}
+            )
+          end
+
+          unless quote.organization.plans.exists?(id: plan_id)
+            return result.validation_failure!(
+              errors: {billing_item: ["plan not found in organization"]}
+            )
+          end
+
+          items[item_index] = updated_item
+          persist_items("plans", items)
+        end
+
+        private
+
+        attr_reader :id, :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/validate_service.rb
+++ b/app/services/quotes/billing_items/validate_service.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    class ValidateService < BaseService
+      Result = BaseResult[:billing_items]
+
+      COUPON_TYPES = %w[fixed_amount percentage].freeze
+      ID_PREFIXES = {
+        "plans" => "qtp",
+        "add_ons" => "qta",
+        "coupons" => "qtc",
+        "wallet_credits" => "qtw"
+      }.freeze
+      RECURRING_RULE_PREFIX = "qtrr"
+
+      def initialize(organization:, order_type:, billing_items:)
+        @organization = organization
+        @order_type = order_type.to_s
+        @billing_items = billing_items || {}
+        super
+      end
+
+      def call
+        errors = []
+
+        errors.concat(validate_type_constraints)
+        errors.concat(validate_plans) if subscription_type?
+        errors.concat(validate_add_ons) if one_off_type?
+        errors.concat(validate_coupons) if subscription_type?
+        errors.concat(validate_wallet_credits) if subscription_type?
+
+        return result.validation_failure!(errors: {billing_items: errors}) if errors.any?
+
+        result.billing_items = normalized_billing_items
+        result
+      end
+
+      private
+
+      attr_reader :organization, :order_type, :billing_items
+
+      def subscription_type?
+        order_type == "subscription_creation" || order_type == "subscription_amendment"
+      end
+
+      def one_off_type?
+        order_type == "one_off"
+      end
+
+      def validate_type_constraints
+        errors = []
+
+        if one_off_type? && plans_present?
+          errors << "plans not allowed for one_off order type"
+        end
+
+        if one_off_type? && coupons_present?
+          errors << "coupons not allowed for one_off order type"
+        end
+
+        if one_off_type? && wallet_credits_present?
+          errors << "wallet_credits not allowed for one_off order type"
+        end
+
+        if subscription_type? && add_ons_present?
+          errors << "add_ons not allowed for subscription order type"
+        end
+
+        errors
+      end
+
+      def validate_plans
+        errors = []
+        plans = billing_items.fetch("plans", [])
+
+        plans.each_with_index do |plan, index|
+          plan_id = plan["plan_id"] || plan[:plan_id]
+
+          if plan_id.blank?
+            errors << "plans[#{index}].plan_id is required"
+            next
+          end
+
+          unless organization.plans.exists?(id: plan_id)
+            errors << "plans[#{index}].plan_id: plan not found in organization"
+          end
+        end
+
+        errors
+      end
+
+      def validate_add_ons
+        errors = []
+        add_ons = billing_items.fetch("add_ons", [])
+
+        add_ons.each_with_index do |add_on, index|
+          add_on_id = add_on["add_on_id"] || add_on[:add_on_id]
+          amount_cents = add_on["amount_cents"] || add_on[:amount_cents]
+          name = add_on["name"] || add_on[:name]
+
+          if name.blank?
+            errors << "add_ons[#{index}].name is required"
+          end
+
+          if add_on_id.present?
+            unless organization.add_ons.exists?(id: add_on_id)
+              errors << "add_ons[#{index}].add_on_id: add_on not found in organization"
+            end
+          elsif amount_cents.blank?
+            errors << "add_ons[#{index}].amount_cents is required when add_on_id is not provided"
+          end
+        end
+
+        errors
+      end
+
+      def validate_coupons
+        errors = []
+        coupons = billing_items.fetch("coupons", [])
+
+        coupons.each_with_index do |coupon, index|
+          coupon_id = coupon["coupon_id"] || coupon[:coupon_id]
+          coupon_type = coupon["coupon_type"] || coupon[:coupon_type]
+
+          if coupon_id.blank?
+            errors << "coupons[#{index}].coupon_id is required"
+            next
+          end
+
+          unless organization.coupons.exists?(id: coupon_id)
+            errors << "coupons[#{index}].coupon_id: coupon not found in organization"
+          end
+
+          unless COUPON_TYPES.include?(coupon_type.to_s)
+            errors << "coupons[#{index}].coupon_type is invalid"
+          end
+        end
+
+        errors
+      end
+
+      def validate_wallet_credits
+        []
+        # No catalog reference needed for wallet credits
+      end
+
+      def normalized_billing_items
+        result = billing_items.dup.transform_keys(&:to_s)
+
+        if subscription_type?
+          result["plans"] = normalize_items(result.fetch("plans", []), prefix: ID_PREFIXES["plans"])
+          result["coupons"] = normalize_items(result.fetch("coupons", []), prefix: ID_PREFIXES["coupons"])
+          result["wallet_credits"] = normalize_wallet_credits(result.fetch("wallet_credits", []))
+        end
+
+        if one_off_type?
+          result["add_ons"] = normalize_items(result.fetch("add_ons", []), prefix: ID_PREFIXES["add_ons"])
+        end
+
+        result
+      end
+
+      def normalize_items(items, prefix:)
+        items.map do |item|
+          item = item.transform_keys(&:to_s)
+          item["id"] = "#{prefix}_#{SecureRandom.uuid}" if item["id"].blank?
+          item
+        end
+      end
+
+      def normalize_wallet_credits(items)
+        items.map do |item|
+          item = item.transform_keys(&:to_s)
+          item["id"] = "#{ID_PREFIXES["wallet_credits"]}_#{SecureRandom.uuid}" if item["id"].blank?
+          item["recurring_transaction_rules"] = normalize_recurring_rules(item.fetch("recurring_transaction_rules", []))
+          item
+        end
+      end
+
+      def normalize_recurring_rules(rules)
+        rules.map do |rule|
+          rule = rule.transform_keys(&:to_s)
+          rule["id"] = "#{RECURRING_RULE_PREFIX}_#{SecureRandom.uuid}" if rule["id"].blank?
+          rule
+        end
+      end
+
+      def plans_present?
+        billing_items.fetch("plans", billing_items.fetch(:plans, [])).any?
+      end
+
+      def coupons_present?
+        billing_items.fetch("coupons", billing_items.fetch(:coupons, [])).any?
+      end
+
+      def wallet_credits_present?
+        billing_items.fetch("wallet_credits", billing_items.fetch(:wallet_credits, [])).any?
+      end
+
+      def add_ons_present?
+        billing_items.fetch("add_ons", billing_items.fetch(:add_ons, [])).any?
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/wallet_credits/add_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/add_service.rb
@@ -13,6 +13,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           unless ALLOWED_ORDER_TYPES.include?(quote.order_type)

--- a/app/services/quotes/billing_items/wallet_credits/add_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/add_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module WalletCredits
+      class AddService < Quotes::BillingItems::BaseMutationService
+        ALLOWED_ORDER_TYPES = %w[subscription_creation subscription_amendment].freeze
+
+        def initialize(quote:, params:)
+          @quote = quote
+          @params = params
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          unless ALLOWED_ORDER_TYPES.include?(quote.order_type)
+            return result.validation_failure!(
+              errors: {billing_item: ["wallet_credits not allowed for one_off order type"]}
+            )
+          end
+
+          item = params.transform_keys(&:to_s)
+          item["id"] ||= "qtw_#{SecureRandom.uuid}"
+          item["recurring_transaction_rules"] = normalize_recurring_rules(item.fetch("recurring_transaction_rules", []))
+
+          persist_items("wallet_credits", current_items("wallet_credits") + [item])
+        end
+
+        private
+
+        attr_reader :params
+
+        def normalize_recurring_rules(rules)
+          rules.map do |rule|
+            rule = rule.transform_keys(&:to_s)
+            rule["id"] ||= "qtrr_#{SecureRandom.uuid}"
+            rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/wallet_credits/remove_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/remove_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module WalletCredits
+      class RemoveService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote:, id:)
+          @quote = quote
+          @id = id
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          items = current_items("wallet_credits")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          items.delete_at(item_index)
+          persist_items("wallet_credits", items)
+        end
+
+        private
+
+        attr_reader :id
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/wallet_credits/remove_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/remove_service.rb
@@ -11,6 +11,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           items = current_items("wallet_credits")

--- a/app/services/quotes/billing_items/wallet_credits/update_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/update_service.rb
@@ -12,6 +12,8 @@ module Quotes
         end
 
         def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote") unless quote
           return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
 
           items = current_items("wallet_credits")

--- a/app/services/quotes/billing_items/wallet_credits/update_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/update_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module WalletCredits
+      class UpdateService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote:, id:, params:)
+          @quote = quote
+          @id = id
+          @params = params
+          super
+        end
+
+        def call
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote.draft?
+
+          items = current_items("wallet_credits")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          updated_item = items[item_index].merge(params.transform_keys(&:to_s))
+
+          if params.key?(:recurring_transaction_rules) || params.key?("recurring_transaction_rules")
+            updated_item["recurring_transaction_rules"] = normalize_recurring_rules(
+              updated_item.fetch("recurring_transaction_rules", [])
+            )
+          end
+
+          items[item_index] = updated_item
+          persist_items("wallet_credits", items)
+        end
+
+        private
+
+        attr_reader :id, :params
+
+        def normalize_recurring_rules(rules)
+          rules.map do |rule|
+            rule = rule.transform_keys(&:to_s)
+            rule["id"] ||= "qtrr_#{SecureRandom.uuid}"
+            rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/quotes/clone_service.rb
+++ b/app/services/quotes/clone_service.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Quotes
+  class CloneService < BaseService
+    class CloneError < StandardError
+      attr_reader :cause, :errors
+
+      def initialize(cause: nil, errors: {})
+        @cause = cause
+        @errors = errors
+        super("Quote clone failed due to #{cause.class}")
+      end
+    end
+
+    attr_reader :quote
+
+    Result = BaseResult[:quote]
+
+    def initialize(quote:)
+      @quote = quote
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless clonable?
+
+      cloned = Quote.transaction do
+        cloned = create_next_version(quote:)
+        copy_owners!(quote:, cloned:)
+        void!(quote:)
+        result.quote = cloned
+      end
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.cloned", cloned)
+
+      result
+    rescue CloneError => e
+      result.service_failure!(code: "clone_failed", message: e.message, error: e)
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    def clonable?
+      return false if quote.approved?
+      return false if quote.organization.quotes.where(
+        sequential_id: quote.sequential_id,
+        version: (quote.version + 1)..
+      ).exists?
+
+      true
+    end
+
+    def create_next_version(quote:)
+      quote.dup.tap do |cloned|
+        cloned.status = :draft
+        cloned.version += 1
+        cloned.share_token = nil # will be generated on saving
+        cloned.save!
+      end
+    end
+
+    def copy_owners!(quote:, cloned:)
+      quote.owner_ids.each do |user_id|
+        cloned.quote_owners.create!(
+          organization_id: cloned.organization_id,
+          user_id: user_id
+        )
+      end
+    end
+
+    def void!(quote:)
+      return if quote.voided?
+
+      void_result = Quotes::VoidService.new(
+        quote: quote,
+        reason: :superseded
+      ).call
+
+      raise CloneError.new(errors: void_result.errors, cause: void_result) unless void_result&.success?
+    end
+  end
+end

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Quotes
+  class CreateService < BaseService
+    attr_reader :organization, :customer, :params
+
+    Result = BaseResult[:quote]
+
+    def initialize(organization:, customer:, params:)
+      @organization = organization
+      @customer = customer
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "organization") unless organization
+      return result.not_found_failure!(resource: "customer") unless customer
+      return result.forbidden_failure! unless organization.feature_flag_enabled?(:order_forms)
+
+      create_params = params.slice(
+        :auto_execute,
+        :backdated_billing,
+        :billing_items,
+        :commercial_terms,
+        :contacts,
+        :content,
+        :currency,
+        :description,
+        :execution_mode,
+        :internal_notes,
+        :legal_text,
+        :metadata,
+        :order_type
+      )
+
+      quote = Quote.transaction do
+        quote = organization.quotes.create!(
+          customer:,
+          **create_params
+        )
+        add_owners!(quote:, owners: params[:owners]) if params.has_key?(:owners)
+        quote
+      end
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.created", quote)
+
+      result.quote = quote
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    def add_owners!(quote:, owners:)
+      return if owners.blank?
+
+      owners.uniq.each do |user_id|
+        quote.quote_owners.create!(organization:, user_id:)
+      end
+    end
+  end
+end

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -23,7 +23,6 @@ module Quotes
       create_params = params.slice(
         :auto_execute,
         :backdated_billing,
-        :billing_items,
         :commercial_terms,
         :contacts,
         :content,
@@ -35,6 +34,17 @@ module Quotes
         :metadata,
         :order_type
       )
+
+      if params.key?(:billing_items)
+        validation = Quotes::BillingItems::ValidateService.call(
+          organization:,
+          order_type: params[:order_type],
+          billing_items: params[:billing_items]
+        )
+        return validation unless validation.success?
+
+        create_params[:billing_items] = validation.billing_items
+      end
 
       quote = Quote.transaction do
         quote = organization.quotes.create!(

--- a/app/services/quotes/destroy_service.rb
+++ b/app/services/quotes/destroy_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Quotes
+  class DestroyService < BaseService
+    attr_reader :quote
+
+    Result = BaseResult[:quote]
+
+    def initialize(quote:)
+      @quote = quote
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless destroyable?
+
+      quote.destroy!
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.deleted", quote)
+
+      result.quote = quote
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    def destroyable?
+      return false if quote.approved?
+      return false if quote.order_form.present?
+      return false if quote.order.present?
+      true
+    end
+  end
+end

--- a/app/services/quotes/update_service.rb
+++ b/app/services/quotes/update_service.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Quotes
+  class UpdateService < BaseService
+    attr_reader :quote, :params
+
+    Result = BaseResult[:quote]
+
+    def initialize(quote:, params:)
+      @quote = quote
+      @params = params
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless editable?
+
+      update_params = params.slice(
+        :auto_execute,
+        :backdated_billing,
+        :billing_items,
+        :commercial_terms,
+        :contacts,
+        :content,
+        :currency,
+        :description,
+        :execution_mode,
+        :internal_notes,
+        :legal_text,
+        :metadata,
+        :order_type
+      )
+      Quote.transaction do
+        quote.update!(update_params)
+        sync_owners!(quote:, owners: params[:owners]) if params.has_key?(:owners)
+      end
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.updated", quote)
+
+      result.quote = quote.reload
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    def editable?
+      quote.draft?
+    end
+
+    def sync_owners!(quote:, owners:)
+      new_owners = owners.uniq
+      current_owners = quote.owner_ids
+
+      owners_to_remove = current_owners - new_owners
+      quote.quote_owners.where(user_id: owners_to_remove).delete_all if owners_to_remove.any?
+
+      owners_to_add = new_owners - current_owners
+      owners_to_add.each do |user_id|
+        quote.quote_owners.create!(
+          organization_id: quote.organization_id,
+          user_id: user_id
+        )
+      end
+    end
+  end
+end

--- a/app/services/quotes/update_service.rb
+++ b/app/services/quotes/update_service.rb
@@ -21,7 +21,6 @@ module Quotes
       update_params = params.slice(
         :auto_execute,
         :backdated_billing,
-        :billing_items,
         :commercial_terms,
         :contacts,
         :content,
@@ -33,6 +32,18 @@ module Quotes
         :metadata,
         :order_type
       )
+
+      if params.key?(:billing_items)
+        validation = Quotes::BillingItems::ValidateService.call(
+          organization: quote.organization,
+          order_type: quote.order_type,
+          billing_items: params[:billing_items]
+        )
+        return validation unless validation.success?
+
+        update_params[:billing_items] = validation.billing_items
+      end
+
       Quote.transaction do
         quote.update!(update_params)
         sync_owners!(quote:, owners: params[:owners]) if params.has_key?(:owners)

--- a/app/services/quotes/void_service.rb
+++ b/app/services/quotes/void_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Quotes
+  class VoidService < BaseService
+    attr_reader :quote, :reason
+
+    Result = BaseResult[:quote]
+
+    def initialize(quote:, reason:)
+      @quote = quote
+      @reason = reason
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.validation_failure!(errors: {quote: ["invalid_void_reason"]}) unless is_valid?(reason:)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless voidable?
+
+      quote.update!(
+        status: :voided,
+        void_reason: reason,
+        voided_at: Time.current,
+        share_token: nil
+      )
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.voided", quote)
+
+      result.quote = quote
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    def voidable?
+      quote.approved? || quote.draft?
+    end
+
+    def is_valid?(reason:)
+      return false if reason.blank?
+
+      Quote::VOID_REASONS.has_key?(reason.to_sym)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
         invalid_rate: invalid_rate
         invalid_size: invalid_size
         invalid_timezone: invalid_timezone
+        invalid_void_reason: invalid_void_reason
         invalid_volume_ranges: invalid_volume_ranges
         language_code_invalid: not_a_valid_language_code
         less_than_or_equal_to: value_is_out_of_range

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -128,6 +128,40 @@ invoice_custom_sections:
     - finance
   delete:
     - finance
+quotes:
+  view:
+    - finance
+    - manager
+  create:
+    - manager
+  update:
+    - manager
+  delete:
+    - manager
+  approve:
+    - manager
+  clone:
+    - manager
+  void:
+    - manager
+order_forms:
+  view:
+    - finance
+    - manager
+  create:
+    - manager
+  void:
+    - manager
+  sign:
+    - manager
+orders:
+  view:
+    - finance
+    - manager
+  create:
+    - manager
+  execute:
+    - manager
 organization:
   view:
     - finance

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,15 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :quotes, only: [] do
+        scope module: :quotes do
+          resources :plans, only: %i[create update destroy], controller: "billing_items/plans"
+          resources :add_ons, only: %i[create update destroy], controller: "billing_items/add_ons"
+          resources :coupons, only: %i[create update destroy], controller: "billing_items/coupons"
+          resources :wallet_credits, only: %i[create update destroy], controller: "billing_items/wallet_credits"
+        end
+      end
+
       resources :coupons, param: :code, code: /.*/
       resources :credit_notes, only: %i[create update show index] do
         post :download, on: :member, action: :download_pdf

--- a/db/migrate/20260304074158_add_order_forms_foundations.rb
+++ b/db/migrate/20260304074158_add_order_forms_foundations.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+class AddOrderFormsFoundations < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :quote_status, %w[draft approved voided]
+
+    create_table :quotes, id: :uuid do |t|
+      # identity
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique index below
+        type: :uuid
+      t.references :customer,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.string :number, null: false
+      t.integer :version, null: false, default: 1
+      t.integer :sequential_id, null: false
+      t.integer :order_type, null: false, comment: "Rails enum"
+      t.string :currency
+      t.text :description
+      # lifecycle
+      t.enum :status,
+        enum_type: :quote_status,
+        null: false,
+        default: "draft"
+      t.datetime :approved_at
+      t.datetime :voided_at
+      t.integer :void_reason, comment: "Rails enum"
+      t.timestamps
+      # content
+      t.jsonb :billing_items
+      t.jsonb :commercial_terms
+      t.text :content
+      t.text :legal_text
+      t.text :internal_notes
+      t.jsonb :contacts
+      t.jsonb :metadata
+      t.boolean :auto_execute, null: false, default: false
+      t.integer :backdated_billing, comment: "Rails enum"
+      t.integer :execution_mode, comment: "Rails enum"
+      t.string :share_token
+
+      # constraints and indices
+      t.check_constraint "version > 0",
+        name: "quotes_constraint_version_positive"
+      t.check_constraint "sequential_id > 0",
+        name: "quotes_constraint_sequentialid_positive"
+      t.index [:organization_id, :sequential_id, :version],
+        unique: true,
+        order: {version: :desc},
+        name: "index_unique_quotes_on_organization_sequentialid_version"
+      t.index [:organization_id, :number],
+        name: "index_quotes_on_organization_number"
+      t.index :share_token,
+        unique: true,
+        name: "index_unique_quotes_on_share_token"
+    end
+
+    create_enum :order_form_status, %w[generated signed expired voided]
+
+    create_table :order_forms, id: :uuid do |t|
+      # identity
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique index below
+        type: :uuid
+      t.references :customer,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :quote,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.string :number, null: false
+      t.integer :sequential_id, null: false
+      # lifecycle
+      t.enum :status,
+        enum_type: :order_form_status,
+        null: false,
+        default: "generated"
+      t.integer :void_reason, comment: "Rails enum"
+      t.references :signed_by_user,
+        foreign_key: {to_table: :users},
+        index: false,
+        null: true,
+        type: :uuid
+      t.uuid :contract_uploaded_by_user
+      t.datetime :contract_uploaded_at
+      t.datetime :expires_at
+      t.datetime :signed_at
+      t.datetime :voided_at
+      t.timestamps
+      # content
+      t.jsonb :billing_snapshot, null: false
+      t.text :content
+      t.text :legal_text
+
+      # constraints and indices
+      t.check_constraint "sequential_id > 0",
+        name: "order_forms_constraint_sequentialid_positive"
+      t.index [:organization_id, :sequential_id],
+        unique: true,
+        name: "index_unique_order_forms_on_organization_sequentialid"
+      t.index [:organization_id, :number],
+        unique: true,
+        name: "index_unique_order_forms_on_organization_number"
+    end
+
+    create_enum :order_status, %w[created executed]
+
+    create_table :orders, id: :uuid do |t|
+      # identity
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique index below
+        type: :uuid
+      t.references :customer,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :order_form,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.string :number, null: false
+      t.integer :sequential_id, null: false
+      t.integer :order_type, null: false, comment: "Rails enum"
+      # lifecycle
+      t.enum :status,
+        enum_type: :order_status,
+        null: false,
+        default: "created"
+      t.datetime :executed_at
+      t.timestamps
+      # content
+      t.string :currency
+      t.jsonb :billing_snapshot, null: false
+      t.integer :execution_mode, comment: "Rails enum"
+      t.integer :backdated_billing, comment: "Rails enum"
+      t.json :execution_record
+
+      # constraints and indices
+      t.check_constraint "sequential_id > 0",
+        name: "orders_constraint_sequentialid_positive"
+      t.index [:organization_id, :sequential_id],
+        unique: true,
+        name: "index_unique_orders_on_organization_sequentialid"
+      t.index [:organization_id, :number],
+        unique: true,
+        name: "index_unique_orders_on_organization_number"
+    end
+
+    create_table :quote_owners do |t|
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :quote,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique index below
+        type: :uuid
+      t.references :user,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.timestamps
+
+      t.index [:quote_id, :user_id],
+        unique: true,
+        name: "index_unique_quote_owners_on_quote_user"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -13,6 +13,7 @@ ALTER TABLE IF EXISTS ONLY public.membership_roles DROP CONSTRAINT IF EXISTS mem
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_ff75b29299;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_ff548a9f4c;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_fea16bf2e7;
+ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS fk_rails_fe8af6535c;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaign_thresholds DROP CONSTRAINT IF EXISTS fk_rails_fd84cdb7c6;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS fk_rails_fd60209637;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_fd399a23d3;
@@ -45,6 +46,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_de7694c307;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
 ALTER TABLE IF EXISTS ONLY public.invites DROP CONSTRAINT IF EXISTS fk_rails_dd342449a6;
 ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_dc444f5f29;
@@ -85,6 +87,7 @@ ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_r
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_b974dac270;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_b8f3cabc8e;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS fk_rails_b749d2045d;
+ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS fk_rails_b687c6e23a;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_b61aa73940;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_b50dc82c1e;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_b3864df641;
@@ -100,6 +103,7 @@ ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_a7f20c73bb;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_a710519346;
 ALTER TABLE IF EXISTS ONLY public.group_properties DROP CONSTRAINT IF EXISTS fk_rails_a2d2cb3819;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_a1ab65f1f7;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_9f22076477;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_9ea6759859;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_9e3f99b7a2;
@@ -151,6 +155,7 @@ ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_7886e1bc34;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_77f2d4440d;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_778360c382;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_7734750af9;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_76ceb88c74;
 ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rails_755d734f25;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
@@ -177,7 +182,9 @@ ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_63ac282e70;
 ALTER TABLE IF EXISTS ONLY public.invoice_metadata DROP CONSTRAINT IF EXISTS fk_rails_63683837a2;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_62d18ea517;
+ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS fk_rails_6298debfc7;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_626209b8d2;
+ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS fk_rails_60bc1d491f;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_6023b3f2dd;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_5efea6fe31;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges DROP CONSTRAINT IF EXISTS fk_rails_5e06da3c18;
@@ -199,17 +206,20 @@ ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_51ac39a0c6;
 ALTER TABLE IF EXISTS ONLY public.billable_metric_filters DROP CONSTRAINT IF EXISTS fk_rails_51077e7c0e;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_50d46d3679;
+ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS fk_rails_4ed54bfec0;
 ALTER TABLE IF EXISTS ONLY public.billing_entities DROP CONSTRAINT IF EXISTS fk_rails_4aa58496c3;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_49fcc221b0;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_49212d501e;
 ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk_rails_47d8081062;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_45230f8485;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_4117574b51;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_41088c7d45;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_3ff27d7624;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_3f7be5debc;
 ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF EXISTS fk_rails_3ec3563cf3;
 ALTER TABLE IF EXISTS ONLY public.entitlement_privileges DROP CONSTRAINT IF EXISTS fk_rails_3e4df02771;
+ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS fk_rails_3dad120da9;
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_3d568ff9de;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_3cfe1d68d7;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_3c7c3920c0;
@@ -263,6 +273,7 @@ ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EX
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_19c47827ba;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_189f2a3949;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_1811b32fcd;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_173327f0dc;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_150139409e;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
@@ -273,6 +284,7 @@ ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAIN
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_103e187859;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_0f807322b1;
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_0f762162b0;
+ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS fk_rails_0f6233ccbc;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_0e464363cb;
 ALTER TABLE IF EXISTS ONLY public.ai_conversations DROP CONSTRAINT IF EXISTS fk_rails_0da056ac92;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_0d349e632f;
@@ -363,6 +375,13 @@ DROP INDEX IF EXISTS public.index_usage_monitoring_alert_thresholds_on_organizat
 DROP INDEX IF EXISTS public.index_unique_transaction_id;
 DROP INDEX IF EXISTS public.index_unique_terminating_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_starting_invoice_subscription;
+DROP INDEX IF EXISTS public.index_unique_quotes_on_share_token;
+DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_sequentialid_version;
+DROP INDEX IF EXISTS public.index_unique_quote_owners_on_quote_user;
+DROP INDEX IF EXISTS public.index_unique_orders_on_organization_sequentialid;
+DROP INDEX IF EXISTS public.index_unique_orders_on_organization_number;
+DROP INDEX IF EXISTS public.index_unique_order_forms_on_organization_sequentialid;
+DROP INDEX IF EXISTS public.index_unique_order_forms_on_organization_number;
 DROP INDEX IF EXISTS public.index_unique_applied_to_organization_per_organization;
 DROP INDEX IF EXISTS public.index_uniq_wallet_code_per_customer;
 DROP INDEX IF EXISTS public.index_uniq_invoice_subscriptions_on_fixed_charges_boundaries;
@@ -398,6 +417,10 @@ DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_started_at;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_expiration_at;
+DROP INDEX IF EXISTS public.index_quotes_on_organization_number;
+DROP INDEX IF EXISTS public.index_quotes_on_customer_id;
+DROP INDEX IF EXISTS public.index_quote_owners_on_user_id;
+DROP INDEX IF EXISTS public.index_quote_owners_on_organization_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_organization_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_group_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_external_id;
@@ -460,6 +483,10 @@ DROP INDEX IF EXISTS public.index_password_resets_on_user_id;
 DROP INDEX IF EXISTS public.index_password_resets_on_token;
 DROP INDEX IF EXISTS public.index_organizations_on_hmac_key;
 DROP INDEX IF EXISTS public.index_organizations_on_api_key;
+DROP INDEX IF EXISTS public.index_orders_on_order_form_id;
+DROP INDEX IF EXISTS public.index_orders_on_customer_id;
+DROP INDEX IF EXISTS public.index_order_forms_on_quote_id;
+DROP INDEX IF EXISTS public.index_order_forms_on_customer_id;
 DROP INDEX IF EXISTS public.index_memberships_on_user_id_and_organization_id;
 DROP INDEX IF EXISTS public.index_memberships_on_user_id;
 DROP INDEX IF EXISTS public.index_memberships_on_organization_id;
@@ -832,6 +859,8 @@ ALTER TABLE IF EXISTS ONLY public.roles DROP CONSTRAINT IF EXISTS roles_pkey;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS refunds_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS recurring_transaction_rules_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS recurring_transaction_rules_invoice_custom_sections_pkey;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS quotes_pkey;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS quote_owners_pkey;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
@@ -849,6 +878,8 @@ ALTER TABLE IF EXISTS ONLY public.payment_methods DROP CONSTRAINT IF EXISTS paym
 ALTER TABLE IF EXISTS ONLY public.payment_intents DROP CONSTRAINT IF EXISTS payment_intents_pkey;
 ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS password_resets_pkey;
 ALTER TABLE IF EXISTS ONLY public.organizations DROP CONSTRAINT IF EXISTS organizations_pkey;
+ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS orders_pkey;
+ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS order_forms_pkey;
 ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS memberships_pkey;
 ALTER TABLE IF EXISTS ONLY public.membership_roles DROP CONSTRAINT IF EXISTS membership_roles_pkey;
 ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS lifetime_usages_pkey;
@@ -928,6 +959,7 @@ ALTER TABLE IF EXISTS ONLY public.active_storage_blobs DROP CONSTRAINT IF EXISTS
 ALTER TABLE IF EXISTS ONLY public.active_storage_attachments DROP CONSTRAINT IF EXISTS active_storage_attachments_pkey;
 ALTER TABLE IF EXISTS public.versions ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.usage_monitoring_subscription_activities ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE IF EXISTS public.quote_owners ALTER COLUMN id DROP DEFAULT;
 DROP TABLE IF EXISTS public.webhooks;
 DROP TABLE IF EXISTS public.webhook_endpoints;
 DROP TABLE IF EXISTS public.wallets_invoice_custom_sections;
@@ -949,6 +981,9 @@ DROP TABLE IF EXISTS public.roles;
 DROP TABLE IF EXISTS public.refunds;
 DROP TABLE IF EXISTS public.recurring_transaction_rules_invoice_custom_sections;
 DROP TABLE IF EXISTS public.recurring_transaction_rules;
+DROP TABLE IF EXISTS public.quotes;
+DROP SEQUENCE IF EXISTS public.quote_owners_id_seq;
+DROP TABLE IF EXISTS public.quote_owners;
 DROP TABLE IF EXISTS public.quantified_events;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
@@ -959,6 +994,8 @@ DROP TABLE IF EXISTS public.payment_providers;
 DROP TABLE IF EXISTS public.payment_methods;
 DROP TABLE IF EXISTS public.payment_intents;
 DROP TABLE IF EXISTS public.password_resets;
+DROP TABLE IF EXISTS public.orders;
+DROP TABLE IF EXISTS public.order_forms;
 DROP TABLE IF EXISTS public.memberships;
 DROP TABLE IF EXISTS public.membership_roles;
 DROP TABLE IF EXISTS public.lifetime_usages;
@@ -1096,9 +1133,12 @@ DROP TYPE IF EXISTS public.subscription_invoice_issuing_date_adjustments;
 DROP TYPE IF EXISTS public.subscription_cancelation_reasons;
 DROP TYPE IF EXISTS public.subscription_activation_rule_types;
 DROP TYPE IF EXISTS public.subscription_activation_rule_statuses;
+DROP TYPE IF EXISTS public.quote_status;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
 DROP TYPE IF EXISTS public.payment_method_types;
+DROP TYPE IF EXISTS public.order_status;
+DROP TYPE IF EXISTS public.order_form_status;
 DROP TYPE IF EXISTS public.invoice_settlement_settlement_type;
 DROP TYPE IF EXISTS public.invoice_custom_section_type;
 DROP TYPE IF EXISTS public.inbound_webhook_status;
@@ -1280,6 +1320,28 @@ CREATE TYPE public.invoice_settlement_settlement_type AS ENUM (
 
 
 --
+-- Name: order_form_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.order_form_status AS ENUM (
+    'generated',
+    'signed',
+    'expired',
+    'voided'
+);
+
+
+--
+-- Name: order_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.order_status AS ENUM (
+    'created',
+    'executed'
+);
+
+
+--
 -- Name: payment_method_types; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -1308,6 +1370,17 @@ CREATE TYPE public.payment_payable_payment_status AS ENUM (
 CREATE TYPE public.payment_type AS ENUM (
     'provider',
     'manual'
+);
+
+
+--
+-- Name: quote_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.quote_status AS ENUM (
+    'draft',
+    'approved',
+    'voided'
 );
 
 
@@ -4439,6 +4512,59 @@ CREATE TABLE public.memberships (
 
 
 --
+-- Name: order_forms; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.order_forms (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    customer_id uuid NOT NULL,
+    quote_id uuid NOT NULL,
+    number character varying NOT NULL,
+    sequential_id integer NOT NULL,
+    status public.order_form_status DEFAULT 'generated'::public.order_form_status NOT NULL,
+    void_reason integer,
+    signed_by_user_id uuid,
+    contract_uploaded_by_user uuid,
+    contract_uploaded_at timestamp(6) without time zone,
+    expires_at timestamp(6) without time zone,
+    signed_at timestamp(6) without time zone,
+    voided_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    billing_snapshot jsonb NOT NULL,
+    content text,
+    legal_text text,
+    CONSTRAINT order_forms_constraint_sequentialid_positive CHECK ((sequential_id > 0))
+);
+
+
+--
+-- Name: orders; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.orders (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    customer_id uuid NOT NULL,
+    order_form_id uuid NOT NULL,
+    number character varying NOT NULL,
+    sequential_id integer NOT NULL,
+    order_type integer NOT NULL,
+    status public.order_status DEFAULT 'created'::public.order_status NOT NULL,
+    executed_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    currency character varying,
+    billing_snapshot jsonb NOT NULL,
+    execution_mode integer,
+    backdated_billing integer,
+    execution_record json,
+    CONSTRAINT orders_constraint_sequentialid_positive CHECK ((sequential_id > 0))
+);
+
+
+--
 -- Name: password_resets; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4610,6 +4736,75 @@ CREATE TABLE public.quantified_events (
     organization_id uuid NOT NULL,
     grouped_by jsonb DEFAULT '{}'::jsonb NOT NULL,
     charge_filter_id uuid
+);
+
+
+--
+-- Name: quote_owners; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quote_owners (
+    id bigint NOT NULL,
+    organization_id uuid NOT NULL,
+    quote_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: quote_owners_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.quote_owners_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: quote_owners_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.quote_owners_id_seq OWNED BY public.quote_owners.id;
+
+
+--
+-- Name: quotes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quotes (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    customer_id uuid NOT NULL,
+    number character varying NOT NULL,
+    version integer DEFAULT 1 NOT NULL,
+    sequential_id integer NOT NULL,
+    order_type integer NOT NULL,
+    currency character varying,
+    description text,
+    status public.quote_status DEFAULT 'draft'::public.quote_status NOT NULL,
+    approved_at timestamp(6) without time zone,
+    voided_at timestamp(6) without time zone,
+    void_reason integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    billing_items jsonb,
+    commercial_terms jsonb,
+    content text,
+    legal_text text,
+    internal_notes text,
+    contacts jsonb,
+    metadata jsonb,
+    auto_execute boolean DEFAULT false NOT NULL,
+    backdated_billing integer,
+    execution_mode integer,
+    share_token character varying,
+    CONSTRAINT quotes_constraint_sequentialid_positive CHECK ((sequential_id > 0)),
+    CONSTRAINT quotes_constraint_version_positive CHECK ((version > 0))
 );
 
 
@@ -4987,6 +5182,13 @@ CREATE TABLE public.webhooks (
 --
 
 ALTER TABLE ONLY public.enriched_events ATTACH PARTITION public.enriched_events_default DEFAULT;
+
+
+--
+-- Name: quote_owners id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners ALTER COLUMN id SET DEFAULT nextval('public.quote_owners_id_seq'::regclass);
 
 
 --
@@ -5620,6 +5822,22 @@ ALTER TABLE ONLY public.memberships
 
 
 --
+-- Name: order_forms order_forms_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.order_forms
+    ADD CONSTRAINT order_forms_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: orders orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orders
+    ADD CONSTRAINT orders_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5753,6 +5971,22 @@ ALTER TABLE ONLY public.pricing_units
 
 ALTER TABLE ONLY public.quantified_events
     ADD CONSTRAINT quantified_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quote_owners quote_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT quote_owners_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quotes quotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT quotes_pkey PRIMARY KEY (id);
 
 
 --
@@ -8417,6 +8651,34 @@ CREATE UNIQUE INDEX index_memberships_on_user_id_and_organization_id ON public.m
 
 
 --
+-- Name: index_order_forms_on_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_order_forms_on_customer_id ON public.order_forms USING btree (customer_id);
+
+
+--
+-- Name: index_order_forms_on_quote_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_order_forms_on_quote_id ON public.order_forms USING btree (quote_id);
+
+
+--
+-- Name: index_orders_on_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orders_on_customer_id ON public.orders USING btree (customer_id);
+
+
+--
+-- Name: index_orders_on_order_form_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orders_on_order_form_id ON public.orders USING btree (order_form_id);
+
+
+--
 -- Name: index_organizations_on_api_key; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8851,6 +9113,34 @@ CREATE INDEX index_quantified_events_on_organization_id ON public.quantified_eve
 
 
 --
+-- Name: index_quote_owners_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_owners_on_organization_id ON public.quote_owners USING btree (organization_id);
+
+
+--
+-- Name: index_quote_owners_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_owners_on_user_id ON public.quote_owners USING btree (user_id);
+
+
+--
+-- Name: index_quotes_on_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quotes_on_customer_id ON public.quotes USING btree (customer_id);
+
+
+--
+-- Name: index_quotes_on_organization_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quotes_on_organization_number ON public.quotes USING btree (organization_id, number);
+
+
+--
 -- Name: index_recurring_transaction_rules_on_expiration_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9093,6 +9383,55 @@ CREATE UNIQUE INDEX index_uniq_wallet_code_per_customer ON public.wallets USING 
 --
 
 CREATE UNIQUE INDEX index_unique_applied_to_organization_per_organization ON public.dunning_campaigns USING btree (organization_id) WHERE ((applied_to_organization = true) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_unique_order_forms_on_organization_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_order_forms_on_organization_number ON public.order_forms USING btree (organization_id, number);
+
+
+--
+-- Name: index_unique_order_forms_on_organization_sequentialid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_order_forms_on_organization_sequentialid ON public.order_forms USING btree (organization_id, sequential_id);
+
+
+--
+-- Name: index_unique_orders_on_organization_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_orders_on_organization_number ON public.orders USING btree (organization_id, number);
+
+
+--
+-- Name: index_unique_orders_on_organization_sequentialid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_orders_on_organization_sequentialid ON public.orders USING btree (organization_id, sequential_id);
+
+
+--
+-- Name: index_unique_quote_owners_on_quote_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_owners_on_quote_user ON public.quote_owners USING btree (quote_id, user_id);
+
+
+--
+-- Name: index_unique_quotes_on_organization_sequentialid_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quotes_on_organization_sequentialid_version ON public.quotes USING btree (organization_id, sequential_id, version DESC);
+
+
+--
+-- Name: index_unique_quotes_on_share_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quotes_on_share_token ON public.quotes USING btree (share_token);
 
 
 --
@@ -9646,6 +9985,14 @@ ALTER TABLE ONLY public.integration_customers
 
 
 --
+-- Name: order_forms fk_rails_0f6233ccbc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.order_forms
+    ADD CONSTRAINT fk_rails_0f6233ccbc FOREIGN KEY (signed_by_user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: integration_mappings fk_rails_0f762162b0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9723,6 +10070,14 @@ ALTER TABLE ONLY public.invoice_subscriptions
 
 ALTER TABLE ONLY public.entitlement_entitlements
     ADD CONSTRAINT fk_rails_173327f0dc FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
+
+
+--
+-- Name: quote_owners fk_rails_1811b32fcd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_1811b32fcd FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -10150,6 +10505,14 @@ ALTER TABLE ONLY public.integration_collection_mappings
 
 
 --
+-- Name: orders fk_rails_3dad120da9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orders
+    ADD CONSTRAINT fk_rails_3dad120da9 FOREIGN KEY (customer_id) REFERENCES public.customers(id);
+
+
+--
 -- Name: entitlement_privileges fk_rails_3e4df02771; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10198,6 +10561,14 @@ ALTER TABLE ONLY public.credit_notes
 
 
 --
+-- Name: quote_owners fk_rails_45230f8485; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_45230f8485 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: integration_items fk_rails_47d8081062; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10235,6 +10606,14 @@ ALTER TABLE ONLY public.recurring_transaction_rules_invoice_custom_sections
 
 ALTER TABLE ONLY public.billing_entities
     ADD CONSTRAINT fk_rails_4aa58496c3 FOREIGN KEY (applied_dunning_campaign_id) REFERENCES public.dunning_campaigns(id) ON DELETE SET NULL;
+
+
+--
+-- Name: order_forms fk_rails_4ed54bfec0; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.order_forms
+    ADD CONSTRAINT fk_rails_4ed54bfec0 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -10406,11 +10785,27 @@ ALTER TABLE ONLY public.fees
 
 
 --
+-- Name: order_forms fk_rails_60bc1d491f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.order_forms
+    ADD CONSTRAINT fk_rails_60bc1d491f FOREIGN KEY (quote_id) REFERENCES public.quotes(id);
+
+
+--
 -- Name: credit_notes_taxes fk_rails_626209b8d2; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.credit_notes_taxes
     ADD CONSTRAINT fk_rails_626209b8d2 FOREIGN KEY (tax_id) REFERENCES public.taxes(id);
+
+
+--
+-- Name: order_forms fk_rails_6298debfc7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.order_forms
+    ADD CONSTRAINT fk_rails_6298debfc7 FOREIGN KEY (customer_id) REFERENCES public.customers(id);
 
 
 --
@@ -10619,6 +11014,14 @@ ALTER TABLE ONLY public.integrations
 
 ALTER TABLE ONLY public.commitments
     ADD CONSTRAINT fk_rails_76ceb88c74 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: quote_owners fk_rails_7734750af9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_7734750af9 FOREIGN KEY (quote_id) REFERENCES public.quotes(id);
 
 
 --
@@ -11030,6 +11433,14 @@ ALTER TABLE ONLY public.credit_note_items
 
 
 --
+-- Name: quotes fk_rails_a1ab65f1f7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT fk_rails_a1ab65f1f7 FOREIGN KEY (customer_id) REFERENCES public.customers(id);
+
+
+--
 -- Name: group_properties fk_rails_a2d2cb3819; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11147,6 +11558,14 @@ ALTER TABLE ONLY public.fees
 
 ALTER TABLE ONLY public.entitlement_entitlements
     ADD CONSTRAINT fk_rails_b61aa73940 FOREIGN KEY (entitlement_feature_id) REFERENCES public.entitlement_features(id);
+
+
+--
+-- Name: orders fk_rails_b687c6e23a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orders
+    ADD CONSTRAINT fk_rails_b687c6e23a FOREIGN KEY (order_form_id) REFERENCES public.order_forms(id);
 
 
 --
@@ -11470,6 +11889,14 @@ ALTER TABLE ONLY public.coupon_targets
 
 
 --
+-- Name: quotes fk_rails_de7694c307; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT fk_rails_de7694c307 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: credit_note_items fk_rails_dea748e529; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11726,6 +12153,14 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 
 
 --
+-- Name: orders fk_rails_fe8af6535c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orders
+    ADD CONSTRAINT fk_rails_fe8af6535c FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: fixed_charges_taxes fk_rails_fea16bf2e7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11787,6 +12222,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260305161303'),
 ('20260305161302'),
 ('20260305100007'),
+('20260304074158'),
 ('20260227184913'),
 ('20260224134805'),
 ('20260220131101'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -6385,6 +6385,7 @@ enum IntegrationTypeEnum {
   multi_entities_pro
   netsuite
   okta
+  order_forms
   preview
   progressive_billing
   projected_usage
@@ -9163,6 +9164,13 @@ enum PermissionEnum {
   invoices_update
   invoices_view
   invoices_void
+  order_forms_create
+  order_forms_sign
+  order_forms_view
+  order_forms_void
+  orders_create
+  orders_execute
+  orders_view
   organization_emails_update
   organization_emails_view
   organization_integrations_create
@@ -9194,6 +9202,13 @@ enum PermissionEnum {
   pricing_units_create
   pricing_units_update
   pricing_units_view
+  quotes_approve
+  quotes_clone
+  quotes_create
+  quotes_delete
+  quotes_update
+  quotes_view
+  quotes_void
   roles_create
   roles_delete
   roles_update
@@ -9270,6 +9285,13 @@ type Permissions {
   invoicesUpdate: Boolean!
   invoicesView: Boolean!
   invoicesVoid: Boolean!
+  orderFormsCreate: Boolean!
+  orderFormsSign: Boolean!
+  orderFormsView: Boolean!
+  orderFormsVoid: Boolean!
+  ordersCreate: Boolean!
+  ordersExecute: Boolean!
+  ordersView: Boolean!
   organizationEmailsUpdate: Boolean!
   organizationEmailsView: Boolean!
   organizationIntegrationsCreate: Boolean!
@@ -9301,6 +9323,13 @@ type Permissions {
   pricingUnitsCreate: Boolean!
   pricingUnitsUpdate: Boolean!
   pricingUnitsView: Boolean!
+  quotesApprove: Boolean!
+  quotesClone: Boolean!
+  quotesCreate: Boolean!
+  quotesDelete: Boolean!
+  quotesUpdate: Boolean!
+  quotesView: Boolean!
+  quotesVoid: Boolean!
   rolesCreate: Boolean!
   rolesDelete: Boolean!
   rolesUpdate: Boolean!
@@ -9440,6 +9469,7 @@ enum PremiumIntegrationTypeEnum {
   multi_entities_pro
   netsuite
   okta
+  order_forms
   preview
   progressive_billing
   projected_usage

--- a/schema.graphql
+++ b/schema.graphql
@@ -5730,6 +5730,7 @@ enum FeatureFlagEnum {
   multi_currency
   multiple_payment_methods
   non_persistable_charge_cache_optimization
+  order_forms
   payment_gated_subscriptions
   postgres_enriched_events
   wallet_traceability

--- a/schema.json
+++ b/schema.json
@@ -27798,6 +27798,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/schema.json
+++ b/schema.json
@@ -32738,6 +32738,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -44486,6 +44492,90 @@
               "deprecationReason": null
             },
             {
+              "name": "quotes_view",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_create",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_update",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_delete",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_approve",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_clone",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_void",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms_view",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms_create",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms_void",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms_sign",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders_view",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders_create",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders_execute",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -45680,6 +45770,118 @@
               "deprecationReason": null
             },
             {
+              "name": "orderFormsCreate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderFormsSign",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderFormsView",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderFormsVoid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ordersCreate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ordersExecute",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ordersView",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organizationEmailsUpdate",
               "description": null,
               "args": [],
@@ -46161,6 +46363,118 @@
             },
             {
               "name": "pricingUnitsView",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesApprove",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesClone",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesCreate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesDelete",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesUpdate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesView",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesVoid",
               "description": null,
               "args": [],
               "type": {
@@ -47595,6 +47909,12 @@
             },
             {
               "name": "granular_lifetime_usage",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/quotes.rb
+++ b/spec/factories/quotes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :quote do
+    organization
+    customer
+    sequential_id { 1 }
+    version { 1 }
+    status { :draft }
+    order_type { :subscription_creation }
+
+    trait :approved do
+      status { :approved }
+      approved_at { Time.current }
+    end
+
+    trait :voided do
+      status { :voided }
+      voided_at { Time.current }
+      void_reason { :manual }
+    end
+  end
+end

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
       events_targeting_wallets
       security_logs
       granular_lifetime_usage
+      order_forms
     ]
   end
 

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quote do
+  subject(:quote) { create(:quote) }
+
+  it do
+    expect(subject).to define_enum_for(:status)
+      .backed_by_column_of_type(:enum)
+      .with_values(
+        {
+          draft: "draft",
+          approved: "approved",
+          voided: "voided"
+        }
+      )
+      .with_default(:draft)
+      .validating(allowing_nil: false)
+
+    expect(subject).to define_enum_for(:void_reason)
+      .backed_by_column_of_type(:integer)
+      .with_values(
+        {
+          manual: 0,
+          superseded: 1,
+          cascade_of_expired: 2,
+          cascade_of_voided: 3
+        }
+      )
+      .without_instance_methods
+      .validating(allowing_nil: true)
+  end
+end

--- a/spec/requests/api/v1/quotes/billing_items/add_ons_controller_spec.rb
+++ b/spec/requests/api/v1/quotes/billing_items/add_ons_controller_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Quotes::BillingItems::AddOnsController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+
+  describe "POST /api/v1/quotes/:quote_id/add_ons" do
+    subject do
+      post_with_token(organization, "/api/v1/quotes/#{quote.id}/add_ons", {add_on: create_params})
+    end
+
+    let(:create_params) { {add_on_id: add_on.id, name: "Implementation", amount_cents: 100_000, position: 1} }
+
+    it "adds an add_on and returns the updated quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["add_ons"].length).to eq(1)
+      expect(json[:quote][:billing_items]["add_ons"].first["name"]).to eq("Implementation")
+      expect(json[:quote][:billing_items]["add_ons"].first["id"]).to start_with("qta_")
+    end
+
+    context "when quote does not belong to organization" do
+      it "returns not_found_error" do
+        post_with_token(organization, "/api/v1/quotes/#{create(:quote).id}/add_ons", {add_on: create_params})
+        expect(response).to be_not_found_error("quote")
+      end
+    end
+
+    context "when order type is subscription_creation" do
+      let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+
+      it "returns unprocessable_entity" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :voided, voided_at: Time.current, void_reason: :manual) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+
+  describe "PUT /api/v1/quotes/:quote_id/add_ons/:id" do
+    subject do
+      put_with_token(organization, "/api/v1/quotes/#{quote.id}/add_ons/#{item_id}", {add_on: update_params})
+    end
+
+    let(:item_id) { "qta_existing" }
+    let(:update_params) { {name: "Updated Name", amount_cents: 200_000} }
+
+    before do
+      quote.update!(billing_items: {"add_ons" => [{"id" => item_id, "name" => "Original", "amount_cents" => 100_000}]})
+    end
+
+    it "updates the add_on and returns the quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["add_ons"].first["name"]).to eq("Updated Name")
+    end
+
+    context "when item id is not found" do
+      it "returns not_found_error" do
+        put_with_token(organization, "/api/v1/quotes/#{quote.id}/add_ons/qta_nonexistent", {add_on: update_params})
+        expect(response).to be_not_found_error("billing_item")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :voided, voided_at: Time.current, void_reason: :manual) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/quotes/:quote_id/add_ons/:id" do
+    subject do
+      delete_with_token(organization, "/api/v1/quotes/#{quote.id}/add_ons/#{item_id}")
+    end
+
+    let(:item_id) { "qta_to_remove" }
+
+    before do
+      quote.update!(billing_items: {"add_ons" => [{"id" => item_id, "name" => "Work", "amount_cents" => 1000}]})
+    end
+
+    it "removes the add_on and returns the updated quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["add_ons"]).to be_empty
+    end
+
+    context "when item id is not found" do
+      it "returns not_found_error" do
+        delete_with_token(organization, "/api/v1/quotes/#{quote.id}/add_ons/qta_nonexistent")
+        expect(response).to be_not_found_error("billing_item")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :voided, voided_at: Time.current, void_reason: :manual) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/quotes/billing_items/coupons_controller_spec.rb
+++ b/spec/requests/api/v1/quotes/billing_items/coupons_controller_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Quotes::BillingItems::CouponsController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+
+  describe "POST /api/v1/quotes/:quote_id/coupons" do
+    subject do
+      post_with_token(organization, "/api/v1/quotes/#{quote.id}/coupons", {coupon: create_params})
+    end
+
+    let(:create_params) { {coupon_id: coupon.id, coupon_type: "fixed_amount", amount_cents: 5000, position: 1} }
+
+    it "adds a coupon and returns the updated quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["coupons"].length).to eq(1)
+      expect(json[:quote][:billing_items]["coupons"].first["coupon_id"]).to eq(coupon.id)
+      expect(json[:quote][:billing_items]["coupons"].first["id"]).to start_with("qtc_")
+    end
+
+    context "when quote does not belong to organization" do
+      it "returns not_found_error" do
+        post_with_token(organization, "/api/v1/quotes/#{create(:quote).id}/coupons", {coupon: create_params})
+        expect(response).to be_not_found_error("quote")
+      end
+    end
+
+    context "when order type is one_off" do
+      let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+
+      it "returns unprocessable_entity" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+
+  describe "PUT /api/v1/quotes/:quote_id/coupons/:id" do
+    subject do
+      put_with_token(organization, "/api/v1/quotes/#{quote.id}/coupons/#{item_id}", {coupon: update_params})
+    end
+
+    let(:item_id) { "qtc_existing" }
+    let(:update_params) { {amount_cents: 10_000} }
+
+    before do
+      quote.update!(billing_items: {
+        "coupons" => [{"id" => item_id, "coupon_id" => coupon.id, "coupon_type" => "fixed_amount", "amount_cents" => 5000}]
+      })
+    end
+
+    it "updates the coupon and returns the quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["coupons"].first["amount_cents"]).to eq(10_000)
+    end
+
+    context "when item id is not found" do
+      it "returns not_found_error" do
+        put_with_token(organization, "/api/v1/quotes/#{quote.id}/coupons/qtc_nonexistent", {coupon: update_params})
+        expect(response).to be_not_found_error("billing_item")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/quotes/:quote_id/coupons/:id" do
+    subject do
+      delete_with_token(organization, "/api/v1/quotes/#{quote.id}/coupons/#{item_id}")
+    end
+
+    let(:item_id) { "qtc_to_remove" }
+
+    before do
+      quote.update!(billing_items: {
+        "coupons" => [{"id" => item_id, "coupon_id" => coupon.id, "coupon_type" => "fixed_amount"}]
+      })
+    end
+
+    it "removes the coupon and returns the updated quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["coupons"]).to be_empty
+    end
+
+    context "when item id is not found" do
+      it "returns not_found_error" do
+        delete_with_token(organization, "/api/v1/quotes/#{quote.id}/coupons/qtc_nonexistent")
+        expect(response).to be_not_found_error("billing_item")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/quotes/billing_items/plans_controller_spec.rb
+++ b/spec/requests/api/v1/quotes/billing_items/plans_controller_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Quotes::BillingItems::PlansController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+
+  describe "POST /api/v1/quotes/:quote_id/plans" do
+    subject do
+      post_with_token(organization, "/api/v1/quotes/#{quote.id}/plans", {plan: create_params})
+    end
+
+    let(:create_params) { {plan_id: plan.id, plan_name: "Enterprise", position: 1} }
+
+    it "adds a plan and returns the updated quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:lago_id]).to eq(quote.id)
+      expect(json[:quote][:billing_items]["plans"].length).to eq(1)
+      expect(json[:quote][:billing_items]["plans"].first["plan_id"]).to eq(plan.id)
+      expect(json[:quote][:billing_items]["plans"].first["id"]).to start_with("qtp_")
+    end
+
+    context "when quote does not belong to organization" do
+      let(:other_quote) { create(:quote) }
+
+      it "returns not_found_error" do
+        post_with_token(organization, "/api/v1/quotes/#{other_quote.id}/plans", {plan: create_params})
+        expect(response).to be_not_found_error("quote")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+
+    context "when plan does not belong to organization" do
+      let(:create_params) { {plan_id: create(:plan).id, plan_name: "Other"} }
+
+      it "returns unprocessable_entity" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "PUT /api/v1/quotes/:quote_id/plans/:id" do
+    subject do
+      put_with_token(organization, "/api/v1/quotes/#{quote.id}/plans/#{item_id}", {plan: update_params})
+    end
+
+    let(:item_id) { "qtp_existing" }
+    let(:update_params) { {plan_name: "Updated Name"} }
+
+    before do
+      quote.update!(billing_items: {"plans" => [{"id" => item_id, "plan_id" => plan.id, "plan_name" => "Original"}]})
+    end
+
+    it "updates the plan and returns the quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["plans"].first["plan_name"]).to eq("Updated Name")
+      expect(json[:quote][:billing_items]["plans"].first["id"]).to eq(item_id)
+    end
+
+    context "when item id is not found" do
+      it "returns not_found_error" do
+        put_with_token(organization, "/api/v1/quotes/#{quote.id}/plans/qtp_nonexistent", {plan: update_params})
+        expect(response).to be_not_found_error("billing_item")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/quotes/:quote_id/plans/:id" do
+    subject do
+      delete_with_token(organization, "/api/v1/quotes/#{quote.id}/plans/#{item_id}")
+    end
+
+    let(:item_id) { "qtp_to_remove" }
+
+    before do
+      quote.update!(billing_items: {"plans" => [{"id" => item_id, "plan_id" => plan.id}]})
+    end
+
+    it "removes the plan and returns the updated quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["plans"]).to be_empty
+    end
+
+    context "when item id is not found" do
+      it "returns not_found_error" do
+        delete_with_token(organization, "/api/v1/quotes/#{quote.id}/plans/qtp_nonexistent")
+        expect(response).to be_not_found_error("billing_item")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/quotes/billing_items/wallet_credits_controller_spec.rb
+++ b/spec/requests/api/v1/quotes/billing_items/wallet_credits_controller_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Quotes::BillingItems::WalletCreditsController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+
+  describe "POST /api/v1/quotes/:quote_id/wallet_credits" do
+    subject do
+      post_with_token(organization, "/api/v1/quotes/#{quote.id}/wallet_credits", {wallet_credit: create_params})
+    end
+
+    let(:create_params) do
+      {
+        name: "Monthly credits",
+        currency: "EUR",
+        rate_amount: "1.0",
+        paid_credits: "500.0",
+        granted_credits: "500.0",
+        position: 1
+      }
+    end
+
+    it "adds a wallet credit and returns the updated quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["wallet_credits"].length).to eq(1)
+      expect(json[:quote][:billing_items]["wallet_credits"].first["name"]).to eq("Monthly credits")
+      expect(json[:quote][:billing_items]["wallet_credits"].first["id"]).to start_with("qtw_")
+    end
+
+    context "when quote does not belong to organization" do
+      it "returns not_found_error" do
+        post_with_token(organization, "/api/v1/quotes/#{create(:quote).id}/wallet_credits", {wallet_credit: create_params})
+        expect(response).to be_not_found_error("quote")
+      end
+    end
+
+    context "when order type is one_off" do
+      let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+
+      it "returns unprocessable_entity" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+
+  describe "PUT /api/v1/quotes/:quote_id/wallet_credits/:id" do
+    subject do
+      put_with_token(organization, "/api/v1/quotes/#{quote.id}/wallet_credits/#{item_id}", {wallet_credit: update_params})
+    end
+
+    let(:item_id) { "qtw_existing" }
+    let(:update_params) { {paid_credits: "1000.0"} }
+
+    before do
+      quote.update!(billing_items: {
+        "wallet_credits" => [{"id" => item_id, "name" => "Credits", "currency" => "EUR", "paid_credits" => "500.0"}]
+      })
+    end
+
+    it "updates the wallet credit and returns the quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["wallet_credits"].first["paid_credits"]).to eq("1000.0")
+    end
+
+    context "when item id is not found" do
+      it "returns not_found_error" do
+        put_with_token(organization, "/api/v1/quotes/#{quote.id}/wallet_credits/qtw_nonexistent", {wallet_credit: update_params})
+        expect(response).to be_not_found_error("billing_item")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/quotes/:quote_id/wallet_credits/:id" do
+    subject do
+      delete_with_token(organization, "/api/v1/quotes/#{quote.id}/wallet_credits/#{item_id}")
+    end
+
+    let(:item_id) { "qtw_to_remove" }
+
+    before do
+      quote.update!(billing_items: {
+        "wallet_credits" => [{"id" => item_id, "name" => "Credits", "currency" => "EUR"}]
+      })
+    end
+
+    it "removes the wallet credit and returns the updated quote" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:quote][:billing_items]["wallet_credits"]).to be_empty
+    end
+
+    context "when item id is not found" do
+      it "returns not_found_error" do
+        delete_with_token(organization, "/api/v1/quotes/#{quote.id}/wallet_credits/qtw_nonexistent")
+        expect(response).to be_not_found_error("billing_item")
+      end
+    end
+
+    context "when quote is not draft" do
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns method_not_allowed" do
+        subject
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+  end
+end

--- a/spec/services/quotes/approve_service_spec.rb
+++ b/spec/services/quotes/approve_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::ApproveService do
+  subject(:approve_service) { described_class.new(quote:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, organization:) }
+
+  describe ".call" do
+    let(:result) { approve_service.call }
+
+    context "when the quote is approvable", :premium do
+      it "approves the quote" do
+        freeze_time do
+          expect(result).to be_success
+          expect(result.quote.approved?).to eq(true)
+          expect(result.quote.approved_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context "when the quote is voided", :premium do
+      let(:quote) { create(:quote, :voided, organization:) }
+
+      it "does not approve the quote" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+
+        quote.reload
+        expect(quote.approved?).to eq(false)
+        expect(quote.approved_at).to eq(nil)
+      end
+    end
+
+    context "when the quote is already approved", :premium do
+      let(:quote) { create(:quote, :approved, organization:) }
+
+      it "does not approve the quote" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/add_ons/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/add_service_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe Quotes::BillingItems::AddOns::AddService do
       end
     end
 
+    context "when quote is nil" do
+      let(:params) { {name: "Work", amount_cents: 1000} }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, params:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:params) { {name: "Work", amount_cents: 1000} }
 

--- a/spec/services/quotes/billing_items/add_ons/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/add_service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::AddOns::AddService do
+  subject(:service) { described_class.new(quote:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "with catalog add_on reference" do
+      let(:params) { {add_on_id: add_on.id, name: "Implementation", amount_cents: 100_000, position: 1} }
+
+      it "appends the add_on and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["add_ons"].length).to eq(1)
+        expect(result.quote.billing_items["add_ons"].first["add_on_id"]).to eq(add_on.id)
+      end
+
+      it "generates a stable id with qta_ prefix" do
+        expect(result.quote.billing_items["add_ons"].first["id"]).to start_with("qta_")
+      end
+    end
+
+    context "with custom add_on (no catalog reference)" do
+      let(:params) { {name: "Custom Work", amount_cents: 50_000, position: 1} }
+
+      it "returns success and generates id" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["add_ons"].first["id"]).to start_with("qta_")
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:params) { {name: "Work", amount_cents: 1000} }
+
+      before { quote.update!(status: :voided, voided_at: Time.current, void_reason: :manual) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when order type is subscription_creation" do
+      let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+      let(:params) { {name: "Work", amount_cents: 1000} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("add_ons not allowed for subscription order type")
+      end
+    end
+
+    context "when name is missing" do
+      let(:params) { {amount_cents: 1000} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("name is required")
+      end
+    end
+
+    context "when add_on_id is absent and amount_cents is missing" do
+      let(:params) { {name: "Custom Work"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("amount_cents is required when add_on_id is not provided")
+      end
+    end
+
+    context "when add_on does not belong to organization" do
+      let(:other_add_on) { create(:add_on) }
+      let(:params) { {add_on_id: other_add_on.id, name: "Work", amount_cents: 1000} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("add_on not found in organization")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/add_ons/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/remove_service_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe Quotes::BillingItems::AddOns::RemoveService do
       end
     end
 
+    context "when quote is nil" do
+      let(:id) { item_id }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, id:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:id) { item_id }
 

--- a/spec/services/quotes/billing_items/add_ons/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/remove_service_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::AddOns::RemoveService do
+  subject(:service) { described_class.new(quote:, id:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:item_id) { "qta_to_remove" }
+  let(:quote) do
+    create(:quote, organization:, customer:, order_type: :one_off,
+      billing_items: {"add_ons" => [{"id" => item_id, "name" => "Work", "amount_cents" => 1000}]})
+  end
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "when item exists" do
+      let(:id) { item_id }
+
+      it "removes the add_on from billing_items and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["add_ons"]).to be_empty
+      end
+
+      it "only removes the targeted item when multiple add_ons exist" do
+        other_item = {"id" => "qta_other", "name" => "Other", "amount_cents" => 500}
+        quote.update!(billing_items: {"add_ons" => [{"id" => item_id, "name" => "Work", "amount_cents" => 1000}, other_item]})
+
+        expect(result.quote.billing_items["add_ons"].map { |a| a["id"] }).to eq(["qta_other"])
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:id) { item_id }
+
+      before { quote.update!(status: :voided, voided_at: Time.current, void_reason: :manual) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when item id is not found" do
+      let(:id) { "qta_nonexistent" }
+
+      it "returns not_found_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_item")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/add_ons/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/update_service_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe Quotes::BillingItems::AddOns::UpdateService do
       end
     end
 
+    context "when quote is nil" do
+      let(:id) { item_id }
+      let(:params) { {name: "Updated"} }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, id:, params:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:params) { {name: "Updated"} }
 

--- a/spec/services/quotes/billing_items/add_ons/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/update_service_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::AddOns::UpdateService do
+  subject(:service) { described_class.new(quote:, id:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:item_id) { "qta_existing" }
+  let(:quote) do
+    create(:quote, organization:, customer:, order_type: :one_off,
+      billing_items: {
+        "add_ons" => [{"id" => item_id, "add_on_id" => add_on.id, "name" => "Original", "amount_cents" => 1000}]
+      })
+  end
+
+  describe "#call" do
+    let(:result) { service.call }
+    let(:id) { item_id }
+
+    context "with valid params" do
+      let(:params) { {name: "Updated Name", amount_cents: 2000} }
+
+      it "updates the add_on fields and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["add_ons"].first["name"]).to eq("Updated Name")
+        expect(result.quote.billing_items["add_ons"].first["amount_cents"]).to eq(2000)
+      end
+
+      it "preserves the existing id" do
+        expect(result.quote.billing_items["add_ons"].first["id"]).to eq(item_id)
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:params) { {name: "Updated"} }
+
+      before { quote.update!(status: :voided, voided_at: Time.current, void_reason: :manual) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when item id is not found" do
+      let(:id) { "qta_nonexistent" }
+      let(:params) { {name: "Updated"} }
+
+      it "returns not_found_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_item")
+      end
+    end
+
+    context "when name is cleared" do
+      let(:params) { {name: nil} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("name is required")
+      end
+    end
+
+    context "when add_on_id is updated to one from another organization" do
+      let(:other_add_on) { create(:add_on) }
+      let(:params) { {add_on_id: other_add_on.id} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("add_on not found in organization")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/coupons/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/coupons/add_service_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe Quotes::BillingItems::Coupons::AddService do
       end
     end
 
+    context "when quote is nil" do
+      let(:params) { {coupon_id: coupon.id, coupon_type: "fixed_amount"} }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, params:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:params) { {coupon_id: coupon.id, coupon_type: "fixed_amount"} }
 

--- a/spec/services/quotes/billing_items/coupons/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/coupons/add_service_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Coupons::AddService do
+  subject(:service) { described_class.new(quote:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "with valid params" do
+      let(:params) { {coupon_id: coupon.id, coupon_type: "fixed_amount", amount_cents: 5000, position: 1} }
+
+      it "appends the coupon and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["coupons"].length).to eq(1)
+        expect(result.quote.billing_items["coupons"].first["coupon_id"]).to eq(coupon.id)
+      end
+
+      it "generates a stable id with qtc_ prefix" do
+        expect(result.quote.billing_items["coupons"].first["id"]).to start_with("qtc_")
+      end
+    end
+
+    context "with percentage coupon type" do
+      let(:params) { {coupon_id: coupon.id, coupon_type: "percentage", percentage_rate: "20.0", position: 1} }
+
+      it "returns success" do
+        expect(result).to be_success
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:params) { {coupon_id: coupon.id, coupon_type: "fixed_amount"} }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when order type is one_off" do
+      let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+      let(:params) { {coupon_id: coupon.id, coupon_type: "fixed_amount"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("coupons not allowed for one_off order type")
+      end
+    end
+
+    context "when coupon_id is missing" do
+      let(:params) { {coupon_type: "fixed_amount"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("coupon_id is required")
+      end
+    end
+
+    context "when coupon does not belong to organization" do
+      let(:other_coupon) { create(:coupon) }
+      let(:params) { {coupon_id: other_coupon.id, coupon_type: "fixed_amount"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("coupon not found in organization")
+      end
+    end
+
+    context "when coupon_type is invalid" do
+      let(:params) { {coupon_id: coupon.id, coupon_type: "unknown"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("coupon_type is invalid")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/coupons/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/coupons/remove_service_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Coupons::RemoveService do
+  subject(:service) { described_class.new(quote:, id:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:item_id) { "qtc_to_remove" }
+  let(:quote) do
+    create(:quote, organization:, customer:, order_type: :subscription_creation,
+      billing_items: {"coupons" => [{"id" => item_id, "coupon_id" => coupon.id, "coupon_type" => "fixed_amount"}]})
+  end
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "when item exists" do
+      let(:id) { item_id }
+
+      it "removes the coupon from billing_items and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["coupons"]).to be_empty
+      end
+
+      it "only removes the targeted item when multiple coupons exist" do
+        other_item = {"id" => "qtc_other", "coupon_id" => create(:coupon, organization:).id, "coupon_type" => "percentage"}
+        quote.update!(billing_items: {
+          "coupons" => [
+            {"id" => item_id, "coupon_id" => coupon.id, "coupon_type" => "fixed_amount"},
+            other_item
+          ]
+        })
+
+        expect(result.quote.billing_items["coupons"].map { |c| c["id"] }).to eq(["qtc_other"])
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:id) { item_id }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when item id is not found" do
+      let(:id) { "qtc_nonexistent" }
+
+      it "returns not_found_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_item")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/coupons/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/coupons/remove_service_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe Quotes::BillingItems::Coupons::RemoveService do
       end
     end
 
+    context "when quote is nil" do
+      let(:id) { item_id }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, id:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:id) { item_id }
 

--- a/spec/services/quotes/billing_items/coupons/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/coupons/update_service_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Coupons::UpdateService do
+  subject(:service) { described_class.new(quote:, id:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:item_id) { "qtc_existing" }
+  let(:quote) do
+    create(:quote, organization:, customer:, order_type: :subscription_creation,
+      billing_items: {
+        "coupons" => [{"id" => item_id, "coupon_id" => coupon.id, "coupon_type" => "fixed_amount", "amount_cents" => 5000}]
+      })
+  end
+
+  describe "#call" do
+    let(:result) { service.call }
+    let(:id) { item_id }
+
+    context "with valid params" do
+      let(:params) { {amount_cents: 10_000} }
+
+      it "updates the coupon fields and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["coupons"].first["amount_cents"]).to eq(10_000)
+      end
+
+      it "preserves the existing id" do
+        expect(result.quote.billing_items["coupons"].first["id"]).to eq(item_id)
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:params) { {amount_cents: 10_000} }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when item id is not found" do
+      let(:id) { "qtc_nonexistent" }
+      let(:params) { {amount_cents: 1000} }
+
+      it "returns not_found_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_item")
+      end
+    end
+
+    context "when coupon_type is updated to an invalid value" do
+      let(:params) { {coupon_type: "unknown"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("coupon_type is invalid")
+      end
+    end
+
+    context "when coupon_id is updated to one from another organization" do
+      let(:other_coupon) { create(:coupon) }
+      let(:params) { {coupon_id: other_coupon.id} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("coupon not found in organization")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/coupons/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/coupons/update_service_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Quotes::BillingItems::Coupons::UpdateService do
       end
     end
 
+    context "when quote is nil" do
+      let(:id) { item_id }
+      let(:params) { {amount_cents: 1000} }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, id:, params:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:params) { {amount_cents: 10_000} }
 

--- a/spec/services/quotes/billing_items/plans/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/add_service_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Plans::AddService do
+  subject(:service) { described_class.new(quote:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "with valid params" do
+      let(:params) { {plan_id: plan.id, plan_name: "Enterprise", position: 1} }
+
+      it "appends the plan to billing_items and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["plans"].length).to eq(1)
+        expect(result.quote.billing_items["plans"].first["plan_id"]).to eq(plan.id)
+      end
+
+      it "generates a stable id with qtp_ prefix" do
+        expect(result.quote.billing_items["plans"].first["id"]).to start_with("qtp_")
+      end
+
+      it "preserves an existing id" do
+        params[:id] = "qtp_existing"
+        expect(result.quote.billing_items["plans"].first["id"]).to eq("qtp_existing")
+      end
+
+      it "appends to existing plans without replacing them" do
+        existing_item = {"id" => "qtp_first", "plan_id" => create(:plan, organization:).id}
+        quote.update!(billing_items: {"plans" => [existing_item]})
+
+        expect(result.quote.billing_items["plans"].length).to eq(2)
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:params) { {plan_id: plan.id} }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when order type is one_off" do
+      let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+      let(:params) { {plan_id: plan.id} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:billing_item]).to include("plans not allowed for one_off order type")
+      end
+    end
+
+    context "when plan_id is missing" do
+      let(:params) { {plan_name: "Enterprise"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("plan_id is required")
+      end
+    end
+
+    context "when plan does not belong to organization" do
+      let(:other_plan) { create(:plan) }
+      let(:params) { {plan_id: other_plan.id, plan_name: "Other"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("plan not found in organization")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/plans/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/add_service_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe Quotes::BillingItems::Plans::AddService do
       end
     end
 
+    context "when quote is nil" do
+      let(:params) { {plan_id: plan.id} }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, params:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:params) { {plan_id: plan.id} }
 

--- a/spec/services/quotes/billing_items/plans/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/remove_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Plans::RemoveService do
+  subject(:service) { described_class.new(quote:, id:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:item_id) { "qtp_to_remove" }
+  let(:quote) do
+    create(:quote, organization:, customer:, order_type: :subscription_creation,
+      billing_items: {"plans" => [{"id" => item_id, "plan_id" => plan.id}]})
+  end
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "when item exists" do
+      let(:id) { item_id }
+
+      it "removes the plan from billing_items and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["plans"]).to be_empty
+      end
+
+      it "only removes the targeted item when multiple plans exist" do
+        other_item = {"id" => "qtp_other", "plan_id" => create(:plan, organization:).id}
+        quote.update!(billing_items: {"plans" => [{"id" => item_id, "plan_id" => plan.id}, other_item]})
+
+        expect(result.quote.billing_items["plans"].map { |p| p["id"] }).to eq(["qtp_other"])
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:id) { item_id }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when item id is not found" do
+      let(:id) { "qtp_nonexistent" }
+
+      it "returns not_found_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_item")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/plans/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/remove_service_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe Quotes::BillingItems::Plans::RemoveService do
       end
     end
 
+    context "when quote is nil" do
+      let(:id) { item_id }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, id:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:id) { item_id }
 

--- a/spec/services/quotes/billing_items/plans/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/update_service_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Plans::UpdateService do
+  subject(:service) { described_class.new(quote:, id:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:item_id) { "qtp_existing" }
+  let(:quote) do
+    create(:quote, organization:, customer:, order_type: :subscription_creation,
+      billing_items: {"plans" => [{"id" => item_id, "plan_id" => plan.id, "plan_name" => "Original"}]})
+  end
+
+  describe "#call" do
+    let(:result) { service.call }
+    let(:id) { item_id }
+
+    context "with valid params" do
+      let(:params) { {plan_name: "Updated Name"} }
+
+      it "updates the plan fields and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["plans"].first["plan_name"]).to eq("Updated Name")
+      end
+
+      it "preserves the existing id" do
+        expect(result.quote.billing_items["plans"].first["id"]).to eq(item_id)
+      end
+
+      it "preserves fields not included in params" do
+        expect(result.quote.billing_items["plans"].first["plan_id"]).to eq(plan.id)
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:params) { {plan_name: "Updated"} }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when item id is not found" do
+      let(:id) { "qtp_nonexistent" }
+      let(:params) { {plan_name: "Updated"} }
+
+      it "returns not_found_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_item")
+      end
+    end
+
+    context "when updated plan_id does not belong to organization" do
+      let(:other_plan) { create(:plan) }
+      let(:params) { {plan_id: other_plan.id} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("plan not found in organization")
+      end
+    end
+
+    context "when plan_id is cleared" do
+      let(:params) { {plan_id: nil} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("plan_id is required")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/plans/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/update_service_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe Quotes::BillingItems::Plans::UpdateService do
       end
     end
 
+    context "when quote is nil" do
+      let(:id) { item_id }
+      let(:params) { {plan_name: "Updated"} }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, id:, params:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:params) { {plan_name: "Updated"} }
 

--- a/spec/services/quotes/billing_items/validate_service_spec.rb
+++ b/spec/services/quotes/billing_items/validate_service_spec.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::ValidateService do
+  subject(:service) { described_class.new(organization:, order_type:, billing_items:) }
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "with subscription_creation order type" do
+      let(:order_type) { "subscription_creation" }
+
+      context "with valid plans" do
+        let(:billing_items) do
+          {
+            "plans" => [{"plan_id" => plan.id, "plan_name" => "Enterprise", "position" => 1}],
+            "coupons" => [],
+            "wallet_credits" => []
+          }
+        end
+
+        it "returns success with billing_items" do
+          expect(result).to be_success
+          expect(result.billing_items["plans"].first["plan_id"]).to eq(plan.id)
+        end
+
+        it "generates ids for items missing them" do
+          expect(result.billing_items["plans"].first["id"]).to start_with("qtp_")
+        end
+
+        it "preserves existing ids" do
+          billing_items["plans"].first["id"] = "qtp_existing"
+          expect(result.billing_items["plans"].first["id"]).to eq("qtp_existing")
+        end
+      end
+
+      context "with valid coupons" do
+        let(:billing_items) do
+          {
+            "plans" => [{"plan_id" => plan.id, "plan_name" => "Enterprise", "position" => 1}],
+            "coupons" => [{"coupon_id" => coupon.id, "coupon_type" => "fixed_amount", "amount_cents" => 5000, "position" => 1}],
+            "wallet_credits" => []
+          }
+        end
+
+        it "returns success and generates coupon id" do
+          expect(result).to be_success
+          expect(result.billing_items["coupons"].first["id"]).to start_with("qtc_")
+        end
+      end
+
+      context "with valid wallet_credits" do
+        let(:billing_items) do
+          {
+            "plans" => [{"plan_id" => plan.id, "plan_name" => "Enterprise", "position" => 1}],
+            "wallet_credits" => [
+              {
+                "name" => "Credits",
+                "currency" => "EUR",
+                "rate_amount" => "1.0",
+                "paid_credits" => "500.0",
+                "granted_credits" => "500.0",
+                "position" => 1,
+                "recurring_transaction_rules" => [
+                  {"trigger" => "interval", "interval" => "monthly", "paid_credits" => "500.0", "granted_credits" => "500.0"}
+                ]
+              }
+            ]
+          }
+        end
+
+        it "generates ids for wallet credit and its recurring rules" do
+          expect(result).to be_success
+          credit = result.billing_items["wallet_credits"].first
+          expect(credit["id"]).to start_with("qtw_")
+          expect(credit["recurring_transaction_rules"].first["id"]).to start_with("qtrr_")
+        end
+      end
+
+      context "when add_ons are present" do
+        let(:billing_items) do
+          {"add_ons" => [{"name" => "X", "amount_cents" => 100, "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:billing_items]).to include("add_ons not allowed for subscription order type")
+        end
+      end
+
+      context "when plan_id is missing" do
+        let(:billing_items) do
+          {"plans" => [{"plan_name" => "Enterprise", "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error.messages[:billing_items]).to include("plans[0].plan_id is required")
+        end
+      end
+
+      context "when plan does not belong to organization" do
+        let(:other_plan) { create(:plan) }
+        let(:billing_items) do
+          {"plans" => [{"plan_id" => other_plan.id, "plan_name" => "X", "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error.messages[:billing_items]).to include("plans[0].plan_id: plan not found in organization")
+        end
+      end
+
+      context "when coupon_type is invalid" do
+        let(:billing_items) do
+          {"coupons" => [{"coupon_id" => coupon.id, "coupon_type" => "unknown", "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error.messages[:billing_items]).to include("coupons[0].coupon_type is invalid")
+        end
+      end
+
+      context "when coupon does not belong to organization" do
+        let(:other_coupon) { create(:coupon) }
+        let(:billing_items) do
+          {"coupons" => [{"coupon_id" => other_coupon.id, "coupon_type" => "fixed_amount", "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error.messages[:billing_items]).to include("coupons[0].coupon_id: coupon not found in organization")
+        end
+      end
+    end
+
+    context "with one_off order type" do
+      let(:order_type) { "one_off" }
+
+      context "with valid add_ons using catalog reference" do
+        let(:billing_items) do
+          {"add_ons" => [{"add_on_id" => add_on.id, "name" => "Implementation", "amount_cents" => 100_000, "position" => 1}]}
+        end
+
+        it "returns success and generates id" do
+          expect(result).to be_success
+          expect(result.billing_items["add_ons"].first["id"]).to start_with("qta_")
+        end
+      end
+
+      context "with custom add_on (no catalog reference)" do
+        let(:billing_items) do
+          {"add_ons" => [{"name" => "Custom Work", "amount_cents" => 50_000, "position" => 1}]}
+        end
+
+        it "returns success" do
+          expect(result).to be_success
+          expect(result.billing_items["add_ons"].first["id"]).to start_with("qta_")
+        end
+      end
+
+      context "when add_on_id does not belong to organization" do
+        let(:other_add_on) { create(:add_on) }
+        let(:billing_items) do
+          {"add_ons" => [{"add_on_id" => other_add_on.id, "name" => "X", "amount_cents" => 1, "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error.messages[:billing_items]).to include("add_ons[0].add_on_id: add_on not found in organization")
+        end
+      end
+
+      context "when no add_on_id and amount_cents is missing" do
+        let(:billing_items) do
+          {"add_ons" => [{"name" => "Custom", "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error.messages[:billing_items]).to include("add_ons[0].amount_cents is required when add_on_id is not provided")
+        end
+      end
+
+      context "when add_on name is missing" do
+        let(:billing_items) do
+          {"add_ons" => [{"amount_cents" => 1000, "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error.messages[:billing_items]).to include("add_ons[0].name is required")
+        end
+      end
+
+      context "when plans are present" do
+        let(:billing_items) do
+          {"plans" => [{"plan_id" => plan.id, "plan_name" => "X", "position" => 1}]}
+        end
+
+        it "returns validation error" do
+          expect(result).not_to be_success
+          expect(result.error.messages[:billing_items]).to include("plans not allowed for one_off order type")
+        end
+      end
+    end
+
+    context "with empty billing_items" do
+      let(:order_type) { "subscription_creation" }
+      let(:billing_items) { {} }
+
+      it "returns success with normalized empty structure" do
+        expect(result).to be_success
+        expect(result.billing_items["plans"]).to eq([])
+        expect(result.billing_items["coupons"]).to eq([])
+        expect(result.billing_items["wallet_credits"]).to eq([])
+      end
+    end
+
+    context "with nil billing_items" do
+      let(:order_type) { "one_off" }
+      let(:billing_items) { nil }
+
+      it "returns success" do
+        expect(result).to be_success
+        expect(result.billing_items["add_ons"]).to eq([])
+      end
+    end
+
+    context "with multiple errors" do
+      let(:order_type) { "subscription_creation" }
+      let(:billing_items) do
+        {
+          "plans" => [
+            {"plan_name" => "Missing ID"},
+            {"plan_id" => "non-existent-uuid", "plan_name" => "Bad ID"}
+          ]
+        }
+      end
+
+      it "returns all errors at once" do
+        expect(result).not_to be_success
+        errors = result.error.messages[:billing_items]
+        expect(errors).to include("plans[0].plan_id is required")
+        expect(errors).to include("plans[1].plan_id: plan not found in organization")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/wallet_credits/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/add_service_spec.rb
@@ -61,6 +61,17 @@ RSpec.describe Quotes::BillingItems::WalletCredits::AddService do
       end
     end
 
+    context "when quote is nil" do
+      let(:params) { {name: "Credits", currency: "EUR", rate_amount: "1.0", paid_credits: "500.0", granted_credits: "500.0"} }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, params:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:params) { {name: "Credits", currency: "EUR", rate_amount: "1.0", paid_credits: "500.0", granted_credits: "500.0"} }
 

--- a/spec/services/quotes/billing_items/wallet_credits/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/add_service_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::WalletCredits::AddService do
+  subject(:service) { described_class.new(quote:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "with valid params" do
+      let(:params) do
+        {
+          name: "Monthly credits",
+          currency: "EUR",
+          rate_amount: "1.0",
+          paid_credits: "500.0",
+          granted_credits: "500.0",
+          position: 1
+        }
+      end
+
+      it "appends the wallet credit and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["wallet_credits"].length).to eq(1)
+        expect(result.quote.billing_items["wallet_credits"].first["name"]).to eq("Monthly credits")
+      end
+
+      it "generates a stable id with qtw_ prefix" do
+        expect(result.quote.billing_items["wallet_credits"].first["id"]).to start_with("qtw_")
+      end
+    end
+
+    context "with recurring_transaction_rules" do
+      let(:params) do
+        {
+          name: "Credits",
+          currency: "EUR",
+          rate_amount: "1.0",
+          paid_credits: "500.0",
+          granted_credits: "500.0",
+          recurring_transaction_rules: [
+            {trigger: "interval", interval: "monthly", paid_credits: "500.0", granted_credits: "500.0"}
+          ]
+        }
+      end
+
+      it "generates ids for nested recurring rules" do
+        rules = result.quote.billing_items["wallet_credits"].first["recurring_transaction_rules"]
+        expect(rules.first["id"]).to start_with("qtrr_")
+      end
+
+      it "preserves existing rule ids" do
+        params[:recurring_transaction_rules].first[:id] = "qtrr_existing"
+        rules = result.quote.billing_items["wallet_credits"].first["recurring_transaction_rules"]
+        expect(rules.first["id"]).to eq("qtrr_existing")
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:params) { {name: "Credits", currency: "EUR", rate_amount: "1.0", paid_credits: "500.0", granted_credits: "500.0"} }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when order type is one_off" do
+      let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+      let(:params) { {name: "Credits", currency: "EUR", rate_amount: "1.0", paid_credits: "500.0", granted_credits: "500.0"} }
+
+      it "returns validation_failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_item]).to include("wallet_credits not allowed for one_off order type")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/wallet_credits/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/remove_service_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe Quotes::BillingItems::WalletCredits::RemoveService do
       end
     end
 
+    context "when quote is nil" do
+      let(:id) { item_id }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, id:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:id) { item_id }
 

--- a/spec/services/quotes/billing_items/wallet_credits/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/remove_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::WalletCredits::RemoveService do
+  subject(:service) { described_class.new(quote:, id:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:item_id) { "qtw_to_remove" }
+  let(:quote) do
+    create(:quote, organization:, customer:, order_type: :subscription_creation,
+      billing_items: {
+        "wallet_credits" => [{"id" => item_id, "name" => "Credits", "currency" => "EUR"}]
+      })
+  end
+
+  describe "#call" do
+    let(:result) { service.call }
+
+    context "when item exists" do
+      let(:id) { item_id }
+
+      it "removes the wallet credit from billing_items and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["wallet_credits"]).to be_empty
+      end
+
+      it "only removes the targeted item when multiple wallet credits exist" do
+        other_item = {"id" => "qtw_other", "name" => "Other Credits", "currency" => "EUR"}
+        quote.update!(billing_items: {
+          "wallet_credits" => [
+            {"id" => item_id, "name" => "Credits", "currency" => "EUR"},
+            other_item
+          ]
+        })
+
+        expect(result.quote.billing_items["wallet_credits"].map { |w| w["id"] }).to eq(["qtw_other"])
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:id) { item_id }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when item id is not found" do
+      let(:id) { "qtw_nonexistent" }
+
+      it "returns not_found_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_item")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/wallet_credits/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/update_service_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe Quotes::BillingItems::WalletCredits::UpdateService do
       end
     end
 
+    context "when quote is nil" do
+      let(:id) { item_id }
+      let(:params) { {name: "Updated"} }
+
+      it "returns not_found_failure" do
+        result = described_class.new(quote: nil, id:, params:).call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("quote")
+      end
+    end
+
     context "when quote is not draft" do
       let(:params) { {name: "Updated"} }
 

--- a/spec/services/quotes/billing_items/wallet_credits/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/update_service_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::WalletCredits::UpdateService do
+  subject(:service) { described_class.new(quote:, id:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:item_id) { "qtw_existing" }
+  let(:quote) do
+    create(:quote, organization:, customer:, order_type: :subscription_creation,
+      billing_items: {
+        "wallet_credits" => [{
+          "id" => item_id,
+          "name" => "Monthly credits",
+          "currency" => "EUR",
+          "rate_amount" => "1.0",
+          "paid_credits" => "500.0",
+          "granted_credits" => "500.0",
+          "recurring_transaction_rules" => [{"id" => "qtrr_existing", "trigger" => "interval"}]
+        }]
+      })
+  end
+
+  describe "#call" do
+    let(:result) { service.call }
+    let(:id) { item_id }
+
+    context "with valid params" do
+      let(:params) { {name: "Updated credits", paid_credits: "1000.0"} }
+
+      it "updates the wallet credit fields and returns the quote" do
+        expect(result).to be_success
+        expect(result.quote.billing_items["wallet_credits"].first["name"]).to eq("Updated credits")
+        expect(result.quote.billing_items["wallet_credits"].first["paid_credits"]).to eq("1000.0")
+      end
+
+      it "preserves the existing id" do
+        expect(result.quote.billing_items["wallet_credits"].first["id"]).to eq(item_id)
+      end
+
+      it "preserves existing recurring_transaction_rules when not included in params" do
+        rules = result.quote.billing_items["wallet_credits"].first["recurring_transaction_rules"]
+        expect(rules.first["id"]).to eq("qtrr_existing")
+      end
+    end
+
+    context "when recurring_transaction_rules are updated" do
+      let(:params) do
+        {
+          recurring_transaction_rules: [
+            {trigger: "interval", interval: "monthly", paid_credits: "500.0"}
+          ]
+        }
+      end
+
+      it "generates ids for new rules" do
+        rules = result.quote.billing_items["wallet_credits"].first["recurring_transaction_rules"]
+        expect(rules.first["id"]).to start_with("qtrr_")
+      end
+    end
+
+    context "when quote is not draft" do
+      let(:params) { {name: "Updated"} }
+
+      before { quote.update!(status: :approved, approved_at: Time.current) }
+
+      it "returns not_allowed_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+      end
+    end
+
+    context "when item id is not found" do
+      let(:id) { "qtw_nonexistent" }
+      let(:params) { {name: "Updated"} }
+
+      it "returns not_found_failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_item")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/clone_service_spec.rb
+++ b/spec/services/quotes/clone_service_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::CloneService do
+  subject(:clone_service) { described_class.new(quote:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:owner) { create(:user) }
+  let(:quote) { create(:quote, organization:) }
+
+  describe ".call" do
+    let(:result) { clone_service.call }
+
+    context "when the quote is clonable", :premium do
+      before do
+        quote.quote_owners.create!(
+          organization_id: quote.organization_id,
+          user_id: owner.id
+        )
+      end
+
+      it "creates an clone and voids the original quote" do
+        expect(result).to be_success
+        cloned = result.quote
+        expect(cloned.id).not_to eq(quote.id)
+        expect(cloned.organization.id).to eq(quote.organization.id)
+        expect(cloned.customer.id).to eq(quote.customer.id)
+        expect(cloned.sequential_id).to eq(quote.sequential_id)
+        expect(cloned.version).to eq(quote.version + 1)
+        expect(cloned.number).to eq(quote.number)
+        expect(cloned.draft?).to eq(true)
+        expect(cloned.owner_ids).to eq([owner.id])
+
+        quote.reload
+        expect(quote.voided?).to eq(true)
+        expect(quote.void_reason).to eq("superseded")
+      end
+    end
+
+    context "when the quote is not clonable", :premium do
+      let(:quote) { create(:quote, :approved, organization:) }
+
+      it "does not create a clone" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+
+        quote.reload
+        expect(quote.approved?).to eq(true)
+        expect(quote.void_reason).to eq(nil)
+        expect(quote.voided_at).to eq(nil)
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::CreateService do
+  subject(:create_service) { described_class.new(organization:, customer:, params: create_params) }
+
+  let(:owner) { create(:user) }
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:create_params) {
+    {
+      auto_execute: true,
+      backdated_billing: nil,
+      billing_items: {},
+      commercial_terms: {},
+      contacts: {},
+      content: "Test content",
+      currency: "USD",
+      description: "Test description",
+      execution_mode: nil,
+      internal_notes: "Test internal notes",
+      legal_text: "Test legal text",
+      metadata: {},
+      order_type: :subscription_creation,
+      owners: [owner.id]
+    }
+  }
+
+  describe ".call" do
+    let(:result) { create_service.call }
+
+    context "when license is premium", :premium do
+      it "creates an empty draft quote" do
+        travel_to(DateTime.new(2025, 3, 11, 20, 0, 0)) do
+          expect(result).to be_success
+          expect(result.quote.organization.id).to eq(organization.id)
+          expect(result.quote.customer.id).to eq(customer.id)
+          expect(result.quote.version).to eq(1)
+          expect(result.quote.sequential_id).to eq(1)
+          expect(result.quote.number).to eq("QT-2025-0001")
+          expect(result.quote.draft?).to eq(true)
+          expect(result.quote.auto_execute).to eq(true)
+          expect(result.quote.backdated_billing).to eq(nil)
+          expect(result.quote.billing_items).to eq({})
+          expect(result.quote.commercial_terms).to eq({})
+          expect(result.quote.contacts).to eq({})
+          expect(result.quote.content).to eq("Test content")
+          expect(result.quote.currency).to eq("USD")
+          expect(result.quote.description).to eq("Test description")
+          expect(result.quote.execution_mode).to eq(nil)
+          expect(result.quote.internal_notes).to eq("Test internal notes")
+          expect(result.quote.legal_text).to eq("Test legal text")
+          expect(result.quote.metadata).to eq({})
+          expect(result.quote.order_type).to eq("subscription_creation")
+          expect(result.quote.owner_ids).to eq([owner.id])
+        end
+      end
+    end
+
+    context "when organization does not exist", :premium do
+      let(:organization) { nil }
+      let(:customer) { create(:customer) }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("organization_not_found")
+      end
+    end
+
+    context "when customer does not exist", :premium do
+      let(:customer) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("customer_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/destroy_service_spec.rb
+++ b/spec/services/quotes/destroy_service_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::DestroyService do
+  subject(:destroy_service) { described_class.new(quote:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, organization:) }
+
+  describe ".call" do
+    let(:result) { destroy_service.call }
+
+    context "when quote exists", :premium do
+      before { quote }
+
+      it "destroys the quote" do
+        expect { result }.to change(Quote, :count).by(-1)
+        expect(result).to be_success
+      end
+    end
+
+    context "when approved quote", :premium do
+      let(:quote) { create(:quote, :approved, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/update_service_spec.rb
+++ b/spec/services/quotes/update_service_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::UpdateService do
+  subject(:update_service) { described_class.new(quote:, params: update_params) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:owner) { create(:user) }
+  let(:quote) { create(:quote, organization:) }
+  let(:update_params) {
+    {
+      auto_execute: true,
+      backdated_billing: nil,
+      billing_items: {},
+      commercial_terms: {},
+      contacts: {},
+      content: "Test content",
+      currency: "USD",
+      description: "Test description",
+      execution_mode: nil,
+      internal_notes: "Test internal notes",
+      legal_text: "Test legal text",
+      metadata: {},
+      order_type: :subscription_creation,
+      owners: [owner.id]
+    }
+  }
+
+  describe ".call" do
+    let(:result) { update_service.call }
+
+    context "when draft quote", :premium do
+      it "updates the quote" do
+        expect(result).to be_success
+        expect(result.quote.id).to eq(quote.id)
+        expect(result.quote.organization_id).to eq(quote.organization_id)
+        expect(result.quote.customer_id).to eq(quote.customer_id)
+        expect(result.quote.version).to eq(quote.version)
+        expect(result.quote.sequential_id).to eq(quote.sequential_id)
+        expect(result.quote.number).to eq(quote.number)
+        expect(result.quote.draft?).to eq(true)
+
+        expect(result.quote.auto_execute).to eq(true)
+        expect(result.quote.backdated_billing).to eq(nil)
+        expect(result.quote.billing_items).to eq({})
+        expect(result.quote.commercial_terms).to eq({})
+        expect(result.quote.contacts).to eq({})
+        expect(result.quote.content).to eq("Test content")
+        expect(result.quote.currency).to eq("USD")
+        expect(result.quote.description).to eq("Test description")
+        expect(result.quote.execution_mode).to eq(nil)
+        expect(result.quote.internal_notes).to eq("Test internal notes")
+        expect(result.quote.legal_text).to eq("Test legal text")
+        expect(result.quote.metadata).to eq({})
+        expect(result.quote.order_type).to eq("subscription_creation")
+        expect(result.quote.owner_ids).to eq([owner.id])
+      end
+    end
+
+    context "when approved quote", :premium do
+      let(:quote) { create(:quote, :approved, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when voided quote", :premium do
+      let(:quote) { create(:quote, :voided, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/void_service_spec.rb
+++ b/spec/services/quotes/void_service_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::VoidService do
+  subject(:void_service) { described_class.new(quote:, reason:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, organization:) }
+  let(:reason) { "manual" }
+
+  describe ".call" do
+    let(:result) { void_service.call }
+
+    context "when quote is voidable", :premium do
+      it "voides the quote" do
+        freeze_time do
+          expect(result).to be_success
+          expect(result.quote.voided?).to eq(true)
+          expect(result.quote.void_reason).to eq(reason)
+          expect(result.quote.voided_at).to eq(Time.current)
+          expect(result.quote.share_token).to eq(nil)
+        end
+      end
+    end
+
+    context "when quote isn't voidable", :premium do
+      let(:quote) { create(:quote, :voided, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when reason is invalid", :premium do
+      context "when reason is blank" do
+        let(:reason) { nil }
+
+        it "returns validation failure" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:quote]).to eq(["invalid_void_reason"])
+        end
+      end
+
+      context "when reason is undefined" do
+        let(:reason) { "invalid_reason" }
+
+        it "returns validation failure" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:quote]).to eq(["invalid_void_reason"])
+        end
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `BaseMutationService` with shared JSONB helpers (`current_items`, `persist_items`) used by all 12 per-item services
- Implement Add/Update/Remove services for each billing item type: `Plans`, `AddOns`, `Coupons`, `WalletCredits`, each surgically mutates one section of the `billing_items` JSONB, matching the FE's per-section save model
- All services block writes on non-draft quotes, enforce type gating, validate catalog references inline, and generate stable prefixed IDs (`qtp_`, `qta_`, `qtc_`, `qtw_`, `qtrr_`)
- Add `Types::Quotes::Object` GraphQL type exposing all quote fields (JSONB fields via `GraphQL::Types::JSON`)
- Wire all 12 services to GraphQL via `Mutations::Quotes::BillingItems::{Plans,AddOns,Coupons,WalletCredits}::{Add,Update,Remove}` mutations
- Register 12 new mutations in `MutationType`
- Add `V1::QuoteSerializer` and 4 REST controllers under `Api::V1::Quotes::BillingItems::`, each with `create`, `update`, `destroy` actions calling the same services
- Register nested REST routes: `POST/PUT/DELETE /api/v1/quotes/:quote_id/{plans,add_ons,coupons,wallet_credits}(/:id)`

## Context

### Why per-item services instead of replacing the full billing_items blob

The FE saves billing item data section by section, when the user finishes configuring a plan (with all its overrides), the FE sends just that plan's payload, not the entire `billing_items` JSONB. The same applies to coupons, wallet credits, and add-ons. Each service therefore mutates one section of the JSONB array (append, merge-by-id, or delete-by-id) rather than replacing the whole structure, preventing concurrent edits on different sections from overwriting each other.

### Request lifecycle

Both the GraphQL and REST paths call the same service layer, only the transport differs.

**GraphQL (FE/UI):**
1. FE calls e.g. `mutation { addQuotePlan(quoteId: "...", planId: "...") { id billingItems } }`
2. `GraphqlController#execute` receives it and builds context with `current_organization`
3. `Mutations::Quotes::BillingItems::Plans::Add#resolve` runs:
   - Looks up `current_organization.quotes.find_by(id: quote_id)`, scoped to org, returns `nil` if not found
   - Calls `Quotes::BillingItems::Plans::AddService.call(quote:, params:)`
4. Service enforces in order: `License.premium?` → draft check → type gate → catalog validation → ID generation → JSONB mutation → `quote.update!`
5. On success → returns `result.quote` → serialized as `Types::Quotes::Object`
6. On failure → `result_error(result)` translates the service failure into a `GraphQL::ExecutionError` (405 / 404 / 422)

**REST (external API consumers):**
1. External caller sends e.g. `POST /api/v1/quotes/:quote_id/plans` with `{ plan: { plan_id: "..." } }`
2. `Api::V1::Quotes::BillingItems::PlansController#create` runs:
   - Same `current_organization.quotes.find_by(id: params[:quote_id])` lookup
   - Same `Quotes::BillingItems::Plans::AddService.call(quote:, params: create_params.to_h)`
3. On success → renders `V1::QuoteSerializer` response with `root_name: "quote"`
4. On failure → `render_error_response(result)` maps service failures to HTTP status codes identically

### Stable IDs

Every billing item gets a prefixed UUID on creation (`qtp_` plans, `qta_` add-ons, `qtc_` coupons, `qtw_` wallet credits, `qtrr_` recurring rules). These IDs are stored inside the JSONB and are the only way to address individual items in Update/Remove operations. They are never DB row IDs.