### PR TITLE
fix(wallets): retry RefreshWalletJob on transient Nango/Anrok errors

### DIFF
--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -15,7 +15,7 @@ module Customers
 
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
     retry_on BaseService::TooManyProviderRequestsFailure, wait: :polynomially_longer, attempts: 25
-    retry_on *Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6
+    retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
 
     def perform(customer)
       return unless customer.awaiting_wallet_refresh?

--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -2,8 +2,6 @@
 
 module Customers
   class RefreshWalletJob < ApplicationJob
-    OUT_OF_MEMORY_ERROR = "function_runtime_out_of_memory"
-
     queue_as do
       customer = arguments.first
       if Utils::DedicatedWorkerConfig.enabled_for?(customer&.organization_id)
@@ -17,9 +15,7 @@ module Customers
 
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
     retry_on BaseService::TooManyProviderRequestsFailure, wait: :polynomially_longer, attempts: 25
-    retry_on Net::ReadTimeout,
-      Integrations::Aggregator::BadGatewayError,
-      Integrations::Aggregator::OutOfMemoryError, wait: :polynomially_longer, attempts: 6
+    retry_on *Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6
 
     def perform(customer)
       return unless customer.awaiting_wallet_refresh?
@@ -29,7 +25,6 @@ module Customers
     rescue BaseService::ValidationFailure => e
       tax_error = Array(e.messages[:tax_error])
 
