### PR TITLE
feat(quote): add list filters

### DIFF
--- a/app/contracts/queries/quotes_query_filters_contract.rb
+++ b/app/contracts/queries/quotes_query_filters_contract.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Queries
+  class QuotesQueryFiltersContract < Dry::Validation::Contract
+    params do
+      optional(:customer).maybe { array(:string, format?: Regex::UUID) }
+      optional(:status).maybe do
+        value(:string, included_in?: Quote::STATUSES.values) |
+          array(:string, included_in?: Quote::STATUSES.values)
+      end
+      optional(:number).maybe { array(:string, format?: /\AQT-\d{4}-\d{4,}\z/i) }
+      optional(:version).maybe { array(:integer, gt?: 0) }
+      optional(:from_date).maybe(:date)
+      optional(:to_date).maybe(:date)
+      optional(:owners).maybe { array(:string, format?: Regex::UUID) }
+    end
+  end
+end

--- a/app/graphql/resolvers/quotes_resolver.rb
+++ b/app/graphql/resolvers/quotes_resolver.rb
@@ -9,18 +9,33 @@ module Resolvers
 
     description "Query quotes of an organization"
 
+    argument :customer, [ID], required: false
+    argument :from_date, GraphQL::Types::ISO8601Date, required: false
+    argument :latest_version_only, Boolean, required: false
     argument :limit, Integer, required: false
+    argument :number, [String], required: false
+    argument :owners, [ID], required: false
     argument :page, Integer, required: false
+    argument :status, [Types::Quotes::StatusEnum], required: false
+    argument :to_date, GraphQL::Types::ISO8601Date, required: false
+    argument :version, [Integer], required: false
 
     type Types::Quotes::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil)
+    def resolve(page: nil, limit: nil, customer: nil, number: nil, latest_version_only: false, status: nil, version: nil, from_date: nil, to_date: nil, owners: nil)
       result = ::QuotesQuery.call(
         organization: current_organization,
-        pagination: {
-          page:,
-          limit:
-        }
+        filters: {
+          customer:,
+          status:,
+          number:,
+          version:,
+          from_date:,
+          to_date:,
+          owners:
+        },
+        latest_version_only:,
+        pagination: {page:, limit:}
       )
       return result_error(result) unless result.success?
 

--- a/app/queries/quotes_query.rb
+++ b/app/queries/quotes_query.rb
@@ -1,19 +1,78 @@
 # frozen_string_literal: true
 
 class QuotesQuery < BaseQuery
+  attr_reader :latest_version_only
+
   Result = BaseResult[:quotes]
+  Filters = BaseFilters[:customer, :status, :number, :version, :from_date, :to_date, :owners]
+
+  def initialize(latest_version_only: false, **args)
+    @latest_version_only = latest_version_only
+    super(**args)
+  end
 
   def call
-    quotes = base_scope.order(number: :desc, version: :desc)
+    return result unless validate_filters.success?
+
+    quotes = base_scope
+
+    quotes = with_customer(quotes) if filters.customer.present?
+    quotes = with_number(quotes) if filters.number.present?
+    quotes = with_status(quotes) if filters.status.present?
+    quotes = with_version(quotes) if filters.version.present?
+    quotes = with_date(quotes) if filters.from_date.present? || filters.to_date.present?
+    quotes = with_owners(quotes) if filters.owners.present?
+
+    if latest_version_only
+      quotes = Quote.from(with_latest_version_only(quotes), :quotes)
+    end
+
+    quotes = quotes.order(number: :desc, version: :desc)
     quotes = paginate(quotes)
 
     result.quotes = quotes
+    result
+  rescue BaseService::FailedResult
     result
   end
 
   private
 
+  def filters_contract
+    @filters_contract ||= Queries::QuotesQueryFiltersContract.new
+  end
+
   def base_scope
     Quote.where(organization:)
+  end
+
+  def with_customer(scope)
+    scope.where(customer_id: filters.customer)
+  end
+
+  def with_status(scope)
+    scope.where(status: filters.status)
+  end
+
+  def with_number(scope)
+    scope.where(number: filters.number)
+  end
+
+  def with_version(scope)
+    scope.where(version: filters.version)
+  end
+
+  def with_date(scope)
+    scope.where(created_at: filters.from_date..filters.to_date)
+  end
+
+  def with_owners(scope)
+    scope.where(id: QuoteOwner.where(user_id: filters.owners).select(:quote_id))
+  end
+
+  def with_latest_version_only(scope)
+    scope.distinct(false)
+      .select("DISTINCT ON (quotes.sequential_id) quotes.*")
+      .order("quotes.sequential_id, quotes.version DESC")
   end
 end

