### PR TITLE
feat(presentation_group_keys): Clear presentation_breakdowns for adjusted fees

### DIFF
--- a/app/services/adjusted_fees/estimate_service.rb
+++ b/app/services/adjusted_fees/estimate_service.rb
@@ -28,6 +28,8 @@ module AdjustedFees
         init_from_charge_fee(adjusted_fee)
       end
 
+      reset_presentation_breakdowns(estimated_fee)
+
       apply_taxes_and_assign_ids(estimated_fee) unless customer.tax_customer
       result.fee = estimated_fee
       result
@@ -93,6 +95,10 @@ module AdjustedFees
       fee.invoice_display_name = adjusted_fee.invoice_display_name if params[:invoice_display_name].present?
 
       fee
+    end
+
+    def reset_presentation_breakdowns(fee)
+      fee.presentation_breakdowns = []
     end
 
     def initialize_adjusted_fee(fee, params)

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -168,10 +168,28 @@ module Fees
         fee = init_fee(amount_result, properties:, charge_filter:)
         next if fee.nil?
 
-        build_breakdowns_for_fee(fee:, breakdowns:)
+        unless adjusted_units_overridden?(amount_result:, fee:, charge_filter:)
+          build_breakdowns_for_fee(fee:, breakdowns:)
+        end
 
         fee
       end.compact
+    end
+
+    def adjusted_units_overridden?(amount_result:, fee:, charge_filter:)
+      return false unless applicable_adjusted_fee(amount_result:, charge_filter:)
+
+      amount_result.units != fee.units
+    end
+
+    def applicable_adjusted_fee(amount_result:, charge_filter:)
+      return nil if current_usage
+      return nil unless invoice&.draft?
+
+      adjusted = adjusted_fee(charge_filter:, grouped_by: amount_result.grouped_by)
+      return nil if adjusted.nil? || adjusted.adjusted_display_name?
+
+      adjusted
     end
 
     def build_breakdowns_for_fee(fee:, breakdowns:)
@@ -200,19 +218,18 @@ module Fees
     def init_fee(amount_result, properties:, charge_filter:)
       # NOTE: Build fee for case when there is adjusted fee and units or amount has been adjusted.
       # Base fee creation flow handles case when only name has been adjusted
-      if !current_usage && invoice&.draft? && (adjusted = adjusted_fee(
-        charge_filter:,
-        grouped_by: amount_result.grouped_by
-      )) && !adjusted.adjusted_display_name?
+      if (adjusted = applicable_adjusted_fee(amount_result:, charge_filter:))
         adjustement_result = Fees::InitFromAdjustedChargeFeeService.call(
           adjusted_fee: adjusted,
           boundaries:,
           properties:
         )
-        return result.fail_with_error!(adjustement_result.error) unless adjustement_result.success?
+        unless adjustement_result.success?
+          result.fail_with_error!(adjustement_result.error)
+          return nil
+        end
 
-        result.fees << adjustement_result.fee
-        return
+        return adjustement_result.fee
       end
 
       # Prevent trying to create a fee with negative units or amount.

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -165,21 +165,16 @@ module Fees
         # TODO: check if this is still needed as we now skip certain zero units fees
         next if current_usage && charge_filter && amount_result.units.zero? && !with_zero_units_filters
 
-        fee = init_fee(amount_result, properties:, charge_filter:)
+        adjusted = applicable_adjusted_fee(amount_result:, charge_filter:)
+        fee = init_fee(amount_result, properties:, charge_filter:, adjusted:)
         next if fee.nil?
 
-        unless adjusted_units_overridden?(amount_result:, fee:, charge_filter:)
+        if adjusted.nil? || amount_result.units == fee.units
           build_breakdowns_for_fee(fee:, breakdowns:)
         end
 
         fee
       end.compact
-    end
-
-    def adjusted_units_overridden?(amount_result:, fee:, charge_filter:)
-      return false unless applicable_adjusted_fee(amount_result:, charge_filter:)
-
-      amount_result.units != fee.units
     end
 
     def applicable_adjusted_fee(amount_result:, charge_filter:)
@@ -215,10 +210,10 @@ module Fees
       charge_fees.filter { |f| should_persist_fee?(f, charge_fees) }
     end
 
-    def init_fee(amount_result, properties:, charge_filter:)
+    def init_fee(amount_result, properties:, charge_filter:, adjusted:)
       # NOTE: Build fee for case when there is adjusted fee and units or amount has been adjusted.
       # Base fee creation flow handles case when only name has been adjusted