-      raise Integrations::Aggregator::OutOfMemoryError if tax_error.any? { |msg| msg.include?(OUT_OF_MEMORY_ERROR) }
       raise unless tax_error.any? { |msg| msg.include?(Integrations::Aggregator::Taxes::BaseService::CUSTOMER_ADDRESS_INVALID) }
 
       ErrorDetails::CreateService.call!(

--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -10,6 +10,7 @@ module Invoices
       retry_on OpenSSL::SSL::SSLError, wait: :polynomially_longer, attempts: 6
       retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 6
       retry_on Net::OpenTimeout, wait: :polynomially_longer, attempts: 6
+      retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
       retry_on Customers::FailedToAcquireLock, ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: MAX_LOCK_RETRY_ATTEMPTS
 
       def perform(invoice:)

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -9,6 +9,14 @@ module Integrations
       REQUEST_LIMIT_ERROR_CODE = "SSS_REQUEST_LIMIT_EXCEEDED"
       BAD_GATEWAY_ERROR = "502 Bad Gateway"
 
+      def self.retryable_errors
+        [
+          BadGatewayError, RequestLimitError, OutOfMemoryError,
+          TaskInProgressError, TaskExpiredError, OrchestratorFailureError,
+          ServerContentionError, TimeoutError
+        ]
+      end
+
       def initialize(integration:, options: {})
         @integration = integration
         @options = options
@@ -177,6 +185,18 @@ module Integrations
       def bad_gateway_error?(http_error)
         http_error.error_code.to_s == "502" ||
           http_error.error_body.include?(BAD_GATEWAY_ERROR)
+      end
+
+      def task_in_progress_error?(http_error)
+        code(http_error) == "action_script_failure" && message(http_error).include?("is in progress")
+      end
+
+      def task_expired_error?(http_error)
+        code(http_error) == "action_script_failure" && message(http_error).include?("expired")
+      end
+
+      def orchestrator_failure_error?(http_error)
+        code(http_error) == "action_script_failure" && message(http_error).include?("/v1/immediate failed")
       end
 
       def parse_response(response)

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -8,6 +8,9 @@ module Integrations
       BASE_URL = "https://api.nango.dev/"
       REQUEST_LIMIT_ERROR_CODE = "SSS_REQUEST_LIMIT_EXCEEDED"
       BAD_GATEWAY_ERROR = "502 Bad Gateway"
+      TASK_IN_PROGRESS_PATTERN = /\bTask\b.*\bis in progress\b/.freeze
+      TASK_EXPIRED_PATTERN = /\bTask\b.*\bexpired\b/.freeze
+      ORCHESTRATOR_FAILURE_PATTERN = %r{POST https?://nango-orchestrator-svc\.nango/v1/immediate failed}.freeze
 
       def self.retryable_errors
         [
@@ -188,15 +191,15 @@ module Integrations
       end
 
       def task_in_progress_error?(http_error)
-        code(http_error) == "action_script_failure" && message(http_error).include?("is in progress")
+        code(http_error) == "action_script_failure" && TASK_IN_PROGRESS_PATTERN.match?(message(http_error))
       end
 
       def task_expired_error?(http_error)
-        code(http_error) == "action_script_failure" && message(http_error).include?("expired")
+        code(http_error) == "action_script_failure" && TASK_EXPIRED_PATTERN.match?(message(http_error))
       end
 
       def orchestrator_failure_error?(http_error)
-        code(http_error) == "action_script_failure" && message(http_error).include?("/v1/immediate failed")
+        code(http_error) == "action_script_failure" && ORCHESTRATOR_FAILURE_PATTERN.match?(message(http_error))
       end
 
       def parse_response(response)

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -8,9 +8,9 @@ module Integrations
       BASE_URL = "https://api.nango.dev/"
       REQUEST_LIMIT_ERROR_CODE = "SSS_REQUEST_LIMIT_EXCEEDED"
       BAD_GATEWAY_ERROR = "502 Bad Gateway"
-      TASK_IN_PROGRESS_PATTERN = /\bTask\b.*\bis in progress\b/.freeze
-      TASK_EXPIRED_PATTERN = /\bTask\b.*\bexpired\b/.freeze
-      ORCHESTRATOR_FAILURE_PATTERN = %r{POST https?://nango-orchestrator-svc\.nango/v1/immediate failed}.freeze
+      TASK_IN_PROGRESS_PATTERN = /\bTask\b.*\bis in progress\b/
+      TASK_EXPIRED_PATTERN = /\bTask\b.*\bexpired\b/
+      ORCHESTRATOR_FAILURE_PATTERN = %r{POST https?://nango-orchestrator-svc\.nango/v1/immediate failed}
 
       def self.retryable_errors
         [

--- a/app/services/integrations/aggregator/orchestrator_failure_error.rb
+++ b/app/services/integrations/aggregator/orchestrator_failure_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class OrchestratorFailureError < StandardError
+    end
+  end
+end

--- a/app/services/integrations/aggregator/server_contention_error.rb
+++ b/app/services/integrations/aggregator/server_contention_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class ServerContentionError < StandardError
+    end
+  end
+end

--- a/app/services/integrations/aggregator/task_expired_error.rb
+++ b/app/services/integrations/aggregator/task_expired_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class TaskExpiredError < StandardError
+    end
+  end
+end

--- a/app/services/integrations/aggregator/task_in_progress_error.rb
+++ b/app/services/integrations/aggregator/task_in_progress_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class TaskInProgressError < StandardError
+    end
+  end
+end

--- a/app/services/integrations/aggregator/taxes/base_service.rb
+++ b/app/services/integrations/aggregator/taxes/base_service.rb
@@ -6,6 +6,7 @@ module Integrations
       class BaseService < Integrations::Aggregator::BaseService
         SPECIAL_TAXATION_TYPES = %w[exempt notCollecting productNotTaxed jurisNotTaxed jurisHasNoTax].freeze
         CUSTOMER_ADDRESS_INVALID = "customerAddressCouldNotResolve"
+        OUT_OF_MEMORY_ERROR = "function_runtime_out_of_memory"
 
         def initialize
           super(integration:)
@@ -61,13 +62,10 @@ module Integrations
           else
             code, message = retrieve_error_details(body["failedInvoices"].first["validation_errors"])
 
-            # Temp fix for the API limit issue
-            message = "API limit" if message == "Internal server error: resource contention."
+            raise Integrations::Aggregator::OutOfMemoryError if message.include?(OUT_OF_MEMORY_ERROR)
+            raise Integrations::Aggregator::ServerContentionError, message if server_contention_error?(message)
 
-            unless message.include?("API limit")
-              deliver_tax_error_webhook(customer:, code:, message:) if customer.persisted? # Do not send this webhook in preview mode
-            end
-
+            deliver_tax_error_webhook(customer:, code:, message:) if customer.persisted? # Do not send this webhook in preview mode
             result.service_failure!(code:, message:)
           end
         end
@@ -107,6 +105,10 @@ module Integrations
               )
             end
           end
+        end
+
+        def server_contention_error?(message)
+          message.include?("API limit") || message.include?("resource contention")
         end
 
         def retrieve_error_details(validation_error)

--- a/app/services/integrations/aggregator/taxes/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/base_service.rb
@@ -25,8 +25,11 @@ module Integrations
               result.invoice_id = invoice_id
             else
               code, message = retrieve_error_details(body["failedInvoices"].first["validation_errors"])
-              deliver_tax_error_webhook(customer:, code:, message:)
 
+              raise Integrations::Aggregator::OutOfMemoryError if message.include?(OUT_OF_MEMORY_ERROR)
+              raise Integrations::Aggregator::ServerContentionError, message if server_contention_error?(message)
+
+              deliver_tax_error_webhook(customer:, code:, message:)
               result.service_failure!(code:, message:)
             end
           end

--- a/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
@@ -24,11 +24,16 @@ module Integrations
           rescue LagoHttpClient::HttpError => e
             raise RequestLimitError(e) if request_limit_error?(e)
             raise Integrations::Aggregator::BadGatewayError.new(e.error_body, e.uri) if bad_gateway_error?(e)
+            raise Integrations::Aggregator::TaskInProgressError if task_in_progress_error?(e)
+            raise Integrations::Aggregator::TaskExpiredError if task_expired_error?(e)
+            raise Integrations::Aggregator::OrchestratorFailureError if orchestrator_failure_error?(e)
 
             code = code(e)
             message = message(e)
 
             result.service_failure!(code:, message:)
+          rescue Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError => e
+            raise Integrations::Aggregator::TimeoutError, e.message
           end
 
           private

--- a/app/services/integrations/aggregator/taxes/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_service.rb
@@ -26,11 +26,16 @@ module Integrations
           rescue LagoHttpClient::HttpError => e
             raise Integrations::Aggregator::RequestLimitError(e) if request_limit_error?(e)
             raise Integrations::Aggregator::BadGatewayError.new(e.error_body, e.uri) if bad_gateway_error?(e)
+            raise Integrations::Aggregator::TaskInProgressError if task_in_progress_error?(e)
+            raise Integrations::Aggregator::TaskExpiredError if task_expired_error?(e)
+            raise Integrations::Aggregator::OrchestratorFailureError if orchestrator_failure_error?(e)
 
             code = code(e)
             message = message(e)
 
             result.service_failure!(code:, message:)
+          rescue Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError => e
+            raise Integrations::Aggregator::TimeoutError, e.message
           end
 
           private

--- a/app/services/integrations/aggregator/taxes/invoices/negate_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/negate_service.rb
@@ -21,11 +21,17 @@ module Integrations
             result
           rescue LagoHttpClient::HttpError => e
             raise RequestLimitError(e) if request_limit_error?(e)
+            raise Integrations::Aggregator::BadGatewayError.new(e.error_body, e.uri) if bad_gateway_error?(e)
+            raise Integrations::Aggregator::TaskInProgressError if task_in_progress_error?(e)
+            raise Integrations::Aggregator::TaskExpiredError if task_expired_error?(e)
+            raise Integrations::Aggregator::OrchestratorFailureError if orchestrator_failure_error?(e)
 
             code = code(e)
             message = message(e)
 
             result.service_failure!(code:, message:)
+          rescue Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError => e
+            raise Integrations::Aggregator::TimeoutError, e.message
           end
 
           private

--- a/app/services/integrations/aggregator/taxes/invoices/void_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/void_service.rb
@@ -21,11 +21,17 @@ module Integrations
             result
           rescue LagoHttpClient::HttpError => e
             raise RequestLimitError(e) if request_limit_error?(e)
+            raise Integrations::Aggregator::BadGatewayError.new(e.error_body, e.uri) if bad_gateway_error?(e)
+            raise Integrations::Aggregator::TaskInProgressError if task_in_progress_error?(e)
+            raise Integrations::Aggregator::TaskExpiredError if task_expired_error?(e)
+            raise Integrations::Aggregator::OrchestratorFailureError if orchestrator_failure_error?(e)
 
             code = code(e)
             message = message(e)
 
             result.service_failure!(code:, message:)
+          rescue Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError => e
+            raise Integrations::Aggregator::TimeoutError, e.message
           end
 
           private

--- a/app/services/integrations/aggregator/timeout_error.rb
+++ b/app/services/integrations/aggregator/timeout_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class TimeoutError < StandardError
+    end
+  end
+end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -310,7 +310,7 @@ module Invoices
       else
         apply_zero_tax
       end
-    rescue BaseService::ThrottlingError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError
+    rescue BaseService::ThrottlingError, *Integrations::Aggregator::BaseService.retryable_errors
       apply_zero_tax
     end
 

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -86,13 +86,85 @@ RSpec.describe Customers::RefreshWalletJob do
         end
 
         context "when the error is an out of memory error" do
-          let(:result) { BaseService::Result.new.validation_failure!(errors: {tax_error: ["function_runtime_out_of_memory"]}) }
+          before do
+            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::OutOfMemoryError)
+          end
 
           it "raises the error and retries the job" do
             assert_performed_jobs(6, only: [described_class]) do
               expect do
                 described_class.perform_later(customer)
               end.to raise_error(Integrations::Aggregator::OutOfMemoryError)
+            end
+          end
+        end
+
+        context "when the error is a task in progress error" do
+          before do
+            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::TaskInProgressError)
+          end
+
+          it "raises the error and retries the job" do
+            assert_performed_jobs(6, only: [described_class]) do
+              expect do
+                described_class.perform_later(customer)
+              end.to raise_error(Integrations::Aggregator::TaskInProgressError)
+            end
+          end
+        end
+
+        context "when the error is a task expired error" do
+          before do
+            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::TaskExpiredError)
+          end
+
+          it "raises the error and retries the job" do
+            assert_performed_jobs(6, only: [described_class]) do
+              expect do
+                described_class.perform_later(customer)
+              end.to raise_error(Integrations::Aggregator::TaskExpiredError)
+            end
+          end
+        end
+
+        context "when the error is an orchestrator failure error" do
+          before do
+            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::OrchestratorFailureError)
+          end
+
+          it "raises the error and retries the job" do
+            assert_performed_jobs(6, only: [described_class]) do
+              expect do
+                described_class.perform_later(customer)
+              end.to raise_error(Integrations::Aggregator::OrchestratorFailureError)
+            end
+          end
+        end
+
+        context "when the error is a server contention error" do
+          before do
+            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::ServerContentionError)
+          end
+
+          it "raises the error and retries the job" do
+            assert_performed_jobs(6, only: [described_class]) do
+              expect do
+                described_class.perform_later(customer)
+              end.to raise_error(Integrations::Aggregator::ServerContentionError)
+            end
+          end
+        end
+
+        context "when the error is a timeout error" do
+          before do
+            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::TimeoutError)
+          end
+
+          it "raises the error and retries the job" do
+            assert_performed_jobs(6, only: [described_class]) do
+              expect do
+                described_class.perform_later(customer)
+              end.to raise_error(Integrations::Aggregator::TimeoutError)
             end
           end
         end

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -85,86 +85,25 @@ RSpec.describe Customers::RefreshWalletJob do
           end
         end
 
