### PR TITLE
fix(payment-gated-subs): Modify validation service to ensure a default payment method exists

### DIFF
--- a/app/services/subscriptions/activation_rules/payment/validate_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/validate_service.rb
@@ -26,12 +26,54 @@ module Subscriptions
         end
 
         def valid_payment_method?
-          return true if args[:payment_method].present? && args[:payment_method][:payment_method_type] == PaymentMethod::PAYMENT_METHOD_TYPES[:provider]
-          return true if args[:payment_method].blank? && args[:subscription]&.payment_method_type == PaymentMethod::PAYMENT_METHOD_TYPES[:provider]
-          return true if args[:payment_method].blank? && args[:subscription].nil? && args[:customer]&.payment_provider.present?
+          return true if payment_provider? && payment_method_available?
 
-          return add_error(field: :payment_method, error_code: "no_linked_payment_provider") if args[:payment_method].blank? && args[:subscription].nil?
-          add_error(field: :payment_method, error_code: "invalid_for_payment_activation_rules")
+          add_error(field: :payment_method, error_code: failure_error_code)
+        end
+
+        def payment_provider?
+          return custom_payment_method_type_provider? if custom_payment_method?
+          return subscription_payment_method_type_provider? if args[:subscription]
+
+          customer_payment_provider?
+        end
+
+        def payment_method_available?
+          return custom_payment_method_id? || customer&.default_payment_method.present? if custom_payment_method?
+          return args[:subscription].payment_method_id.present? || customer&.default_payment_method.present? if args[:subscription]
+
+          customer&.default_payment_method.present?
+        end
+
+        def failure_error_code
+          return "customer_has_no_linked_payment_provider" if !custom_payment_method? && args[:subscription].nil? && !customer_payment_provider?
+          return "customer_has_no_default_payment_method" if payment_provider?
+
+          "manual_payment_method_invalid_for_payment_activation_rules"
+        end
+
+        def custom_payment_method?
+          args[:payment_method].present?
+        end
+
+        def custom_payment_method_type_provider?
+          args[:payment_method][:payment_method_type] == PaymentMethod::PAYMENT_METHOD_TYPES[:provider]
+        end
+
+        def custom_payment_method_id?
+          custom_payment_method? && args[:payment_method][:payment_method_id].present?
+        end
+
+        def subscription_payment_method_type_provider?
+          args[:subscription].payment_method_type == PaymentMethod::PAYMENT_METHOD_TYPES[:provider]
+        end
+
+        def customer_payment_provider?
+          args[:customer]&.payment_provider.present?
+        end
+
+        def customer
+          @customer ||= args[:customer] || args[:subscription]&.customer
         end
       end
     end

--- a/app/services/subscriptions/activation_rules/payment/validate_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/validate_service.rb
@@ -26,54 +26,51 @@ module Subscriptions
         end
 
         def valid_payment_method?
-          return true if payment_provider? && payment_method_available?
+          if effective_payment_method_type.present?
+            return true if effective_payment_method_type_provider? && resolved_payment_method.present?
+          elsif customer_payment_provider? && resolved_payment_method.present?
+            return true
+          end
 
-          add_error(field: :payment_method, error_code: failure_error_code)
+          add_error(field: :customer, error_code: failure_error_code)
         end
 
-        def payment_provider?
-          return custom_payment_method_type_provider? if custom_payment_method?
-          return subscription_payment_method_type_provider? if args[:subscription]
-
-          customer_payment_provider?
+        def effective_payment_method_type_provider?
+          effective_payment_method_type == PaymentMethod::PAYMENT_METHOD_TYPES[:provider]
         end
 
-        def payment_method_available?
-          return custom_payment_method_id? || customer&.default_payment_method.present? if custom_payment_method?
-          return args[:subscription].payment_method_id.present? || customer&.default_payment_method.present? if args[:subscription]
+        def effective_payment_method_type
+          return args[:payment_method][:payment_method_type] if args[:payment_method]&.key?(:payment_method_type)
 
