### PR TITLE
fix(fees): Add original_fee_id with improved uniqueness index

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -360,6 +360,7 @@ end
 #  invoice_id                          :uuid
 #  invoiceable_id                      :uuid
 #  organization_id                     :uuid             not null
+#  original_fee_id                     :uuid
 #  pay_in_advance_event_id             :uuid
 #  pay_in_advance_event_transaction_id :string
 #  subscription_id                     :uuid
@@ -367,8 +368,8 @@ end
 #
 # Indexes
 #
-#  idx_pay_in_advance_duplication_guard_charge         (pay_in_advance_event_transaction_id,charge_id) UNIQUE WHERE ((deleted_at IS NULL) AND (charge_filter_id IS NULL) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true) AND (duplicated_in_advance = false))
-#  idx_pay_in_advance_duplication_guard_charge_filter  (pay_in_advance_event_transaction_id,charge_id,charge_filter_id) UNIQUE WHERE ((deleted_at IS NULL) AND (charge_filter_id IS NOT NULL) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true) AND (duplicated_in_advance = false))
+#  idx_pay_in_advance_duplication_guard_charge         (pay_in_advance_event_transaction_id,charge_id) UNIQUE WHERE ((deleted_at IS NULL) AND (charge_filter_id IS NULL) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true) AND (duplicated_in_advance = false) AND (original_fee_id IS NULL))
+#  idx_pay_in_advance_duplication_guard_charge_filter  (pay_in_advance_event_transaction_id,charge_id,charge_filter_id) UNIQUE WHERE ((deleted_at IS NULL) AND (charge_filter_id IS NOT NULL) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true) AND (duplicated_in_advance = false) AND (original_fee_id IS NULL))
 #  index_fees_on_add_on_id                             (add_on_id)
 #  index_fees_on_applied_add_on_id                     (applied_add_on_id)
 #  index_fees_on_billing_entity_id                     (billing_entity_id)
@@ -381,6 +382,7 @@ end
 #  index_fees_on_invoice_id                            (invoice_id)
 #  index_fees_on_invoiceable                           (invoiceable_type,invoiceable_id)
 #  index_fees_on_organization_id                       (organization_id)
+#  index_fees_on_original_fee_id                       (original_fee_id)
 #  index_fees_on_pay_in_advance_event_transaction_id   (pay_in_advance_event_transaction_id) WHERE (deleted_at IS NULL)
 #  index_fees_on_subscription_id                       (subscription_id)
 #  index_fees_on_true_up_parent_fee_id                 (true_up_parent_fee_id)
@@ -395,6 +397,7 @@ end
 #  fk_rails_...  (group_id => groups.id)
 #  fk_rails_...  (invoice_id => invoices.id)
 #  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (original_fee_id => fees.id)
 #  fk_rails_...  (subscription_id => subscriptions.id)
 #  fk_rails_...  (true_up_parent_fee_id => fees.id)
 #

--- a/db/migrate/20260421013319_add_original_fee_id_to_fees.rb
+++ b/db/migrate/20260421013319_add_original_fee_id_to_fees.rb
@@ -5,5 +5,6 @@ class AddOriginalFeeIdToFees < ActiveRecord::Migration[8.0]
 
   def change
     add_reference :fees, :original_fee, type: :uuid, index: {algorithm: :concurrently}
+    add_foreign_key :fees, :fees, column: :original_fee_id, validate: false
   end
 end

--- a/db/migrate/20260421013319_add_original_fee_id_to_fees.rb
+++ b/db/migrate/20260421013319_add_original_fee_id_to_fees.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOriginalFeeIdToFees < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :fees, :original_fee, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20260421021503_validate_fees_original_fee_id_foreign_key.rb
+++ b/db/migrate/20260421021503_validate_fees_original_fee_id_foreign_key.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ValidateFeesOriginalFeeIdForeignKey < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    validate_foreign_key :fees, column: :original_fee_id
+  end
+end

--- a/db/migrate/20260421103557_update_pay_in_advance_duplication_guard_indexes.rb
+++ b/db/migrate/20260421103557_update_pay_in_advance_duplication_guard_indexes.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
+# Given the fees table is large, this migration builds the new indexes under
+# temporary names first, then drops the old ones, then renames.
+# This keeps a unique constraint enforcing the guard at all times,
+# avoiding a window where duplicate pay-in-advance fees could be inserted and
+# later cause the concurrent build to fail and leave an INVALID index behind.
 class UpdatePayInAdvanceDuplicationGuardIndexes < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
