### PR TITLE
feat(quotes): Add plan billing item services and GraphQL mutations

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -25,3 +25,7 @@ multi_currency:
 payment_gated_subscriptions:
   description: "Enable payment-gated subscription activation rules"
   owners: ["@osmarluz", "@ancorcruz"]
+
+order_forms:
+  description: "Enable quotes, order forms and orders"
+  owners: ["@murparreira", "@toommz", "@rinasergeeva"]

--- a/app/graphql/mutations/quotes/billing_items/plans/add.rb
+++ b/app/graphql/mutations/quotes/billing_items/plans/add.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Plans
+        class Add < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "AddQuotePlan"
+          description "Adds a plan billing item to a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :plan_id, ID, required: true
+          argument :external_subscription_id, String, required: false
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::Plans::AddService.call(
+              quote_version:,
+              params: args.except(:quote_version_id)
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/plans/remove.rb
+++ b/app/graphql/mutations/quotes/billing_items/plans/remove.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Plans
+        class Remove < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "RemoveQuotePlan"
+          description "Removes a plan billing item from a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :id, ID, required: true
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::Plans::RemoveService.call(
+              quote_version:,
+              id: args[:id]
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/plans/update.rb
+++ b/app/graphql/mutations/quotes/billing_items/plans/update.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module Plans
+        class Update < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "UpdateQuotePlan"
+          description "Updates a plan billing item on a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :id, ID, required: true
+          argument :plan_id, ID, required: false
+          argument :external_subscription_id, String, required: false
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::Plans::UpdateService.call(
+              quote_version:,
+              id: args[:id],
+              params: args.except(:quote_version_id, :id)
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -238,5 +238,9 @@ module Types
     field :remove_subscription_entitlement, mutation: Mutations::Entitlement::RemoveSubscriptionEntitlement
 
     field :create_ai_conversation, mutation: Mutations::AiConversations::Create
+
+    field :add_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Add
+    field :update_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Update
+    field :remove_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Remove
   end
 end

--- a/app/graphql/types/quote_versions/object.rb
+++ b/app/graphql/types/quote_versions/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module QuoteVersions
+    class Object < Types::BaseObject
+      graphql_name "QuoteVersion"
+
+      field :id, ID, null: false
+      field :status, String, null: false
+      field :version, Integer, null: false
+      field :billing_items, GraphQL::Types::JSON, null: true
+      field :content, String, null: true
+      field :share_token, String, null: true
+      field :approved_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :quote_id, ID, null: false
+    end
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -7,7 +7,7 @@ class ApiKey < ApplicationRecord
     activity_log add_on analytic api_log billable_metric coupon applied_coupon credit_note customer_usage
     customer event fee invoice organization payment payment_receipt payment_request payment_method plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
-    billing_entity alert feature security_log
+    billing_entity alert feature security_log quote
   ].freeze
 
   MODES = %w[read write].freeze

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -63,6 +63,7 @@ class Customer < ApplicationRecord
   has_many :applied_add_ons
   has_many :add_ons, through: :applied_add_ons
   has_many :daily_usages
+  has_many :quotes
   has_many :wallets
   has_many :wallet_transactions, through: :wallets
   has_many :payment_provider_customers,

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,6 +75,8 @@ class Organization < ApplicationRecord
   has_many :error_details
   has_many :dunning_campaigns
   has_many :roles
+  has_many :quotes
+  has_many :quote_versions
   has_many :activity_logs, class_name: "Clickhouse::ActivityLog"
   has_many :features, class_name: "Entitlement::Feature"
   has_many :privileges, class_name: "Entitlement::Privilege"
@@ -144,6 +146,7 @@ class Organization < ApplicationRecord
     events_targeting_wallets
     security_logs
     granular_lifetime_usage
+    order_forms
   ].freeze
 
   SECURITY_LOGS_RETENTION_DAYS = 90

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class Quote < ApplicationRecord
+  include Sequenced
+
+  ORDER_TYPES = {
+    subscription_creation: "subscription_creation",
+    subscription_amendment: "subscription_amendment",
+    one_off: "one_off"
+  }.freeze
+
+  before_save :ensure_number
+
+  belongs_to :organization
+  belongs_to :customer
+  belongs_to :subscription, optional: true
+
+  has_many :quote_owners, dependent: :destroy
+  has_many :owners, through: :quote_owners, source: :user, class_name: "User"
+
+  has_many :versions, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
+  has_one :current_version, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
+
+  enum :order_type, ORDER_TYPES,
+    instance_methods: false,
+    validate: true
+
+  validates :subscription_id,
+    presence: true,
+    if: -> { order_type == "subscription_amendment" }
+
+  sequenced(
+    scope: ->(quote) { quote.organization.quotes },
+    lock_key: ->(quote) { quote.organization_id }
+  )
+
+  private
+
+  def ensure_number
+    return if number.present?
+    return if sequential_id.blank?
+
+    time = created_at || Time.current
+    formatted_sequential_id = format("%04d", sequential_id)
+    self.number = "QT-#{time.strftime("%Y")}-#{formatted_sequential_id}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: quotes
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  number          :string           not null
+#  order_type      :enum             not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  customer_id     :uuid             not null
+#  organization_id :uuid             not null
+#  sequential_id   :integer          not null
+#  subscription_id :uuid
+#
+# Indexes
+#
+#  index_quotes_on_customer_id                        (customer_id)
+#  index_quotes_on_subscription_id                    (subscription_id)
+#  index_unique_quotes_on_organization_number         (organization_id,number) UNIQUE
+#  index_unique_quotes_on_organization_sequential_id  (organization_id,sequential_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (subscription_id => subscriptions.id)
+#

--- a/app/models/quote_owner.rb
+++ b/app/models/quote_owner.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class QuoteOwner < ApplicationRecord
+  belongs_to :organization
+  belongs_to :quote
+  belongs_to :user
+end
+
+# == Schema Information
+#
+# Table name: quote_owners
+# Database name: primary
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  quote_id        :uuid             not null
+#  user_id         :uuid             not null
+#
+# Indexes
+#
+#  index_quote_owners_on_organization_id    (organization_id)
+#  index_quote_owners_on_user_id            (user_id)
+#  index_unique_quote_owners_on_quote_user  (quote_id,user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (quote_id => quotes.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+class QuoteVersion < ApplicationRecord
+  include Sequenced
+
+  STATUSES = {
+    draft: "draft",
+    approved: "approved",
+    voided: "voided"
+  }.freeze
+
+  VOID_REASONS = {
+    manual: "manual",
+    superseded: "superseded",
+    cascade_of_expired: "cascade_of_expired",
+    cascade_of_voided: "cascade_of_voided"
+  }.freeze
+
+  before_save :ensure_share_token
+
+  belongs_to :organization
+  belongs_to :quote
+
+  has_one :order_form
+  has_one :order, through: :order_form
+
+  enum :status, STATUSES,
+    default: :draft,
+    validate: true
+  enum :void_reason, VOID_REASONS,
+    instance_methods: false,
+    validate: {allow_nil: true}
+
+  validates :share_token,
+    on: :update,
+    presence: true,
+    if: -> { draft? || approved? }
+
+  validates :void_reason, :voided_at,
+    presence: true,
+    if: -> { voided? }
+
+  validates :approved_at,
+    presence: true,
+    if: -> { approved? }
+
+  sequenced(
+    scope: ->(quote_version) { quote_version.quote.versions },
+    lock_key: ->(quote_version) { quote_version.quote_id }
+  )
+
+  def version = sequential_id
+
+  private
+
+  def ensure_share_token
+    return if voided?
+
+    self.share_token ||= SecureRandom.uuid
+  end
+end
+
+# == Schema Information
+#
+# Table name: quote_versions
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  approved_at     :datetime
+#  billing_items   :jsonb
+#  content         :text
+#  share_token     :string
+#  status          :enum             default("draft"), not null
+#  void_reason     :enum
+#  voided_at       :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  quote_id        :uuid             not null
+#  sequential_id   :integer          not null
+#
+# Indexes
+#
+#  index_quote_versions_on_organization_id             (organization_id)
+#  index_quote_versions_on_quote_id                    (quote_id)
+#  index_unique_quote_versions_on_quote_active_status  (quote_id) UNIQUE WHERE (status = ANY (ARRAY['draft'::quote_status, 'approved'::quote_status]))
+#  index_unique_quote_versions_on_quote_sequential_id  (quote_id,sequential_id) UNIQUE
+#  index_unique_quote_versions_on_share_token          (share_token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (quote_id => quotes.id)
+#

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ApplicationRecord
   has_many :active_memberships, -> { where(status: "active") }, class_name: "Membership"
   has_many :active_organizations, through: :active_memberships, source: :organization
 
+  has_many :quote_owners, dependent: :destroy
+  has_many :quotes, through: :quote_owners
+
   validates :email, presence: true
   validates :password, presence: true
 

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class ApproveService < BaseService
+    attr_reader :quote_version
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(quote_version:)
+      @quote_version = quote_version
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless approvable?
+      validation_errors = validate
+      return result.validation_failure!(errors: {quote_version: validation_errors}) if validation_errors.any?
+
+      quote_version.update!(
+        status: :approved,
+        approved_at: Time.current
+      )
+
+      # TODO: OrderForms::CreateService.call
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.approved", quote_version)
+
+      result.quote_version = quote_version
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "approval_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def approvable?
+      quote_version.draft?
+    end
+
+    def validate
+      []
+      # TODO: payload checks
+    end
+  end
+end

--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class CloneService < BaseService
+    class CloneError < StandardError
+      attr_reader :cause, :error
+
+      def initialize(cause: nil, error: nil)
+        @cause = cause
+        @error = error
+        super("QuoteVersion clone failed due to #{cause.class}")
+      end
+    end
+
+    attr_reader :quote_version
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(quote_version:)
+      @quote_version = quote_version
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless clonable?
+
+      cloned = QuoteVersion.transaction do
+        void!(quote_version:)
+        create_next_version(quote_version:)
+      end
+
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.cloned", cloned)
+
+      result.quote_version = cloned
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue CloneError, ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "clone_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def clonable?
+      return false if quote_version.approved?
+
+      true
+    end
+
+    def create_next_version(quote_version:)
+      quote_version.dup.tap do |cloned|
+        cloned.status = :draft
+        cloned.sequential_id = nil
+        cloned.share_token = nil # will be generated on saving
+        cloned.void_reason = nil
+        cloned.voided_at = nil
+        cloned.approved_at = nil
+        cloned.save!
+      end
+    end
+
+    def void!(quote_version:)
+      return if quote_version.voided?
+
+      void_result = QuoteVersions::VoidService.new(
+        quote_version: quote_version,
+        reason: :superseded
+      ).call
+
+      raise CloneError.new(error: void_result.error, cause: void_result) unless void_result&.success?
+    end
+  end
+end

--- a/app/services/quote_versions/create_service.rb
+++ b/app/services/quote_versions/create_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class CreateService < BaseService
+    attr_reader :organization, :quote, :params
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(organization:, quote:, params: {})
+      @organization = organization
+      @quote = quote
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "organization") unless organization
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless organization.feature_flag_enabled?(:order_forms)
+
+      create_params = params.slice(
+        :billing_items,
+        :content
+      )
+
+      quote_version = quote.versions.create!(
+        organization:,
+        **create_params
+      )
+
+      result.quote_version = quote_version
+
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.created", quote_version)
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "create_failed", message: e.message, error: e)
+    end
+  end
+end