-        context "when the error is an out of memory error" do
-          before do
-            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::OutOfMemoryError)
-          end
-
-          it "raises the error and retries the job" do
-            assert_performed_jobs(6, only: [described_class]) do
-              expect do
-                described_class.perform_later(customer)
-              end.to raise_error(Integrations::Aggregator::OutOfMemoryError)
+        [
+          Integrations::Aggregator::OutOfMemoryError,
+          Integrations::Aggregator::TaskInProgressError,
+          Integrations::Aggregator::TaskExpiredError,
+          Integrations::Aggregator::OrchestratorFailureError,
+          Integrations::Aggregator::ServerContentionError,
+          Integrations::Aggregator::TimeoutError
+        ].each do |error_class|
+          context "when the error is #{error_class.name.demodulize.underscore.humanize.downcase}" do
+            before do
+              allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(error_class)
             end
-          end
-        end
 
-        context "when the error is a task in progress error" do
-          before do
-            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::TaskInProgressError)
-          end
-
-          it "raises the error and retries the job" do
-            assert_performed_jobs(6, only: [described_class]) do
-              expect do
-                described_class.perform_later(customer)
-              end.to raise_error(Integrations::Aggregator::TaskInProgressError)
-            end
-          end
-        end
-
-        context "when the error is a task expired error" do
-          before do
-            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::TaskExpiredError)
-          end
-
-          it "raises the error and retries the job" do
-            assert_performed_jobs(6, only: [described_class]) do
-              expect do
-                described_class.perform_later(customer)
-              end.to raise_error(Integrations::Aggregator::TaskExpiredError)
-            end
-          end
-        end
-
-        context "when the error is an orchestrator failure error" do
-          before do
-            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::OrchestratorFailureError)
-          end
-
-          it "raises the error and retries the job" do
-            assert_performed_jobs(6, only: [described_class]) do
-              expect do
-                described_class.perform_later(customer)
-              end.to raise_error(Integrations::Aggregator::OrchestratorFailureError)
-            end
-          end
-        end
-
-        context "when the error is a server contention error" do
-          before do
-            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::ServerContentionError)
-          end
-
-          it "raises the error and retries the job" do
-            assert_performed_jobs(6, only: [described_class]) do
-              expect do
-                described_class.perform_later(customer)
-              end.to raise_error(Integrations::Aggregator::ServerContentionError)
-            end
-          end
-        end
-
-        context "when the error is a timeout error" do
-          before do
-            allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(Integrations::Aggregator::TimeoutError)
-          end
-
-          it "raises the error and retries the job" do
-            assert_performed_jobs(6, only: [described_class]) do
-              expect do
-                described_class.perform_later(customer)
-              end.to raise_error(Integrations::Aggregator::TimeoutError)
+            it "raises the error and retries the job" do
+              assert_performed_jobs(6, only: [described_class]) do
+                expect do
+                  described_class.perform_later(customer)
+                end.to raise_error(error_class)
+              end
             end
           end
         end

