### PR TITLE
fix: skip flaky clickhouse tests

### DIFF
--- a/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/clean_duplicated_service_spec.rb
@@ -2,9 +2,8 @@
 
 require "spec_helper"
 
-RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse do
-  skip "Temporarily disabled as it fails randomly because of the Clickhouse automatic deduplication"
-
+RSpec.describe Events::Stores::Clickhouse::CleanDuplicatedService, :clickhouse,
+  skip: "Temporarily disabled as it fails randomly because of the Clickhouse automatic deduplication" do
   subject(:clean_service) { described_class.new(subscription:, timestamp:) }
 
   let(:organization) { create(:organization, clickhouse_events_store: true) }


### PR DESCRIPTION
## Description

Previous `skip` command hasn't work as intended so we had to change it and move to the example.