### PR TITLE
fix(applied_coupons): Validate frequency_duration for recurring coupons

### DIFF
--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -28,6 +28,8 @@ class AppliedCoupon < ApplicationRecord
 
   validates :amount_cents, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
   validates :amount_currency, inclusion: {in: currency_list}, allow_nil: true
+  validates :frequency_duration, presence: true, numericality: {greater_than: 0}, if: :recurring?
+  validates :frequency_duration_remaining, presence: true, numericality: {greater_than_or_equal_to: 0}, if: :recurring?
 
   def mark_as_terminated!(timestamp = Time.zone.now)
     self.terminated_at ||= timestamp

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -59,6 +59,8 @@ class Coupon < ApplicationRecord
 
   validates :percentage_rate, presence: true, if: :percentage?
 
+  validates :frequency_duration, presence: true, numericality: {greater_than: 0}, if: :recurring?
+
   validates :reusable, exclusion: [nil]
 
   default_scope -> { kept }

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -39,7 +39,10 @@ module Credits
         fee.save!
       end
 
-      applied_coupon.frequency_duration_remaining -= 1 if applied_coupon.recurring?
+      if applied_coupon.recurring?
+        applied_coupon.frequency_duration_remaining = [applied_coupon.frequency_duration_remaining.to_i - 1, 0].max
+      end
+
       if should_terminate_applied_coupon?(credit_amount)
         applied_coupon.mark_as_terminated!
       elsif applied_coupon.recurring?

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -39,9 +39,7 @@ module Credits
         fee.save!
       end
 
-      if applied_coupon.recurring?
-        applied_coupon.frequency_duration_remaining = [applied_coupon.frequency_duration_remaining.to_i - 1, 0].max
-      end
+      decrement_frequency_duration_remaining if applied_coupon.recurring?
 
       if should_terminate_applied_coupon?(credit_amount)
         applied_coupon.mark_as_terminated!
@@ -83,6 +81,10 @@ module Credits
       else
         applied_coupon.frequency_duration_remaining <= 0
       end
+    end
+
+    def decrement_frequency_duration_remaining
+      applied_coupon.frequency_duration_remaining = [applied_coupon.frequency_duration_remaining.to_i - 1, 0].max
     end
 
     # TODO: ensure targeted amount is right with BM/plan limitation

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -27,9 +27,11 @@ RSpec.describe AppliedCoupon do
     it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_inclusion_of(:amount_currency).in_array(described_class.currency_list) }
 
-    describe "frequency_duration" do
+    describe "of frequency_duration" do
+      subject(:applied_coupon) { build(:applied_coupon, frequency:) }
+
       context "when recurring" do
-        subject(:applied_coupon) { build(:applied_coupon, frequency: "recurring") }
+        let(:frequency) { "recurring" }
 
         it { is_expected.to validate_presence_of(:frequency_duration).with_message("value_is_mandatory") }
         it { is_expected.to validate_numericality_of(:frequency_duration).is_greater_than(0) }
@@ -41,12 +43,14 @@ RSpec.describe AppliedCoupon do
         let(:frequency) { "once" }
 
         it { is_expected.not_to validate_presence_of(:frequency_duration) }
+        it { is_expected.not_to validate_presence_of(:frequency_duration_remaining) }
       end
 
       context "when forever" do
         let(:frequency) { "forever" }
 
         it { is_expected.not_to validate_presence_of(:frequency_duration) }
+        it { is_expected.not_to validate_presence_of(:frequency_duration_remaining) }
       end
     end
   end

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe AppliedCoupon do
   describe "validations" do
     it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_inclusion_of(:amount_currency).in_array(described_class.currency_list) }
+
+    context "when recurring" do
+      subject(:applied_coupon) do
+        build(:applied_coupon, frequency: "recurring", frequency_duration: 3, frequency_duration_remaining: 3)
+      end
+
+      it { is_expected.to validate_presence_of(:frequency_duration).with_message("value_is_mandatory") }
+      it { is_expected.to validate_numericality_of(:frequency_duration).is_greater_than(0) }
+      it { is_expected.to validate_presence_of(:frequency_duration_remaining).with_message("value_is_mandatory") }
+      it { is_expected.to validate_numericality_of(:frequency_duration_remaining).is_greater_than_or_equal_to(0) }
+    end
   end
 
   describe "#remaining_amount" do

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -27,15 +27,27 @@ RSpec.describe AppliedCoupon do
     it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_inclusion_of(:amount_currency).in_array(described_class.currency_list) }
 
