### PR TITLE
fix(clickhouse): Deadletter queue timestamp parsing

### DIFF
--- a/db/clickhouse_migrate/20260430075848_update_events_dead_letter_mv.rb
+++ b/db/clickhouse_migrate/20260430075848_update_events_dead_letter_mv.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class UpdateEventsDeadLetterMv < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      execute <<~SQL
+        ALTER TABLE events_dead_letter_mv MODIFY QUERY
+        SELECT
+          JSONExtractString(event, 'organization_id') AS organization_id,
+          JSONExtractString(event, 'external_subscription_id') AS external_subscription_id,
+          JSONExtractString(event, 'code') AS code,
+          JSONExtractString(event, 'transaction_id') AS transaction_id,
+          COALESCE(
+            toDateTime64OrNull(JSONExtractString(event, 'timestamp'), 3),
+            toDateTime64(
+              toFloat64OrNull(JSONExtractString(event, 'timestamp')), 3
+            ),
+            toDateTime64(JSONExtractString(event, 'ingested_at'), 3)
+          ) AS timestamp,
+          toDateTime64(JSONExtractString(event, 'ingested_at'), 3) AS ingested_at,
+          toDateTime64(parseDateTime64BestEffort(failed_at), 3) as failed_at,
+          event,
+          error_code,
+          error_message,
+          initial_error_message
+        FROM events_dead_letter_queue;
+      SQL
+    end
+  end
+end

--- a/db/clickhouse_migrate/cloud/08_events_dead_letter_mv.sql
+++ b/db/clickhouse_migrate/cloud/08_events_dead_letter_mv.sql
@@ -17,7 +17,11 @@ AS SELECT
   event.external_subscription_id AS external_subscription_id,
   event.code AS code,
   event.transaction_id AS transaction_id,
-  toDateTime64OrNull(toString(event.timestamp), 3) AS timestamp,
+  coalesce(
+    toDateTime64OrNull(toString(event.timestamp), 3),
+    toDateTime64(toFloat64OrNull(event.timestamp), 3),
+    toDateTime64(event.ingested_at, 3)
+  ) AS timestamp,
   toDateTime64(event.ingested_at, 3) AS ingested_at,
   failed_at,
   event,


### PR DESCRIPTION
## Description

This PR fixes the parsing of `event.timestamp` in the `events_dead_letter_mv` materialized view.

The timestamp is a unix timestamp stored as a string and finally parsed into a datetime. With some values, for example "3600.0", the Datetime conversion was failing because Clickhouse was not considering the value as a timestamp, but as date that it was then failing to parse.

The new logic adds a fallback on a Float64 conversion before converting into a Datetime, and finally on the event `ingested_at` value as a last resort, to avoid failing the pipeline completly since the `events_dead_letter` table is expecting a not null value for timestamp