### PR TITLE
feat(quotes): Add wallet credit billing item services and GraphQL mutations

### DIFF
--- a/app/graphql/mutations/quotes/billing_items/wallet_credits/add.rb
+++ b/app/graphql/mutations/quotes/billing_items/wallet_credits/add.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module WalletCredits
+        class Add < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "AddQuoteWalletCredit"
+          description "Adds a wallet credit billing item to a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :paid_credits, String, required: false
+          argument :granted_credits, String, required: false
+          argument :recurring_transaction_rules, GraphQL::Types::JSON, required: false
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::WalletCredits::AddService.call(
+              quote_version:,
+              params: args.except(:quote_version_id)
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/wallet_credits/remove.rb
+++ b/app/graphql/mutations/quotes/billing_items/wallet_credits/remove.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module WalletCredits
+        class Remove < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "RemoveQuoteWalletCredit"
+          description "Removes a wallet credit billing item from a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :id, ID, required: true
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::WalletCredits::RemoveService.call(
+              quote_version:,
+              id: args[:id]
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/quotes/billing_items/wallet_credits/update.rb
+++ b/app/graphql/mutations/quotes/billing_items/wallet_credits/update.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quotes
+    module BillingItems
+      module WalletCredits
+        class Update < BaseMutation
+          include AuthenticableApiUser
+          include RequiredOrganization
+
+          REQUIRED_PERMISSION = "quotes:update"
+
+          graphql_name "UpdateQuoteWalletCredit"
+          description "Updates a wallet credit billing item on a quote version"
+
+          argument :quote_version_id, ID, required: true
+          argument :id, ID, required: true
+          argument :paid_credits, String, required: false
+          argument :granted_credits, String, required: false
+          argument :recurring_transaction_rules, GraphQL::Types::JSON, required: false
+
+          type Types::QuoteVersions::Object
+
+          def resolve(**args)
+            quote_version = current_organization.quote_versions.find_by(id: args[:quote_version_id])
+            result = ::Quotes::BillingItems::WalletCredits::UpdateService.call(
+              quote_version:,
+              id: args[:id],
+              params: args.except(:quote_version_id, :id)
+            )
+            result.success? ? result.quote_version : result_error(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -250,5 +250,9 @@ module Types
     field :add_quote_coupon, mutation: Mutations::Quotes::BillingItems::Coupons::Add
     field :update_quote_coupon, mutation: Mutations::Quotes::BillingItems::Coupons::Update
     field :remove_quote_coupon, mutation: Mutations::Quotes::BillingItems::Coupons::Remove
+
+    field :add_quote_wallet_credit, mutation: Mutations::Quotes::BillingItems::WalletCredits::Add
+    field :update_quote_wallet_credit, mutation: Mutations::Quotes::BillingItems::WalletCredits::Update
+    field :remove_quote_wallet_credit, mutation: Mutations::Quotes::BillingItems::WalletCredits::Remove
   end
 end

--- a/app/services/quotes/billing_items/wallet_credits/add_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/add_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module WalletCredits
+      class AddService < Quotes::BillingItems::BaseMutationService
+        ALLOWED_ORDER_TYPES = %w[subscription_creation subscription_amendment].freeze
+        RECURRING_RULE_PREFIX = "qtrr"
+
+        def initialize(quote_version:, params:)
+          @quote_version = quote_version
+          @params = params
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          unless ALLOWED_ORDER_TYPES.include?(quote_version.quote.order_type)
+            return result.validation_failure!(
+              errors: {billing_item: ["wallet_credits not allowed for one_off order type"]}
+            )
+          end
+
+          item = params.transform_keys(&:to_s)
+          item["id"] ||= "qtw_#{SecureRandom.uuid}"
+          item["recurring_transaction_rules"] = normalize_recurring_rules(
+            item.fetch("recurring_transaction_rules", [])
+          )
+
+          persist_items("wallet_credits", current_items("wallet_credits") + [item])
+        end
+
+        private
+
+        attr_reader :params
+
+        def normalize_recurring_rules(rules)
+          rules.map do |rule|
+            rule = rule.transform_keys(&:to_s)
+            rule["id"] ||= "#{RECURRING_RULE_PREFIX}_#{SecureRandom.uuid}"
+            rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/wallet_credits/remove_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/remove_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module WalletCredits
+      class RemoveService < Quotes::BillingItems::BaseMutationService
+        def initialize(quote_version:, id:)
+          @quote_version = quote_version
+          @id = id
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          items = current_items("wallet_credits")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          items.delete_at(item_index)
+          persist_items("wallet_credits", items)
+        end
+
+        private
+
+        attr_reader :id
+      end
+    end
+  end
+end

--- a/app/services/quotes/billing_items/wallet_credits/update_service.rb
+++ b/app/services/quotes/billing_items/wallet_credits/update_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Quotes
+  module BillingItems
+    module WalletCredits
+      class UpdateService < Quotes::BillingItems::BaseMutationService
+        RECURRING_RULE_PREFIX = "qtrr"
+
+        def initialize(quote_version:, id:, params:)
+          @quote_version = quote_version
+          @id = id
+          @params = params
+          super
+        end
+
+        def call
+          return result.forbidden_failure! unless License.premium?
+          return result.not_found_failure!(resource: "quote_version") unless quote_version
+          return result.forbidden_failure! unless quote_version.organization.feature_flag_enabled?(:order_forms)
+          return result.not_allowed_failure!(code: "inappropriate_state") unless quote_version.draft?
+
+          items = current_items("wallet_credits")
+          item_index = items.index { |item| item["id"] == id }
+          return result.not_found_failure!(resource: "billing_item") if item_index.nil?
+
+          updated_item = items[item_index].merge(params.transform_keys(&:to_s))
+
+          if params.key?(:recurring_transaction_rules) || params.key?("recurring_transaction_rules")
+            updated_item["recurring_transaction_rules"] = normalize_recurring_rules(
+              updated_item.fetch("recurring_transaction_rules", [])
+            )
+          end
+
+          items[item_index] = updated_item
+          persist_items("wallet_credits", items)
+        end
+
+        private
+
+        attr_reader :id, :params
+
+        def normalize_recurring_rules(rules)
+          rules.map do |rule|
+            rule = rule.transform_keys(&:to_s)
+            rule["id"] ||= "#{RECURRING_RULE_PREFIX}_#{SecureRandom.uuid}"
+            rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/wallet_credits/add_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/add_service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::WalletCredits::AddService, type: :service do
+  subject(:result) { described_class.call(quote_version:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation) }
+  let(:quote_version) { quote.current_version }
+  let(:params) { {paid_credits: "100.0"} }
+
+  before { allow(License).to receive(:premium?).and_return(true) }
+
+  it "adds the wallet credit to billing_items and returns the quote_version" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["wallet_credits"].length).to eq(1)
+    expect(result.quote_version.billing_items["wallet_credits"].first["paid_credits"]).to eq("100.0")
+    expect(result.quote_version.billing_items["wallet_credits"].first["id"]).to start_with("qtw_")
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when order_forms feature flag is disabled" do
+    let(:organization) { create(:organization) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation, version_trait: :approved) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when order_type is one_off" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :one_off) }
+
+    it "returns validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+    end
+  end
+
+  context "with recurring_transaction_rules" do
+    let(:params) { {paid_credits: "100.0", recurring_transaction_rules: [{"trigger" => "interval", "interval" => "monthly"}]} }
+
+    it "normalizes recurring rules with generated ids" do
+      expect(result).to be_success
+      rules = result.quote_version.billing_items["wallet_credits"].first["recurring_transaction_rules"]
+      expect(rules.first["id"]).to start_with("qtrr_")
+      expect(rules.first["trigger"]).to eq("interval")
+    end
+  end
+
+  context "when recurring rule already has an id" do
+    let(:existing_rule_id) { "qtrr_existing" }
+    let(:params) { {paid_credits: "100.0", recurring_transaction_rules: [{"id" => existing_rule_id, "trigger" => "interval"}]} }
+
+    it "preserves existing rule id" do
+      expect(result).to be_success
+      rules = result.quote_version.billing_items["wallet_credits"].first["recurring_transaction_rules"]
+      expect(rules.first["id"]).to eq(existing_rule_id)
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/wallet_credits/remove_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/remove_service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::WalletCredits::RemoveService, type: :service do
+  subject(:result) { described_class.call(quote_version:, id:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:item_id) { "qtw_#{SecureRandom.uuid}" }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation) }
+  let(:quote_version) { quote.current_version }
+  let(:id) { item_id }
+
+  before do
+    allow(License).to receive(:premium?).and_return(true)
+    quote_version.update!(billing_items: {
+      "wallet_credits" => [{"id" => item_id, "paid_credits" => "100.0"}]
+    })
+  end
+
+  it "removes the wallet credit billing item" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["wallet_credits"]).to be_empty
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation, version_trait: :approved) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when item id is not found" do
+    let(:id) { "qtw_nonexistent" }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+end