-    context "when recurring" do
-      subject(:applied_coupon) do
-        build(:applied_coupon, frequency: "recurring", frequency_duration: 3, frequency_duration_remaining: 3)
+    describe "frequency_duration" do
+      context "when recurring" do
+        subject(:applied_coupon) { build(:applied_coupon, frequency: "recurring") }
+
+        it { is_expected.to validate_presence_of(:frequency_duration).with_message("value_is_mandatory") }
+        it { is_expected.to validate_numericality_of(:frequency_duration).is_greater_than(0) }
+        it { is_expected.to validate_presence_of(:frequency_duration_remaining).with_message("value_is_mandatory") }
+        it { is_expected.to validate_numericality_of(:frequency_duration_remaining).is_greater_than_or_equal_to(0) }
       end
 
-      it { is_expected.to validate_presence_of(:frequency_duration).with_message("value_is_mandatory") }
-      it { is_expected.to validate_numericality_of(:frequency_duration).is_greater_than(0) }
-      it { is_expected.to validate_presence_of(:frequency_duration_remaining).with_message("value_is_mandatory") }
-      it { is_expected.to validate_numericality_of(:frequency_duration_remaining).is_greater_than_or_equal_to(0) }
+      context "when once" do
+        let(:frequency) { "once" }
+
+        it { is_expected.not_to validate_presence_of(:frequency_duration) }
+      end
+
+      context "when forever" do
+        let(:frequency) { "forever" }
+
+        it { is_expected.not_to validate_presence_of(:frequency_duration) }
+      end
     end
   end
 

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -78,27 +78,25 @@ RSpec.describe Coupon do
     end
 
     describe "of frequency_duration" do
+      subject(:coupon) { build(:coupon, frequency:) }
+
       context "when recurring" do
-        subject(:coupon) { build(:coupon, frequency: "recurring") }
+        let(:frequency) { "recurring" }
 
         it { is_expected.to validate_presence_of(:frequency_duration).with_message("value_is_mandatory") }
         it { is_expected.to validate_numericality_of(:frequency_duration).is_greater_than(0) }
       end
 
-      context "not recurring" do
-        subject(:coupon) { build(:coupon, frequency:) }
+      context "when once" do
+        let(:frequency) { "once" }
 
-        context "when once" do
-          let(:frequency) { "once" }
+        it { is_expected.not_to validate_presence_of(:frequency_duration) }
+      end
 
-          it { is_expected.not_to validate_presence_of(:frequency_duration) }
-        end
+      context "when forever" do
+        let(:frequency) { "forever" }
 
-        context "when forever" do
-          let(:frequency) { "forever" }
-
-          it { is_expected.not_to validate_presence_of(:frequency_duration) }
-        end
+        it { is_expected.not_to validate_presence_of(:frequency_duration) }
       end
     end
   end

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -76,6 +76,31 @@ RSpec.describe Coupon do
         it { is_expected.to validate_presence_of(:percentage_rate) }
       end
     end
+
+    describe "of frequency_duration" do
+      context "when recurring" do
+        subject(:coupon) { build(:coupon, frequency: "recurring") }
+
+        it { is_expected.to validate_presence_of(:frequency_duration).with_message("value_is_mandatory") }
+        it { is_expected.to validate_numericality_of(:frequency_duration).is_greater_than(0) }
+      end
+
+      context "not recurring" do
+        subject(:coupon) { build(:coupon, frequency:) }
+
+        context "when once" do
+          let(:frequency) { "once" }
+
+          it { is_expected.not_to validate_presence_of(:frequency_duration) }
+        end
+
+        context "when forever" do
+          let(:frequency) { "forever" }
+
+          it { is_expected.not_to validate_presence_of(:frequency_duration) }
+        end
+      end
+    end
   end
 
   describe ".mark_as_terminated" do

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -264,7 +264,8 @@ RSpec.describe AppliedCoupons::CreateService do
 
         expect(create_result).not_to be_success
         expect(create_result.error).to be_a(BaseService::ValidationFailure)
