### PR TITLE
feat(presentation_group_keys): Change stores and aggregators to support breakdowns query

### DIFF
--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -10,6 +10,11 @@ module BillableMetrics
         result.current_usage_units = result.aggregation
         result.count = result.aggregation
         result.pay_in_advance_aggregation = BigDecimal(1)
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_count(uniq_grouped_by_and_presentation_by)
+        end
+
         result.options = {running_total: running_total(options, aggregation: result.aggregation)}
         result
       end
@@ -36,6 +41,10 @@ module BillableMetrics
           group_result.current_usage_units = aggregation[:value]
           group_result.options = {running_total: running_total(options, aggregation: group_result.aggregation)}
           group_result
+        end
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_count(uniq_grouped_by_and_presentation_by)
         end
 
         result

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -15,6 +15,11 @@ module BillableMetrics
 
         result.aggregation = compute_aggregation_value(event_store.last)
         result.count = event_store.count
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_last(uniq_grouped_by_and_presentation_by)
+        end
+
         result.options = options
         result
       rescue ActiveRecord::StatementInvalid => e
@@ -40,6 +45,10 @@ module BillableMetrics
           count = counts.find { |c| c[:groups] == aggregation[:groups] } || {}
           group_result.count = count[:value] || 0
           group_result
+        end
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_last(uniq_grouped_by_and_presentation_by)
         end
 
         result

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -15,6 +15,11 @@ module BillableMetrics
 
         result.aggregation = event_store.max || 0
         result.count = event_store.count
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_max(uniq_grouped_by_and_presentation_by)
+        end
+
         result.options = options
         result
       rescue ActiveRecord::StatementInvalid => e
@@ -39,6 +44,10 @@ module BillableMetrics
           group_result.count = count[:value] || 0
 
           group_result
+        end
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_max(uniq_grouped_by_and_presentation_by)
         end
 
         result

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -22,6 +22,11 @@ module BillableMetrics
         end
 
         result.pay_in_advance_aggregation = BigDecimal(compute_pay_in_advance_aggregation)
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by)
+        end
+
         result.options = {running_total: running_total(options, aggregation:)}
         result.count = result.aggregation
         result
@@ -54,6 +59,10 @@ module BillableMetrics
           group_result.count = aggregation[:value]
           group_result.options = {running_total: running_total(options, aggregation: group_result.aggregation)}
           group_result
+        end
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by)
         end
 
         result

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -19,6 +19,10 @@ module BillableMetrics
         result.total_aggregated_units = result.variation
         result.options = {}
 
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_weighted_sum(uniq_grouped_by_and_presentation_by, initial_value:)
+        end
+
         if billable_metric.recurring?
           result.total_aggregated_units = latest_value + result.variation
           result.recurring_updated_at = event_store.last_event&.timestamp || from_datetime
@@ -44,6 +48,10 @@ module BillableMetrics
         if billable_metric.recurring?
           latest_values = grouped_latest_values
           last_events = event_store.grouped_last_event
+        end
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_weighted_sum(uniq_grouped_by_and_presentation_by, initial_values: grouped_latest_values)
         end
 
         result.aggregations = aggregations.map do |aggregation|

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -34,6 +34,11 @@ module BillableMetrics
 
         result.pay_in_advance_aggregation = compute_pay_in_advance_aggregation(aggregation_without_proration:)
         result.count = aggregation_without_proration.count
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by)
+        end
+
         result.options = options
         result
       rescue ActiveRecord::StatementInvalid => e
@@ -88,6 +93,10 @@ module BillableMetrics
           group_result.options = options
 
           group_result
+        end
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by)
         end
 
         result

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -33,6 +33,10 @@ module BillableMetrics
           result.aggregation = aggregation
         end
 
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by)
+        end
+
         result.pay_in_advance_aggregation = compute_pay_in_advance_aggregation(aggregation_without_proration:)
         result.options = options
         result.count = result.aggregation
@@ -87,6 +91,10 @@ module BillableMetrics
           group_result.options = options
 
           group_result
+        end
+
+        if presentation_by.present?
+          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by)
         end
 
         result

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -12,7 +12,6 @@ module Events
 
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
-        @presentation_by = filters[:presentation_by]
 
         @charge_id = filters[:charge_id]
         @charge_filter_id = filters[:charge_filter]&.id

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -140,7 +140,7 @@ module Events
         @timezone ||= customer.applicable_timezone
       end
 
-      attr_accessor :numeric_property, :aggregation_property, :use_from_boundary, :grouped_by, :presentation_by, :charge_id, :charge_filter_id
+      attr_accessor :numeric_property, :aggregation_property, :use_from_boundary, :grouped_by, :charge_id, :charge_filter_id
 
       protected
 

--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -288,10 +288,19 @@ module Events
           :with_ctes,
           :charges_duration,
           :events_cte_queries,
-          :joined_group_names,
           :grouped_arel_columns,
           :operation_type_sql,
           to: :store
+
+        def joined_group_names
+          _, names = grouped_arel_columns
+
+          if names.is_a?(Array)
+            return names.join(", ")
+          end
+
+          names
+        end
 
         def events_cte_sql
           # NOTE: Common table expression returning event's timestamp, property name and operation type.

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -55,11 +55,23 @@ module Events
           :with_ctes,
           :charges_duration,
           :events_cte_queries,
-          :group_names,
-          :joined_group_names,
           :grouped_arel_columns,
           :grouped_by_columns,
           to: :store
+
+        def group_names
+          _, names = grouped_arel_columns
+
+          if names.is_a?(Array)
+            return names
+          end
+
+          names.to_s.split(",")
+        end
+
+        def joined_group_names
+          group_names.join(", ")
+        end
 
         def events_cte_sql
           events_cte = events_cte_queries(

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -250,7 +250,7 @@ module Events
         end
       end
 
-      def grouped_count
+      def grouped_count(_columns = grouped_by)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[value], select: [arel_table[:sorted_grouped_by]]), <<-SQL)
             SELECT
@@ -334,7 +334,7 @@ module Events
         end
       end
 
-      def grouped_unique_count
+      def grouped_unique_count(_columns = grouped_by)
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
           sql = ActiveRecord::Base.sanitize_sql_for_conditions(
@@ -404,7 +404,7 @@ module Events
         end
       end
 
-      def grouped_max
+      def grouped_max(_columns = grouped_by)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(
             deduplicated_columns: %w[decimal_value],
@@ -434,7 +434,7 @@ module Events
         end
       end
 
-      def grouped_last
+      def grouped_last(_columns = grouped_by)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
             SELECT
@@ -459,7 +459,7 @@ module Events
         end
       end
 
-      def grouped_sum
+      def grouped_sum(_columns = grouped_by)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
             SELECT
@@ -613,7 +613,7 @@ module Events
         BigDecimal(result["aggregation"].presence || 0)
       end
 
-      def grouped_weighted_sum(initial_values: [])
+      def grouped_weighted_sum(_columns = grouped_by, initial_values: [])
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           query = Clickhouse::WeightedSumQuery.new(store: self)
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -395,7 +395,7 @@ module Events
 
       def grouped_last(columns = grouped_by)
         groups, column_names = grouped_arel_columns(columns)
-        distinct_on_names = grouped_by.present? ? group_names.join(", ") : nil
+        distinct_on_names = grouped_by.present? ? grouped_arel_columns.last : nil
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
@@ -782,14 +782,6 @@ module Events
           columns.map.with_index { |col, i| Arel::Nodes::SqlLiteral.new(sanitized_property_name(col)).as("g_#{i}") },
           names.join(", ")
         ]
-      end
-
-      def group_names
-        @group_names ||= Array.new(grouped_by.count) { |index| "g_#{index}" }
-      end
-
-      def joined_group_names
-        @joined_group_names ||= group_names.join(", ")
       end
 
       def grouped_by_columns(values)

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -396,6 +396,7 @@ module Events
 
       def grouped_last(columns = grouped_by)
         groups, column_names = grouped_arel_columns(columns)
+        distinct_on_names = grouped_by.present? ? group_names.join(", ") : nil
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
@@ -403,13 +404,24 @@ module Events
             deduplicated_columns: %w[decimal_value properties]
           )
 
