### PR TITLE
feat(graphql): expose downgrade_plan_date and previous relations on Subscription

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -32,11 +32,14 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :downgrade_plan_date, GraphQL::Types::ISO8601Date
       field :next_name, String, null: true
       field :next_plan, Types::Plans::Object
       field :next_subscription, Types::Subscriptions::Object
       field :next_subscription_at, GraphQL::Types::ISO8601DateTime
       field :next_subscription_type, Types::Subscriptions::NextSubscriptionTypeEnum
+      field :previous_plan, Types::Plans::Object
+      field :previous_subscription, Types::Subscriptions::Object
 
       field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :charges, [Types::Charges::Object], null: true
@@ -57,6 +60,10 @@ module Types
 
       def next_plan
         object.next_subscription&.plan
+      end
+
+      def previous_plan
+        object.previous_subscription&.plan
       end
 
       def next_name

--- a/schema.graphql
+++ b/schema.graphql
@@ -11105,6 +11105,7 @@ type Subscription {
   currentBillingPeriodEndingAt: ISO8601DateTime
   currentBillingPeriodStartedAt: ISO8601DateTime
   customer: Customer!
+  downgradePlanDate: ISO8601Date
   endingAt: ISO8601DateTime
   externalId: String!
   fees: [Fee!]
@@ -11123,6 +11124,8 @@ type Subscription {
   paymentMethodType: PaymentMethodTypeEnum
   periodEndDate: ISO8601Date
   plan: Plan!
+  previousPlan: Plan
+  previousSubscription: Subscription
   progressiveBillingDisabled: Boolean
   selectedInvoiceCustomSections: [InvoiceCustomSection!]
   skipInvoiceCustomSections: Boolean

--- a/schema.json
+++ b/schema.json
@@ -59456,6 +59456,18 @@
               "deprecationReason": null
             },
             {
+              "name": "downgradePlanDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "endingAt",
               "description": null,
               "args": [],
@@ -59699,6 +59711,30 @@
                   "name": "Plan",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previousPlan",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Plan",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previousSubscription",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Subscription",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/resolvers/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscription_resolver_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe Resolvers::SubscriptionResolver do
           }
           nextSubscriptionType
           nextSubscriptionAt
+          downgradePlanDate
+          previousPlan {
+            id
+            name
+          }
+          previousSubscription {
+            id
+            downgradePlanDate
+          }
           usageThresholds { amountCents thresholdDisplayName recurring }
         }
       }
@@ -117,6 +126,75 @@ RSpec.describe Resolvers::SubscriptionResolver do
       )
 
       expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+
+  context "when subscription has a pending downgrade" do
+    let(:plan) { create(:plan, organization:, amount_cents: 500_00) }
+    let(:lower_plan) { create(:plan, organization:, amount_cents: 100_00) }
+    let(:subscription) do
+      create(:subscription, :anniversary, customer:, plan:, subscription_at: Time.zone.parse("2026-04-22 00:00:00"), started_at: Time.zone.parse("2026-04-22 00:00:00"))
+    end
+    let(:pending_subscription) do
+      create(:subscription, :pending, customer:, plan: lower_plan, previous_subscription: subscription)
+    end
+
+    before { pending_subscription }
+
+    it "returns downgradePlanDate computed from the current billing period" do
+      travel_to Time.zone.parse("2026-04-25 12:00:00") do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {subscriptionId: subscription.id}
+        )
+
+        subscription_response = result["data"]["subscription"]
+        expect(subscription_response["downgradePlanDate"]).to eq("2026-05-22")
+        expect(subscription_response["nextSubscriptionType"]).to eq("downgrade")
+      end
+    end
+
+    it "exposes previousPlan and previousSubscription.downgradePlanDate on the pending subscription" do
+      travel_to Time.zone.parse("2026-04-25 12:00:00") do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {subscriptionId: pending_subscription.id}
+        )
+
+        subscription_response = result["data"]["subscription"]
+        expect(subscription_response["previousPlan"]).to include(
+          "id" => plan.id,
+          "name" => plan.name
+        )
+        expect(subscription_response["downgradePlanDate"]).to be_nil
+        expect(subscription_response["previousSubscription"]).to include(
+          "id" => subscription.id,
+          "downgradePlanDate" => "2026-05-22"
+        )
+      end
+    end
+  end
+
+  context "when subscription has no previous subscription" do
+    it "returns null for previousPlan, previousSubscription and downgradePlanDate" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {subscriptionId: subscription.id}
+      )
+
+      subscription_response = result["data"]["subscription"]
+      expect(subscription_response["previousPlan"]).to be_nil
+      expect(subscription_response["previousSubscription"]).to be_nil
+      expect(subscription_response["downgradePlanDate"]).to be_nil
     end
   end
 

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe Types::Subscriptions::Object do
     expect(subject).to have_field(:next_subscription).of_type("Subscription")
     expect(subject).to have_field(:next_subscription_type).of_type("NextSubscriptionTypeEnum")
     expect(subject).to have_field(:next_subscription_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:downgrade_plan_date).of_type("ISO8601Date")
+    expect(subject).to have_field(:previous_plan).of_type("Plan")
+    expect(subject).to have_field(:previous_subscription).of_type("Subscription")
 
     expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:charges).of_type("[Charge!]")


### PR DESCRIPTION
## Context

Related ticket: [ISSUE-1845 — Wrong downgrade date displayed when downgrade is pending](https://linear.app/getlago/issue/ISSUE-1845/wrong-downgrade-date-displayed-when-downgrade-is-pending)

This is **not** a bug fix in the API — the REST serializer already returns the correct `downgrade_plan_date`. It is a schema change that **exposes the attributes the front-end needs to render the correct messaging** on the subscription details page. The actual UI fix lives in the front-end PR.

## Problem

On a subscription with a pending downgrade, the front-end was rendering "Downgrading to X on DATE" from `nextSubscriptionAt`. The resolver for that field returns `next_subscription&.started_at || next_subscription&.subscription_at`, i.e. the pending sub's scheduling date, not the date the downgrade actually takes effect. So users saw e.g. `April 22, 2026` instead of `May 22, 2026`.

The correct value (`end of current billing period + 1.day`) already exists on `Subscription#downgrade_plan_date` and is shipped via the REST serializer, but had no GraphQL entry point.

## Changes

`Types::Subscriptions::Object` gains three fields:

- **`downgrade_plan_date`** (`ISO8601Date`) — delegates to the existing model method. Returns the effective downgrade date when a pending downgrade exists, otherwise `nil`.
- **`previous_plan`** (`Plan`) — shortcut mirroring the existing `next_plan`, resolves to `previous_subscription&.plan`. Used by the FE to render "Downgrading from [plan name]" on the pending sub view.
- **`previous_subscription`** (`Subscription`) — the full relation, so callers that need the previous sub's own fields (e.g. its `downgrade_plan_date`, which is the pending sub's activation date) can read them directly instead of overloading `downgrade_plan_date` with dual semantics.

`schema.graphql` / `schema.json` are regenerated (required by the `LagoApiSchema` matcher spec and by front-end codegen).

## Companion PR

Front-end: https://github.com/getlago/lago-front/pull/new/issue-1845 (linked once opened)