-  def up
-    remove_index :fees, name: :idx_pay_in_advance_duplication_guard_charge, if_exists: true
-    remove_index :fees, name: :idx_pay_in_advance_duplication_guard_charge_filter, if_exists: true
+  CHARGE_INDEX = :idx_pay_in_advance_duplication_guard_charge
+  CHARGE_FILTER_INDEX = :idx_pay_in_advance_duplication_guard_charge_filter
+  CHARGE_INDEX_NEW = :idx_pay_in_advance_duplication_guard_charge_new
+  CHARGE_FILTER_INDEX_NEW = :idx_pay_in_advance_duplication_guard_charge_filter_new
 
+  def up
     add_index :fees,
       [:pay_in_advance_event_transaction_id, :charge_id],
       unique: true,
-      name: :idx_pay_in_advance_duplication_guard_charge,
+      name: CHARGE_INDEX_NEW,
       where: "deleted_at IS NULL AND charge_filter_id IS NULL AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true AND duplicated_in_advance = false AND original_fee_id IS NULL",
       algorithm: :concurrently,
       if_not_exists: true
@@ -18,20 +25,25 @@ class UpdatePayInAdvanceDuplicationGuardIndexes < ActiveRecord::Migration[8.0]
     add_index :fees,
       [:pay_in_advance_event_transaction_id, :charge_id, :charge_filter_id],
       unique: true,
-      name: :idx_pay_in_advance_duplication_guard_charge_filter,
+      name: CHARGE_FILTER_INDEX_NEW,
       where: "deleted_at IS NULL AND charge_filter_id IS NOT NULL AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true AND duplicated_in_advance = false AND original_fee_id IS NULL",
       algorithm: :concurrently,
       if_not_exists: true
+
+    remove_index :fees, name: CHARGE_INDEX, if_exists: true
+    remove_index :fees, name: CHARGE_FILTER_INDEX, if_exists: true
+
+    safety_assured do
+      execute "ALTER INDEX #{CHARGE_INDEX_NEW} RENAME TO #{CHARGE_INDEX}"
+      execute "ALTER INDEX #{CHARGE_FILTER_INDEX_NEW} RENAME TO #{CHARGE_FILTER_INDEX}"
+    end
   end
 
   def down
-    remove_index :fees, name: :idx_pay_in_advance_duplication_guard_charge, if_exists: true
-    remove_index :fees, name: :idx_pay_in_advance_duplication_guard_charge_filter, if_exists: true
-
     add_index :fees,
       [:pay_in_advance_event_transaction_id, :charge_id],
       unique: true,
-      name: :idx_pay_in_advance_duplication_guard_charge,
+      name: CHARGE_INDEX_NEW,
       where: "deleted_at IS NULL AND charge_filter_id IS NULL AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true AND duplicated_in_advance = false",
       algorithm: :concurrently,
       if_not_exists: true
@@ -39,9 +51,17 @@ class UpdatePayInAdvanceDuplicationGuardIndexes < ActiveRecord::Migration[8.0]
     add_index :fees,
       [:pay_in_advance_event_transaction_id, :charge_id, :charge_filter_id],
       unique: true,
-      name: :idx_pay_in_advance_duplication_guard_charge_filter,
+      name: CHARGE_FILTER_INDEX_NEW,
       where: "deleted_at IS NULL AND charge_filter_id IS NOT NULL AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true AND duplicated_in_advance = false",
       algorithm: :concurrently,
       if_not_exists: true
+
+    remove_index :fees, name: CHARGE_INDEX, if_exists: true
+    remove_index :fees, name: CHARGE_FILTER_INDEX, if_exists: true
+
+    safety_assured do
+      execute "ALTER INDEX #{CHARGE_INDEX_NEW} RENAME TO #{CHARGE_INDEX}"
+      execute "ALTER INDEX #{CHARGE_FILTER_INDEX_NEW} RENAME TO #{CHARGE_FILTER_INDEX}"
+    end
   end
 end