-          sql = with_ctes(ctes_sql, <<-SQL)
-            SELECT
-              DISTINCT ON (#{column_names}) #{column_names},
-              property
-            FROM events
-            ORDER BY #{column_names}, events.timestamp DESC
-          SQL
+          sql = if distinct_on_names
+            with_ctes(ctes_sql, <<-SQL)
+              SELECT
+                DISTINCT ON (#{distinct_on_names}) #{column_names},
+                property
+              FROM events
+              ORDER BY #{distinct_on_names}, events.timestamp DESC
+            SQL
+          else
+            with_ctes(ctes_sql, <<-SQL)
+              SELECT
+                #{column_names},
+                property
+              FROM events
+              ORDER BY events.timestamp DESC
+              LIMIT 1
+            SQL
+          end
 
           prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
         end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -316,7 +316,6 @@ module Events
       def grouped_unique_count(columns = grouped_by)
         duplicated_unique_count_store = dup
         duplicated_unique_count_store.grouped_by = columns
-        duplicated_unique_count_store.presentation_by = nil
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: duplicated_unique_count_store)
@@ -609,7 +608,6 @@ module Events
       def grouped_weighted_sum(columns = grouped_by, initial_value: 0, initial_values: [])
         duplicated_weighted_sum_store = dup
         duplicated_weighted_sum_store.grouped_by = columns
-        duplicated_weighted_sum_store.presentation_by = nil
 
         baseline_initial_values = if initial_values.present?
           initial_values

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -205,8 +205,8 @@ module Events
         end
       end
 
-      def grouped_count
-        groups, group_names = grouped_arel_columns
+      def grouped_count(columns = grouped_by)
+        groups, column_names = grouped_arel_columns(columns)
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
@@ -216,13 +216,13 @@ module Events
 
           sql = with_ctes(ctes_sql, <<-SQL)
             SELECT
-              #{group_names},
+              #{column_names},
               toDecimal32(count(), 0)
             FROM events
-            GROUP BY #{group_names}
+            GROUP BY #{column_names}
           SQL
 
-          prepare_grouped_result(connection.select_all(sql).rows)
+          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
         end
       end
 
@@ -313,9 +313,13 @@ module Events
         end
       end
 
-      def grouped_unique_count
+      def grouped_unique_count(columns = grouped_by)
+        duplicated_unique_count_store = dup
+        duplicated_unique_count_store.grouped_by = columns
+        duplicated_unique_count_store.presentation_by = nil
+
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
-          query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
+          query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: duplicated_unique_count_store)
           sql = ActiveRecord::Base.sanitize_sql_for_conditions(
             [
               sanitize_colon(query.grouped_query),
@@ -326,7 +330,7 @@ module Events
             ]
           )
 
-          prepare_grouped_result(connection.select_all(sql).rows)
+          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
         end
       end
 
@@ -359,8 +363,8 @@ module Events
         end
       end
 
-      def grouped_max
-        groups, group_names = grouped_arel_columns
+      def grouped_max(columns = grouped_by)
+        groups, column_names = grouped_arel_columns(columns)
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
@@ -370,13 +374,13 @@ module Events
 
           sql = with_ctes(ctes_sql, <<-SQL)
             SELECT
-              #{group_names},
+              #{column_names},
               MAX(property)
             FROM events
-            GROUP BY #{group_names}
+            GROUP BY #{column_names}
           SQL
 
-          prepare_grouped_result(connection.select_all(sql).rows)
+          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
         end
       end
 
@@ -390,8 +394,8 @@ module Events
         BigDecimal(value)
       end
 
-      def grouped_last
-        groups, group_names = grouped_arel_columns
+      def grouped_last(columns = grouped_by)
+        groups, column_names = grouped_arel_columns(columns)
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
@@ -401,13 +405,13 @@ module Events
 
           sql = with_ctes(ctes_sql, <<-SQL)
             SELECT
