### PR TITLE
feat(usage): Add filter_by_metric_code to current usage endpoint

### DIFF
--- a/app/models/usage_filters.rb
+++ b/app/models/usage_filters.rb
@@ -11,7 +11,7 @@ class UsageFilters
   # skip_grouping    - when set, will ignore grouping by pricing_group_keys
   # full_usage       - when set, will ignore boundaries and will return usage since subscription.started_at
 
-  attr_reader :filter_by_charge_id, :filter_by_charge_code, :filter_by_group, :filter_by_presentation, :skip_grouping, :full_usage
+  attr_reader :filter_by_charge_id, :filter_by_charge_code, :filter_by_metric_code, :filter_by_group, :filter_by_presentation, :skip_grouping, :full_usage
 
   def self.init_from_params(params)
     group = params[:filter_by_group]
@@ -25,6 +25,7 @@ class UsageFilters
     new(
       filter_by_charge_id: params[:filter_by_charge_id],
       filter_by_charge_code: params[:filter_by_charge_code],
+      filter_by_metric_code: params[:filter_by_metric_code],
       filter_by_group: group,
       filter_by_presentation: presentation,
       skip_grouping: ActiveModel::Type::Boolean.new.cast(params[:skip_grouping]),
@@ -32,9 +33,10 @@ class UsageFilters
     )
   end
 
-  def initialize(filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_group: nil, filter_by_presentation: nil, skip_grouping: false, full_usage: false)
+  def initialize(filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_metric_code: nil, filter_by_group: nil, filter_by_presentation: nil, skip_grouping: false, full_usage: false)
     @filter_by_charge_id = filter_by_charge_id
     @filter_by_charge_code = filter_by_charge_code
+    @filter_by_metric_code = filter_by_metric_code
     @filter_by_group = filter_by_group&.transform_values { |v| Array(v) }
     @filter_by_presentation = filter_by_presentation
     @skip_grouping = skip_grouping
@@ -42,7 +44,7 @@ class UsageFilters
   end
 
   def has_charge_filter?
-    filter_by_charge_id.present? || filter_by_charge_code.present?
+    filter_by_charge_id.present? || filter_by_charge_code.present? || filter_by_metric_code.present?
   end
 
   NONE = new.freeze

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -78,6 +78,8 @@ module Invoices
         charges = charges.where(id: usage_filters.filter_by_charge_id)
       elsif usage_filters.filter_by_charge_code.present?
         charges = charges.where(code: usage_filters.filter_by_charge_code)
+      elsif usage_filters.filter_by_metric_code.present?
+        charges = charges.where(billable_metrics: {code: usage_filters.filter_by_metric_code})
       end
       @charges = charges
     end

--- a/spec/models/usage_filters_spec.rb
+++ b/spec/models/usage_filters_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe UsageFilters do
 
       expect(filters.filter_by_charge_id).to be_nil
       expect(filters.filter_by_charge_code).to be_nil
+      expect(filters.filter_by_metric_code).to be_nil
       expect(filters.filter_by_group).to be_nil
       expect(filters.filter_by_presentation).to be_nil
       expect(filters.skip_grouping).to be(false)
