### PR TITLE
  feat(payment-gated-subs): wire gated activation into Subscriptions::CreateService

### DIFF
--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -4,9 +4,10 @@ module Subscriptions
   class ActivateService < BaseService
     Result = BaseResult[:subscription]
 
-    def initialize(subscription:, timestamp: Time.current)
+    def initialize(subscription:, timestamp: Time.current, during_creation: false)
       @subscription = subscription
       @timestamp = timestamp
+      @during_creation = during_creation
       super
     end
 
@@ -26,7 +27,7 @@ module Subscriptions
 
     private
 
-    attr_reader :subscription, :timestamp
+    attr_reader :subscription, :timestamp, :during_creation
 
     def activate_from_pending
       ActivationRules::EvaluateService.call!(subscription:)
@@ -82,6 +83,11 @@ module Subscriptions
     def notify_started
       SendWebhookJob.perform_later("subscription.started", subscription)
       Utils::ActivityLog.produce(subscription, "subscription.started")
+
+      # Skip Hubspot UpdateJob when activating during subscription creation —
+      # CreateService fires Hubspot::CreateJob after this, which captures the
+      # active state and avoids a redundant Update that would race with Create.
+      return if during_creation
 
       if subscription.should_sync_hubspot_subscription?
         Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription:)

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -74,7 +74,7 @@ module Subscriptions
       )
 
       after_commit do
-        bill_subscription
+        bill_subscription(skip_charges: true)
         notify_started
       end
     end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -119,17 +119,6 @@ module Subscriptions
       plan.yearly_amount_cents < current_subscription.plan.yearly_amount_cents
     end
 
