### PR TITLE
feat(quotes): Add add-on billing item services and GraphQL mutations

### DIFF
--- a/app/graphql/mutations/quotes/billing_items/add_ons/add.rb
+++ b/app/graphql/mutations/quotes/billing_items/add_ons/add.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module AddOns
+        class Add < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "AddQuoteAddOn"
+          description "Adds an add-on billing item to a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :name, String, required: true
+          argument :add_on_id, ID, required: false
+          argument :amount_cents, GraphQL::Types::BigInt, required: false
+          argument :amount_currency, String, required: false
+          argument :description, String, required: false
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::AddOns::AddService.call(
+              quote_version:,
+              params: args.except(:quote_version_id)
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/add_ons/remove.rb
+++ b/app/graphql/mutations/quotes/billing_items/add_ons/remove.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module AddOns
+        class Remove < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "RemoveQuoteAddOn"
+          description "Removes an add-on billing item from a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :id, ID, required: true
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::AddOns::RemoveService.call(
+              quote_version:,
+              id: args[:id]
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/add_ons/update.rb
+++ b/app/graphql/mutations/quotes/billing_items/add_ons/update.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module AddOns
+        class Update < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "UpdateQuoteAddOn"
+          description "Updates an add-on billing item on a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :id, ID, required: true
+          argument :name, String, required: false
+          argument :add_on_id, ID, required: false
+          argument :amount_cents, GraphQL::Types::BigInt, required: false
+          argument :amount_currency, String, required: false
+          argument :description, String, required: false
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::AddOns::UpdateService.call(
+              quote_version:,
+              id: args[:id],
+              params: args.except(:quote_version_id, :id)
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -242,5 +242,9 @@ module Types
     field :add_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Add
     field :update_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Update
     field :remove_quote_plan, mutation: Mutations::Quotes::BillingItems::Plans::Remove
+
+    field :add_quote_add_on, mutation: Mutations::Quotes::BillingItems::AddOns::Add
+    field :update_quote_add_on, mutation: Mutations::Quotes::BillingItems::AddOns::Update
+    field :remove_quote_add_on, mutation: Mutations::Quotes::BillingItems::AddOns::Remove
   end
 end

--- a/app/services/quotes/billing_items/add_ons/add_service.rb
+++ b/app/services/quotes/billing_items/add_ons/add_service.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module AddOns
+      class AddService < Quotes::BillingItems::BaseMutationService
+        ALLOWED_ORDER_TYPES = %w[one_off].freeze
+
+        def initialize(quote_version:, params:)
+          @quote_version = quote_version
+          @params = params
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          unless ALLOWED_ORDER_TYPES.include?(quote_version.quote.order_type)
+            return result.validation_failure!(
+              errors: {billing_item: ["add_ons not allowed for subscription order type"]}
+            )
+          end
+
+          name = params[:name] || params["name"]
+          add_on_id = params[:add_on_id] || params["add_on_id"]
+          amount_cents = params[:amount_cents] || params["amount_cents"]
+
+          if name.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["name is required"]}
+            )
+          end
+
+          if add_on_id.present?
+            unless quote_version.organization.add_ons.exists?(id: add_on_id)
+              return result.validation_failure!(
+                errors: {billing_item: ["add_on not found in organization"]}
+              )
+            end
+          elsif amount_cents.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["amount_cents is required when add_on_id is not provided"]}
+            )
+          end
+
+          item = params.transform_keys(&:to_s)
+          item["id"] ||= "qta_#{SecureRandom.uuid}"
+
+          persist_items("add_ons", current_items("add_ons") + [item])
+        end
+
+        private
+
+        attr_reader :params
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/add_ons/remove_service.rb
+++ b/app/services/quotes/billing_items/add_ons/remove_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module AddOns
+      class RemoveService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote_version:, id:)
+          @quote_version = quote_version
+          @id = id
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          items = current_items("add_ons")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          items.delete_at(item_index)
+          persist_items("add_ons", items)
+        end
+
+        private
+
+        attr_reader :id
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/add_ons/update_service.rb
+++ b/app/services/quotes/billing_items/add_ons/update_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module AddOns
+      class UpdateService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote_version:, id:, params:)
+          @quote_version = quote_version
+          @id = id
+          @params = params
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          items = current_items("add_ons")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          updated_item = items[item_index].merge(params.transform_keys(&:to_s))
+
+          name = updated_item["name"]
+          add_on_id = updated_item["add_on_id"]
+          amount_cents = updated_item["amount_cents"]
+
+          if name.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["name is required"]}
+            )
+          end
+
+          if add_on_id.present?
+            unless quote_version.organization.add_ons.exists?(id: add_on_id)
+              return result.validation_failure!(
+                errors: {billing_item: ["add_on not found in organization"]}
+              )
+            end
+          elsif amount_cents.blank?
+            return result.validation_failure!(
+              errors: {billing_item: ["amount_cents is required when add_on_id is not provided"]}
+            )
+          end
+
+          items[item_index] = updated_item
+          persist_items("add_ons", items)
+        end
+
+        private
+
+        attr_reader :id, :params
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/add_ons/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/add_service_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::AddOns::AddService, type: :service do
+  subject(:result) { described_class.call(quote_version:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :one_off) }
+  let(:quote_version) { quote.current_version }
+  let(:params) { {name: "My Add-on", add_on_id: add_on.id} }
+
+  before { allow(License).to receive(:premium?).and_return(true) }
+
+  it "adds the add-on to billing_items and returns the quote_version" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["add_ons"].length).to eq(1)
+    expect(result.quote_version.billing_items["add_ons"].first["add_on_id"]).to eq(add_on.id)
+    expect(result.quote_version.billing_items["add_ons"].first["id"]).to start_with("qta_")
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when order_forms feature flag is disabled" do
+    let(:organization) { create(:organization) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :one_off, version_trait: :voided) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when order_type is subscription_creation" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation) }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "when name is blank" do
+    let(:params) { {add_on_id: add_on.id} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "when add_on_id is absent and amount_cents is missing" do
+    let(:params) { {name: "Custom"} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "when add_on_id is absent and amount_cents is provided" do
+    let(:params) { {name: "Custom", amount_cents: 1000} }
+
+    it "adds the item successfully" do
+      expect(result).to be_success
+      expect(result.quote_version.billing_items["add_ons"].first["amount_cents"]).to eq(1000)
+    end
+  end
+
+  context "when add_on does not belong to organization" do
+    let(:params) { {name: "Test", add_on_id: create(:add_on).id} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/add_ons/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/remove_service_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::AddOns::RemoveService, type: :service do
+  subject(:result) { described_class.call(quote_version:, id:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:item_id) { "qta_#{SecureRandom.uuid}" }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :one_off) }
+  let(:quote_version) { quote.current_version }
+  let(:id) { item_id }
+
+  before do
+    allow(License).to receive(:premium?).and_return(true)
+    quote_version.update!(billing_items: {
+      "add_ons" => [{"id" => item_id, "name" => "Test", "add_on_id" => add_on.id}]
+    })
+  end
+
+  it "removes the add-on billing item" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["add_ons"]).to be_empty
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :one_off, version_trait: :voided) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when item id is not found" do
+    let(:id) { "qta_nonexistent" }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/add_ons/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/add_ons/update_service_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::AddOns::UpdateService, type: :service do
+  subject(:result) { described_class.call(quote_version:, id:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:item_id) { "qta_#{SecureRandom.uuid}" }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :one_off) }
+  let(:quote_version) { quote.current_version }
+  let(:id) { item_id }
+  let(:params) { {name: "Updated Name"} }
+
+  before do
+    allow(License).to receive(:premium?).and_return(true)
+    quote_version.update!(billing_items: {
+      "add_ons" => [{"id" => item_id, "name" => "Original", "add_on_id" => add_on.id}]
+    })
+  end
+
+  it "updates the add-on billing item" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["add_ons"].first["name"]).to eq("Updated Name")
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :one_off, version_trait: :voided) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when item id is not found" do
+    let(:id) { "qta_nonexistent" }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when name is blank" do
+    let(:params) { {name: ""} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "when add_on does not belong to organization" do
+    let(:params) { {name: "Test", add_on_id: create(:add_on).id} }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Add-ons are the billing item type for one_off order quotes. Unlike plans, they don't require a catalog reference, a custom add-on can be specified with just a name and amount.

## Description
- Adds` AddOns::AddService, AddOns::UpdateService, AddOns::RemoveService`.
- Only valid on `one_off` order type.
- name is always required. Either `add_on_id` (catalog reference, validated against the org) or `amount_cents` must be provided, not both required.
- Item IDs prefixed `qta_`.
- Adds three GraphQL mutations: `addQuoteAddOn, updateQuoteAddOn, removeQuoteAddOn.`

Required permission: `quotes:update`

GraphQL mutations:
```
 mutation AddQuoteAddOn(
   $quoteVersionId: ID!
   $name: String!
   $addOnId: ID
   $amountCents: BigInt
   $amountCurrency: String
   $description: String
 ) {
   addQuoteAddOn(
     quoteVersionId: $quoteVersionId
     name: $name
     addOnId: $addOnId
     amountCents: $amountCents
     amountCurrency: $amountCurrency
     description: $description
   ) {
     id
     billingItems
   }
 }

 mutation UpdateQuoteAddOn(
   $quoteVersionId: ID!
   $id: ID!
   $name: String
   $addOnId: ID
   $amountCents: BigInt
   $amountCurrency: String
   $description: String
 ) {
   updateQuoteAddOn(
     quoteVersionId: $quoteVersionId
     id: $id
     name: $name
     addOnId: $addOnId
     amountCents: $amountCents
     amountCurrency: $amountCurrency
     description: $description
   ) {
     id
     billingItems
   }
 }

 mutation RemoveQuoteAddOn($quoteVersionId: ID!, $id: ID!) {
   removeQuoteAddOn(quoteVersionId: $quoteVersionId, id: $id) {
     id
     billingItems
   }
 }

 billingItems shape for add-ons:
 {
   "add_ons": [
     {
       "id": "qta_<uuid>",
       "name": "My Add-on",
       "add_on_id": "<uuid> (optional, catalog reference)",
       "amount_cents": 5000,
       "amount_currency": "EUR",
       "description": "optional"
     }
   ]
 }
```
If `addOnId` is provided, `amountCents` is optional (price comes from catalog). If `addOnId` is absent, `amountCents` is required.