### PR TITLE
feat(speedup): Use subscription loop to filter events in order to use…

### DIFF
--- a/lib/tasks/recipes/events.rake
+++ b/lib/tasks/recipes/events.rake
@@ -2,7 +2,7 @@
 
 require_relative "../../task_prompt"
 
-BATCH_SIZE = 1000
+BATCH_SIZE = 2000
 
 # rubocop:disable Rails/Output,Rails/Exit
 namespace :recipes do
@@ -14,32 +14,50 @@ namespace :recipes do
 
       from_time, to_time = TaskPrompt.ask_for_timestamp_range
 
-      events = Event.where(organization_id: organization.id)
-        .from_datetime(from_time)
-        .to_datetime(to_time)
+      subscriptions = organization.subscriptions.pluck(:external_id)
 
-      count = events.count
+      if subscriptions.empty?
+        puts "No subscriptions found for this organization."
+        next
+      end
 
-      if count.zero?
+      puts "Found #{subscriptions.size} subscriptions."
+
+      puts "\nThis will soft-delete events from \"#{organization.name}\" " \
+        "from #{from_time.utc} to #{to_time.utc} (inclusive)."
+      TaskPrompt.confirm!("Continue? (y/n): ")
+
+      total_deleted = 0
+
+      # rubocop:disable Rails/SkipsModelValidations
+      subscriptions.each_with_index do |external_id, index|
+        events = Event.where(
+          organization_id: organization.id,
+          external_subscription_id: external_id
+        ).from_datetime(from_time).to_datetime(to_time)
+
+        sub_deleted = 0
+        prefix = "[#{index + 1}/#{subscriptions.size}]"
+
+        events.in_batches(of: BATCH_SIZE) do |batch|
+          sub_deleted += batch.update_all(deleted_at: Time.current)
+          print "\r#{prefix} Subscription #{external_id}: #{sub_deleted} events deleted. Total: #{total_deleted + sub_deleted}"
+        end
+
+        if sub_deleted.zero?
+          print "\r#{prefix} Subscription #{external_id}: no events, skipped."
+        end
+
+        total_deleted += sub_deleted
+      end
+      # rubocop:enable Rails/SkipsModelValidations
+
+      if total_deleted.zero?
         puts "No events found in the given time range. Nothing to delete."
         next
       end
 
-      puts "\nThis will soft-delete #{count} events from \"#{organization.name}\" " \
-        "from #{from_time.utc} to #{to_time.utc} (inclusive)."
-      TaskPrompt.confirm!("Continue? (y/n): ")
-
-      deleted = 0
-
-      # rubocop:disable Rails/SkipsModelValidations
-      events.in_batches(of: BATCH_SIZE) do |batch|
-        batch.update_all(deleted_at: Time.current)
-        deleted += BATCH_SIZE
-        print "\rDeleted #{[deleted, count].min}/#{count} events..."
-      end
-      # rubocop:enable Rails/SkipsModelValidations
-
-      puts "\nDone. #{count} events soft-deleted."
+      puts "\nDone. #{total_deleted} events soft-deleted across #{subscriptions.size} subscriptions."
     end
   end
 end

--- a/lib/tasks/recipes/events.rake
+++ b/lib/tasks/recipes/events.rake
@@ -14,14 +14,14 @@ namespace :recipes do
 
       from_time, to_time = TaskPrompt.ask_for_timestamp_range
 
-      subscriptions = organization.subscriptions.pluck(:external_id)
+      subscriptions = organization.subscriptions.distinct.pluck(:external_id)
 
       if subscriptions.empty?
         puts "No subscriptions found for this organization."
         next
       end
 
-      puts "Found #{subscriptions.size} subscriptions."
+      puts "Found #{subscriptions.size} distinct subscriptions."
 
       puts "\nThis will soft-delete events from \"#{organization.name}\" " \
         "from #{from_time.utc} to #{to_time.utc} (inclusive)."

--- a/spec/lib/tasks/recipes/events_rake_spec.rb
+++ b/spec/lib/tasks/recipes/events_rake_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "recipes:events:delete_in_range" do # rubocop:disable RSpec/Descr
     end
   end
 
-  context "when no events match the time range" do
+  context "when organization has no subscriptions" do
     before { stub_stdin(organization.id, "y", from_timestamp, to_timestamp) }
 
     it "finishes without deleting anything" do
@@ -64,12 +64,23 @@ RSpec.describe "recipes:events:delete_in_range" do # rubocop:disable RSpec/Descr
   end
 
   context "when events exist in the time range" do
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:, organization:) }
+
     let!(:event_in_range) do
-      create(:event, organization:, timestamp: Time.zone.parse("2026-04-10 12:00:00"))
+      create(:event,
+        organization_id: organization.id,
+        subscription:,
+        external_subscription_id: subscription.external_id,
+        timestamp: Time.zone.parse("2026-04-10 12:00:00"))
     end
 
     let!(:event_out_of_range) do
-      create(:event, organization:, timestamp: Time.zone.parse("2026-04-01 12:00:00"))
+      create(:event,
+        organization_id: organization.id,
+        subscription:,
+        external_subscription_id: subscription.external_id,
+        timestamp: Time.zone.parse("2026-04-01 12:00:00"))
     end
 
     context "when user confirms deletion" do
@@ -89,6 +100,28 @@ RSpec.describe "recipes:events:delete_in_range" do # rubocop:disable RSpec/Descr
       it "aborts without deleting events" do
         expect { task.invoke }.to raise_error(SystemExit)
         expect(event_in_range.reload.deleted_at).to be_nil
+      end
+    end
+
+    context "when events span multiple subscriptions" do
+      let(:other_subscription) { create(:subscription, customer:, organization:) }
+
+      let!(:event_other_sub) do
+        create(:event,
+          organization_id: organization.id,
+          subscription: other_subscription,
+          external_subscription_id: other_subscription.external_id,
+          timestamp: Time.zone.parse("2026-04-12 12:00:00"))
+      end
+
+      before { stub_stdin(organization.id, "y", from_timestamp, to_timestamp, "y") }
+
+      it "soft-deletes events across all subscriptions" do
+        task.invoke
+
+        expect(event_in_range.reload.deleted_at).to be_present
+        expect(event_other_sub.reload.deleted_at).to be_present
+        expect(event_out_of_range.reload.deleted_at).to be_nil
       end
     end
   end


### PR DESCRIPTION
Use subscription loop to speedup the process of event queries so it uses `idx_events_for_distinct_codes` index. 