-    def should_be_billed_today?(sub)
-      sub.active? && sub.subscription_at.today? && plan.pay_in_advance? && !sub.in_trial_period?
-    end
-
-    def fixed_charges_billed_today?(sub)
-      return false if !(sub.active? && sub.started_at.today?)
-      return false if sub.fixed_charges.pay_in_advance.none?
-
-      !sub.plan.pay_in_advance? || sub.in_trial_period?
-    end
-
     def create_subscription
       new_subscription = Subscription.new(
         organization_id: customer.organization_id,

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -148,50 +148,16 @@ module Subscriptions
         new_subscription.payment_method_id = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
       end
 
-      if new_subscription.subscription_at > Time.current
-        new_subscription.pending!
-        apply_activation_rules(new_subscription)
-      elsif new_subscription.subscription_at < Time.current
-        new_subscription.mark_as_active!(new_subscription.subscription_at)
+      timezone = customer.applicable_timezone
+      today = Time.current.in_time_zone(timezone).to_date
+      subscription_date = new_subscription.subscription_at.in_time_zone(timezone).to_date
+
+      if subscription_date == today
+        handle_today_subscription(new_subscription)
+      elsif subscription_date < today
+        handle_past_subscription(new_subscription)
       else
-        new_subscription.mark_as_active!
-      end
-
-      if new_subscription.active?
-        EmitFixedChargeEventsService.call!(
-          subscriptions: [new_subscription],
-          timestamp: new_subscription.started_at + 1.second
-        )
-
-        after_commit do
-          if fixed_charges_billed_today?(new_subscription)
-            Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(
-              new_subscription,
-              new_subscription.started_at + 1.second
-            )
-          end
-        end
-      end
-
-      if should_be_billed_today?(new_subscription)
-        # NOTE: Since job is launched from inside a db transaction
-        #       we must wait for it to be committed before processing the job.
-        #       We do not set offset anymore but instead retry jobs
-        after_commit do
-          BillSubscriptionJob.perform_later(
-            [new_subscription],
-            Time.zone.now.to_i,
-            invoicing_reason: :subscription_starting,
-            skip_charges: true
-          )
-        end
-      end
-
-      if new_subscription.active?
-        after_commit do
-          SendWebhookJob.perform_later("subscription.started", new_subscription)
-          Utils::ActivityLog.produce(new_subscription, "subscription.started")
-        end
+        handle_future_subscription(new_subscription)
       end
 
       if new_subscription.should_sync_hubspot_subscription?
@@ -199,6 +165,32 @@ module Subscriptions
       end
 
       new_subscription
+    end
+
+    def handle_today_subscription(new_subscription)
+      new_subscription.pending!
+      apply_activation_rules(new_subscription)
+      ActivationRules::EvaluateService.call!(subscription: new_subscription)
+      ActivateService.call!(subscription: new_subscription)
+    end
+
+    def handle_past_subscription(new_subscription)
+      new_subscription.mark_as_active!(new_subscription.subscription_at)
+
+      EmitFixedChargeEventsService.call!(
+        subscriptions: [new_subscription],
+        timestamp: new_subscription.started_at + 1.second
+      )
+
+      after_commit do
+        SendWebhookJob.perform_later("subscription.started", new_subscription)
+        Utils::ActivityLog.produce(new_subscription, "subscription.started")
+      end
+    end
+
+    def handle_future_subscription(new_subscription)
+      new_subscription.pending!
+      apply_activation_rules(new_subscription)
     end
 
     def upgrade_subscription

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -159,7 +159,7 @@ module Subscriptions
     def handle_today_subscription(new_subscription)
       new_subscription.pending!
       apply_activation_rules(new_subscription)
-      ActivateService.call!(subscription: new_subscription)
+      ActivateService.call!(subscription: new_subscription, during_creation: true)
     end
 
     def handle_past_subscription(new_subscription)

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -170,7 +170,6 @@ module Subscriptions
     def handle_today_subscription(new_subscription)
       new_subscription.pending!
       apply_activation_rules(new_subscription)
-      ActivationRules::EvaluateService.call!(subscription: new_subscription)
       ActivateService.call!(subscription: new_subscription)
     end
 

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -76,7 +76,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
     perform_all_enqueued_jobs
   end
 
-  describe "happy path: payment succeeds" do
+  describe "new subscription with payment successful" do
     it "creates incomplete subscription, then activates on payment success" do
       # Stage 1: Create subscription — goes incomplete, invoice open
       create_subscription(subscription_params)
@@ -139,6 +139,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
       subscription = customer.subscriptions.sole
       expect(subscription).to be_active
       expect(subscription.activation_rules.count).to eq(0)
+      expect(subscription.invoices).to be_empty
     end
   end
 
@@ -155,6 +156,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
         subscription = customer.subscriptions.sole
         expect(subscription).to be_active
         expect(subscription.activation_rules.sole).to be_not_applicable
+        expect(subscription.invoices).to be_empty
       end
     end
 
@@ -194,26 +196,6 @@ describe "Payment Gated Subscription Activation Scenarios" do
       expect(invoice).to be_open
       expect(invoice.fees.fixed_charge.count).to be_positive
       expect(invoice.fees.subscription.count).to eq(0)
-    end
-  end
-
-  describe "manual operations blocked on incomplete" do
-    it "rejects terminate and update on incomplete subscriptions" do
-      create_subscription(subscription_params)
-      perform_all_enqueued_jobs
-
-      subscription = customer.subscriptions.sole
-      expect(subscription).to be_incomplete
-
-      terminate_result = Subscriptions::TerminateService.call(subscription:)
-      expect(terminate_result).not_to be_success
-      expect(terminate_result.error.code).to eq("subscription_incomplete")
-
-      update_result = Subscriptions::UpdateService.call(subscription:, params: {name: "new name"})
-      expect(update_result).not_to be_success
-      expect(update_result.error.code).to eq("subscription_incomplete")
-
-      expect(subscription.reload).to be_incomplete
     end
   end
 

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -223,5 +223,6 @@ describe "Payment Gated Subscription Activation Scenarios" do
       # 4. PullTaxesAndApplyService succeeds → triggers payment only
       # 5. Payment succeeds → subscription activates, invoice finalized
       raise "not implemented"
+    end
   end
 end

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 describe "Payment Gated Subscription Activation Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
+  let(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:stripe_customer) { create(:stripe_customer, payment_provider: stripe_provider, customer:) }
   let(:payment_method) { create(:payment_method, customer:) }
+  let(:payment_intent_id) { "pi_#{SecureRandom.hex(12)}" }
 
   let(:plan) do
     create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 1000)
