### PR TITLE
fix: handle n+1 issue in wallet serializer

### DIFF
--- a/app/controllers/concerns/wallet_actions.rb
+++ b/app/controllers/concerns/wallet_actions.rb
@@ -60,7 +60,13 @@ module WalletActions
     if result.success?
       render(
         json: ::CollectionSerializer.new(
-          result.wallets.includes(:recurring_transaction_rules),
+          result.wallets.includes(
+            :customer,
+            :metadata,
+            :billable_metrics,
+            {applied_invoice_custom_sections: :invoice_custom_section},
+            {recurring_transaction_rules: {applied_invoice_custom_sections: :invoice_custom_section}}
+          ),
           ::V1::WalletSerializer,
           collection_name: "wallets",
           meta: pagination_metadata(result.wallets),

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -51,6 +51,10 @@ class RecurringTransactionRule < ApplicationRecord
   }
   scope :expired, -> { where("recurring_transaction_rules.expiration_at::timestamp(0) <= ?", Time.current) }
 
+  def currently_active?
+    active? && (expiration_at.nil? || expiration_at > Time.current)
+  end
+
   def mark_as_terminated!(timestamp = Time.zone.now)
     self.terminated_at ||= timestamp
     terminated!

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -43,10 +43,16 @@ module V1
 
     def recurring_transaction_rules
       ::CollectionSerializer.new(
-        model.recurring_transaction_rules.active,
+        active_recurring_transaction_rules,
         ::V1::Wallets::RecurringTransactionRuleSerializer,
         collection_name: "recurring_transaction_rules"
       ).serialize
+    end
+
+    def active_recurring_transaction_rules
+      model.recurring_transaction_rules.select do |rule|
+        rule.active? && (rule.expiration_at.nil? || rule.expiration_at > Time.current)
+      end
     end
 
     def limitations

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -50,9 +50,7 @@ module V1
     end
 
     def active_recurring_transaction_rules
-      model.recurring_transaction_rules.select do |rule|
-        rule.active? && (rule.expiration_at.nil? || rule.expiration_at > Time.current)
-      end
+      model.recurring_transaction_rules.select(&:currently_active?)
     end
 
     def limitations

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -38,6 +38,28 @@ RSpec.describe RecurringTransactionRule do
     end
   end
 
+  describe "#currently_active?" do
+    it "returns true for active rules with no expiration" do
+      rule = build_stubbed(:recurring_transaction_rule, status: :active, expiration_at: nil)
+      expect(rule.currently_active?).to be true
+    end
+
+    it "returns true for active rules expiring in the future" do
+      rule = build_stubbed(:recurring_transaction_rule, status: :active, expiration_at: 1.day.from_now)
+      expect(rule.currently_active?).to be true
+    end
+
+    it "returns false for active rules whose expiration has passed" do
+      rule = build_stubbed(:recurring_transaction_rule, status: :active, expiration_at: 1.day.ago)
+      expect(rule.currently_active?).to be false
+    end
+
+    it "returns false for terminated rules" do
+      rule = build_stubbed(:recurring_transaction_rule, status: :terminated, expiration_at: nil)
+      expect(rule.currently_active?).to be false
+    end
+  end
+
   describe "#mark_as_terminated!" do
     let(:recurring_transaction_rule) { create(:recurring_transaction_rule, status: :active) }
 

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -51,4 +51,25 @@ RSpec.describe ::V1::WalletSerializer do
     expect(result["wallet"]["payment_method"]["payment_method_id"]).to eq(nil)
     expect(result["wallet"]["payment_method"]["payment_method_type"]).to eq("provider")
   end
+
+  describe "recurring_transaction_rules filtering" do
+    let(:active_rule) { create(:recurring_transaction_rule, wallet:) }
+    let(:active_future_expiration_rule) { create(:recurring_transaction_rule, wallet:, expiration_at: 1.day.from_now) }
+    let(:active_past_expiration_rule) { create(:recurring_transaction_rule, wallet:, expiration_at: 1.day.ago) }
+    let(:terminated_rule) { create(:recurring_transaction_rule, wallet:, status: :terminated) }
+
+    before do
+      active_rule
+      active_future_expiration_rule
+      active_past_expiration_rule
+      terminated_rule
+    end
+
+    it "includes only active rules that have not expired" do
+      result = JSON.parse(serializer.to_json)
+      ids = result["wallet"]["recurring_transaction_rules"].map { |r| r["lago_id"] }
+
+      expect(ids).to match_array([recurring_transaction_rule.id, active_rule.id, active_future_expiration_rule.id])
+    end
+  end
 end

--- a/spec/support/shared_examples/wallet_actions.rb
+++ b/spec/support/shared_examples/wallet_actions.rb
@@ -1183,4 +1183,28 @@ RSpec.shared_examples "a wallet index endpoint" do
       expect(json[:wallets].first[:lago_id]).to eq(brl_wallet.id)
     end
   end
+
+  context "with N+1 query detection", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+    let(:params) { {} }
+
+    before do
+      [wallet, create(:wallet, customer:), create(:wallet, customer:)].each do |w|
+        create(:wallet_target, wallet: w)
+        create(:wallet_applied_invoice_custom_section, wallet: w)
+        create(:recurring_transaction_rule, wallet: w)
+      end
+    end
+
+    it "does not trigger N+1 queries on wallet associations" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:wallets].count).to eq(3)
+      json[:wallets].each do |wallet_payload|
+        expect(wallet_payload[:applies_to][:billable_metric_codes]).to be_present
+        expect(wallet_payload[:recurring_transaction_rules]).to be_present
+        expect(wallet_payload[:applied_invoice_custom_sections]).to be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

`GET /api/v1/wallets triggers` an N+1 query pattern: each wallet on the page issues additional round-trips to RDS for `customers`, `recurring_transaction_rules`, `billable_metrics` (via wallet_targets), `invoice_custom_sections`, and `item_metadata`.

## Description

This PR eager loads associated wallet records. For recurring transaction rules small helper method is added because `.active` scope used to disable loaded records and we still had to hit DB for each recurring rule. With the new approach recurring rules are filtered in memory.