--- a/spec/services/quotes/billing_items/wallet_credits/update_service_spec.rb
+++ b/spec/services/quotes/billing_items/wallet_credits/update_service_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::BillingItems::WalletCredits::UpdateService, type: :service do
+  subject(:result) { described_class.call(quote_version:, id:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:item_id) { "qtw_#{SecureRandom.uuid}" }
+  let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation) }
+  let(:quote_version) { quote.current_version }
+  let(:id) { item_id }
+  let(:params) { {paid_credits: "200.0"} }
+
+  before do
+    allow(License).to receive(:premium?).and_return(true)
+    quote_version.update!(billing_items: {
+      "wallet_credits" => [{"id" => item_id, "paid_credits" => "100.0"}]
+    })
+  end
+
+  it "updates the wallet credit billing item" do
+    expect(result).to be_success
+    expect(result.quote_version.billing_items["wallet_credits"].first["paid_credits"]).to eq("200.0")
+  end
+
+  context "when not premium" do
+    before { allow(License).to receive(:premium?).and_return(false) }
+
+    it "returns forbidden failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ForbiddenFailure)
+    end
+  end
+
+  context "when quote_version is nil" do
+    let(:quote_version) { nil }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when quote_version is not draft" do
+    let(:quote) { create(:quote, :with_version, organization:, order_type: :subscription_creation, version_trait: :approved) }
+
+    it "returns not allowed failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotAllowedFailure)
+    end
+  end
+
+  context "when item id is not found" do
+    let(:id) { "qtw_nonexistent" }
+
+    it "returns not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when updating recurring_transaction_rules" do
+    let(:params) { {recurring_transaction_rules: [{"trigger" => "interval"}]} }
+
+    it "normalizes rules with generated ids" do
+      expect(result).to be_success
+      rules = result.quote_version.billing_items["wallet_credits"].first["recurring_transaction_rules"]
+      expect(rules.first["id"]).to start_with("qtrr_")
+    end
+  end
+end


