### PR TITLE
fix(typo): Receipes -> Recipes

### DIFF
--- a/lib/tasks/recipes/events.rake
+++ b/lib/tasks/recipes/events.rake
@@ -5,7 +5,7 @@ require_relative "../../task_prompt"
 BATCH_SIZE = 1000
 
 # rubocop:disable Rails/Output,Rails/Exit
-namespace :receipes do
+namespace :recipes do
   namespace :events do
     desc "Soft-delete PG events for an organization within a time range"
     task delete_in_range: :environment do

--- a/spec/lib/tasks/recipes/events_rake_spec.rb
+++ b/spec/lib/tasks/recipes/events_rake_spec.rb
@@ -4,15 +4,15 @@ require "rails_helper"
 
 require "rake"
 
-RSpec.describe "receipes:events:delete_in_range" do # rubocop:disable RSpec/DescribeClass
-  let(:task) { Rake::Task["receipes:events:delete_in_range"] }
+RSpec.describe "recipes:events:delete_in_range" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["recipes:events:delete_in_range"] }
 
   let(:organization) { create(:organization) }
   let(:from_timestamp) { "2026-04-09 19:00:00" }
   let(:to_timestamp) { "2026-04-27 23:59:59" }
 
   before do
-    Rake.application.rake_require("tasks/receipes/events")
+    Rake.application.rake_require("tasks/recipes/events")
     Rake::Task.define_task(:environment)
     task.reenable
   end


### PR DESCRIPTION
This just fix a typo in the folder name `Receipes` -> `Recipes`. 