### PR TITLE
feat(multiple-billing-entity): add multiple billing entity feature flag definition

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -25,3 +25,7 @@ multi_currency:
 payment_gated_subscriptions:
   description: "Enable payment-gated subscription activation rules"
   owners: ["@osmarluz", "@ancorcruz"]
+
+multi_entity_billing:
+  description: "Allow customers to have billing objects across multiple billing entities"
+  owners: ["@lovrocolic", "@feliperodrigues", "@mariohd"]

--- a/schema.graphql
+++ b/schema.graphql
@@ -5739,6 +5739,7 @@ Organization Feature Flag Values
 enum FeatureFlagEnum {
   enriched_events_aggregation
   multi_currency
+  multi_entity_billing
   multiple_payment_methods
   non_persistable_charge_cache_optimization
   payment_gated_subscriptions

--- a/schema.json
+++ b/schema.json
@@ -27881,6 +27881,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "multi_entity_billing",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/spec/models/feature_flag_spec.rb
+++ b/spec/models/feature_flag_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe FeatureFlag do
       expect(described_class.valid?("multiple_payment_methods")).to be(true)
     end
 
+    it "returns true for the multi_entity_billing flag" do
+      expect(described_class.valid?("multi_entity_billing")).to be(true)
+    end
+
     it "returns false for an invalid flag" do
       expect(described_class.valid?("invalid_flag")).to be(false)
     end


### PR DESCRIPTION
## Context

Currently a customer can be associated with only one billing entity.

## Description

The _Multiple billing entity_ feature allows customers to be associated with billing objects that belong to different billing entities.

This PR is the first step in implementing the feature, and it adds feature flag definition.