-              DISTINCT ON (#{group_names}) #{group_names},
+              DISTINCT ON (#{column_names}) #{column_names},
               property
             FROM events
-            ORDER BY #{group_names}, events.timestamp DESC
+            ORDER BY #{column_names}, events.timestamp DESC
           SQL
 
-          prepare_grouped_result(connection.select_all(sql).rows)
+          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
         end
       end
 
@@ -454,24 +458,24 @@ module Events
         end
       end
 
-      def grouped_sum
-        groups, group_names = grouped_arel_columns
+      def grouped_sum(columns = grouped_by)
+        groups, column_names = grouped_arel_columns(columns)
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
             select: groups + [arel_table[:decimal_value].as("property")],
-            deduplicated_columns: %w[decimal_value]
+            deduplicated_columns: %w[decimal_value properties]
           )
 
           sql = with_ctes(ctes_sql, <<-SQL)
             SELECT
-              #{group_names},
+              #{column_names},
               sum(events.property)
             FROM events
-            GROUP BY #{group_names}
+            GROUP BY #{column_names}
           SQL
 
-          prepare_grouped_result(connection.select_all(sql).rows)
+          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
         end
       end
 
@@ -590,30 +594,28 @@ module Events
         BigDecimal(result["aggregation"].presence || 0)
       end
 
-      def grouped_weighted_sum(initial_values: [])
+      def grouped_weighted_sum(columns = grouped_by, initial_value: 0, initial_values: [])
+        duplicated_weighted_sum_store = dup
+        duplicated_weighted_sum_store.grouped_by = columns
+        duplicated_weighted_sum_store.presentation_by = nil
+
+        baseline_initial_values = if initial_values.present?
+          initial_values
+        elsif initial_value.to_d.nonzero?
+          [{groups: {}, value: initial_value}]
+        else
+          []
+        end
+
+        formatted_initial_values = duplicated_weighted_sum_store.formatted_weighted_sum_initial_values(baseline_initial_values)
+        return [] if formatted_initial_values.empty?
+
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
-          query = Clickhouse::WeightedSumQuery.new(store: self)
-
-          # NOTE: build the list of initial values for each groups
-          #       from the events in the period
-          formated_initial_values = grouped_count.map do |group|
-            value = 0
-            previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
-            value = previous_group[:value] if previous_group
-            {groups: group[:groups], value:}
-          end
-
-          # NOTE: add the initial values for groups that are not in the events
-          initial_values.each do |intial_value|
-            next if formated_initial_values.find { |g| g[:groups] == intial_value[:groups] }
-
-            formated_initial_values << intial_value
-          end
-          return [] if formated_initial_values.empty?
+          query = Clickhouse::WeightedSumQuery.new(store: duplicated_weighted_sum_store)
 
           sql = ActiveRecord::Base.sanitize_sql_for_conditions(
             [
-              sanitize_colon(query.grouped_query(initial_values: formated_initial_values)),
+              sanitize_colon(query.grouped_query(initial_values: formatted_initial_values)),
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
@@ -622,7 +624,7 @@ module Events
             ]
           )
 
-          prepare_grouped_result(connection.select_all(sql).rows, decimal: true)
+          prepare_grouped_result(connection.select_all(sql).rows, decimal: true, columns: columns)
         end
       end
 
@@ -744,13 +746,13 @@ module Events
       # NOTE: returns the values for each groups
       #       The result format will be an array of hash with the format:
       #       [{ groups: { 'cloud' => 'aws', 'region' => 'us_east_1' }, value: 12.9 }, ...]
-      def prepare_grouped_result(rows, timestamp: false, decimal: false)
+      def prepare_grouped_result(rows, timestamp: false, decimal: false, columns: grouped_by)
         rows.map do |row|
           last_group = timestamp ? -2 : -1
           groups = row.flatten[...last_group].map(&:presence)
 
           result = {
-            groups: grouped_by.each_with_object({}).with_index { |(g, r), i| r.merge!(g => groups[i]) },
+            groups: columns.each_with_object({}).with_index { |(g, r), i| r.merge!(g => groups[i]) },
             value: decimal ? BigDecimal(row.last.presence || 0) : row.last
           }
 
@@ -764,12 +766,11 @@ module Events
         @arel_table ||= ::Clickhouse::EventsEnriched.arel_table
       end
 
-      def grouped_arel_columns
+      def grouped_arel_columns(columns = grouped_by)
+        names = Array.new(columns.count) { |i| "g_#{i}" }
         [
-          grouped_by.map.with_index do |group, index|
-            Arel::Nodes::SqlLiteral.new(sanitized_property_name(group)).as("g_#{index}")
-          end,
-          group_names.join(", ")
+          columns.map.with_index { |col, i| Arel::Nodes::SqlLiteral.new(sanitized_property_name(col)).as("g_#{i}") },
+          names.join(", ")
         ]
       end
 
@@ -789,6 +790,23 @@ module Events
 
       def operation_type_sql
         "events_enriched.sorted_properties['operation_type']"
+      end
+
+      def formatted_weighted_sum_initial_values(initial_values)
+        formatted_initial_values = grouped_count.map do |group|
+          value = 0
+          previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
+          value = previous_group[:value] if previous_group
+          {groups: group[:groups], value:}
+        end
+
+        initial_values.each do |initial_value|
+          next if formatted_initial_values.find { |g| g[:groups] == initial_value[:groups] }
+
+          formatted_initial_values << initial_value
+        end
+
+        formatted_initial_values
       end
     end
   end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -150,10 +150,8 @@ module Events
 
       def grouped_unique_count(columns = grouped_by)
         # NOTE: Important to use a dup to avoid mutate the current object (self) to associate the columns
-        # also, set presentation_by to nil to avoid any confusion in the query building having duplicated keys
         duplicated_unique_count_store = dup
         duplicated_unique_count_store.grouped_by = columns
-        duplicated_unique_count_store.presentation_by = nil
 
         query = Events::Stores::Postgres::UniqueCountQuery.new(store: duplicated_unique_count_store)
 
@@ -313,10 +311,8 @@ module Events
 
       def grouped_weighted_sum(columns = grouped_by, initial_value: 0, initial_values: [])
         # NOTE: Important to use a dup to avoid mutate the current object (self) to associate the columns
-        # also, set presentation_by to nil to avoid any confusion in the query building having duplicated keys
         duplicated_weighted_sum_store = dup
         duplicated_weighted_sum_store.grouped_by = columns
-        duplicated_weighted_sum_store.presentation_by = nil
 
         baseline_initial_values = if initial_values.present?
           initial_values

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -198,13 +198,22 @@ module Events
 
       def grouped_last(columns = grouped_by)
         sanitized_columns = columns.map { sanitized_property_name(it) }
+        distinct_on_columns = grouped_by.present? ? grouped_by.map { sanitized_property_name(it) } : []
 
-        sql = events
-          .order(Arel.sql((sanitized_columns + ["events.timestamp DESC, created_at DESC"]).join(", ")))
-          .select(
-            "DISTINCT ON (#{sanitized_columns.join(", ")}) #{sanitized_columns.join(", ")}, (#{sanitized_property_name})::numeric AS value"
-          )
-          .to_sql
+        sql = if distinct_on_columns.empty?
+          events
+            .order(Arel.sql("events.timestamp DESC, created_at DESC"))
+            .select("#{sanitized_columns.join(", ")}, (#{sanitized_property_name})::numeric AS value")
+            .limit(1)
+            .to_sql
+        else
+          events
+            .order(Arel.sql((distinct_on_columns + ["events.timestamp DESC, created_at DESC"]).join(", ")))
+            .select(
+              "DISTINCT ON (#{distinct_on_columns.join(", ")}) #{sanitized_columns.join(", ")}, (#{sanitized_property_name})::numeric AS value"
+            )
+            .to_sql
+        end
 
         prepare_grouped_result(select_all(sql).rows, columns: columns)
       end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -76,13 +76,13 @@ module Events
         events(ordered: true).pluck(Arel.sql("(#{sanitized_property_name})::numeric * (#{ratio_sql})::numeric"))
       end
 
-      def grouped_count
+      def grouped_count(columns = grouped_by)
         results = events
-          .group(sanitized_grouped_by)
+          .group(columns.map { sanitized_property_name(it) })
           .count
           .map { |group, value| [group, value].flatten }
 
-        prepare_grouped_result(results)
+        prepare_grouped_result(results, columns: columns)
       end
 
       # NOTE: check if an event created before the current on belongs to an active (as in present and not removed)
@@ -148,14 +148,20 @@ module Events
         select_all(sql).to_a
       end
 
-      def grouped_unique_count
-        query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
+      def grouped_unique_count(columns = grouped_by)
+        # NOTE: Important to use a dup to avoid mutate the current object (self) to associate the columns
+        # also, set presentation_by to nil to avoid any confusion in the query building having duplicated keys
+        duplicated_unique_count_store = dup
+        duplicated_unique_count_store.grouped_by = columns
+        duplicated_unique_count_store.presentation_by = nil
+
+        query = Events::Stores::Postgres::UniqueCountQuery.new(store: duplicated_unique_count_store)
 
         sql = sanitize_sql_for_conditions(
           [query.grouped_query]
         )
 
-        prepare_grouped_result(select_all(sql).rows)
+        prepare_grouped_result(select_all(sql).rows, columns: columns)
       end
 
       def grouped_prorated_unique_count
@@ -177,30 +183,30 @@ module Events
         events.maximum("(#{sanitized_property_name})::numeric")
       end
 
-      def grouped_max
+      def grouped_max(columns = grouped_by)
         results = events
-          .group(sanitized_grouped_by)
+          .group(columns.map { sanitized_property_name(it) })
           .maximum("(#{sanitized_property_name})::numeric")
           .map { |group, value| [group, value].flatten }
 
-        prepare_grouped_result(results)
+        prepare_grouped_result(results, columns: columns)
       end
 
       def last
         events.order(timestamp: :desc, created_at: :desc).first&.properties&.[](aggregation_property)
       end
 
-      def grouped_last
-        groups = sanitized_grouped_by
+      def grouped_last(columns = grouped_by)
+        sanitized_columns = columns.map { sanitized_property_name(it) }
 
         sql = events
-          .order(Arel.sql((groups + ["events.timestamp DESC, created_at DESC"]).join(", ")))
+          .order(Arel.sql((sanitized_columns + ["events.timestamp DESC, created_at DESC"]).join(", ")))
           .select(
-            "DISTINCT ON (#{groups.join(", ")}) #{groups.join(", ")}, (#{sanitized_property_name})::numeric AS value"
+            "DISTINCT ON (#{sanitized_columns.join(", ")}) #{sanitized_columns.join(", ")}, (#{sanitized_property_name})::numeric AS value"
           )
           .to_sql
 
-        prepare_grouped_result(select_all(sql).rows)
+        prepare_grouped_result(select_all(sql).rows, columns: columns)
       end
 
       def sum_precise_total_amount_cents
@@ -296,29 +302,29 @@ module Events
         result["aggregation"]
       end
 
-      def grouped_weighted_sum(initial_values: [])
-        query = Events::Stores::Postgres::WeightedSumQuery.new(store: self)
+      def grouped_weighted_sum(columns = grouped_by, initial_value: 0, initial_values: [])
+        # NOTE: Important to use a dup to avoid mutate the current object (self) to associate the columns
+        # also, set presentation_by to nil to avoid any confusion in the query building having duplicated keys
+        duplicated_weighted_sum_store = dup
+        duplicated_weighted_sum_store.grouped_by = columns
+        duplicated_weighted_sum_store.presentation_by = nil
 
-        # NOTE: build the list of initial values for each groups
-        #       from the events in the period
-        formated_initial_values = grouped_count.map do |group|
-          value = 0
-          previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
-          value = previous_group[:value] if previous_group
-          {groups: group[:groups], value:}
+        baseline_initial_values = if initial_values.present?
+          initial_values
+        elsif initial_value.to_d.nonzero?
+          [{groups: {}, value: initial_value}]
+        else
+          []
         end
 
-        # NOTE: add the initial values for groups that are not in the events
-        initial_values.each do |intial_value|
-          next if formated_initial_values.find { |g| g[:groups] == intial_value[:groups] }
+        query = Events::Stores::Postgres::WeightedSumQuery.new(store: duplicated_weighted_sum_store)
 
-          formated_initial_values << intial_value
-        end
-        return [] if formated_initial_values.empty?
+        formatted_initial_values = duplicated_weighted_sum_store.formatted_weighted_sum_initial_values(baseline_initial_values)
+        return [] if formatted_initial_values.empty?
 
         sql = sanitize_sql_for_conditions(
           [
-            sanitize_colon(query.grouped_query(initial_values: formated_initial_values)),
+            sanitize_colon(query.grouped_query(initial_values: formatted_initial_values)),
             {
               from_datetime:,
               to_datetime: to_datetime.ceil
@@ -326,7 +332,27 @@ module Events
           ]
         )
 
-        prepare_grouped_result(select_all(sql).rows)
+        prepare_grouped_result(select_all(sql).rows, columns: columns)
+      end
+
+      def formatted_weighted_sum_initial_values(initial_values)
+        # NOTE: build the list of initial values for each groups
+        #       from the events in the period
+        formatted_initial_values = grouped_count.map do |group|
+          value = 0
+          previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
+          value = previous_group[:value] if previous_group
+          {groups: group[:groups], value:}
+        end
+
+        # NOTE: add the initial values for groups that are not in the events
+        initial_values.each do |initial_value|
+          next if formatted_initial_values.find { |g| g[:groups] == initial_value[:groups] }
+
+          formatted_initial_values << initial_value
+        end
+
+        formatted_initial_values
       end
 
       # NOTE: not used in production, only for debug purpose to check the computed values before aggregation

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -20,13 +20,14 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:bypass_aggregation) { false }
   let(:filters) do
-    {event: pay_in_advance_event, grouped_by:, matching_filters:, ignored_filters:}
+    {event: pay_in_advance_event, grouped_by:, presentation_by:, matching_filters:, ignored_filters:}
   end
 
   let(:subscription) { create(:subscription, organization:) }
   let(:organization) { create(:organization) }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
+  let(:presentation_by) { nil }
   let(:matching_filters) { {} }
   let(:ignored_filters) { [] }
 
@@ -145,6 +146,96 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
       result = count_service.aggregate
 
       expect(result.pay_in_advance_aggregation).to eq(1)
+    end
+  end
+
+  context "with presentation group keys" do
+    let(:presentation_by) { ["cloud"] }
+
+    let(:event_list) do
+      create_list(
+        :event,
+        3,
+        organization_id: organization.id,
+        code: billable_metric.code,
+        subscription:,
+        customer:,
+        timestamp: Time.zone.now - 1.day,
+        properties: {"cloud" => "aws"}
+      ) + create_list(
+        :event,
+        1,
+        organization_id: organization.id,
+        code: billable_metric.code,
+        subscription:,
+        customer:,
+        timestamp: Time.zone.now - 1.day,
+        properties: {"cloud" => "gcp"}
+      )
+    end
+
+    it "returns the aggregations per group" do
+      result = count_service.aggregate
+
+      expect(result.breakdowns).to match_array([
+        {groups: {"cloud" => "aws"}, value: 3},
+        {groups: {"cloud" => "gcp"}, value: 1}
+      ])
+    end
+
+    context "with grouped_by" do
+      let(:grouped_by) { ["agent_name"] }
+
+      let(:event_list) do
+        [
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            subscription:,
+            customer:,
+            timestamp: Time.zone.now - 1.day,
+            properties: {"agent_name" => "frodo", "cloud" => "aws"}
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            subscription:,
+            customer:,
+            timestamp: Time.zone.now - 1.day,
+            properties: {"agent_name" => "frodo", "cloud" => "aws"}
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            subscription:,
+            customer:,
+            timestamp: Time.zone.now - 1.day,
+            properties: {"agent_name" => "frodo", "cloud" => "gcp"}
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            subscription:,
+            customer:,
+            timestamp: Time.zone.now - 1.day,
+            properties: {"agent_name" => "aragorn", "cloud" => "aws"}
+          )
+        ]
+      end
+
+      it "returns the aggregations per group" do
+        result = count_service.aggregate
+
+        expect(result.breakdowns).to match_array([
+          {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
+          {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1},
+          {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1}
+        ])
+      end
     end
   end
 

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -372,7 +372,6 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
       result = latest_service.aggregate
 
       expect(result.breakdowns).to match_array([
-        {groups: {"cloud" => "aws"}, value: BigDecimal(14)},
         {groups: {"cloud" => "gcp"}, value: BigDecimal(-5)}
       ])
     end
@@ -428,7 +427,6 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
         result = latest_service.aggregate
 
         expect(result.breakdowns).to match_array([
-          {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: BigDecimal(10)},
           {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: BigDecimal(12)},
           {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: BigDecimal(3)}
         ])

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -19,12 +19,13 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
 
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:bypass_aggregation) { false }
-  let(:filters) { {grouped_by:, matching_filters:, ignored_filters:} }
+  let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
+  let(:presentation_by) { nil }
   let(:matching_filters) { {} }
   let(:ignored_filters) { [] }
 