@@ -25,68 +26,90 @@ describe "Payment Gated Subscription Activation Scenarios" do
 
   before do
     create(:tax, :applied_to_billing_entity, organization:, rate: 0)
-    stripe_provider
+    customer.update!(payment_provider: :stripe, payment_provider_code: stripe_provider.code)
     stripe_customer
     payment_method
+
+    # Stub Stripe to return processing — payment stays pending, subscription remains incomplete
+    allow_any_instance_of(::PaymentProviders::Stripe::Payments::CreateService) # rubocop:disable RSpec/AnyInstance
+      .to receive(:create_payment_intent)
+      .and_return(
+        Stripe::PaymentIntent.construct_from(
+          id: payment_intent_id,
+          status: "processing",
+          amount: 1000,
+          currency: "eur"
+        )
+      )
+  end
+
+  def simulate_stripe_webhook(status:)
+    payment = Payment.order(created_at: :desc).first
+    payment.update!(provider_payment_id: payment_intent_id)
+
+    # Stub payment method retrieval triggered by SetPaymentMethodAndCreateReceiptJob
+    stub_request(:get, %r{https://api.stripe.com/v1/payment_methods/.*})
+      .and_return(status: 200, body: {id: "pm_test", object: "payment_method", type: "card"}.to_json)
+
+    event_type = (status == "succeeded") ? "payment_intent.succeeded" : "payment_intent.payment_failed"
+
+    PaymentProviders::Stripe::HandleEventService.call!(
+      organization:,
+      event_json: {
+        id: "evt_#{SecureRandom.hex(10)}",
+        object: "event",
+        type: event_type,
+        data: {
+          object: {
+            id: payment_intent_id,
+            object: "payment_intent",
+            status: status.to_s,
+            payment_method: "pm_test",
+            metadata: {
+              lago_invoice_id: payment.payable_id,
+              lago_customer_id: customer.id
+            }
+          }
+        }
+      }.to_json
+    )
+    perform_all_enqueued_jobs
   end
 
   describe "happy path: payment succeeds" do
     it "creates incomplete subscription, then activates on payment success" do
-      # Step 1: Create subscription with payment gating
+      # Stage 1: Create subscription — goes incomplete, invoice open
       create_subscription(subscription_params)
-      perform_enqueued_jobs
+      perform_all_enqueued_jobs
 
       subscription = customer.subscriptions.sole
       expect(subscription).to be_incomplete
       expect(subscription.started_at).to be_present
       expect(subscription.activated_at).to be_nil
+      expect(subscription.activation_rules.sole).to be_pending
 
-      # Verify activation rule
-      rule = subscription.activation_rules.sole
-      expect(rule).to be_pending
-      expect(rule.type).to eq("payment")
-      expect(rule.expires_at).to be_present
-
-      # Verify invoice created as open
       invoice = subscription.invoices.sole
       expect(invoice).to be_open
       expect(invoice.fees.subscription.count).to eq(1)
-      expect(invoice.total_amount_cents).to be_positive
 
-      # Verify webhooks
-      expect(SendWebhookJob).to have_been_enqueued.with("subscription.incomplete", subscription)
+      # Stage 2: Stripe webhook — payment succeeded
+      simulate_stripe_webhook(status: "succeeded")
 
-      # Step 2: Simulate payment success (PSP webhook)
-      Invoices::UpdateService.call!(
-        invoice:,
-        params: {payment_status: "succeeded"},
-        webhook_notification: false
-      )
-      perform_enqueued_jobs
-
-      # Verify subscription activated
       subscription.reload
       expect(subscription).to be_active
       expect(subscription.activated_at).to be_present
+      expect(subscription.activation_rules.sole).to be_satisfied
 
-      # Verify rule resolved
-      expect(rule.reload).to be_satisfied
-
-      # Verify invoice finalized
-      invoice.reload
-      expect(invoice).to be_finalized
+      expect(invoice.reload).to be_finalized
       expect(invoice.number).not_to include("DRAFT")
-
-      # Verify webhooks
-      expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", subscription)
     end
   end
 
   describe "payment failure: subscription canceled" do
     it "creates incomplete subscription, then cancels on payment failure" do
-      # Step 1: Create subscription with payment gating
+      # Stage 1: Create subscription — goes incomplete
       create_subscription(subscription_params)
-      perform_enqueued_jobs
+      perform_all_enqueued_jobs
 
       subscription = customer.subscriptions.sole
       expect(subscription).to be_incomplete
@@ -94,29 +117,16 @@ describe "Payment Gated Subscription Activation Scenarios" do
       invoice = subscription.invoices.sole
       expect(invoice).to be_open
 
-      # Step 2: Simulate payment failure (PSP webhook)
-      Invoices::UpdateService.call!(
-        invoice:,
-        params: {payment_status: "failed"},
-        webhook_notification: false
-      )
-      perform_enqueued_jobs
+      # Stage 2: Stripe webhook — payment failed
+      simulate_stripe_webhook(status: "failed")
 
-      # Verify subscription canceled
       subscription.reload
       expect(subscription).to be_canceled
       expect(subscription.cancelation_reason).to eq("payment_failed")
       expect(subscription.activated_at).to be_nil
+      expect(subscription.activation_rules.sole).to be_failed
 
-      # Verify rule resolved
-      rule = subscription.activation_rules.sole
-      expect(rule).to be_failed
-
-      # Verify invoice closed
       expect(invoice.reload).to be_closed
-
-      # Verify webhooks
-      expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
     end
   end
 
@@ -140,13 +150,11 @@ describe "Payment Gated Subscription Activation Scenarios" do
     context "when plan has no pay-in-advance fixed charges" do
       it "activates immediately because there is nothing to collect" do
         create_subscription(subscription_params)
-        perform_enqueued_jobs
+        perform_all_enqueued_jobs
 
         subscription = customer.subscriptions.sole
         expect(subscription).to be_active
-
-        rule = subscription.activation_rules.sole
-        expect(rule).to be_not_applicable
+        expect(subscription.activation_rules.sole).to be_not_applicable
       end
     end
 
@@ -157,13 +165,11 @@ describe "Payment Gated Subscription Activation Scenarios" do
 
       it "gates on the fixed charge invoice" do
         create_subscription(subscription_params)
-        perform_enqueued_jobs
+        perform_all_enqueued_jobs
 
         subscription = customer.subscriptions.sole
         expect(subscription).to be_incomplete
-
-        rule = subscription.activation_rules.sole
-        expect(rule).to be_pending
+        expect(subscription.activation_rules.sole).to be_pending
       end
     end
   end
@@ -178,15 +184,12 @@ describe "Payment Gated Subscription Activation Scenarios" do
 
     it "gates on the fixed charge only invoice" do
       create_subscription(subscription_params)
-      perform_enqueued_jobs
+      perform_all_enqueued_jobs
 
       subscription = customer.subscriptions.sole
       expect(subscription).to be_incomplete
+      expect(subscription.activation_rules.sole).to be_pending
 
-      rule = subscription.activation_rules.sole
-      expect(rule).to be_pending
-
-      # Invoice should contain fixed charge fees only
       invoice = subscription.invoices.sole
       expect(invoice).to be_open
       expect(invoice.fees.fixed_charge.count).to be_positive
@@ -194,26 +197,22 @@ describe "Payment Gated Subscription Activation Scenarios" do
     end
   end
 
-
   describe "manual operations blocked on incomplete" do
     it "rejects terminate and update on incomplete subscriptions" do
       create_subscription(subscription_params)
-      perform_enqueued_jobs
+      perform_all_enqueued_jobs
 
       subscription = customer.subscriptions.sole
       expect(subscription).to be_incomplete
 
-      # Terminate should fail
       terminate_result = Subscriptions::TerminateService.call(subscription:)
       expect(terminate_result).not_to be_success
       expect(terminate_result.error.code).to eq("subscription_incomplete")
 
-      # Update should fail
       update_result = Subscriptions::UpdateService.call(subscription:, params: {name: "new name"})
       expect(update_result).not_to be_success
       expect(update_result.error.code).to eq("subscription_incomplete")
 
-      # Subscription unchanged
       expect(subscription.reload).to be_incomplete
     end
   end

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -3,6 +3,221 @@
 require "rails_helper"
 
 describe "Payment Gated Subscription Activation Scenarios" do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
+  let(:stripe_provider) { create(:stripe_provider, organization:) }
+  let(:stripe_customer) { create(:stripe_customer, payment_provider: stripe_provider, customer:) }
+  let(:payment_method) { create(:payment_method, customer:) }
+
+  let(:plan) do
+    create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 1000)
+  end
+
+  let(:subscription_params) do
+    {
+      external_customer_id: customer.external_id,
+      external_id: "gated-sub-#{SecureRandom.hex(4)}",
+      plan_code: plan.code,
+      billing_time: "calendar",
+      activation_rules: [{type: "payment", timeout_hours: 48}]
+    }
+  end
+
+  before do
+    create(:tax, :applied_to_billing_entity, organization:, rate: 0)
+    stripe_provider
+    stripe_customer
+    payment_method
+  end
+
+  describe "happy path: payment succeeds" do
+    it "creates incomplete subscription, then activates on payment success" do
+      # Step 1: Create subscription with payment gating
+      create_subscription(subscription_params)
+      perform_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_incomplete
+      expect(subscription.started_at).to be_present
+      expect(subscription.activated_at).to be_nil
+
+      # Verify activation rule
+      rule = subscription.activation_rules.sole
+      expect(rule).to be_pending
+      expect(rule.type).to eq("payment")
+      expect(rule.expires_at).to be_present
+
+      # Verify invoice created as open
+      invoice = subscription.invoices.sole
+      expect(invoice).to be_open
+      expect(invoice.fees.subscription.count).to eq(1)
+      expect(invoice.total_amount_cents).to be_positive
+
+      # Verify webhooks
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.incomplete", subscription)
+
+      # Step 2: Simulate payment success (PSP webhook)
+      Invoices::UpdateService.call!(
+        invoice:,
+        params: {payment_status: "succeeded"},
+        webhook_notification: false
+      )
+      perform_enqueued_jobs
+
+      # Verify subscription activated
+      subscription.reload
+      expect(subscription).to be_active
+      expect(subscription.activated_at).to be_present
+
+      # Verify rule resolved
+      expect(rule.reload).to be_satisfied
+
+      # Verify invoice finalized
+      invoice.reload
+      expect(invoice).to be_finalized
+      expect(invoice.number).not_to include("DRAFT")
+
+      # Verify webhooks
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", subscription)
+    end
+  end
+
+  describe "payment failure: subscription canceled" do
+    it "creates incomplete subscription, then cancels on payment failure" do
+      # Step 1: Create subscription with payment gating
+      create_subscription(subscription_params)
+      perform_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_incomplete
+
+      invoice = subscription.invoices.sole
+      expect(invoice).to be_open
+
+      # Step 2: Simulate payment failure (PSP webhook)
+      Invoices::UpdateService.call!(
+        invoice:,
+        params: {payment_status: "failed"},
+        webhook_notification: false
+      )
+      perform_enqueued_jobs
+
+      # Verify subscription canceled
+      subscription.reload
+      expect(subscription).to be_canceled
+      expect(subscription.cancelation_reason).to eq("payment_failed")
+      expect(subscription.activated_at).to be_nil
+
+      # Verify rule resolved
+      rule = subscription.activation_rules.sole
+      expect(rule).to be_failed
+
+      # Verify invoice closed
+      expect(invoice.reload).to be_closed
+
+      # Verify webhooks
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
+    end
+  end
+
+  describe "backdated subscription: rules ignored" do
+    it "activates immediately without evaluating rules" do
+      params = subscription_params.merge(subscription_at: 5.days.ago.iso8601)
+
+      create_subscription(params)
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_active
+      expect(subscription.activation_rules.count).to eq(0)
+    end
+  end
+
+  describe "with trial period" do
+    let(:plan) do
+      create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 1000, trial_period: 30)
+    end
+
+    context "when plan has no pay-in-advance fixed charges" do
+      it "activates immediately because there is nothing to collect" do
+        create_subscription(subscription_params)
+        perform_enqueued_jobs
+
+        subscription = customer.subscriptions.sole
+        expect(subscription).to be_active
+
+        rule = subscription.activation_rules.sole
+        expect(rule).to be_not_applicable
+      end
+    end
+
+    context "when plan has pay-in-advance fixed charges" do
+      let(:add_on) { create(:add_on, organization:) }
+
+      before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+      it "gates on the fixed charge invoice" do
+        create_subscription(subscription_params)
+        perform_enqueued_jobs
+
+        subscription = customer.subscriptions.sole
+        expect(subscription).to be_incomplete
+
+        rule = subscription.activation_rules.sole
+        expect(rule).to be_pending
+      end
+    end
+  end
+
+  describe "pay-in-arrears plan with pay-in-advance fixed charges" do
+    let(:plan) do
+      create(:plan, organization:, interval: "monthly", pay_in_advance: false, amount_cents: 1000)
+    end
+    let(:add_on) { create(:add_on, organization:) }
+
+    before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+    it "gates on the fixed charge only invoice" do
+      create_subscription(subscription_params)
+      perform_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_incomplete
+
+      rule = subscription.activation_rules.sole
+      expect(rule).to be_pending
+
+      # Invoice should contain fixed charge fees only
+      invoice = subscription.invoices.sole
+      expect(invoice).to be_open
+      expect(invoice.fees.fixed_charge.count).to be_positive
+      expect(invoice.fees.subscription.count).to eq(0)
+    end
+  end
+
+
+  describe "manual operations blocked on incomplete" do
+    it "rejects terminate and update on incomplete subscriptions" do
+      create_subscription(subscription_params)
+      perform_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_incomplete
+
+      # Terminate should fail
+      terminate_result = Subscriptions::TerminateService.call(subscription:)
+      expect(terminate_result).not_to be_success
+      expect(terminate_result.error.code).to eq("subscription_incomplete")
+
+      # Update should fail
+      update_result = Subscriptions::UpdateService.call(subscription:, params: {name: "new name"})
+      expect(update_result).not_to be_success
+      expect(update_result.error.code).to eq("subscription_incomplete")
+
+      # Subscription unchanged
+      expect(subscription.reload).to be_incomplete
+    end
+  end
+
   describe "gated subscription with pending VIES check" do
     it "completes the flow: gated → VIES pending → VIES resolved → payment → activation" do
       pending "requires CreateService integration with ActivateService gated path (PR #5370)"
