### PR TITLE
feat(payment-gated-subs): handle gated invoices in tax edge case services

### DIFF
--- a/app/jobs/customers/vies_check_job.rb
+++ b/app/jobs/customers/vies_check_job.rb
@@ -33,7 +33,7 @@ module Customers
 
     def enqueue_pending_invoice_finalization(customer)
       customer.invoices
-        .where(status: %i[pending open], tax_status: "pending")
+        .where(status: %i[pending open], tax_status: :pending)
         .find_each do |invoice|
           Invoices::FinalizePendingViesInvoiceJob.perform_later(invoice)
         end

--- a/app/jobs/customers/vies_check_job.rb
+++ b/app/jobs/customers/vies_check_job.rb
@@ -32,9 +32,11 @@ module Customers
     end
 
     def enqueue_pending_invoice_finalization(customer)
-      customer.invoices.pending.where(tax_status: "pending").find_each do |invoice|
-        Invoices::FinalizePendingViesInvoiceJob.perform_later(invoice)
-      end
+      customer.invoices
+        .where(status: %i[pending open], tax_status: "pending")
+        .find_each do |invoice|
+          Invoices::FinalizePendingViesInvoiceJob.perform_later(invoice)
+        end
     end
 
     def retry_delay(pending_vies_check)

--- a/app/jobs/customers/vies_check_job.rb
+++ b/app/jobs/customers/vies_check_job.rb
@@ -32,6 +32,11 @@ module Customers
     end
 
     def enqueue_pending_invoice_finalization(customer)
+      # status :open + tax_status :pending only occurs for gated invoices —
+      # EnsureCompletedViesCheckService keeps gated VIES-blocked invoices :open
+      # instead of transitioning them to :pending — so adding :open to the
+      # status set is enough to pick up gated cases without an explicit
+      # subscription_gated? check.
       customer.invoices
         .where(status: %i[pending open], tax_status: :pending)
         .find_each do |invoice|

--- a/app/services/invoices/compute_taxes_and_totals_service.rb
+++ b/app/services/invoices/compute_taxes_and_totals_service.rb
@@ -34,9 +34,7 @@ module Invoices
     attr_reader :invoice, :finalizing
 
     def set_pending_tax_status!
-      if finalizing
-        invoice.status = invoice.subscription_gated? ? :open : :pending
-      end
+      invoice.status = (invoice.subscription_gated? ? :open : :pending) if finalizing
       invoice.tax_status = :pending
       invoice.save!
     end

--- a/app/services/invoices/compute_taxes_and_totals_service.rb
+++ b/app/services/invoices/compute_taxes_and_totals_service.rb
@@ -34,7 +34,9 @@ module Invoices
     attr_reader :invoice, :finalizing
 
     def set_pending_tax_status!
-      invoice.status = "pending" if finalizing
+      if finalizing
+        invoice.status = invoice.subscription_gated? ? "open" : "pending"
+      end
       invoice.tax_status = "pending"
       invoice.save!
     end

--- a/app/services/invoices/compute_taxes_and_totals_service.rb
+++ b/app/services/invoices/compute_taxes_and_totals_service.rb
@@ -35,9 +35,9 @@ module Invoices
 
     def set_pending_tax_status!
       if finalizing
-        invoice.status = invoice.subscription_gated? ? "open" : "pending"
+        invoice.status = invoice.subscription_gated? ? :open : :pending
       end
-      invoice.tax_status = "pending"
+      invoice.tax_status = :pending
       invoice.save!
     end
 

--- a/app/services/invoices/ensure_completed_vies_check_service.rb
+++ b/app/services/invoices/ensure_completed_vies_check_service.rb
@@ -19,7 +19,7 @@ module Invoices
       # Check if VIES validation is pending
       return result unless customer.vies_check_in_progress?
 
-      invoice.status = :pending if finalizing
+      invoice.status = (invoice.subscription_gated? ? :open : :pending) if finalizing
       invoice.tax_status = :pending
       invoice.save!
 

--- a/app/services/invoices/finalize_pending_vies_invoice_service.rb
+++ b/app/services/invoices/finalize_pending_vies_invoice_service.rb
@@ -12,7 +12,7 @@ module Invoices
 
     def call
       return result.not_found_failure!(resource: "invoice") unless invoice
