### PR TITLE
test(payment-gated-subs): add WIP tests for late-payment refund routing

### DIFF
--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -127,4 +127,58 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
       expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
     end
   end
+
+  context "when payment succeeds late on a canceled subscription with closed invoice" do
+    let(:subscription) { create(:subscription, :canceled, organization:, customer:, plan:) }
+    let(:invoice) do
+      create(:invoice, organization:, customer:, status: :closed, invoice_type: :subscription,
+        total_amount_cents: 100, fees_amount_cents: 100)
+    end
+    let(:payment_status) { :succeeded }
+
+    it "enqueues a refund job for the invoice" do
+      result
+
+      expect(Payments::RefundJob).to have_been_enqueued.with(invoice)
+    end
+
+    it "does not change the rule status" do
+      result
+
+      expect(rule.reload.status).to eq("pending")
+    end
+
+    it "does not finalize the invoice" do
+      result
+
+      expect(invoice.reload.status).to eq("closed")
+    end
+
+    it "does not reactivate the subscription" do
+      result
+
+      expect(subscription.reload).to be_canceled
+    end
+  end
+
+  context "when payment fails late on a canceled subscription with closed invoice" do
+    let(:subscription) { create(:subscription, :canceled, organization:, customer:, plan:) }
+    let(:invoice) do
+      create(:invoice, organization:, customer:, status: :closed, invoice_type: :subscription,
+        total_amount_cents: 100, fees_amount_cents: 100)
+    end
+    let(:payment_status) { :failed }
+
+    it "does not enqueue a refund job" do
+      result
+
+      expect(Payments::RefundJob).not_to have_been_enqueued
+    end
+
+    it "does not change the rule status" do
+      result
+
+      expect(rule.reload.status).to eq("pending")
+    end
+  end
 end


### PR DESCRIPTION
## Context

The dive-in calls for a late-payment refund branch in Payment::ResolveService#handle_success: when a payment succeeds after the subscription was already canceled and the invoice closed (e.g. via a future timeout/expire mechanism), the service should enqueue a refund job rather than attempt to finalize the invoice.

The branch is unreachable in M1 — no timeout mechanism exists yet, and Invoices::UpdateService.handle_payment_gated_activation short-circuits canceled subscriptions before reaching the resolve service. The referenced Payments::RefundJob is M3 work and does not yet exist.

## Description

Add failing unit tests that pin the expected routing for the canceled + closed pair, on both succeeded and failed payment statuses. The tests fail today by referencing the non-existent Payments::RefundJob and stay in place as a guide for the M3 implementation that will introduce the job, the timeout mechanism, and the matching update to Invoices::UpdateService.

## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}

## Context

Include relevant motivation and context.

## Description

Describe your changes in detail.

List any dependencies that are required.