@@ -31,6 +32,7 @@ RSpec.describe UsageFilters do
       filters = described_class.new(
         filter_by_charge_id: "charge-id",
         filter_by_charge_code: "charge-code",
+        filter_by_metric_code: "api-call",
         filter_by_group: {"cloud" => ["aws"]},
         filter_by_presentation: ["region"],
         skip_grouping: true,
@@ -39,6 +41,7 @@ RSpec.describe UsageFilters do
 
       expect(filters.filter_by_charge_id).to eq("charge-id")
       expect(filters.filter_by_charge_code).to eq("charge-code")
+      expect(filters.filter_by_metric_code).to eq("api-call")
       expect(filters.filter_by_group).to eq({"cloud" => ["aws"]})
       expect(filters.filter_by_presentation).to eq(["region"])
       expect(filters.skip_grouping).to be(true)
@@ -51,6 +54,7 @@ RSpec.describe UsageFilters do
       params = {
         filter_by_charge_id: "charge-id",
         filter_by_charge_code: "charge-code",
+        filter_by_metric_code: "api-call",
         filter_by_group: {cloud: "aws"},
         filter_by_presentation: ["compact"],
         skip_grouping: "true",
@@ -61,6 +65,7 @@ RSpec.describe UsageFilters do
 
       expect(filters.filter_by_charge_id).to eq("charge-id")
       expect(filters.filter_by_charge_code).to eq("charge-code")
+      expect(filters.filter_by_metric_code).to eq("api-call")
       expect(filters.filter_by_group).to eq({cloud: ["aws"]})
       expect(filters.filter_by_presentation).to eq(["compact"])
       expect(filters.skip_grouping).to be(true)
@@ -86,10 +91,29 @@ RSpec.describe UsageFilters do
 
       expect(filters.filter_by_charge_id).to be_nil
       expect(filters.filter_by_charge_code).to be_nil
+      expect(filters.filter_by_metric_code).to be_nil
       expect(filters.filter_by_group).to be_nil
       expect(filters.filter_by_presentation).to be_nil
       expect(filters.skip_grouping).to be_nil
       expect(filters.full_usage).to be_nil
+    end
+  end
+
+  describe "#has_charge_filter?" do
+    it "returns false when no charge filters are set" do
+      expect(described_class.new.has_charge_filter?).to be(false)
+    end
+
+    it "returns true when filter_by_charge_id is set" do
+      expect(described_class.new(filter_by_charge_id: "charge-id").has_charge_filter?).to be(true)
+    end
+
+    it "returns true when filter_by_charge_code is set" do
+      expect(described_class.new(filter_by_charge_code: "api-call-2").has_charge_filter?).to be(true)
+    end
+
+    it "returns true when filter_by_metric_code is set" do
+      expect(described_class.new(filter_by_metric_code: "api-call").has_charge_filter?).to be(true)
     end
   end
 
@@ -98,6 +122,7 @@ RSpec.describe UsageFilters do
       expect(described_class::NONE).to be_frozen
       expect(described_class::NONE.filter_by_charge_id).to be_nil
       expect(described_class::NONE.filter_by_charge_code).to be_nil
+      expect(described_class::NONE.filter_by_metric_code).to be_nil
       expect(described_class::NONE.filter_by_group).to be_nil
       expect(described_class::NONE.filter_by_presentation).to be_nil
       expect(described_class::NONE.skip_grouping).to be(false)

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -232,6 +232,67 @@ RSpec.describe Api::V1::Customers::UsageController do
         end
       end
 
+      context "when filter_by_metric_code is provided" do
+        let(:params) { {external_subscription_id: subscription.external_id, filter_by_metric_code: metric_a.code, apply_taxes: false} }
+
+        it "returns only charges for the given billable metric" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:customer_usage][:charges_usage].count).to eq(1)
+
+          charge_usage = json[:customer_usage][:charges_usage].first
+          expect(charge_usage[:billable_metric][:code]).to eq(metric_a.code)
+          expect(charge_usage[:units]).to eq("14.0")
+          expect(charge_usage[:amount_cents]).to eq(14_000)
+        end
+      end
+
+      context "when filter_by_metric_code matches multiple charges sharing the same metric" do
+        let(:charge_a2) do
+          create(
+            :standard_charge,
+            plan: subscription.plan,
+            billable_metric: metric_a,
+            organization:,
+            properties: {amount: "5", pricing_group_keys: []}
+          )
+        end
+
+        let(:params) { {external_subscription_id: subscription.external_id, filter_by_metric_code: metric_a.code, apply_taxes: false} }
+
+        before { charge_a2 }
+
+        it "returns all charges for the metric" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:customer_usage][:charges_usage].count).to eq(2)
+          expect(json[:customer_usage][:charges_usage].map { |c| c[:billable_metric][:code] }).to all(eq(metric_a.code))
+        end
+      end
+
+      context "when filter_by_metric_code does not match any charge" do
+        let(:params) { {external_subscription_id: subscription.external_id, filter_by_metric_code: "nonexistent_metric"} }
+
+        it "returns not found" do
+          subject
+
+          expect(response).to be_not_found_error("charge")
+        end
+      end
+
+      context "when filter_by_metric_code belongs to another organization" do
+        let(:other_metric) { create(:billable_metric) }
+        let(:params) { {external_subscription_id: subscription.external_id, filter_by_metric_code: other_metric.code} }
+
+        it "returns not found" do
+          subject
+
+          expect(response).to be_not_found_error("charge")
+        end
+      end
+
       context "when full_usage is true without filter" do
         let(:params) { {external_subscription_id: subscription.external_id, full_usage: true} }
 

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -269,6 +269,9 @@ RSpec.describe Api::V1::Customers::UsageController do
           expect(response).to have_http_status(:success)
           expect(json[:customer_usage][:charges_usage].count).to eq(2)
           expect(json[:customer_usage][:charges_usage].map { |c| c[:billable_metric][:code] }).to all(eq(metric_a.code))