-      return result unless invoice.pending? && invoice.tax_pending?
+      return result unless (invoice.pending? || invoice.subscription_gated?) && invoice.tax_pending?
       return result if customer.tax_customer
       return result if customer.vies_check_in_progress?
 
@@ -36,7 +36,9 @@ module Invoices
         result.invoice = invoice
       end
 
-      if invoice.finalized?
+      if invoice.subscription_gated?
+        after_commit { create_payment }
+      elsif invoice.finalized?
         after_commit do
           SendWebhookJob.perform_later(webhook_type, invoice)
           Utils::ActivityLog.produce(invoice, webhook_type)

--- a/app/services/invoices/finalize_pending_vies_invoice_service.rb
+++ b/app/services/invoices/finalize_pending_vies_invoice_service.rb
@@ -12,7 +12,8 @@ module Invoices
 
     def call
       return result.not_found_failure!(resource: "invoice") unless invoice
-      return result unless (invoice.pending? || invoice.subscription_gated?) && invoice.tax_pending?
+      return result if !invoice.pending? && !invoice.subscription_gated?
+      return result unless invoice.tax_pending?
       return result if customer.tax_customer
       return result if customer.vies_check_in_progress?
 

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -12,7 +12,7 @@ module Invoices
       def call
         return result.not_found_failure!(resource: "invoice") unless invoice
         return result.not_found_failure!(resource: "integration_customer") unless customer.tax_customer
-        return result unless invoice.pending? || invoice.draft?
+        return result unless invoice.pending? || invoice.draft? || invoice.subscription_gated?
         return result unless invoice.tax_pending?
 
         invoice.error_details.tax_error.discard_all # rubocop:disable Lago/DiscardAll
@@ -54,7 +54,9 @@ module Invoices
           result.invoice = invoice
         end
 
-        if invoice.finalized?
+        if invoice.subscription_gated?
+          Invoices::Payments::CreateService.call_async(invoice:)
+        elsif invoice.finalized?
           SendWebhookJob.perform_later("invoice.created", invoice)
           Utils::ActivityLog.produce(invoice, "invoice.created")
           GenerateDocumentsJob.perform_later(invoice:, notify: should_deliver_email?)

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -12,7 +12,7 @@ module Invoices
       return result.not_found_failure!(resource: "invoice") unless invoice
       return result.not_allowed_failure!(code: "invalid_status") unless invoice.failed?
 
-      invoice.status = "pending"
+      invoice.status = invoice.subscriptions.any?(&:gated?) ? "open" : "pending"
       invoice.tax_status = "pending"
       invoice.save!
 

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -12,7 +12,7 @@ module Invoices
       return result.not_found_failure!(resource: "invoice") unless invoice
       return result.not_allowed_failure!(code: "invalid_status") unless invoice.failed?
 
-      invoice.status = invoice.subscriptions.any?(&:gated?) ? "open" : "pending"
+      invoice.status = invoice.subscriptions.any?(&:gated?) ? :open : :pending
       invoice.tax_status = "pending"
       invoice.save!
 

--- a/spec/jobs/customers/vies_check_job_spec.rb
+++ b/spec/jobs/customers/vies_check_job_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe Customers::ViesCheckJob do
 
     context "when customer has pending invoices blocked by VIES" do
       let(:pending_invoice) do
-        create(:invoice, :pending, customer:, organization: customer.organization, tax_status: "pending")
+        create(:invoice, :pending, customer:, organization: customer.organization, tax_status: :pending)
       end
       let(:finalized_invoice) do
         create(:invoice, :finalized, customer:, organization: customer.organization)
       end
       let(:pending_but_tax_succeeded_invoice) do
-        create(:invoice, :pending, customer:, organization: customer.organization, tax_status: "succeeded")
+        create(:invoice, :pending, customer:, organization: customer.organization, tax_status: :succeeded)
       end
 
       before do
