### PR TITLE
fix(presentation_breakdowns): Change presentation_breakdowns units to remove precision

### DIFF
--- a/app/models/presentation_breakdown.rb
+++ b/app/models/presentation_breakdown.rb
@@ -12,7 +12,7 @@ end
 #
 #  id              :uuid             not null, primary key
 #  presentation_by :jsonb            not null
-#  units           :decimal(30, 10)  default(0.0), not null
+#  units           :decimal(, )      default(0.0), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  fee_id          :uuid             not null

--- a/db/migrate/20260420114717_change_presentation_breakdowns_units_decimal.rb
+++ b/db/migrate/20260420114717_change_presentation_breakdowns_units_decimal.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ChangePresentationBreakdownsUnitsDecimal < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      remove_column :presentation_breakdowns, :units # rubocop:disable Lago/NoDropColumnOrTable
+    end
+    add_column :presentation_breakdowns, :units, :decimal, null: false, default: 0
+  end
+
+  def down
+    safety_assured do
+      remove_column :presentation_breakdowns, :units # rubocop:disable Lago/NoDropColumnOrTable
+    end
+
+    add_column :presentation_breakdowns, :units, :decimal, precision: 30, scale: 10, null: false, default: 0
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4551,9 +4551,9 @@ CREATE TABLE public.presentation_breakdowns (
     organization_id uuid NOT NULL,
     fee_id uuid NOT NULL,
     presentation_by jsonb DEFAULT '[]'::jsonb NOT NULL,
-    units numeric(30,10) DEFAULT 0.0 NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    units numeric DEFAULT 0.0 NOT NULL
 );
 
 
@@ -11773,6 +11773,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260420114717'),
 ('20260416124233'),
 ('20260416124232'),
 ('20260416111923'),


### PR DESCRIPTION
This commit changes the unused column of presentation_breakdowns units to avoid rounding. Having an value computed from WeightedSumService, like `0.99998341049382716049e0` and associated to a presentation breakdown, it causes a rounding.

The change is quite simple, change the units column to match the fees units. Since the table is not used yet, it will not be an issue remove it in production. 