-      if (adjusted = applicable_adjusted_fee(amount_result:, charge_filter:))
+      if adjusted
         adjustement_result = Fees::InitFromAdjustedChargeFeeService.call(
           adjusted_fee: adjusted,
           boundaries:,

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -211,7 +211,7 @@ module Fees
     end
 
     def init_fee(amount_result, properties:, charge_filter:, adjusted:)
-      # NOTE: Build fee for case when there is adjusted fee and units or amount has been adjusted.
+      # NOTE: Build fee for case when there is adjusted fee and units or amount has been adjusted (see applicable_adjusted_fee method).
       # Base fee creation flow handles case when only name has been adjusted
       if adjusted
         adjustement_result = Fees::InitFromAdjustedChargeFeeService.call(

--- a/app/services/invoices/regenerate_from_voided_service.rb
+++ b/app/services/invoices/regenerate_from_voided_service.rb
@@ -173,6 +173,7 @@ module Invoices
           fee.precise_amount_cents = units * unit_cents
         end
 
+        fee.presentation_breakdowns.destroy_all if fee.units_changed?
         fee.save!
       end
     end
@@ -213,6 +214,15 @@ module Invoices
       dup_fee.taxes_rate = 0
       dup_fee.original_fee = voided_fee.original_fee || voided_fee
       dup_fee.save!
+
+      voided_fee.presentation_breakdowns.each do |breakdown|
+        dup_fee.presentation_breakdowns.create!(
+          organization_id: breakdown.organization_id,
+          presentation_by: breakdown.presentation_by,
+          units: breakdown.units
+        )
+      end
+
       dup_fee
     end
 

--- a/app/services/invoices/regenerate_from_voided_service.rb
+++ b/app/services/invoices/regenerate_from_voided_service.rb
@@ -172,6 +172,7 @@ module Invoices
           fee.amount_cents = amount_cents
           fee.precise_amount_cents = units * unit_cents
         end
+
         fee.save!
       end
     end

--- a/app/services/invoices/regenerate_from_voided_service.rb
+++ b/app/services/invoices/regenerate_from_voided_service.rb
@@ -172,8 +172,6 @@ module Invoices
           fee.amount_cents = amount_cents
           fee.precise_amount_cents = units * unit_cents
         end
-
-        fee.presentation_breakdowns.destroy_all if fee.units_changed?
         fee.save!
       end
     end
@@ -182,7 +180,7 @@ module Invoices
       fees_params.each do |fee_params|
         if fee_params[:id].present?
           voided_fee = voided_invoice.fees.find_by(id: fee_params[:id])
-          dep_fee = duplicate_fee(voided_fee) if voided_fee
+          dup_fee = duplicate_fee(voided_fee, fee_params) if voided_fee
         end
 
         adjusted_fee_params = {
@@ -193,7 +191,7 @@ module Invoices
           subscription_id: fee_params[:subscription_id]
         }
         adjusted_fee_params[:unit_precise_amount] = fee_params[:unit_amount_cents] if fee_params[:unit_amount_cents].present?
-        adjusted_fee_params[:fee_id] = dep_fee.id if dep_fee
+        adjusted_fee_params[:fee_id] = dup_fee.id if dup_fee
 
         AdjustedFees::CreateService.call(
           invoice: regenerated_invoice,
@@ -203,7 +201,7 @@ module Invoices
       end
     end
 
-    def duplicate_fee(voided_fee)
+    def duplicate_fee(voided_fee, fee_params)
       dup_fee = voided_fee.dup
       dup_fee.invoice = regenerated_invoice
       dup_fee.payment_status = :pending
@@ -215,6 +213,8 @@ module Invoices
       dup_fee.original_fee = voided_fee.original_fee || voided_fee
       dup_fee.save!
 
+      return dup_fee if adjusting_units?(voided_fee, fee_params)
+
       voided_fee.presentation_breakdowns.each do |breakdown|
         dup_fee.presentation_breakdowns.create!(
           organization_id: breakdown.organization_id,
@@ -224,6 +224,12 @@ module Invoices
       end
 
       dup_fee
+    end
+
+    def adjusting_units?(voided_fee, fee_params)
+      return true if fee_params[:units].blank?
+
+      BigDecimal(fee_params[:units].to_s) != voided_fee.units
     end
 
     def create_invoice_subscriptions

--- a/spec/services/adjusted_fees/estimate_service_spec.rb
+++ b/spec/services/adjusted_fees/estimate_service_spec.rb
@@ -429,4 +429,91 @@ RSpec.describe AdjustedFees::EstimateService do
       end
     end
   end
+
+  describe "presentation_breakdowns" do
+    context "when adjusting subscription fees" do
+      before do
+        create(:presentation_breakdown, fee: fee_subscription, presentation_by: {"department" => "eng"}, units: 6)
+        create(:presentation_breakdown, fee: fee_subscription, presentation_by: {"department" => "sales"}, units: 4)
+        fee_subscription.reload
+      end
+
+      context "when adjusting units" do
+        let(:params) do
+          {
+            fee_id: fee_subscription.id,
+            subscription_id: fee_subscription.subscription_id,
+            units: 5
+          }
+        end
+
+        it "returns the fee without presentation_breakdowns" do
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
+      end
+
+      context "when adjusting display name only" do
+        let(:params) do
+          {
+            fee_id: fee_subscription.id,
+            subscription_id: fee_subscription.subscription_id,
+            invoice_display_name: "renamed"
+          }
+        end
+
+        it "preserves the existing presentation_breakdowns on the fee" do
+          expect(result.fee.presentation_breakdowns.map { |b| b.units.to_f }).to match_array([6.0, 4.0])
+        end
+      end
+    end
+
+    context "when adjusting charge fees" do
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:charge) do
+        create(
+          :standard_charge,
+          billable_metric:,
+          plan:,
+          properties: {amount: "10", presentation_group_keys: [{value: "department"}]}
+        )
+      end
+      let(:charge_fee) do
+        create(:charge_fee, invoice:, subscription:, charge:, precise_unit_amount: 10.00, units: 5)
+      end
+
+      before do
+        create(:presentation_breakdown, fee: charge_fee, presentation_by: {"department" => "eng"}, units: 3)
+        create(:presentation_breakdown, fee: charge_fee, presentation_by: {"department" => "sales"}, units: 2)
+      end
+
+      context "when adjusting units" do
+        let(:params) { {fee_id: charge_fee.id, units: 8} }
+
+        it "returns a fee without presentation_breakdowns" do
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
+      end
+    end
+
+    context "when adjusting fixed charge fees" do
+      let(:add_on) { create(:add_on, organization:) }
+      let(:fixed_charge) { create(:fixed_charge, plan:, add_on:, properties: {amount: "25"}) }
+      let(:fixed_charge_fee) do
+        create(:fixed_charge_fee, invoice:, subscription:, fixed_charge:, precise_unit_amount: 25.00, units: 8)
+      end
+
+      before do
+        create(:presentation_breakdown, fee: fixed_charge_fee, presentation_by: {"region" => "eu"}, units: 5)
+        create(:presentation_breakdown, fee: fixed_charge_fee, presentation_by: {"region" => "us"}, units: 3)
+      end
+
+      context "when adjusting units" do
+        let(:params) { {fee_id: fixed_charge_fee.id, units: 12} }
+
+        it "returns a fee without presentation_breakdowns" do
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/services/adjusted_fees/estimate_service_spec.rb
+++ b/spec/services/adjusted_fees/estimate_service_spec.rb
@@ -120,6 +120,43 @@ RSpec.describe AdjustedFees::EstimateService do
         )
       end
     end
+
+    context "with presentation_breakdowns" do
+      before do
+        create(:presentation_breakdown, fee: fee_subscription, presentation_by: {"department" => "eng"}, units: 6)
+        create(:presentation_breakdown, fee: fee_subscription, presentation_by: {"department" => "sales"}, units: 4)
+        fee_subscription.reload
+      end
+
+      context "when adjusting units" do
+        let(:params) do
+          {
+            fee_id: fee_subscription.id,
+            subscription_id: fee_subscription.subscription_id,
+            units: 5
+          }
+        end
+
+        it "returns the fee without presentation_breakdowns" do
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
+      end
+
+      context "when keeping units the same" do
+        let(:params) do
+          {
+            fee_id: fee_subscription.id,
+            subscription_id: fee_subscription.subscription_id,
+            units: 10
+          }
+        end
+
+        it "returns the fee without presentation_breakdowns" do
+          expect(fee_subscription.units).to eq(result.fee.units)
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
+      end
+    end
   end
 
   context "when adjusting fixed charge fees" do
@@ -268,6 +305,30 @@ RSpec.describe AdjustedFees::EstimateService do
         expect(result).to be_failure
         expect(result.error).to be_a(BaseService::NotFoundFailure)
         expect(result.error.message).to eq("fixed_charge_not_found")
+      end
+    end
+
+    context "with presentation_breakdowns" do
+      before do
+        create(:presentation_breakdown, fee: fixed_charge_fee, presentation_by: {"region" => "eu"}, units: 5)
+        create(:presentation_breakdown, fee: fixed_charge_fee, presentation_by: {"region" => "us"}, units: 3)
+      end
+
+      context "when adjusting units" do
+        let(:params) { {fee_id: fixed_charge_fee.id, units: 12} }
+
+        it "returns a fee without presentation_breakdowns" do
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
+      end
+
+      context "when keeping units the same" do
+        let(:params) { {fee_id: fixed_charge_fee.id, units: 8} }
+
+        it "returns the fee without presentation_breakdowns" do
+          expect(fixed_charge_fee.units).to eq(result.fee.units)
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
       end
     end
   end
@@ -428,48 +489,8 @@ RSpec.describe AdjustedFees::EstimateService do
         expect(result.error.message).to eq("charge_not_found")
       end
     end
-  end
 
-  describe "presentation_breakdowns" do
-    context "when adjusting subscription fees" do
-      before do
-        create(:presentation_breakdown, fee: fee_subscription, presentation_by: {"department" => "eng"}, units: 6)
-        create(:presentation_breakdown, fee: fee_subscription, presentation_by: {"department" => "sales"}, units: 4)
-        fee_subscription.reload
-      end
-
-      context "when adjusting units" do
-        let(:params) do
-          {
-            fee_id: fee_subscription.id,
-            subscription_id: fee_subscription.subscription_id,
-            units: 5
-          }
-        end
-
-        it "returns the fee without presentation_breakdowns" do
-          expect(result.fee.presentation_breakdowns).to be_empty
-        end
-      end
-
-      context "when keeping units the same" do
-        let(:params) do
-          {
-            fee_id: fee_subscription.id,
-            subscription_id: fee_subscription.subscription_id,
-            units: 10
-          }
-        end
-
-        it "returns the fee without presentation_breakdowns" do
-          expect(fee_subscription.units).to eq(result.fee.units)
-          expect(result.fee.presentation_breakdowns).to be_empty
-        end
-      end
-    end
-
-    context "when adjusting charge fees" do
-      let(:billable_metric) { create(:billable_metric, organization:) }
+    context "with presentation_breakdowns" do
       let(:charge) do
         create(
           :standard_charge,
@@ -500,36 +521,6 @@ RSpec.describe AdjustedFees::EstimateService do
 
         it "returns the fee without presentation_breakdowns" do
           expect(charge_fee.units).to eq(result.fee.units)
-          expect(result.fee.presentation_breakdowns).to be_empty
-        end
-      end
-    end
-
-    context "when adjusting fixed charge fees" do
-      let(:add_on) { create(:add_on, organization:) }
-      let(:fixed_charge) { create(:fixed_charge, plan:, add_on:, properties: {amount: "25"}) }
-      let(:fixed_charge_fee) do
-        create(:fixed_charge_fee, invoice:, subscription:, fixed_charge:, precise_unit_amount: 25.00, units: 8)
-      end
-
-      before do
-        create(:presentation_breakdown, fee: fixed_charge_fee, presentation_by: {"region" => "eu"}, units: 5)
-        create(:presentation_breakdown, fee: fixed_charge_fee, presentation_by: {"region" => "us"}, units: 3)
-      end
-
-      context "when adjusting units" do
-        let(:params) { {fee_id: fixed_charge_fee.id, units: 12} }
-
-        it "returns a fee without presentation_breakdowns" do
-          expect(result.fee.presentation_breakdowns).to be_empty
-        end
-      end
-
-      context "when keeping units the same" do
-        let(:params) { {fee_id: fixed_charge_fee.id, units: 8} }
-
-        it "returns the fee without presentation_breakdowns" do
-          expect(fixed_charge_fee.units).to eq(result.fee.units)
           expect(result.fee.presentation_breakdowns).to be_empty
         end
       end

--- a/spec/services/adjusted_fees/estimate_service_spec.rb
+++ b/spec/services/adjusted_fees/estimate_service_spec.rb
@@ -457,11 +457,12 @@ RSpec.describe AdjustedFees::EstimateService do
           {
             fee_id: fee_subscription.id,
             subscription_id: fee_subscription.subscription_id,
-            amount: 10
+            units: 10
           }
         end
 
         it "returns the fee without presentation_breakdowns" do
+          expect(fee_subscription.units).to eq(result.fee.units)
           expect(result.fee.presentation_breakdowns).to be_empty
         end
       end
@@ -495,9 +496,10 @@ RSpec.describe AdjustedFees::EstimateService do
       end
 
       context "when keeping units the same" do
-        let(:params) { {fee_id: charge_fee.id, amount: 5} }
+        let(:params) { {fee_id: charge_fee.id, units: 5} }
 
         it "returns the fee without presentation_breakdowns" do
+          expect(charge_fee.units).to eq(result.fee.units)
           expect(result.fee.presentation_breakdowns).to be_empty
         end
       end
@@ -524,9 +526,10 @@ RSpec.describe AdjustedFees::EstimateService do
       end
 
       context "when keeping units the same" do
-        let(:params) { {fee_id: fixed_charge_fee.id, amount: 8} }
+        let(:params) { {fee_id: fixed_charge_fee.id, units: 8} }
 
         it "returns the fee without presentation_breakdowns" do
+          expect(fixed_charge_fee.units).to eq(result.fee.units)
           expect(result.fee.presentation_breakdowns).to be_empty
         end
       end

--- a/spec/services/adjusted_fees/estimate_service_spec.rb
+++ b/spec/services/adjusted_fees/estimate_service_spec.rb
@@ -452,17 +452,17 @@ RSpec.describe AdjustedFees::EstimateService do
         end
       end
 
-      context "when adjusting display name only" do
+      context "when keeping units the same" do
         let(:params) do
           {
             fee_id: fee_subscription.id,
             subscription_id: fee_subscription.subscription_id,
-            invoice_display_name: "renamed"
+            amount: 10
           }
         end
 
-        it "preserves the existing presentation_breakdowns on the fee" do
-          expect(result.fee.presentation_breakdowns.map { |b| b.units.to_f }).to match_array([6.0, 4.0])
+        it "returns the fee without presentation_breakdowns" do
+          expect(result.fee.presentation_breakdowns).to be_empty
         end
       end
     end
@@ -493,6 +493,14 @@ RSpec.describe AdjustedFees::EstimateService do
           expect(result.fee.presentation_breakdowns).to be_empty
         end
       end
+
+      context "when keeping units the same" do
+        let(:params) { {fee_id: charge_fee.id, amount: 5} }
+
+        it "returns the fee without presentation_breakdowns" do
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
+      end
     end
 
     context "when adjusting fixed charge fees" do
@@ -511,6 +519,14 @@ RSpec.describe AdjustedFees::EstimateService do
         let(:params) { {fee_id: fixed_charge_fee.id, units: 12} }
 
         it "returns a fee without presentation_breakdowns" do
+          expect(result.fee.presentation_breakdowns).to be_empty
+        end
+      end
+
+      context "when keeping units the same" do
+        let(:params) { {fee_id: fixed_charge_fee.id, amount: 8} }
+
+        it "returns the fee without presentation_breakdowns" do
           expect(result.fee.presentation_breakdowns).to be_empty
         end
       end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -4466,4 +4466,100 @@ RSpec.describe Fees::ChargeService, :premium do
       end
     end
   end
+
+  describe "presentation_breakdowns interaction with adjusted fees" do
+    let(:billable_metric) do
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "value")
+    end
+    let(:charge) do
+      create(
+        :standard_charge,
+        plan: subscription.plan,
+        billable_metric:,
+        properties: {
+          amount: "20",
+          pricing_group_keys: ["cloud"],
+          presentation_group_keys: [{value: "region"}]
+        }
+      )
+    end
+
+    let(:invoice) { create(:invoice, customer:, organization:, status: :draft) }
+
+    before do
+      create(
+        :event, organization:, subscription:,
+        code: billable_metric.code,
+        timestamp: Time.zone.parse("2022-03-16"),
+        properties: {cloud: "aws", value: 10, region: "eu"}
+      )
+      create(
+        :event, organization:, subscription:,
+        code: billable_metric.code,
+        timestamp: Time.zone.parse("2022-03-16"),
+        properties: {cloud: "aws", value: 5, region: "us"}
+      )
+      adjusted_fee
+    end
+
+    context "when the adjustment changes units" do
+      let(:adjusted_fee) do
+        create(
+          :adjusted_fee,
+          invoice:,
+          subscription:,
+          charge:,
+          properties: {
+            charges_from_datetime: boundaries.charges_from_datetime,
+            charges_to_datetime: boundaries.charges_to_datetime
+          },
+          fee_type: :charge,
+          adjusted_units: true,
+          adjusted_amount: false,
+          units: 3,
+          grouped_by: {"cloud" => "aws"}
+        )
+      end
+
+      it "does not build presentation_breakdowns on the fee replaced by an adjustment" do
+        result = charge_subscription_service.call
+        expect(result).to be_success
+
+        aws_fee = result.fees.find { |f| f.grouped_by["cloud"] == "aws" }
+        expect(aws_fee.units).to eq(3)
+        expect(aws_fee.presentation_breakdowns).to be_empty
+      end
+    end
+
+    context "when the adjustment only renames the fee" do
+      let(:adjusted_fee) do
+        create(
+          :adjusted_fee,
+          invoice:,
+          subscription:,
+          charge:,
+          properties: {
+            charges_from_datetime: boundaries.charges_from_datetime,
+            charges_to_datetime: boundaries.charges_to_datetime
+          },
+          fee_type: :charge,
+          adjusted_units: false,
+          adjusted_amount: false,
+          invoice_display_name: "renamed",
+          grouped_by: {"cloud" => "aws"}
+        )
+      end
+
+      it "still builds presentation_breakdowns from current events on the adjusted fee" do
+        result = charge_subscription_service.call
+        expect(result).to be_success
+
+        aws_fee = result.fees.find { |f| f.grouped_by["cloud"] == "aws" }
+        expect(aws_fee.presentation_breakdowns.map(&:presentation_by))
+          .to match_array([{"region" => "eu"}, {"region" => "us"}])
+        expect(aws_fee.presentation_breakdowns.map { |b| b.units.to_f })
+          .to match_array([10.0, 5.0])
+      end
+    end
+  end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -4531,7 +4531,7 @@ RSpec.describe Fees::ChargeService, :premium do
       end
     end
 
-    context "when the adjustment only renames the fee" do
+    context "when the adjustment keeps units the same" do
       let(:adjusted_fee) do
         create(
           :adjusted_fee,
@@ -4543,14 +4543,16 @@ RSpec.describe Fees::ChargeService, :premium do
             charges_to_datetime: boundaries.charges_to_datetime
           },
           fee_type: :charge,
-          adjusted_units: false,
-          adjusted_amount: false,
+          adjusted_units: true,
+          adjusted_amount: true,
           invoice_display_name: "renamed",
+          units: 15,
+          unit_amount_cents: 100,
           grouped_by: {"cloud" => "aws"}
         )
       end
 
-      it "still builds presentation_breakdowns from current events on the adjusted fee" do
+      it "builds presentation_breakdowns from current events on the adjusted fee" do
         result = charge_subscription_service.call
         expect(result).to be_success
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -4563,5 +4563,37 @@ RSpec.describe Fees::ChargeService, :premium do
           .to match_array([10.0, 5.0])
       end
     end
+
+    context "when the adjustment only changes the display name" do
+      let(:adjusted_fee) do
+        create(
+          :adjusted_fee,
+          invoice:,
+          subscription:,
+          charge:,
+          properties: {
+            charges_from_datetime: boundaries.charges_from_datetime,
+            charges_to_datetime: boundaries.charges_to_datetime
+          },
+          fee_type: :charge,
+          adjusted_units: false,
+          adjusted_amount: false,
+          invoice_display_name: "renamed",
+          grouped_by: {"cloud" => "aws"}
+        )
+      end
+
+      it "builds presentation_breakdowns from current events on the adjusted fee" do
+        result = charge_subscription_service.call
+        expect(result).to be_success
+
+        aws_fee = result.fees.find { |f| f.grouped_by["cloud"] == "aws" }
+        expect(aws_fee.invoice_display_name).to eq("renamed")
+        expect(aws_fee.presentation_breakdowns.map(&:presentation_by))
+          .to match_array([{"region" => "eu"}, {"region" => "us"}])
+        expect(aws_fee.presentation_breakdowns.map { |b| b.units.to_f })
+          .to match_array([10.0, 5.0])
+      end
+    end
   end
 end

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -250,6 +250,48 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService do
     end
   end
 
+  context "with presentation_breakdowns on the source fee" do
+    let(:source_fee) do
+      create(:charge_fee, invoice:, subscription:, charge:, units: source_units)
+    end
+
+    before do
+      create(:presentation_breakdown, fee: source_fee, presentation_by: {"department" => "eng"}, units: 6)
+      create(:presentation_breakdown, fee: source_fee, presentation_by: {"department" => "sales"}, units: 4)
+      adjusted_fee.update!(fee: source_fee)
+    end
+
+    context "when adjusted units differ from the source fee units" do
+      let(:source_units) { 10 }
+
+      it "returns a brand-new fee with no presentation_breakdowns built" do
+        result = init_service.call
+
+        expect(result).to be_success
+        expect(result.fee.presentation_breakdowns).to be_empty
+      end
+
+      it "does not destroy the breakdowns persisted on the source fee" do
+        expect { init_service.call }.not_to change(PresentationBreakdown, :count)
+      end
+    end
+
+    context "when adjusted units match the source fee units" do
+      let(:source_units) { adjusted_fee.units }
+
+      it "still returns a brand-new fee with no presentation_breakdowns built" do
+        result = init_service.call
+
+        expect(result).to be_success
+        expect(result.fee.presentation_breakdowns).to be_empty
+      end
+
+      it "does not destroy the breakdowns persisted on the source fee" do
+        expect { init_service.call }.not_to change(PresentationBreakdown, :count)
+      end
+    end
+  end
+
   context "with charge model error" do
     let(:error_result) do
       BaseService::Result.new.tap do |result|

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -250,48 +250,6 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService do
     end
   end
 
-  context "with presentation_breakdowns on the source fee" do
-    let(:source_fee) do
-      create(:charge_fee, invoice:, subscription:, charge:, units: source_units)
-    end
-
-    before do
-      create(:presentation_breakdown, fee: source_fee, presentation_by: {"department" => "eng"}, units: 6)
-      create(:presentation_breakdown, fee: source_fee, presentation_by: {"department" => "sales"}, units: 4)
-      adjusted_fee.update!(fee: source_fee)
-    end
-
-    context "when adjusted units differ from the source fee units" do
-      let(:source_units) { 10 }
-
-      it "returns a brand-new fee with no presentation_breakdowns built" do
-        result = init_service.call
-
-        expect(result).to be_success
-        expect(result.fee.presentation_breakdowns).to be_empty
-      end
-
-      it "does not destroy the breakdowns persisted on the source fee" do
-        expect { init_service.call }.not_to change(PresentationBreakdown, :count)
-      end
-    end
-
-    context "when adjusted units match the source fee units" do
-      let(:source_units) { adjusted_fee.units }
-
-      it "still returns a brand-new fee with no presentation_breakdowns built" do
-        result = init_service.call
-
-        expect(result).to be_success
-        expect(result.fee.presentation_breakdowns).to be_empty
-      end
-
-      it "does not destroy the breakdowns persisted on the source fee" do
-        expect { init_service.call }.not_to change(PresentationBreakdown, :count)
-      end
-    end
-  end
-
   context "with charge model error" do
     let(:error_result) do
       BaseService::Result.new.tap do |result|

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -180,6 +180,123 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
       let(:service_call) { regenerate_result }
     end
 
+    describe "presentation_breakdowns handling" do
+      before do
+        create(:presentation_breakdown, fee: original_fee, presentation_by: {"department" => "eng"}, units: 6)
+        create(:presentation_breakdown, fee: original_fee, presentation_by: {"department" => "sales"}, units: 4)
+      end
+
+      context "when adjusting units" do
+        let(:fees_params) do
+          [
+            {
+              id: original_fee.id,
+              subscription_id: subscription.id,
+              units: 3
+            }
+          ]
+        end
+
+        it "regenerates the fee without presentation_breakdowns" do
+          regenerated_fee = regenerate_result.invoice.fees.first
+
+          expect(regenerated_fee.presentation_breakdowns).to be_empty
+        end
+      end
+
+      context "when adjusting unit amount but keeping units" do
+        let(:fees_params) do
+          [
+            {
+              id: original_fee.id,
+              subscription_id: subscription.id,
+              units: original_fee.units,
+              unit_amount_cents: 99.99
+            }
+          ]
+        end
+
+        it "preserves the breakdowns on the regenerated fee" do
+          regenerated_fee = regenerate_result.invoice.fees.first
+
+          expect(regenerated_fee.presentation_breakdowns.map { |b| b.units.to_f })
+            .to match_array([6.0, 4.0])
+        end
+      end
+
+      context "when adjusting display name only" do
+        let(:fees_params) do
+          [
+            {
+              id: original_fee.id,
+              subscription_id: subscription.id,
+              invoice_display_name: "renamed",
+              units: original_fee.units
+            }
+          ]
+        end
+
+        it "preserves the breakdowns on the regenerated fee" do
+          regenerated_fee = regenerate_result.invoice.fees.first
+
+          expect(regenerated_fee.invoice_display_name).to eq("renamed")
+          expect(regenerated_fee.presentation_breakdowns.map(&:presentation_by))
+            .to match_array([{"department" => "eng"}, {"department" => "sales"}])
+        end
+      end
+
+      context "when the voided fee is a fixed_charge fee with adjusted units" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, charge_model: "standard", properties: {amount: "10"}) }
+
+        let(:original_invoice) do
+          travel_to(DateTime.new(2023, 1, 15)) { perform_billing }
+          invoice = subscription.invoices.first
+
+          create(
+            :fixed_charge_fee,
+            invoice:,
+            subscription:,
+            fixed_charge:,
+            amount_cents: 5000,
+            precise_amount_cents: 5000.0,
+            units: 5,
+            unit_amount_cents: 1000,
+            precise_unit_amount: 10,
+            properties: {
+              fixed_charges_from_datetime: subscription.started_at.beginning_of_day,
+              fixed_charges_to_datetime: subscription.started_at.end_of_month.end_of_day
+            }
+          )
+
+          invoice.update!(status: :voided)
+          invoice
+        end
+
+        let(:fixed_charge_fee) { original_invoice.fees.find_by(fee_type: :fixed_charge) }
+        let(:fees_params) do
+          [
+            {
+              id: fixed_charge_fee.id,
+              subscription_id: subscription.id,
+              units: 9
+            }
+          ]
+        end
+
+        before do
+          create(:presentation_breakdown, fee: fixed_charge_fee, presentation_by: {"region" => "eu"}, units: 3)
+          create(:presentation_breakdown, fee: fixed_charge_fee, presentation_by: {"region" => "us"}, units: 2)
+        end
+
+        it "regenerates the fixed-charge fee without presentation_breakdowns" do
+          regenerated_fee = regenerate_result.invoice.fees.find_by(fixed_charge_id: fixed_charge.id)
+
+          expect(regenerated_fee.units).to eq(9)
+          expect(regenerated_fee.presentation_breakdowns).to be_empty
+        end
+      end
+    end
+
     context "with updated units" do
       let(:fees_params) do
         [

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -295,6 +295,25 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
           expect(regenerated_fee.presentation_breakdowns).to be_empty
         end
       end
+
+      context "when only invoice_display_name changed" do
+        let(:fees_params) do
+          [
+            {
+              id: original_fee.id,
+              subscription_id: subscription.id,
+              invoice_display_name: "renamed"
+            }
+          ]
+        end
+
+        it "does not preserve stale breakdowns on the regenerated fee" do
+          regenerated_fee = regenerate_result.invoice.fees.first
+
+          expect(regenerated_fee.units).not_to eq(original_fee.units)
+          expect(regenerated_fee.presentation_breakdowns).to be_empty
+        end
+      end
     end
 
     context "with updated units" do


### PR DESCRIPTION
## Context
Once the fees are generated and associated with an Invoice calling the services, fees can be adjusted, which means, users can change some attributes that directly affect the presentation_breakdowns. 

If the units changed, the breakdown is not valid anymore and should be cleared.

## Description

- `AdjustedFees::EstimateService` - clears `presentation_breakdowns` on the estimated fee unconditionally.
- `Fees::ChargeService` - when an adjusted fee applies, skips breakdown building only when units changed. Refactored the in-scope adjusted-fee check into a single `applicable_adjusted_fee` helper used by both `init_fee` and the breakdown gate.
- `Invoices::RegenerateFromVoidedService` - copies breakdowns from the voided fee onto the duplicated fee only when units aren't being adjusted.

Test coverage added across all three services for the units-changed, units-unchanged, amount-only, display-name-only, and fixed-charge paths, plus a regression test for the case where
`fee_params[:units]` is omitted by the GraphQL caller.

## Testing
2 Main UI scenarios:
- Edit fee units on Draft invoice.
- Edit fee units when regenerating a voided invoice.