--- a/db/migrate/20260421103557_update_pay_in_advance_duplication_guard_indexes.rb
+++ b/db/migrate/20260421103557_update_pay_in_advance_duplication_guard_indexes.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class UpdatePayInAdvanceDuplicationGuardIndexes < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :fees, name: :idx_pay_in_advance_duplication_guard_charge, if_exists: true
+    remove_index :fees, name: :idx_pay_in_advance_duplication_guard_charge_filter, if_exists: true
+
+    add_index :fees,
+      [:pay_in_advance_event_transaction_id, :charge_id],
+      unique: true,
+      name: :idx_pay_in_advance_duplication_guard_charge,
+      where: "deleted_at IS NULL AND charge_filter_id IS NULL AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true AND duplicated_in_advance = false AND original_fee_id IS NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+
+    add_index :fees,
+      [:pay_in_advance_event_transaction_id, :charge_id, :charge_filter_id],
+      unique: true,
+      name: :idx_pay_in_advance_duplication_guard_charge_filter,
+      where: "deleted_at IS NULL AND charge_filter_id IS NOT NULL AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true AND duplicated_in_advance = false AND original_fee_id IS NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+
+  def down
+    remove_index :fees, name: :idx_pay_in_advance_duplication_guard_charge, if_exists: true
+    remove_index :fees, name: :idx_pay_in_advance_duplication_guard_charge_filter, if_exists: true
+
+    add_index :fees,
+      [:pay_in_advance_event_transaction_id, :charge_id],
+      unique: true,
+      name: :idx_pay_in_advance_duplication_guard_charge,
+      where: "deleted_at IS NULL AND charge_filter_id IS NULL AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true AND duplicated_in_advance = false",
+      algorithm: :concurrently,
+      if_not_exists: true
+
+    add_index :fees,
+      [:pay_in_advance_event_transaction_id, :charge_id, :charge_filter_id],
+      unique: true,
+      name: :idx_pay_in_advance_duplication_guard_charge_filter,
+      where: "deleted_at IS NULL AND charge_filter_id IS NOT NULL AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true AND duplicated_in_advance = false",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260421103557_update_pay_in_advance_duplication_guard_indexes.rb
+++ b/db/migrate/20260421103557_update_pay_in_advance_duplication_guard_indexes.rb
@@ -30,8 +30,8 @@ class UpdatePayInAdvanceDuplicationGuardIndexes < ActiveRecord::Migration[8.0]
       algorithm: :concurrently,
       if_not_exists: true
 
-    remove_index :fees, name: CHARGE_INDEX, if_exists: true
-    remove_index :fees, name: CHARGE_FILTER_INDEX, if_exists: true
+    remove_index :fees, name: CHARGE_INDEX, if_exists: true, algorithm: :concurrently
+    remove_index :fees, name: CHARGE_FILTER_INDEX, if_exists: true, algorithm: :concurrently
 
     safety_assured do
       execute "ALTER INDEX #{CHARGE_INDEX_NEW} RENAME TO #{CHARGE_INDEX}"
@@ -56,8 +56,8 @@ class UpdatePayInAdvanceDuplicationGuardIndexes < ActiveRecord::Migration[8.0]
       algorithm: :concurrently,
       if_not_exists: true
 
-    remove_index :fees, name: CHARGE_INDEX, if_exists: true
-    remove_index :fees, name: CHARGE_FILTER_INDEX, if_exists: true
+    remove_index :fees, name: CHARGE_INDEX, if_exists: true, algorithm: :concurrently
+    remove_index :fees, name: CHARGE_FILTER_INDEX, if_exists: true, algorithm: :concurrently
 
     safety_assured do
       execute "ALTER INDEX #{CHARGE_INDEX_NEW} RENAME TO #{CHARGE_INDEX}"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10661,7 +10661,7 @@ ALTER TABLE ONLY public.commitments
 --
 
 ALTER TABLE ONLY public.fees
-    ADD CONSTRAINT fk_rails_775eb0ecd8 FOREIGN KEY (original_fee_id) REFERENCES public.fees(id) NOT VALID;
+    ADD CONSTRAINT fk_rails_775eb0ecd8 FOREIGN KEY (original_fee_id) REFERENCES public.fees(id);
 
 
 --
@@ -11809,6 +11809,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260421123920'),
 ('20260421103557'),
