### PR TITLE
feat(presentation_group_keys): Update graphql resolvers and mutations

### DIFF
--- a/app/graphql/types/charges/presentation_group_key.rb
+++ b/app/graphql/types/charges/presentation_group_key.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  module Charges
+    class PresentationGroupKey < Types::BaseObject
+      field :options, Types::Charges::PresentationGroupKeyOptions, null: true
+      field :value, String, null: false
+    end
+  end
+end

--- a/app/graphql/types/charges/presentation_group_key_input.rb
+++ b/app/graphql/types/charges/presentation_group_key_input.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  module Charges
+    class PresentationGroupKeyInput < Types::BaseInputObject
+      argument :options, Types::Charges::PresentationGroupKeyOptionsInput, required: false
+      argument :value, String, required: true
+    end
+  end
+end

--- a/app/graphql/types/charges/presentation_group_key_options.rb
+++ b/app/graphql/types/charges/presentation_group_key_options.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  module Charges
+    class PresentationGroupKeyOptions < Types::BaseObject
+      field :display_in_invoice, Boolean, null: true
+    end
+  end
+end

--- a/app/graphql/types/charges/presentation_group_key_options_input.rb
+++ b/app/graphql/types/charges/presentation_group_key_options_input.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  module Charges
+    class PresentationGroupKeyOptionsInput < Types::BaseInputObject
+      argument :display_in_invoice, Boolean, required: false
+    end
+  end
+end

--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -10,6 +10,9 @@ module Types
       # NOTE: Graduated charge model
       field :graduated_ranges, [Types::ChargeModels::GraduatedRange], null: true
 
+      # NOTE: presentation group keys for all charge models
+      field :presentation_group_keys, [Types::Charges::PresentationGroupKey], null: true
+
       # NOTE: Graduated percentage modle
       field :graduated_percentage_ranges, [Types::ChargeModels::GraduatedPercentageRange], null: true
 

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -7,6 +7,9 @@ module Types
       argument :amount, String, required: false
       argument :pricing_group_keys, [String], required: false
 
+      # NOTE: presentation group keys
+      argument :presentation_group_keys, [Types::Charges::PresentationGroupKeyInput], required: false
+
       # NOTE: Graduated charge model
       argument :graduated_ranges, [Types::ChargeModels::GraduatedRangeInput], required: false
 

--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -61,7 +61,7 @@ module Types
         end
 
         def presentation_breakdowns
-          Types::Fees::PresentationBreakdownBuilder.call(object)
+          Types::Fees::PresentationBreakdownBuilder.call(object, filter: Types::Fees::PresentationBreakdownBuilder::UNGROUPED)
         end
       end
     end

--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -16,6 +16,7 @@ module Types
         field :charge, Types::Charges::Object, null: false
         field :filters, [Types::Customers::Usage::ChargeFilter], null: true
         field :grouped_usage, [Types::Customers::Usage::GroupedUsage], null: false
+        field :presentation_breakdowns, [Types::Customers::Usage::PresentationBreakdown], null: true
 
         def id
           SecureRandom.uuid
@@ -57,6 +58,10 @@ module Types
           return [] unless object.any? { |f| f.grouped_by.present? }
 
           object.group_by(&:grouped_by).values
+        end
+
+        def presentation_breakdowns
+          Types::Fees::PresentationBreakdownBuilder.call(object)
         end
       end
     end

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -14,6 +14,7 @@ module Types
 
         field :filters, [Types::Customers::Usage::ChargeFilter], null: true
         field :grouped_by, GraphQL::Types::JSON, null: true
+        field :presentation_breakdowns, [Types::Customers::Usage::PresentationBreakdown], null: true
 
         def id
           SecureRandom.uuid
@@ -45,6 +46,10 @@ module Types
           return [] unless object.first.has_charge_filters?
 
           object.sort_by { |f| f.charge_filter&.display_name.to_s }
+        end
+
+        def presentation_breakdowns
+          Types::Fees::PresentationBreakdownBuilder.call(object)
         end
       end
     end

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -49,7 +49,7 @@ module Types
         end
 
         def presentation_breakdowns
-          Types::Fees::PresentationBreakdownBuilder.call(object)
+          Types::Fees::PresentationBreakdownBuilder.call(object, filter: Types::Fees::PresentationBreakdownBuilder::GROUPED)
         end
       end
     end

--- a/app/graphql/types/customers/usage/presentation_breakdown.rb
+++ b/app/graphql/types/customers/usage/presentation_breakdown.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module Customers
+    module Usage
+      class PresentationBreakdown < Types::BaseObject
+        graphql_name "PresentationBreakdownUsage"
+
+        field :presentation_by, GraphQL::Types::JSON, null: false
+        field :units, GraphQL::Types::String, null: false
+      end
+    end
+  end
+end

--- a/app/graphql/types/customers/usage/projected_charge.rb
+++ b/app/graphql/types/customers/usage/projected_charge.rb
@@ -19,6 +19,7 @@ module Types
         field :charge, Types::Charges::Object, null: false
         field :filters, [Types::Customers::Usage::ProjectedChargeFilter], null: true
         field :grouped_usage, [Types::Customers::Usage::ProjectedGroupedUsage], null: false
+        field :presentation_breakdowns, [Types::Customers::Usage::PresentationBreakdown], null: true
 
         def id
           SecureRandom.uuid
@@ -67,11 +68,15 @@ module Types
         end
 
         def projected_units
-          calculate_projection(:projected_units, BigDecimal("0"))
+          calculate_projection(:projected_units, BigDecimal(0))
         end
 
         def projected_amount_cents
           calculate_projection(:projected_amount_cents, 0)
+        end
+
+        def presentation_breakdowns
+          Types::Fees::PresentationBreakdownBuilder.call(object)
         end
 
         private

--- a/app/graphql/types/customers/usage/projected_charge.rb
+++ b/app/graphql/types/customers/usage/projected_charge.rb
@@ -76,7 +76,7 @@ module Types
         end
 
         def presentation_breakdowns
-          Types::Fees::PresentationBreakdownBuilder.call(object)
+          Types::Fees::PresentationBreakdownBuilder.call(object, filter: Types::Fees::PresentationBreakdownBuilder::UNGROUPED)
         end
 
         private

--- a/app/graphql/types/customers/usage/projected_grouped_usage.rb
+++ b/app/graphql/types/customers/usage/projected_grouped_usage.rb
@@ -58,7 +58,7 @@ module Types
         end
 
         def presentation_breakdowns
-          Types::Fees::PresentationBreakdownBuilder.call(object)
+          Types::Fees::PresentationBreakdownBuilder.call(object, filter: Types::Fees::PresentationBreakdownBuilder::GROUPED)
         end
 
         private

--- a/app/graphql/types/customers/usage/projected_grouped_usage.rb
+++ b/app/graphql/types/customers/usage/projected_grouped_usage.rb
@@ -19,6 +19,7 @@ module Types
 
         field :filters, [Types::Customers::Usage::ProjectedChargeFilter], null: true
         field :grouped_by, GraphQL::Types::JSON, null: true
+        field :presentation_breakdowns, [Types::Customers::Usage::PresentationBreakdown], null: true
 
         def id
           SecureRandom.uuid
@@ -54,6 +55,10 @@ module Types
           return [] unless object.first.has_charge_filters?
 
           object.sort_by { |f| f.charge_filter&.display_name.to_s }
+        end
+
+        def presentation_breakdowns
+          Types::Fees::PresentationBreakdownBuilder.call(object)
         end
 
         private

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -72,7 +72,7 @@ module Types
       end
 
       def presentation_breakdowns