+
+          amounts = json[:customer_usage][:charges_usage].map { |c| c[:amount_cents] }.sort
+          expect(amounts).to eq([7_000, 14_000])
         end
       end
 
@@ -309,6 +312,41 @@ RSpec.describe Api::V1::Customers::UsageController do
           {
             external_subscription_id: subscription.external_id,
             filter_by_charge_code: charge_a.code,
+            full_usage: true,
+            apply_taxes: false
+          }
+        end
+
+        it "returns method not allowed without premium integration" do
+          subject
+
+          expect(response).to have_http_status(:method_not_allowed)
+          expect(json[:code]).to eq("full_usage_not_allowed")
+        end
+
+        context "with granular_lifetime_usage premium integration", :premium do
+          before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+
+          it "returns usage aggregated from subscription start" do
+            subject
+
+            expect(response).to have_http_status(:success)
+            expect(json[:customer_usage][:charges_usage].count).to eq(1)
+
+            charge_usage = json[:customer_usage][:charges_usage].first
+            expect(charge_usage[:billable_metric][:code]).to eq(metric_a.code)
+            # All periods: aws(5+4+4) + gcp(7+6) = 26 units
+            expect(charge_usage[:units]).to eq("26.0")
+            expect(charge_usage[:amount_cents]).to eq(26_000)
+          end
+        end
+      end
+
+      context "when full_usage is true with filter_by_metric_code" do
+        let(:params) do
+          {
+            external_subscription_id: subscription.external_id,
+            filter_by_metric_code: metric_a.code,
             full_usage: true,
             apply_taxes: false
           }


### PR DESCRIPTION
## Context

 When a plan has multiple charges sharing the same billable metric, Lago auto-suffixes charge codes to enforce uniqueness (e.g. `advanced_support_plan` becomes `advanced_support_plan_2`). The `current_usage` endpoint already supports `filter_by_charge_code`, but that requires customers to first fetch the plan and inspect the suffixed codes, which aren't stable or human-readable. The `billable_metric.code` is already surfaced in the response, but there was no way to use it as a filter directly.

## Description

 Adds `filter_by_metric_code` as a new query parameter to `GET /customers/:id/current_usage`. When passed, it filters charges by `billable_metrics.code` instead of `charges.code`, letting customers use the stable metric code they already see in the response.  The join on `billable_metrics` is already present in the query, so no extra join is needed. When multiple charges share the same metric (the core use case), all of them are returned. A missing or foreign metric code returns a `404`, consistent with the existing `filter_by_charge_code` behaviour. The `full_usage` flag also works with this new filter since it routes through the same `has_charge_filter?` check.