@@ -319,6 +320,118 @@ RSpec.describe BillableMetrics::Aggregations::LatestService do
         expect(aggregation.aggregation).to eq(0)
         expect(aggregation.count).to eq(0)
         expect(aggregation.grouped_by).to eq({"agent_name" => nil})
+      end
+    end
+  end
+
+  context "with presentation group keys" do
+    let(:presentation_by) { ["cloud"] }
+
+    let(:events) do
+      [
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: Time.current - 2.days,
+          properties: {
+            total_count: 18,
+            cloud: "aws"
+          }
+        ),
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: Time.current - 1.day,
+          properties: {
+            total_count: 14,
+            cloud: "aws"
+          }
+        ),
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: Time.current - 1.day,
+          properties: {
+            total_count: -5,
+            cloud: "gcp"
+          }
+        )
+      ]
+    end
+
+    it "returns the aggregations per group" do
+      result = latest_service.aggregate
+
+      expect(result.breakdowns).to match_array([
+        {groups: {"cloud" => "aws"}, value: BigDecimal(14)},
+        {groups: {"cloud" => "gcp"}, value: BigDecimal(-5)}
+      ])
+    end
+
+    context "with grouped_by" do
+      let(:grouped_by) { ["agent_name"] }
+
+      let(:events) do
+        [
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: Time.current - 2.days,
+            properties: {
+              total_count: 10,
+              agent_name: "frodo",
+              cloud: "aws"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: Time.current - 1.day,
+            properties: {
+              total_count: 12,
+              agent_name: "frodo",
+              cloud: "gcp"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: Time.current - 1.day,
+            properties: {
+              total_count: 3,
+              agent_name: "aragorn",
+              cloud: "aws"
+            }
+          )
+        ]
+      end
+
+      it "returns the aggregations per group" do
+        result = latest_service.aggregate
+
+        expect(result.breakdowns).to match_array([
+          {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: BigDecimal(10)},
+          {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: BigDecimal(12)},
+          {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: BigDecimal(3)}
+        ])
       end
     end
   end

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -19,12 +19,13 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
 
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:bypass_aggregation) { false }
-  let(:filters) { {grouped_by:, matching_filters:, ignored_filters:} }
+  let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
+  let(:presentation_by) { nil }
   let(:matching_filters) { {} }
   let(:ignored_filters) { [] }
 
