### PR TITLE
fix(eu-tax): Resolve EU tax from customer country backfill task

### DIFF
--- a/lib/tasks/customers.rake
+++ b/lib/tasks/customers.rake
@@ -182,7 +182,7 @@ namespace :customers do
           preserved_codes = customer.taxes.where.not("code ILIKE 'lago_eu%'").pluck(:code)
           tax_codes = (preserved_codes + [result.tax_code]).uniq
 
-          Customers::ApplyTaxesService.call(customer: customer, tax_codes: tax_codes).raise_if_error!
+          Customers::ApplyTaxesService.call!(customer: customer, tax_codes: tax_codes)
         end
 
         total_processed += customer_ids.size

--- a/lib/tasks/customers.rake
+++ b/lib/tasks/customers.rake
@@ -102,4 +102,101 @@ namespace :customers do
       Customers::TerminateRelationsService.call(customer: cust)
     end
   end
+
+  desc "Backfill EU auto-taxes for customers whose applied lago_eu_XX_standard no longer matches customers.country"
+  task :backfill_eu_auto_taxes, [:organization_id] => :environment do |_task, args|
+    organization_id = args[:organization_id]
+    abort "Missing organization_id argument\n\nUsage: rake customers:backfill_eu_auto_taxes[organization_id]" if organization_id.blank?
+
+    batch_size = (ENV["BATCH_SIZE"] || 500).to_i
+    abort "BATCH_SIZE must be positive" if batch_size <= 0
+
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+    mode = dry_run ? "DRY RUN" : "LIVE"
+
+    total_processed = 0
+    counters = {reapply: 0, vies_pending: 0, skipped: 0}
+
+    puts "Starting EU auto-taxes backfill [#{mode}] for organization #{organization_id} (batch_size: #{batch_size})..."
+
+    preview_customer = lambda do |customer|
+      result = nil
+      ActiveRecord::Base.transaction(requires_new: true) do
+        result = Customers::EuAutoTaxesService.call(
+          customer: customer,
+          new_record: false,
+          tax_attributes_changed: true
+        )
+        raise ActiveRecord::Rollback
+      end
+
+      current_eu_codes = customer.taxes.where("code ILIKE ?", "lago_eu%").pluck(:code)
+
+      if result.success?
+        counters[:reapply] += 1
+        puts "  [DRY RUN] customer=#{customer.id} country=#{customer.country} current_eu=#{current_eu_codes.inspect} -> target=#{result.tax_code} (would re-apply)"
+      elsif result.error.is_a?(BaseService::ServiceFailure) && result.error.code == "vies_check_pending"
+        counters[:vies_pending] += 1
+        puts "  [DRY RUN] customer=#{customer.id} country=#{customer.country} current_eu=#{current_eu_codes.inspect} would schedule VIES check"
+      else
+        code = result.error.respond_to?(:code) ? result.error.code : "unknown"
+        counters[:skipped] += 1
+        puts "  [DRY RUN] customer=#{customer.id} country=#{customer.country} current_eu=#{current_eu_codes.inspect} skipped (#{code})"
+      end
+    end
+
+    scope = Customer
+      .joins(applied_taxes: :tax)
+      .joins(:billing_entity)
+      .where(customers: {organization_id: organization_id})
+      .where(billing_entities: {eu_tax_management: true})
+      .where.not(customers: {country: nil})
+      .where("taxes.code ~ '^lago_eu_[a-z]{2}_standard$'")
+      .where("taxes.code <> CONCAT('lago_eu_', LOWER(customers.country), '_standard')")
+      .where("NOT EXISTS (SELECT 1 FROM pending_vies_checks pvc WHERE pvc.customer_id = customers.id)")
+      .distinct
+
+    if dry_run
+      candidate_ids = scope.pluck(:id)
+      puts "  Candidates found: #{candidate_ids.size}"
+
+      candidate_ids.each_slice(batch_size) do |ids|
+        Customer.where(id: ids).find_each(&preview_customer)
+
+        total_processed += ids.size
+        puts "  Batch processed: #{ids.size} customers (total: #{total_processed})"
+      end
+    else
+      loop do
+        customer_ids = scope.limit(batch_size).pluck(:id)
+        break if customer_ids.empty?
+
+        Customer.where(id: customer_ids).find_each do |customer|
+          result = Customers::EuAutoTaxesService.call(
+            customer: customer,
+            new_record: false,
+            tax_attributes_changed: true
+          )
+          next unless result.success?
+
+          preserved_codes = customer.taxes.where.not("code ILIKE 'lago_eu%'").pluck(:code)
+          tax_codes = (preserved_codes + [result.tax_code]).uniq
+
+          Customers::ApplyTaxesService.call(customer: customer, tax_codes: tax_codes).raise_if_error!
+        end
+
+        total_processed += customer_ids.size
+        puts "  Batch processed: #{customer_ids.size} customers (total: #{total_processed})"
+        break if customer_ids.size < batch_size
+      end
+    end
+
+    puts "Done [#{mode}]. Total processed: #{total_processed}."
+    if dry_run
+      puts "  Would re-apply: #{counters[:reapply]}"
+      puts "  Would schedule VIES check: #{counters[:vies_pending]}"
+      puts "  Would skip: #{counters[:skipped]}"
+    end
+  end
 end
