### PR TITLE
fix(clickhouse): Speedup events deduplication

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -10,14 +10,22 @@ module Events
       # processed on the events processor side
       CLICKHOUSE_MERGE_DELAY = 15.seconds
 
+      DEDUP_KEY_COLUMNS = %w[code organization_id external_subscription_id transaction_id timestamp].freeze
+
       def events(force_from: false, ordered: false)
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = if deduplicate
-            deduplicated_subquery = deduplicated_events_sql(
-              from_datetime: (from_datetime if force_from || use_from_boundary),
-              to_datetime: (applicable_to_datetime if applicable_to_datetime),
-              deduplicated_columns: %w[value decimal_value properties precise_total_amount_cents]
-            ).to_sql
+            events_from = (from_datetime if force_from || use_from_boundary)
+            events_to = (applicable_to_datetime if applicable_to_datetime)
+
+            deduplicated_subquery = <<~SQL.squish
+              WITH latest_enriched AS (#{latest_enriched_sql(from_datetime: events_from, to_datetime: events_to)})
+              #{deduplicated_events_sql(
+                from_datetime: events_from,
+                to_datetime: events_to,
+                deduplicated_columns: %w[value decimal_value properties precise_total_amount_cents]
+              )}
+            SQL
 
             ::Clickhouse::EventsEnriched.from("(#{deduplicated_subquery}) AS events_enriched")
           else
@@ -69,11 +77,8 @@ module Events
         order_column = deduplicated_columns.include?("decimal_value") ? "decimal_value" : "value"
         deduplicated_columns << order_column if ordered
 
-        base_sql = deduplicated_events_sql(
-          from_datetime: (from_datetime if force_from || use_from_boundary),
-          to_datetime: (applicable_to_datetime if applicable_to_datetime),
-          deduplicated_columns:
-        ).to_sql
+        events_from = (from_datetime if force_from || use_from_boundary)
+        events_to = (applicable_to_datetime if applicable_to_datetime)
 
         query = arel_table
         query = query.order(arel_table[:timestamp].desc, arel_table[order_column]) if ordered
@@ -82,22 +87,29 @@ module Events
         query = arel_filters_scope(query)
 
         {
-          "events_enriched" => base_sql, # Override events table name with deduplicated events
+          "latest_enriched" => latest_enriched_sql(from_datetime: events_from, to_datetime: events_to),
+          "events_enriched" => deduplicated_events_sql(from_datetime: events_from, to_datetime: events_to, deduplicated_columns:),
           "events" => query.project(select).to_sql
         }
       end
 
-      # Clickhouse cannot garanty that events_enriched will be deduplicated all the time
-      # To address this problem, we have to implement deduplication at query time.
-      # This is done by grouping events on transaction_id and timestamp (unicity key) and
-      # by using `argMax` function, to keep only the most recent event of each group
-      def deduplicated_events_sql(from_datetime:, to_datetime:, deduplicated_columns: [])
-        query = arel_table.where(
-          arel_table[:external_subscription_id].eq(subscription.external_id)
-          .and(arel_table[:organization_id].eq(subscription.organization.id)
-          .and(arel_table[:code].eq(code)))
-        ).then { with_timestamp_boundaries(it, from_datetime, to_datetime) }
+      # ClickHouse cannot guarantee that events_enriched will be deduplicated all the time,
+      # so we deduplicate at query time using a two-pass strategy:
+      # 1. `latest_enriched_sql` groups events by their dedup key and gets the latest enriched_at.
+      # 2. `deduplicated_events_sql` filters `latest_enriched` and uses `INNER ANY JOIN` to
+      #    fetch the requested columns from events_enriched. `ANY JOIN` returns at most one
+      #    matching row, so duplicated enriched_at are filtered at the join layer
+      # This replaces a previous implementation with `argMax` which caused ClickHouse OOM on large subscriptions.
+      def latest_enriched_sql(from_datetime:, to_datetime:)
+        <<~SQL.squish
+          SELECT #{DEDUP_KEY_COLUMNS.join(", ")}, max(enriched_at) AS max_enriched_at
+          FROM events_enriched
+          WHERE #{deduplicated_events_where_sql(from_datetime:, to_datetime:)}
+          GROUP BY #{DEDUP_KEY_COLUMNS.join(", ")}
+        SQL
+      end
 
