### PR TITLE
fix(entitlements): Fix EntitlementValue NameError on rescue branch

### DIFF
--- a/app/services/entitlement/plan_entitlements_update_service.rb
+++ b/app/services/entitlement/plan_entitlements_update_service.rb
@@ -35,7 +35,7 @@ module Entitlement
     rescue ValidationFailure => e
       result.fail_with_error!(e)
     rescue ActiveRecord::RecordInvalid => e
-      if e.record.is_a?(Entitlement::EntitlementValue)
+      if e.record.is_a?(EntitlementValue)
         errors = e.record.errors.messages.transform_keys { |key| :"privilege.#{key}" }
         result.validation_failure!(errors:)
       else

--- a/app/services/entitlement/subscription_entitlements_update_service.rb
+++ b/app/services/entitlement/subscription_entitlements_update_service.rb
@@ -33,7 +33,7 @@ module Entitlement
     rescue BaseService::FailedResult => e
       result.fail_with_error!(e)
     rescue ActiveRecord::RecordInvalid => e
-      if e.record.is_a?(Entitlement::EntitlementValue)
+      if e.record.is_a?(EntitlementValue)
         errors = e.record.errors.messages.transform_keys { |key| :"privilege.#{key}" }
         result.validation_failure!(errors:)
       else

--- a/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
@@ -226,6 +226,22 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService do
       end
     end
 
+    context "when privilege value is nil" do
+      let(:entitlements_params) do
+        {
+          "seats" => {
+            "max" => nil
+          }
+        }
+      end
+
+      it "returns a validation failure with privilege-prefixed errors" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({"privilege.value": ["value_is_mandatory"]})
+      end
+    end
+
     context "when privilege value is not in select_options" do
       let(:privilege) { create(:privilege, organization:, feature:, code: "invitation", value_type: "select", config: {select_options: ["email", "phone", "slack"]}) }
       let(:entitlements_params) do

--- a/spec/services/entitlement/subscription_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/subscription_entitlements_update_service-full_spec.rb
@@ -334,6 +334,22 @@ RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService do
       end
     end
 
+    context "when privilege value is nil" do
+      let(:entitlements_params) do
+        {
+          "seats" => {
+            "max" => nil
+          }
+        }
+      end
+
+      it "returns a validation failure with privilege-prefixed errors" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({"privilege.value": ["value_is_mandatory"]})
+      end
+    end
+
     context "when value is invalid" do
       let(:entitlements_params) do
         {


### PR DESCRIPTION
## Context
`Entitlement::EntitlementValue` looked up `Entitlement::Entitlement::EntitlementValue` and raised a NameError inside the `rescue ActiveRecord::RecordInvalid` branch.

## Description

- Removed the redundant `Entitlement::` prefix so the constant is resolved correctly.
- Added tests covering the rescue branch
