### PR TITLE
chore(eu-vat): Update Romania and Estonia VAT rates

### DIFF
--- a/lib/lago_eu_vat/lago_eu_vat/eu_vat_rates.json
+++ b/lib/lago_eu_vat/lago_eu_vat/eu_vat_rates.json
@@ -264,6 +264,14 @@
     ],
     "RO": [
       {
+        "effective_from": "2025-08-01",
+        "rates": {
+          "reduced1": 5,
+          "reduced2": 9,
+          "standard": 21
+        }
+      },
+      {
         "effective_from": "2017-01-01",
         "rates": {
           "reduced1": 5,
@@ -289,6 +297,13 @@
       }
     ],
     "EE": [
+      {
+        "effective_from": "2025-07-01",
+        "rates": {
+          "reduced": 13,
+          "standard": 24
+        }
+      },
       {
         "effective_from": "2025-01-01",
         "rates": {


### PR DESCRIPTION
## Summary

- **Romania**: standard VAT **19% → 21%**, effective 2025-08-01
- **Estonia**: standard VAT **22% → 24%**, effective 2025-07-01

Both countries' arrays already follow the reverse-chronological pattern, so `LagoEuVat::Rate.country_rates` picks the new entry automatically once `Time.zone.now >= effective_from`. Reduced rates left untouched (issue scope).

## Context

Flagged by Mistral as out of date. Since the EU Tax Management integration is moving to deprecated, keeping rates current prior to deprecation.

## Sources

- [EY — Romanian tax changes, new fiscal measures](https://www.ey.com/en_gl/technical/tax-alerts/romanian-tax-changes-introduced-by-new-fiscal-and-budgetary-measures)
- [KPMG — Estonia: increase in standard VAT rate effective July 1, 2025](https://kpmg.com/us/en/taxnewsflash/news/2025/07/tnf-estonia-increase-in-standard-vat-rate-effective-july-1-2025.html)

Upstream data source remains [ibericode/vat-rates](https://github.com/ibericode/vat-rates) (MIT).

## Refs

Closes ISSUE-1815

Similar prior PRs: #2638 (FI), #3352 (bulk upstream refresh).

## Test plan

- [x] JSON validated locally (parses, 27 countries, RO/EE entries ordered correctly)
- [x] \`bundle exec rubocop lib/lago_eu_vat/\` — no offenses on our code (5 unrelated pre-existing offenses on main, not in this diff)
- [ ] CI rspec
- [ ] CI rubocop