### PR TITLE
Multi be foundations

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -11,8 +11,8 @@ class Subscription < ApplicationRecord
   belongs_to :previous_subscription, class_name: "Subscription", optional: true
   belongs_to :organization
   belongs_to :payment_method, optional: true
+  belongs_to :billing_entity, optional: true
 
-  has_one :billing_entity, through: :customer
   has_many :next_subscriptions, class_name: "Subscription", foreign_key: :previous_subscription_id
   has_many :events
   has_many :invoice_subscriptions
@@ -101,6 +101,10 @@ class Subscription < ApplicationRecord
 
   def self.ransackable_associations(_ = nil)
     %w[customer plan]
+  end
+
+  def billing_entity
+    super || customer&.billing_entity
   end
 
   def mark_as_active!(timestamp = Time.current)
@@ -325,6 +329,7 @@ end
 #  trial_ended_at               :datetime
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
+#  billing_entity_id            :uuid
 #  customer_id                  :uuid             not null
 #  external_id                  :string           not null
 #  organization_id              :uuid             not null
@@ -334,6 +339,7 @@ end
 #
 # Indexes
 #
+#  index_subscriptions_on_billing_entity_id                    (billing_entity_id)
 #  index_subscriptions_on_customer_id                          (customer_id)
 #  index_subscriptions_on_ending_at_active                     (ending_at) WHERE ((status = 1) AND (ending_at IS NOT NULL))
 #  index_subscriptions_on_external_id                          (external_id)
@@ -349,6 +355,7 @@ end
 #
 # Foreign Keys
 #
+#  fk_rails_...  (billing_entity_id => billing_entities.id)
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_method_id => payment_methods.id)

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -7,6 +7,7 @@ class Wallet < ApplicationRecord
   belongs_to :customer, -> { with_discarded }
   belongs_to :organization
   belongs_to :payment_method, optional: true
+  belongs_to :billing_entity, optional: true
 
   has_many :wallet_transactions
   has_many :recurring_transaction_rules
@@ -63,6 +64,10 @@ class Wallet < ApplicationRecord
 
   def self.in_application_order
     order(:priority, :created_at)
+  end
+
+  def billing_entity
+    super || customer&.billing_entity
   end
 
   def mark_as_terminated!(timestamp = Time.zone.now)
@@ -157,6 +162,7 @@ end
 #  traceable                           :boolean          default(FALSE), not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
+#  billing_entity_id                   :uuid
 #  customer_id                         :uuid             not null
 #  organization_id                     :uuid             not null
 #  payment_method_id                   :uuid
@@ -164,6 +170,7 @@ end
 # Indexes
 #
 #  index_uniq_wallet_code_per_customer               (customer_id,code) UNIQUE WHERE (status = 0)
+#  index_wallets_on_billing_entity_id                (billing_entity_id)
 #  index_wallets_on_customer_id                      (customer_id)
 #  index_wallets_on_organization_id                  (organization_id)
 #  index_wallets_on_organization_id_and_customer_id  (organization_id,customer_id)
@@ -172,6 +179,7 @@ end
 #
 # Foreign Keys
 #
+#  fk_rails_...  (billing_entity_id => billing_entities.id)
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_method_id => payment_methods.id)

--- a/db/migrate/20260429123434_add_billing_entity_to_wallets.rb
+++ b/db/migrate/20260429123434_add_billing_entity_to_wallets.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddBillingEntityToWallets < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :wallets, :billing_entity, type: :uuid, null: true,
+      index: {algorithm: :concurrently}
+    add_foreign_key :wallets, :billing_entities, validate: false
+  end
+end

--- a/db/migrate/20260429133747_add_billing_entity_to_subscriptions.rb
+++ b/db/migrate/20260429133747_add_billing_entity_to_subscriptions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddBillingEntityToSubscriptions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :subscriptions, :billing_entity, type: :uuid, null: true,
+      index: {algorithm: :concurrently}
+    add_foreign_key :subscriptions, :billing_entities, validate: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -201,6 +201,7 @@ ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_51ac39a0c6;
 ALTER TABLE IF EXISTS ONLY public.billable_metric_filters DROP CONSTRAINT IF EXISTS fk_rails_51077e7c0e;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_50d46d3679;
+ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_4ff087c52e;
 ALTER TABLE IF EXISTS ONLY public.billing_entities DROP CONSTRAINT IF EXISTS fk_rails_4aa58496c3;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_49fcc221b0;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
@@ -337,6 +338,7 @@ DROP INDEX IF EXISTS public.index_wallets_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_wallets_on_organization_id_and_customer_id;
 DROP INDEX IF EXISTS public.index_wallets_on_organization_id;
 DROP INDEX IF EXISTS public.index_wallets_on_customer_id;
+DROP INDEX IF EXISTS public.index_wallets_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_wallets_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_wallets_invoice_custom_sections_on_wallet_id;
 DROP INDEX IF EXISTS public.index_wallets_invoice_custom_sections_on_organization_id;
@@ -4066,7 +4068,8 @@ CREATE TABLE public.wallets (
     payment_method_type public.payment_method_types DEFAULT 'provider'::public.payment_method_types NOT NULL,
     skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
     traceable boolean DEFAULT false NOT NULL,
-    code character varying
+    code character varying,
+    billing_entity_id uuid
 );
 
 
@@ -9345,6 +9348,13 @@ CREATE UNIQUE INDEX index_wallets_invoice_custom_sections_unique ON public.walle
 
 
 --
+-- Name: index_wallets_on_billing_entity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_wallets_on_billing_entity_id ON public.wallets USING btree (billing_entity_id);
+
+
+--
 -- Name: index_wallets_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10288,6 +10298,14 @@ ALTER TABLE ONLY public.recurring_transaction_rules_invoice_custom_sections
 
 ALTER TABLE ONLY public.billing_entities
     ADD CONSTRAINT fk_rails_4aa58496c3 FOREIGN KEY (applied_dunning_campaign_id) REFERENCES public.dunning_campaigns(id) ON DELETE SET NULL;
+
+
+--
+-- Name: wallets fk_rails_4ff087c52e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wallets
+    ADD CONSTRAINT fk_rails_4ff087c52e FOREIGN KEY (billing_entity_id) REFERENCES public.billing_entities(id) NOT VALID;
 
 
 --