--- a/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
@@ -29,7 +29,15 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob do
       [LagoHttpClient::HttpError.new(401, "body", "uri"), 6],
       [OpenSSL::SSL::SSLError.new("OpenSSL::SSL::SSLError"), 6],
       [Net::ReadTimeout.new("Net::ReadTimeout"), 6],
-      [Net::OpenTimeout.new("Net::OpenTimeout"), 6]
+      [Net::OpenTimeout.new("Net::OpenTimeout"), 6],
+      [Integrations::Aggregator::BadGatewayError.new("body", "uri"), 6],
+      [Integrations::Aggregator::RequestLimitError.new(LagoHttpClient::HttpError.new(429, "limit", "uri")), 6],
+      [Integrations::Aggregator::OutOfMemoryError.new, 6],
+      [Integrations::Aggregator::TaskInProgressError.new, 6],
+      [Integrations::Aggregator::TaskExpiredError.new, 6],
+      [Integrations::Aggregator::OrchestratorFailureError.new, 6],
+      [Integrations::Aggregator::ServerContentionError.new, 6],
+      [Integrations::Aggregator::TimeoutError.new, 6]
     ].each do |error, attempts|
       error_class = error.class
 

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -312,6 +312,41 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
           expect(result.error.code).to eq("action_script_runtime_error")
         end
       end