+      def deduplicated_events_sql(from_datetime:, to_datetime:, deduplicated_columns: [])
         columns = deduplicated_columns.dup
 
         # Grouping and filtering is made based on the properties
@@ -105,26 +117,35 @@ module Events
           columns << "properties"
         end
 
-        arel_columns = columns.uniq.map do
-          Arel::Nodes::NamedFunction.new("argMax", [arel_table[it.to_sym], arel_table[:enriched_at]]).as(it)
-        end
+        picked_columns = columns.uniq.map { "e.#{it}" }
+        selected_columns = (DEDUP_KEY_COLUMNS.map { "l.#{it}" } + picked_columns).join(", ")
+        join_conditions = (DEDUP_KEY_COLUMNS.map { "e.#{it} = l.#{it}" } + ["e.enriched_at = l.max_enriched_at"]).join(" AND ")
 
-        query = query.group(
-          arel_table[:code],
-          arel_table[:organization_id],
-          arel_table[:external_subscription_id],
-          arel_table[:timestamp],
-          arel_table[:transaction_id]
-        )
-        query.project(
-          [
-            arel_table[:code],
-            arel_table[:organization_id],
-            arel_table[:external_subscription_id],
-            arel_table[:transaction_id],
-            arel_table[:timestamp]
-          ] + arel_columns
-        )
+        <<~SQL.squish
+          SELECT #{selected_columns}
+          FROM latest_enriched AS l
+          INNER ANY JOIN events_enriched AS e ON #{join_conditions}
+          WHERE #{deduplicated_events_where_sql(from_datetime:, to_datetime:, alias_prefix: "e")}
+        SQL
+      end
+
+      def deduplicated_events_where_sql(from_datetime:, to_datetime:, alias_prefix: nil)
+        prefix = alias_prefix ? "#{alias_prefix}." : ""
+
+        conditions = [
+          ActiveRecord::Base.sanitize_sql_for_conditions(
+            [
+              "#{prefix}organization_id = ? AND #{prefix}code = ? AND #{prefix}external_subscription_id = ?",
+              subscription.organization_id,
+              code,
+              subscription.external_id
+            ]
+          )
+        ]
+
+        conditions << ActiveRecord::Base.sanitize_sql_for_conditions(["#{prefix}timestamp >= ?", from_datetime]) if from_datetime
+        conditions << ActiveRecord::Base.sanitize_sql_for_conditions(["#{prefix}timestamp <= ?", to_datetime]) if to_datetime
+        conditions.join(" AND ")
       end
 
       def distinct_codes

--- a/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
@@ -2,33 +2,66 @@
 
 require "spec_helper"
 
-RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse,
-  skip: "Temporarily disabled as it fails randomly because of the Clickhouse automatic deduplication" do
+RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse do
   subject(:clean_service) { described_class.new(subscription:, timestamp:) }
 
   let(:organization) { create(:organization, clickhouse_events_store: true) }
   let(:subscription) { create(:subscription, organization:) }
   let(:timestamp) { Time.current }
 
