### PR TITLE
fix(stripe): handle non-card payment methods in FetchDefaultPaymentMe…

### DIFF
--- a/app/services/payment_providers/stripe/customers/fetch_default_payment_method_service.rb
+++ b/app/services/payment_providers/stripe/customers/fetch_default_payment_method_service.rb
@@ -48,10 +48,10 @@ module PaymentProviders
 
           PaymentMethods::CardDetails.new(
             type: pm.type,
-            last4: pm.card&.last4,
-            brand: pm.card&.display_brand,
-            expiration_month: pm.card&.exp_month,
-            expiration_year: pm.card&.exp_year,
+            last4: pm.try(:card)&.last4,
+            brand: pm.try(:card)&.display_brand,
+            expiration_month: pm.try(:card)&.exp_month,
+            expiration_year: pm.try(:card)&.exp_year,
             card_holder_name: nil,
             issuer: nil
           ).to_h

--- a/app/services/payment_providers/stripe/customers/fetch_default_payment_method_service.rb
+++ b/app/services/payment_providers/stripe/customers/fetch_default_payment_method_service.rb
@@ -46,15 +46,19 @@ module PaymentProviders
             {api_key: provider_customer.payment_provider.secret_key}
           )
 
-          PaymentMethods::CardDetails.new(
-            type: pm.type,
-            last4: pm.try(:card)&.last4,
-            brand: pm.try(:card)&.display_brand,
-            expiration_month: pm.try(:card)&.exp_month,
-            expiration_year: pm.try(:card)&.exp_year,
-            card_holder_name: nil,
-            issuer: nil
-          ).to_h
+          if pm.type == "card"
+            PaymentMethods::CardDetails.new(
+              type: pm.type,
+              last4: pm.card&.last4,
+              brand: pm.card&.display_brand,
+              expiration_month: pm.card&.exp_month,
+              expiration_year: pm.card&.exp_year,
+              card_holder_name: nil,
+              issuer: nil
+            ).to_h
+          else
+            {type: pm.type}
+          end
         end
       end
     end

--- a/spec/services/payment_providers/stripe/customers/fetch_default_payment_method_service_spec.rb
+++ b/spec/services/payment_providers/stripe/customers/fetch_default_payment_method_service_spec.rb
@@ -109,18 +109,14 @@ RSpec.describe PaymentProviders::Stripe::Customers::FetchDefaultPaymentMethodSer
           )
         end
 
-        it "creates a payment method with nil card details" do
+        it "creates a payment method with only the type" do
           result = service.call
 
           payment_method = customer.payment_methods.order(created_at: :desc).first
 
           expect(result).to be_success
           expect(payment_method.provider_method_id).to eq(payment_method_id)
-          expect(payment_method.details["type"]).to eq("link")
-          expect(payment_method.details["last4"]).to be_nil
-          expect(payment_method.details["brand"]).to be_nil
-          expect(payment_method.details["expiration_month"]).to be_nil
-          expect(payment_method.details["expiration_year"]).to be_nil
+          expect(payment_method.details).to eq("type" => "link")
         end
       end
 

--- a/spec/services/payment_providers/stripe/customers/fetch_default_payment_method_service_spec.rb
+++ b/spec/services/payment_providers/stripe/customers/fetch_default_payment_method_service_spec.rb
@@ -91,6 +91,39 @@ RSpec.describe PaymentProviders::Stripe::Customers::FetchDefaultPaymentMethodSer
         expect(payment_method.details["expiration_year"]).to eq(2025)
       end
 
+      context "when payment method type is not card" do
+        let(:stripe_payment_method) do
+          Stripe::PaymentMethod.construct_from(
+            id: payment_method_id,
+            object: "payment_method",
+            type: "link",
+            customer: provider_customer_id,
+            link: {email: "this@test.email"},
+            billing_details: {
+              address: {city: nil, country: "US", line1: nil, line2: nil, postal_code: "94105", state: nil},
+              email: "this@test.email",
+              name: nil,
+              phone: nil
+            },
+            metadata: {}
+          )
+        end
+
+        it "creates a payment method with nil card details" do
+          result = service.call
+
+          payment_method = customer.payment_methods.order(created_at: :desc).first
+
+          expect(result).to be_success
+          expect(payment_method.provider_method_id).to eq(payment_method_id)
+          expect(payment_method.details["type"]).to eq("link")
+          expect(payment_method.details["last4"]).to be_nil
+          expect(payment_method.details["brand"]).to be_nil
+          expect(payment_method.details["expiration_month"]).to be_nil
+          expect(payment_method.details["expiration_year"]).to be_nil
+        end
+      end
+
       context "when payment method already exists in Lago" do
         let!(:existing_payment_method) do
           create(


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Fix `NoMethodError` in `FetchDefaultPaymentMethodService` when the Stripe payment method type is not `card` (e.g. `link`)                                                                                      
  - Branch on `pm.type == "card"` so card attributes (`last4`, `brand`, `exp_month`, `exp_year`) are only accessed for card payment methods                                                                          
  - For non-card types, store only `{type: pm.type}` instead of a hash full of nil card fields                                             
  - Add test scenario with a realistic Stripe `link` payment method response                                                                                                                                         
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  - [x] Card payment method: creates payment method with full card details (last4, brand, expiration)                                                                                                                
  - [x] Non-card payment method (link): creates payment method with only `{type: "link"}`                                                                                                                            
  - [x] No provider_customer_id: returns without creating payment method                 
  - [x] No payment method found on Stripe: returns without creating payment method                                                                                                                                   
  - [x] Existing payment method: returns existing without creating duplicate   