+
+      context "when it is a task in progress error" do
+        let(:response_status) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Task is in progress"}}.to_json }
+
+        it "raises TaskInProgressError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TaskInProgressError)
+        end
+      end
+
+      context "when it is a task expired error" do
+        let(:response_status) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Task has expired"}}.to_json }
+
+        it "raises TaskExpiredError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TaskExpiredError)
+        end
+      end
+
+      context "when it is an orchestrator failure error" do
+        let(:response_status) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Call to /v1/immediate failed"}}.to_json }
+
+        it "raises OrchestratorFailureError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::OrchestratorFailureError)
+        end
+      end
+
+      context "when a network timeout occurs" do
+        before { stub_request(:post, endpoint).to_raise(Net::ReadTimeout) }
+
+        it "raises TimeoutError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TimeoutError)
+        end
+      end
     end
   end
 end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -253,6 +253,26 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
             expect { service_call }.to raise_error(Integrations::Aggregator::BadGatewayError)
           end
         end
+
+        context "when it is an out of memory error" do
+          let(:body) do
+            {"succeededInvoices" => [], "failedInvoices" => [{"validation_errors" => "function_runtime_out_of_memory"}]}.to_json
+          end
+
+          it "raises OutOfMemoryError" do
+            expect { service_call }.to raise_error(Integrations::Aggregator::OutOfMemoryError)
+          end
+        end
+
+        context "when it is a server contention error" do
+          let(:body) do
+            {"succeededInvoices" => [], "failedInvoices" => [{"validation_errors" => "API limit exceeded"}]}.to_json
+          end
+
+          it "raises ServerContentionError" do
+            expect { service_call }.to raise_error(Integrations::Aggregator::ServerContentionError)
+          end
+        end
       end
     end
 
@@ -315,7 +335,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
 
       context "when it is a task in progress error" do
         let(:response_status) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Task is in progress"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "Task abc12345-1234-1234-1234-abc123456789 is in progress"}}.to_json }
 
         it "raises TaskInProgressError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::TaskInProgressError)
@@ -324,7 +344,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
 
       context "when it is a task expired error" do
         let(:response_status) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Task has expired"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "Task abc12345-1234-1234-1234-abc123456789 expired"}}.to_json }
 
         it "raises TaskExpiredError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::TaskExpiredError)