### PR DESCRIPTION
## Context
Wallet credits allow pre-loading credits into a customer wallet as part of a subscription quote. They support optional recurring transaction rules for automatic top-ups.

## Description
- Adds `WalletCredits::AddService, WalletCredits::UpdateService, WalletCredits::RemoveService.`
- Only valid on subscription_creation and subscription_amendment order types.
- No catalog reference needed. recurring_transaction_rules items get auto-generated IDs (qtrr_<uuid>) if not provided.
- Item IDs prefixed `qtw_`.
- Adds three GraphQL mutations: `addQuoteWalletCredit, updateQuoteWalletCredit, removeQuoteWalletCredit.`

Required permission: `quotes:update`

GraphQL mutations:
```
mutation AddQuoteWalletCredit(
   $quoteVersionId: ID!
   $paidCredits: String
   $grantedCredits: String
   $recurringTransactionRules: JSON
 ) {
   addQuoteWalletCredit(
     quoteVersionId: $quoteVersionId
     paidCredits: $paidCredits
     grantedCredits: $grantedCredits
     recurringTransactionRules: $recurringTransactionRules
   ) {
     id
     billingItems
   }
 }

 mutation UpdateQuoteWalletCredit(
   $quoteVersionId: ID!
   $id: ID!
   $paidCredits: String
   $grantedCredits: String
   $recurringTransactionRules: JSON
 ) {
   updateQuoteWalletCredit(
     quoteVersionId: $quoteVersionId
     id: $id
     paidCredits: $paidCredits
     grantedCredits: $grantedCredits
     recurringTransactionRules: $recurringTransactionRules
   ) {
     id
     billingItems
   }
 }

 mutation RemoveQuoteWalletCredit($quoteVersionId: ID!, $id: ID!) {
   removeQuoteWalletCredit(quoteVersionId: $quoteVersionId, id: $id) {
     id
     billingItems
   }
 }

 billingItems shape for wallet credits:
 {
   "wallet_credits": [
     {
       "id": "qtw_<uuid>",
       "paid_credits": "100.0",
       "granted_credits": "10.0",
       "recurring_transaction_rules": [
         {
           "id": "qtrr_<uuid>",
           "trigger": "interval",
           "interval": "monthly"
         }
       ]
     }
   ]
 }
```
On `updateQuoteWalletCredit`, `recurringTransactionRules` replaces the existing rules entirely when provided. Each rule gets an auto-generated id if none is supplied.