### PR TITLE
fix(lifetime_usage): Fix clock query performances

### DIFF
--- a/app/jobs/clock/refresh_lifetime_usages_job.rb
+++ b/app/jobs/clock/refresh_lifetime_usages_job.rb
@@ -7,12 +7,17 @@ module Clock
     def perform
       return unless License.premium?
 
-      # NOTE: Only `recalculate_invoiced_usage` is set now.
-      #       `recalculate_current_usage` isn't used anymore (handled by SubscriptionActivity)
-      #       but we keep looking at both flags because of the upgrade/deploy/selfhosting situation.
-      LifetimeUsage.joins(:organization).merge(Organization.with_progressive_billing_support.or(Organization.with_lifetime_usage_support)).needs_recalculation.find_each do |ltu|
-        LifetimeUsages::RecalculateAndCheckJob.perform_later(ltu)
-      end
+      Organization
+        .with_progressive_billing_support
+        .or(Organization.with_lifetime_usage_support)
+        .find_each do |organization|
+          LifetimeUsage
+            .where(organization_id: organization.id)
+            .where(recalculate_invoiced_usage: true)
+            .find_each do |ltu|
+              LifetimeUsages::RecalculateAndCheckJob.perform_later(ltu)
+            end
+        end
     end
   end
 end

--- a/app/models/lifetime_usage.rb
+++ b/app/models/lifetime_usage.rb
@@ -20,8 +20,6 @@ class LifetimeUsage < ApplicationRecord
 
   default_scope -> { kept }
 
-  scope :needs_recalculation, -> { where(recalculate_current_usage: true).or(where(recalculate_invoiced_usage: true)) }
-
   def total_amount_cents
     historical_usage_amount_cents + invoiced_usage_amount_cents + current_usage_amount_cents
   end

--- a/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
+++ b/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
@@ -8,7 +8,7 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
   describe ".perform" do
     let(:organization) { create(:organization) }
     let(:lifetime_usage1) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: true) }
-    let(:lifetime_usage3) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: false) }
+    let(:lifetime_usage2) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: false) }
 
     before do
       lifetime_usage1
@@ -19,7 +19,7 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
       it "does not call the refresh service" do
         described_class.perform_now
         expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage1)
-        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage3)
+        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage2)
       end
     end
 
@@ -28,7 +28,7 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
         described_class.perform_now
 
         expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage1)
-        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage3)
+        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage2)
       end
     end
 
@@ -39,7 +39,7 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
         described_class.perform_now
 
         expect(LifetimeUsages::RecalculateAndCheckJob).to have_been_enqueued.with(lifetime_usage1)
-        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage3)
+        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage2)
       end
     end
   end

--- a/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
+++ b/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
@@ -12,7 +12,6 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
 
     before do
       lifetime_usage1
-      lifetime_usage2
       lifetime_usage3
     end
 

--- a/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
+++ b/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
@@ -20,7 +20,6 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
       it "does not call the refresh service" do
         described_class.perform_now
         expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage1)
-        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage2)
         expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage3)
       end
     end
@@ -30,7 +29,6 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
         described_class.perform_now
 
         expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage1)
-        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage2)
         expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage3)
       end
     end
@@ -42,7 +40,6 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
         described_class.perform_now
 
         expect(LifetimeUsages::RecalculateAndCheckJob).to have_been_enqueued.with(lifetime_usage1)
-        expect(LifetimeUsages::RecalculateAndCheckJob).to have_been_enqueued.with(lifetime_usage2)
         expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage3)
       end
     end

--- a/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
+++ b/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
@@ -12,7 +12,7 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
 
     before do
       lifetime_usage1
-      lifetime_usage3
+      lifetime_usage2
     end
 
     context "when freemium" do

--- a/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
+++ b/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
@@ -8,8 +8,7 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
   describe ".perform" do
     let(:organization) { create(:organization) }
     let(:lifetime_usage1) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: true) }
-    let(:lifetime_usage2) { create(:lifetime_usage, organization:, recalculate_current_usage: true) }
-    let(:lifetime_usage3) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: false, recalculate_current_usage: false) }
+    let(:lifetime_usage3) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: false) }
 
     before do
       lifetime_usage1

--- a/spec/models/lifetime_usage_spec.rb
+++ b/spec/models/lifetime_usage_spec.rb
@@ -45,22 +45,6 @@ RSpec.describe LifetimeUsage do
     end
   end
 
-  describe ".needs_recalculation scope" do
-    let(:lifetime_usage1) { create(:lifetime_usage, recalculate_invoiced_usage: true) }
-    let(:lifetime_usage2) { create(:lifetime_usage, recalculate_current_usage: true) }
-    let(:lifetime_usage3) { create(:lifetime_usage, recalculate_invoiced_usage: false, recalculate_current_usage: false) }
-
-    before do
-      lifetime_usage1
-      lifetime_usage2
-      lifetime_usage3
-    end
-
-    it "returns only the lifetime_usages with a recalculate flag set" do
-      expect(described_class.needs_recalculation).to match_array([lifetime_usage1, lifetime_usage2])
-    end
-  end
-
   describe "#total_amount_cents" do
     it "returns the sum of the historical, invoiced, and current usage" do
       lifetime_usage.historical_usage_amount_cents = 100


### PR DESCRIPTION
- Move global query to a per organization query to optimize index usage
- New query with a simple organization_id filter is now done in 0,500ms
- Remove `recalculate_current_usage` from `LifetimeUsage` model and from the query filters, its not used anymore