@@ -333,7 +353,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
 
       context "when it is an orchestrator failure error" do
         let(:response_status) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Call to /v1/immediate failed"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "POST http://nango-orchestrator-svc.nango/v1/immediate failed"}}.to_json }
 
         it "raises OrchestratorFailureError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::OrchestratorFailureError)

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -375,6 +375,8 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
       end
 
       context "when a network timeout occurs" do
+        let(:body) { "" }
+
         before { stub_request(:post, endpoint).to_raise(Net::ReadTimeout) }
 
         it "raises TimeoutError" do

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -346,6 +346,41 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
           expect(result.error.code).to eq("action_script_runtime_error")
         end
       end
+
+      context "when it is a task in progress error" do
+        let(:response_status) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Task is in progress"}}.to_json }
+
+        it "raises TaskInProgressError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TaskInProgressError)
+        end
+      end
+
+      context "when it is a task expired error" do
+        let(:response_status) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Task has expired"}}.to_json }
+
+        it "raises TaskExpiredError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TaskExpiredError)
+        end
+      end
+
+      context "when it is an orchestrator failure error" do
+        let(:response_status) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Call to /v1/immediate failed"}}.to_json }
+
+        it "raises OrchestratorFailureError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::OrchestratorFailureError)
+        end
+      end
+
+      context "when a network timeout occurs" do
+        before { stub_request(:post, endpoint).to_raise(Net::ReadTimeout) }
+
+        it "raises TimeoutError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TimeoutError)
+        end
+      end
     end
   end
 end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -317,6 +317,26 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
             expect { service_call }.to raise_error(Integrations::Aggregator::BadGatewayError)
           end
         end
+
+        context "when it is an out of memory error" do
+          let(:body) do
+            {"succeededInvoices" => [], "failedInvoices" => [{"validation_errors" => "function_runtime_out_of_memory"}]}.to_json
+          end
+
+          it "raises OutOfMemoryError" do
+            expect { service_call }.to raise_error(Integrations::Aggregator::OutOfMemoryError)
+          end
+        end
+
+        context "when it is a server contention error" do
+          let(:body) do
+            {"succeededInvoices" => [], "failedInvoices" => [{"validation_errors" => "API limit exceeded"}]}.to_json
+          end
+
+          it "raises ServerContentionError" do
+            expect { service_call }.to raise_error(Integrations::Aggregator::ServerContentionError)
+          end
+        end
       end
     end
 
@@ -349,7 +369,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
 
       context "when it is a task in progress error" do
         let(:response_status) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Task is in progress"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "Task abc12345-1234-1234-1234-abc123456789 is in progress"}}.to_json }
 
         it "raises TaskInProgressError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::TaskInProgressError)
@@ -358,7 +378,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
 
       context "when it is a task expired error" do
         let(:response_status) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Task has expired"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "Task abc12345-1234-1234-1234-abc123456789 expired"}}.to_json }
 
         it "raises TaskExpiredError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::TaskExpiredError)
@@ -367,7 +387,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
 
       context "when it is an orchestrator failure error" do
         let(:response_status) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Call to /v1/immediate failed"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "POST http://nango-orchestrator-svc.nango/v1/immediate failed"}}.to_json }
 
         it "raises OrchestratorFailureError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::OrchestratorFailureError)

--- a/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
@@ -162,6 +162,8 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
       end
 
       context "when a network timeout occurs" do
+        let(:error_code) { 500 }
+
         before do
           allow(lago_client).to receive(:post_with_response).with(params, headers).and_raise(Net::ReadTimeout)
         end

--- a/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
@@ -133,6 +133,43 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
           expect(result.error.code).to eq("action_script_runtime_error")
         end
       end
+
+      context "when it is a task in progress error" do
+        let(:error_code) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Task is in progress"}}.to_json }
+
+        it "raises TaskInProgressError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TaskInProgressError)
+        end
+      end
+
+      context "when it is a task expired error" do
+        let(:error_code) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Task has expired"}}.to_json }
+
+        it "raises TaskExpiredError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TaskExpiredError)
+        end
+      end
+
+      context "when it is an orchestrator failure error" do
+        let(:error_code) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Call to /v1/immediate failed"}}.to_json }
+
+        it "raises OrchestratorFailureError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::OrchestratorFailureError)
+        end
+      end
+
+      context "when a network timeout occurs" do
+        before do
+          allow(lago_client).to receive(:post_with_response).with(params, headers).and_raise(Net::ReadTimeout)
+        end
+
+        it "raises TimeoutError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TimeoutError)
+        end
+      end
     end
   end
 end