--- a/app/services/quote_versions/update_service.rb
+++ b/app/services/quote_versions/update_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class UpdateService < BaseService
+    attr_reader :quote_version, :params
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(quote_version:, params:)
+      @quote_version = quote_version
+      @params = params
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless editable?
+
+      update_params = params.slice(
+        :billing_items,
+        :content
+      )
+      quote_version.update!(update_params)
+      result.quote_version = quote_version
+
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.updated", quote_version)
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "update_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def editable?
+      quote_version.draft?
+    end
+  end
+end

--- a/app/services/quote_versions/void_service.rb
+++ b/app/services/quote_versions/void_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class VoidService < BaseService
+    attr_reader :quote_version, :reason
+
+    Result = BaseResult[:quote_version]
+
+    def initialize(quote_version:, reason:)
+      @quote_version = quote_version
+      @reason = reason
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+      return result.validation_failure!(errors: {quote_version: ["invalid_void_reason"]}) unless valid_reason?(reason:)
+      return result.not_allowed_failure!(code: "inappropriate_state") unless voidable?
+
+      quote_version.update!(
+        status: :voided,
+        void_reason: reason,
+        voided_at: Time.current,
+        share_token: nil,
+        approved_at: nil
+      )
+
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.voided", quote_version)
+
+      result.quote_version = quote_version
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "void_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def voidable?
+      quote_version.approved? || quote_version.draft?
+    end
+
+    def valid_reason?(reason:)
+      return false if reason.blank?
+
+      QuoteVersion::VOID_REASONS.has_key?(reason.to_s.to_sym)
+    end
+  end
+end