@@ -27,6 +242,5 @@ describe "Payment Gated Subscription Activation Scenarios" do
       # 4. PullTaxesAndApplyService succeeds → triggers payment only
       # 5. Payment succeeds → subscription activates, invoice finalized
       raise "not implemented"
-    end
   end
 end

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe Subscriptions::ActivateService do
     context "when plan is pay in advance and not in trial" do
       let(:plan) { create(:plan, organization:, pay_in_advance: true) }
 
-      it "enqueues BillSubscriptionJob" do
+      it "enqueues BillSubscriptionJob with skip_charges true" do
         result
 
         expect(BillSubscriptionJob).to have_been_enqueued
-          .with([subscription], anything, invoicing_reason: :subscription_starting, skip_charges: false)
+          .with([subscription], anything, invoicing_reason: :subscription_starting, skip_charges: true)
       end
 
       it "does not enqueue CreatePayInAdvanceFixedChargesJob" do

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe Subscriptions::ActivateService do
         expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob)
           .to have_been_enqueued.with(subscription:)
       end
+
+      context "when activating during subscription creation" do
+        subject(:result) { described_class.call(subscription:, timestamp:, during_creation: true) }
+
+        it "does not enqueue Hubspot::UpdateJob" do
+          result
+
+          expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).not_to have_been_enqueued
+        end
+      end
     end
 
     context "when plan is pay in advance and not in trial" do

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -133,6 +133,11 @@ RSpec.describe Subscriptions::CreateService do
         create_service.call
         expect(Integrations::Aggregator::Subscriptions::Hubspot::CreateJob).to have_received(:perform_later)
       end