-          customer&.default_payment_method.present?
+          args[:subscription]&.payment_method_type
+        end
+
+        def effective_payment_method_id
+          return args[:payment_method][:payment_method_id] if args[:payment_method]&.key?(:payment_method_id)
+
+          args[:subscription]&.payment_method_id
+        end
+
+        def resolved_payment_method
+          return args[:customer].payment_methods.find_by(id: effective_payment_method_id) if effective_payment_method_id.present?
+
+          args[:customer].default_payment_method
         end
 
         def failure_error_code
-          return "customer_has_no_linked_payment_provider" if !custom_payment_method? && args[:subscription].nil? && !customer_payment_provider?
-          return "customer_has_no_default_payment_method" if payment_provider?
+          if effective_payment_method_type.present?
+            return "manual_payment_method_invalid_for_payment_activation_rules" unless effective_payment_method_type_provider?
+          elsif !customer_payment_provider?
+            return "no_linked_payment_provider"
+          end
 
-          "manual_payment_method_invalid_for_payment_activation_rules"
-        end
+          return "payment_method_not_found" if effective_payment_method_id.present?
 
-        def custom_payment_method?
-          args[:payment_method].present?
-        end
-
-        def custom_payment_method_type_provider?
-          args[:payment_method][:payment_method_type] == PaymentMethod::PAYMENT_METHOD_TYPES[:provider]
-        end
-
-        def custom_payment_method_id?
-          custom_payment_method? && args[:payment_method][:payment_method_id].present?
-        end
-
-        def subscription_payment_method_type_provider?
-          args[:subscription].payment_method_type == PaymentMethod::PAYMENT_METHOD_TYPES[:provider]
+          "no_default_payment_method"
         end
 
         def customer_payment_provider?
-          args[:customer]&.payment_provider.present?
-        end
-
-        def customer
-          @customer ||= args[:customer] || args[:subscription]&.customer
+          args[:customer].payment_provider.present?
         end
       end
     end

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -150,6 +150,8 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
       GQL
     end
 
+    before { create(:payment_method, customer:, organization:) }
+
     it "creates a subscription with activation rules" do
       result = execute_graphql(
         current_user: membership.user,

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -149,6 +149,8 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
   end
 
   context "with activation rules" do
+    before { create(:payment_method, customer: subscription.customer, organization:) }
+
     let(:query) do
       <<~GQL
         mutation($input: UpdateSubscriptionInput!) {

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -752,7 +752,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           subject
 
           expect(response).to have_http_status(:unprocessable_content)
-          expect(json[:error_details]).to eq({payment_method: %w[invalid_for_payment_activation_rules]})
+          expect(json[:error_details]).to eq({payment_method: %w[manual_payment_method_invalid_for_payment_activation_rules]})
         end
       end
 
@@ -763,7 +763,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           subject
 
           expect(response).to have_http_status(:unprocessable_content)
-          expect(json[:error_details]).to eq({payment_method: %w[no_linked_payment_provider]})
+          expect(json[:error_details]).to eq({payment_method: %w[customer_has_no_linked_payment_provider]})
         end
       end
     end
@@ -1649,6 +1649,8 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
     context "with activation_rules" do
       let(:subscription) { create(:subscription, :pending, customer:, plan:, subscription_at: Time.current + 3.days) }
       let(:update_params) { {activation_rules: [{type: "payment", timeout_hours: 24}]} }
+
+      before { create(:payment_method, customer:, organization:) }
 
       context "when feature flag is enabled" do
         before { organization.enable_feature_flag!(:payment_gated_subscriptions) }

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -752,7 +752,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           subject
 
           expect(response).to have_http_status(:unprocessable_content)
-          expect(json[:error_details]).to eq({payment_method: %w[manual_payment_method_invalid_for_payment_activation_rules]})
+          expect(json[:error_details]).to eq({customer: %w[manual_payment_method_invalid_for_payment_activation_rules]})
         end
       end
 
@@ -763,7 +763,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           subject
 
           expect(response).to have_http_status(:unprocessable_content)
-          expect(json[:error_details]).to eq({payment_method: %w[customer_has_no_linked_payment_provider]})
+          expect(json[:error_details]).to eq({customer: %w[no_linked_payment_provider]})
         end
       end
     end

--- a/spec/services/subscriptions/activation_rules/payment/validate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/validate_service_spec.rb
@@ -24,17 +24,23 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
 
   describe "#valid?" do
     context "with valid payment rule" do
+      before { create(:payment_method, customer:, organization:) }
+
       it { is_expected.to be_valid }
     end
 
     context "when timeout_hours is absent" do
       let(:rule) { {type: "payment"} }
 
+      before { create(:payment_method, customer:, organization:) }
+
       it { is_expected.to be_valid }
     end
 
     context "when timeout_hours is zero" do
       let(:rule) { {type: "payment", timeout_hours: 0} }
+
+      before { create(:payment_method, customer:, organization:) }
 
       it { is_expected.to be_valid }
     end
@@ -61,16 +67,36 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
       context "when payment_method_type is manual" do
         let(:payment_method_params) { {payment_method_type: "manual"} }
 
-        it "is invalid with invalid_for_payment_activation_rules error" do
+        it "is invalid with manual_payment_method_invalid_for_payment_activation_rules error" do
           expect(validate_service).not_to be_valid
-          expect(result.error.messages[:payment_method]).to eq(["invalid_for_payment_activation_rules"])
+          expect(result.error.messages[:payment_method]).to eq(["manual_payment_method_invalid_for_payment_activation_rules"])
         end
       end
 
       context "when payment_method_type is provider" do
         let(:payment_method_params) { {payment_method_type: "provider"} }
 
-        it { is_expected.to be_valid }
+        context "when customer has a default payment method" do
+          before { create(:payment_method, customer:, organization:) }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when customer has no default payment method" do
+          it "is invalid with customer_has_no_default_payment_method error" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:payment_method]).to eq(["customer_has_no_default_payment_method"])
+          end
+        end
+      end
+
+      context "when payment_method params include a payment_method_id" do
+        let(:payment_method) { create(:payment_method, customer:, organization:, is_default: false) }
+        let(:payment_method_params) { {payment_method_type: "provider", payment_method_id: payment_method.id} }
+
+        it "is valid when the payment method id is provided" do
+          expect(validate_service).to be_valid
+        end
       end
     end
 