@@ -331,6 +332,89 @@ RSpec.describe BillableMetrics::Aggregations::MaxService do
         expect(aggregation.aggregation).to eq(0)
         expect(aggregation.count).to eq(0)
         expect(aggregation.grouped_by).to eq({"agent_name" => nil})
+      end
+    end
+  end
+
+  context "with presentation group keys" do
+    let(:presentation_by) { ["cloud"] }
+
+    let(:events) do
+      [
+        create_list(
+          :event,
+          3,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: Time.zone.now - 1.day,
+          properties: {total_count: 10, cloud: "aws"}
+        ),
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: Time.zone.now - 1.day,
+          properties: {total_count: 12, cloud: "gcp"}
+        )
+      ].flatten
+    end
+
+    it "returns the aggregations per group" do
+      result = max_service.aggregate
+
+      expect(result.breakdowns).to match_array([
+        {groups: {"cloud" => "aws"}, value: 10},
+        {groups: {"cloud" => "gcp"}, value: 12}
+      ])
+    end
+
+    context "with grouped_by" do
+      let(:grouped_by) { ["agent_name"] }
+
+      let(:events) do
+        [
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: Time.zone.now - 1.day,
+            properties: {total_count: 2, agent_name: "frodo", cloud: "aws"}
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: Time.zone.now - 1.day,
+            properties: {total_count: 7, agent_name: "frodo", cloud: "gcp"}
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: Time.zone.now - 1.day,
+            properties: {total_count: 3, agent_name: "aragorn", cloud: "aws"}
+          )
+        ]
+      end
+
+      it "returns the aggregations per group" do
+        result = max_service.aggregate
+
+        expect(result.breakdowns).to match_array([
+          {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
+          {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
+          {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
+        ])
       end
     end
   end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -20,13 +20,14 @@ RSpec.describe BillableMetrics::Aggregations::SumService, transaction: false do
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:bypass_aggregation) { false }
   let(:filters) do
-    {event: pay_in_advance_event, grouped_by:, charge_filter:, matching_filters:, ignored_filters:}
+    {event: pay_in_advance_event, grouped_by:, presentation_by:, charge_filter:, matching_filters:, ignored_filters:}
   end
 
   let(:subscription) { create(:subscription, started_at: Time.current.beginning_of_month - 6.months) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
+  let(:presentation_by) { nil }
   let(:charge_filter) { nil }
   let(:matching_filters) { nil }
   let(:ignored_filters) { nil }
@@ -1005,6 +1006,90 @@ RSpec.describe BillableMetrics::Aggregations::SumService, transaction: false do
         result.aggregations.each_with_index do |aggregation, index|
           expect(aggregation.options[:running_total]).to eq([12])
         end
+      end
+    end
+  end
+
+  context "with presentation group keys" do
+    let(:presentation_by) { ["cloud"] }
+    let(:old_events) { [] }
+
+    let(:latest_events) do
+      [
+        create_list(
+          :event,
+          3,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: to_datetime - 1.day,
+          properties: {total_count: 10, cloud: "aws"}
+        ),
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: to_datetime - 1.day,
+          properties: {total_count: 12, cloud: "gcp"}
+        )
+      ].flatten
+    end
+
+    it "returns the aggregations per group" do
+      result = sum_service.aggregate
+
+      expect(result.breakdowns).to match_array([
+        {groups: {"cloud" => "aws"}, value: 30},
+        {groups: {"cloud" => "gcp"}, value: 12}
+      ])
+    end
+
+    context "with grouped_by" do
+      let(:grouped_by) { ["agent_name"] }
+
+      let(:latest_events) do
+        [
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: to_datetime - 1.day,
+            properties: {total_count: 2, agent_name: "frodo", cloud: "aws"}
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: to_datetime - 1.day,
+            properties: {total_count: 7, agent_name: "frodo", cloud: "gcp"}
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: to_datetime - 1.day,
+            properties: {total_count: 3, agent_name: "aragorn", cloud: "aws"}
+          )
+        ]
+      end
+
+      it "returns the aggregations per group" do
+        result = sum_service.aggregate
+
+        expect(result.breakdowns).to match_array([
+          {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
+          {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
+          {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
+        ])
       end
     end
   end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:bypass_aggregation) { false }
   let(:filters) do
-    {event: pay_in_advance_event, grouped_by:, charge_filter:, matching_filters:, ignored_filters:}
+    {event: pay_in_advance_event, grouped_by:, presentation_by:, charge_filter:, matching_filters:, ignored_filters:}
   end
 
   let(:subscription) do
@@ -38,6 +38,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
+  let(:presentation_by) { nil }
   let(:charge_filter) { nil }
   let(:matching_filters) { nil }
   let(:ignored_filters) { nil }
@@ -79,6 +80,93 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
 
   describe "#aggregate" do
     let(:result) { count_service.aggregate }
+
+    context "with presentation group keys" do
+      let(:presentation_by) { ["cloud"] }
+
+      let(:unique_count_event) do
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
+          timestamp: added_at,
+          properties: {unique_id: "001", cloud: "aws"}
+        )
+      end
+
+      let(:new_unique_count_event) do
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
+          timestamp: from_datetime + 10.days,
+          properties: {unique_id: "002", cloud: "gcp"}
+        )
+      end
+
+      before { new_unique_count_event }
+
+      it "returns the aggregations per group" do
+        expect(result.breakdowns).to match_array([
+          {groups: {"cloud" => "aws"}, value: 1},
+          {groups: {"cloud" => "gcp"}, value: 1}
+        ])
+      end
+
+      context "with grouped_by" do
+        let(:grouped_by) { ["agent_name"] }
+        let(:unique_count_event) { nil }
+
+        let(:unique_count_events) do
+          [
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at,
+              properties: {unique_id: "001", agent_name: "frodo", cloud: "aws"}
+            ),
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
+              timestamp: from_datetime + 10.days,
+              properties: {unique_id: "002", agent_name: "frodo", cloud: "gcp"}
+            ),
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at,
+              properties: {unique_id: "003", agent_name: "aragorn", cloud: "aws"}
+            )
+          ]
+        end
+
+        before do
+          unique_count_events
+        end
+
+        it "returns the aggregations per group" do
+          expect(result.breakdowns).to match_array([
+            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 1},
+            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1},
+            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1},
+            {groups: {"agent_name" => nil, "cloud" => "gcp"}, value: 1}
+          ])
+        end
+      end
+    end
 
     context "when there is persisted event and event added in period" do
       let(:new_unique_count_event) do
@@ -804,7 +892,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
         )
       end
 