--- a/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
@@ -106,6 +106,26 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
               }
             )
         end
+
+        context "when the response contains an out of memory error" do
+          let(:body) do
+            {"succeededInvoices" => [], "failedInvoices" => [{"validation_errors" => "function_runtime_out_of_memory"}]}.to_json
+          end
+
+          it "raises OutOfMemoryError" do
+            expect { service_call }.to raise_error(Integrations::Aggregator::OutOfMemoryError)
+          end
+        end
+
+        context "when the response contains a server contention error" do
+          let(:body) do
+            {"succeededInvoices" => [], "failedInvoices" => [{"validation_errors" => "API limit exceeded"}]}.to_json
+          end
+
+          it "raises ServerContentionError" do
+            expect { service_call }.to raise_error(Integrations::Aggregator::ServerContentionError)
+          end
+        end
       end
     end
 
@@ -136,7 +156,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
 
       context "when it is a task in progress error" do
         let(:error_code) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Task is in progress"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "Task abc12345-1234-1234-1234-abc123456789 is in progress"}}.to_json }
 
         it "raises TaskInProgressError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::TaskInProgressError)
@@ -145,7 +165,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
 
       context "when it is a task expired error" do
         let(:error_code) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Task has expired"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "Task abc12345-1234-1234-1234-abc123456789 expired"}}.to_json }
 
         it "raises TaskExpiredError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::TaskExpiredError)
@@ -154,7 +174,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
 
       context "when it is an orchestrator failure error" do
         let(:error_code) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Call to /v1/immediate failed"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "POST http://nango-orchestrator-svc.nango/v1/immediate failed"}}.to_json }
 
         it "raises OrchestratorFailureError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::OrchestratorFailureError)

--- a/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
@@ -169,6 +169,43 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
           expect(result.error.code).to eq("action_script_runtime_error")
         end
       end
+
+      context "when it is a task in progress error" do
+        let(:error_code) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Task is in progress"}}.to_json }
+
+        it "raises TaskInProgressError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TaskInProgressError)
+        end
+      end
+
+      context "when it is a task expired error" do
+        let(:error_code) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Task has expired"}}.to_json }
+
+        it "raises TaskExpiredError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TaskExpiredError)
+        end
+      end
+
+      context "when it is an orchestrator failure error" do
+        let(:error_code) { 500 }
+        let(:body) { {error: {code: "action_script_failure", message: "Call to /v1/immediate failed"}}.to_json }
+
+        it "raises OrchestratorFailureError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::OrchestratorFailureError)
+        end
+      end
+
+      context "when a network timeout occurs" do
+        before do
+          allow(lago_client).to receive(:post_with_response).with(params, headers).and_raise(Net::ReadTimeout)
+        end
+
+        it "raises TimeoutError" do
+          expect { service_call }.to raise_error(Integrations::Aggregator::TimeoutError)
+        end
+      end
     end
   end
 end

--- a/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
@@ -142,6 +142,26 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
               }
             )
         end
+
+        context "when the response contains an out of memory error" do
+          let(:body) do
+            {"succeededInvoices" => [], "failedInvoices" => [{"validation_errors" => "function_runtime_out_of_memory"}]}.to_json
+          end
+
+          it "raises OutOfMemoryError" do
+            expect { service_call }.to raise_error(Integrations::Aggregator::OutOfMemoryError)
+          end
+        end
+
+        context "when the response contains a server contention error" do
+          let(:body) do
+            {"succeededInvoices" => [], "failedInvoices" => [{"validation_errors" => "API limit exceeded"}]}.to_json
+          end
+
+          it "raises ServerContentionError" do
+            expect { service_call }.to raise_error(Integrations::Aggregator::ServerContentionError)
+          end
+        end
       end
     end
 
@@ -172,7 +192,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
 
       context "when it is a task in progress error" do
         let(:error_code) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Task is in progress"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "Task abc12345-1234-1234-1234-abc123456789 is in progress"}}.to_json }
 
         it "raises TaskInProgressError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::TaskInProgressError)
@@ -181,7 +201,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
 
       context "when it is a task expired error" do
         let(:error_code) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Task has expired"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "Task abc12345-1234-1234-1234-abc123456789 expired"}}.to_json }
 
         it "raises TaskExpiredError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::TaskExpiredError)