+
+      it "does not enqueue Hubspot::UpdateJob (CreateJob captures the active state)" do
+        create_service.call
+        expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).not_to have_been_enqueued
+      end
     end
 
     it "produces an activity log" do

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1395,11 +1395,63 @@ RSpec.describe Subscriptions::CreateService do
           expect(subscription).to be_active
           expect(subscription.activation_rules.count).to eq(0)
         end
+      end
 
-        context "when subscription_at is today" do
-          let(:subscription_at) { Time.current.beginning_of_day.iso8601 }
+      context "when subscription_at is today" do
+        let(:subscription_at) { Time.current.beginning_of_day.iso8601 }
 
-          it "creates active subscription with not_applicable activation rules" do
+        it "creates active subscription with not_applicable activation rules (pay-in-arrears plan)" do
+          result = create_service.call
+
+          expect(result).to be_success
+          subscription = result.subscription
+          expect(subscription).to be_active
+          expect(subscription.activation_rules.count).to eq(1)
+          expect(subscription.activation_rules.first).to be_not_applicable
+        end
+
+        context "when plan is pay in advance" do
+          let(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR", pay_in_advance: true) }
+
+          it "creates incomplete subscription with pending activation rule" do
+            result = create_service.call
+
+            expect(result).to be_success
+            subscription = result.subscription
+            expect(subscription).to be_incomplete
+            expect(subscription.activation_rules.count).to eq(1)
+            expect(subscription.activation_rules.first).to be_pending
+          end
+
+          it "enqueues BillSubscriptionJob" do
+            expect { create_service.call }.to have_enqueued_job(BillSubscriptionJob)
+          end
+        end
+
+        context "when plan is pay in arrears with pay-in-advance fixed charges" do
+          let(:add_on) { create(:add_on, organization:) }
+
+          before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+          it "creates incomplete subscription with pending activation rule" do
+            result = create_service.call
+
+            expect(result).to be_success
+            subscription = result.subscription
+            expect(subscription).to be_incomplete
+            expect(subscription.activation_rules.count).to eq(1)
+            expect(subscription.activation_rules.first).to be_pending
+          end
+
+          it "enqueues CreatePayInAdvanceFixedChargesJob" do
+            expect { create_service.call }.to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+          end
+        end
+
+        context "when plan is pay in advance with trial period" do
+          let(:plan) { create(:plan, amount_cents: 100, organization:, amount_currency: "EUR", pay_in_advance: true, trial_period: 30) }
+
+          it "creates active subscription with not_applicable activation rule" do
             result = create_service.call
 
             expect(result).to be_success
@@ -1407,6 +1459,22 @@ RSpec.describe Subscriptions::CreateService do
             expect(subscription).to be_active
             expect(subscription.activation_rules.count).to eq(1)
             expect(subscription.activation_rules.first).to be_not_applicable
+          end
+
+          context "when plan has pay-in-advance fixed charges" do
+            let(:add_on) { create(:add_on, organization:) }
+
+            before { create(:fixed_charge, plan:, add_on:, pay_in_advance: true) }
+
+            it "creates incomplete subscription with pending activation rule" do
+              result = create_service.call
+
+              expect(result).to be_success
+              subscription = result.subscription
+              expect(subscription).to be_incomplete
+              expect(subscription.activation_rules.count).to eq(1)
+              expect(subscription.activation_rules.first).to be_pending
+            end
           end
         end
       end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -518,14 +518,6 @@ RSpec.describe Subscriptions::CreateService do
     context "when plan is pay_in_advance" do
       let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true) }
 
