### PR TITLE
fix(events): Rescue ArgumentError in datetime filter parsing

### DIFF
--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -53,6 +53,9 @@ class BaseQuery < BaseService
     return value if [Time, ActiveSupport::TimeWithZone, Date, DateTime].include?(value.class)
 
     DateTime.iso8601(value)
+  # Date::Error inherits from ArgumentError so it is caught here too.
+  # A bare ArgumentError is raised e.g. for strings longer than 128 chars
+  # ("string length exceeds the limit 128").
   rescue ArgumentError
     result.single_validation_failure!(field: field_name.to_sym, error_code: "invalid_date")
       .raise_if_error!

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -53,7 +53,7 @@ class BaseQuery < BaseService
     return value if [Time, ActiveSupport::TimeWithZone, Date, DateTime].include?(value.class)
 
     DateTime.iso8601(value)
-  rescue Date::Error
+  rescue ArgumentError
     result.single_validation_failure!(field: field_name.to_sym, error_code: "invalid_date")
       .raise_if_error!
   end

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe EventsQuery do
         expect(result).to be_success
         expect(result.events.count).to eq(1)
       end
+
+      context "when a timestamp value raises ArgumentError during iso8601 parsing" do
+        let(:filters) { {timestamp_from: "1" * 200} }
+
+        it "returns a validation failure instead of raising" do
+          expect { events_query.call }.not_to raise_error
+
+          result = events_query.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({timestamp_from: ["invalid_date"]})
+        end
+      end
     end
 
     context "with timestamp_from_started filter" do

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -81,9 +81,8 @@ RSpec.describe EventsQuery do
         let(:filters) { {timestamp_from: "1" * 200} }
 
         it "returns a validation failure instead of raising" do
-          expect { events_query.call }.not_to raise_error
-
-          result = events_query.call
+          result = nil
+          expect { result = events_query.call }.not_to raise_error
 
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)


### PR DESCRIPTION
## Description

Extend the rescue clause to catch `ArgumentError` (which is a superset of `Date::Error`) so those inputs surface as a proper `invalid_date` validation failure. The helper is shared, so this auto-fixes every query using it: events, fees, invoices, credit notes, activity logs, security logs.

Regression test added on `EventsQuery` using a 200-char input that specifically exercises the previously unhandled `ArgumentError` path (verified it fails on the old rescue and passes on the new one).