### PR TITLE
fix(coupons): Backfill invalid coupon frequency duration

### DIFF
--- a/db/migrate/20260422153456_backfill_invalid_coupon_frequency_duration.rb
+++ b/db/migrate/20260422153456_backfill_invalid_coupon_frequency_duration.rb
@@ -3,8 +3,8 @@
 class BackfillInvalidCouponFrequencyDuration < ActiveRecord::Migration[8.0]
   def up
     backfill_applied_coupon_remaining
-    terminate_invalid_applied_coupons
-    terminate_invalid_coupons
+    backfill_invalid_applied_coupons
+    backfill_invalid_coupons
   end
 
   def down
@@ -20,28 +20,27 @@ class BackfillInvalidCouponFrequencyDuration < ActiveRecord::Migration[8.0]
       .update_all("frequency_duration_remaining = frequency_duration, updated_at = NOW()")
   end
 
-  def terminate_invalid_applied_coupons
+  def backfill_invalid_applied_coupons
     AppliedCoupon
-      .where(frequency: AppliedCoupon.frequencies[:recurring], status: AppliedCoupon.statuses[:active])
-      .where(
-        "frequency_duration IS NULL OR frequency_duration <= 0 OR " \
-        "frequency_duration_remaining IS NULL OR frequency_duration_remaining <= 0"
-      )
-      .update_all(
-        status: AppliedCoupon.statuses[:terminated],
-        terminated_at: Time.current,
-        updated_at: Time.current
-      )
+      .where(frequency: AppliedCoupon.frequencies[:recurring])
+      .where(frequency_duration: nil)
+      .update_all(frequency_duration: 1, frequency_duration_remaining: 1, updated_at: Time.current)
+
+    AppliedCoupon
+      .where(frequency: AppliedCoupon.frequencies[:recurring])
+      .where("frequency_duration < 0")
+      .update_all(frequency_duration: 0, updated_at: Time.current)
   end
 
-  def terminate_invalid_coupons
+  def backfill_invalid_coupons
     Coupon
       .where(frequency: Coupon.frequencies[:recurring], status: Coupon.statuses[:active])
-      .where("frequency_duration IS NULL OR frequency_duration <= 0")
-      .update_all(
-        status: Coupon.statuses[:terminated],
-        terminated_at: Time.current,
-        updated_at: Time.current
-      )
+      .where("frequency_duration IS NULL")
+      .update_all(frequency_duration: 1, updated_at: Time.current)
+
+    Coupon
+      .where(frequency: Coupon.frequencies[:recurring], status: Coupon.statuses[:active])
+      .where("frequency_duration < 0")
+      .update_all(frequency_duration: 0, updated_at: Time.current)
   end
 end

--- a/db/migrate/20260422153456_backfill_invalid_coupon_frequency_duration.rb
+++ b/db/migrate/20260422153456_backfill_invalid_coupon_frequency_duration.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class BackfillInvalidCouponFrequencyDuration < ActiveRecord::Migration[8.0]
+  def up
+    backfill_applied_coupon_remaining
+    terminate_invalid_applied_coupons
+    terminate_invalid_coupons
+  end
+
+  def down
+    # No-op: terminated records and backfilled values must not be reversed
+  end
+
+  private
+
+  def backfill_applied_coupon_remaining
+    AppliedCoupon
+      .where(frequency: AppliedCoupon.frequencies[:recurring], frequency_duration_remaining: nil)
+      .where("frequency_duration > 0")
+      .update_all("frequency_duration_remaining = frequency_duration, updated_at = NOW()")
+  end
+
+  def terminate_invalid_applied_coupons
+    AppliedCoupon
+      .where(frequency: AppliedCoupon.frequencies[:recurring], status: AppliedCoupon.statuses[:active])
+      .where(
+        "frequency_duration IS NULL OR frequency_duration <= 0 OR " \
+        "frequency_duration_remaining IS NULL OR frequency_duration_remaining <= 0"
+      )
+      .update_all(
+        status: AppliedCoupon.statuses[:terminated],
+        terminated_at: Time.current,
+        updated_at: Time.current
+      )
+  end
+
+  def terminate_invalid_coupons
+    Coupon
+      .where(frequency: Coupon.frequencies[:recurring], status: Coupon.statuses[:active])
+      .where("frequency_duration IS NULL OR frequency_duration <= 0")
+      .update_all(
+        status: Coupon.statuses[:terminated],
+        terminated_at: Time.current,
+        updated_at: Time.current
+      )
+  end
+end

--- a/db/migrate/20260422153456_backfill_invalid_coupon_frequency_duration.rb
+++ b/db/migrate/20260422153456_backfill_invalid_coupon_frequency_duration.rb
@@ -17,30 +17,30 @@ class BackfillInvalidCouponFrequencyDuration < ActiveRecord::Migration[8.0]
     AppliedCoupon
       .where(frequency: AppliedCoupon.frequencies[:recurring], frequency_duration_remaining: nil)
       .where("frequency_duration > 0")
-      .update_all("frequency_duration_remaining = frequency_duration, updated_at = NOW()")
+      .update_all("frequency_duration_remaining = frequency_duration, updated_at = NOW()") # rubocop:disable Rails/SkipsModelValidations
   end
 
   def backfill_invalid_applied_coupons
     AppliedCoupon
       .where(frequency: AppliedCoupon.frequencies[:recurring])
       .where(frequency_duration: nil)
-      .update_all(frequency_duration: 1, frequency_duration_remaining: 1, updated_at: Time.current)
+      .update_all(frequency_duration: 1, frequency_duration_remaining: 1, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
 
     AppliedCoupon
       .where(frequency: AppliedCoupon.frequencies[:recurring])
       .where("frequency_duration < 0")
-      .update_all(frequency_duration: 0, updated_at: Time.current)
+      .update_all(frequency_duration: 0, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def backfill_invalid_coupons
     Coupon
       .where(frequency: Coupon.frequencies[:recurring], status: Coupon.statuses[:active])
       .where("frequency_duration IS NULL")
-      .update_all(frequency_duration: 1, updated_at: Time.current)
+      .update_all(frequency_duration: 1, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
 
     Coupon
       .where(frequency: Coupon.frequencies[:recurring], status: Coupon.statuses[:active])
       .where("frequency_duration < 0")
-      .update_all(frequency_duration: 0, updated_at: Time.current)
+      .update_all(frequency_duration: 0, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11789,6 +11789,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260422153456'),
 ('20260420114717'),
 ('20260416124233'),
 ('20260416124232'),


### PR DESCRIPTION
## Context
Related to #5377
As the new validation was added, it is necessary to backfill existing records with correct values.

## Description

Added backfill migration for `frequency_duration` and `frequency_duration_remaining`