### PR TITLE
misc(invoices): Backfill updated_at from metadata

### DIFF
--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -70,13 +70,15 @@ namespace :invoices do
         UPDATE invoices
         SET updated_at = stale.max_metadata_updated_at
         FROM (
-          SELECT invoices.id, MAX(im.updated_at) AS max_metadata_updated_at
-          FROM invoices
-          JOIN invoice_metadata im ON im.invoice_id = invoices.id
-          WHERE invoices.organization_id = $1
+          SELECT im.invoice_id AS id, MAX(im.updated_at) AS max_metadata_updated_at
+          FROM invoice_metadata im
+          JOIN invoices
+            ON invoices.id = im.invoice_id
+           AND im.updated_at > invoices.updated_at
+          WHERE im.organization_id = $1
             AND invoices.status IN (#{visible_statuses_sql})
-          GROUP BY invoices.id
-          HAVING MAX(im.updated_at) > invoices.updated_at
+          GROUP BY im.invoice_id
+          ORDER BY im.invoice_id
           LIMIT #{effective_limit}
         ) AS stale
         WHERE invoices.id = stale.id

--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -43,4 +43,59 @@ namespace :invoices do
   task fill_expected_finalization_date: :environment do
     Invoice.in_batches(of: 10_000).update_all("expected_finalization_date = COALESCE(expected_finalization_date, issuing_date)") # rubocop:disable Rails/SkipsModelValidations
   end
+
+  desc "Touch invoices.updated_at to MAX(invoice_metadata.updated_at) so Prequel re-syncs stale metadata"
+  task :backfill_metadata_updated_at, [:organization_id] => :environment do |_task, args|
+    organization_id = args[:organization_id]
+    abort "Missing organization_id argument\n\nUsage: rake invoices:backfill_metadata_updated_at[organization_id]" if organization_id.blank?
+
+    batch_size = (ENV["BATCH_SIZE"] || 1_000).to_i
+    total_limit = (ENV["TOTAL_LIMIT"] || 10_000).to_i
+    abort "BATCH_SIZE must be positive" if batch_size <= 0
+    abort "TOTAL_LIMIT must be positive" if total_limit <= 0
+
+    # Interpolated directly since these are trusted integer constants, not user input.
+    visible_statuses_sql = Invoice::VISIBLE_STATUS.values.join(",")
+    total_updated = 0
+
+    puts "Starting backfill for organization #{organization_id} (batch_size: #{batch_size}, total_limit: #{total_limit})..."
+
+    loop do
+      remaining_budget = total_limit - total_updated
+      break if remaining_budget <= 0
+
+      effective_limit = [batch_size, remaining_budget].min
+
+      update_sql = <<~SQL.squish
+        UPDATE invoices
+        SET updated_at = stale.max_metadata_updated_at
+        FROM (
+          SELECT invoices.id, MAX(im.updated_at) AS max_metadata_updated_at
+          FROM invoices
+          JOIN invoice_metadata im ON im.invoice_id = invoices.id
+          WHERE invoices.organization_id = $1
+            AND invoices.status IN (#{visible_statuses_sql})
+          GROUP BY invoices.id
+          HAVING MAX(im.updated_at) > invoices.updated_at
+          LIMIT #{effective_limit}
+        ) AS stale
+        WHERE invoices.id = stale.id
+          AND invoices.updated_at < stale.max_metadata_updated_at
+      SQL
+
+      rows = ActiveRecord::Base.connection.exec_update(update_sql, "BackfillInvoiceMetadataUpdatedAt", [organization_id])
+      total_updated += rows
+      puts "  Batch updated: #{rows} rows (total: #{total_updated})"
+      break if rows < effective_limit
+    end
+
+    remaining = Invoice
+      .joins("JOIN invoice_metadata im ON im.invoice_id = invoices.id")
+      .where(organization_id: organization_id, status: Invoice::VISIBLE_STATUS.keys)
+      .where("invoices.updated_at < im.updated_at")
+      .distinct
+      .count
+
+    puts "Done. Total updated: #{total_updated}. Remaining stale invoices: #{remaining}."
+  end
 end

--- a/spec/lib/tasks/invoices_rake_spec.rb
+++ b/spec/lib/tasks/invoices_rake_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "invoices:backfill_metadata_updated_at" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["invoices:backfill_metadata_updated_at"] }
+
+  let(:organization) { create(:organization) }
+
+  before do
+    Rake.application.rake_require("tasks/invoices")
+    Rake::Task.define_task(:environment)
+    task.reenable
+  end
+
+  # Create an invoice whose updated_at is older than its metadata's updated_at
+  # (reproduces the pre-fix historical state).
+  def create_stale_invoice(org: organization, status: :finalized)
+    invoice = create(:invoice, organization: org, status: status)
+    create(:invoice_metadata, invoice: invoice, organization: org)
+    invoice.update_column(:updated_at, 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
+    invoice
+  end
+
+  context "when there are no stale invoices" do
+    it "reports 0 remaining and updates nothing" do
+      expect { task.invoke(organization.id) }.to output(/Remaining stale invoices: 0/).to_stdout
+    end
+  end
+
+  context "with one stale invoice" do
+    let!(:invoice) { create_stale_invoice }
+
+    it "bumps invoice.updated_at to the metadata timestamp" do
+      metadata_updated_at = invoice.metadata.first.updated_at
+      original_updated_at = invoice.updated_at
+
+      expect { task.invoke(organization.id) }.to output(/Done/).to_stdout
+
+      invoice.reload
+      expect(invoice.updated_at).to be > original_updated_at
+      expect(invoice.updated_at).to be_within(1.second).of(metadata_updated_at)
+    end
+  end
+
+  context "with invoices in invisible statuses" do
+    let!(:generating_invoice) { create_stale_invoice(status: :generating) }
+    let!(:open_invoice) { create_stale_invoice(status: :open) }
+    let!(:closed_invoice) { create_stale_invoice(status: :closed) }
+
+    it "does not touch generating, open, or closed invoices" do
+      original_updated_ats = [generating_invoice, open_invoice, closed_invoice].map(&:updated_at)
+
+      task.invoke(organization.id)
+
+      [generating_invoice, open_invoice, closed_invoice].each_with_index do |invoice, index|
+        expect(invoice.reload.updated_at).to be_within(1.second).of(original_updated_ats[index])
+      end
+    end
+  end
+
+  context "with invoices in a different organization" do
+    let(:other_organization) { create(:organization) }
+    let!(:other_invoice) { create_stale_invoice(org: other_organization) }
+
+    it "does not touch invoices outside the target organization" do
+      original_updated_at = other_invoice.updated_at
+
+      task.invoke(organization.id)
+
+      expect(other_invoice.reload.updated_at).to be_within(1.second).of(original_updated_at)
+    end
+  end
+
+  context "when run twice" do
+    before { create_stale_invoice }
+
+    it "is idempotent: the second run updates zero rows" do
+      task.invoke(organization.id)
+      task.reenable
+
+      expect { task.invoke(organization.id) }.to output(/Batch updated: 0 rows/).to_stdout
+    end
+  end
+
+  context "with TOTAL_LIMIT set below the stale count" do
+    before do
+      2.times { create_stale_invoice }
+      ENV["BATCH_SIZE"] = "1"
+      ENV["TOTAL_LIMIT"] = "1"
+    end
+
+    after do
+      ENV.delete("BATCH_SIZE")
+      ENV.delete("TOTAL_LIMIT")
+    end
+
+    it "stops processing once the cap is reached" do
+      expect { task.invoke(organization.id) }.to output(/Remaining stale invoices: 1/).to_stdout
+    end
+  end
+
+  context "without an organization_id argument" do
+    it "aborts with a usage message" do
+      expect { task.invoke }.to raise_error(SystemExit).and output(/Missing organization_id argument/).to_stderr
+    end
+  end
+end

--- a/spec/lib/tasks/invoices_rake_spec.rb
+++ b/spec/lib/tasks/invoices_rake_spec.rb
@@ -85,6 +85,29 @@ RSpec.describe "invoices:backfill_metadata_updated_at" do # rubocop:disable RSpe
     end
   end
 
+  context "with multiple stale invoices across multiple batches" do
+    let!(:stale_invoices) { Array.new(3) { create_stale_invoice } }
+
+    before do
+      ENV["BATCH_SIZE"] = "1"
+      ENV["TOTAL_LIMIT"] = "10"
+    end
+
+    after do
+      ENV.delete("BATCH_SIZE")
+      ENV.delete("TOTAL_LIMIT")
+    end
+
+    it "processes every stale invoice across iterations and reports zero remaining" do
+      expect { task.invoke(organization.id) }.to output(/Remaining stale invoices: 0/).to_stdout
+
+      stale_invoices.each do |invoice|
+        metadata_updated_at = invoice.metadata.first.updated_at
+        expect(invoice.reload.updated_at).to be_within(1.second).of(metadata_updated_at)
+      end
+    end
+  end
+
   context "with TOTAL_LIMIT set below the stale count" do
     before do
       2.times { create_stale_invoice }


### PR DESCRIPTION
## Context

Invoice metadata created before `belongs_to :invoice, touch: true` was added to `Metadata::InvoiceMetadata` does not bump the parent invoice's `updated_at`. Downstream data sync pipelines that watch that column to detect changes therefore skip those invoices and their metadata never propagates, even though it is perfectly visible inside Lago.

New writes are now correct, but the historical drift is still there for organizations that accumulated metadata before the `touch: true` fix landed. This PR adds the tool to converge those rows back to a consistent state on demand, without a migration (this is a targeted, operator-run fix rather than something every Lago deployment needs to apply).

## Description

Adds a rake task:

```
rake invoices:backfill_metadata_updated_at[organization_id]
```

For each visible-status invoice belonging to the given organization whose `updated_at` lags behind the latest metadata row, the task updates `updated_at` to `MAX(invoice_metadata.updated_at)`. It runs in batches, respects a total cap, and is idempotent.

Key design choices:

- **Batched with a total cap** (`BATCH_SIZE` default 1_000, `TOTAL_LIMIT` default 10_000). Keeps each transaction short-lived and lets an operator observe the first few batches before running at full volume.
- **Idempotent**. The outer ``WHERE invoices.updated_at < stale.max_metadata_updated_at`` guard means rows already bumped by an earlier invocation (or by a concurrent touch) are not rewritten.
- **Scoped to visible statuses only** (`Invoice::VISIBLE_STATUS`), matching the export view that sync consumers read from. `generating`, `open`, and `closed` invoices are intentionally left alone.
- **Functional-dependency GROUP BY**. Postgres allows the bare `invoices.updated_at` reference in `HAVING` because the GROUP BY is on `invoices.id` (the primary key), so no aggregate wrapper is needed and the stale filter runs inside the LIMITed subquery.

## How to try locally

1. In a Rails console, pick an org and attach metadata to one of its visible invoices, then backdate the invoice so it looks historically stale:

   ```ruby
   org = Organization.first
   invoice = org.invoices.visible.last
   invoice.metadata.create!(organization: org, key: "k", value: "v")  # touches invoice
   invoice.update_column(:updated_at, 1.day.ago)
   ```

2. Run the task with small limits so you can eyeball the output:

   ```
   lago exec api bundle exec rake 'invoices:backfill_metadata_updated_at[<org_id>]' BATCH_SIZE=100 TOTAL_LIMIT=100
   ```

   Expected output:

   ```
   Starting backfill for organization <org_id> (batch_size: 100, total_limit: 100)...
     Batch updated: 1 rows (total: 1)
   Done. Total updated: 1. Remaining stale invoices: 0.
   ```

3. Re-run the same command to confirm idempotency: the second run reports `Batch updated: 0 rows` and does not touch the invoice again.

4. Run the spec:

   ```
   lago exec api bundle exec rspec spec/lib/tasks/invoices_rake_spec.rb
   ```

   7 examples covering the empty case, a single stale invoice, invisible-status invoices, cross-org scoping, idempotency, the `TOTAL_LIMIT` cap, and the missing-argument abort.