### PR TITLE
fix(payment_receipts): retry mailer when PDF files are missing

### DIFF
--- a/app/jobs/send_email_job.rb
+++ b/app/jobs/send_email_job.rb
@@ -37,6 +37,7 @@ class SendEmailJob < ActionMailer::MailDeliveryJob
   retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 6
   retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 6
   retry_on Net::SMTPServerBusy, wait: :polynomially_longer, attempts: 25
+  retry_on PaymentReceipts::FilesNotReadyError, wait: :polynomially_longer, attempts: 8
 
   after_discard { |job, error| job.log(error:) }
 

--- a/app/mailers/payment_receipt_mailer.rb
+++ b/app/mailers/payment_receipt_mailer.rb
@@ -12,10 +12,11 @@ class PaymentReceiptMailer < DocumentMailer
   def ensure_pdf
     PaymentReceipts::GeneratePdfService.new(payment_receipt: document).call
 
-    raise PaymentReceipts::FilesNotReadyError, "payment_receipt #{document.id} file missing" if document.file.blank?
+    raise PaymentReceipts::FilesNotReadyError, "payment_receipt #{document.id} file missing" unless document.file.attached?
 
     invoices = document.payment.payable.is_a?(Invoice) ? [document.payment.payable] : document.payment.payable.invoices
-    raise PaymentReceipts::FilesNotReadyError, "one or more invoice files missing" if invoices.any? { |invoice| !invoice.file.attached? }
+    missing_invoice_ids = invoices.reject { |invoice| invoice.file.attached? }.map(&:id)
+    raise PaymentReceipts::FilesNotReadyError, "invoice files missing: #{missing_invoice_ids.join(", ")}" if missing_invoice_ids.any?
   end
 
   def create_mail

--- a/app/mailers/payment_receipt_mailer.rb
+++ b/app/mailers/payment_receipt_mailer.rb
@@ -12,12 +12,10 @@ class PaymentReceiptMailer < DocumentMailer
   def ensure_pdf
     PaymentReceipts::GeneratePdfService.new(payment_receipt: document).call
 
+    invoices = document.payment.payable.is_a?(Invoice) ? [document.payment.payable] : document.payment.payable.invoices
+
     raise PaymentReceipts::FilesNotReadyError unless document.file.attached?
     raise PaymentReceipts::FilesNotReadyError unless invoices.all? { |invoice| invoice.file.attached? }
-  end
-
-  def invoices
-    @invoices ||= document.payment.payable.is_a?(Invoice) ? [document.payment.payable] : document.payment.payable.invoices
   end
 
   def create_mail

--- a/app/mailers/payment_receipt_mailer.rb
+++ b/app/mailers/payment_receipt_mailer.rb
@@ -12,11 +12,12 @@ class PaymentReceiptMailer < DocumentMailer
   def ensure_pdf
     PaymentReceipts::GeneratePdfService.new(payment_receipt: document).call
 
-    raise PaymentReceipts::FilesNotReadyError, "payment_receipt #{document.id} file missing" unless document.file.attached?
+    raise PaymentReceipts::FilesNotReadyError unless document.file.attached?
+    raise PaymentReceipts::FilesNotReadyError unless invoices.all? { |invoice| invoice.file.attached? }
+  end
 
-    invoices = document.payment.payable.is_a?(Invoice) ? [document.payment.payable] : document.payment.payable.invoices
-    missing_invoice_ids = invoices.reject { |invoice| invoice.file.attached? }.map(&:id)
-    raise PaymentReceipts::FilesNotReadyError, "invoice files missing: #{missing_invoice_ids.join(", ")}" if missing_invoice_ids.any?
+  def invoices
+    @invoices ||= document.payment.payable.is_a?(Invoice) ? [document.payment.payable] : document.payment.payable.invoices
   end
 
   def create_mail

--- a/app/mailers/payment_receipt_mailer.rb
+++ b/app/mailers/payment_receipt_mailer.rb
@@ -11,6 +11,11 @@ class PaymentReceiptMailer < DocumentMailer
 
   def ensure_pdf
     PaymentReceipts::GeneratePdfService.new(payment_receipt: document).call
+
+    raise PaymentReceipts::FilesNotReadyError, "payment_receipt #{document.id} file missing" if document.file.blank?
+
+    invoices = document.payment.payable.is_a?(Invoice) ? [document.payment.payable] : document.payment.payable.invoices
+    raise PaymentReceipts::FilesNotReadyError, "one or more invoice files missing" if invoices.any? { |invoice| !invoice.file.attached? }
   end
 
   def create_mail

--- a/app/services/payment_receipts/files_not_ready_error.rb
+++ b/app/services/payment_receipts/files_not_ready_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module PaymentReceipts
+  class FilesNotReadyError < StandardError; end
+end

--- a/spec/jobs/send_email_job_spec.rb
+++ b/spec/jobs/send_email_job_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe SendEmailJob do
     end
   end
 