@@ -79,16 +105,36 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
         context "when subscription payment_method_type is manual" do
           let(:subscription) { create(:subscription, customer:, plan:, organization:, payment_method_type: "manual") }
 
-          it "is invalid with invalid_for_payment_activation_rules error" do
+          it "is invalid with manual_payment_method_invalid_for_payment_activation_rules error" do
             expect(validate_service).not_to be_valid
-            expect(result.error.messages[:payment_method]).to eq(["invalid_for_payment_activation_rules"])
+            expect(result.error.messages[:payment_method]).to eq(["manual_payment_method_invalid_for_payment_activation_rules"])
           end
         end
 
         context "when subscription payment_method_type is provider" do
           let(:subscription) { create(:subscription, customer:, plan:, organization:, payment_method_type: "provider") }
 
-          it { is_expected.to be_valid }
+          context "when customer has a default payment method" do
+            before { create(:payment_method, customer:, organization:) }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "when subscription has its own payment_method_id" do
+            let(:subscription_payment_method) { create(:payment_method, customer:, organization:, is_default: false) }
+            let(:subscription) { create(:subscription, customer:, plan:, organization:, payment_method_type: "provider", payment_method: subscription_payment_method) }
+
+            it "is valid even when customer has no default payment method" do
+              expect(validate_service).to be_valid
+            end
+          end
+
+          context "when subscription has no payment_method_id and customer has no default payment method" do
+            it "is invalid with customer_has_no_default_payment_method error" do
+              expect(validate_service).not_to be_valid
+              expect(result.error.messages[:payment_method]).to eq(["customer_has_no_default_payment_method"])
+            end
+          end
         end
       end
 
@@ -98,15 +144,35 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
         context "when customer has a payment provider" do
           let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
 
