### PR TITLE
fix(cache): Report Redis cache errors as warnings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,10 +60,9 @@ Rails.application.configure do
       },
       pool: {size: ENV.fetch("LAGO_REDIS_CACHE_POOL_SIZE", 5)},
       error_handler: lambda { |method:, returning:, exception:|
-        Rails.logger.error(exception.message)
-        Rails.logger.error(exception.backtrace.join("\n"))
+        Rails.logger.warn(exception.message)
 
-        Sentry.capture_exception(exception)
+        Sentry.capture_exception(exception, level: :warning)
       }
     }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -56,10 +56,9 @@ Rails.application.configure do
         url: ENV["LAGO_REDIS_CACHE_URL"],
         pool: {size: ENV.fetch("LAGO_REDIS_CACHE_POOL_SIZE", 5)},
         error_handler: lambda { |method:, returning:, exception:|
-          Rails.logger.error(exception.message)
-          Rails.logger.error(exception.backtrace.join("\n"))
+          Rails.logger.warn(exception.message)
 
-          Sentry.capture_exception(exception)
+          Sentry.capture_exception(exception, level: :warning)
         }
       }
   end


### PR DESCRIPTION
## Summary

- Downgrade the Redis cache `error_handler` in production and staging to log at `warn` and report to Sentry with `level: :warning`
- Drop the backtrace log line; Sentry still captures it with the event
- Avoids flooding Sentry with error-level events during transient Redis issues (see INC-142)