+  describe "retry configuration" do
+    it "retries on PaymentReceipts::FilesNotReadyError" do
+      matcher = described_class.rescue_handlers.find { |klass, _| klass == "PaymentReceipts::FilesNotReadyError" }
+      expect(matcher).not_to be_nil
+    end
+  end
+
   context "when delivery fails with retryable error" do
     before { allow_any_instance_of(Mail::Message).to receive(:deliver).and_raise(error) }
 

--- a/spec/mailers/payment_receipt_mailer_spec.rb
+++ b/spec/mailers/payment_receipt_mailer_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PaymentReceiptMailer do
       it "raises FilesNotReadyError" do
         expect {
           payment_receipt_mailer.with(payment_receipt:).created
-        }.to raise_error(PaymentReceipts::FilesNotReadyError, /payment_receipt .* file missing/)
+        }.to raise_error(PaymentReceipts::FilesNotReadyError)
 
         expect(PaymentReceipts::GeneratePdfService).to have_received(:new)
       end
@@ -58,10 +58,10 @@ RSpec.describe PaymentReceiptMailer do
     context "when an invoice file is missing" do
       before { invoice.file.purge }
 
-      it "raises FilesNotReadyError including the missing invoice id" do
+      it "raises FilesNotReadyError" do
         expect {
           payment_receipt_mailer.with(payment_receipt:).created
-        }.to raise_error(PaymentReceipts::FilesNotReadyError, /invoice files missing: #{invoice.id}/)
+        }.to raise_error(PaymentReceipts::FilesNotReadyError)
       end
     end
 

--- a/spec/mailers/payment_receipt_mailer_spec.rb
+++ b/spec/mailers/payment_receipt_mailer_spec.rb
@@ -89,10 +89,10 @@ RSpec.describe PaymentReceiptMailer do
       end
 
       context "when one invoice in the request is missing its file" do
-        it "raises FilesNotReadyError including the missing invoice id" do
+        it "raises FilesNotReadyError" do
           expect {
             payment_receipt_mailer.with(payment_receipt:).created
-          }.to raise_error(PaymentReceipts::FilesNotReadyError, /invoice files missing: #{other_invoice.id}/)
+          }.to raise_error(PaymentReceipts::FilesNotReadyError)
         end
       end
     end

--- a/spec/mailers/payment_receipt_mailer_spec.rb
+++ b/spec/mailers/payment_receipt_mailer_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe PaymentReceiptMailer do
 
       it "raises FilesNotReadyError" do
         expect {
-          payment_receipt_mailer.with(payment_receipt:).created
+          payment_receipt_mailer.with(payment_receipt:).created.deliver_now
         }.to raise_error(PaymentReceipts::FilesNotReadyError)
 
         expect(PaymentReceipts::GeneratePdfService).to have_received(:new)
@@ -60,7 +60,7 @@ RSpec.describe PaymentReceiptMailer do
 
       it "raises FilesNotReadyError" do
         expect {
-          payment_receipt_mailer.with(payment_receipt:).created
+          payment_receipt_mailer.with(payment_receipt:).created.deliver_now
         }.to raise_error(PaymentReceipts::FilesNotReadyError)
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe PaymentReceiptMailer do
       context "when one invoice in the request is missing its file" do
         it "raises FilesNotReadyError" do
           expect {
-            payment_receipt_mailer.with(payment_receipt:).created
+            payment_receipt_mailer.with(payment_receipt:).created.deliver_now
           }.to raise_error(PaymentReceipts::FilesNotReadyError)
         end
       end

--- a/spec/mailers/payment_receipt_mailer_spec.rb
+++ b/spec/mailers/payment_receipt_mailer_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe PaymentReceiptMailer do
     end
 
     context "when pdfs are disabled" do
-      before { ENV["LAGO_DISABLE_PDF_GENERATION"] = "true" }
+      around do |example|
+        ENV["LAGO_DISABLE_PDF_GENERATION"] = "true"
+        example.run
+        ENV.delete("LAGO_DISABLE_PDF_GENERATION")
+      end
 
       it "does not attach the pdf" do
         mailer = payment_receipt_mailer.with(payment_receipt:).created
@@ -54,10 +58,42 @@ RSpec.describe PaymentReceiptMailer do
     context "when an invoice file is missing" do
       before { invoice.file.purge }
 
