### PR TITLE
misc: add new events composite index

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -85,10 +85,11 @@ end
 #
 # Indexes
 #
-#  idx_events_billing_lookup                 (external_subscription_id,organization_id,code,timestamp) WHERE (deleted_at IS NULL)
-#  idx_events_for_distinct_codes             (external_subscription_id,organization_id,timestamp) WHERE (deleted_at IS NULL)
-#  index_events_on_created_at                (created_at) WHERE (deleted_at IS NULL)
-#  index_events_on_organization_id           (organization_id)
-#  index_events_on_organization_id_and_code  (organization_id,code)
-#  index_unique_transaction_id               (organization_id,external_subscription_id,transaction_id) UNIQUE
+#  idx_events_billing_lookup                       (external_subscription_id,organization_id,code,timestamp) WHERE (deleted_at IS NULL)
+#  idx_events_for_distinct_codes                   (external_subscription_id,organization_id,timestamp) WHERE (deleted_at IS NULL)
+#  index_events_on_created_at                      (created_at) WHERE (deleted_at IS NULL)
+#  index_events_on_organization_id                 (organization_id)
+#  index_events_on_organization_id_and_code        (organization_id,code)
+#  index_events_on_organization_id_and_created_at  (organization_id,created_at DESC) WHERE (deleted_at IS NULL)
+#  index_unique_transaction_id                     (organization_id,external_subscription_id,transaction_id) UNIQUE
 #

--- a/db/migrate/20260424170418_add_events_organization_created_at_index.rb
+++ b/db/migrate/20260424170418_add_events_organization_created_at_index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddEventsOrganizationCreatedAtIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :events,
+      [:organization_id, :created_at],
+      order: {created_at: :desc},
+      where: "deleted_at IS NULL",
+      name: "index_events_on_organization_id_and_created_at",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -581,6 +581,7 @@ DROP INDEX IF EXISTS public.index_fees_on_charge_filter_id;
 DROP INDEX IF EXISTS public.index_fees_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_fees_on_applied_add_on_id;
 DROP INDEX IF EXISTS public.index_fees_on_add_on_id;
+DROP INDEX IF EXISTS public.index_events_on_organization_id_and_created_at;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_events_on_organization_id;
 DROP INDEX IF EXISTS public.index_events_on_created_at;
@@ -7595,6 +7596,13 @@ CREATE INDEX index_events_on_organization_id_and_code ON public.events USING btr
 
 
 --
+-- Name: index_events_on_organization_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_on_organization_id_and_created_at ON public.events USING btree (organization_id, created_at DESC) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: index_fees_on_add_on_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11789,6 +11797,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260424170418'),
 ('20260421123920'),
 ('20260420114717'),
 ('20260416124233'),


### PR DESCRIPTION
## Context

This PR adds partial composite index on `events(organization_id, created_at DESC) WHERE deleted_at IS NULL`.

We missed this index and we had to sort all entries before returning paginated result, so the query was really slow and had blocked pending migrations.