### PR TITLE
fix(stripe-webhooks): Stripe webhook jobs errors for parallel processing

### DIFF
--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -71,6 +71,14 @@ module PaymentRequests
       rescue ActiveRecord::RecordInvalid => e
         result.record_validation_failure!(record: e.record)
       rescue ActiveRecord::RecordNotUnique
+        # NOTE: Another writer (a parallel webhook worker, or PaymentProviders::Stripe::Payments::CreateService)
+        #       committed the Payment first. Hand the persisted row back so the
+        #       caller can still enqueue downstream side effects (e.g. SetPaymentMethodAndCreateReceiptJob).
+        payment = Payment.find_by(provider_payment_id: stripe_payment.id)
+        if payment
+          result.payment = payment
+          result.payable = payment.payable
+        end
         result
       rescue BaseService::FailedResult => e
         result.fail_with_error!(e)

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -50,15 +50,15 @@ module PaymentRequests
           return result
         end
 
-        result.payment = payment
-        result.payable = payment.payable
-
         processing = status == "processing"
         payment.status = status
 
         payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
         payment.payable_payment_status = payable_payment_status
         payment.save!
+
+        result.payment = payment
+        result.payable = payment.payable
 
         update_payable_payment_status(payment_status: payable_payment_status, processing:)
         update_invoices_payment_status(payment_status: payable_payment_status, processing:)

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -72,7 +72,7 @@ module PaymentRequests
         result.record_validation_failure!(record: e.record)
       rescue ActiveRecord::RecordNotUnique
         # NOTE: Another writer (a parallel webhook worker, or PaymentProviders::Stripe::Payments::CreateService)
-        #       committed the Payment first. Hand the persisted row back so the
+        #       committed the Payment first. Return the persisted row so the
         #       caller can still enqueue downstream side effects (e.g. SetPaymentMethodAndCreateReceiptJob).
         payment = Payment.find_by(provider_payment_id: stripe_payment.id)
         if payment

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -644,6 +644,21 @@ RSpec.describe PaymentRequests::Payments::StripeService do
               status: "succeeded"
             )
           end
+
+          context "when a concurrent webhook has already persisted the payment" do
+            let(:new_payment) { build(:payment, payable: payment_request) }
+
+            before do
+              allow(Payment).to receive(:new).and_return(new_payment)
+              allow(new_payment).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique)
+            end
+
+            it "returns a success result without a non-persisted payment" do
+              expect(result).to be_success
+              expect(result.payment).to be_nil
+              expect(result.payable).to be_nil
+            end
+          end
         end
       end
     end

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -645,18 +645,31 @@ RSpec.describe PaymentRequests::Payments::StripeService do
             )
           end
 
-          context "when a concurrent webhook has already persisted the payment" do
-            let(:new_payment) { build(:payment, payable: payment_request) }
-
-            before do
-              allow(Payment).to receive(:new).and_return(new_payment)
-              allow(new_payment).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique)
+          context "when a concurrent writer has already persisted the payment" do
+            let(:payment) do
+              create(
+                :payment,
+                payable: payment_request,
+                provider_payment_id: stripe_payment.id,
+                payment_provider: stripe_payment_provider,
+                payment_provider_customer: stripe_customer
+              )
             end
 
-            it "returns a success result without a non-persisted payment" do
+            before do
+              payment
+              # Force the initial lookup to miss so the service falls through to handle_missing_payment.
+              # The rescue's re-fetch then finds the row the winning writer (a parallel webhook worker
+              # or PaymentProviders::Stripe::Payments::CreateService) committed in the meantime.
+              allow(Payment).to receive(:find_by)
+                .with(provider_payment_id: stripe_payment.id)
+                .and_return(nil, payment)
+            end
+
+            it "returns a success result with the persisted payment" do
               expect(result).to be_success
-              expect(result.payment).to be_nil
-              expect(result.payable).to be_nil
+              expect(result.payment).to eq(payment)
+              expect(result.payable).to eq(payment_request)
             end
           end
         end


### PR DESCRIPTION
## Context

Concurrent writers for the same `payment_intent.succeeded` (parallel webhook workers, or `PaymentProviders::Stripe::Payments::CreateService` racing with the webhook) both try to insert a Payment. The losing worker's `save!` hits the unique index on `(provider_payment_id, payment_provider_id)` and raises `ActiveRecord::RecordNotUnique`. The existing rescue swallowed the error but had already assigned the unsaved `Payment.new` to `result.payment`, so `PaymentIntentSucceededService` enqueued `SetPaymentMethodAndCreateReceiptJob` with it and crashed with `ActiveJob::SerializationError`.

Simply returning an empty result on rescue would silence the error but skip the enqueue entirely — leaving the persisted Payment without `provider_payment_method_id` / `provider_payment_method_data`, since `SetPaymentMethodAndCreateReceiptJob` is the only path that sets them.

## Description

- Set `result.payment` / `result.payable` only after `payment.save!` succeeds.
- In the `RecordNotUnique` rescue, re-fetch the Payment by `provider_payment_id` and assign the persisted row, so the caller still enqueues `SetPaymentMethodAndCreateReceiptJob` against it (the job is idempotent).
- Add a regression spec that lets the real Postgres unique index raise `RecordNotUnique` and asserts the rescue's re-fetch returns the persisted Payment.