--- a/app/services/quotes/billing_items/base_mutation_service.rb
+++ b/app/services/quotes/billing_items/base_mutation_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    class BaseMutationService < BaseService
+      Result = BaseResult[:quote_version]
+
+      private
+
+      attr_reader :quote_version
+
+      def current_items(type)
+        billing_items = (quote_version.billing_items || {}).transform_keys(&:to_s)
+        billing_items.fetch(type.to_s, []).map { |item| item.transform_keys(&:to_s) }
+      end
+
+      def persist_items(type, items)
+        existing = (quote_version.billing_items || {}).transform_keys(&:to_s)
+        quote_version.update!(billing_items: existing.merge(type.to_s => items))
+        result.quote_version = quote_version.reload
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/plans/add_service.rb
+++ b/app/services/quotes/billing_items/plans/add_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Plans
+      class AddService < Quotes::BillingItems::BaseMutationService
+        ALLOWED_ORDER_TYPES = %w[subscription_creation subscription_amendment].freeze
+
+        def initialize(quote_version:, params:)
+          @quote_version = quote_version
+          @params = params
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          unless ALLOWED_ORDER_TYPES.include?(quote_version.quote.order_type)
+            return result.validation_failure!(
+              errors: {billing_item: ["plans not allowed for one_off order type"]}
+            )
+          end
+
+          plan_id = params[:plan_id] || params["plan_id"]
+
+          if plan_id.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["plan_id is required"]}
+            )
+          end
+
+          unless quote_version.organization.plans.exists?(id: plan_id)
+            return result.validation_failure!(
+              errors: {billing_item: ["plan not found in organization"]}
+            )
+          end
+
+          item = params.transform_keys(&:to_s)
+          item["id"] ||= "qtp_#{SecureRandom.uuid}"
+
+          persist_items("plans", current_items("plans") + [item])
+        end
+
+        private
+
+        attr_reader :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/plans/remove_service.rb
+++ b/app/services/quotes/billing_items/plans/remove_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Plans
+      class RemoveService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote_version:, id:)
+          @quote_version = quote_version
+          @id = id
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          items = current_items("plans")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          items.delete_at(item_index)
+          persist_items("plans", items)
+        end
+
+        private
+
+        attr_reader :id
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/plans/update_service.rb
+++ b/app/services/quotes/billing_items/plans/update_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module Plans
+      class UpdateService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote_version:, id:, params:)
+          @quote_version = quote_version
+          @id = id
+          @params = params
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          items = current_items("plans")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          updated_item = items[item_index].merge(params.transform_keys(&:to_s))
+
+          plan_id = updated_item["plan_id"]
+
+          if plan_id.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["plan_id is required"]}
+            )
+          end
+
+          unless quote_version.organization.plans.exists?(id: plan_id)
+            return result.validation_failure!(
+              errors: {billing_item: ["plan not found in organization"]}
+            )
+          end
+
+          items[item_index] = updated_item
+          persist_items("plans", items)
+        end
+
+        private
+
+        attr_reader :id, :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/validate_service.rb
+++ b/app/services/quotes/billing_items/validate_service.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    class ValidateService < BaseService
+      Result = BaseResult[:billing_items]
+
+      COUPON_TYPES = %w[fixed_amount percentage].freeze
+      ID_PREFIXES = {
+        "plans" => "qtp",
+        "add_ons" => "qta",
+        "coupons" => "qtc",
+        "wallet_credits" => "qtw"
+      }.freeze
+      RECURRING_RULE_PREFIX = "qtrr"
+
+      def initialize(organization:, order_type:, billing_items:)
+        @organization = organization
+        @order_type = order_type.to_s
+        @billing_items = billing_items || {}
+        super
+      end
+
+      def call
+        errors = []
+
+        errors.concat(validate_type_constraints)
+        errors.concat(validate_plans) if subscription_type?
+        errors.concat(validate_add_ons) if one_off_type?
+        errors.concat(validate_coupons) if subscription_type?
+        errors.concat(validate_wallet_credits) if subscription_type?
+
+        return result.validation_failure!(errors: {billing_items: errors}) if errors.any?
+
+        result.billing_items = normalized_billing_items
+        result
+      end
+
+      private
+
+      attr_reader :organization, :order_type, :billing_items
+
+      def subscription_type?
+        order_type == "subscription_creation" || order_type == "subscription_amendment"
+      end
+
+      def one_off_type?
+        order_type == "one_off"
+      end
+
+      def validate_type_constraints
+        errors = []
+
+        if one_off_type? && plans_present?
+          errors << "plans not allowed for one_off order type"
+        end
+
+        if one_off_type? && coupons_present?
+          errors << "coupons not allowed for one_off order type"
+        end
+
+        if one_off_type? && wallet_credits_present?
+          errors << "wallet_credits not allowed for one_off order type"
+        end
+
+        if subscription_type? && add_ons_present?
+          errors << "add_ons not allowed for subscription order type"
+        end
+
+        errors
+      end
+
+      def validate_plans
+        errors = []
+        plans = billing_items.fetch("plans", [])
+
+        plans.each_with_index do |plan, index|
+          plan_id = plan["plan_id"] || plan[:plan_id]
+
+          if plan_id.blank?
+            errors << "plans[#{index}].plan_id is required"
+            next
+          end
+
+          unless organization.plans.exists?(id: plan_id)
+            errors << "plans[#{index}].plan_id: plan not found in organization"
+          end
+        end
+
+        errors
+      end
+
+      def validate_add_ons
+        errors = []
+        add_ons = billing_items.fetch("add_ons", [])
+
+        add_ons.each_with_index do |add_on, index|
+          add_on_id = add_on["add_on_id"] || add_on[:add_on_id]
+          amount_cents = add_on["amount_cents"] || add_on[:amount_cents]
+          name = add_on["name"] || add_on[:name]
+
+          if name.blank?
+            errors << "add_ons[#{index}].name is required"
+          end
+
+          if add_on_id.present?
+            unless organization.add_ons.exists?(id: add_on_id)
+              errors << "add_ons[#{index}].add_on_id: add_on not found in organization"
+            end
+          elsif amount_cents.blank?
+            errors << "add_ons[#{index}].amount_cents is required when add_on_id is not provided"
+          end
+        end
+
+        errors
+      end
+
+      def validate_coupons
+        errors = []
+        coupons = billing_items.fetch("coupons", [])
+
+        coupons.each_with_index do |coupon, index|
+          coupon_id = coupon["coupon_id"] || coupon[:coupon_id]
+          coupon_type = coupon["coupon_type"] || coupon[:coupon_type]
+
+          if coupon_id.blank?
+            errors << "coupons[#{index}].coupon_id is required"
+            next
+          end
+
+          unless organization.coupons.exists?(id: coupon_id)
+            errors << "coupons[#{index}].coupon_id: coupon not found in organization"
+          end
+
+          unless COUPON_TYPES.include?(coupon_type.to_s)
+            errors << "coupons[#{index}].coupon_type is invalid"
+          end
+        end
+
+        errors
+      end
+
+      def validate_wallet_credits
+        []
+        # No catalog reference needed for wallet credits
+      end
+
+      def normalized_billing_items
+        result = billing_items.dup.transform_keys(&:to_s)
+
+        if subscription_type?
+          result["plans"] = normalize_items(result.fetch("plans", []), prefix: ID_PREFIXES["plans"])
+          result["coupons"] = normalize_items(result.fetch("coupons", []), prefix: ID_PREFIXES["coupons"])
+          result["wallet_credits"] = normalize_wallet_credits(result.fetch("wallet_credits", []))
+        end
+
+        if one_off_type?
+          result["add_ons"] = normalize_items(result.fetch("add_ons", []), prefix: ID_PREFIXES["add_ons"])
+        end
+
+        result
+      end
+
+      def normalize_items(items, prefix:)
+        items.map do |item|
+          item = item.transform_keys(&:to_s)
+          item["id"] = "#{prefix}_#{SecureRandom.uuid}" if item["id"].blank?
+          item
+        end
+      end
+
+      def normalize_wallet_credits(items)
+        items.map do |item|
+          item = item.transform_keys(&:to_s)
+          item["id"] = "#{ID_PREFIXES["wallet_credits"]}_#{SecureRandom.uuid}" if item["id"].blank?
+          item["recurring_transaction_rules"] = normalize_recurring_rules(item.fetch("recurring_transaction_rules", []))
+          item
+        end
+      end
+
+      def normalize_recurring_rules(rules)
+        rules.map do |rule|
+          rule = rule.transform_keys(&:to_s)
+          rule["id"] = "#{RECURRING_RULE_PREFIX}_#{SecureRandom.uuid}" if rule["id"].blank?
+          rule
+        end
+      end
+
+      def plans_present?
+        billing_items.fetch("plans", billing_items.fetch(:plans, [])).any?
+      end
+
+      def coupons_present?
+        billing_items.fetch("coupons", billing_items.fetch(:coupons, [])).any?
+      end
+
+      def wallet_credits_present?
+        billing_items.fetch("wallet_credits", billing_items.fetch(:wallet_credits, [])).any?
+      end
+
+      def add_ons_present?
+        billing_items.fetch("add_ons", billing_items.fetch(:add_ons, [])).any?
+      end
+    end
+  end
+end

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Quotes
+  class CreateService < BaseService
+    class CreateError < StandardError
+      attr_reader :cause, :error
+
+      def initialize(cause: nil, error: nil)
+        @cause = cause
+        @error = error
+        super("Quote creation failed due to #{cause.class}")
+      end
+    end
+
+    attr_reader :organization, :customer, :subscription, :params, :owners
+
+    Result = BaseResult[:quote]
+
+    def initialize(organization:, customer:, subscription: nil, params: {})
+      @organization = organization
+      @customer = customer
+      @subscription = subscription
+      @params = params
+      @owners = normalize_owners(owners: params[:owners])
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "organization") unless organization
+      return result.not_found_failure!(resource: "customer") unless customer
+      return result.not_found_failure!(resource: "subscription") if subscription_required? && subscription.blank?
+      return result.forbidden_failure! unless organization.feature_flag_enabled?(:order_forms)
+      return result.validation_failure!(errors: {quotes: ["invalid_owner"]}) unless check_owners(owners:)
+
+      quote_create_params = params.slice(
+        :order_type
+      )
+      quote_version_create_params = params.slice(
+        :billing_items,
+        :content
+      )
+
+      Quote.transaction do
+        quote = organization.quotes.create!(
+          customer:,
+          subscription:,
+          **quote_create_params
+        )
+        initialize_version!(
+          quote:,
+          version_params: quote_version_create_params
+        )
+        add_owners!(quote:, owners:)
+        result.quote = quote
+      end
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.created", quote)
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue CreateError, ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "create_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def subscription_required?
+      params[:order_type].to_s == "subscription_amendment"
+    end
+
+    def check_owners(owners:)
+      return true if owners.blank?
+
+      valid_owners = organization.memberships.active.pluck(:user_id)
+      invalid_owners = owners - valid_owners
+      return false if invalid_owners.any?
+
+      true
+    end
+
+    def initialize_version!(quote:, version_params: {})
+      create_result = QuoteVersions::CreateService.new(
+        organization: quote.organization,
+        quote: quote,
+        params: version_params
+      ).call
+
+      raise CreateError.new(error: create_result.error, cause: create_result) unless create_result&.success?
+    end
+
+    def add_owners!(quote:, owners:)
+      return if owners.blank?
+
+      owners.each do |user_id|
+        quote.quote_owners.create!(organization:, user_id:)
+      end
+    end
+
+    def normalize_owners(owners:)
+      return [] if owners.blank?
+      return owners.map(&:to_s).uniq if owners.is_a?(Array)
+
+      [owners.to_s]
+    end
+  end
+end

--- a/app/services/quotes/update_service.rb
+++ b/app/services/quotes/update_service.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Quotes
+  class UpdateService < BaseService
+    attr_reader :quote, :params, :owners
+
+    Result = BaseResult[:quote]
+
+    def initialize(quote:, params:)
+      @quote = quote
+      @params = params
+      @owners = normalize_owners(owners: params[:owners])
+      super
+    end
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "quote") unless quote
+      return result.forbidden_failure! unless quote.organization.feature_flag_enabled?(:order_forms)
+      return result.validation_failure!(errors: {quotes: ["invalid_owner"]}) unless check_owners(owners:)
+
+      sync_owners!(quote:, owners:) if params.has_key?(:owners)
+
+      # TODO: SendWebhookJob.perform_after_commit("quote.updated", quote)
+
+      result.quote = quote.reload
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::ActiveRecordError => e
+      result.service_failure!(code: "update_failed", message: e.message, error: e)
+    end
+
+    private
+
+    def check_owners(owners:)
+      return true if owners.blank?
+
+      valid_owners = quote.organization.memberships.active.pluck(:user_id)
+      invalid_owners = owners - valid_owners
+      return false if invalid_owners.any?
+
+      true
+    end
+
+    def normalize_owners(owners:)
+      return [] if owners.blank?
+      return owners.map(&:to_s).uniq if owners.is_a?(Array)
+
+      [owners.to_s]
+    end
+
+    def sync_owners!(quote:, owners:)
+      QuoteOwner.transaction do
+        current_owners = quote.owner_ids
+
+        owners_to_remove = current_owners - owners
+        quote.quote_owners.where(user_id: owners_to_remove).delete_all if owners_to_remove.any?
+
+        owners_to_add = owners - current_owners
+        owners_to_add.each do |user_id|
+          quote.quote_owners.create!(
+            organization_id: quote.organization_id,
+            user_id: user_id
+          )
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,11 +32,13 @@ en:
         invalid_free_units_per_total_aggregation: invalid_free_units_per_total_aggregation
         invalid_graduated_ranges: invalid_graduated_ranges
         invalid_organization: invalid_organization
+        invalid_owner: invalid_owner
         invalid_package_size: invalid_package_size
         invalid_per_unit_amount: invalid_per_unit_amount
         invalid_rate: invalid_rate
         invalid_size: invalid_size
         invalid_timezone: invalid_timezone
+        invalid_void_reason: invalid_void_reason
         invalid_volume_ranges: invalid_volume_ranges
         language_code_invalid: not_a_valid_language_code
         less_than_or_equal_to: value_is_out_of_range

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -128,6 +128,20 @@ invoice_custom_sections:
     - finance
   delete:
     - finance
+quotes:
+  view:
+    - finance
+    - manager
+  create:
+    - manager
+  update:
+    - manager
+  approve:
+    - manager
+  clone:
+    - manager
+  void:
+    - manager
 organization:
   view:
     - finance