-        expect(create_result.error.messages.keys).to include(:frequency_duration, :frequency_duration_remaining)
+        expect(create_result.error.messages[:frequency_duration]).to eq(["value_is_mandatory", "is not a number"])
+        expect(create_result.error.messages[:frequency_duration_remaining]).to eq(["value_is_mandatory", "is not a number"])
       end
     end
   end

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -244,5 +244,28 @@ RSpec.describe AppliedCoupons::CreateService do
         expect(customer.reload.currency).to eq(amount_currency)
       end
     end
+
+    context "when frequency is overridden to recurring without frequency_duration" do
+      let(:coupon) do
+        create(:coupon, status: "active", organization:, frequency: "once", frequency_duration: nil)
+      end
+
+      let(:params) do
+        {
+          amount_cents:,
+          amount_currency:,
+          percentage_rate:,
+          frequency: "recurring"
+        }
+      end
+
+      it "fails with a validation error" do
+        expect { create_result }.not_to change(AppliedCoupon, :count)
+
+        expect(create_result).not_to be_success
+        expect(create_result.error).to be_a(BaseService::ValidationFailure)
+        expect(create_result.error.messages.keys).to include(:frequency_duration, :frequency_duration_remaining)
+      end
+    end
   end
 end

--- a/spec/services/applied_coupons/recredit_service_spec.rb
+++ b/spec/services/applied_coupons/recredit_service_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe AppliedCoupons::RecreditService do
           customer:,
           organization:,
           frequency: :recurring,
+          frequency_duration: 3,
           frequency_duration_remaining: 2)
       end
 

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Coupons::CreateService do
         result = create_service.call
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages.keys).to include(:frequency_duration)
+        expect(result.error.messages[:frequency_duration]).to eq(["value_is_mandatory", "is not a number"])
       end
     end
 

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -117,6 +117,31 @@ RSpec.describe Coupons::CreateService do
       end
     end
 
+    context "when frequency is recurring without frequency_duration" do
+      let(:create_args) do
+        {
+          name: "Super Coupon",
+          code: coupon_code,
+          organization_id: organization.id,
+          coupon_type: "fixed_amount",
+          frequency: "recurring",
+          amount_cents: 100,
+          amount_currency: "EUR",
+          expiration: "no_expiration",
+          reusable: false
+        }
+      end
+
+      it "fails with a validation error" do
+        expect { create_service.call }.not_to change(Coupon, :count)
+
+        result = create_service.call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages.keys).to include(:frequency_duration)
+      end
+    end
+
     context "with plan limitations in graphql context" do
       let(:plan) { create(:plan, organization:) }
       let(:create_args) do

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -60,6 +60,28 @@ RSpec.describe Coupons::UpdateService do
       end
     end
 
+    context "when frequency is recurring without frequency_duration" do
+      let(:params) do
+        {
+          name:,
+          coupon_type: "fixed_amount",
+          frequency: "recurring",
+          amount_cents: 100,
+          amount_currency: "EUR",
+          expiration: "no_expiration",
+          reusable: false
+        }
+      end
+
+      it "fails with a validation error" do
+        result = update_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:frequency_duration]).to eq(["value_is_mandatory", "is not a number"])
+      end
+    end
+
     context "with new plan limitations" do
       let(:plan) { create(:plan, organization:) }
       let(:plan_second) { create(:plan, organization:) }

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -507,6 +507,28 @@ RSpec.describe Credits::AppliedCouponService do
           end
         end
       end
+
+      context "when frequency_duration_remaining is already 0" do
+        let(:coupon) { create(:coupon, organization:, frequency: "recurring", frequency_duration: 3) }
+        let(:applied_coupon) do
+          create(
+            :applied_coupon,
+            coupon:,
+            customer:,
+            amount_cents: 12,
+            frequency: "recurring",
+            frequency_duration: 3,
+            frequency_duration_remaining: 0
+          )
+        end
+
+        it "does not decrement frequency_duration_remaining below 0" do
+          result = credit_service.call
+
+          expect(result).to be_success
+          expect(applied_coupon.reload.frequency_duration_remaining).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Recurring coupons can be created through the API with `frequency: "recurring"` and `frequency_duration: nil`. This leads to applied coupons with `frequency_duration_remaining: nil`, and invoice finalization fails when `Credits::AppliedCouponService` decrements the remaining duration. The same applies to coupons as well.

## Description

Add validation for `frequency_duration` and `frequency_duration_remaining` when the coupon/applied coupon is `recurring`.