-      let(:filters) { {grouped_by:, matching_filters:, ignored_filters:, event:} }
+      let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:, event:} }
+      let(:presentation_by) { nil }
 
       it "includes the event value in the result" do
         result = count_service.per_event_aggregation(include_event_value: true)

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, transaction: f
 
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:bypass_aggregation) { false }
-  let(:filters) { {grouped_by:, matching_filters:, ignored_filters:} }
+  let(:filters) { {grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) { create(:subscription, started_at: DateTime.parse("2023-04-01 22:22:22")) }
   let(:organization) { subscription.organization }
@@ -28,6 +28,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, transaction: f
   let(:grouped_by) { nil }
   let(:matching_filters) { nil }
   let(:ignored_filters) { nil }
+  let(:presentation_by) { nil }
 
   let(:billable_metric) { create(:weighted_sum_billable_metric, organization:) }
 
@@ -77,6 +78,28 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, transaction: f
 
     expect(result.aggregation.round(5).to_s).to eq("0.02218")
     expect(result.count).to eq(7)
+  end
+
+  context "when using presentation_by" do
+    let(:presentation_by) { ["region"] }
+
+    let(:events_values) do
+      [
+        {timestamp: Time.zone.parse("2023-08-01 00:00:00.000"), value: 2, region: "eu"},
+        {timestamp: Time.zone.parse("2023-08-01 01:00:00"), value: 3, region: "us"},
+        {timestamp: Time.zone.parse("2023-08-01 02:00:00"), value: -1, region: "eu"}
+      ]
+    end
+
+    it "returns aggregations per group" do
+      result = aggregator.aggregate
+
+      region_eu = result.breakdowns.find { |b| b[:groups]["region"] == "eu" }
+      expect(region_eu[:value].round(5).to_s).to eq("1.00269")
+
+      region_us = result.breakdowns.find { |b| b[:groups]["region"] == "us" }
+      expect(region_us[:value].round(5).to_s).to eq("2.99597")
+    end
   end
 
   context "with a single event" do
@@ -220,6 +243,27 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, transaction: f
           expect(result.variation).to eq(0)
           expect(result.total_aggregated_units).to eq(10)
           expect(result.recurring_updated_at).to eq(from_datetime)
+        end
+
+        context "when using presentation_by" do
+          let(:presentation_by) { ["region"] }
+
+          let(:events_values) do
+            [
+              {timestamp: Time.zone.parse("2023-08-01 00:00:00.000"), value: 2, region: "eu"},
+              {timestamp: Time.zone.parse("2023-08-01 01:00:00"), value: 3, region: "eu"}
+            ]
+          end
+
+          it "returns aggregations per group" do
+            result = aggregator.aggregate
+
+            region_eu = result.breakdowns.find { |b| b[:groups]["region"] == "eu" }
+            expect(region_eu[:value].round(5).to_s).to eq("4.99597")
+
+            region_nil = result.breakdowns.find { |b| b[:groups]["region"].nil? }
+            expect(region_nil[:value].round(5).to_s).to eq("10.0")
+          end
         end
       end
     end

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -18,12 +18,13 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { {event: pay_in_advance_event, grouped_by:, matching_filters:, ignored_filters:} }
+  let(:filters) { {event: pay_in_advance_event, grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) { create(:subscription, started_at: Time.zone.parse("2022-12-01 00:00:00")) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
+  let(:presentation_by) { nil }
   let(:matching_filters) { {} }
   let(:ignored_filters) { [] }
 
@@ -89,6 +90,108 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
     expect(result.aggregation).to eq(9.64517) # 5 + (12*6/31) + (12*6/31)
     expect(result.pay_in_advance_aggregation).to be_zero
     expect(result.count).to eq(4)
+  end
+
+  context "with presentation group keys" do
+    let(:presentation_by) { ["cloud"] }
+
+    let(:latest_events) do
+      create_list(
+        :event,
+        2,
+        organization_id: organization.id,
+        code: billable_metric.code,
+        customer:,
+        subscription:,
+        timestamp: from_datetime + 25.days,
+        properties: {
+          total_count: 12,
+          cloud: "aws"
+        }
+      ) + [
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: from_datetime + 25.days,
+          properties: {
+            total_count: 7,
+            cloud: "gcp"
+          }
+        )
+      ]
+    end
+
+    it "returns the presentation breakdowns" do
+      result = sum_service.aggregate(options:)
+
+      aws = result.breakdowns.find { |b| b[:groups]["cloud"] == "aws" }
+      gcp = result.breakdowns.find { |b| b[:groups]["cloud"] == "gcp" }
+
+      expect(aws[:value]).to eq(24)
+      expect(gcp[:value]).to eq(7)
+    end
+
+    context "with grouped_by" do
+      let(:grouped_by) { ["agent_name"] }
+      let(:latest_events) do
+        [
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: from_datetime + 25.days,
+            properties: {
+              total_count: 12,
+              agent_name: "aragorn",
+              cloud: "aws"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: from_datetime + 25.days,
+            properties: {
+              total_count: 7,
+              agent_name: "aragorn",
+              cloud: "gcp"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: from_datetime + 25.days,
+            properties: {
+              total_count: 3,
+              agent_name: "frodo",
+              cloud: "aws"
+            }
+          )
+        ]
+      end
+
+      it "returns the presentation breakdowns per group" do
+        result = sum_service.aggregate(options:)
+
+        aragorn_aws = result.breakdowns.find { |b| b[:groups] == {"agent_name" => "aragorn", "cloud" => "aws"} }
+        aragorn_gcp = result.breakdowns.find { |b| b[:groups] == {"agent_name" => "aragorn", "cloud" => "gcp"} }
+        frodo_aws = result.breakdowns.find { |b| b[:groups] == {"agent_name" => "frodo", "cloud" => "aws"} }
+
+        expect(aragorn_aws[:value]).to eq(12)
+        expect(aragorn_gcp[:value]).to eq(7)
+        expect(frodo_aws[:value]).to eq(3)
+      end
+    end
   end
 
   context "when aggregation is performed on billing date for pay in advance case" do

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { {event: pay_in_advance_event, grouped_by:, matching_filters:, ignored_filters:} }
+  let(:filters) { {event: pay_in_advance_event, grouped_by:, presentation_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) do
     create(
@@ -36,6 +36,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:grouped_by) { nil }
+  let(:presentation_by) { nil }
   let(:matching_filters) { nil }
   let(:ignored_filters) { nil }
 
@@ -60,7 +61,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
   let(:to_datetime) { Time.zone.parse("2022-08-08 23:59:59 UTC") }
 
   let(:added_at) { from_datetime - 1.month }
-  let(:removed_at) { nil }
   let(:event) do
     create(
       :event,
@@ -76,6 +76,86 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
 
   describe "#aggregate" do
     let(:result) { unique_count_service.aggregate(options:) }
+
+    context "with presentation group keys" do
+      let(:presentation_by) { ["cloud"] }
+
+      let(:event) do
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          external_subscription_id: subscription.external_id,
+          timestamp: added_at,
+          properties: {unique_id: "001", cloud: "aws"}
+        )
+      end
+
+      let(:new_event) do
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          external_subscription_id: subscription.external_id,
+          timestamp: from_datetime + 10.days,
+          properties: {unique_id: "002", cloud: "gcp"}
+        )
+      end
+
+      before { new_event }
+
+      it "returns the presentation breakdowns" do
+        expect(result.breakdowns).to match_array([
+          {groups: {"cloud" => "aws"}, value: 1},
+          {groups: {"cloud" => "gcp"}, value: 1}
+        ])
+      end
+
+      context "with grouped_by" do
+        let(:grouped_by) { ["agent_name"] }
+        let(:event) { nil }
+
+        let(:unique_count_events) do
+          [
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at,
+              properties: {unique_id: "003", agent_name: "frodo", cloud: "aws"}
+            ),
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: from_datetime + 10.days,
+              properties: {unique_id: "004", agent_name: "frodo", cloud: "gcp"}
+            ),
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at,
+              properties: {unique_id: "005", agent_name: "aragorn", cloud: "aws"}
+            )
+          ]
+        end
+
+        before { unique_count_events }
+
+        it "returns the presentation breakdowns per group" do
+          expect(result.breakdowns).to match_array([
+            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 1},
+            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1},
+            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1},
+            {groups: {"agent_name" => nil, "cloud" => "gcp"}, value: 1}
+          ])
+        end
+      end
+    end
 
     context "with persisted metric on full period" do
       it "returns the number of persisted metric" do

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -41,10 +41,12 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
   end
 
   context "without deduplication" do