--- a/db/migrate/20260304074158_add_quotes.rb
+++ b/db/migrate/20260304074158_add_quotes.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+class AddQuotes < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :quote_status, %w[draft approved voided]
+    create_enum :quote_void_reason, %w[manual superseded cascade_of_expired cascade_of_voided]
+    create_enum :order_type, %w[subscription_creation subscription_amendment one_off]
+
+    create_table :quotes, id: :uuid do |t|
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique index below
+        type: :uuid
+      t.references :customer,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :subscription,
+        foreign_key: true,
+        type: :uuid
+      t.string :number, null: false
+      t.integer :sequential_id, null: false
+      t.enum :order_type,
+        enum_type: :order_type,
+        null: false
+      t.timestamps
+
+      # constraints and indices
+      t.check_constraint "sequential_id > 0",
+        name: "quotes_constraint_sequential_id_positive"
+      t.index [:organization_id, :sequential_id],
+        unique: true,
+        name: "index_unique_quotes_on_organization_sequential_id"
+      t.index [:organization_id, :number],
+        unique: true,
+        name: "index_unique_quotes_on_organization_number"
+    end
+
+    create_table :quote_versions, id: :uuid do |t|
+      # identity
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :quote,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.integer :sequential_id, null: false # acts as version number
+      # lifecycle
+      t.enum :status,
+        enum_type: :quote_status,
+        null: false,
+        default: "draft"
+      t.datetime :approved_at
+      t.datetime :voided_at
+      t.enum :void_reason, enum_type: :quote_void_reason
+      # content
+      t.jsonb :billing_items
+      t.text :content
+      t.string :share_token
+      t.timestamps
+
+      # constraints and indices
+      t.check_constraint "sequential_id > 0",
+        name: "quote_versions_constraint_sequential_id_positive"
+      t.check_constraint "(status = 'voided') = (void_reason IS NOT NULL AND voided_at IS NOT NULL)",
+        name: "quote_versions_constraint_void_fields_match_status"
+      t.check_constraint "(status = 'approved') = (approved_at IS NOT NULL)",
+        name: "quote_versions_constraint_approved_at_matches_status"
+      t.index [:quote_id, :sequential_id],
+        unique: true,
+        name: "index_unique_quote_versions_on_quote_sequential_id"
+      t.index :quote_id,
+        unique: true,
+        where: "status IN ('draft', 'approved')",
+        name: "index_unique_quote_versions_on_quote_active_status"
+      t.index :share_token,
+        unique: true,
+        name: "index_unique_quote_versions_on_share_token"
+    end
+
+    create_table :quote_owners do |t|
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :quote,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique index below
+        type: :uuid
+      t.references :user,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.timestamps
+
+      t.index [:quote_id, :user_id],
+        unique: true,
+        name: "index_unique_quote_owners_on_quote_user"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -45,6 +45,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_de7694c307;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
 ALTER TABLE IF EXISTS ONLY public.invites DROP CONSTRAINT IF EXISTS fk_rails_dd342449a6;
 ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_dc444f5f29;
@@ -58,6 +59,7 @@ ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EX
 ALTER TABLE IF EXISTS ONLY public.idempotency_records DROP CONSTRAINT IF EXISTS fk_rails_d4f02c82b2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transaction_consumptions DROP CONSTRAINT IF EXISTS fk_rails_d4abfdb375;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_d384ec1ebf;
+ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS fk_rails_d2d917b73a;
 ALTER TABLE IF EXISTS ONLY public.item_metadata DROP CONSTRAINT IF EXISTS fk_rails_d0b1714507;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_d07bc24ce3;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ce2c63d69f;
@@ -100,6 +102,7 @@ ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_a7f20c73bb;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_a710519346;
 ALTER TABLE IF EXISTS ONLY public.group_properties DROP CONSTRAINT IF EXISTS fk_rails_a2d2cb3819;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_a1ab65f1f7;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_9f22076477;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_9ea6759859;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_9e3f99b7a2;
@@ -151,6 +154,7 @@ ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_7886e1bc34;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_77f2d4440d;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_778360c382;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_7734750af9;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_76ceb88c74;
 ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rails_755d734f25;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
@@ -185,6 +189,7 @@ ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_5cb2f24c3d;
 ALTER TABLE IF EXISTS ONLY public.payment_receipts DROP CONSTRAINT IF EXISTS fk_rails_5c2e0b6d34;
 ALTER TABLE IF EXISTS ONLY public.error_details DROP CONSTRAINT IF EXISTS fk_rails_5c21eece29;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_5bb40a7bae;
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_5ade8984b1;
 ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS fk_rails_5a4b906a16;
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS fk_rails_5a43da571b;
@@ -204,6 +209,7 @@ ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sec
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_49212d501e;
 ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk_rails_47d8081062;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_45230f8485;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_4117574b51;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_41088c7d45;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_3ff27d7624;
@@ -263,12 +269,14 @@ ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EX
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_19c47827ba;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_189f2a3949;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS fk_rails_1811b32fcd;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_173327f0dc;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_150139409e;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_142809fee1;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_12d29bc654;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_123667657c;
+ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS fk_rails_10ee148d0d;
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_10428ecad2;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_103e187859;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_0f807322b1;
@@ -364,6 +372,12 @@ DROP INDEX IF EXISTS public.index_usage_monitoring_alert_thresholds_on_organizat
 DROP INDEX IF EXISTS public.index_unique_transaction_id;
 DROP INDEX IF EXISTS public.index_unique_terminating_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_starting_invoice_subscription;
+DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_sequential_id;
+DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_number;
+DROP INDEX IF EXISTS public.index_unique_quote_versions_on_share_token;
+DROP INDEX IF EXISTS public.index_unique_quote_versions_on_quote_sequential_id;
+DROP INDEX IF EXISTS public.index_unique_quote_versions_on_quote_active_status;
+DROP INDEX IF EXISTS public.index_unique_quote_owners_on_quote_user;
 DROP INDEX IF EXISTS public.index_unique_applied_to_organization_per_organization;
 DROP INDEX IF EXISTS public.index_uniq_wallet_code_per_customer;
 DROP INDEX IF EXISTS public.index_uniq_invoice_subscriptions_on_fixed_charges_boundaries;
@@ -400,6 +414,12 @@ DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_started_at;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_expiration_at;
+DROP INDEX IF EXISTS public.index_quotes_on_subscription_id;
+DROP INDEX IF EXISTS public.index_quotes_on_customer_id;
+DROP INDEX IF EXISTS public.index_quote_versions_on_quote_id;
+DROP INDEX IF EXISTS public.index_quote_versions_on_organization_id;
+DROP INDEX IF EXISTS public.index_quote_owners_on_user_id;
+DROP INDEX IF EXISTS public.index_quote_owners_on_organization_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_organization_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_group_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_external_id;
@@ -835,6 +855,9 @@ ALTER TABLE IF EXISTS ONLY public.roles DROP CONSTRAINT IF EXISTS roles_pkey;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS refunds_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS recurring_transaction_rules_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS recurring_transaction_rules_invoice_custom_sections_pkey;
+ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS quotes_pkey;
+ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS quote_versions_pkey;
+ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS quote_owners_pkey;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
@@ -931,6 +954,7 @@ ALTER TABLE IF EXISTS ONLY public.active_storage_blobs DROP CONSTRAINT IF EXISTS
 ALTER TABLE IF EXISTS ONLY public.active_storage_attachments DROP CONSTRAINT IF EXISTS active_storage_attachments_pkey;
 ALTER TABLE IF EXISTS public.versions ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.usage_monitoring_subscription_activities ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE IF EXISTS public.quote_owners ALTER COLUMN id DROP DEFAULT;
 DROP TABLE IF EXISTS public.webhooks;
 DROP TABLE IF EXISTS public.webhook_endpoints;
 DROP TABLE IF EXISTS public.wallets_invoice_custom_sections;
@@ -952,6 +976,10 @@ DROP TABLE IF EXISTS public.roles;
 DROP TABLE IF EXISTS public.refunds;
 DROP TABLE IF EXISTS public.recurring_transaction_rules_invoice_custom_sections;
 DROP TABLE IF EXISTS public.recurring_transaction_rules;
+DROP TABLE IF EXISTS public.quotes;
+DROP TABLE IF EXISTS public.quote_versions;
+DROP SEQUENCE IF EXISTS public.quote_owners_id_seq;
+DROP TABLE IF EXISTS public.quote_owners;
 DROP TABLE IF EXISTS public.quantified_events;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
@@ -1099,9 +1127,12 @@ DROP TYPE IF EXISTS public.subscription_invoice_issuing_date_adjustments;
 DROP TYPE IF EXISTS public.subscription_cancelation_reasons;
 DROP TYPE IF EXISTS public.subscription_activation_rule_types;
 DROP TYPE IF EXISTS public.subscription_activation_rule_statuses;
+DROP TYPE IF EXISTS public.quote_void_reason;
+DROP TYPE IF EXISTS public.quote_status;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
 DROP TYPE IF EXISTS public.payment_method_types;
+DROP TYPE IF EXISTS public.order_type;
 DROP TYPE IF EXISTS public.invoice_settlement_settlement_type;
 DROP TYPE IF EXISTS public.invoice_custom_section_type;
 DROP TYPE IF EXISTS public.inbound_webhook_status;