+

--- a/spec/lib/tasks/customers_rake_spec.rb
+++ b/spec/lib/tasks/customers_rake_spec.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "customers:backfill_eu_auto_taxes" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["customers:backfill_eu_auto_taxes"] }
+
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: true) }
+
+  let(:fr_standard) { create(:tax, organization:, code: "lago_eu_fr_standard") }
+
+  before do
+    Rake.application.rake_require("tasks/customers")
+    Rake::Task.define_task(:environment)
+    task.reenable
+    create(:tax, organization:, code: "lago_eu_de_standard")
+  end
+
+  def apply_tax(customer, tax)
+    create(:customer_applied_tax, customer:, tax:)
+  end
+
+  context "without an organization_id argument" do
+    it "aborts with a usage message" do
+      expect { task.invoke }.to raise_error(SystemExit).and output(/Missing organization_id argument/).to_stderr
+    end
+  end
+
+  context "when DRY_RUN is disabled" do
+    around do |example|
+      ENV["DRY_RUN"] = "false"
+      example.run
+    ensure
+      ENV["DRY_RUN"] = nil
+    end
+
+    context "when customer country differs from currently applied EU standard tax" do
+      let(:customer) do
+        create(:customer, organization:, billing_entity:, country: "DE", zipcode: "10115", tax_identification_number: nil)
+      end
+
+      before { apply_tax(customer, fr_standard) }
+
+      it "re-applies the customer country standard tax" do
+        task.invoke(organization.id)
+
+        expect(customer.reload.taxes.pluck(:code)).to contain_exactly("lago_eu_de_standard")
+      end
+
+      context "when the customer also has a manually applied non-EU tax" do
+        let!(:custom_tax) { create(:tax, organization:, code: "custom_local_tax") }
+
+        before { apply_tax(customer, custom_tax) }
+
+        it "preserves the manually applied non-EU tax" do
+          task.invoke(organization.id)
+
+          expect(customer.reload.taxes.pluck(:code)).to match_array(["lago_eu_de_standard", "custom_local_tax"])
+        end
+      end
+    end
+
+    context "when customer country matches the currently applied EU standard tax" do
+      let(:customer) { create(:customer, organization:, billing_entity:, country: "FR") }
+
+      before { apply_tax(customer, fr_standard) }
+
+      it "does not change the applied tax" do
+        expect { task.invoke(organization.id) }.not_to change { customer.reload.taxes.pluck(:code) }
+      end
+    end
+
+    context "when billing entity has eu_tax_management disabled" do
+      let(:billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: false) }
+      let(:customer) { create(:customer, organization:, billing_entity:, country: "DE") }
+
+      before { apply_tax(customer, fr_standard) }
+
+      it "does not process the customer" do
+        expect { task.invoke(organization.id) }.not_to change { customer.reload.taxes.pluck(:code) }
+      end
+    end
+
+    context "when customer has no country" do
+      let(:customer) { create(:customer, organization:, billing_entity:, country: nil) }
+
+      before { apply_tax(customer, fr_standard) }
+
+      it "does not process the customer" do
+        expect { task.invoke(organization.id) }.not_to change { customer.reload.taxes.pluck(:code) }
+      end
+    end
+
+    context "when customer is on a reverse charge tax" do
+      let!(:reverse_charge) { create(:tax, organization:, code: "lago_eu_reverse_charge") }
+      let(:customer) { create(:customer, organization:, billing_entity:, country: "DE") }
+
+      before { apply_tax(customer, reverse_charge) }
+
+      it "does not process the customer" do
+        expect { task.invoke(organization.id) }.not_to change { customer.reload.taxes.pluck(:code) }
+      end
+    end
+
+    context "when customer is on an exception tax code" do
+      let!(:exception_tax) { create(:tax, organization:, code: "lago_eu_fr_exception_corsica") }
+      let(:customer) { create(:customer, organization:, billing_entity:, country: "FR", zipcode: "20000") }
+
+      before { apply_tax(customer, exception_tax) }
+
+      it "does not process the customer" do
+        expect { task.invoke(organization.id) }.not_to change { customer.reload.taxes.pluck(:code) }
+      end
+    end
+
+    context "when customer already has a pending VIES check" do
+      let(:customer) do
+        create(:customer, organization:, billing_entity:, country: "DE", tax_identification_number: "DE123456789")
+      end
+
+      before do
+        apply_tax(customer, fr_standard)
+        create(:pending_vies_check, customer:)
+      end
+
+      it "does not process the customer" do
+        expect { task.invoke(organization.id) }.not_to change { customer.reload.taxes.pluck(:code) }
+      end
+    end
+
+    context "when customer has a tax identification number but no pending VIES check" do
+      let(:customer) do
+        create(:customer, organization:, billing_entity:, country: "DE", tax_identification_number: "DE123456789")
+      end
+
+      before { apply_tax(customer, fr_standard) }
+
+      it "schedules an async VIES check and leaves the tax unchanged for now" do
+        expect { task.invoke(organization.id) }.to change(PendingViesCheck, :count).by(1)
+        expect(customer.reload.taxes.pluck(:code)).to contain_exactly("lago_eu_fr_standard")
+      end
+    end
+
+    context "when BATCH_SIZE is smaller than the number of matching customers" do
+      before do
+        ENV["BATCH_SIZE"] = "1"
+
+        2.times do
+          customer = create(:customer, organization:, billing_entity:, country: "DE", tax_identification_number: nil)
+          apply_tax(customer, fr_standard)
+        end
+      end
+
+      after { ENV.delete("BATCH_SIZE") }
+
+      it "processes all customers across multiple batches" do
+        task.invoke(organization.id)
+
+        expect(Customer.where(organization:).flat_map { |c| c.taxes.pluck(:code) }.uniq)
+          .to contain_exactly("lago_eu_de_standard")
+      end
+    end
+
+    context "when the affected customer belongs to another organization" do
+      let(:other_organization) { create(:organization) }
+      let(:other_billing_entity) do
+        create(:billing_entity, organization: other_organization, country: "FR", eu_tax_management: true)
+      end
+      let(:other_customer) do
+        create(:customer, organization: other_organization, billing_entity: other_billing_entity, country: "DE", tax_identification_number: nil)
+      end
+      let(:other_fr_standard) { create(:tax, organization: other_organization, code: "lago_eu_fr_standard") }
+
+      before do
+        create(:tax, organization: other_organization, code: "lago_eu_de_standard")
+        apply_tax(other_customer, other_fr_standard)
+      end
+
+      it "does not process the customer" do
+        expect { task.invoke(organization.id) }.not_to change { other_customer.reload.taxes.pluck(:code) }
+      end
+    end
+  end
+
+  context "when DRY_RUN is enabled" do
+    around do |example|
+      ENV["DRY_RUN"] = "true"
+      example.run
+    ensure
+      ENV["DRY_RUN"] = nil
+    end
+
+    context "when customer country differs from currently applied EU standard tax" do
+      let(:customer) do
+        create(:customer, organization:, billing_entity:, country: "DE", zipcode: "10115", tax_identification_number: nil)
+      end
+
+      before { apply_tax(customer, fr_standard) }
+
+      it "does not change the applied taxes" do
+        expect { task.invoke(organization.id) }.not_to change { customer.reload.taxes.pluck(:code) }
+      end
+
+      it "does not enqueue a ViesCheckJob" do
+        expect { task.invoke(organization.id) }.not_to have_enqueued_job(Customers::ViesCheckJob)
+      end
+
+      it "prints a dry-run preview with the target tax code" do
+        expect { task.invoke(organization.id) }
+          .to output(/\[DRY RUN\].*target=lago_eu_de_standard.*would re-apply/).to_stdout
+      end
+    end
+
+    context "when customer has a tax identification number" do
+      let(:customer) do
+        create(:customer, organization:, billing_entity:, country: "DE", tax_identification_number: "DE123456789")
+      end
+
+      before { apply_tax(customer, fr_standard) }
+
+      it "does not create a PendingViesCheck record" do
+        expect { task.invoke(organization.id) }.not_to change(PendingViesCheck, :count)
+      end
+
+      it "does not enqueue a ViesCheckJob" do
+        expect { task.invoke(organization.id) }.not_to have_enqueued_job(Customers::ViesCheckJob)
+      end
+
+      it "prints a dry-run preview indicating a VIES check would be scheduled" do
+        expect { task.invoke(organization.id) }
+          .to output(/\[DRY RUN\].*would schedule VIES check/).to_stdout
+      end
+    end
+
+    context "when there are no matching candidates" do
+      let(:customer) { create(:customer, organization:, billing_entity:, country: "FR") }
+
+      before { apply_tax(customer, fr_standard) }
+
+      it "prints the DRY RUN header and summary" do
+        expect { task.invoke(organization.id) }
+          .to output(/Starting EU auto-taxes backfill \[DRY RUN\].*Done \[DRY RUN\]/m).to_stdout
+      end
+    end
+  end
+
+  context "when DRY_RUN is not set" do
+    around do |example|
+      ENV.delete("DRY_RUN")
+      example.run
+    end
+
+    let(:customer) do
+      create(:customer, organization:, billing_entity:, country: "DE", zipcode: "10115", tax_identification_number: nil)
+    end
+
+    before { apply_tax(customer, fr_standard) }
+
+    it "defaults to dry-run mode and does not change applied taxes" do
+      expect { task.invoke(organization.id) }.not_to change { customer.reload.taxes.pluck(:code) }
+    end
+
+    it "prints a DRY RUN preview" do
+      expect { task.invoke(organization.id) }
+        .to output(/Starting EU auto-taxes backfill \[DRY RUN\]/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ship a one-off rake task `customers:backfill_eu_auto_taxes[organization_id]` to converge customers already on a mismatched `lago_eu_XX_standard` tax. Scoped per org via argument, batched (`BATCH_SIZE`, default 500), idempotent, and skips customers with a pending VIES check, reverse-charge, or exception tax codes.