+  # ReplacingMergeTree dedupes rows sharing the ORDER BY tuple at merge time, which prevents
+  # the issue the service is supposed to clean.
+  # TRUNCATE before each test gives us a clean slate (no inactive parts/mutations),
+  # and inserting all rows in a single block with `optimize_on_insert=0` keeps every duplicate
+  # inside the same data part so the engine has nothing to merge across.
+  before do
+    ::Clickhouse::EventsEnriched.connection.execute("TRUNCATE TABLE events_enriched")
+  end
+
+  def insert_enriched_events(rows)
+    conn = ::Clickhouse::EventsEnriched.connection
+    values = rows.map { |row|
+      "(" + [
+        conn.quote(row[:organization_id]),
+        conn.quote(row[:external_subscription_id]),
+        conn.quote(row[:code]),
+        conn.quote(row[:timestamp].utc.strftime("%Y-%m-%d %H:%M:%S.%3N")),
+        conn.quote(row[:transaction_id]),
+        "{}",
+        "'21.0'",
+        conn.quote(row[:enriched_at].utc.strftime("%Y-%m-%d %H:%M:%S.%3N"))
+      ].join(", ") + ")"
+    }.join(", ")
+
+    sql = <<~SQL.squish
+      INSERT INTO events_enriched
+        (organization_id, external_subscription_id, code, timestamp, transaction_id, properties, value, enriched_at)
+      VALUES #{values}
+    SQL
+
+    conn.execute(sql, format: nil, settings: {optimize_on_insert: 0})
+  end
+
   describe "#call" do
     let(:transaction_id) { SecureRandom.uuid }
     let(:timestamp) { Time.current.change(usec: 0) }
+    let(:base_enriched_at) { Time.current.change(usec: 0) - 10.minutes }
 
-    let(:base_enriched_at) { Time.current - 10.minutes }
-
-    before do
-      3.times do |i|
-        create(
-          :clickhouse_events_enriched,
+    let(:duplicated_rows) do
+      Array.new(3) do |i|
+        {
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           transaction_id: transaction_id,
           timestamp: timestamp,
           code: "event_code",
           enriched_at: base_enriched_at + i.minutes
-        )
+        }
       end
+    end
 
+    before do
+      insert_enriched_events(duplicated_rows)
       allow(Subscriptions::ChargeCacheService).to receive(:expire_for_subscription)
     end
 
@@ -50,15 +83,14 @@ RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse,
       let(:other_code) { "other_event_code" }
 
       before do
-        create(
-          :clickhouse_events_enriched,
+        insert_enriched_events([{
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           transaction_id: transaction_id,
           timestamp: timestamp,
           code: other_code,
           enriched_at: base_enriched_at
-        )
+        }])
       end
 
       it "does not delete events with a different code" do
@@ -71,19 +103,16 @@ RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse,
     end
 
     context "when duplicate events share the same enriched_at timestamp" do
-      before do
-        ::Clickhouse::EventsEnriched.where(transaction_id:, timestamp:).delete_all
-
-        2.times do
-          create(
-            :clickhouse_events_enriched,
+      let(:duplicated_rows) do
+        Array.new(2) do
+          {
             organization_id: organization.id,
             external_subscription_id: subscription.external_id,
             transaction_id: transaction_id,
             timestamp: timestamp,
             code: "event_code",
             enriched_at: base_enriched_at
-          )
+          }
         end
       end
 


### PR DESCRIPTION
## Context

Today, the deduplication logic in the Clickhouse event store uses two distinct approach:

The `ReplacingMergeTree` defined on the `events_enriched` table witch merge duplicated records when they are ingested. But because of the eventual consistency of this logic, we have no guaranty of when the records will be merged, they might even remain unmerged forever.

Because of this issue, a "forced" deduplication is added, and relies on the "argMax" aggregation that keeps the last state of every timestamp/transaction_id tuple. 

The issue with the argMax approach is that it is slow and cost a lot of resources (memory/cpu). It can even lead to Out Of Memory errors in case of usage pick on the Clickhouse cluster.

Many different approach have been tested to remediate this issue, and it appears that replacing the `argMax` with a two pass strategy (on to retrieve the max enriched_at of each tuple and a second to filter against this list before applying the other condition) is less intensive on both memory and CPU front.

## Description

This PR reworks the `Events::Stores::ClickhouseEventStore` deduplicated strategy with this new approach

The PR also fixes the specs of the `Events::Stores::Clickhouse::CleanDuplicatedService` as they were temporary disabled because of some unreliability. 