@@ -1283,6 +1314,17 @@ CREATE TYPE public.invoice_settlement_settlement_type AS ENUM (
 
 
 --
+-- Name: order_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.order_type AS ENUM (
+    'subscription_creation',
+    'subscription_amendment',
+    'one_off'
+);
+
+
+--
 -- Name: payment_method_types; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -1311,6 +1353,29 @@ CREATE TYPE public.payment_payable_payment_status AS ENUM (
 CREATE TYPE public.payment_type AS ENUM (
     'provider',
     'manual'
+);
+
+
+--
+-- Name: quote_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.quote_status AS ENUM (
+    'draft',
+    'approved',
+    'voided'
+);
+
+
+--
+-- Name: quote_void_reason; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.quote_void_reason AS ENUM (
+    'manual',
+    'superseded',
+    'cascade_of_expired',
+    'cascade_of_voided'
 );
 
 
@@ -4618,6 +4683,81 @@ CREATE TABLE public.quantified_events (
 
 
 --
+-- Name: quote_owners; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quote_owners (
+    id bigint NOT NULL,
+    organization_id uuid NOT NULL,
+    quote_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: quote_owners_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.quote_owners_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: quote_owners_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.quote_owners_id_seq OWNED BY public.quote_owners.id;
+
+
+--
+-- Name: quote_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quote_versions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    quote_id uuid NOT NULL,
+    sequential_id integer NOT NULL,
+    status public.quote_status DEFAULT 'draft'::public.quote_status NOT NULL,
+    approved_at timestamp(6) without time zone,
+    voided_at timestamp(6) without time zone,
+    void_reason public.quote_void_reason,
+    billing_items jsonb,
+    content text,
+    share_token character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT quote_versions_constraint_approved_at_matches_status CHECK (((status = 'approved'::public.quote_status) = (approved_at IS NOT NULL))),
+    CONSTRAINT quote_versions_constraint_sequential_id_positive CHECK ((sequential_id > 0)),
+    CONSTRAINT quote_versions_constraint_void_fields_match_status CHECK (((status = 'voided'::public.quote_status) = ((void_reason IS NOT NULL) AND (voided_at IS NOT NULL))))
+);
+
+
+--
+-- Name: quotes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quotes (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    customer_id uuid NOT NULL,
+    subscription_id uuid,
+    number character varying NOT NULL,
+    sequential_id integer NOT NULL,
+    order_type public.order_type NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT quotes_constraint_sequential_id_positive CHECK ((sequential_id > 0))
+);
+
+
+--
 -- Name: recurring_transaction_rules; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4991,6 +5131,13 @@ CREATE TABLE public.webhooks (
 --
 
 ALTER TABLE ONLY public.enriched_events ATTACH PARTITION public.enriched_events_default DEFAULT;
+
+
+--
+-- Name: quote_owners id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners ALTER COLUMN id SET DEFAULT nextval('public.quote_owners_id_seq'::regclass);
 
 
 --
@@ -5757,6 +5904,30 @@ ALTER TABLE ONLY public.pricing_units
 
 ALTER TABLE ONLY public.quantified_events
     ADD CONSTRAINT quantified_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quote_owners quote_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT quote_owners_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quote_versions quote_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_versions
+    ADD CONSTRAINT quote_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quotes quotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT quotes_pkey PRIMARY KEY (id);
 
 
 --
@@ -8862,6 +9033,48 @@ CREATE INDEX index_quantified_events_on_organization_id ON public.quantified_eve
 
 
 --
+-- Name: index_quote_owners_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_owners_on_organization_id ON public.quote_owners USING btree (organization_id);
+
+
+--
+-- Name: index_quote_owners_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_owners_on_user_id ON public.quote_owners USING btree (user_id);
+
+
+--
+-- Name: index_quote_versions_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_versions_on_organization_id ON public.quote_versions USING btree (organization_id);
+
+
+--
+-- Name: index_quote_versions_on_quote_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quote_versions_on_quote_id ON public.quote_versions USING btree (quote_id);
+
+
+--
+-- Name: index_quotes_on_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quotes_on_customer_id ON public.quotes USING btree (customer_id);
+
+
+--
+-- Name: index_quotes_on_subscription_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quotes_on_subscription_id ON public.quotes USING btree (subscription_id);
+
+
+--
 -- Name: index_recurring_transaction_rules_on_expiration_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9111,6 +9324,48 @@ CREATE UNIQUE INDEX index_uniq_wallet_code_per_customer ON public.wallets USING 
 --
 
 CREATE UNIQUE INDEX index_unique_applied_to_organization_per_organization ON public.dunning_campaigns USING btree (organization_id) WHERE ((applied_to_organization = true) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_unique_quote_owners_on_quote_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_owners_on_quote_user ON public.quote_owners USING btree (quote_id, user_id);
+
+
+--
+-- Name: index_unique_quote_versions_on_quote_active_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_versions_on_quote_active_status ON public.quote_versions USING btree (quote_id) WHERE (status = ANY (ARRAY['draft'::public.quote_status, 'approved'::public.quote_status]));
+
+
+--
+-- Name: index_unique_quote_versions_on_quote_sequential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_versions_on_quote_sequential_id ON public.quote_versions USING btree (quote_id, sequential_id);
+
+
+--
+-- Name: index_unique_quote_versions_on_share_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quote_versions_on_share_token ON public.quote_versions USING btree (share_token);
+
+
+--
+-- Name: index_unique_quotes_on_organization_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quotes_on_organization_number ON public.quotes USING btree (organization_id, number);
+
+
+--
+-- Name: index_unique_quotes_on_organization_sequential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_quotes_on_organization_sequential_id ON public.quotes USING btree (organization_id, sequential_id);
 
 
 --
@@ -9703,6 +9958,14 @@ ALTER TABLE ONLY public.applied_invoice_custom_sections
 
 
 --
+-- Name: quote_versions fk_rails_10ee148d0d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_versions
+    ADD CONSTRAINT fk_rails_10ee148d0d FOREIGN KEY (quote_id) REFERENCES public.quotes(id);
+
+
+--
 -- Name: entitlement_subscription_feature_removals fk_rails_123667657c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9748,6 +10011,14 @@ ALTER TABLE ONLY public.invoice_subscriptions
 
 ALTER TABLE ONLY public.entitlement_entitlements
     ADD CONSTRAINT fk_rails_173327f0dc FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
+
+
+--
+-- Name: quote_owners fk_rails_1811b32fcd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_1811b32fcd FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -10223,6 +10494,14 @@ ALTER TABLE ONLY public.credit_notes
 
 
 --
+-- Name: quote_owners fk_rails_45230f8485; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_45230f8485 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: integration_items fk_rails_47d8081062; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10372,6 +10651,14 @@ ALTER TABLE ONLY public.invoice_settlements
 
 ALTER TABLE ONLY public.add_ons_taxes
     ADD CONSTRAINT fk_rails_5ade8984b1 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: quotes fk_rails_5bb40a7bae; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT fk_rails_5bb40a7bae FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
 
 
 --
@@ -10644,6 +10931,14 @@ ALTER TABLE ONLY public.integrations
 
 ALTER TABLE ONLY public.commitments
     ADD CONSTRAINT fk_rails_76ceb88c74 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: quote_owners fk_rails_7734750af9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_owners
+    ADD CONSTRAINT fk_rails_7734750af9 FOREIGN KEY (quote_id) REFERENCES public.quotes(id);
 
 
 --
@@ -11055,6 +11350,14 @@ ALTER TABLE ONLY public.credit_note_items
 
 
 --
+-- Name: quotes fk_rails_a1ab65f1f7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT fk_rails_a1ab65f1f7 FOREIGN KEY (customer_id) REFERENCES public.customers(id);
+
+
+--
 -- Name: group_properties fk_rails_a2d2cb3819; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11391,6 +11694,14 @@ ALTER TABLE ONLY public.item_metadata
 
 
 --
+-- Name: quote_versions fk_rails_d2d917b73a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quote_versions
+    ADD CONSTRAINT fk_rails_d2d917b73a FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: payments fk_rails_d384ec1ebf; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11492,6 +11803,14 @@ ALTER TABLE ONLY public.invites
 
 ALTER TABLE ONLY public.coupon_targets
     ADD CONSTRAINT fk_rails_de6b3c3138 FOREIGN KEY (plan_id) REFERENCES public.plans(id);
+
+
+--
+-- Name: quotes fk_rails_de7694c307; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quotes
+    ADD CONSTRAINT fk_rails_de7694c307 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -11820,6 +12139,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260305161303'),
 ('20260305161302'),
 ('20260305100007'),
+('20260304074158'),
 ('20260227184913'),
 ('20260224134805'),
 ('20260220131101'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -5731,6 +5731,7 @@ enum FeatureFlagEnum {
   multi_currency
   multiple_payment_methods
   non_persistable_charge_cache_optimization
+  order_forms
   payment_gated_subscriptions
   postgres_enriched_events
   wallet_traceability
@@ -6386,6 +6387,7 @@ enum IntegrationTypeEnum {
   multi_entities_pro
   netsuite
   okta
+  order_forms
   preview
   progressive_billing
   projected_usage
@@ -9196,6 +9198,12 @@ enum PermissionEnum {
   pricing_units_create
   pricing_units_update
   pricing_units_view
+  quotes_approve
+  quotes_clone
+  quotes_create
+  quotes_update
+  quotes_view
+  quotes_void
   roles_create
   roles_delete
   roles_update
@@ -9303,6 +9311,12 @@ type Permissions {
   pricingUnitsCreate: Boolean!
   pricingUnitsUpdate: Boolean!
   pricingUnitsView: Boolean!
+  quotesApprove: Boolean!
+  quotesClone: Boolean!
+  quotesCreate: Boolean!
+  quotesUpdate: Boolean!
+  quotesView: Boolean!
+  quotesVoid: Boolean!
   rolesCreate: Boolean!
   rolesDelete: Boolean!
   rolesUpdate: Boolean!
@@ -9442,6 +9456,7 @@ enum PremiumIntegrationTypeEnum {
   multi_entities_pro
   netsuite
   okta
+  order_forms
   preview
   progressive_billing
   projected_usage

--- a/schema.json
+++ b/schema.json
@@ -27814,6 +27814,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -32751,6 +32757,12 @@
             },
             {
               "name": "granular_lifetime_usage",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -44518,6 +44530,42 @@
               "deprecationReason": null
             },
             {
+              "name": "quotes_view",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_create",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_update",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_approve",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_clone",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotes_void",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -46208,6 +46256,102 @@
               "deprecationReason": null
             },
             {
+              "name": "quotesApprove",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesClone",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesCreate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesUpdate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesView",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quotesVoid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rolesCreate",
               "description": null,
               "args": [],
@@ -47627,6 +47771,12 @@
             },
             {
               "name": "granular_lifetime_usage",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_forms",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/quote_versions.rb
+++ b/spec/factories/quote_versions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :quote_version do
+    quote
+    organization { quote.organization }
+    status { :draft }
+    sequence(:sequential_id) { |n| n }
+
+    trait :approved do
+      status { :approved }
+      approved_at { Time.current }
+    end
+
+    trait :voided do
+      status { :voided }
+      voided_at { Time.current }
+      void_reason { :manual }
+    end
+  end
+end

--- a/spec/factories/quotes.rb
+++ b/spec/factories/quotes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :quote do
+    organization
+    customer
+    order_type { :subscription_creation }
+    sequence(:sequential_id) { |n| n }
+
+    trait :with_version do
+      transient do
+        version_trait { nil }
+      end
+
+      after(:create) do |quote, evaluator|
+        traits = Array(evaluator.version_trait)
+        create(
+          :quote_version,
+          *traits,
+          quote: quote,
+          organization: quote.organization
+        )
+      end
+    end
+  end
+end

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
       events_targeting_wallets
       security_logs
       granular_lifetime_usage
+      order_forms
     ]
   end
 

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quote do
+  subject(:quote) { create(:quote) }
+
+  describe "enums" do
+    it "defines enums" do
+      expect(subject).to define_enum_for(:order_type)
+        .backed_by_column_of_type(:enum)
+        .with_values(
+          {
+            subscription_creation: "subscription_creation",
+            subscription_amendment: "subscription_amendment",
+            one_off: "one_off"
+          }
+        )
+        .without_instance_methods
+        .validating(allowing_nil: false)
+    end
+  end
+
+  describe "associations" do
+    it "has the expected associations" do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:customer)
+      expect(subject).to belong_to(:subscription).optional
+      expect(subject).to have_many(:quote_owners).dependent(:destroy)
+      expect(subject).to have_many(:owners).through(:quote_owners)
+      expect(subject).to have_many(:versions).class_name("QuoteVersion").order(sequential_id: :desc)
+      expect(subject).to have_one(:current_version).class_name("QuoteVersion").order(sequential_id: :desc)
+    end
+  end
+
+  describe "validations" do
+    it "requires subscription_id when order_type is subscription_amendment" do
+      subscription = create(:subscription)
+      quote = build(:quote, order_type: :subscription_amendment, subscription: nil, organization: subscription.organization, customer: create(:customer, organization: subscription.organization))
+      expect(quote).not_to be_valid
+      quote.subscription = subscription
+      expect(quote).to be_valid
+    end
+  end
+
+  describe "callbacks" do
+    describe "ensure_number" do
+      it "assigns a formatted number when sequential_id and created_at are present" do
+        quote = create(:quote, sequential_id: 123, number: nil, created_at: Time.zone.local(2020, 1, 2))
+        expect(quote.number).to eq("QT-2020-0123")
+      end
+    end
+  end
+end

--- a/spec/models/quote_version_spec.rb
+++ b/spec/models/quote_version_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersion do
+  subject(:quote_version) { create(:quote_version) }
+
+  describe "enums" do
+    it "defines enums" do
+      expect(subject).to define_enum_for(:status)
+        .backed_by_column_of_type(:enum)
+        .with_values(
+          {
+            draft: "draft",
+            approved: "approved",
+            voided: "voided"
+          }
+        )
+        .with_default(:draft)
+        .validating(allowing_nil: false)
+
+      expect(subject).to define_enum_for(:void_reason)
+        .backed_by_column_of_type(:enum)
+        .with_values(
+          {
+            manual: "manual",
+            superseded: "superseded",
+            cascade_of_expired: "cascade_of_expired",
+            cascade_of_voided: "cascade_of_voided"
+          }
+        )
+        .without_instance_methods
+        .validating(allowing_nil: true)
+    end
+  end
+
+  describe "associations" do
+    it "has the expected associations" do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:quote)
+
+      # TODO: Uncomment when the order form and order associations are implemented
+      # expect(subject).to have_one(:order_form)
+      # expect(subject).to have_one(:order).through(:order_form)
+    end
+  end
+
+  describe "validations" do
+    it "requires share_token for draft and approved statuses on update" do
+      draft = build(:quote_version, status: :draft, share_token: nil)
+      expect(draft.valid?(:update)).to be false
+
+      approved = build(:quote_version, status: :approved, share_token: nil, approved_at: Time.current)
+      expect(approved.valid?(:update)).to be false
+    end
+
+    it "requires void_reason and voided_at when voided" do
+      quote_version = build(:quote_version, status: :voided, void_reason: nil, voided_at: nil)
+      expect(quote_version).not_to be_valid
+
+      quote_version.void_reason = :manual
+      quote_version.voided_at = Time.current
+      expect(quote_version).to be_valid
+    end
+
+    it "requires approved_at when approved" do
+      quote_version = build(:quote_version, status: :approved, approved_at: nil)
+      expect(quote_version).not_to be_valid
+    end
+  end
+
+  describe "callbacks" do
+    describe "ensure_share_token" do
+      it "generates a share_token for draft versions" do
+        quote_version = create(:quote_version, status: :draft, share_token: nil)
+        expect(quote_version.share_token).to be_present
+      end
+
+      it "does not generate a share_token for voided versions" do
+        quote_version = create(:quote_version, :voided)
+        expect(quote_version.share_token).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::ApproveService do
+  subject(:approve_service) { described_class.new(quote_version:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, organization:) }
+  let(:quote_version) { create(:quote_version, quote:, organization:) }
+
+  describe ".call" do
+    let(:result) { approve_service.call }
+
+    context "when the quote version is approvable", :premium do
+      it "approves the quote version" do
+        freeze_time do
+          expect(result).to be_success
+          expect(result.quote_version.approved?).to eq(true)
+          expect(result.quote_version.approved_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context "when the quote version is voided", :premium do
+      let(:quote_version) { create(:quote_version, :voided, quote:, organization:) }
+
+      it "does not approve the quote version" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+
+        quote_version.reload
+        expect(quote_version.approved?).to eq(false)
+        expect(quote_version.approved_at).to eq(nil)
+      end
+    end
+
+    context "when the quote version is already approved", :premium do
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+      it "does not approve the quote version" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when quote version does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::CloneService do
+  subject(:clone_service) { described_class.new(quote_version:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let!(:quote) { create(:quote, organization:) }
+  let!(:versions) do
+    QuoteVersion.transaction do
+      v1 = create(:quote_version, :voided, quote:, organization:)
+      v2 = create(:quote_version, :voided, quote:, organization:)
+      [v1, v2]
+    end
+  end
+  let(:quote_version) { versions.last }
+
+  describe ".call" do
+    let(:result) { clone_service.call }
+
+    context "when the quote version is clonable", :premium do
+      context "when the quote version is already voided" do
+        it "creates a clone and doesn't override the original quote version" do
+          expect(result).to be_success
+          cloned = result.quote_version
+          expect(cloned.id).not_to eq(quote_version.id)
+          expect(cloned.organization_id).to eq(quote_version.organization_id)
+          expect(cloned.quote_id).to eq(quote_version.quote_id)
+          expect(cloned.version).to eq(quote_version.version + 1)
+          expect(cloned.draft?).to eq(true)
+          expect(cloned.void_reason).to eq(nil)
+          expect(cloned.voided_at).to eq(nil)
+          expect(cloned.approved_at).to eq(nil)
+
+          expect(quote.reload.current_version).to eq(cloned)
+
+          quote_version.reload
+          expect(quote_version.voided?).to eq(true)
+          expect(quote_version.void_reason).to eq("manual")
+          expect(quote_version.voided_at).not_to eq(nil)
+        end
+      end
+
+      context "when the quote version is draft" do
+        let!(:versions) do
+          QuoteVersion.transaction do
+            v1 = create(:quote_version, :voided, quote:, organization:)
+            v2 = create(:quote_version, :draft, quote:, organization:)
+            [v1, v2]
+          end
+        end
+        let(:quote_version) { versions.last }
+
+        it "creates an clone and voids the original quote version" do
+          expect(result).to be_success
+          cloned = result.quote_version
+          expect(cloned.id).not_to eq(quote_version.id)
+          expect(cloned.organization_id).to eq(quote_version.organization_id)
+          expect(cloned.quote_id).to eq(quote_version.quote_id)
+          expect(cloned.version).to eq(quote_version.version + 1)
+          expect(cloned.draft?).to eq(true)
+          expect(cloned.void_reason).to eq(nil)
+          expect(cloned.voided_at).to eq(nil)
+          expect(cloned.approved_at).to eq(nil)
+
+          expect(quote.reload.current_version).to eq(cloned)
+
+          quote_version.reload
+          expect(quote_version.voided?).to eq(true)
+          expect(quote_version.void_reason).to eq("superseded")
+          expect(quote_version.voided_at).not_to eq(nil)
+        end
+      end
+    end
+
+    context "when the quote version is not clonable", :premium do
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+      it "does not create a clone" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+
+        quote_version.reload
+        expect(quote_version.approved?).to eq(true)
+        expect(quote_version.void_reason).to eq(nil)
+        expect(quote_version.voided_at).to eq(nil)
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::CreateService do
+  subject(:create_service) {
+    described_class.new(
+      organization:,
+      quote:,
+      params: create_params
+    )
+  }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:create_params) {
+    {
+      billing_items: {},
+      content: "Test content"
+    }
+  }
+
+  describe ".call" do
+    let(:result) { create_service.call }
+
+    context "when license is premium", :premium do
+      it "creates draft quote version" do
+        expect(result).to be_success
+        expect(result.quote_version.quote_id).to eq(quote.id)
+        expect(result.quote_version.organization_id).to eq(quote.organization_id)
+        expect(result.quote_version.version).to eq(1)
+        expect(result.quote_version.draft?).to eq(true)
+        expect(result.quote_version.content).to eq("Test content")
+        expect(result.quote_version.share_token).not_to be_nil
+        expect(result.quote_version.billing_items).to eq({})
+      end
+    end
+
+    context "when organization does not exist", :premium do
+      let(:organization) { nil }
+      let(:customer) { create(:customer) }
+      let(:quote) { create(:quote) }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("organization_not_found")
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/update_service_spec.rb
+++ b/spec/services/quote_versions/update_service_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::UpdateService do
+  subject(:update_service) { described_class.new(quote_version:, params: update_params) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, organization:) }
+  let(:quote_version) { create(:quote_version, quote:, organization:) }
+  let(:update_params) {
+    {
+      billing_items: {},
+      content: "Test content"
+    }
+  }
+
+  describe ".call" do
+    let(:result) { update_service.call }
+
+    context "when draft quote version", :premium do
+      it "updates the quote version" do
+        expect(result).to be_success
+        expect(result.quote_version.id).to eq(quote_version.id)
+        expect(result.quote_version.quote_id).to eq(quote_version.quote_id)
+        expect(result.quote_version.organization_id).to eq(quote_version.organization_id)
+        expect(result.quote_version.version).to eq(quote_version.version)
+        expect(result.quote_version.draft?).to eq(true)
+        expect(result.quote_version.billing_items).to eq({})
+        expect(result.quote_version.content).to eq("Test content")
+      end
+    end
+
+    context "when approved quote version", :premium do
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when voided quote version", :premium do
+      let(:quote_version) { create(:quote_version, :voided, quote:, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when quote version does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::VoidService do
+  subject(:void_service) { described_class.new(quote_version:, reason:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote_version) { create(:quote_version, organization:) }
+  let(:reason) { "manual" }
+
+  describe ".call" do
+    let(:result) { void_service.call }
+
+    context "when quote is voidable", :premium do
+      it "voides the quote" do
+        freeze_time do
+          expect(result).to be_success
+          expect(result.quote_version.voided?).to eq(true)
+          expect(result.quote_version.void_reason).to eq(reason)
+          expect(result.quote_version.voided_at).to eq(Time.current)
+          expect(result.quote_version.share_token).to eq(nil)
+          expect(result.quote_version.approved_at).to eq(nil)
+        end
+      end
+    end
+
+    context "when quote isn't voidable", :premium do
+      let(:quote_version) { create(:quote_version, :voided, organization:) }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("inappropriate_state")
+      end
+    end
+
+    context "when reason is invalid", :premium do
+      context "when reason is blank" do
+        let(:reason) { nil }
+
+        it "returns validation failure" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:quote_version]).to eq(["invalid_void_reason"])
+        end
+      end
+
+      context "when reason is undefined" do
+        let(:reason) { "invalid_reason" }
+
+        it "returns validation failure" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:quote_version]).to eq(["invalid_void_reason"])
+        end
+      end
+    end
+
+    context "when quote_version does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/plans/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/add_service_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Plans::AddService, type: :service do
+  subject(:result) { described_class.call(quote_version:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:plan) { create(:plan, organization:) }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation) }
+  let(:quote_version) { quote.current_version }
+  let(:params) { {plan_id: plan.id} }
+
+  before { allow(License).to receive(:premium?).and_return(true) }
+
+  it "adds the plan to billing_items and returns the quote_version" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["plans"].length).to eq(1)
+    expect(result.quote_version.billing_items["plans"].first["plan_id"]).to eq(plan.id)
+    expect(result.quote_version.billing_items["plans"].first["id"]).to start_with("qtp_")
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when order_forms feature flag is disabled" do
+    let(:organization) { create(:organization) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation, version_trait: :approved) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when order_type is one_off" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :one_off) }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "when plan_id is blank" do
+    let(:params) { {} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "when plan does not belong to organization" do
+    let(:params) { {plan_id: create(:plan).id} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "when a plan already exists in billing_items" do
+    before { quote_version.update!(billing_items: {"plans" => [{"id" => "qtp_existing", "plan_id" => plan.id}]}) }
+
+    it "appends the new plan" do
+      expect(result).to be_success
+      expect(result.quote_version.billing_items["plans"].length).to eq(2)
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/plans/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/remove_service_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Plans::RemoveService, type: :service do
+  subject(:result) { described_class.call(quote_version:, id:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:plan) { create(:plan, organization:) }
+  let(:item_id) { "qtp_#{SecureRandom.uuid}" }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation) }
+  let(:quote_version) { quote.current_version }
+  let(:id) { item_id }
+
+  before do
+    allow(License).to receive(:premium?).and_return(true)
+    quote_version.update!(billing_items: {"plans" => [{"id" => item_id, "plan_id" => plan.id}]})
+  end
+
+  it "removes the plan billing item" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["plans"]).to be_empty
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation, version_trait: :approved) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when item id is not found" do
+    let(:id) { "qtp_nonexistent" }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/plans/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/plans/update_service_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::Plans::UpdateService, type: :service do
+  subject(:result) { described_class.call(quote_version:, id:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:plan) { create(:plan, organization:) }
+  let(:new_plan) { create(:plan, organization:) }
+  let(:item_id) { "qtp_#{SecureRandom.uuid}" }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation) }
+  let(:quote_version) { quote.current_version }
+  let(:id) { item_id }
+  let(:params) { {plan_id: new_plan.id} }
+
+  before do
+    allow(License).to receive(:premium?).and_return(true)
+    quote_version.update!(billing_items: {"plans" => [{"id" => item_id, "plan_id" => plan.id}]})
+  end
+
+  it "updates the plan billing item" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["plans"].first["plan_id"]).to eq(new_plan.id)
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation, version_trait: :approved) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when item id is not found" do
+    let(:id) { "qtp_nonexistent" }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when plan_id is blank" do
+    let(:params) { {plan_id: ""} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "when plan does not belong to organization" do
+    let(:params) { {plan_id: create(:plan).id} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/validate_service_spec.rb
+++ b/spec/services/quotes/billing_items/validate_service_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::ValidateService, type: :service do
+  subject(:result) { described_class.call(organization:, order_type:, billing_items:) }
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+
+  describe "subscription_creation order type" do
+    let(:order_type) { "subscription_creation" }
+
+    context "with valid plans" do
+      let(:billing_items) { {"plans" => [{"plan_id" => plan.id}]} }
+
+      it "returns success with normalized billing_items" do
+        expect(result).to be_success
+        expect(result.billing_items["plans"].first["id"]).to start_with("qtp_")
+        expect(result.billing_items["plans"].first["plan_id"]).to eq(plan.id)
+      end
+    end
+
+    context "when plan_id is missing" do
+      let(:billing_items) { {"plans" => [{}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:billing_items]).to include("plans[0].plan_id is required")
+      end
+    end
+
+    context "when plan does not belong to organization" do
+      let(:billing_items) { {"plans" => [{"plan_id" => create(:plan).id}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_items]).to include("plans[0].plan_id: plan not found in organization")
+      end
+    end
+
+    context "with add_ons (not allowed for subscription type)" do
+      let(:billing_items) { {"add_ons" => [{"add_on_id" => add_on.id, "name" => "Test"}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_items]).to include("add_ons not allowed for subscription order type")
+      end
+    end
+
+    context "with valid coupons" do
+      let(:billing_items) { {"coupons" => [{"coupon_id" => coupon.id, "coupon_type" => "fixed_amount"}]} }
+
+      it "returns success with normalized billing_items" do
+        expect(result).to be_success
+        expect(result.billing_items["coupons"].first["id"]).to start_with("qtc_")
+      end
+    end
+
+    context "when coupon_id is missing" do
+      let(:billing_items) { {"coupons" => [{"coupon_type" => "fixed_amount"}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_items]).to include("coupons[0].coupon_id is required")
+      end
+    end
+
+    context "when coupon_type is invalid" do
+      let(:billing_items) { {"coupons" => [{"coupon_id" => coupon.id, "coupon_type" => "invalid"}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_items]).to include("coupons[0].coupon_type is invalid")
+      end
+    end
+
+    context "with valid wallet_credits" do
+      let(:billing_items) { {"wallet_credits" => [{"amount" => "100"}]} }
+
+      it "returns success with normalized billing_items" do
+        expect(result).to be_success
+        expect(result.billing_items["wallet_credits"].first["id"]).to start_with("qtw_")
+      end
+    end
+
+    context "with wallet_credits including recurring_transaction_rules" do
+      let(:billing_items) do
+        {"wallet_credits" => [{"amount" => "100", "recurring_transaction_rules" => [{"trigger" => "interval"}]}]}
+      end
+
+      it "assigns ids to recurring rules" do
+        expect(result).to be_success
+        expect(result.billing_items["wallet_credits"].first["recurring_transaction_rules"].first["id"]).to start_with("qtrr_")
+      end
+    end
+  end
+
+  describe "one_off order type" do
+    let(:order_type) { "one_off" }
+
+    context "with valid add_ons using add_on_id" do
+      let(:billing_items) { {"add_ons" => [{"add_on_id" => add_on.id, "name" => "My Add-on"}]} }
+
+      it "returns success with normalized billing_items" do
+        expect(result).to be_success
+        expect(result.billing_items["add_ons"].first["id"]).to start_with("qta_")
+      end
+    end
+
+    context "with valid add_ons without add_on_id" do
+      let(:billing_items) { {"add_ons" => [{"name" => "Custom", "amount_cents" => 1000}]} }
+
+      it "returns success" do
+        expect(result).to be_success
+      end
+    end
+
+    context "when add_on name is missing" do
+      let(:billing_items) { {"add_ons" => [{"add_on_id" => add_on.id}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_items]).to include("add_ons[0].name is required")
+      end
+    end
+
+    context "when add_on_id is absent and amount_cents is missing" do
+      let(:billing_items) { {"add_ons" => [{"name" => "Custom"}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_items]).to include("add_ons[0].amount_cents is required when add_on_id is not provided")
+      end
+    end
+
+    context "when add_on_id does not belong to organization" do
+      let(:billing_items) { {"add_ons" => [{"add_on_id" => create(:add_on).id, "name" => "Test"}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_items]).to include("add_ons[0].add_on_id: add_on not found in organization")
+      end
+    end
+
+    context "with plans (not allowed for one_off)" do
+      let(:billing_items) { {"plans" => [{"plan_id" => plan.id}]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_items]).to include("plans not allowed for one_off order type")
+      end
+    end
+  end
+
+  context "when billing_items is nil" do
+    let(:order_type) { "subscription_creation" }
+    let(:billing_items) { nil }
+
+    it "returns success with empty normalized items" do
+      expect(result).to be_success
+    end
+  end
+end

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::CreateService do
+  subject(:create_service) {
+    described_class.new(
+      organization:,
+      customer:,
+      subscription:,
+      params: create_params
+    )
+  }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:membership) { create(:membership, organization:) }
+  let(:owner) { membership.user }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { nil }
+  let(:create_params) {
+    {
+      billing_items: {},
+      content: "Test content",
+      order_type: :subscription_creation,
+      owners: [owner.id]
+    }
+  }
+
+  describe ".call" do
+    let(:result) { create_service.call }
+
+    context "when license is premium", :premium do
+      it "creates an empty draft quote" do
+        travel_to(DateTime.new(2025, 3, 11, 20, 0, 0)) do
+          expect(result).to be_success
+          expect(result.quote.organization_id).to eq(organization.id)
+          expect(result.quote.customer_id).to eq(customer.id)
+          expect(result.quote.sequential_id).to eq(1)
+          expect(result.quote.number).to eq("QT-2025-0001")
+          expect(result.quote.order_type).to eq("subscription_creation")
+          expect(result.quote.owner_ids).to eq([owner.id])
+
+          expect(result.quote.versions.size).to eq(1)
+          expect(result.quote.current_version.version).to eq(1)
+          expect(result.quote.current_version.draft?).to eq(true)
+          expect(result.quote.current_version.content).to eq("Test content")
+        end
+      end
+    end
+
+    context "when owners include invalid user ids", :premium do
+      let(:create_params) {
+        {
+          order_type: :subscription_creation,
+          owners: ["invalid_user_id"]
+        }
+      }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:quotes]).to eq(["invalid_owner"])
+      end
+    end
+
+    context "when organization does not exist", :premium do
+      let(:organization) { nil }
+      let(:customer) { create(:customer) }
+      let(:membership) { create(:membership) }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("organization_not_found")
+      end
+    end
+
+    context "when customer does not exist", :premium do
+      let(:customer) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("customer_not_found")
+      end
+    end
+
+    context "when subscription is required but not provided", :premium do
+      let(:create_params) { {order_type: "subscription_amendment"} }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("subscription_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/services/quotes/update_service_spec.rb
+++ b/spec/services/quotes/update_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::UpdateService do
+  subject(:update_service) { described_class.new(quote:, params: update_params) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:membership) { create(:membership, organization:) }
+  let(:owner) { membership.user }
+  let(:quote) { create(:quote, organization:) }
+  let(:update_params) {
+    {
+      owners: [owner.id]
+    }
+  }
+
+  describe ".call" do
+    let(:result) { update_service.call }
+
+    it "updates the quote", :premium do
+      expect(result).to be_success
+      expect(result.quote.id).to eq(quote.id)
+      expect(result.quote.organization_id).to eq(quote.organization_id)
+      expect(result.quote.customer_id).to eq(quote.customer_id)
+      expect(result.quote.sequential_id).to eq(quote.sequential_id)
+      expect(result.quote.number).to eq(quote.number)
+      expect(result.quote.owner_ids).to eq([owner.id])
+    end
+
+    context "when owners include invalid user ids", :premium do
+      let(:update_params) { {owners: ["invalid_user_id"]} }
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:quotes]).to eq(["invalid_owner"])
+      end
+    end
+
+    context "when quote does not exist", :premium do
+      let(:quote) { nil }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_not_found")
+      end
+    end
+
+    context "when license is not premium" do
+      it "returns forbidden status" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Order forms (quotes) support multiple billing item types that need to be managed independently on a `QuoteVersion`. This PR introduces the shared foundation and the first billing item type: plans. Plans are only valid for `subscription_creation` and `subscription_amendment` order types.

 ## Description
- Introduces `Quotes::BillingItems::BaseMutationService`, shared base class that reads/writes the `billing_items` jsonb column on `QuoteVersion`.
  - Introduces `Quotes::BillingItems::ValidateService`, standalone validation service for bulk billing item creation (validates
  type constraints, org membership, normalizes IDs).
  - Introduces `Types::QuoteVersions::Object` GraphQL type (returned by all billing item mutations across the stack).
  - Adds `Plans::AddService`, `Plans::UpdateService`, `Plans::RemoveService` with full guard sequence: premium license -> quote version exists -> order_forms feature flag -> draft state -> allowed order type -> plan validation.
  - Adds three GraphQL mutations: `addQuotePlan`, `updateQuotePlan`, `removeQuotePlan`.

Required permission: `quotes:update`

GraphQL mutations:
```
 mutation AddQuotePlan(
   $quoteVersionId: ID!
   $planId: ID!
   $externalSubscriptionId: String
 ) {
   addQuotePlan(
     quoteVersionId: $quoteVersionId
     planId: $planId
     externalSubscriptionId: $externalSubscriptionId
   ) {
     id
     status
     version
     billingItems
     quoteId
     updatedAt
   }
 }

 mutation UpdateQuotePlan(
   $quoteVersionId: ID!
   $id: ID!
   $planId: ID
   $externalSubscriptionId: String
 ) {
   updateQuotePlan(
     quoteVersionId: $quoteVersionId
     id: $id
     planId: $planId
     externalSubscriptionId: $externalSubscriptionId
   ) {
     id
     billingItems
   }
 }

 mutation RemoveQuotePlan($quoteVersionId: ID!, $id: ID!) {
   removeQuotePlan(quoteVersionId: $quoteVersionId, id: $id) {
     id
     billingItems
   }
 }

 QuoteVersion type fields:

 ┌──────────────┬──────────────────────────────────┐
 │    Field     │               Type               │
 ├──────────────┼──────────────────────────────────┤
 │ id           │ ID                               │
 ├──────────────┼──────────────────────────────────┤
 │ status       │ String (draft, approved, voided) │
 ├──────────────┼──────────────────────────────────┤
 │ version      │ Int                              │
 ├──────────────┼──────────────────────────────────┤
 │ billingItems │ JSON                             │
 ├──────────────┼──────────────────────────────────┤
 │ content      │ String                           │
 ├──────────────┼──────────────────────────────────┤
 │ shareToken   │ String                           │
 ├──────────────┼──────────────────────────────────┤
 │ approvedAt   │ ISO8601DateTime                  │
 ├──────────────┼──────────────────────────────────┤
 │ voidedAt     │ ISO8601DateTime                  │
 ├──────────────┼──────────────────────────────────┤
 │ createdAt    │ ISO8601DateTime                  │
 ├──────────────┼──────────────────────────────────┤
 │ updatedAt    │ ISO8601DateTime                  │
 ├──────────────┼──────────────────────────────────┤
 │ quoteId      │ ID                               │
 └──────────────┴──────────────────────────────────┘

 billingItems shape for plans:
 {
   "plans": [
     {
       "id": "qtp_<uuid>",
       "plan_id": "<uuid>",
       "external_subscription_id": "optional"
     }
   ]
 }
```
All mutations return the full `QuoteVersion` type. The updated `billingItems` JSON is keyed by type, plans live under "plans", each with a stable id prefixed `qtp_`.

QuoteVersion fields: `id, status (draft/approved/voided), version, billingItems (JSON), content, shareToken, approvedAt, voidedAt, createdAt, updatedAt, quoteId`