@@ -69,12 +69,12 @@ RSpec.describe Customers::ViesCheckJob do
       context "when customer has gated invoices blocked by VIES" do
         let(:subscription) do
           create(:subscription, :incomplete, :with_activation_rules,
-            activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+            activation_rules_config: [{type: :payment, timeout_hours: 48, status: :pending}],
             customer:, organization: customer.organization)
         end
         let(:gated_invoice) do
           create(:invoice, :with_subscriptions, customer:, organization: customer.organization,
-            status: :open, tax_status: "pending", subscriptions: [subscription])
+            status: :open, tax_status: :pending, subscriptions: [subscription])
         end
 
         before { gated_invoice }
@@ -89,7 +89,7 @@ RSpec.describe Customers::ViesCheckJob do
 
   context "when valvat has an error" do
     let(:pending_invoice) do
-      create(:invoice, :pending, customer:, organization: customer.organization, tax_status: "pending")
+      create(:invoice, :pending, customer:, organization: customer.organization, tax_status: :pending)
     end
 
     before do

--- a/spec/jobs/customers/vies_check_job_spec.rb
+++ b/spec/jobs/customers/vies_check_job_spec.rb
@@ -65,6 +65,25 @@ RSpec.describe Customers::ViesCheckJob do
         expect { described_class.perform_now(customer) }
           .not_to have_enqueued_job(Invoices::FinalizePendingViesInvoiceJob).with(pending_but_tax_succeeded_invoice)
       end
+
+      context "when customer has gated invoices blocked by VIES" do
+        let(:subscription) do
+          create(:subscription, :incomplete, :with_activation_rules,
+            activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+            customer:, organization: customer.organization)
+        end
+        let(:gated_invoice) do
+          create(:invoice, :with_subscriptions, customer:, organization: customer.organization,
+            status: :open, tax_status: "pending", subscriptions: [subscription])
+        end
+
+        before { gated_invoice }
+
+        it "enqueues FinalizePendingViesInvoiceJob for gated invoices with pending tax_status" do
+          expect { described_class.perform_now(customer) }
+            .to have_enqueued_job(Invoices::FinalizePendingViesInvoiceJob).with(gated_invoice)
+        end
+      end
     end
   end
 

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Payment Gated Subscription Activation Scenarios" do
+  describe "gated subscription with pending VIES check" do
+    it "completes the flow: gated → VIES pending → VIES resolved → payment → activation" do
+      pending "requires CreateService integration with ActivateService gated path (PR #5370)"
+
+      # 1. Create subscription with payment gating + customer has pending VIES check
+      # 2. Invoice created as open, tax_status: pending (VIES blocks tax calculation)
+      # 3. No payment triggered yet (can't pay without taxes)
+      # 4. VIES resolves → ViesCheckJob picks up the open invoice
+      # 5. FinalizePendingViesInvoiceService applies taxes, triggers payment only
+      # 6. Payment succeeds → subscription activates, invoice finalized
+      raise "not implemented"
+    end
+  end
+
+  describe "gated subscription with provider tax failure" do
+    it "completes the flow: gated → tax failure → retry → payment → activation" do
+      pending "requires CreateService integration with ActivateService gated path (PR #5370)"
+
+      # 1. Create subscription with payment gating + customer has tax provider
+      # 2. Invoice created as open, tax provider fails → invoice status: failed
+      # 3. User retries → RetryService sets status back to open (not pending)
+      # 4. PullTaxesAndApplyService succeeds → triggers payment only
+      # 5. Payment succeeds → subscription activates, invoice finalized
+      raise "not implemented"
+    end
+  end
+end

--- a/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
+++ b/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService do
       context "when invoice is subscription_gated" do
         let(:subscription) do
           create(:subscription, :incomplete, :with_activation_rules,
-            activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+            activation_rules_config: [{type: :payment, timeout_hours: 48, status: :pending}],
             plan:, subscription_at: started_at, started_at:, created_at: started_at)
         end
 
@@ -157,8 +157,8 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService do
         it "keeps invoice status as open and sets tax_status to pending" do
           totals_service.call
 
-          expect(invoice.reload.status).to eq("open")
-          expect(invoice.reload.tax_status).to eq("pending")
+          expect(invoice.reload).to be_open
+          expect(invoice.reload).to be_tax_pending
         end
       end
 