-          it { is_expected.to be_valid }
+          context "when customer has a default payment method" do
+            before { create(:payment_method, customer:, organization:) }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "when customer has no default payment method" do
+            it "is invalid with customer_has_no_default_payment_method error" do
+              expect(validate_service).not_to be_valid
+              expect(result.error.messages[:payment_method]).to eq(["customer_has_no_default_payment_method"])
+            end
+          end
+
+          context "when customer has payment methods but none is default" do
+            before { create(:payment_method, customer:, organization:, is_default: false) }
+
+            it "is invalid with customer_has_no_default_payment_method error" do
+              expect(validate_service).not_to be_valid
+              expect(result.error.messages[:payment_method]).to eq(["customer_has_no_default_payment_method"])
+            end
+          end
         end
 
         context "when customer has no payment provider" do
           let(:customer) { create(:customer, organization:, payment_provider: nil) }
 
-          it "is invalid with no_linked_payment_provider error" do
+          it "is invalid with customer_has_no_linked_payment_provider error" do
             expect(validate_service).not_to be_valid
-            expect(result.error.messages[:payment_method]).to eq(["no_linked_payment_provider"])
+            expect(result.error.messages[:payment_method]).to eq(["customer_has_no_linked_payment_provider"])
           end
         end
       end

--- a/spec/services/subscriptions/activation_rules/payment/validate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/validate_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
 
         it "is invalid with manual_payment_method_invalid_for_payment_activation_rules error" do
           expect(validate_service).not_to be_valid
-          expect(result.error.messages[:payment_method]).to eq(["manual_payment_method_invalid_for_payment_activation_rules"])
+          expect(result.error.messages[:customer]).to eq(["manual_payment_method_invalid_for_payment_activation_rules"])
         end
       end
 
@@ -83,9 +83,9 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
         end
 
         context "when customer has no default payment method" do
-          it "is invalid with customer_has_no_default_payment_method error" do
+          it "is invalid with no_default_payment_method error" do
             expect(validate_service).not_to be_valid
-            expect(result.error.messages[:payment_method]).to eq(["customer_has_no_default_payment_method"])
+            expect(result.error.messages[:customer]).to eq(["no_default_payment_method"])
           end
         end
       end
@@ -97,6 +97,34 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
         it "is valid when the payment method id is provided" do
           expect(validate_service).to be_valid
         end
+
+        context "when payment_method_id refers to a non-existent payment method" do
+          let(:payment_method_params) { {payment_method_type: "provider", payment_method_id: "00000000-0000-0000-0000-000000000000"} }
+
+          it "is invalid with payment_method_not_found error" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:customer]).to eq(["payment_method_not_found"])
+          end
+        end
+
+        context "when payment_method_id belongs to another customer" do
+          let(:other_customer) { create(:customer, organization:) }
+          let(:payment_method) { create(:payment_method, customer: other_customer, organization:, is_default: false) }
+
+          it "is invalid with payment_method_not_found error" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:customer]).to eq(["payment_method_not_found"])
+          end
+        end
+
+        context "when payment_method_id refers to a soft-deleted payment method" do
+          before { payment_method.discard! }
+
+          it "is invalid with payment_method_not_found error" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:customer]).to eq(["payment_method_not_found"])
+          end
+        end
       end
     end
 
@@ -107,7 +135,7 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
 
           it "is invalid with manual_payment_method_invalid_for_payment_activation_rules error" do
             expect(validate_service).not_to be_valid
-            expect(result.error.messages[:payment_method]).to eq(["manual_payment_method_invalid_for_payment_activation_rules"])
+            expect(result.error.messages[:customer]).to eq(["manual_payment_method_invalid_for_payment_activation_rules"])
           end
         end
 
@@ -127,12 +155,21 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
             it "is valid even when customer has no default payment method" do
               expect(validate_service).to be_valid
             end
+
+            context "when the subscription payment method is soft-deleted" do
+              before { subscription_payment_method.discard! }
+
+              it "is invalid with payment_method_not_found error" do
+                expect(validate_service).not_to be_valid
+                expect(result.error.messages[:customer]).to eq(["payment_method_not_found"])
+              end
+            end
           end
 
           context "when subscription has no payment_method_id and customer has no default payment method" do
-            it "is invalid with customer_has_no_default_payment_method error" do
+            it "is invalid with no_default_payment_method error" do
               expect(validate_service).not_to be_valid
-              expect(result.error.messages[:payment_method]).to eq(["customer_has_no_default_payment_method"])
+              expect(result.error.messages[:customer]).to eq(["no_default_payment_method"])
             end
           end
         end