--- a/app/queries/quotes_query.rb
+++ b/app/queries/quotes_query.rb
@@ -63,7 +63,9 @@ class QuotesQuery < BaseQuery
   end
 
   def with_date(scope)
-    scope.where(created_at: filters.from_date..filters.to_date)
+    scope = scope.where(created_at: filters.from_date..) if filters.from_date
+    scope = scope.where(created_at: ..filters.to_date.end_of_day) if filters.to_date
+    scope
   end
 
   def with_owners(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -10340,7 +10340,7 @@ type Query {
   """
   Query quotes of an organization
   """
-  quotes(limit: Int, page: Int): QuoteCollection!
+  quotes(customer: [ID!], fromDate: ISO8601Date, latestVersionOnly: Boolean, limit: Int, number: [String!], owners: [ID!], page: Int, status: [QuoteStatusEnum!], toDate: ISO8601Date, version: [Int!]): QuoteCollection!
 
   """
   Query a single role

--- a/schema.json
+++ b/schema.json
@@ -55473,6 +55473,50 @@
               "description": "Query quotes of an organization",
               "args": [
                 {
+                  "name": "customer",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "fromDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "latestVersionOnly",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -55485,12 +55529,104 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "number",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "owners",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "page",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "QuoteStatusEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "toDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Int",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/spec/contracts/queries/quotes_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/quotes_query_filters_contract_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Queries::QuotesQueryFiltersContract do
+  subject(:result) { described_class.new.call(filters.to_h) }
+
+  let(:filters) { {} }
+
+  context "when filtering by customer" do
+    let(:filters) { {customer: [SecureRandom.uuid]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by status" do
+    let(:filters) { {status: "draft"} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+
+    context "when filter is an array" do
+      let(:filters) { {status: ["draft", "approved"]} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+  end
+
+  context "when filtering by number" do
+    let(:filters) { {number: ["QT-2024-0001"]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+
+    context "when the number has more than 4 digits" do
+      let(:filters) { {number: ["QT-2024-00001"]} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+  end
+
+  context "when filtering by version" do
+    let(:filters) { {version: [1, 2]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by from_date" do
+    let(:filters) { {from_date: Date.today} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by to_date" do
+    let(:filters) { {to_date: Date.today} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by owners" do
+    let(:filters) { {owners: [SecureRandom.uuid]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filters are invalid" do
+    it_behaves_like "an invalid filter", :customer, SecureRandom.uuid, ["must be an array"]
+    it_behaves_like "an invalid filter", :customer, %w[random], {0 => ["is in invalid format"]}
+    it_behaves_like "an invalid filter", :status, "random", ["must be one of: draft, approved, voided or must be an array"]
+    it_behaves_like "an invalid filter", :status, ["draft", "random"], {1 => ["must be one of: draft, approved, voided"]}
+    it_behaves_like "an invalid filter", :number, "QT-2024-0001", ["must be an array"]
+    it_behaves_like "an invalid filter", :number, ["random"], {0 => ["is in invalid format"]}
+    it_behaves_like "an invalid filter", :version, [0], {0 => ["must be greater than 0"]}
+    it_behaves_like "an invalid filter", :version, ["not-an-integer"], {0 => ["must be an integer"]}
+    it_behaves_like "an invalid filter", :from_date, "not-a-date", ["must be a date"]
+    it_behaves_like "an invalid filter", :to_date, "not-a-date", ["must be a date"]
+    it_behaves_like "an invalid filter", :owners, SecureRandom.uuid, ["must be an array"]
+    it_behaves_like "an invalid filter", :owners, %w[random], {0 => ["is in invalid format"]}
+  end
+end

--- a/spec/contracts/queries/quotes_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/quotes_query_filters_contract_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Queries::QuotesQueryFiltersContract do
     it_behaves_like "an invalid filter", :number, "QT-2024-0001", ["must be an array"]
     it_behaves_like "an invalid filter", :number, ["random"], {0 => ["is in invalid format"]}
     it_behaves_like "an invalid filter", :version, [0], {0 => ["must be greater than 0"]}
+    it_behaves_like "an invalid filter", :version, [-1], {0 => ["must be greater than 0"]}
     it_behaves_like "an invalid filter", :version, ["not-an-integer"], {0 => ["must be an integer"]}
     it_behaves_like "an invalid filter", :from_date, "not-a-date", ["must be a date"]
     it_behaves_like "an invalid filter", :to_date, "not-a-date", ["must be a date"]

--- a/spec/graphql/resolvers/quotes_resolver_spec.rb
+++ b/spec/graphql/resolvers/quotes_resolver_spec.rb
@@ -80,4 +80,209 @@ RSpec.describe Resolvers::QuotesResolver do
       expect(quotes_response["metadata"]["totalCount"]).to eq(5)
     end
   end
+
+  context "when filtering by customer" do
+    let(:other_customer) { create(:customer, organization:) }
+    let(:query) do
+      <<~GQL
+        query($customer: [ID!]) {
+          quotes(limit: 5, customer: $customer) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      create(:quote, organization:, customer: other_customer, sequential_id: 2, number: "QT-2025-0002")
+    end
+
+    it "returns only quotes for the passed customer" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customer: [customer.id]}
+      )
+
+      quotes_response = result["data"]["quotes"]
+      expect(quotes_response["metadata"]["totalCount"]).to eq(5)
+    end
+  end
+
+  context "when filtering by status" do
+    let(:query) do
+      <<~GQL
+        query {
+          quotes(limit: 5, status: [draft]) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    let!(:draft_quote) do
+      create(:quote, organization:, customer:, sequential_id: 2, number: "QT-2025-0002", status: :draft)
+    end
+
+    it "returns only quotes with the passed status" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      quotes_response = result["data"]["quotes"]
+      expect(quotes_response["collection"].count).to eq(1)
+      expect(quotes_response["collection"].first["id"]).to eq(draft_quote.id)
+    end
+  end
+
+  context "when filtering by number" do
+    let(:query) do
+      <<~GQL
+        query {
+          quotes(limit: 5, number: ["QT-2025-0002"]) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    let!(:other_quote) do
+      create(:quote, organization:, customer:, sequential_id: 2, number: "QT-2025-0002")
+    end
+
+    it "returns only quotes matching the numbers" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      quotes_response = result["data"]["quotes"]
+      expect(quotes_response["collection"].count).to eq(1)
+      expect(quotes_response["collection"].first["id"]).to eq(other_quote.id)
+    end
+  end
+
+  context "when filtering by version" do
+    let(:query) do
+      <<~GQL
+        query {
+          quotes(limit: 5, version: [5]) {
+            collection { id version }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only quotes at the passed versions" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      quotes_response = result["data"]["quotes"]
+      expect(quotes_response["collection"].count).to eq(1)
+      expect(quotes_response["collection"].first["version"]).to eq(5)
+    end
+  end
+
+  context "when filtering by date window" do
+    let(:query) do
+      <<~GQL
+        query($fromDate: ISO8601Date, $toDate: ISO8601Date) {
+          quotes(limit: 5, fromDate: $fromDate, toDate: $toDate) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns quotes created within the window" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {fromDate: Date.yesterday.iso8601, toDate: Date.tomorrow.iso8601}
+      )
+
+      quotes_response = result["data"]["quotes"]
+      expect(quotes_response["metadata"]["totalCount"]).to eq(5)
+    end
+  end
+
+  context "when filtering by owners" do
+    let(:query) do
+      <<~GQL
+        query($owners: [ID!]) {
+          quotes(limit: 5, owners: $owners) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    let(:owner_user) { create(:user) }
+    let(:owned_quote) do
+      create(:quote, organization:, customer:, sequential_id: 2, number: "QT-2025-0002")
+    end
+
+    before do
+      create(:quote_owner, organization:, quote: owned_quote, user: owner_user)
+    end
+
+    it "returns only quotes with the matching owners" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {owners: [owner_user.id]}
+      )
+
+      quotes_response = result["data"]["quotes"]
+      expect(quotes_response["collection"].count).to eq(1)
+      expect(quotes_response["collection"].first["id"]).to eq(owned_quote.id)
+    end
+  end
+
+  context "when filtering by latest_version_only" do
+    let(:query) do
+      <<~GQL
+        query {
+          quotes(limit: 5, latestVersionOnly: true) {
+            collection { id version }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only the highest version per sequential_id" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      quotes_response = result["data"]["quotes"]
+      expect(quotes_response["collection"].count).to eq(1)
+      expect(quotes_response["collection"].first["version"]).to eq(5)
+    end
+  end
 end

--- a/spec/graphql/resolvers/quotes_resolver_spec.rb
+++ b/spec/graphql/resolvers/quotes_resolver_spec.rb
@@ -110,6 +110,29 @@ RSpec.describe Resolvers::QuotesResolver do
       quotes_response = result["data"]["quotes"]
       expect(quotes_response["metadata"]["totalCount"]).to eq(5)
     end
+
+    context "when the filter targets a customer from another organization" do
+      let(:other_organization) { create(:organization) }
+      let(:foreign_customer) { create(:customer, organization: other_organization) }
+
+      before do
+        create(:quote, organization: other_organization, customer: foreign_customer, sequential_id: 1, number: "QT-2025-0099")
+      end
+
+      it "does not leak quotes from other organizations" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {customer: [foreign_customer.id]}
+        )
+
+        quotes_response = result["data"]["quotes"]
+        expect(quotes_response["collection"]).to be_empty
+        expect(quotes_response["metadata"]["totalCount"]).to eq(0)
+      end
+    end
   end
 
   context "when filtering by status" do

--- a/spec/queries/quotes_query_spec.rb
+++ b/spec/queries/quotes_query_spec.rb
@@ -177,6 +177,27 @@ RSpec.describe QuotesQuery do
       end
     end
 
+    context "with to_date only" do
+      let!(:yesterday_quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001", created_at: 1.day.ago) }
+      let!(:today_quote) { create(:quote, organization:, customer:, sequential_id: 2, version: 1, number: "QT-2024-0002", created_at: Time.current) }
+      let(:filters) { {to_date: Date.today} }
+
+      it "returns quotes created up to the end of to_date" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to match_array([yesterday_quote.id, today_quote.id])
+      end
+    end
+
+    context "with to_date equal to the created day" do
+      let!(:quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001", created_at: Time.current) }
+      let(:filters) { {to_date: Date.current} }
+
+      it "includes quotes created earlier the same day" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([quote.id])
+      end
+    end
+
     context "with owners filter" do
       let(:user_one) { create(:user) }
       let(:user_two) { create(:user) }
@@ -228,6 +249,23 @@ RSpec.describe QuotesQuery do
         expect(result.quotes.pluck(:number, :version)).to eq([
           ["QT-2024-0002", 1],
           ["QT-2024-0001", 3]
+        ])
+      end
+    end
+
+    context "with latest_version_only combined with a status filter" do
+      let!(:draft_v1) { create(:quote, organization:, customer:, sequential_id: 10, version: 1, number: "QT-2025-0010", status: :draft) }
+      let!(:approved_v2) { create(:quote, organization:, customer:, sequential_id: 10, version: 2, number: "QT-2025-0010", status: :approved) }
+
+      let(:latest_version_only) { true }
+      let(:filters) { {status: ["draft"]} }
+
+      it "filters first, then picks the latest among the filtered versions" do
+        # Intended behaviour: when a quote has v1=draft and v2=approved, and the
+        # caller filters on status=draft with latest_version_only, we surface v1.
+        # The filter applies BEFORE the DISTINCT ON roll-up.
+        expect(result.quotes.pluck(:number, :version)).to eq([
+          ["QT-2025-0010", 1]
         ])
       end
     end

--- a/spec/queries/quotes_query_spec.rb
+++ b/spec/queries/quotes_query_spec.rb
@@ -4,12 +4,14 @@ require "rails_helper"
 
 RSpec.describe QuotesQuery do
   subject(:result) do
-    described_class.call(organization:, pagination:)
+    described_class.call(organization:, pagination:, filters:, latest_version_only:)
   end
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:pagination) { nil }
+  let(:filters) { {} }
+  let(:latest_version_only) { false }
 
   describe "ordering" do
     let!(:q1_v1) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
@@ -102,6 +104,149 @@ RSpec.describe QuotesQuery do
         expect(result.quotes).to be_empty
         expect(result.quotes.total_count).to eq(4)
         expect(result.quotes.total_pages).to eq(2)
+      end
+    end
+  end
+
+  describe "filters" do
+    context "with customer filter" do
+      let(:other_customer) { create(:customer, organization:) }
+      let!(:matching_quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let!(:other_quote) { create(:quote, organization:, customer: other_customer, sequential_id: 2, version: 1, number: "QT-2024-0002") }
+      let(:filters) { {customer: [customer.id]} }
+
+      it "returns only quotes for the passed customer" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([matching_quote.id])
+      end
+    end
+
+    context "with status filter" do
+      let!(:draft_quote) { create(:quote, organization:, customer:, status: :draft, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let!(:approved_quote) { create(:quote, organization:, customer:, status: :approved, sequential_id: 2, version: 1, number: "QT-2024-0002") }
+      let!(:voided_quote) { create(:quote, organization:, customer:, status: :voided, sequential_id: 3, version: 1, number: "QT-2024-0003") }
+      let(:filters) { {status: ["draft", "voided"]} }
+
+      it "returns only quotes with the passed statuses" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to match_array([draft_quote.id, voided_quote.id])
+      end
+    end
+
+    context "with number filter" do
+      let!(:matching_quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let!(:other_quote) { create(:quote, organization:, customer:, sequential_id: 2, version: 1, number: "QT-2024-0002") }
+      let(:filters) { {number: ["QT-2024-0001"]} }
+
+      it "returns only quotes matching the numbers" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([matching_quote.id])
+      end
+    end
+
+    context "with version filter" do
+      let!(:v1) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let!(:v2) { create(:quote, organization:, customer:, sequential_id: 1, version: 2, number: "QT-2024-0001") }
+      let!(:v3) { create(:quote, organization:, customer:, sequential_id: 1, version: 3, number: "QT-2024-0001") }
+      let(:filters) { {version: [1, 3]} }
+
+      it "returns only quotes at the passed versions" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to match_array([v1.id, v3.id])
+      end
+    end
+
+    context "with date window" do
+      let!(:old_quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001", created_at: 10.days.ago) }
+      let!(:recent_quote) { create(:quote, organization:, customer:, sequential_id: 2, version: 1, number: "QT-2024-0002", created_at: 1.day.ago) }
+      let(:filters) { {from_date: 5.days.ago.to_date, to_date: Date.today} }
+
+      it "returns only quotes created within the window" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([recent_quote.id])
+      end
+    end
+
+    context "with from_date as a Date object" do
+      let!(:quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let(:filters) { {from_date: Date.today - 1} }
+
+      it "does not fail validation" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([quote.id])
+      end
+    end
+
+    context "with owners filter" do
+      let(:user_one) { create(:user) }
+      let(:user_two) { create(:user) }
+      let!(:matching_quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let!(:other_quote) { create(:quote, organization:, customer:, sequential_id: 2, version: 1, number: "QT-2024-0002") }
+      let(:filters) { {owners: [user_one.id]} }
+
+      before do
+        create(:quote_owner, organization:, quote: matching_quote, user: user_one)
+        create(:quote_owner, organization:, quote: other_quote, user: user_two)
+      end
+
+      it "returns only quotes with the matching owners" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([matching_quote.id])
+      end
+    end
+
+    context "with owners filter matching multiple users" do
+      let(:user_one) { create(:user) }
+      let(:user_two) { create(:user) }
+      let!(:quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let(:filters) { {owners: [user_one.id, user_two.id]} }
+
+      before do
+        create(:quote_owner, organization:, quote:, user: user_one)
+        create(:quote_owner, organization:, quote:, user: user_two)
+      end
+
+      it "returns the quote exactly once" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([quote.id])
+      end
+    end
+
+    context "with latest_version_only" do
+      let!(:q1_v1) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let!(:q1_v2) { create(:quote, organization:, customer:, sequential_id: 1, version: 2, number: "QT-2024-0001") }
+      let!(:q1_v3) { create(:quote, organization:, customer:, sequential_id: 1, version: 3, number: "QT-2024-0001") }
+      let!(:q2_v1) { create(:quote, organization:, customer:, sequential_id: 2, version: 1, number: "QT-2024-0002") }
+      let(:latest_version_only) { true }
+
+      it "returns the highest version per sequential_id" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to match_array([q1_v3.id, q2_v1.id])
+      end
+
+      it "orders the deduped set by number DESC then version DESC" do
+        expect(result.quotes.pluck(:number, :version)).to eq([
+          ["QT-2024-0002", 1],
+          ["QT-2024-0001", 3]
+        ])
+      end
+    end
+
+    context "with latest_version_only combined with owners filter" do
+      let(:user_one) { create(:user) }
+      let!(:q1_v1) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let!(:q1_v2) { create(:quote, organization:, customer:, sequential_id: 1, version: 2, number: "QT-2024-0001") }
+      let(:filters) { {owners: [user_one.id]} }
+      let(:latest_version_only) { true }
+
+      before do
+        create(:quote_owner, organization:, quote: q1_v1, user: user_one)
+        create(:quote_owner, organization:, quote: q1_v2, user: user_one)
+      end
+
+      it "combines filters without raising an ambiguous column error" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([q1_v2.id])
       end
     end
   end

--- a/spec/queries/quotes_query_spec.rb
+++ b/spec/queries/quotes_query_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe QuotesQuery do
         expect(result.quotes.total_pages).to eq(2)
       end
     end
+
+    context "with pagination combined with a filter" do
+      let(:pagination) { {page: 2, limit: 2} }
+      let(:filters) { {status: ["draft"]} }
+
+      it "paginates within the filtered set" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:number)).to eq(["QT-2024-0002", "QT-2024-0001"])
+        expect(result.quotes.total_count).to eq(4)
+        expect(result.quotes.total_pages).to eq(2)
+      end
+    end
   end
 
   describe "filters" do
@@ -121,6 +133,32 @@ RSpec.describe QuotesQuery do
       end
     end
 
+    context "with an empty customer filter" do
+      let!(:quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let(:filters) { {customer: []} }
+
+      it "behaves as no filter and returns all quotes" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([quote.id])
+      end
+    end
+
+    context "with combined customer and status filters" do
+      let(:other_customer) { create(:customer, organization:) }
+      let!(:draft_for_customer) { create(:quote, organization:, customer:, status: :draft, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let(:filters) { {customer: [customer.id], status: ["draft"]} }
+
+      before do
+        create(:quote, organization:, customer:, status: :approved, sequential_id: 2, version: 1, number: "QT-2024-0002")
+        create(:quote, organization:, customer: other_customer, status: :draft, sequential_id: 3, version: 1, number: "QT-2024-0003")
+      end
+
+      it "returns the intersection of matching customer and status" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([draft_for_customer.id])
+      end
+    end
+
     context "with status filter" do
       let!(:draft_quote) { create(:quote, organization:, customer:, status: :draft, sequential_id: 1, version: 1, number: "QT-2024-0001") }
       let!(:approved_quote) { create(:quote, organization:, customer:, status: :approved, sequential_id: 2, version: 1, number: "QT-2024-0002") }
@@ -133,6 +171,16 @@ RSpec.describe QuotesQuery do
       end
     end
 
+    context "with an empty status filter" do
+      let!(:quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let(:filters) { {status: []} }
+
+      it "behaves as no filter and returns all quotes" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([quote.id])
+      end
+    end
+
     context "with number filter" do
       let!(:matching_quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
       let!(:other_quote) { create(:quote, organization:, customer:, sequential_id: 2, version: 1, number: "QT-2024-0002") }
@@ -141,6 +189,16 @@ RSpec.describe QuotesQuery do
       it "returns only quotes matching the numbers" do
         expect(result).to be_success
         expect(result.quotes.pluck(:id)).to eq([matching_quote.id])
+      end
+    end
+
+    context "with a number filter matching no existing quote" do
+      let!(:quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let(:filters) { {number: ["QT-2025-9999"]} }
+
+      it "returns an empty collection" do
+        expect(result).to be_success
+        expect(result.quotes).to be_empty
       end
     end
 
@@ -198,6 +256,32 @@ RSpec.describe QuotesQuery do
       end
     end
 
+    context "with from_date in the future" do
+      let(:filters) { {from_date: 1.week.from_now.to_date} }
+
+      before do
+        create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001")
+      end
+
+      it "returns an empty collection" do
+        expect(result).to be_success
+        expect(result.quotes).to be_empty
+      end
+    end
+
+    context "with to_date earlier than from_date" do
+      let(:filters) { {from_date: Date.current, to_date: 7.days.ago.to_date} }
+
+      before do
+        create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001")
+      end
+
+      it "returns an empty collection" do
+        expect(result).to be_success
+        expect(result.quotes).to be_empty
+      end
+    end
+
     context "with owners filter" do
       let(:user_one) { create(:user) }
       let(:user_two) { create(:user) }
@@ -213,6 +297,16 @@ RSpec.describe QuotesQuery do
       it "returns only quotes with the matching owners" do
         expect(result).to be_success
         expect(result.quotes.pluck(:id)).to eq([matching_quote.id])
+      end
+    end
+
+    context "with an empty owners filter" do
+      let!(:quote) { create(:quote, organization:, customer:, sequential_id: 1, version: 1, number: "QT-2024-0001") }
+      let(:filters) { {owners: []} }
+
+      it "behaves as no filter and returns all quotes" do
+        expect(result).to be_success
+        expect(result.quotes.pluck(:id)).to eq([quote.id])
       end
     end
 
@@ -250,6 +344,15 @@ RSpec.describe QuotesQuery do
           ["QT-2024-0002", 1],
           ["QT-2024-0001", 3]
         ])
+      end
+    end
+
+    context "with latest_version_only and no quotes" do
+      let(:latest_version_only) { true }
+
+      it "returns an empty collection without raising" do
+        expect(result).to be_success
+        expect(result.quotes).to be_empty
       end
     end
 


### PR DESCRIPTION
## Context

The foundation slice ([#5376](https://github.com/getlago/lago-api/pull/5376)) shipped `QuotesQuery` and `QuotesResolver` as pagination-only so the first review pass could focus on the schema and read path. The frontend needs to filter and narrow the quote list — by customer, status, number, version, date window, owners, and "latest version only" — before any mutation work becomes useful. This PR adds those eight filter arguments.

## Description

A new `Queries::QuotesQueryFiltersContract` validates each filter with Dry::Validation. `from_date` and `to_date` are declared as `maybe(:date)` to match the `ISO8601Date` type that graphql-ruby exposes on the resolver; `status` accepts the PG-enum string values; `number` enforces the `QT-YYYY-NNNN` format via regex; `customer` / `owners` enforce UUID shape; `version` only accepts positive integers.

`QuotesQuery` gained the eight `with_*` filter methods. `with_date` builds each bound separately and applies `end_of_day` to the upper bound so a `to_date: Date.current` actually includes quotes created earlier in the same day — matching the date-window idiom used by `invoices_query.rb`. `with_owners` uses a subquery-IN form (`scope.where(id: QuoteOwner.where(user_id: filters.owners).select(:quote_id))`) which avoids the `SELECT DISTINCT … ORDER BY` conflict that `pluck(:id)` surfaces with a joined-and-distinct relation. `with_latest_version_only` projects `quotes.*` with qualified column names and resets the relation's `distinct` flag so it composes cleanly with the other filters; the outer call wraps the deduplicated subquery in `Quote.from(subquery, :quotes)` so the final `(number DESC, version DESC)` ordering and Kaminari pagination apply to the roll-up, not to the pre-dedup set.

`QuotesResolver` forwards the new arguments to the query, keeps the existing `result_error` short-circuit, and preserves the `.includes(:customer, :organization, :subscription, :owners)` preload.

Specs cover each filter path individually, the combined filter semantics, the pagination-with-filter case, and the cross-organization guard that confirms a filter targeting a foreign customer does not leak data. The schema files were regenerated after the resolver signature changed.

## Test plan
- [x] `lago exec api bundle exec rspec spec/contracts/queries/quotes_query_filters_contract_spec.rb`
- [x] `lago exec api bundle exec rspec spec/queries/quotes_query_spec.rb`
- [x] `lago exec api bundle exec rspec spec/graphql/resolvers/quotes_resolver_spec.rb`
- [x] Foundation regression suite still green (`spec/models/quote*`, `spec/graphql/resolvers/quote_resolver_spec.rb`, `spec/graphql/types/quotes/`)
- [x] `schema.graphql` / `schema.json` regenerated; the `quotes` field on `Query` now carries the eight new arguments

Stacked on top of #5376.