+('20260421021503'),
 ('20260421013319'),
 ('20260420114717'),
 ('20260416124233'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -151,6 +151,7 @@ ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_7886e1bc34;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_77f2d4440d;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_778360c382;
+ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_775eb0ecd8;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_76ceb88c74;
 ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rails_755d734f25;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
@@ -10653,6 +10654,14 @@ ALTER TABLE ONLY public.integrations
 
 ALTER TABLE ONLY public.commitments
     ADD CONSTRAINT fk_rails_76ceb88c74 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: fees fk_rails_775eb0ecd8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fees
+    ADD CONSTRAINT fk_rails_775eb0ecd8 FOREIGN KEY (original_fee_id) REFERENCES public.fees(id) NOT VALID;
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -569,6 +569,7 @@ DROP INDEX IF EXISTS public.index_fees_taxes_on_fee_id;
 DROP INDEX IF EXISTS public.index_fees_on_true_up_parent_fee_id;
 DROP INDEX IF EXISTS public.index_fees_on_subscription_id;
 DROP INDEX IF EXISTS public.index_fees_on_pay_in_advance_event_transaction_id;
+DROP INDEX IF EXISTS public.index_fees_on_original_fee_id;
 DROP INDEX IF EXISTS public.index_fees_on_organization_id;
 DROP INDEX IF EXISTS public.index_fees_on_invoiceable;
 DROP INDEX IF EXISTS public.index_fees_on_invoice_id;
@@ -3089,7 +3090,8 @@ CREATE TABLE public.fees (
     billing_entity_id uuid NOT NULL,
     precise_credit_notes_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL,
     fixed_charge_id uuid,
-    duplicated_in_advance boolean DEFAULT false
+    duplicated_in_advance boolean DEFAULT false,
+    original_fee_id uuid
 );
 
 
@@ -6383,14 +6385,14 @@ CREATE INDEX idx_on_wallet_transaction_id_ac2826109e ON public.wallet_transactio
 -- Name: idx_pay_in_advance_duplication_guard_charge; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_pay_in_advance_duplication_guard_charge ON public.fees USING btree (pay_in_advance_event_transaction_id, charge_id) WHERE ((deleted_at IS NULL) AND (charge_filter_id IS NULL) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true) AND (duplicated_in_advance = false));
+CREATE UNIQUE INDEX idx_pay_in_advance_duplication_guard_charge ON public.fees USING btree (pay_in_advance_event_transaction_id, charge_id) WHERE ((deleted_at IS NULL) AND (charge_filter_id IS NULL) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true) AND (duplicated_in_advance = false) AND (original_fee_id IS NULL));
 
 
 --
 -- Name: idx_pay_in_advance_duplication_guard_charge_filter; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_pay_in_advance_duplication_guard_charge_filter ON public.fees USING btree (pay_in_advance_event_transaction_id, charge_id, charge_filter_id) WHERE ((deleted_at IS NULL) AND (charge_filter_id IS NOT NULL) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true) AND (duplicated_in_advance = false));
+CREATE UNIQUE INDEX idx_pay_in_advance_duplication_guard_charge_filter ON public.fees USING btree (pay_in_advance_event_transaction_id, charge_id, charge_filter_id) WHERE ((deleted_at IS NULL) AND (charge_filter_id IS NOT NULL) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true) AND (duplicated_in_advance = false) AND (original_fee_id IS NULL));
 
 
 --
@@ -7676,6 +7678,13 @@ CREATE INDEX index_fees_on_invoiceable ON public.fees USING btree (invoiceable_t
 --
 
 CREATE INDEX index_fees_on_organization_id ON public.fees USING btree (organization_id);
+
+
+--
+-- Name: index_fees_on_original_fee_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fees_on_original_fee_id ON public.fees USING btree (original_fee_id);
 
 
 --
@@ -11790,6 +11799,8 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260421123920'),
+('20260421103557'),
+('20260421013319'),
 ('20260420114717'),
 ('20260416124233'),
 ('20260416124232'),


### PR DESCRIPTION
## Context

This PR should be deployed before #5330.

In the regenerate-voided-invoice flow, fees are duplicated onto a new invoice. For pay-in-advance charges, fees have a `pay_in_advance_event_transaction_id`, and duplicate fees should keep the same `id` since they refer to the same event. The existing uniqueness index on `(pay_in_advance_event_transaction_id, charge_id)` prevented that, so it needs to be scoped to exclude duplicates.

## Description

- Added `original_fee_id` on fees, pointing to the root fee in a void/regenerate chain.
- Narrowed the pay-in-advance duplication-guard indexes with `original_fee_id IS NULL` so only root fees enforce uniqueness and duplicated fees are exempt.