-      it "raises FilesNotReadyError" do
+      it "raises FilesNotReadyError including the missing invoice id" do
         expect {
           payment_receipt_mailer.with(payment_receipt:).created
-        }.to raise_error(PaymentReceipts::FilesNotReadyError, /invoice files missing/)
+        }.to raise_error(PaymentReceipts::FilesNotReadyError, /invoice files missing: #{invoice.id}/)
+      end
+    end
+
+    context "when the payment is for a payment request covering multiple invoices" do
+      let(:other_invoice) { create(:invoice, organization: invoice.organization, customer: invoice.customer) }
+      let(:payment_request) do
+        create(:payment_request, organization: invoice.organization, customer: invoice.customer, invoices: [invoice, other_invoice])
+      end
+
+      before do
+        payment_receipt.payment.update!(payable: payment_request)
+        allow(other_invoice).to receive(:file_url).and_return("https://example.com/other.pdf")
+      end
+
+      context "when every invoice has a file attached" do
+        before do
+          other_invoice.file.attach(io: File.open(Rails.root.join("spec/fixtures/blank.pdf")), filename: "blank.pdf")
+        end
+
+        it "renders the email" do
+          mailer = payment_receipt_mailer.with(payment_receipt:).created
+
+          expect(mailer.to).to eq([payment_request.customer.email])
+        end
+      end
+
+      context "when one invoice in the request is missing its file" do
+        it "raises FilesNotReadyError including the missing invoice id" do
+          expect {
+            payment_receipt_mailer.with(payment_receipt:).created
+          }.to raise_error(PaymentReceipts::FilesNotReadyError, /invoice files missing: #{other_invoice.id}/)
+        end
       end
     end
 

--- a/spec/mailers/payment_receipt_mailer_spec.rb
+++ b/spec/mailers/payment_receipt_mailer_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe PaymentReceiptMailer do
   subject(:payment_receipt_mailer) { described_class }
 
   let(:payment_receipt) { create(:payment_receipt) }
+  let(:invoice) { payment_receipt.payment.payable }
 
   before do
     payment_receipt.file.attach(io: File.open(Rails.root.join("spec/fixtures/blank.pdf")), filename: "blank.pdf")
+    invoice.file.attach(io: File.open(Rails.root.join("spec/fixtures/blank.pdf")), filename: "blank.pdf")
     allow(payment_receipt.payment.payable).to receive(:file_url).and_return("https://example.com/invoice.pdf")
   end
 
@@ -32,22 +34,30 @@ RSpec.describe PaymentReceiptMailer do
       end
     end
 
-    context "with no pdf file" do
-      let(:pdf_service) { instance_double(PaymentReceipts::GeneratePdfService) }
+    context "when the payment receipt file is still missing after generation" do
+      let(:pdf_service) { instance_double(PaymentReceipts::GeneratePdfService, call: nil) }
 
       before do
-        payment_receipt.file = nil
-
-        allow(PaymentReceipts::GeneratePdfService).to receive(:new)
-          .and_return(pdf_service)
-        allow(pdf_service).to receive(:call)
+        payment_receipt.file.purge
+        allow(PaymentReceipts::GeneratePdfService).to receive(:new).and_return(pdf_service)
       end
 
-      it "calls the payment_receipt pdf generate service" do
-        mailer = payment_receipt_mailer.with(payment_receipt:).created
+      it "raises FilesNotReadyError" do
+        expect {
+          payment_receipt_mailer.with(payment_receipt:).created
+        }.to raise_error(PaymentReceipts::FilesNotReadyError, /payment_receipt .* file missing/)
 
-        expect(mailer.to).not_to be_nil
         expect(PaymentReceipts::GeneratePdfService).to have_received(:new)
+      end
+    end
+
+    context "when an invoice file is missing" do
+      before { invoice.file.purge }
+
+      it "raises FilesNotReadyError" do
+        expect {
+          payment_receipt_mailer.with(payment_receipt:).created
+        }.to raise_error(PaymentReceipts::FilesNotReadyError, /invoice files missing/)
       end
     end
 


### PR DESCRIPTION
## Context

`PaymentReceiptMailer` was crashing in production with:

```
ActionView::Template::Error: No route matches {}
```

`SendEmailJob`: the receipt email was being rendered before the linked invoice PDFs had finished generating. The Slim template at `app/views/payment_receipt_mailer/created.slim:41` calls `link_to invoice.number, invoice.file_url`, and `Invoice#file_url` returns `nil` when the ActiveStorage attachment isn't present yet — that nil flows into `url_for({})`, which has no route to match in a mailer context (no request).

The receipt PDF is generated synchronously by `PaymentReceiptMailer#ensure_pdf`, but the *invoice* PDFs are produced by `Invoices::GeneratePdfService` from a separate async job. When the receipt mailer runs before that job completes, the template blows up. Manually retrying the same Sidekiq job succeeded — confirming the fix is to defer rendering until the files exist.

Closes [ISSUE-1832](https://linear.app/getlago/issue/ISSUE-1832/add-guard-and-retry-for-missing-receipt-files)

## Description

- New `PaymentReceipts::FilesNotReadyError` defined in `app/services/payment_receipts/files_not_ready_error.rb`, following the existing convention used by `Invoices::Payments::ConnectionError` / `RateLimitError`.
- `PaymentReceiptMailer#ensure_pdf` now raises this error when either the receipt's own PDF or any linked invoice PDF is not yet attached. Multi-invoice `PaymentRequest` payables are covered too.
- `SendEmailJob` registers `retry_on PaymentReceipts::FilesNotReadyError, wait: :polynomially_longer, attempts: 8`. Polynomial backoff gives the async invoice-PDF jobs roughly an hour to catch up before the email is discarded.
- customers either get a complete email with working PDF links, or no email at all — never a broken one.