--- a/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
+++ b/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
@@ -145,6 +145,23 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService do
         expect(invoice.reload.tax_status).to eq("pending")
       end
 
+      context "when invoice is subscription_gated" do
+        let(:subscription) do
+          create(:subscription, :incomplete, :with_activation_rules,
+            activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+            plan:, subscription_at: started_at, started_at:, created_at: started_at)
+        end
+
+        before { invoice.update!(status: :open) }
+
+        it "keeps invoice status as open and sets tax_status to pending" do
+          totals_service.call
+
+          expect(invoice.reload.status).to eq("open")
+          expect(invoice.reload.tax_status).to eq("pending")
+        end
+      end
+
       context "when invoice is draft" do
         before { invoice.update!(status: :draft) }
 

--- a/spec/services/invoices/ensure_completed_vies_check_service_spec.rb
+++ b/spec/services/invoices/ensure_completed_vies_check_service_spec.rb
@@ -63,15 +63,15 @@ RSpec.describe Invoices::EnsureCompletedViesCheckService do
         context "when invoice is subscription_gated" do
           let(:subscription) do
             create(:subscription, :incomplete, :with_activation_rules,
-              activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+              activation_rules_config: [{type: :payment, timeout_hours: 48, status: :pending}],
               customer:, organization:)
           end
           let(:invoice) { create(:invoice, :with_subscriptions, customer:, organization:, billing_entity:, status: :open, subscriptions: [subscription]) }
 
           it "keeps invoice status as open and sets tax_status to pending" do
             expect(result).to be_failure
-            expect(invoice.reload.status).to eq("open")
-            expect(invoice.tax_status).to eq("pending")
+            expect(invoice.reload).to be_open
+            expect(invoice).to be_tax_pending
           end
         end
 

--- a/spec/services/invoices/ensure_completed_vies_check_service_spec.rb
+++ b/spec/services/invoices/ensure_completed_vies_check_service_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe Invoices::EnsureCompletedViesCheckService do
           expect(invoice.tax_status).to eq("pending")
         end
 
+        context "when invoice is subscription_gated" do
+          let(:subscription) do
+            create(:subscription, :incomplete, :with_activation_rules,
+              activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+              customer:, organization:)
+          end
+          let(:invoice) { create(:invoice, :with_subscriptions, customer:, organization:, billing_entity:, status: :open, subscriptions: [subscription]) }
+
+          it "keeps invoice status as open and sets tax_status to pending" do
+            expect(result).to be_failure
+            expect(invoice.reload.status).to eq("open")
+            expect(invoice.tax_status).to eq("pending")
+          end
+        end
+
         context "when finalizing is false" do
           subject(:result) { described_class.call(invoice:, finalizing: false) }
 

--- a/spec/services/invoices/finalize_pending_vies_invoice_service_spec.rb
+++ b/spec/services/invoices/finalize_pending_vies_invoice_service_spec.rb
@@ -530,12 +530,21 @@ RSpec.describe Invoices::FinalizePendingViesInvoiceService do
     context "when invoice is subscription_gated" do
       let(:subscription) do
         create(:subscription, :incomplete, :with_activation_rules,
-          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+          activation_rules_config: [{type: :payment, timeout_hours: 48, status: :pending}],
           customer:, organization:)
       end
       let(:invoice) do
-        create(:invoice, :with_subscriptions, customer:, organization:, billing_entity:,
-          status: :open, tax_status: :pending, currency: "EUR", subscriptions: [subscription])
+        create(
+          :invoice,
+          :with_subscriptions,
+          customer:,
+          organization:,
+          billing_entity:,
+          status: :open,
+          tax_status: :pending,
+          currency: "EUR",
+          subscriptions: [subscription]
+        )
       end
 
       it "allows processing and triggers payment only" do

--- a/spec/services/invoices/finalize_pending_vies_invoice_service_spec.rb
+++ b/spec/services/invoices/finalize_pending_vies_invoice_service_spec.rb
@@ -526,5 +526,26 @@ RSpec.describe Invoices::FinalizePendingViesInvoiceService do
         end
       end
     end
