### PR TITLE
fix(eu-tax): Resolve EU tax from customer country

### DIFF
--- a/app/services/customers/concerns/eu_tax_code_resolver.rb
+++ b/app/services/customers/concerns/eu_tax_code_resolver.rb
@@ -22,7 +22,7 @@ module Customers
 
       def process_not_vies_tax
         return "lago_eu_#{billing_country_code.downcase}_standard" if customer.country.blank?
-        return "lago_eu_#{billing_country_code.downcase}_standard" if eu_countries_code.include?(customer.country.upcase)
+        return "lago_eu_#{customer.country.downcase}_standard" if eu_countries_code.include?(customer.country.upcase)
 
         "lago_eu_tax_exempt"
       end

--- a/spec/scenarios/customers/customer_eu_taxes_spec.rb
+++ b/spec/scenarios/customers/customer_eu_taxes_spec.rb
@@ -61,13 +61,13 @@ describe "Add customer-specific taxes" do
       expect(Customer.find_by(external_id: "user_fr_123").taxes.sole.code).to eq "lago_eu_fr_standard"
 
       create_or_update_customer(italian_attributes.merge(external_id: "user_it_123"))
-      expect(Customer.find_by(external_id: "user_it_123").taxes.sole.code).to eq "lago_eu_fr_standard"
+      expect(Customer.find_by(external_id: "user_it_123").taxes.sole.code).to eq "lago_eu_it_standard"
 
       webhooks_sent.clear
       # Update customer to provide an INVALID EU VAT identifier
       # Nothing changes and no API call is made
       create_or_update_customer({external_id: "user_it_123", tax_identification_number: "IT123"})
