### PR TITLE
feat(payment-gated-subs): handle gated subscriptions in CreatePayInAdvanceFixedChargesService

### DIFF
--- a/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
+++ b/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
@@ -14,7 +14,7 @@ module Invoices
     end
 
     def call
-      return result unless subscription.active?
+      return result unless subscription.active? || subscription.gated?
       return result if fixed_charge_events.empty?
 
       # Calculate fees for all fixed charge events
@@ -26,6 +26,7 @@ module Invoices
 
       ActiveRecord::Base.transaction do
         create_generating_invoice
+        invoice.status = :open if subscription.gated?
         fees.each do |fee|
           fee.invoice = invoice
           fee.save!
@@ -58,7 +59,9 @@ module Invoices
         return result
       end
 
-      unless invoice.closed?
+      if subscription.gated?
+        Invoices::Payments::CreateService.call_async(invoice:)
+      elsif !invoice.closed?
         Utils::SegmentTrack.invoice_created(invoice)
         deliver_webhooks
         Utils::ActivityLog.produce(invoice, "invoice.created")

--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -662,5 +662,40 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
         expect(result.invoice).to be_nil
       end
     end
+
+    context "when subscription is gated" do
+      let(:subscription) do
+        create(:subscription, :incomplete, :with_activation_rules,
+          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+          customer:, plan:, organization:)
+      end
+
+      it "creates an open invoice" do
+        result = invoice_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to be_open
+      end
+
+      it "does not send invoice.created webhook" do
+        invoice_service.call
+
+        expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
+      end
+
+      it "does not generate documents" do
+        invoice_service.call
+
+        expect(Invoices::GenerateDocumentsJob).not_to have_been_enqueued
+      end
+
+      it "triggers payment" do
+        allow(Invoices::Payments::CreateService).to receive(:call_async)
+
+        invoice_service.call
+
+        expect(Invoices::Payments::CreateService).to have_received(:call_async)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

When a gated subscription has pay-in-advance fixed charges on a pay-in-arrears plan, the fixed charge invoice must be created as open and only trigger payment, deferring all other side effects until payment succeeds.

## Description

Allow the service to process gated subscriptions alongside active ones. After creating the generating invoice, set status to open if the subscription is gated. Route post-billing side effects to payment only for gated invoices, skipping webhooks, documents, integrations, and segment tracking.