### PR TITLE
feat(payment-gated-subs): handle gated subscriptions in Invoices::SubscriptionService

### DIFF
--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -24,6 +24,7 @@ module Invoices
       return result if active_subscriptions.empty? && recurring
 
       create_generating_invoice unless invoice
+      invoice.status = :open if subscription_gated?
       result.invoice = invoice
 
       fee_result = ActiveRecord::Base.transaction do
@@ -68,7 +69,9 @@ module Invoices
         return result
       end
 
-      if grace_period?
+      if subscription_gated?
+        Invoices::Payments::CreateService.call_async(invoice:)
+      elsif grace_period?
         SendWebhookJob.perform_after_commit("invoice.drafted", invoice)
         Utils::ActivityLog.produce_after_commit(invoice, "invoice.drafted")
       else
@@ -116,6 +119,10 @@ module Invoices
       @active_subscriptions ||= subscriptions.select(&:active?)
     end
 
+    def subscription_gated?
+      @subscription_gated ||= subscriptions.any?(&:gated?)
+    end
+
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
         customer:,
@@ -136,6 +143,8 @@ module Invoices
     end
 
     def grace_period?
+      return false if subscription_gated?
+
       @grace_period ||= customer.applicable_invoice_grace_period.positive?
     end
 

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -573,6 +573,48 @@ RSpec.describe Invoices::SubscriptionService do
       end
     end
 
+    context "when subscription is gated" do
+      let(:invoicing_reason) { :subscription_starting }
+      let(:pay_in_advance) { true }
+      let(:subscription) do
+        create(:subscription, :incomplete, :with_activation_rules,
+          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+          plan:, customer:, organization: customer.organization,
+          subscription_at: started_at.to_date, started_at:, created_at: started_at)
+      end
+
+      it "creates an open invoice" do
+        result = invoice_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to be_open
+      end
+
+      it "skips grace period" do
+        result = invoice_service.call
+
+        expect(result.invoice.issuing_date.to_s).to eq(Time.zone.at(timestamp).to_date.to_s)
+      end
+
+      it "does not send invoice.created webhook" do
+        invoice_service.call
+
+        expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
+      end
+
+      it "does not generate documents" do
+        invoice_service.call
+
+        expect(Invoices::GenerateDocumentsJob).not_to have_been_enqueued
+      end
+
+      it "triggers payment" do
+        invoice_service.call
+
+        expect(Invoices::Payments::CreateService).to have_received(:call_async)
+      end
+    end
+
     context "when an error occurs" do
       context "with a stale object error" do
         it "propagates the error" do


### PR DESCRIPTION
## Context

When a gated subscription is billed, the invoice must be created as open (not finalized or draft), the grace period must be skipped, and side effects like webhooks and document generation must be deferred until payment succeeds. Only the payment attempt should be triggered.

## Description

Add gated subscription handling to Invoices::SubscriptionService. After creating the generating invoice, set status to open if any subscription is gated. Skip grace period for gated subscriptions. In the post-billing side effects, route gated invoices to payment only, skipping webhooks, documents, integrations, and segment tracking.