-      expect(Customer.find_by(external_id: "user_it_123").taxes.reload.sole.code).to eq "lago_eu_fr_standard"
+      expect(Customer.find_by(external_id: "user_it_123").taxes.reload.sole.code).to eq "lago_eu_it_standard"
       expect(webhooks_sent.find { it["webhook_type"] == "customer.vies_check" }.dig("customer", "vies_check")).to eq({
         "valid" => false,
         "valid_format" => false
@@ -104,7 +104,7 @@ describe "Add customer-specific taxes" do
       # Then, remove the tax_identification_number for the customer
       # The custom tax is overridden by the default VAT of the country, even if an invoice used the previous taxes
       create_or_update_customer({external_id: customer.external_id, tax_identification_number: nil})
-      expect(customer.taxes.sole.code).to eq "lago_eu_fr_standard"
+      expect(customer.taxes.sole.code).to eq "lago_eu_it_standard"
     end
   end
 
@@ -145,7 +145,7 @@ describe "Add customer-specific taxes" do
 
       create_or_update_customer(italian_attributes.merge(external_id: "user_it_123"))
       customer = Customer.find_by(external_id: "user_it_123")
-      expect(customer.taxes.sole.code).to eq "lago_eu_fr_standard"
+      expect(customer.taxes.sole.code).to eq "lago_eu_it_standard"
 
       # Update with VAT number - VIES fails
       allow_any_instance_of(Valvat).to receive(:exists?) # rubocop:disable RSpec/AnyInstance
@@ -323,7 +323,7 @@ describe "Add customer-specific taxes" do
       expect(customer.reload.taxes.sole.code).to eq "lago_eu_fr_standard"
 
       create_or_update_customer({external_id: customer.external_id, country: "DE"})
-      expect(customer.reload.taxes.sole.code).to eq "lago_eu_fr_standard"
+      expect(customer.reload.taxes.sole.code).to eq "lago_eu_de_standard"
     end
   end
 
@@ -333,7 +333,7 @@ describe "Add customer-specific taxes" do
 
       create_or_update_customer(italian_attributes.merge(external_id: "user_it_123"))
       customer = Customer.find_by(external_id: "user_it_123")
-      expect(customer.taxes.sole.code).to eq "lago_eu_fr_standard"
+      expect(customer.taxes.sole.code).to eq "lago_eu_it_standard"
 
       # Make an invoice with another tax
       create_tax({name: "Banking rates", code: "banking_rates", rate: 1.3})
@@ -342,7 +342,7 @@ describe "Add customer-specific taxes" do
       expect(customer.invoices.sole.taxes.sole.code).to eq "banking_rates"
 
       # The customer tax is unaffected
-      expect(customer.taxes.sole.code).to eq "lago_eu_fr_standard"
+      expect(customer.taxes.sole.code).to eq "lago_eu_it_standard"
     end
   end
 

--- a/spec/services/customers/eu_auto_taxes_service_spec.rb
+++ b/spec/services/customers/eu_auto_taxes_service_spec.rb
@@ -52,10 +52,10 @@ RSpec.describe Customers::EuAutoTaxesService do
         customer.update!(country: "DE")
       end
 
-      it "returns the billing_entity country tax code" do
+      it "returns the customer country tax code" do
         result = eu_tax_service.call
 
-        expect(result.tax_code).to eq("lago_eu_fr_standard")
+        expect(result.tax_code).to eq("lago_eu_de_standard")
       end
     end
 
@@ -64,10 +64,10 @@ RSpec.describe Customers::EuAutoTaxesService do
 
       before { customer.update!(country: "DE") }
 
-      it "returns the billing entity country tax code" do
+      it "returns the customer country tax code" do
         result = eu_tax_service.call
 
-        expect(result.tax_code).to eq("lago_eu_fr_standard")
+        expect(result.tax_code).to eq("lago_eu_de_standard")
       end
 
       it "does not enqueue ViesCheckJob" do
@@ -133,10 +133,10 @@ RSpec.describe Customers::EuAutoTaxesService do
       context "when the customer country is in europe" do
         before { customer.update(country: "DE") }
 
-        it "returns the billing entity country tax code" do
+        it "returns the customer country tax code" do
           result = eu_tax_service.call
 
-          expect(result.tax_code).to eq("lago_eu_fr_standard")
+          expect(result.tax_code).to eq("lago_eu_de_standard")
         end
       end
 
@@ -315,13 +315,13 @@ RSpec.describe Customers::EuAutoTaxesService do
         it "falls through when zipcode does not match any exception" do
           customer.update(country: "ES", zipcode: "28001")
           result = eu_tax_service.call
-          expect(result.tax_code).to eq("lago_eu_fr_standard")
+          expect(result.tax_code).to eq("lago_eu_es_standard")
         end
 
         it "falls through when customer has no zipcode" do
           customer.update(country: "DE")
           result = eu_tax_service.call
-          expect(result.tax_code).to eq("lago_eu_fr_standard")
+          expect(result.tax_code).to eq("lago_eu_de_standard")
         end
 
         it "falls through when customer has no country" do

--- a/spec/services/customers/vies_check_service_spec.rb
+++ b/spec/services/customers/vies_check_service_spec.rb
@@ -105,10 +105,10 @@ RSpec.describe Customers::ViesCheckService do
           allow_any_instance_of(Valvat).to receive(:exists?).and_call_original # rubocop:disable RSpec/AnyInstance
         end
 
-        it "returns the billing entity country tax code and vies_check details" do
+        it "returns the customer country tax code and vies_check details" do
           result = vies_check_service.call
 
-          expect(result.tax_code).to eq("lago_eu_fr_standard")
+          expect(result.tax_code).to eq("lago_eu_de_standard")
           expect(result.vies_check).to eq({valid: false, valid_format: false})
         end
 
@@ -207,10 +207,10 @@ RSpec.describe Customers::ViesCheckService do
         end
 
         context "when the customer country is in europe" do
-          it "returns the billing entity country tax code" do
+          it "returns the customer country tax code" do
             result = vies_check_service.call
 
-            expect(result.tax_code).to eq("lago_eu_fr_standard")
+            expect(result.tax_code).to eq("lago_eu_de_standard")
           end
         end
 


### PR DESCRIPTION
## Context

A change in the VIES tax assignation made for a customer created a problem for another customer.

## Description

We are reverting to where the code was before the problematic fix. In a future PR we we will introduce a backfill to fix customer's corrupted data.

Reverts #5056