### PR TITLE
feat(payment-gated-subs): fire deferred invoice side effects on payment success

### DIFF
--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -15,10 +15,7 @@ module Invoices
         return result
       end
 
-      ActiveRecord::Base.transaction do
-        invoice.status = :finalized
-        invoice.save!
-      end
+      invoice.finalized!
 
       result.invoice = invoice
       result

--- a/app/services/subscriptions/activation_rules/payment/resolve_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/resolve_service.rb
@@ -36,6 +36,15 @@ module Subscriptions
           EvaluateService.call!(rule: payment_rule, status: :satisfied)
           Invoices::FinalizeService.call!(invoice:)
           ActivationRules::ResolveSubscriptionStatusService.call!(subscription:)
+
+          after_commit do
+            SendWebhookJob.perform_later("invoice.created", invoice)
+            Utils::ActivityLog.produce(invoice, "invoice.created")
+            Invoices::GenerateDocumentsJob.perform_later(invoice:, notify: should_deliver_email?)
+            Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+            Integrations::Aggregator::Invoices::Hubspot::CreateJob.perform_later(invoice:) if invoice.should_sync_hubspot_invoice?
+            Utils::SegmentTrack.invoice_created(invoice)
+          end
         end
 
         def handle_failure
@@ -49,6 +58,11 @@ module Subscriptions
 
         def payment_rule
           @payment_rule ||= subscription.activation_rules.payment.sole
+        end
+
+        def should_deliver_email?
+          License.premium? &&
+            invoice.billing_entity.email_settings.include?("invoice.finalized")
         end
       end
     end

--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -99,10 +99,28 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
       expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
     end
 
-    it "enqueues GenerateDocumentsJob" do
+    it "enqueues GenerateDocumentsJob with notify false" do
       result
 
       expect(Invoices::GenerateDocumentsJob).to have_been_enqueued.with(invoice:, notify: false)
+    end
+
+    context "with lago_premium", :premium do
+      it "enqueues GenerateDocumentsJob with notify true" do
+        result
+
+        expect(Invoices::GenerateDocumentsJob).to have_been_enqueued.with(invoice:, notify: true)
+      end
+
+      context "when billing entity does not have invoice.finalized email setting" do
+        before { invoice.billing_entity.update!(email_settings: []) }
+
+        it "enqueues GenerateDocumentsJob with notify false" do
+          result
+
+          expect(Invoices::GenerateDocumentsJob).to have_been_enqueued.with(invoice:, notify: false)
+        end
+      end
     end
 
     it "tracks invoice creation in segment" do

--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -87,6 +87,72 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
       expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", subscription)
     end
 
+    it "sends an invoice.created webhook" do
+      result
+
+      expect(SendWebhookJob).to have_been_enqueued.with("invoice.created", invoice)
+    end
+
+    it "produces an invoice.created activity log" do
+      result
+
+      expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
+    end
+
+    it "enqueues GenerateDocumentsJob" do
+      result
+
+      expect(Invoices::GenerateDocumentsJob).to have_been_enqueued.with(invoice:, notify: false)
+    end
+
+    it "tracks invoice creation in segment" do
+      allow(Utils::SegmentTrack).to receive(:invoice_created)
+
+      result
+
+      expect(Utils::SegmentTrack).to have_received(:invoice_created).with(invoice)
+    end
+
+    context "when invoice should be synced to accounting integration" do
+      before { allow(invoice).to receive(:should_sync_invoice?).and_return(true) }
+
+      it "enqueues Aggregator::Invoices::CreateJob" do
+        result
+
+        expect(Integrations::Aggregator::Invoices::CreateJob).to have_been_enqueued.with(invoice:)
+      end
+    end
+
+    context "when invoice should not be synced to accounting integration" do
+      before { allow(invoice).to receive(:should_sync_invoice?).and_return(false) }
+
+      it "does not enqueue Aggregator::Invoices::CreateJob" do
+        result
+
+        expect(Integrations::Aggregator::Invoices::CreateJob).not_to have_been_enqueued
+      end
+    end
+
+    context "when invoice should be synced to hubspot" do
+      before { allow(invoice).to receive(:should_sync_hubspot_invoice?).and_return(true) }
+
+      it "enqueues Aggregator::Invoices::Hubspot::CreateJob" do
+        result
+
+        expect(Integrations::Aggregator::Invoices::Hubspot::CreateJob).to have_been_enqueued.with(invoice:)
+      end
+    end
+
+    context "when invoice should not be synced to hubspot" do
+      before { allow(invoice).to receive(:should_sync_hubspot_invoice?).and_return(false) }
+
+      it "does not enqueue Aggregator::Invoices::Hubspot::CreateJob" do
+        result
+
+        expect(Integrations::Aggregator::Invoices::Hubspot::CreateJob).not_to have_been_enqueued
+      end
+    end
+
     context "when subscription is already active (idempotency)" do
       let(:subscription) { create(:subscription, organization:, customer:, plan:) }
 


### PR DESCRIPTION
## Context

When a subscription is gated by a payment activation rule, the invoice is created in :open status and the standard invoice.created side effects (webhook, activity log, document generation, accounting/CRM sync, analytics tracking) are deliberately skipped — outside actors should not see the invoice until payment has been collected.

## Description

Fire the deferred side effects in Payment::ResolveService#handle_success after FinalizeService transitions the invoice to :finalized and ResolveSubscriptionStatusService activates the subscription. Side effects are wrapped in an after_commit block so they only run if the surrounding transaction commits.