-        Types::Fees::PresentationBreakdownBuilder.call([object])
+        Types::Fees::PresentationBreakdownBuilder.call([object], filter: Types::Fees::PresentationBreakdownBuilder::ALL)
       end
     end
   end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -40,6 +40,7 @@ module Types
       field :adjusted_fee_type, Types::AdjustedFees::AdjustedFeeTypeEnum, null: true
 
       field :charge_filter, Types::ChargeFilters::Object, null: true
+      field :presentation_breakdowns, [Types::Customers::Usage::PresentationBreakdown], null: true
       field :pricing_unit_usage, Types::PricingUnitUsages::Object, null: true
       field :properties, Types::Fees::Properties, null: true, method: :itself
 
@@ -68,6 +69,10 @@ module Types
         return nil if object.adjusted_fee.adjusted_display_name?
 
         object.adjusted_fee.adjusted_units? ? "adjusted_units" : "adjusted_amount"
+      end
+
+      def presentation_breakdowns
+        Types::Fees::PresentationBreakdownBuilder.call([object])
       end
     end
   end

--- a/app/graphql/types/fees/presentation_breakdown_builder.rb
+++ b/app/graphql/types/fees/presentation_breakdown_builder.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Types
+  module Fees
+    class PresentationBreakdownBuilder
+      def self.call(fees)
+        units_by_presentation = Hash.new { |hash, key| hash[key] = BigDecimal(0) }
+
+        Array(fees).each do |fee|
+          fee.presentation_breakdowns.each do |breakdown|
+            units_by_presentation[breakdown.presentation_by] += BigDecimal((breakdown.units || 0).to_s)
+          end
+        end
+
+        units_by_presentation.map do |presentation_by, units|
+          {
+            presentation_by:,
+            units: units.to_s
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/fees/presentation_breakdown_builder.rb
+++ b/app/graphql/types/fees/presentation_breakdown_builder.rb
@@ -3,22 +3,36 @@
 module Types
   module Fees
     class PresentationBreakdownBuilder
-      def self.call(fees)
-        units_by_presentation = Hash.new { |hash, key| hash[key] = BigDecimal(0) }
+      ALL = :all
+      UNGROUPED = :ungrouped
+      GROUPED = :grouped
 
-        Array(fees).each do |fee|
-          fee.presentation_breakdowns.each do |breakdown|
-            units_by_presentation[breakdown.presentation_by] += BigDecimal((breakdown.units || 0).to_s)
+      def self.call(fees, filter:)
+        new(fees, filter:).call
+      end
+
+      def initialize(fees, filter:)
+        @fees = fees
+        @filter = filter
+      end
+
+      def call
+        Array(fees).flat_map do |fee|
+          next [] if filter == UNGROUPED && fee.grouped_by.present?
+          next [] if filter == GROUPED && fee.grouped_by.blank?
+
+          fee.presentation_breakdowns.map do |breakdown|
+            {
+              presentation_by: breakdown.presentation_by,
+              units: breakdown.units.to_s
+            }
           end
         end
-
-        units_by_presentation.map do |presentation_by, units|
-          {
-            presentation_by:,
-            units: units.to_s
-          }
-        end
       end
+
+      private
+
+      attr_reader :fees, :filter
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1175,6 +1175,7 @@ type ChargeUsage {
   filters: [ChargeFilterUsage!]
   groupedUsage: [GroupedChargeUsage!]!
   id: ID!
+  presentationBreakdowns: [PresentationBreakdownUsage!]
   pricingUnitAmountCents: BigInt
   units: Float!
 }
@@ -5787,6 +5788,7 @@ type Fee implements InvoiceItem {
   itemType: String!
   offsettableAmountCents: BigInt!
   preciseUnitAmount: Float!
+  presentationBreakdowns: [PresentationBreakdownUsage!]
   pricingUnitUsage: PricingUnitUsage
   properties: FeeProperties
   subscription: Subscription
@@ -6252,6 +6254,7 @@ type GroupedChargeUsage {
   filters: [ChargeFilterUsage!]
   groupedBy: JSON
   id: ID!
+  presentationBreakdowns: [PresentationBreakdownUsage!]
   pricingUnitAmountCents: BigInt
   units: Float!
 }
@@ -9453,6 +9456,29 @@ enum PremiumIntegrationTypeEnum {
   xero
 }
 
+type PresentationBreakdownUsage {
+  presentationBy: JSON!
+  units: String!
+}
+
+type PresentationGroupKey {
+  options: PresentationGroupKeyOptions
+  value: String!
+}
+
+input PresentationGroupKeyInput {
+  options: PresentationGroupKeyOptionsInput
+  value: String!
+}
+
+type PresentationGroupKeyOptions {
+  displayInInvoice: Boolean
+}
+
+input PresentationGroupKeyOptionsInput {
+  displayInInvoice: Boolean
+}
+
 """
 Create Adjusted Fee Input
 """
@@ -9568,6 +9594,7 @@ type ProjectedChargeUsage {
   filters: [ProjectedChargeFilterUsage!]
   groupedUsage: [ProjectedGroupedChargeUsage!]!
   id: ID!
+  presentationBreakdowns: [PresentationBreakdownUsage!]
   pricingUnitAmountCents: BigInt
   pricingUnitProjectedAmountCents: BigInt
   projectedAmountCents: BigInt!
@@ -9581,6 +9608,7 @@ type ProjectedGroupedChargeUsage {
   filters: [ProjectedChargeFilterUsage!]
   groupedBy: JSON
   id: ID!
+  presentationBreakdowns: [PresentationBreakdownUsage!]
   pricingUnitAmountCents: BigInt
   pricingUnitProjectedAmountCents: BigInt
   projectedAmountCents: BigInt!
@@ -9600,6 +9628,7 @@ type Properties {
   packageSize: BigInt
   perTransactionMaxAmount: String
   perTransactionMinAmount: String
+  presentationGroupKeys: [PresentationGroupKey!]
   pricingGroupKeys: [String!]
   rate: String
   volumeRanges: [VolumeRange!]
@@ -9617,6 +9646,7 @@ input PropertiesInput {
   packageSize: BigInt
   perTransactionMaxAmount: String
   perTransactionMinAmount: String
+  presentationGroupKeys: [PresentationGroupKeyInput!]
   pricingGroupKeys: [String!]
   rate: String
   volumeRanges: [VolumeRangeInput!]

--- a/schema.json
+++ b/schema.json
@@ -7493,6 +7493,26 @@
               "deprecationReason": null
             },
             {
+              "name": "presentationBreakdowns",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PresentationBreakdownUsage",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "pricingUnitAmountCents",
               "description": null,
               "args": [],
@@ -28358,6 +28378,26 @@
               "deprecationReason": null
             },
             {
+              "name": "presentationBreakdowns",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PresentationBreakdownUsage",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "pricingUnitUsage",
               "description": null,
               "args": [],
@@ -31805,6 +31845,26 @@
                   "kind": "SCALAR",
                   "name": "ID",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "presentationBreakdowns",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PresentationBreakdownUsage",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,
@@ -47635,6 +47695,173 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "PresentationBreakdownUsage",
+          "description": null,
+          "fields": [
+            {
+              "name": "presentationBy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "units",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PresentationGroupKey",
+          "description": null,
+          "fields": [
+            {
+              "name": "options",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PresentationGroupKeyOptions",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PresentationGroupKeyInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "options",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PresentationGroupKeyOptionsInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PresentationGroupKeyOptions",
+          "description": null,
+          "fields": [
+            {
+              "name": "displayInInvoice",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PresentationGroupKeyOptionsInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "displayInInvoice",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "PreviewAdjustedFeeInput",
           "description": "Create Adjusted Fee Input",
@@ -48591,6 +48818,26 @@
               "deprecationReason": null
             },
             {
+              "name": "presentationBreakdowns",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PresentationBreakdownUsage",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "pricingUnitAmountCents",
               "description": null,
               "args": [],
@@ -48748,6 +48995,26 @@
                   "kind": "SCALAR",
                   "name": "ID",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "presentationBreakdowns",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PresentationBreakdownUsage",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,
@@ -48985,6 +49252,26 @@
               "deprecationReason": null
             },
             {
+              "name": "presentationGroupKeys",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PresentationGroupKey",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "pricingGroupKeys",
               "description": null,
               "args": [],
@@ -49072,6 +49359,26 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "presentationGroupKeys",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "PresentationGroupKeyInput",
                     "ofType": null
                   }
                 }

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Mutations::Plans::Create, :premium do
             }
             properties {
               amount,
+              presentationGroupKeys { value options { displayInInvoice } }
               freeUnits,
               packageSize,
               rate,
@@ -67,7 +68,10 @@ RSpec.describe Mutations::Plans::Create, :premium do
             filters {
               invoiceDisplayName
               values
-              properties { amount }
+              properties {
+                amount
+                presentationGroupKeys { value options { displayInInvoice } }
+              }
             }
           }
           fixedCharges {
@@ -146,7 +150,17 @@ RSpec.describe Mutations::Plans::Create, :premium do
             {
               billableMetricId: billable_metrics[0].id,
               chargeModel: "standard",
-              properties: {amount: "100.00"},
+              properties: {
+                amount: "100.00",
+                presentationGroupKeys: [
+                  {
+                    value: "region",
+                    options: {
+                      displayInInvoice: true
+                    }
+                  }
+                ]
+              },
               taxCodes: [charge_tax.code],
               appliedPricingUnit: {
                 code: pricing_unit.code,
@@ -155,7 +169,17 @@ RSpec.describe Mutations::Plans::Create, :premium do
               filters: [
                 {
                   invoiceDisplayName: "Payment Method",
-                  properties: {amount: "100.00"},
+                  properties: {
+                    amount: "100.00",
+                    presentationGroupKeys: [
+                      {
+                        value: "country",
+                        options: {
+                          displayInInvoice: false
+                        }
+                      }
+                    ]
+                  },
                   values: {billable_metric_filter.key => %w[card sepa]}
                 }
               ]
@@ -331,6 +355,9 @@ RSpec.describe Mutations::Plans::Create, :premium do
 
     standard_charge = result_data["charges"][0]
     expect(standard_charge["properties"]["amount"]).to eq("100.00")
+    expect(standard_charge.dig("properties", "presentationGroupKeys")).to eq([
+      {"value" => "region", "options" => {"displayInInvoice" => true}}
+    ])
     expect(standard_charge["chargeModel"]).to eq("standard")
     expect(standard_charge["taxes"].count).to eq(1)
     expect(standard_charge["taxes"].first["code"]).to eq(charge_tax.code)
@@ -344,6 +371,9 @@ RSpec.describe Mutations::Plans::Create, :premium do
     filter = standard_charge["filters"].first
     expect(filter["invoiceDisplayName"]).to eq("Payment Method")
     expect(filter["properties"]["amount"]).to eq("100.00")
+    expect(filter.dig("properties", "presentationGroupKeys")).to eq([
+      {"value" => "country", "options" => {"displayInInvoice" => false}}
+    ])
     expect(filter["values"]).to eq("payment_method" => %w[card sepa])
 
     package_charge = result_data["charges"][1]

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Mutations::Plans::Update do
             },
             properties {
               amount,
+              presentationGroupKeys { value options { displayInInvoice } }
               freeUnits,
               packageSize,
               rate,
@@ -61,7 +62,10 @@ RSpec.describe Mutations::Plans::Update do
             filters {
               invoiceDisplayName
               values
-              properties { amount }
+              properties {
+                amount
+                presentationGroupKeys { value options { displayInInvoice } }
+              }
             }
           },
           fixedCharges {
@@ -130,7 +134,17 @@ RSpec.describe Mutations::Plans::Update do
             {
               billableMetricId: billable_metrics[0].id,
               chargeModel: "standard",
-              properties: {amount: "100.00"},
+              properties: {
+                amount: "100.00",
+                presentationGroupKeys: [
+                  {
+                    value: "region",
+                    options: {
+                      displayInInvoice: true
+                    }
+                  }
+                ]
+              },
               appliedPricingUnit: {
                 code: pricing_unit.code,
                 conversionRate: 0.1
@@ -138,7 +152,17 @@ RSpec.describe Mutations::Plans::Update do
               filters: [
                 {
                   invoiceDisplayName: "Payment method",
-                  properties: {amount: "10.00"},
+                  properties: {
+                    amount: "10.00",
+                    presentationGroupKeys: [
+                      {
+                        value: "country",
+                        options: {
+                          displayInInvoice: false
+                        }
+                      }
+                    ]
+                  },
                   values: {billable_metric_filter.key => %w[card]}
                 }
               ]
@@ -257,6 +281,9 @@ RSpec.describe Mutations::Plans::Update do
 
       standard_charge = result_data["charges"][0]
       expect(standard_charge["properties"]["amount"]).to eq("100.00")
+      expect(standard_charge.dig("properties", "presentationGroupKeys")).to eq([
+        {"value" => "region", "options" => {"displayInInvoice" => true}}
+      ])
       expect(standard_charge["chargeModel"]).to eq("standard")
 
       applied_pricing_unit = standard_charge["appliedPricingUnit"]
@@ -268,6 +295,9 @@ RSpec.describe Mutations::Plans::Update do
       filter = standard_charge["filters"].first
       expect(filter["invoiceDisplayName"]).to eq("Payment method")
       expect(filter["properties"]["amount"]).to eq("10.00")
+      expect(filter.dig("properties", "presentationGroupKeys")).to eq([
+        {"value" => "country", "options" => {"displayInInvoice" => false}}
+      ])
       expect(filter["values"]).to eq("payment_method" => %w[card])
 
       package_charge = result_data["charges"][1]
@@ -356,6 +386,9 @@ RSpec.describe Mutations::Plans::Update do
 
       standard_charge = result_data["charges"][0]
       expect(standard_charge["properties"]["amount"]).to eq("100.00")
+      expect(standard_charge.dig("properties", "presentationGroupKeys")).to eq([
+        {"value" => "region", "options" => {"displayInInvoice" => true}}
+      ])
       expect(standard_charge["chargeModel"]).to eq("standard")
 
       expect(standard_charge["appliedPricingUnit"]).to be_nil
@@ -632,9 +665,9 @@ RSpec.describe Mutations::Plans::Update do
       expect(FixedChargeEvent.pluck(:fixed_charge_id, :timestamp, :units))
         .to contain_exactly(
           [fixed_charge_2.id, be_within(1.minute).of(Time.current), BigDecimal("20.55")],
-          [fixed_charge_3.id, be_within(1.minute).of(Time.current), BigDecimal("30")],
-          [fixed_charge_4.id, be_within(1.minute).of(1.month.from_now.beginning_of_month), BigDecimal("40")],
-          [fixed_charge_5.id, be_within(1.minute).of(1.month.from_now.beginning_of_month), BigDecimal("50")]
+          [fixed_charge_3.id, be_within(1.minute).of(Time.current), BigDecimal(30)],
+          [fixed_charge_4.id, be_within(1.minute).of(1.month.from_now.beginning_of_month), BigDecimal(40)],
+          [fixed_charge_5.id, be_within(1.minute).of(1.month.from_now.beginning_of_month), BigDecimal(50)]
         )
     end
   end

--- a/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
               eventsCount
               groupedBy
               filters { id units amountCents pricingUnitAmountCents invoiceDisplayName values eventsCount }
+              presentationBreakdowns { presentationBy units }
             }
+            presentationBreakdowns { presentationBy units }
           }
         }
       }
@@ -294,6 +296,49 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
         expect(google_filter_data["units"]).to eq(1)
         expect(google_filter_data["amountCents"]).to eq("400")
         expect(google_filter_data["pricingUnitAmountCents"]).to eq("2000")
+      end
+    end
+  end
+
+  context "with presentation group keys" do
+    let(:standard_charge) do
+      create(
+        :standard_charge,
+        plan: subscription.plan,
+        billable_metric: sum_metric,
+        properties: {
+          amount: 1.to_s,
+          grouped_by: ["agent_name"],
+          presentation_group_keys: [{value: "cloud"}]
+        }
+      )
+    end
+
+    it "returns the presentation breakdowns" do
+      travel_to(Time.parse("2025-07-15T10:00:00Z")) do
+        result = execute_graphql(
+          customer_portal_user: customer,
+          query:,
+          variables: {
+            subscriptionId: subscription.id
+          }
+        )
+
+        charges_usage = result["data"]["customerPortalCustomerProjectedUsage"]["chargesUsage"]
+
+        graduated_charge_usage = charges_usage.find { |usage| usage["charge"]["chargeModel"] == "graduated" }
+        expect(graduated_charge_usage["presentationBreakdowns"]).to be_empty
+
+        standard_charge_usage = charges_usage.find { |usage| usage["charge"]["chargeModel"] == "standard" }
+        expect(standard_charge_usage["presentationBreakdowns"]).to eq([
+          {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+        ])
+
+        grouped_usage = standard_charge_usage["groupedUsage"]
+        expect(grouped_usage.first["presentationBreakdowns"]).to eq([
+          {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+        ])
+        expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
       end
     end
   end

--- a/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
@@ -330,15 +330,81 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
         expect(graduated_charge_usage["presentationBreakdowns"]).to be_empty
 
         standard_charge_usage = charges_usage.find { |usage| usage["charge"]["chargeModel"] == "standard" }
-        expect(standard_charge_usage["presentationBreakdowns"]).to eq([
-          {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
-        ])
+        expect(standard_charge_usage["presentationBreakdowns"]).to be_empty
 
         grouped_usage = standard_charge_usage["groupedUsage"]
         expect(grouped_usage.first["presentationBreakdowns"]).to eq([
           {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
         ])
         expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
+      end
+    end
+
+    context "with two charges without pricing_group_keys" do
+      let(:standard_charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric: sum_metric,
+          properties: {
+            amount: 1.to_s,
+            presentation_group_keys: [{value: "cloud"}]
+          }
+        )
+      end
+      let(:presentation_metric) { create(:sum_billable_metric, organization:) }
+      let(:presentation_charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric: presentation_metric,
+          properties: {
+            amount: "1",
+            presentation_group_keys: [{value: "cloud"}]
+          }
+        )
+      end
+
+      before do
+        presentation_charge
+        travel_to(Time.parse("2025-07-15T10:00:00Z")) do
+          create_list(
+            :event,
+            3,
+            organization:,
+            customer:,
+            subscription:,
+            code: presentation_metric.code,
+            timestamp: Time.zone.now,
+            properties: {cloud: "gcp", item_id: 1}
+          )
+        end
+      end
+
+      it "returns presentation breakdowns for both charges with no grouped_usage" do
+        travel_to(Time.parse("2025-07-15T10:00:00Z")) do
+          result = execute_graphql(
+            customer_portal_user: customer,
+            query:,
+            variables: {
+              subscriptionId: subscription.id
+            }
+          )
+
+          charges_usage = result["data"]["customerPortalCustomerProjectedUsage"]["chargesUsage"]
+          presentation_charge_usage = charges_usage.find { |u| u["billableMetric"]["code"] == presentation_metric.code }
+          sum_charge_usage = charges_usage.find { |u| u["billableMetric"]["code"] == sum_metric.code }
+
+          expect(presentation_charge_usage["groupedUsage"]).to be_empty
+          expect(presentation_charge_usage["presentationBreakdowns"]).to eq([
+            {"presentationBy" => {"cloud" => "gcp"}, "units" => "3.0"}
+          ])
+
+          expect(sum_charge_usage["groupedUsage"]).to be_empty
+          expect(sum_charge_usage["presentationBreakdowns"]).to eq([
+            {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+          ])
+        end
       end
     end
   end

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -337,12 +337,73 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
           )
 
           charges_usage = result["data"]["customerPortalCustomerUsage"]["chargesUsage"]
-          presentation_breakdown_sum_metric = charges_usage.find { |usage| usage["billableMetric"]["code"] == sum_metric.code }["presentationBreakdowns"]
-          expect(presentation_breakdown_sum_metric).to eq([
+          sum_charge = charges_usage.find { |usage| usage["billableMetric"]["code"] == sum_metric.code }
+          expect(sum_charge["presentationBreakdowns"]).to be_empty
+
+          grouped_usage = sum_charge["groupedUsage"]
+          expect(grouped_usage.first["presentationBreakdowns"]).to eq([
             {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
           ])
-          presentation_breakdown_metric = charges_usage.find { |usage| usage["billableMetric"]["code"] == metric.code }["presentationBreakdowns"]
-          expect(presentation_breakdown_metric).to be_empty
+          expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
+
+          metric_charge = charges_usage.find { |usage| usage["billableMetric"]["code"] == metric.code }
+          expect(metric_charge["presentationBreakdowns"]).to be_empty
+        end
+      end
+    end
+
+    context "with two charges without pricing_group_keys" do
+      let(:presentation_metric) { create(:sum_billable_metric, organization:) }
+
+      let(:charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric: presentation_metric,
+          properties: {
+            amount: "1",
+            presentation_group_keys: [{value: "cloud"}]
+          }
+        )
+      end
+
+      before do
+        create_list(
+          :event,
+          3,
+          organization:,
+          customer:,
+          subscription:,
+          code: presentation_metric.code,
+          timestamp: now - 1.hour,
+          properties: {cloud: "gcp", item_id: 1}
+        )
+      end
+
+      it "returns presentation breakdowns for both charges with no grouped_usage" do
+        travel_to(now) do
+          Subscriptions::ChargeCacheService.expire_for_subscription(subscription)
+          result = execute_graphql(
+            customer_portal_user: customer,
+            query:,
+            variables: {
+              subscriptionId: subscription.id
+            }
+          )
+
+          charges_usage = result["data"]["customerPortalCustomerUsage"]["chargesUsage"]
+          presentation_charge_usage = charges_usage.find { |u| u["billableMetric"]["code"] == presentation_metric.code }
+          sum_charge_usage = charges_usage.find { |u| u["billableMetric"]["code"] == sum_metric.code }
+
+          expect(presentation_charge_usage["groupedUsage"]).to be_empty
+          expect(presentation_charge_usage["presentationBreakdowns"]).to eq([
+            {"presentationBy" => {"cloud" => "gcp"}, "units" => "3.0"}
+          ])
+
+          expect(sum_charge_usage["groupedUsage"]).to be_empty
+          expect(sum_charge_usage["presentationBreakdowns"]).to eq([
+            {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+          ])
         end
       end
     end

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
               eventsCount
               groupedBy
               filters { id units amountCents invoiceDisplayName values eventsCount }
+              presentationBreakdowns { presentationBy units }
             }
+            presentationBreakdowns { presentationBy units }
           }
         }
       }
@@ -271,6 +273,77 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
             "eventsCount" => 1
           }
         )
+      end
+    end
+  end
+
+  context "with presentation group keys" do
+    let(:standard_charge) do
+      create(
+        :standard_charge,
+        plan: subscription.plan,
+        billable_metric: sum_metric,
+        properties: {
+          amount: 1.to_s,
+          presentation_group_keys: [{value: "cloud"}]
+        }
+      )
+    end
+
+    it "returns the presentation breakdowns" do
+      travel_to(now) do
+        Subscriptions::ChargeCacheService.expire_for_subscription(subscription)
+        result = execute_graphql(
+          customer_portal_user: customer,
+          query:,
+          variables: {
+            subscriptionId: subscription.id
+          }
+        )
+
+        charges_usage = result["data"]["customerPortalCustomerUsage"]["chargesUsage"]
+        presentation_breakdown_sum_metric = charges_usage.find { |usage| usage["billableMetric"]["code"] == sum_metric.code }["presentationBreakdowns"]
+        expect(presentation_breakdown_sum_metric).to eq([
+          {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+        ])
+        presentation_breakdown_metric = charges_usage.find { |usage| usage["billableMetric"]["code"] == metric.code }["presentationBreakdowns"]
+        expect(presentation_breakdown_metric).to be_empty
+      end
+    end
+
+    context "with pricing group keys" do
+      let(:standard_charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric: sum_metric,
+          properties: {
+            amount: 1.to_s,
+            pricing_group_keys: ["item_id"],
+            presentation_group_keys: [{value: "cloud"}]
+          }
+        )
+      end
+
+      it "returns the presentation breakdowns" do
+        travel_to(now) do
+          Subscriptions::ChargeCacheService.expire_for_subscription(subscription)
+          result = execute_graphql(
+            customer_portal_user: customer,
+            query:,
+            variables: {
+              subscriptionId: subscription.id
+            }
+          )
+
+          charges_usage = result["data"]["customerPortalCustomerUsage"]["chargesUsage"]
+          presentation_breakdown_sum_metric = charges_usage.find { |usage| usage["billableMetric"]["code"] == sum_metric.code }["presentationBreakdowns"]
+          expect(presentation_breakdown_sum_metric).to eq([
+            {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+          ])
+          presentation_breakdown_metric = charges_usage.find { |usage| usage["billableMetric"]["code"] == metric.code }["presentationBreakdowns"]
+          expect(presentation_breakdown_metric).to be_empty
+        end
       end
     end
   end

--- a/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
@@ -347,15 +347,84 @@ RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
         expect(graduated_charge_usage["presentationBreakdowns"]).to be_empty
 
         standard_charge_usage = charges_usage.find { |usage| usage["charge"]["chargeModel"] == "standard" }
-        expect(standard_charge_usage["presentationBreakdowns"]).to eq([
-          {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
-        ])
+        expect(standard_charge_usage["presentationBreakdowns"]).to be_empty
 
         grouped_usage = standard_charge_usage["groupedUsage"]
         expect(grouped_usage.first["presentationBreakdowns"]).to eq([
           {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
         ])
         expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
+      end
+    end
+
+    context "with two charges without pricing_group_keys" do
+      let(:standard_charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric: sum_metric,
+          properties: {
+            amount: 1.to_s,
+            presentation_group_keys: [{value: "cloud"}]
+          }
+        )
+      end
+      let(:presentation_metric) { create(:sum_billable_metric, organization:) }
+      let(:presentation_charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric: presentation_metric,
+          properties: {
+            amount: "1",
+            presentation_group_keys: [{value: "cloud"}]
+          }
+        )
+      end
+
+      before do
+        presentation_charge
+        travel_to(Time.parse("2025-07-15T10:00:00Z")) do
+          create_list(
+            :event,
+            3,
+            organization:,
+            customer:,
+            subscription:,
+            code: presentation_metric.code,
+            timestamp: Time.zone.now,
+            properties: {cloud: "gcp", item_id: 1}
+          )
+        end
+      end
+
+      it "returns presentation breakdowns for both charges with no grouped_usage" do
+        travel_to(Time.parse("2025-07-15T10:00:00Z")) do
+          result = execute_graphql(
+            current_user: membership.user,
+            current_organization: organization,
+            permissions: required_permission,
+            query:,
+            variables: {
+              customerId: customer.id,
+              subscriptionId: subscription.id
+            }
+          )
+
+          charges_usage = result["data"]["customerProjectedUsage"]["chargesUsage"]
+          presentation_charge_usage = charges_usage.find { |u| u["billableMetric"]["code"] == presentation_metric.code }
+          sum_charge_usage = charges_usage.find { |u| u["billableMetric"]["code"] == sum_metric.code }
+
+          expect(presentation_charge_usage["groupedUsage"]).to be_empty
+          expect(presentation_charge_usage["presentationBreakdowns"]).to eq([
+            {"presentationBy" => {"cloud" => "gcp"}, "units" => "3.0"}
+          ])
+
+          expect(sum_charge_usage["groupedUsage"]).to be_empty
+          expect(sum_charge_usage["presentationBreakdowns"]).to eq([
+            {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+          ])
+        end
       end
     end
   end

--- a/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
               eventsCount
               groupedBy
               filters { id units amountCents pricingUnitAmountCents invoiceDisplayName values eventsCount }
+              presentationBreakdowns { presentationBy units }
             }
+            presentationBreakdowns { presentationBy units }
           }
         }
       }
@@ -83,7 +85,7 @@ RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
       billable_metric: sum_metric,
       properties: {
         amount: 1.to_s,
-        grouped_by: ["agent_name"]
+        pricing_group_keys: ["agent_name"]
       }
     )
   end
@@ -308,6 +310,52 @@ RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
         expect(google_filter_data["units"]).to eq(1)
         expect(google_filter_data["amountCents"]).to eq("400")
         expect(google_filter_data["pricingUnitAmountCents"]).to eq("2000")
+      end
+    end
+  end
+
+  context "with presentation group keys" do
+    let(:standard_charge) do
+      create(
+        :standard_charge,
+        plan: subscription.plan,
+        billable_metric: sum_metric,
+        properties: {
+          amount: 1.to_s,
+          pricing_group_keys: ["agent_name"],
+          presentation_group_keys: [{value: "cloud"}]
+        }
+      )
+    end
+
+    it "returns the presentation breakdowns" do
+      travel_to(Time.parse("2025-07-15T10:00:00Z")) do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {
+            customerId: customer.id,
+            subscriptionId: subscription.id
+          }
+        )
+
+        charges_usage = result["data"]["customerProjectedUsage"]["chargesUsage"]
+
+        graduated_charge_usage = charges_usage.find { |usage| usage["charge"]["chargeModel"] == "graduated" }
+        expect(graduated_charge_usage["presentationBreakdowns"]).to be_empty
+
+        standard_charge_usage = charges_usage.find { |usage| usage["charge"]["chargeModel"] == "standard" }
+        expect(standard_charge_usage["presentationBreakdowns"]).to eq([
+          {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+        ])
+
+        grouped_usage = standard_charge_usage["groupedUsage"]
+        expect(grouped_usage.first["presentationBreakdowns"]).to eq([
+          {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+        ])
+        expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
       end
     end
   end

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -242,11 +242,67 @@ RSpec.describe Resolvers::Customers::UsageResolver do
 
         charges_usage = result["data"]["customerUsage"]["chargesUsage"]
         expect(charges_usage.first["presentationBreakdowns"]).to be_empty
-        expect(charges_usage.second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+        expect(charges_usage.second["presentationBreakdowns"]).to be_empty
 
         grouped_usage = charges_usage.second["groupedUsage"]
         expect(grouped_usage.first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
         expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
+      end
+    end
+
+    context "with two charges without pricing_group_keys" do
+      let(:presentation_metric) { create(:sum_billable_metric, organization:) }
+
+      let(:charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric: presentation_metric,
+          properties: {
+            amount: "1",
+            presentation_group_keys: [{value: "cloud"}]
+          }
+        )
+      end
+
+      before do
+        create_list(
+          :event,
+          3,
+          organization:,
+          customer:,
+          subscription:,
+          code: presentation_metric.code,
+          timestamp: Time.zone.now,
+          properties: {cloud: "gcp", item_id: 1}
+        )
+      end
+
+      it "returns presentation breakdowns for both charges with no grouped_usage" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {
+            customerId: customer.id,
+            subscriptionId: subscription.id
+          }
+        )
+
+        charges_usage = result["data"]["customerUsage"]["chargesUsage"]
+        presentation_charge_usage = charges_usage.find { |u| u["billableMetric"]["code"] == presentation_metric.code }
+        sum_charge_usage = charges_usage.find { |u| u["billableMetric"]["code"] == sum_metric.code }
+
+        expect(presentation_charge_usage["groupedUsage"]).to be_empty
+        expect(presentation_charge_usage["presentationBreakdowns"]).to eq([
+          {"presentationBy" => {"cloud" => "gcp"}, "units" => "3.0"}
+        ])
+
+        expect(sum_charge_usage["groupedUsage"]).to be_empty
+        expect(sum_charge_usage["presentationBreakdowns"]).to eq([
+          {"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}
+        ])
       end
     end
   end

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe Resolvers::Customers::UsageResolver do
               eventsCount
               groupedBy
               filters { id units amountCents pricingUnitAmountCents invoiceDisplayName values eventsCount }
+              presentationBreakdowns { presentationBy units }
             }
+            presentationBreakdowns { presentationBy units }
           }
         }
       }
@@ -77,7 +79,7 @@ RSpec.describe Resolvers::Customers::UsageResolver do
       billable_metric: sum_metric,
       properties: {
         amount: 1.to_s,
-        grouped_by: ["agent_name"]
+        pricing_group_keys: ["agent_name"]
       }
     )
   end
@@ -182,6 +184,71 @@ RSpec.describe Resolvers::Customers::UsageResolver do
     expect(grouped_usage["units"]).to eq(4.0)
     expect(grouped_usage["eventsCount"]).to eq(4)
     expect(grouped_usage["groupedBy"]).to eq({"agent_name" => "frodo"})
+  end
+
+  context "with presentation group keys" do
+    let(:properties) do
+      {
+        amount: 1.to_s,
+        presentation_group_keys: [{value: "cloud"}]
+      }
+    end
+    let(:standard_charge) do
+      create(
+        :standard_charge,
+        plan: subscription.plan,
+        billable_metric: sum_metric,
+        properties: properties
+      )
+    end
+
+    it "returns the presentation breakdowns" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {
+          customerId: customer.id,
+          subscriptionId: subscription.id
+        }
+      )
+
+      charges_usage = result["data"]["customerUsage"]["chargesUsage"]
+      expect(charges_usage.first["presentationBreakdowns"]).to be_empty
+      expect(charges_usage.second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+    end
+
+    context "with pricing group keys" do
+      let(:properties) do
+        {
+          amount: 1.to_s,
+          pricing_group_keys: ["item_id"],
+          presentation_group_keys: [{value: "cloud"}]
+        }
+      end
+
+      it "returns the presentation breakdowns" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {
+            customerId: customer.id,
+            subscriptionId: subscription.id
+          }
+        )
+
+        charges_usage = result["data"]["customerUsage"]["chargesUsage"]
+        expect(charges_usage.first["presentationBreakdowns"]).to be_empty
+        expect(charges_usage.second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+
+        grouped_usage = charges_usage.second["groupedUsage"]
+        expect(grouped_usage.first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+        expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
+      end
+    end
   end
 
   context "with filters" do

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Resolvers::InvoiceResolver do
               units
               preciseUnitAmount
               chargeFilter { invoiceDisplayName values }
+              presentationBreakdowns { presentationBy units }
               appliedTaxes {
                 taxCode
                 taxName
@@ -77,6 +78,7 @@ RSpec.describe Resolvers::InvoiceResolver do
             itemCode
             itemName
             creditableAmountCents
+            presentationBreakdowns { presentationBy units }
             charge {
               id
               billableMetric {
@@ -123,7 +125,7 @@ RSpec.describe Resolvers::InvoiceResolver do
       charges_to_datetime: Time.current.end_of_month - 1.month,
       fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
       fixed_charges_to_datetime: Time.current.end_of_month + 1.month
-    })
+    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
   end
   let(:charge_fee) do
     create(:charge_fee, subscription:, invoice:, amount_cents: 10, properties: {
@@ -133,7 +135,7 @@ RSpec.describe Resolvers::InvoiceResolver do
       charges_to_datetime: Time.current.end_of_month - 1.month,
       fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
       fixed_charges_to_datetime: Time.current.end_of_month + 1.month
-    })
+    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
   end
   let(:fixed_charge_fee) do
     create(:fixed_charge_fee, subscription:, invoice:, amount_cents: 10, properties: {
@@ -143,7 +145,7 @@ RSpec.describe Resolvers::InvoiceResolver do
       charges_to_datetime: Time.current.end_of_month - 1.month,
       fixed_charges_from_datetime: Time.current.beginning_of_month + 1.month,
       fixed_charges_to_datetime: Time.current.end_of_month + 1.month
-    })
+    }, presentation_breakdowns: [build(:presentation_breakdown, organization:)])
   end
 
   before do
@@ -183,16 +185,25 @@ RSpec.describe Resolvers::InvoiceResolver do
     expect(subscription_fee["id"]).to eq(fee.id)
     expect(subscription_fee["properties"]["fromDatetime"]).to eq(Time.current.beginning_of_month.to_datetime.iso8601)
     expect(subscription_fee["properties"]["toDatetime"]).to eq(Time.current.end_of_month.to_datetime.iso8601)
+    expect(subscription_fee["presentationBreakdowns"]).to eq([
+      {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
+    ])
 
     charge_fee_result = data["invoiceSubscriptions"][0]["fees"].find { |f| f["itemType"] == "charge" }
     expect(charge_fee_result["id"]).to eq(charge_fee.id)
     expect(charge_fee_result["properties"]["fromDatetime"]).to eq((Time.current.beginning_of_month - 1.month).to_datetime.iso8601)
     expect(charge_fee_result["properties"]["toDatetime"]).to eq((Time.current.end_of_month - 1.month).to_datetime.iso8601)
+    expect(charge_fee_result["presentationBreakdowns"]).to eq([
+      {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
+    ])
 
     fixed_charge_fee_result = data["invoiceSubscriptions"][0]["fees"].find { |f| f["itemType"] == "fixed_charge" }
     expect(fixed_charge_fee_result["id"]).to eq(fixed_charge_fee.id)
     expect(fixed_charge_fee_result["properties"]["fromDatetime"]).to eq((Time.current.beginning_of_month + 1.month).to_datetime.iso8601)
     expect(fixed_charge_fee_result["properties"]["toDatetime"]).to eq((Time.current.end_of_month + 1.month).to_datetime.iso8601)
+    expect(fixed_charge_fee_result["presentationBreakdowns"]).to eq([
+      {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
+    ])
   end
 
   it "includes filters for the fee" do
@@ -231,7 +242,16 @@ RSpec.describe Resolvers::InvoiceResolver do
       unit_amount_cents: 20
     )
 
-    fee_with_usage = create(:fee, subscription:, invoice:, charge:, amount_cents: 100, organization:, pricing_unit_usage:)
+    fee_with_usage = create(
+      :fee,
+      subscription:,
+      invoice:,
+      charge:,
+      amount_cents: 100,
+      organization:,
+      pricing_unit_usage:,
+      presentation_breakdowns: [build(:presentation_breakdown, organization:)]
+    )
 
     result = execute_graphql(
       current_user: membership.user,
@@ -252,6 +272,9 @@ RSpec.describe Resolvers::InvoiceResolver do
     expect(fee_data["pricingUnitUsage"]["shortName"]).to eq(pricing_unit_usage.short_name)
     expect(fee_data["pricingUnitUsage"]["pricingUnit"]["code"]).to eq(pricing_unit.code)
     expect(fee_data["pricingUnitUsage"]["pricingUnit"]["name"]).to eq(pricing_unit.name)
+    expect(fee_data["presentationBreakdowns"]).to eq([
+      {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
+    ])
   end
 
   context "when invoice is not found" do
@@ -285,7 +308,17 @@ RSpec.describe Resolvers::InvoiceResolver do
         values: [billable_metric_filter.values.first]
       )
     end
-    let(:fee) { create(:charge_fee, subscription:, invoice:, charge_filter:, charge:, amount_cents: 10) }
+    let(:fee) do
+      create(
+        :charge_fee,
+        subscription:,
+        invoice:,
+        charge_filter:,
+        charge:,
+        amount_cents: 10,
+        presentation_breakdowns: [build(:presentation_breakdown, organization:)]
+      )
+    end
 
     let(:charge) do
       create(:standard_charge, :deleted, billable_metric:)
@@ -319,7 +352,14 @@ RSpec.describe Resolvers::InvoiceResolver do
     let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10) }
     let(:add_on) { create(:add_on, organization:) }
     let(:applied_add_on) { create(:applied_add_on, add_on:, customer:) }
-    let(:fee) { create(:add_on_fee, invoice:, applied_add_on:) }
+    let(:fee) do
+      create(
+        :add_on_fee,
+        invoice:,
+        applied_add_on:,
+        presentation_breakdowns: [build(:presentation_breakdown, organization:)]
+      )
+    end
 
     it "returns a single invoice" do
       result = execute_graphql(
@@ -344,6 +384,9 @@ RSpec.describe Resolvers::InvoiceResolver do
         "itemCode" => add_on.code,
         "itemName" => add_on.name
       )
+      expect(data["fees"].first["presentationBreakdowns"]).to eq([
+        {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
+      ])
     end
 
     context "with a deleted add_on" do
@@ -373,6 +416,9 @@ RSpec.describe Resolvers::InvoiceResolver do
           "itemCode" => add_on.code,
           "itemName" => add_on.name
         )
+        expect(data["fees"].first["presentationBreakdowns"]).to eq([
+          {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
+        ])
       end
     end
   end
@@ -405,7 +451,14 @@ RSpec.describe Resolvers::InvoiceResolver do
 
   context "with a credit invoice" do
     let(:invoice) { create(:invoice, :credit, customer:, organization:) }
-    let(:fee) { create(:credit_fee, invoice:, invoiceable: wallet_transaction) }
+    let(:fee) do
+      create(
+        :credit_fee,
+        invoice:,
+        invoiceable: wallet_transaction,
+        presentation_breakdowns: [build(:presentation_breakdown, organization:)]
+      )
+    end
     let(:wallet_transaction) { create(:wallet_transaction, organization:, wallet:) }
     let(:wallet) { create(:wallet, organization:, name: "wallet name") }
 
@@ -418,6 +471,9 @@ RSpec.describe Resolvers::InvoiceResolver do
       graphql_wallet_transaction = data.dig("fees", 0, "walletTransaction")
       expect(graphql_wallet_transaction["name"]).to eq("Custom Transaction Name")
       expect(graphql_wallet_transaction["walletName"]).to eq("wallet name")
+      expect(data.dig("fees", 0, "presentationBreakdowns")).to eq([
+        {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
+      ])
     end
   end
 end

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Resolvers::PlanResolver do
             properties {
               amount
               pricingGroupKeys
+              presentationGroupKeys { value options { displayInInvoice } }
               freeUnits
               packageSize
               fixedAmount
@@ -193,13 +194,27 @@ RSpec.describe Resolvers::PlanResolver do
 
   context "when plan has charges" do
     before do
-      create(:standard_charge, billable_metric:, plan:)
+      create(
+        :standard_charge,
+        billable_metric:,
+        plan:,
+        properties: {
+          amount: "100",
+          presentation_group_keys: [
+            {"value" => "region", "options" => {"display_in_invoice" => true}}
+          ]
+        }
+      )
     end
 
     it "returns true for has charges" do
       plan_response = result["data"]["plan"]
 
       expect(plan_response["hasCharges"]).to eq(true)
+
+      expect(plan_response["charges"].sole.dig("properties", "presentationGroupKeys")).to eq([
+        {"value" => "region", "options" => {"displayInInvoice" => true}}
+      ])
     end
   end
 

--- a/spec/graphql/types/charges/presentation_group_key_input_spec.rb
+++ b/spec/graphql/types/charges/presentation_group_key_input_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Charges::PresentationGroupKeyInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:value).of_type("String!")
+    expect(subject).to accept_argument(:options).of_type("PresentationGroupKeyOptionsInput")
+  end
+end

--- a/spec/graphql/types/charges/presentation_group_key_options_input_spec.rb
+++ b/spec/graphql/types/charges/presentation_group_key_options_input_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Charges::PresentationGroupKeyOptionsInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:display_in_invoice).of_type("Boolean")
+  end
+end

--- a/spec/graphql/types/charges/presentation_group_key_options_spec.rb
+++ b/spec/graphql/types/charges/presentation_group_key_options_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Charges::PresentationGroupKeyOptions do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:display_in_invoice).of_type("Boolean")
+  end
+end

--- a/spec/graphql/types/charges/presentation_group_key_spec.rb
+++ b/spec/graphql/types/charges/presentation_group_key_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Charges::PresentationGroupKey do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:value).of_type("String!")
+    expect(subject).to have_field(:options).of_type("PresentationGroupKeyOptions")
+  end
+end

--- a/spec/graphql/types/charges/properties_input_spec.rb
+++ b/spec/graphql/types/charges/properties_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Charges::PropertiesInput do
   it do
     expect(subject).to accept_argument(:amount).of_type("String")
     expect(subject).to accept_argument(:pricing_group_keys).of_type("[String!]")
+    expect(subject).to accept_argument(:presentation_group_keys).of_type("[PresentationGroupKeyInput!]")
 
     expect(subject).to accept_argument(:graduated_ranges).of_type("[GraduatedRangeInput!]")
 

--- a/spec/graphql/types/charges/properties_spec.rb
+++ b/spec/graphql/types/charges/properties_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Types::Charges::Properties do
 
     expect(subject).to have_field(:graduated_ranges).of_type("[GraduatedRange!]")
 
+    expect(subject).to have_field(:presentation_group_keys).of_type("[PresentationGroupKey!]")
     expect(subject).to have_field(:graduated_percentage_ranges).of_type("[GraduatedPercentageRange!]")
 
     expect(subject).to have_field(:free_units).of_type("BigInt")

--- a/spec/graphql/types/customers/usage/grouped_usage_spec.rb
+++ b/spec/graphql/types/customers/usage/grouped_usage_spec.rb
@@ -12,5 +12,6 @@ RSpec.describe Types::Customers::Usage::GroupedUsage do
     expect(subject).to have_field(:units).of_type("Float!")
     expect(subject).to have_field(:filters).of_type("[ChargeFilterUsage!]")
     expect(subject).to have_field(:grouped_by).of_type("JSON")
+    expect(subject).to have_field(:presentation_breakdowns).of_type("[PresentationBreakdownUsage!]")
   end
 end

--- a/spec/graphql/types/customers/usage/presentation_breakdown_spec.rb
+++ b/spec/graphql/types/customers/usage/presentation_breakdown_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Customers::Usage::PresentationBreakdown do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:presentation_by).of_type("JSON!")
+    expect(subject).to have_field(:units).of_type("String!")
+  end
+end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Types::Fees::Object do
     expect(subject).to have_field(:adjusted_fee_type).of_type("AdjustedFeeTypeEnum")
 
     expect(subject).to have_field(:charge_filter).of_type("ChargeFilter")
+    expect(subject).to have_field(:presentation_breakdowns).of_type("[PresentationBreakdownUsage!]")
     expect(subject).to have_field(:pricing_unit_usage).of_type("PricingUnitUsage")
     expect(subject).to have_field(:properties).of_type("FeeProperties")
   end
@@ -62,6 +63,59 @@ RSpec.describe Types::Fees::Object do
 
       it "returns nil" do
         expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe "#presentation_breakdowns" do
+    subject { run_graphql_field("Fee.presentationBreakdowns", fee) }
+
+    context "when fee has no presentation_breakdowns" do
+      let(:fee) { create(:charge_fee) }
+
+      it "returns an empty array" do
+        expect(subject).to eq([])
+      end
+    end
+
+    context "when fee has a presentation_breakdown" do
+      let(:fee) do
+        create(
+          :charge_fee,
+          presentation_breakdowns: [build(:presentation_breakdown)]
+        )
+      end
+
+      it "returns the presentation_breakdowns" do
+        expect(subject).to eq([
+          {
+            presentation_by: {"department" => "engineering"},
+            units: "60.0"
+          }
+        ])
+      end
+    end
+
+    context "when fee has a composite presentation_breakdown" do
+      let(:fee) do
+        create(
+          :charge_fee,
+          presentation_breakdowns: [
+            build(
+              :presentation_breakdown,
+              :with_composite_presentation_by
+            )
+          ]
+        )
+      end
+
+      it "returns the presentation_breakdowns" do
+        expect(subject).to eq([
+          {
+            presentation_by: {"department" => "engineering", "region" => "eu"},
+            units: "60.0"
+          }
+        ])
       end
     end
   end

--- a/spec/graphql/types/fees/presentation_breakdown_builder_spec.rb
+++ b/spec/graphql/types/fees/presentation_breakdown_builder_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Fees::PresentationBreakdownBuilder do
+  subject(:result) { described_class.call(fees) }
+
+  let(:fees) { [fee_one, fee_two] }
+
+  let(:fee_one) do
+    build(
+      :charge_fee,
+      presentation_breakdowns: [
+        build(
+          :presentation_breakdown,
+          fee: nil,
+          presentation_by: {"cloud" => "aws"},
+          units: 1.2
+        )
+      ]
+    )
+  end
+
+  let(:fee_two) do
+    build(
+      :charge_fee,
+      invoice: fee_one.invoice,
+      presentation_breakdowns: [
+        build(
+          :presentation_breakdown,
+          presentation_by: {"cloud" => "aws"},
+          units: 0.3
+        ),
+        build(
+          :presentation_breakdown,
+          presentation_by: {"cloud" => "gcp"},
+          units: 3
+        )
+      ]
+    )
+  end
+
+  it "groups by presentation_by and sums units across fees" do
+    expect(result).to match_array([
+      {presentation_by: {"cloud" => "aws"}, units: "1.5"},
+      {presentation_by: {"cloud" => "gcp"}, units: "3.0"}
+    ])
+  end
+
+  context "when fees contain nil presentation_breakdowns" do
+    let(:fees) { [build(:charge_fee, presentation_breakdowns: [])] }
+
+    it "returns an empty array" do
+      expect(result).to eq([])
+    end
+  end
+end

--- a/spec/graphql/types/fees/presentation_breakdown_builder_spec.rb
+++ b/spec/graphql/types/fees/presentation_breakdown_builder_spec.rb
@@ -3,20 +3,17 @@
 require "rails_helper"
 
 RSpec.describe Types::Fees::PresentationBreakdownBuilder do
-  subject(:result) { described_class.call(fees) }
+  subject(:result) { described_class.call(fees, filter:) }
 
+  let(:filter) { described_class::UNGROUPED }
   let(:fees) { [fee_one, fee_two] }
 
   let(:fee_one) do
     build(
       :charge_fee,
+      grouped_by: {},
       presentation_breakdowns: [
-        build(
-          :presentation_breakdown,
-          fee: nil,
-          presentation_by: {"cloud" => "aws"},
-          units: 1.2
-        )
+        build(:presentation_breakdown, fee: nil, presentation_by: {"cloud" => "aws"}, units: 1.2)
       ]
     )
   end
@@ -25,33 +22,82 @@ RSpec.describe Types::Fees::PresentationBreakdownBuilder do
     build(
       :charge_fee,
       invoice: fee_one.invoice,
+      grouped_by: {},
       presentation_breakdowns: [
-        build(
-          :presentation_breakdown,
-          presentation_by: {"cloud" => "aws"},
-          units: 0.3
-        ),
-        build(
-          :presentation_breakdown,
-          presentation_by: {"cloud" => "gcp"},
-          units: 3
-        )
+        build(:presentation_breakdown, presentation_by: {"cloud" => "aws"}, units: 0.3),
+        build(:presentation_breakdown, presentation_by: {"cloud" => "gcp"}, units: 3)
       ]
     )
   end
 
-  it "groups by presentation_by and sums units across fees" do
-    expect(result).to match_array([
-      {presentation_by: {"cloud" => "aws"}, units: "1.5"},
+  it "returns one entry per breakdown with stringified units" do
+    expect(result).to eq([
+      {presentation_by: {"cloud" => "aws"}, units: "1.2"},
+      {presentation_by: {"cloud" => "aws"}, units: "0.3"},
       {presentation_by: {"cloud" => "gcp"}, units: "3.0"}
     ])
   end
 
-  context "when fees contain nil presentation_breakdowns" do
-    let(:fees) { [build(:charge_fee, presentation_breakdowns: [])] }
+  context "when fees contain no presentation_breakdowns" do
+    let(:fees) { [build(:charge_fee, grouped_by: {}, presentation_breakdowns: [])] }
 
     it "returns an empty array" do
       expect(result).to eq([])
+    end
+  end
+
+  describe "filtering" do
+    let(:ungrouped_fee) do
+      build(
+        :charge_fee,
+        grouped_by: {},
+        presentation_breakdowns: [
+          build(:presentation_breakdown, fee: nil, presentation_by: {"region" => "us"}, units: 1)
+        ]
+      )
+    end
+
+    let(:grouped_fee) do
+      build(
+        :charge_fee,
+        grouped_by: {"region" => "eu"},
+        presentation_breakdowns: [
+          build(:presentation_breakdown, fee: nil, presentation_by: {"region" => "eu"}, units: 2)
+        ]
+      )
+    end
+
+    let(:fees) { [ungrouped_fee, grouped_fee] }
+
+    context "when filter is UNGROUPED" do
+      let(:filter) { described_class::UNGROUPED }
+
+      it "includes only fees with blank grouped_by" do
+        expect(result).to eq([
+          {presentation_by: {"region" => "us"}, units: "1.0"}
+        ])
+      end
+    end
+
+    context "when filter is GROUPED" do
+      let(:filter) { described_class::GROUPED }
+
+      it "includes only fees with present grouped_by" do
+        expect(result).to eq([
+          {presentation_by: {"region" => "eu"}, units: "2.0"}
+        ])
+      end
+    end
+
+    context "when filter is ALL" do
+      let(:filter) { described_class::ALL }
+
+      it "includes breakdowns from all fees regardless of grouped_by" do
+        expect(result).to eq([
+          {presentation_by: {"region" => "us"}, units: "1.0"},
+          {presentation_by: {"region" => "eu"}, units: "2.0"}
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
This commit updates the graphql resolvers to include the presentationBreakdowns.

Also, it's changing some mutations like "create plan" and "update plan" to receive the charge and chargeFilter properties containing presentation_group_keys.
