### PR TITLE
fix(subscriptions): Fix serializer N+1 queries

### DIFF
--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -44,13 +44,13 @@ end
 # Table name: item_metadata
 # Database name: primary
 #
-#  id              :uuid             not null, primary key
-#  owner_type      :string           not null
-#  value           :jsonb            not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organization_id :uuid             not null
-#  owner_id        :uuid             not null
+#  id                                             :uuid             not null, primary key
+#  owner_type(Polymorphic owner type)             :string           not null
+#  value(item_metadata key-value pairs)           :jsonb            not null
+#  created_at                                     :datetime         not null
+#  updated_at                                     :datetime         not null
+#  organization_id(Reference to the organization) :uuid             not null
+#  owner_id(Polymorphic owner id)                 :uuid             not null
 #
 # Indexes
 #

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -40,7 +40,7 @@ module V1
 
     def charge_filters
       ::CollectionSerializer.new(
-        model.filters.includes(:charge, :billable_metric_filters),
+        model.filters.includes(:charge, values: :billable_metric_filter),
         ::V1::ChargeFilterSerializer,
         collection_name: "filters"
       ).serialize

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -40,7 +40,7 @@ module V1
 
     def charges
       ::CollectionSerializer.new(
-        model.charges.includes(:applied_pricing_unit),
+        model.charges.includes(:applied_pricing_unit, :billable_metric, :taxes),
         ::V1::ChargeSerializer,
         collection_name: "charges",
         includes: include?(:taxes) ? %i[taxes] : []


### PR DESCRIPTION
- Since we include a lot of dependencies in the subscription serializer, depending on the plan configuration, we can leverage a lot of DB calls, adding useless latency on this endpoint. 
- `billable_metric_filter` is the perfect example, we should include it to avoid having N (where N is the number of billable metric filter) extra queries.