### PR TITLE
misc(clickhouse): Add re-enrich organization orchestrator

### DIFF
--- a/app/jobs/events/stores/clickhouse/enriched_store_migration/check_job.rb
+++ b/app/jobs/events/stores/clickhouse/enriched_store_migration/check_job.rb
@@ -4,11 +4,11 @@ module Events
   module Stores
     module Clickhouse
       module EnrichedStoreMigration
-        class OrchestratorJob < ApplicationJob
+        class CheckJob < ApplicationJob
           queue_as "low_priority"
 
           def perform(enriched_store_migration)
-            OrchestratorService.call!(enriched_store_migration:)
+            CheckService.call!(enriched_store_migration:)
           end
         end
       end

--- a/app/jobs/events/stores/clickhouse/enriched_store_migration/enable_job.rb
+++ b/app/jobs/events/stores/clickhouse/enriched_store_migration/enable_job.rb
@@ -4,11 +4,11 @@ module Events
   module Stores
     module Clickhouse
       module EnrichedStoreMigration
-        class OrchestratorJob < ApplicationJob
+        class EnableJob < ApplicationJob
           queue_as "low_priority"
 
           def perform(enriched_store_migration)
-            OrchestratorService.call!(enriched_store_migration:)
+            EnableService.call!(enriched_store_migration:)
           end
         end
       end

--- a/app/models/enriched_store_migration.rb
+++ b/app/models/enriched_store_migration.rb
@@ -56,6 +56,11 @@ class EnrichedStoreMigration < ApplicationRecord
   def all_subscriptions_completed?
     subscription_migrations.exists? && subscription_migrations.where.not(status: :completed).none?
   end
+
+  def mark_as_completed!(timestamp: Time.current)
+    self.completed_at = timestamp
+    complete!
+  end
 end
 
 # == Schema Information