@@ -11834,6 +11852,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260429133747'),
+('20260429123434'),
 ('20260424170418'),
 ('20260421123920'),
 ('20260421103557'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -191,6 +191,7 @@ ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS fk_rails_5a43da571b;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_58234c715e;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_56b7167125;
+ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_56b3626631;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_5628a713de;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT IF EXISTS fk_rails_533b639bac;
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_52b72c9b0e;
@@ -382,6 +383,7 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_last_received_event_on;
 DROP INDEX IF EXISTS public.index_subscriptions_on_external_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_ending_at_active;
 DROP INDEX IF EXISTS public.index_subscriptions_on_customer_id;
+DROP INDEX IF EXISTS public.index_subscriptions_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_on_subscription_id;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_on_organization_id;
@@ -3154,7 +3156,8 @@ CREATE TABLE public.subscriptions (
     last_received_event_on date,
     cancelation_reason public.subscription_cancelation_reasons,
     incompleted_at timestamp(6) without time zone,
-    activated_at timestamp(6) without time zone
+    activated_at timestamp(6) without time zone,
+    billing_entity_id uuid
 );
 
 
@@ -9013,6 +9016,13 @@ CREATE UNIQUE INDEX index_subscriptions_invoice_custom_sections_unique ON public
 
 
 --
+-- Name: index_subscriptions_on_billing_entity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscriptions_on_billing_entity_id ON public.subscriptions USING btree (billing_entity_id);
+
+
+--
 -- Name: index_subscriptions_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10350,6 +10360,14 @@ ALTER TABLE ONLY public.entitlement_entitlement_values
 
 ALTER TABLE ONLY public.credits
     ADD CONSTRAINT fk_rails_5628a713de FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: subscriptions fk_rails_56b3626631; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT fk_rails_56b3626631 FOREIGN KEY (billing_entity_id) REFERENCES public.billing_entities(id) NOT VALID;
 
 
 --
@@ -11815,6 +11833,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260429133747'),
 ('20260424170418'),
 ('20260421123920'),
 ('20260421103557'),

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Subscription do
       expect(subject).to belong_to(:plan)
       expect(subject).to belong_to(:previous_subscription).optional
       expect(subject).to belong_to(:organization)
-      expect(subject).to have_one(:billing_entity).through(:customer)
+      expect(subject).to belong_to(:billing_entity).optional
       expect(subject).to have_many(:applied_invoice_custom_sections).class_name("Subscription::AppliedInvoiceCustomSection").dependent(:destroy)
       expect(subject).to have_many(:selected_invoice_custom_sections).through(:applied_invoice_custom_sections).source(:invoice_custom_section)
       expect(subject).to have_many(:next_subscriptions).class_name("Subscription").with_foreign_key(:previous_subscription_id)
@@ -68,6 +68,28 @@ RSpec.describe Subscription do
   describe "Clickhouse associations", clickhouse: true do
     it do
       expect(subject).to have_many(:activity_logs).class_name("Clickhouse::ActivityLog")
+    end
+  end
+
+  describe "#billing_entity" do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    context "when subscription has a billing_entity" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:subscription) { create(:subscription, customer:, billing_entity:) }
+
+      it "returns the subscription billing_entity" do
+        expect(subscription.billing_entity).to eq(billing_entity)
+      end
+    end
+
+    context "when subscription does not have a billing_entity" do
+      let(:subscription) { create(:subscription, customer:, billing_entity: nil) }
+
+      it "falls back to the customer billing_entity" do
+        expect(subscription.billing_entity).to eq(customer.billing_entity)
+      end
     end
   end
 

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Wallet do
     it do
       expect(subject).to belong_to(:organization)
       expect(subject).to belong_to(:customer)
+      expect(subject).to belong_to(:billing_entity).optional
       expect(subject).to have_many(:applied_invoice_custom_sections).class_name("Wallet::AppliedInvoiceCustomSection").dependent(:destroy)
       expect(subject).to have_many(:selected_invoice_custom_sections).through(:applied_invoice_custom_sections).source(:invoice_custom_section)
       expect(subject).to have_one(:metadata).class_name("Metadata::ItemMetadata").dependent(:destroy)
@@ -21,6 +22,28 @@ RSpec.describe Wallet do
 
   describe "Clickhouse associations", clickhouse: true do
     it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
+  describe "#billing_entity" do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    context "when wallet has a billing_entity" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:wallet) { create(:wallet, customer:, billing_entity:) }
+
+      it "returns the wallet billing_entity" do
+        expect(wallet.billing_entity).to eq(billing_entity)
+      end
+    end
+
+    context "when wallet does not have a billing_entity" do
+      let(:wallet) { create(:wallet, customer:, billing_entity: nil) }
+
+      it "falls back to the customer billing_entity" do
+        expect(wallet.billing_entity).to eq(customer.billing_entity)
+      end
+    end
   end
 
   describe ".with_positive_balance" do


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Add optional `billing_entity_id` column to `subscriptions` and `wallets` tables with indexes and foreign keys                                                                                                    
  - Replace `has_one :billing_entity, through: :customer` on Subscription with a direct `belongs_to :billing_entity, optional: true`
  - Add `belongs_to :billing_entity, optional: true` to Wallet                                                                                                                                                       
  - Both models fall back to `customer.billing_entity` when their own `billing_entity_id` is nil                                                                                                                     
                                              
  ## Test plan                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  - [x] Subscription returns its own billing entity when set                                                                                                                                                         
  - [x] Subscription falls back to customer billing entity when nil                                                                                                                                                  
  - [x] Wallet returns its own billing entity when set                                                                                                                                                               
  - [x] Wallet falls back to customer billing entity when nil                                                                                                                                                        