+
+    context "when invoice is subscription_gated" do
+      let(:subscription) do
+        create(:subscription, :incomplete, :with_activation_rules,
+          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+          customer:, organization:)
+      end
+      let(:invoice) do
+        create(:invoice, :with_subscriptions, customer:, organization:, billing_entity:,
+          status: :open, tax_status: :pending, currency: "EUR", subscriptions: [subscription])
+      end
+
+      it "allows processing and triggers payment only" do
+        allow(Invoices::Payments::CreateService).to receive(:call_async)
+
+        finalize_service.call
+
+        expect(Invoices::Payments::CreateService).to have_received(:call_async)
+        expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
+      end
+    end
   end
 end

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -513,5 +513,31 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
         end
       end
     end
+
+    context "when invoice is subscription_gated" do
+      let(:subscription) do
+        create(:subscription, :incomplete, :with_activation_rules,
+          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+          customer:, organization:)
+      end
+      let(:invoice) do
+        create(:invoice, :with_subscriptions, customer:, organization:, status: :open,
+          currency: "EUR", subscriptions: [subscription])
+      end
+
+      before do
+        invoice.update!(tax_status: :pending)
+      end
+
+      it "allows processing and triggers payment only" do
+        allow(Invoices::Payments::CreateService).to receive(:call_async)
+
+        result = pull_taxes_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::CreateService).to have_received(:call_async)
+        expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
+      end
+    end
   end
 end

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -517,7 +517,7 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
     context "when invoice is subscription_gated" do
       let(:subscription) do
         create(:subscription, :incomplete, :with_activation_rules,
-          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+          activation_rules_config: [{type: :payment, timeout_hours: 48, status: :pending}],
           customer:, organization:)
       end
       let(:invoice) do

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -101,9 +101,11 @@ RSpec.describe Invoices::RetryService do
 
     context "when invoice is subscription_gated" do
       let(:gated_subscription) do
-        create(:subscription, :incomplete, :with_activation_rules,
-          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
-          customer:, organization:)
+        create(
+          :subscription, :incomplete, :with_activation_rules,
+          activation_rules_config: [{type: :payment, timeout_hours: 48, status: :pending}],
+          customer:, organization:
+        )
       end
 
       before do
@@ -113,9 +115,10 @@ RSpec.describe Invoices::RetryService do
 
       it "sets invoice status to open instead of pending" do
         retry_service.call
+        invoice.reload
 
-        expect(invoice.reload.status).to eq("open")
-        expect(invoice.reload.tax_status).to eq("pending")
+        expect(invoice).to be_open
+        expect(invoice).to be_tax_pending
       end
     end
   end

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -98,5 +98,25 @@ RSpec.describe Invoices::RetryService do
       expect(invoice.reload.status).to eq("pending")
       expect(invoice.reload.tax_status).to eq("pending")
     end
+
+    context "when invoice is subscription_gated" do
+      let(:gated_subscription) do
+        create(:subscription, :incomplete, :with_activation_rules,
+          activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+          customer:, organization:)
+      end
+
+      before do
+        create(:invoice_subscription, invoice:, subscription: gated_subscription)
+        invoice.update!(status: :failed)
+      end
+
+      it "sets invoice status to open instead of pending" do
+        retry_service.call
+
+        expect(invoice.reload.status).to eq("open")
+        expect(invoice.reload.tax_status).to eq("pending")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

When a gated invoice encounters tax provider errors or pending VIES validation, the invoice status must remain open (not transition to pending) and post-tax-success side effects must route to payment only, deferring webhooks, documents, and integrations until the subscription activates.

## Description

Apply consistent gated invoice handling across six tax-related services and jobs:

- ComputeTaxesAndTotalsService: preserve open status when setting pending tax status for gated invoices
- EnsureCompletedViesCheckService: preserve open status during VIES pending state for gated invoices
- RetryService: restore to open (not pending) when retrying failed tax on gated invoices, checking subscription gated status directly since the invoice is in failed state at retry time
- PullTaxesAndApplyService: expand guard to allow gated invoices and route post-success to payment only
- FinalizePendingViesInvoiceService: expand guard to allow gated invoices and route post-success to payment only
- ViesCheckJob: expand pending invoice query to include open invoices so gated invoices blocked by VIES are picked up for finalization