@@ -190,7 +210,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
 
       context "when it is an orchestrator failure error" do
         let(:error_code) { 500 }
-        let(:body) { {error: {code: "action_script_failure", message: "Call to /v1/immediate failed"}}.to_json }
+        let(:body) { {error: {code: "action_script_failure", message: "POST http://nango-orchestrator-svc.nango/v1/immediate failed"}}.to_json }
 
         it "raises OrchestratorFailureError" do
           expect { service_call }.to raise_error(Integrations::Aggregator::OrchestratorFailureError)

--- a/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
@@ -198,6 +198,8 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
       end
 
       context "when a network timeout occurs" do
+        let(:error_code) { 500 }
+
         before do
           allow(lago_client).to receive(:post_with_response).with(params, headers).and_raise(Net::ReadTimeout)
         end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -1625,7 +1625,7 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
           context "when there is Net::OpenTimeout error" do
             before do
               allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:new)
-                .and_raise(Net::OpenTimeout)
+                .and_raise(Integrations::Aggregator::TimeoutError)
             end
 
             it "uses zero taxes" do

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -441,25 +441,13 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
           File.read(p)
         end
 
-        it "puts invoice in failed status" do
-          result = pull_taxes_service.call
-
-          expect(result).to be_success
-          expect(invoice.reload.status).to eq("failed")
+        it "raises ServerContentionError so the job can retry" do
+          expect { pull_taxes_service.call }.to raise_error(Integrations::Aggregator::ServerContentionError)
         end
 
-        it "resolves old tax error and creates new one" do
-          old_error_id = invoice.reload.error_details.last.id
-
-          pull_taxes_service.call
-
-          expect(invoice.error_details.tax_error.last.id).not_to eql(old_error_id)
-          expect(invoice.error_details.tax_error.count).to be(1)
-          expect(invoice.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
-          expect(invoice.error_details.tax_error.order(created_at: :asc).last.details["tax_error"])
-            .to eq("validationError")
-          expect(invoice.error_details.tax_error.order(created_at: :asc).last.details["tax_error_message"])
-            .to eq("You've exceeded your API limit of 10 per second")
+        it "does not change the invoice status" do
+          expect { pull_taxes_service.call }.to raise_error(Integrations::Aggregator::ServerContentionError)
+          expect(invoice.reload.status).not_to eq("failed")
         end
       end
 


### PR DESCRIPTION
## Context

`Customers::RefreshWalletJob` was dying permanently on any transient Nango/Anrok error that wasn't one of the two patterns already hard-coded in its rescue block (`function_runtime_out_of_memory` and `customerAddressCouldNotResolve`).
Transient conditions, Nango task-queue delays, orchestrator POST failures, response-body rate limits, all fell through to `result.service_failure!`, got wrapped as `validation_failure!(errors: {tax_error: [...]})` by `CustomerUsageService`, and re-raised as `BaseService::ValidationFailure`, which has no `retry_on` in the job. The 12-hour uniqueness lock then blocked re-enqueue until expiry.
We were seing a lot of occurrences on observability channels, with bursts of ~10 dead jobs per 15-second window during Anrok rate-limit spikes.

## Description

Introduced five new retryable error classes under `Integrations::Aggregator` (`TaskInProgressError`, `TaskExpiredError`, `OrchestratorFailureError`, `ServerContentionError`, `TimeoutError`) and added a canonical `retryable_errors` class method on `BaseService` that returns the full list.

Transient conditions are now raised before reaching `service_failure!`:
- `action_script_failure` HTTP errors (task in progress / expired / orchestrator failure) are detected via new predicates in `Aggregator::BaseService` and raised from the HTTP rescue block of all four tax invoice services.
- Response-body rate limits and resource contention are detected in `process_response` and `process_void_response` and raised as `ServerContentionError`.
- Network timeouts (`Net::ReadTimeout`, `Net::OpenTimeout`, `OpenSSL::SSL::SSLError`) are caught in the same rescue block and re-raised as `TimeoutError`.

`RefreshWalletJob` now uses `retry_on *Integrations::Aggregator::BaseService.retryable_errors` instead of the previous ad-hoc list, and its rescue block is simplified to only handle the one non-transient case (`customerAddressCouldNotResolve`). `PreviewService` uses the same list to fall back to zero-tax on any aggregator transient, replacing the previous explicit list of network error types.