--- a/app/services/events/stores/clickhouse/enriched_store_migration/check_service.rb
+++ b/app/services/events/stores/clickhouse/enriched_store_migration/check_service.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        # Runs the pre-enrichment check for the organization and creates one
+        # EnrichedStoreSubscriptionMigration record per active subscription.
+        #
+        # Subscriptions flagged by PreEnrichmentCheckService get their required billable
+        # metric codes populated. All other active subscriptions get an empty codes array
+        # and will skip straight through the comparison fast path.
+        #
+        # After records are created, transitions the org migration to `processing` and
+        # enqueues a SubscriptionOrchestratorJob for each subscription migration.
+        class CheckService < BaseService
+          BATCH_SIZE = 100
+
+          Result = BaseResult[:enriched_store_migration, :subscription_migration_count]
+
+          def initialize(enriched_store_migration:)
+            @enriched_store_migration = enriched_store_migration
+            super
+          end
+
+          def call
+            return result unless enriched_store_migration.checking?
+
+            check_result = ::Events::Stores::Clickhouse::PreEnrichmentCheckService.call(organization:)
+
+            unless check_result.success?
+              fail_migration!(check_result.error&.message || "Pre-enrichment check failed")
+              return result
+            end
+
+            nb_jobs_enqueued = 0
+
+            ActiveRecord::Base.transaction do
+              enriched_store_migration.start_processing!
+
+              organization.subscriptions.active.select(:id).in_batches(of: BATCH_SIZE) do |batch|
+                jobs = create_subscription_migrations(batch, check_result.subscriptions_to_reprocess)
+                after_commit { ActiveJob.perform_all_later(jobs) }
+
+                nb_jobs_enqueued += jobs.size
+              end
+            end
+
+            result.enriched_store_migration = enriched_store_migration
+            result.subscription_migration_count = nb_jobs_enqueued
+            result
+          rescue => e
+            fail_migration!(e.message)
+            result
+          end
+
+          private
+
+          attr_reader :enriched_store_migration
+
+          delegate :organization, to: :enriched_store_migration
+
+          def create_subscription_migrations(batch, subscriptions_to_reprocess)
+            batch.each.map do |subscription|
+              codes = subscriptions_to_reprocess[subscription.id] || []
+
+              migration = EnrichedStoreSubscriptionMigration.create!(
+                enriched_store_migration:,
+                organization:,
+                subscription_id: subscription.id,
+                billable_metric_codes: codes,
+                started_at: Time.current
+              )
+
+              SubscriptionOrchestratorJob.new(migration)
+            end
+          end
+
+          def fail_migration!(message)
+            enriched_store_migration.update!(error_message: message)
+            enriched_store_migration.fail!
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse/enriched_store_migration/enable_service.rb
+++ b/app/services/events/stores/clickhouse/enriched_store_migration/enable_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        # Final step of the enriched store migration. Once every subscription migration
+        # has reached `completed`, this service enables the feature flag and
+        # `pre_filter_events` on the organization, then marks the org migration complete.
+        class EnableService < BaseService
+          Result = BaseResult[:enriched_store_migration]
+
+          def initialize(enriched_store_migration:)
+            @enriched_store_migration = enriched_store_migration
+            super
+          end
+
+          def call
+            return result unless enriched_store_migration.enabling?
+
+            unless enriched_store_migration.all_subscriptions_completed?
+              fail_migration!("Cannot enable: not all subscription migrations are completed")
+              return result
+            end
+
+            ActiveRecord::Base.transaction do
+              organization.pre_filter_events = true
+              organization.enable_feature_flag!(:enriched_events_aggregation)
+              enriched_store_migration.mark_as_completed!
+            end
+
+            result.enriched_store_migration = enriched_store_migration
+            result
+          rescue => e
+            fail_migration!(e.message)
+            result
+          end
+
+          private
+
+          attr_reader :enriched_store_migration
+
+          delegate :organization, to: :enriched_store_migration
+
+          def fail_migration!(message)
+            enriched_store_migration.update!(error_message: message)
+            enriched_store_migration.fail!
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse/enriched_store_migration/orchestrator_service.rb
+++ b/app/services/events/stores/clickhouse/enriched_store_migration/orchestrator_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module EnrichedStoreMigration
+        # Top-level driver for an organization's enriched store migration.
+        # Reads the current org migration state and dispatches the next action. Idempotent.
+        #
+        #   pending    → transition to checking, enqueue CheckJob
+        #   processing → if all subscriptions completed: transition to enabling, enqueue EnableJob
+        #                otherwise: no-op (wait for remaining subscription migrations to finish)
+        #   other      → no-op
+        class OrchestratorService < BaseService
+          Result = BaseResult[:enriched_store_migration]
+
+          def initialize(enriched_store_migration:)
+            @enriched_store_migration = enriched_store_migration
+            super
+          end
+
+          def call
+            case enriched_store_migration.status
+            when "pending"
+              handle_pending
+            when "processing"
+              handle_processing
+            else
+              Rails.logger.error("Unknown status: #{enriched_store_migration.status}")
+            end
+
+            result.enriched_store_migration = enriched_store_migration
+            result
+          end
+
+          private
+
+          attr_reader :enriched_store_migration
+
+          def handle_pending
+            enriched_store_migration.update!(started_at: Time.current) if enriched_store_migration.started_at.nil?
+            enriched_store_migration.start_check!
+            CheckJob.perform_later(enriched_store_migration)
+          end
+
+          def handle_processing
+            return unless enriched_store_migration.all_subscriptions_completed?
+
+            enriched_store_migration.start_enabling!
+            EnableJob.perform_later(enriched_store_migration)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/events/stores/clickhouse/enriched_store_migration/check_job_spec.rb
+++ b/spec/jobs/events/stores/clickhouse/enriched_store_migration/check_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::CheckJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:enriched_store_migration) { create(:enriched_store_migration, :checking, organization:) }
+
+  before do
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::CheckService).to receive(:call!)
+  end
+
+  describe "#perform" do
+    it "calls the CheckService" do
+      described_class.perform_now(enriched_store_migration)
+
+      expect(Events::Stores::Clickhouse::EnrichedStoreMigration::CheckService)
+        .to have_received(:call!).with(enriched_store_migration:)
+    end
+  end
+end

--- a/spec/jobs/events/stores/clickhouse/enriched_store_migration/enable_job_spec.rb
+++ b/spec/jobs/events/stores/clickhouse/enriched_store_migration/enable_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::EnableJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:enriched_store_migration) { create(:enriched_store_migration, :enabling, organization:) }
+
+  before do
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::EnableService).to receive(:call!)
+  end
+
+  describe "#perform" do
+    it "calls the EnableService" do
+      described_class.perform_now(enriched_store_migration)
+
+      expect(Events::Stores::Clickhouse::EnrichedStoreMigration::EnableService)
+        .to have_received(:call!).with(enriched_store_migration:)
+    end
+  end
+end

