### PR TITLE
fix(feedback): Clean the line when new subscription events are being …

### DIFF
--- a/lib/tasks/recipes/events.rake
+++ b/lib/tasks/recipes/events.rake
@@ -41,11 +41,11 @@ namespace :recipes do
 
         events.in_batches(of: BATCH_SIZE) do |batch|
           sub_deleted += batch.update_all(deleted_at: Time.current)
-          print "\r#{prefix} Subscription #{external_id}: #{sub_deleted} events deleted. Total: #{total_deleted + sub_deleted}"
+          print "\r\e[K#{prefix} Subscription #{external_id}: #{sub_deleted} events deleted. Total: #{total_deleted + sub_deleted}"
         end
 
         if sub_deleted.zero?
-          print "\r#{prefix} Subscription #{external_id}: no events, skipped."
+          print "\r\e[K#{prefix} Subscription #{external_id}: no events, skipped."
         end
 
         total_deleted += sub_deleted


### PR DESCRIPTION
This PR cleans the line whenever subscription events are being deleted  and fix things like this, leftovers from previous messages. 
```
[16031/16031] Subscription sub_14203: no events, skipped.d.d..al: 286317184 skipped. Total: 556428
```