### PR TITLE
fix(ci): pin pnpm via front package.json + fetch full history for short SHAs

### DIFF
--- a/.github/workflows/front-compatibility.yml
+++ b/.github/workflows/front-compatibility.yml
@@ -61,9 +61,19 @@ jobs:
           # use whatever ref the operator chose (defaults to main).
           ref: ${{ github.event.inputs.front_ref || 'main' }}
           path: front
+          # Default fetch-depth is 1, which only resolves named refs and
+          # full 40-char SHAs. Setting 0 fetches full history so
+          # operators can paste short SHAs (e.g. `74b4f669`) into the
+          # dispatch input without it failing the fetch step.
+          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
+        with:
+          # lago-front declares its pnpm version in `packageManager`.
+          # Point the action at front's package.json so the version
+          # tracks whatever lago-front pins, no manual upkeep here.
+          package_json_file: front/package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Follow-up to #5435 — fixes two issues that surfaced on the first manual \`workflow_dispatch\` runs of the front-compatibility workflow.

## Failure 1: pnpm version not found

\`\`\`
Error: No pnpm version is specified.
Please specify it by one of the following ways:
  - in the GitHub Action config with the key "version"
  - in the package.json with the key "packageManager"
  - in the package.json with the key "devEngines.packageManager"
\`\`\`

\`pnpm/action-setup\` looks at the workspace root for \`packageManager\`, but lago-front lives under \`front/\` in our checkout layout — root has lago-api's \`Gemfile\`, not a \`package.json\`. Fix: point the action at \`front/package.json\` (which has \`"packageManager": "pnpm@10.33.0"\`). Mirrors the \`node-version-file: front/package.json\` we already set on \`actions/setup-node\` for the same reason.

## Failure 2: short SHA on dispatch input doesn't resolve

\`\`\`
/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin
  +refs/heads/74b4f669*:refs/remotes/origin/74b4f669*
  +refs/tags/74b4f669*:refs/tags/74b4f669*
The process '/usr/bin/git' failed with exit code 1
\`\`\`

Triggered when running the workflow with \`front_ref: 74b4f669\` to demo the bug-replay case. \`actions/checkout\`'s default \`fetch-depth: 1\` only resolves named refs (branches/tags) and full 40-char SHAs — it tried to interpret \`74b4f669\` as a branch/tag glob, found nothing, failed. Setting \`fetch-depth: 0\` fetches full history so any ref — branch, tag, full SHA, or short SHA — resolves correctly. Cost is a slightly slower checkout, fine given this is about to be turned back to main only, hence being able to remove this change
