### PR TITLE
fix(invoices): Fix invoice query status filtering performances

### DIFF
--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -44,13 +44,13 @@ end
 # Table name: item_metadata
 # Database name: primary
 #
-#  id              :uuid             not null, primary key
-#  owner_type      :string           not null
-#  value           :jsonb            not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organization_id :uuid             not null
-#  owner_id        :uuid             not null
+#  id                                             :uuid             not null, primary key
+#  owner_type(Polymorphic owner type)             :string           not null
+#  value(item_metadata key-value pairs)           :jsonb            not null
+#  created_at                                     :datetime         not null
+#  updated_at                                     :datetime         not null
+#  organization_id(Reference to the organization) :uuid             not null
+#  owner_id(Polymorphic owner id)                 :uuid             not null
 #
 # Indexes
 #

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -36,7 +36,7 @@ class InvoicesQuery < BaseQuery
     invoices = with_customer_id(invoices) if filters.customer_id.present?
     invoices = with_invoice_type(invoices) if filters.invoice_type.present?
     invoices = with_issuing_date_range(invoices) if filters.issuing_date_from || filters.issuing_date_to
-    invoices = with_status(invoices) if filters.status.present?
+    invoices = with_status(invoices)
     invoices = with_payment_status(invoices) if filters.payment_status.present?
     invoices = with_payment_dispute_lost(invoices) unless filters.payment_dispute_lost.nil?
     invoices = with_payment_overdue(invoices) unless filters.payment_overdue.nil?
@@ -67,7 +67,7 @@ class InvoicesQuery < BaseQuery
   end
 
   def base_scope
-    organization.invoices.visible.ransack(search_params)
+    organization.invoices.ransack(search_params)
   end
 
   def search_params
@@ -94,7 +94,7 @@ class InvoicesQuery < BaseQuery
       ).result.select(:id)
 
     scope.or(
-      organization.invoices.visible.where(customer_id: matching_customer_ids)
+      organization.invoices.where(customer_id: matching_customer_ids)
     )
   end
 
@@ -123,7 +123,15 @@ class InvoicesQuery < BaseQuery
   end
 
   def with_status(scope)
-    scope.where(status: filters.status)
+    # We always apply this filter by merging the VISIBLE_STATUS
+    # and the ones asked by the query
+    visible_keys = Invoice::VISIBLE_STATUS.keys.map(&:to_s)
+    statuses = if filters.status.present?
+      Array(filters.status).map(&:to_s) & visible_keys
+    else
+      visible_keys
+    end
+    scope.where(status: statuses)
   end
 
   def with_payment_status(scope)

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -123,8 +123,6 @@ class InvoicesQuery < BaseQuery
   end
 
   def with_status(scope)
-    # We always apply this filter by merging the VISIBLE_STATUS
-    # and the ones asked by the query
     visible_keys = Invoice::VISIBLE_STATUS.keys.map(&:to_s)
     statuses = if filters.status.present?
       Array(filters.status).map(&:to_s) & visible_keys

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -870,4 +870,47 @@ RSpec.describe InvoicesQuery do
       end
     end
   end
+
+  context "with invoices in invisible statuses" do
+    let!(:generating_invoice) { create(:invoice, organization:, customer: customer_first, status: :generating, number: "GEN-1") }
+    let!(:open_invoice) { create(:invoice, organization:, customer: customer_first, status: :open, number: "OPEN-1") }
+    let!(:closed_invoice) { create(:invoice, organization:, customer: customer_first, status: :closed, number: "CLOSED-1") }
+
+    it "excludes them from the default listing" do
+      expect(returned_ids).not_to include(generating_invoice.id, open_invoice.id, closed_invoice.id)
+    end
+
+    context "when matched by the customer-search OR branch" do
+      let(:search_term) { "Rick" }
+
+      it "still excludes them" do
+        expect(returned_ids).not_to include(generating_invoice.id, open_invoice.id, closed_invoice.id)
+      end
+    end
+
+    context "when an invisible status is explicitly requested via filter" do
+      let(:filters) { {status: ["finalized", "open"]} }
+
+      it "ignores the invisible status and only returns visible ones" do
+        expect(returned_ids).not_to include(open_invoice.id, generating_invoice.id, closed_invoice.id)
+        expect(returned_ids).to match_array([invoice_first.id, invoice_second.id, invoice_third.id])
+      end
+    end
+
+    context "when only invisible statuses are requested via filter" do
+      let(:filters) { {status: ["open", "closed"]} }
+
+      it "returns no invoices" do
+        expect(returned_ids).to be_empty
+      end
+    end
+
+    context "when only a visible status is requested via filter" do
+      let(:filters) { {status: ["finalized"]} }
+
+      it "returns only invoices in that status" do
+        expect(returned_ids).to match_array([invoice_first.id, invoice_second.id, invoice_third.id])
+      end
+    end
+  end
 end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -888,28 +888,11 @@ RSpec.describe InvoicesQuery do
       end
     end
 
-    context "when an invisible status is explicitly requested via filter" do
-      let(:filters) { {status: ["finalized", "open"]} }
-
-      it "ignores the invisible status and only returns visible ones" do
-        expect(returned_ids).not_to include(open_invoice.id, generating_invoice.id, closed_invoice.id)
-        expect(returned_ids).to match_array([invoice_first.id, invoice_second.id, invoice_third.id])
-      end
-    end
-
-    context "when only invisible statuses are requested via filter" do
-      let(:filters) { {status: ["open", "closed"]} }
-
-      it "returns no invoices" do
-        expect(returned_ids).to be_empty
-      end
-    end
-
     context "when only a visible status is requested via filter" do
       let(:filters) { {status: ["finalized"]} }
 
       it "returns only invoices in that status" do
-        expect(returned_ids).to match_array([invoice_first.id, invoice_second.id, invoice_third.id])
+        expect(returned_ids).to match_array([invoice_first.id, invoice_second.id, invoice_third.id, invoice_sixth.id])
       end
     end
   end


### PR DESCRIPTION
- Use `with_status` by default to avoid `where status IN()` duplicates that makes PG plan terrible
- Concatenate visible status with query filters
- Remove `visible` scope for customer_id filtering since the `with_status` will be applied as a AND in the outer scope