@@ -151,18 +188,18 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
           end
 
           context "when customer has no default payment method" do
-            it "is invalid with customer_has_no_default_payment_method error" do
+            it "is invalid with no_default_payment_method error" do
               expect(validate_service).not_to be_valid
-              expect(result.error.messages[:payment_method]).to eq(["customer_has_no_default_payment_method"])
+              expect(result.error.messages[:customer]).to eq(["no_default_payment_method"])
             end
           end
 
           context "when customer has payment methods but none is default" do
             before { create(:payment_method, customer:, organization:, is_default: false) }
 
-            it "is invalid with customer_has_no_default_payment_method error" do
+            it "is invalid with no_default_payment_method error" do
               expect(validate_service).not_to be_valid
-              expect(result.error.messages[:payment_method]).to eq(["customer_has_no_default_payment_method"])
+              expect(result.error.messages[:customer]).to eq(["no_default_payment_method"])
             end
           end
         end
@@ -170,9 +207,9 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ValidateService do
         context "when customer has no payment provider" do
           let(:customer) { create(:customer, organization:, payment_provider: nil) }
 
-          it "is invalid with customer_has_no_linked_payment_provider error" do
+          it "is invalid with no_linked_payment_provider error" do
             expect(validate_service).not_to be_valid
-            expect(result.error.messages[:payment_method]).to eq(["customer_has_no_linked_payment_provider"])
+            expect(result.error.messages[:customer]).to eq(["no_linked_payment_provider"])
           end
         end
       end

--- a/spec/services/subscriptions/activation_rules/validate_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/validate_service_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Subscriptions::ActivationRules::ValidateService do
     }
   end
 
+  before { create(:payment_method, customer:, organization:) }
+
   describe "#valid?" do
     context "when activation_rules is an empty array" do
       let(:activation_rules) { [] }

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1392,6 +1392,8 @@ RSpec.describe Subscriptions::CreateService do
         }
       end
 
+      before { create(:payment_method, customer:, organization:) }
+
       context "when subscription_at is in the past" do
         let(:subscription_at) { (Time.current - 5.days).iso8601 }
 

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -948,6 +948,8 @@ RSpec.describe Subscriptions::UpdateService do
     end
 
     context "with activation_rules" do
+      before { create(:payment_method, customer: subscription.customer, organization: subscription.organization) }
+
       context "when subscription is pending" do
         context "when activation rules exist" do
           let(:subscription) { create(:subscription, :pending, :with_activation_rules, activation_rules_config: [{type: "payment", timeout_hours: 48}], subscription_at: Time.current + 5.days) }

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -291,6 +291,8 @@ RSpec.describe Subscriptions::ValidateService do
       context "when activation_rules contains valid payment rule" do
         let(:activation_rules) { [{type: "payment", timeout_hours: 48}] }
 
+        before { create(:payment_method, customer:, organization:) }
+
         it { is_expected.to be_valid }
       end
 


### PR DESCRIPTION
## Context

The payment-rule activation validator previously accepted any provider-linked customer even when no payment method had been registered, so a `pending` subscription could enter activation with nothing to charge against. This PR tightens the validator to mirror the resolution logic in `PaymentMethods::DetermineService` and reject cases that would resolve to `nil` at charge time. Distinct error codes are emitted per failure mode so API consumers can act on the specific issue.

## Description

- Resolve the effective `payment_method_type` / `payment_method_id` by overlaying override params on the subscription per-key, matching what `Subscriptions::CreateService` / `Subscriptions::UpdateService` do — the validator now sees a single source of truth
- Reject activation when the resolved payment method would be `nil` at charge time (no override id, no subscription `payment_method_id`, no customer default)
- Move errors from `field: :payment_method` to `field: :customer`, with one of: `no_linked_payment_provider`, `manual_payment_method_invalid_for_payment_activation_rules`, `payment_method_not_found` (new — id was given but the lookup missed), or `no_default_payment_method` (new — no id and no customer default)
- `manual_payment_method_invalid_for_payment_activation_rules` is only emitted when the effective type is actually `"manual"`
