### PR TITLE
[ING-17] fix: handle invalid nil assignment for recurring rule credits

### DIFF
--- a/app/services/wallets/recurring_transaction_rules/update_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/update_service.rb
@@ -23,6 +23,10 @@ module Wallets
           # Normalize transaction_name to nil if empty
           rule_attributes[:transaction_name] = rule_attributes[:transaction_name].presence if rule_attributes.key?(:transaction_name)
 
+          %i[paid_credits granted_credits threshold_credits].each do |credit_attr|
+            rule_attributes[credit_attr] = 0.0 if rule_attributes.key?(credit_attr) && rule_attributes[credit_attr].nil?
+          end
+
           if rule_attributes.key?(:payment_method)
             rule_attributes[:payment_method_type] = rule_attributes[:payment_method][:payment_method_type] if rule_attributes[:payment_method].key?(:payment_method_type)
             rule_attributes[:payment_method_id] = rule_attributes[:payment_method][:payment_method_id] if rule_attributes[:payment_method].key?(:payment_method_id)

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -112,6 +112,41 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
       end
     end
 
+    context "when paid_credits and granted_credits are explicitly null" do
+      let(:recurring_transaction_rule) do
+        create(:recurring_transaction_rule, wallet:, paid_credits: 200, granted_credits: 200)
+      end
+      let(:params) do
+        [
+          {
+            lago_id: recurring_transaction_rule.id,
+            method: "target",
+            trigger: "interval",
+            interval: "monthly",
+            target_ongoing_balance: "5300",
+            paid_credits: nil,
+            granted_credits: nil,
+            threshold_credits: nil
+          }
+        ]
+      end
+
+      it "coerces nil credit values to 0.0 instead of raising NotNullViolation" do
+        rule = result.wallet.reload.recurring_transaction_rules.active.first
+
+        expect(rule).to have_attributes(
+          id: recurring_transaction_rule.id,
+          method: "target",
+          trigger: "interval",
+          interval: "monthly",
+          target_ongoing_balance: 5300.0,
+          paid_credits: 0.0,
+          granted_credits: 0.0,
+          threshold_credits: 0.0
+        )
+      end
+    end
+
     context "when empty array is sent as argument" do
       let(:params) { [] }
 


### PR DESCRIPTION
## Context

Currently it was possible to assign `nil` values to `paid_credits`, `granted_credits` and `threshold_credits` in the API update path for wallet recurring transaction rules.

## Description

This PR adds service layer changes that prevent described case and assign 0.0 instead.