-    it_behaves_like "an event store", with_event_duplication: false
+    it_behaves_like "an event store", with_event_duplication: false, excluding_features:
+      [:grouped_sum_breakdown, :grouped_count_breakdown, :grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 
   context "with deduplication" do
-    it_behaves_like "an event store", with_event_duplication: true
+    it_behaves_like "an event store", with_event_duplication: true, excluding_features:
+      [:grouped_sum_breakdown, :grouped_count_breakdown, :grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 end

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1453,6 +1453,460 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
     end
   end
 
+  if include_feature?(:grouped_sum_breakdown)
+    describe "#grouped_sum with breakdown columns" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            presentation_by: ["cloud"],
+            matching_filters:,
+            ignored_filters:,
+            charge_id: charge&.id,
+            charge_filter: charge_filter
+          },
+          deduplicate: with_event_duplication
+        )
+      end
+
+      let(:events) { [] }
+
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+      end
+
+      context "without grouped_by" do
+        before do
+          3.times { create_event(timestamp: subscription_started_at + 1.day, value: 10, properties: {"cloud" => "aws"}) }
+          create_event(timestamp: subscription_started_at + 1.day, value: 12, properties: {"cloud" => "gcp"})
+        end
+
+        it "returns the sum breakdown by presentation_by" do
+          result = event_store.grouped_sum(["cloud"])
+
+          expect(result).to match_array([
+            {groups: {"cloud" => "aws"}, value: 30},
+            {groups: {"cloud" => "gcp"}, value: 12}
+          ])
+        end
+      end
+
+      context "with grouped_by" do
+        let(:grouped_by) { ["agent_name"] }
+
+        before do
+          create_event(timestamp: subscription_started_at + 1.day, value: 2, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 1.day, value: 7, properties: {"agent_name" => "frodo", "cloud" => "gcp"})
+          create_event(timestamp: subscription_started_at + 1.day, value: 3, properties: {"agent_name" => "aragorn", "cloud" => "aws"})
+        end
+
+        it "returns the sum breakdown per group" do
+          result = event_store.grouped_sum(["agent_name", "cloud"])
+
+          expect(result).to match_array([
+            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
+            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
+            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
+          ])
+        end
+      end
+    end
+  end
+
+  if include_feature?(:grouped_count_breakdown)
+    describe "#grouped_count with breakdown columns" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            presentation_by: ["cloud"],
+            matching_filters:,
+            ignored_filters:,
+            charge_id: charge&.id,
+            charge_filter: charge_filter
+          },
+          deduplicate: with_event_duplication
+        )
+      end
+
+      let(:events) { [] }
+
+      context "without grouped_by" do
+        before do
+          3.times { create_event(timestamp: subscription_started_at + 1.day, value: 10, properties: {"cloud" => "aws"}) }
+          create_event(timestamp: subscription_started_at + 1.day, value: 12, properties: {"cloud" => "gcp"})
+        end
+
+        it "returns the count breakdown by presentation_by" do
+          result = event_store.grouped_count(["cloud"])
+
+          expect(result).to match_array([
+            {groups: {"cloud" => "aws"}, value: 3},
+            {groups: {"cloud" => "gcp"}, value: 1}
+          ])
+        end
+      end
+
+      context "with grouped_by" do
+        let(:grouped_by) { ["agent_name"] }
+
+        before do
+          2.times { create_event(timestamp: subscription_started_at + 1.day, value: 2, properties: {"agent_name" => "frodo", "cloud" => "aws"}) }
+          create_event(timestamp: subscription_started_at + 1.day, value: 7, properties: {"agent_name" => "frodo", "cloud" => "gcp"})
+          create_event(timestamp: subscription_started_at + 1.day, value: 3, properties: {"agent_name" => "aragorn", "cloud" => "aws"})
+        end
+
+        it "returns the count breakdown per group" do
+          result = event_store.grouped_count(["agent_name", "cloud"])
+
+          expect(result).to match_array([
+            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
+            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1},
+            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1}
+          ])
+        end
+      end
+    end
+  end
+
+  if include_feature?(:grouped_last_breakdown)
+    describe "#grouped_last with breakdown columns" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            presentation_by: ["cloud"],
+            matching_filters:,
+            ignored_filters:,
+            charge_id: charge&.id,
+            charge_filter: charge_filter
+          },
+          deduplicate: with_event_duplication
+        )
+      end
+
+      let(:events) { [] }
+
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+      end
+
+      context "without grouped_by" do
+        before do
+          create_event(timestamp: subscription_started_at + 1.day, value: 10, properties: {"cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 2.days, value: 12, properties: {"cloud" => "gcp"})
+        end
+
+        it "returns the latest value per cloud" do
+          result = event_store.grouped_last(["cloud"])
+
+          expect(result).to match_array([
+            {groups: {"cloud" => "aws"}, value: 10},
+            {groups: {"cloud" => "gcp"}, value: 12}
+          ])
+        end
+      end
+
+      context "with grouped_by" do
+        let(:grouped_by) { ["agent_name"] }
+
+        before do
+          create_event(timestamp: subscription_started_at + 1.day, value: 2, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 2.days, value: 7, properties: {"agent_name" => "frodo", "cloud" => "gcp"})
+          create_event(timestamp: subscription_started_at + 1.day + 1.second, value: 3, properties: {"agent_name" => "aragorn", "cloud" => "aws"})
+        end
+
+        it "returns the latest value per group and cloud" do
+          result = event_store.grouped_last(["agent_name", "cloud"])
+
+          expect(result).to match_array([
+            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
+            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
+            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
+          ])
+        end
+      end
+    end
+  end
+
+  if include_feature?(:grouped_max_breakdown)
+    describe "#grouped_max with breakdown columns" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            presentation_by: ["cloud"],
+            matching_filters:,
+            ignored_filters:,
+            charge_id: charge&.id,
+            charge_filter: charge_filter
+          },
+          deduplicate: with_event_duplication
+        )
+      end
+
+      let(:events) { [] }
+
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+      end
+
+      context "without grouped_by" do
+        before do
+          3.times { create_event(timestamp: subscription_started_at + 1.day, value: 10, properties: {"cloud" => "aws"}) }
+          create_event(timestamp: subscription_started_at + 1.day, value: 12, properties: {"cloud" => "gcp"})
+        end
+
+        it "returns the max value per cloud" do
+          result = event_store.grouped_max(["cloud"])
+
+          expect(result).to match_array([
+            {groups: {"cloud" => "aws"}, value: 10},
+            {groups: {"cloud" => "gcp"}, value: 12}
+          ])
+        end
+      end
+
+      context "with grouped_by" do
+        let(:grouped_by) { ["agent_name"] }
+
+        before do
+          create_event(timestamp: subscription_started_at + 1.day, value: 2, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 1.day, value: 7, properties: {"agent_name" => "frodo", "cloud" => "gcp"})
+          create_event(timestamp: subscription_started_at + 1.day, value: 3, properties: {"agent_name" => "aragorn", "cloud" => "aws"})
+        end
+
+        it "returns the max value per group and cloud" do
+          result = event_store.grouped_max(["agent_name", "cloud"])
+
+          expect(result).to match_array([
+            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
+            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
+            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
+          ])
+        end
+      end
+    end
+  end
+
+  if include_feature?(:grouped_unique_count_breakdown)
+    describe "#grouped_unique_count with breakdown columns" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            presentation_by: ["cloud"],
+            matching_filters:,
+            ignored_filters:,
+            charge_id: charge&.id,
+            charge_filter: charge_filter
+          },
+          deduplicate: with_event_duplication
+        )
+      end
+
+      let(:events) { [] }
+
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+      end
+
+      context "without grouped_by" do
+        before do
+          create_event(timestamp: subscription_started_at + 1.day, value: 1, properties: {"cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 2.days, value: 2, properties: {"cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 3.days, value: 3, properties: {"cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 1.day, value: 1, properties: {"cloud" => "gcp"})
+        end
+
+        it "returns the unique count breakdown by presentation_by" do
+          result = event_store.grouped_unique_count(["cloud"])
+
+          expect(result).to match_array([
+            {groups: {"cloud" => "aws"}, value: 3},
+            {groups: {"cloud" => "gcp"}, value: 1}
+          ])
+        end
+      end
+
+      context "with grouped_by" do
+        let(:grouped_by) { ["agent_name"] }
+
+        before do
+          create_event(timestamp: subscription_started_at + 1.day, value: 1, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 2.days, value: 2, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: subscription_started_at + 1.day, value: 1, properties: {"agent_name" => "frodo", "cloud" => "gcp"})
+          create_event(timestamp: subscription_started_at + 1.day, value: 1, properties: {"agent_name" => "aragorn", "cloud" => "aws"})
+        end
+
+        it "returns the unique count breakdown per group" do
+          result = event_store.grouped_unique_count(["agent_name", "cloud"])
+
+          expect(result).to match_array([
+            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
+            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1},
+            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1}
+          ])
+        end
+      end
+    end
+  end
+
+  if include_feature?(:grouped_weighted_sum_breakdown)
+    describe "#grouped_weighted_sum with breakdown columns" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            presentation_by: ["cloud"],
+            matching_filters:,
+            ignored_filters:,
+            charge_id: charge&.id,
+            charge_filter: charge_filter
+          },
+          deduplicate: with_event_duplication
+        )
+      end
+
+      let(:events) { [] }
+      let(:started_at) { Time.zone.parse("2023-03-01") }
+
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+      end
+
+      context "without grouped_by" do
+        before do
+          create_event(timestamp: Time.zone.parse("2023-03-05 00:00:00"), value: 2, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10, properties: {"cloud" => "aws"})
+
+          create_event(timestamp: Time.zone.parse("2023-03-05 00:00:00"), value: 2, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10, properties: {"cloud" => "gcp"})
+        end
+
+        it "returns the weighted sum breakdown by presentation_by" do
+          result = event_store.grouped_weighted_sum(["cloud"])
+
+          expect(result.size).to eq(2)
+          expect(result.map { |r| r[:groups] }).to match_array([{"cloud" => "aws"}, {"cloud" => "gcp"}])
+          result.each { |r| expect(r[:value].round(5)).to eq(0.02218) }
+        end
+      end
+
+      context "with grouped_by" do
+        let(:grouped_by) { ["agent_name"] }
+
+        before do
+          create_event(timestamp: Time.zone.parse("2023-03-05 00:00:00"), value: 2, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10, properties: {"agent_name" => "frodo", "cloud" => "aws"})
+
+          create_event(timestamp: Time.zone.parse("2023-03-05 00:00:00"), value: 2, properties: {"agent_name" => "aragorn", "cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3, properties: {"agent_name" => "aragorn", "cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1, properties: {"agent_name" => "aragorn", "cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4, properties: {"agent_name" => "aragorn", "cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2, properties: {"agent_name" => "aragorn", "cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10, properties: {"agent_name" => "aragorn", "cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10, properties: {"agent_name" => "aragorn", "cloud" => "gcp"})
+        end
+
+        it "returns the weighted sum breakdown per group" do
+          result = event_store.grouped_weighted_sum(["agent_name", "cloud"])
+
+          expect(result.map { |r| r[:groups] }).to match_array([
+            {"agent_name" => "frodo", "cloud" => "aws"},
+            {"agent_name" => "aragorn", "cloud" => "gcp"}
+          ])
+          result.each { |r| expect(r[:value].round(5)).to eq(0.02218) }
+        end
+      end
+
+      context "with no events" do
+        it "returns an empty array" do
+          result = event_store.grouped_weighted_sum(["cloud"])
+
+          expect(result).to eq([])
+        end
+      end
+
+      context "with initial values" do
+        let(:initial_values) do
+          [
+            {groups: {"cloud" => "aws"}, value: 1000},
+            {groups: {"cloud" => "gcp"}, value: 1000}
+          ]
+        end
+
+        before do
+          create_event(timestamp: Time.zone.parse("2023-03-05 00:00:00"), value: 2, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10, properties: {"cloud" => "aws"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10, properties: {"cloud" => "aws"})
+
+          create_event(timestamp: Time.zone.parse("2023-03-05 00:00:00"), value: 2, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10, properties: {"cloud" => "gcp"})
+          create_event(timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10, properties: {"cloud" => "gcp"})
+        end
+
+        it "uses the initial values in the aggregation" do
+          result = event_store.grouped_weighted_sum(["cloud"], initial_values:)
+
+          expect(result.map { |r| r[:groups] }).to match_array([{"cloud" => "aws"}, {"cloud" => "gcp"}])
+          result.each { |r| expect(r[:value].round(5)).to eq(1000.02218) }
+        end
+      end
+    end
+  end
+
   if include_feature?(:sum_date_breakdown)
     describe "#sum_date_breakdown" do
       it "returns the sum grouped by day" do

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1615,7 +1615,6 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_last(["cloud"])
 
           expect(result).to match_array([
-            {groups: {"cloud" => "aws"}, value: 10},
             {groups: {"cloud" => "gcp"}, value: 12}
           ])
         end
@@ -1634,7 +1633,6 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_last(["agent_name", "cloud"])
 
           expect(result).to match_array([
-            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
             {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
             {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
           ])


### PR DESCRIPTION
This commit changes the aggregations services and stores, PostgresStore and ClickhouseStore in order to perform a query and return the grouped units based on grouped_by + presentation_by keys.

Before, we initially changed the SumService and PostgresStore#grouped_by only to have the initial step, the changes consisted in add the ability to the method to receive arguments, an array of keys and pass it down to the query. 
Having this, we can reuse the grouped_by to perform different queries with different keys.

This commit is part of presentation group keys initiative and it applies the same previous changes done in this PR https://github.com/getlago/lago-api/pull/5355 to another services and aggregators.

We're also touching in ClickhouseEnrichedStore, but just to keep the method compatible, the changes of queries will be addressed in another PR.

This commit is part of these other commits and belongs to presentation
group keys functionality:
- https://github.com/getlago/lago-api/pull/5332
- https://github.com/getlago/lago-api/pull/5335
- https://github.com/getlago/lago-api/pull/5351
- https://github.com/getlago/lago-api/pull/5355
- https://github.com/getlago/lago-api/pull/5402