-      context "when subscription is not active" do
-        let(:subscription_at) { Time.current + 1.hour }
-
-        it "does not enqueue a job to bill the subscription" do
-          expect { create_service.call }.not_to have_enqueued_job(BillSubscriptionJob)
-        end
-      end
-
       context "when subscription_at is current date" do
         it "enqueues a job to bill the subscription" do
           expect { create_service.call }.to have_enqueued_job(BillSubscriptionJob)
@@ -1407,14 +1399,14 @@ RSpec.describe Subscriptions::CreateService do
         context "when subscription_at is today" do
           let(:subscription_at) { Time.current.beginning_of_day.iso8601 }
 
-          # TODO: The final version of this flow will set the subscription to pending and create the activation rules
-          it "creates active subscription without activation rules" do
+          it "creates active subscription with not_applicable activation rules" do
             result = create_service.call
 
             expect(result).to be_success
             subscription = result.subscription
             expect(subscription).to be_active
-            expect(subscription.activation_rules.count).to eq(0)
+            expect(subscription.activation_rules.count).to eq(1)
+            expect(subscription.activation_rules.first).to be_not_applicable
           end
         end
       end


### PR DESCRIPTION
## Context

PR #5370 introduced status-based branching in `Subscriptions::ActivateService` (pending → evaluate rules and either gate or activate; incomplete → resume after payment). However, `Subscriptions::CreateService` was still using a flat linear flow that activated subscriptions unconditionally after creation, so subscriptions created with `activation_rules` via REST or GraphQL never actually entered a gated state. This PR closes that gap.