--- a/spec/jobs/events/stores/clickhouse/enriched_store_migration/orchestrator_job_spec.rb
+++ b/spec/jobs/events/stores/clickhouse/enriched_store_migration/orchestrator_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::OrchestratorJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:enriched_store_migration) { create(:enriched_store_migration, organization:) }
+
+  before do
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::OrchestratorService).to receive(:call!)
+  end
+
+  describe "#perform" do
+    it "calls the OrchestratorService" do
+      described_class.perform_now(enriched_store_migration)
+
+      expect(Events::Stores::Clickhouse::EnrichedStoreMigration::OrchestratorService)
+        .to have_received(:call!).with(enriched_store_migration:)
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/check_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/check_service_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::CheckService do
+  subject(:service) { described_class.new(enriched_store_migration:) }
+
+  let(:organization) { create(:organization) }
+  let(:enriched_store_migration) { create(:enriched_store_migration, :checking, organization:) }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let!(:subscription_with_codes) { create(:subscription, organization:, customer:, plan:) }
+  let!(:subscription_without_codes) { create(:subscription, organization:, customer:, plan:) }
+
+  let(:pre_enrichment_check_result) do
+    result = Events::Stores::Clickhouse::PreEnrichmentCheckService::Result.new
+    result.subscriptions_to_reprocess = {subscription_with_codes.id => ["api_calls"]}
+    result
+  end
+
+  before do
+    allow(Events::Stores::Clickhouse::PreEnrichmentCheckService)
+      .to receive(:call).and_return(pre_enrichment_check_result)
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::SubscriptionOrchestratorJob)
+      .to receive(:perform_later)
+  end
+
+  describe "#call" do
+    context "when migration is in checking state" do
+      it "creates subscription migrations for all active subscriptions" do
+        result = service.call
+
+        expect(result).to be_success
+        expect(result.subscription_migration_count).to eq(2)
+
+        with_codes = enriched_store_migration.subscription_migrations.find_by(subscription: subscription_with_codes)
+        expect(with_codes.billable_metric_codes).to eq(["api_calls"])
+        expect(with_codes).to be_pending
+
+        without_codes = enriched_store_migration.subscription_migrations.find_by(subscription: subscription_without_codes)
+        expect(without_codes.billable_metric_codes).to eq([])
+        expect(without_codes).to be_pending
+      end
+
+      it "transitions the migration to processing" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_processing
+      end
+
+      it "enqueues a SubscriptionOrchestratorJob for each subscription migration" do
+        service.call
+
+        enriched_store_migration.subscription_migrations.each do |subscription_migration|
+          expect(Events::Stores::Clickhouse::EnrichedStoreMigration::SubscriptionOrchestratorJob)
+            .to have_been_enqueued.with(subscription_migration)
+        end
+      end
+    end
+
+    context "when migration is not in checking state" do
+      let(:enriched_store_migration) { create(:enriched_store_migration, organization:) }
+
+      it "does nothing" do
+        result = service.call
+
+        expect(result.subscription_migration_count).to be_nil
+        expect(enriched_store_migration.reload).to be_pending
+        expect(Events::Stores::Clickhouse::PreEnrichmentCheckService).not_to have_received(:call)
+      end
+    end
+
+    context "when PreEnrichmentCheckService fails" do
+      before do
+        failed_result = Events::Stores::Clickhouse::PreEnrichmentCheckService::Result.new
+        failed_result.service_failure!(code: "error", message: "check failed")
+        allow(Events::Stores::Clickhouse::PreEnrichmentCheckService)
+          .to receive(:call).and_return(failed_result)
+      end
+
+      it "transitions the migration to failed" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_failed
+        expect(enriched_store_migration.error_message).to include("check failed")
+      end
+    end
+
+    context "when an exception is raised during subscription migration creation" do
+      before do
+        allow(EnrichedStoreSubscriptionMigration).to receive(:create!).and_raise(StandardError.new("boom"))
+      end
+
+      it "transitions the migration to failed" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_failed
+        expect(enriched_store_migration.error_message).to include("boom")
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/enable_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/enable_service_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::EnableService do
+  subject(:service) { described_class.new(enriched_store_migration:) }
+
+  let(:organization) { create(:organization, pre_filter_events: false) }
+  let(:enriched_store_migration) { create(:enriched_store_migration, :enabling, organization:) }
+
+  describe "#call" do
+    context "when all subscription migrations are completed" do
+      before do
+        create(:enriched_store_subscription_migration, :completed,
+          enriched_store_migration:,
+          organization:,
+          subscription: create(:subscription, organization:))
+      end
+
+      it "enables the feature flag and pre_filter_events" do
+        freeze_time do
+          service.call
+
+          organization.reload
+          expect(organization.feature_flag_enabled?(:enriched_events_aggregation)).to be true
+          expect(organization.pre_filter_events).to be true
+
+          enriched_store_migration.reload
+          expect(enriched_store_migration).to be_completed
+          expect(enriched_store_migration.completed_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context "when not all subscription migrations are completed" do
+      before do
+        create(:enriched_store_subscription_migration, :completed,
+          enriched_store_migration:,
+          organization:,
+          subscription: create(:subscription, organization:))
+        create(:enriched_store_subscription_migration, :reprocessing,
+          enriched_store_migration:,
+          organization:,
+          subscription: create(:subscription, organization:))
+      end
+
+      it "fails the migration and does not flip the flag" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_failed
+        expect(enriched_store_migration.error_message).to include("not all subscription migrations are completed")
+
+        organization.reload
+        expect(organization.feature_flag_enabled?(:enriched_events_aggregation)).to be false
+        expect(organization.pre_filter_events).to be false
+      end
+    end
+
+    context "when migration is not in enabling state" do
+      let(:enriched_store_migration) { create(:enriched_store_migration, :processing, organization:) }
+
+      it "does nothing" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_processing
+        organization.reload
+        expect(organization.feature_flag_enabled?(:enriched_events_aggregation)).to be false
+      end
+    end
+
+    context "when an exception is raised" do
+      before do
+        create(:enriched_store_subscription_migration, :completed,
+          enriched_store_migration:,
+          organization:,
+          subscription: create(:subscription, organization:))
+
+        allow(enriched_store_migration).to receive(:organization).and_return(organization)
+        allow(organization).to receive(:enable_feature_flag!).and_raise(StandardError.new("Unknown feature flag: flag"))
+      end
+
+      it "fails the migration" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_failed
+        expect(enriched_store_migration.error_message).to include("Unknown feature flag: flag")
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/orchestrator_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/orchestrator_service_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::OrchestratorService do
+  subject(:service) { described_class.new(enriched_store_migration:) }
+
+  let(:organization) { create(:organization) }
+
+  before do
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::CheckJob).to receive(:perform_later)
+    allow(Events::Stores::Clickhouse::EnrichedStoreMigration::EnableJob).to receive(:perform_later)
+  end
+
+  describe "#call" do
+    context "when status is pending" do
+      let(:enriched_store_migration) { create(:enriched_store_migration, organization:) }
+
+      it "transitions to checking, sets started_at and enqueues CheckJob" do
+        freeze_time do
+          service.call
+
+          enriched_store_migration.reload
+          expect(enriched_store_migration).to be_checking
+          expect(enriched_store_migration.started_at).to eq(Time.current)
+          expect(Events::Stores::Clickhouse::EnrichedStoreMigration::CheckJob)
+            .to have_received(:perform_later).with(enriched_store_migration)
+        end
+      end
+    end
+
+    context "when status is processing and all subscription migrations completed" do
+      let(:enriched_store_migration) { create(:enriched_store_migration, :processing, organization:) }
+
+      before do
+        create(:enriched_store_subscription_migration, :completed,
+          enriched_store_migration:,
+          organization:,
+          subscription: create(:subscription, organization:))
+      end
+
+      it "transitions to enabling and enqueues EnableJob" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_enabling
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::EnableJob)
+          .to have_received(:perform_later).with(enriched_store_migration)
+      end
+    end
+
+    context "when status is processing but not all subscription migrations completed" do
+      let(:enriched_store_migration) { create(:enriched_store_migration, :processing, organization:) }
+
+      before do
+        create(:enriched_store_subscription_migration, :completed,
+          enriched_store_migration:,
+          organization:,
+          subscription: create(:subscription, organization:))
+        create(:enriched_store_subscription_migration, :reprocessing,
+          enriched_store_migration:,
+          organization:,
+          subscription: create(:subscription, organization:))
+      end
+
+      it "stays in processing and does not enqueue EnableJob" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_processing
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::EnableJob)
+          .not_to have_received(:perform_later)
+      end
+    end
+
+    context "when status is processing with no subscription migrations" do
+      let(:enriched_store_migration) { create(:enriched_store_migration, :processing, organization:) }
+
+      it "stays in processing" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_processing
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::EnableJob)
+          .not_to have_received(:perform_later)
+      end
+    end
+
+    context "when in a non-actionable status" do
+      let(:enriched_store_migration) { create(:enriched_store_migration, :enabling, organization:) }
+
+      it "is a no-op" do
+        service.call
+
+        enriched_store_migration.reload
+        expect(enriched_store_migration).to be_enabling
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::CheckJob).not_to have_received(:perform_later)
+        expect(Events::Stores::Clickhouse::EnrichedStoreMigration::EnableJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5349

Migrating an organization from `Events::Stores::ClickhouseStore` to `Events::Stores::ClickhouseEnrichedStore` today requires running 4+ rake tasks manually in sequence, with manual verification between steps. 

A full migration process with a two-level tracking system (on organizations and subscriptions), relying on resumable state machines, asynchronous and per-subscription independent processes will be added to automate these tasks

## Description

This PR adds the organization state machine to monitor the full migration process at organization level