### PR TITLE
perf(invoices): Preload customer associations on invoices

### DIFF
--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -72,7 +72,6 @@ module InvoiceIndex
             :gocardless_customer,
             :cashfree_customer,
             :adyen_customer,
-            :flutterwave_customer,
             :moneyhash_customer,
             {integration_customers: :integration}
           ]

--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -60,7 +60,23 @@ module InvoiceIndex
 
     if result.success?
       invoices = Invoice.preload_offset_amounts(
-        result.invoices.includes(:metadata, :applied_taxes, :billing_entity, :applied_usage_thresholds)
+        result.invoices.includes(
+          :metadata,
+          :applied_taxes,
+          :billing_entity,
+          :applied_usage_thresholds,
+          customer: [
+            :billing_entity,
+            :metadata,
+            :stripe_customer,
+            :gocardless_customer,
+            :cashfree_customer,
+            :adyen_customer,
+            :flutterwave_customer,
+            :moneyhash_customer,
+            {integration_customers: :integration}
+          ]
+        )
       )
 
       render(

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -332,6 +332,52 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
+    context "with N+1 query detection on customer and tax associations", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+      let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+      before do
+        [customer.billing_entity, other_billing_entity].each do |billing_entity|
+          invoice_customer = create(
+            :customer,
+            organization:,
+            billing_entity:,
+            payment_provider: "stripe",
+            payment_provider_code: "stripe_code"
+          )
+          create(:stripe_customer, customer: invoice_customer)
+          create(:netsuite_customer, customer: invoice_customer)
+
+          invoice = create(:invoice, customer: invoice_customer, organization:, billing_entity:)
+          create(:invoice_applied_tax, invoice:, tax:, organization:)
+
+          invoice.file.attach(
+            io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.pdf"))),
+            filename: "invoice.pdf",
+            content_type: "application/pdf"
+          )
+          invoice.xml_file.attach(
+            io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.xml"))),
+            filename: "invoice.xml",
+            content_type: "application/xml"
+          )
+        end
+      end
+
+      it "does not trigger N+1 queries on applied_taxes, billing_entity, customer, payment_provider_customers, or active_storage_attachments" do
+        get_with_token(organization, "/api/v1/invoices", {})
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(2)
+        json[:invoices].each do |invoice|
+          expect(invoice[:customer][:billing_configuration][:provider_customer_id]).to be_present
+          expect(invoice[:customer][:integration_customers]).to be_present
+          expect(invoice[:applied_taxes]).to be_present
+          expect(invoice[:file_url]).to be_present
+          expect(invoice[:xml_url]).to be_present
+        end
+      end
+    end
+
     context "with unknown params" do
       before do
         allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
-    context "with N+1 query detection on customer and tax associations", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+    context "with N+1 query detection on customer associations", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
       let(:other_billing_entity) { create(:billing_entity, organization:) }
 
       before do
@@ -346,24 +346,14 @@ RSpec.describe Api::V1::InvoicesController do
           )
           create(:stripe_customer, customer: invoice_customer)
           create(:netsuite_customer, customer: invoice_customer)
+          create(:hubspot_customer, customer: invoice_customer)
+          create(:customer_metadata, customer: invoice_customer, organization:)
 
-          invoice = create(:invoice, customer: invoice_customer, organization:, billing_entity:)
-          create(:invoice_applied_tax, invoice:, tax:, organization:)
-
-          invoice.file.attach(
-            io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.pdf"))),
-            filename: "invoice.pdf",
-            content_type: "application/pdf"
-          )
-          invoice.xml_file.attach(
-            io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.xml"))),
-            filename: "invoice.xml",
-            content_type: "application/xml"
-          )
+          create(:invoice, customer: invoice_customer, organization:, billing_entity:)
         end
       end
 
-      it "does not trigger N+1 queries on applied_taxes, billing_entity, customer, payment_provider_customers, or active_storage_attachments" do
+      it "does not trigger N+1 queries on customer and nested associations" do
         get_with_token(organization, "/api/v1/invoices", {})
 
         expect(response).to have_http_status(:success)
@@ -371,9 +361,7 @@ RSpec.describe Api::V1::InvoicesController do
         json[:invoices].each do |invoice|
           expect(invoice[:customer][:billing_configuration][:provider_customer_id]).to be_present
           expect(invoice[:customer][:integration_customers]).to be_present
-          expect(invoice[:applied_taxes]).to be_present
-          expect(invoice[:file_url]).to be_present
-          expect(invoice[:xml_url]).to be_present
+          expect(invoice[:customer][:metadata]).to be_present
         end
       end
     end

--- a/spec/support/shared_examples/invoice_index.rb
+++ b/spec/support/shared_examples/invoice_index.rb
@@ -450,12 +450,16 @@ RSpec.shared_examples "an invoice index endpoint" do
     end
   end
 
-  context "with file attachments N+1 query detection", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+  context "with N+1 query detection", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
     let(:params) { {} }
+    let(:other_billing_entity) { create(:billing_entity, organization:) }
 
     before do
-      invoices = create_list(:invoice, 3, customer:, organization:)
-      invoices.each do |invoice|
+      [customer.billing_entity, other_billing_entity].each do |billing_entity|
+        invoice = create(:invoice, customer:, organization:, billing_entity:)
+        create(:invoice_applied_tax, invoice:, tax:, organization:)
+        create(:invoice_metadata, invoice:, organization:)
+
         invoice.file.attach(
           io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.pdf"))),
           filename: "invoice.pdf",
@@ -469,12 +473,14 @@ RSpec.shared_examples "an invoice index endpoint" do
       end
     end
 
-    it "does not trigger N+1 queries for file_url and xml_url" do
+    it "does not trigger N+1 queries on invoice associations" do
       subject
 
       expect(response).to have_http_status(:success)
-      expect(json[:invoices].count).to eq(3)
+      expect(json[:invoices].count).to eq(2)
       json[:invoices].each do |invoice|
+        expect(invoice[:applied_taxes]).to be_present
+        expect(invoice[:metadata]).to be_present
         expect(invoice[:file_url]).to be_present
         expect(invoice[:xml_url]).to be_present
       end


### PR DESCRIPTION
## Context

The invoice serializer accesses `customer` fields for every invoice. Without eager loading, this has an N+1 queries issue on all invoice list endpoints. This causes some `GET /invoices` requests to be slow (up to 11s)

## Description

Include customer fields in the InvoicesQuery, which is used in all related serializers/resolvers.