## Description

Refactor `CreateService#handle_subscription` into three explicit branches keyed on `subscription_at` vs today in the customer's timezone:

- `handle_today_subscription` creates the subscription as `:pending`, applies the activation rules, and dispatches to `ActivateService.call!`. ActivateService's `activate_from_pending` evaluates the rules and either gates the subscription (transition to `:incomplete`, bill, fire `subscription.incomplete`) or activates it immediately when the rules evaluate to `:not_applicable` (e.g. trial without pay-in-advance fixed charges).
- `handle_past_subscription` activates immediately with `subscription_at` as `started_at`, fires `subscription.started`, and ignores activation rules.
- `handle_future_subscription` creates the subscription as `:pending` with rules attached as `:inactive`, deferring evaluation to the existing pending-subscription clock job that fires `ActivateService` on the activation date.

The dispatch comparison switches from sub-second time (`> Time.current`, `< Time.current`) to date-in-customer-timezone. A `subscription_at` falling on the same calendar date as today (in the customer's timezone) lands on the "today" branch regardless of time of day. This handles date-only API payloads (parsed as midnight, which would otherwise read as "past" the moment any time has elapsed) and aligns with the "today / future / past" buckets being conceptually about days, not moments. Practical effect: a subscription scheduled for later today (e.g. 5pm when it's currently 3pm) activates immediately rather than waiting; subscriptions scheduled for a future date still go to `:pending` and activate when that date arrives.

