### PR TITLE
fix(auth): prevent password overwrite on invite accept for existing u…

### DIFF
--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -79,7 +79,16 @@ class UsersService < BaseService
 
   def register_from_invite(invite, password)
     ActiveRecord::Base.transaction do
-      result.user = User.find_or_create_by!(email: invite.email) { |u| u.password = password }
+      user = User.find_or_initialize_by(email: invite.email)
+
+      if user.new_record?
+        user.password = password
+        user.save!
+      elsif user.memberships.active.none?
+        user.update!(password:)
+      end
+
+      result.user = user
       result.organization = invite.organization
 
       result.membership = Membership.create!(

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -100,13 +100,14 @@ RSpec.describe UsersService do
 
   describe "#register_from_invite" do
     let(:email) { Faker::Internet.email }
+    let(:password) { SecureRandom.hex(16) }
+    let(:invite) { create(:invite, email:) }
 
-    context "when user already exists" do
-      it "creates user and membership if user doesn't exist" do
-        create(:user, email:)
-        invite = create(:invite, email:)
+    context "when is existing user" do
+      let!(:user) { create(:user, email:, password: "old_password") }
 
-        result = user_service.register_from_invite(invite, nil)
+      it "reuse user and adds membership" do
+        result = user_service.register_from_invite(invite, password)
 
         expect(result.user).to be_persisted
         expect(result.user.email).to eq email
@@ -114,13 +115,37 @@ RSpec.describe UsersService do
         expect(result.organization).to eq invite.organization
         expect(result.token).to be_present
       end
+
+      context "without active memberships" do
+        before { create(:membership, user:, status: :revoked) }
+
+        it "updates the password" do
+          result = user_service.register_from_invite(invite, password)
+
+          expect(result.user).to eq user
+          expect(result.user.authenticate(password).id).to eq(user.id)
+          expect(result.user.authenticate("old_password")).to be false
+          expect(result.token).to be_present
+        end
+      end
+
+      context "with active memberships" do
+        before { create(:membership, user:, status: :active) }
+
+        it "keeps the existing password" do
+          result = user_service.register_from_invite(invite, password)
+
+          expect(result.user).to eq user
+          expect(result.user.authenticate(password)).to eq false
+          expect(result.user.authenticate("old_password").id).to eq(user.id)
+          expect(result.token).to be_present
+        end
+      end
     end
 
-    context "when user doesn't exist" do
-      it "creates user and membership if user doesn't exist" do
-        invite = create(:invite, email:)
-
-        result = user_service.register_from_invite(invite, "password")
+    context "when is a new user" do
+      it "creates user and membership" do
+        result = user_service.register_from_invite(invite, password)
 
         expect(result.user).to be_persisted
         expect(result.user.email).to eq email


### PR DESCRIPTION
## Summary                                                                 
                                                                                                                                                                                                                     
  - Fix `register_from_invite` which used `find_or_create_by!` — the block that sets the password only runs on **create**, silently ignoring it for existing users                                                   
  - Replace with `find_or_initialize_by` and explicit branching: new users get the password on creation, existing users without active memberships get their password updated, existing users with active memberships
   keep their current password                                                                                                                                                                                       
  - Update and expand tests to cover all three scenarios with password verification                                                                                                                                  
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                     
                                                                                                                                                                                                                     
  - [x] Existing user reuses account and gets a new membership                                                                                                                                                       
  - [x] Existing user without active memberships gets password updated                                                                                                                                               
  - [x] Existing user with active memberships keeps current password                                                                                                                                                 
  - [x] New user is created with the provided password                                                                                                                                                             
  - [x] All `register_from_invite` tests pass  