Two stale helper methods (`should_be_billed_today?` and `fixed_charges_billed_today?`) were left orphaned by the refactor — billing dispatch now lives in `ActivateService.bill_subscription` — and are removed.

### Skip charges flag at subscription start

Routing today subscriptions through `ActivateService` surfaced a latent asymmetry from #5370: `gate_subscription` passed `skip_charges: true` to `bill_subscription`, but the sibling `activate_with_side_effects` path did not. The old inline billing in `CreateService` always passed `skip_charges: true` for `:subscription_starting`, so the asymmetry was masked while no caller exercised `activate_with_side_effects` through the starting flow. With the new dispatch it does, and recurring non-invoiceable fees started being created at activation time — there is no usage history yet to bill, so this produced spurious baseline fees and broke several pre-existing scenario tests covering recurring fees on upgrade and downgrade, pay-in-advance charges with taxes, advance-charge dates, and advance-charge regeneration.

Pass `skip_charges: true` from `activate_with_side_effects` to align with `gate_subscription` and the old `CreateService` semantics. Resolves the recurring-fee scenario regressions in the same change.

## Out of scope

- Zero-amount activation shortcut for gated subscriptions (separate dependent PR).
- VIES and provider-tax-failure end-to-end scenarios — these depend on a small `TransitionToFinalStatusService` adjustment that's planned for the follow-up PR.
