### PR TITLE
chore(ci): make front compatibility check PR-triggered and non-blocking

### DIFF
--- a/.github/workflows/front-compatibility.yml
+++ b/.github/workflows/front-compatibility.yml
@@ -1,71 +1,41 @@
-name: Front compatibility (post-merge alert)
+name: Front compatibility (PR check, informational)
 
-# Runs after a schema-changing commit lands on main. Validates that the
-# committed schema.graphql is still consumable by lago-front main — i.e.
-# that no schema change broke frontend type-checking via codegen.
+# Runs on PRs targeting main that modify schema.graphql. Regenerates
+# lago-front's types from the PR's schema and runs tsc against
+# lago-front main. Failure is informational only — the job is marked
+# continue-on-error so it never blocks merging. Authors can still see
+# a red/green signal in the PR's checks panel and inspect logs when
+# something breaks.
 #
-# This is intentionally NOT a PR check: it doesn't gate API merges or
-# require coordination work from API authors. It's a late alert: when
-# something here turns red, frontend type-check will be broken and the
-# front team should open a fix PR in lago-front.
-#
-# When this workflow fails, GitHub sends the standard failed-workflow
-# notification email to the commit author and to anyone watching this
-# repo's Actions — that's the alert. No issue is auto-opened.
-#
-# Path filter on schema.graphql — most commits don't change the schema,
-# so the workflow rarely runs. Cost: a few minutes of CI per schema
-# change.
+# Path filter on schema.graphql — most PRs don't change the schema, so
+# the workflow rarely runs. Cost: a few minutes of CI per schema change.
 
 on:
-  # Initial rollout is manual-only. Once we've validated the workflow
-  # works as expected via a few `workflow_dispatch` runs, a follow-up
-  # PR will add the automatic trigger:
-  #
-  #   push:
-  #     branches: [main]
-  #     paths: ['schema.graphql']
-  #
-  # which fires on any merge to main that actually modifies the schema.
-  workflow_dispatch:
-    inputs:
-      api_ref:
-        description: 'lago-api ref — schema.graphql is taken from this commit (branch, tag, or SHA)'
-        required: false
-        default: 'main'
-      front_ref:
-        description: 'lago-front ref to type-check (branch, tag, or SHA)'
-        required: false
-        default: 'main'
+  pull_request:
+    branches: [main]
+    paths: ['schema.graphql']
 
 jobs:
   front-typecheck:
-    name: Front typecheck against new schema
+    name: Front typecheck against PR schema (informational)
     runs-on: ubuntu-latest
+    # Non-blocking: a failure here surfaces in the checks panel but does
+    # not fail the workflow run, so branch protection cannot gate on it.
+    continue-on-error: true
 
     steps:
-      - name: Checkout lago-api (this repo, the new schema)
+      - name: Checkout lago-api (PR head — the new schema)
         uses: actions/checkout@v6
         with:
-          # On push (auto-trigger, once enabled): defaults to the SHA
-          # that triggered the workflow — i.e. the merge commit on main.
-          # On manual dispatch: uses whatever ref the operator chose.
-          ref: ${{ github.event.inputs.api_ref || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           path: api
 
-      - name: Checkout lago-front
+      - name: Checkout lago-front (main — stable baseline)
         uses: actions/checkout@v6
         with:
           repository: getlago/lago-front
-          # On scheduled push runs, always check main. On manual dispatch,
-          # use whatever ref the operator chose (defaults to main).
-          ref: ${{ github.event.inputs.front_ref || 'main' }}
+          ref: main
           path: front
-          # Default fetch-depth is 1, which only resolves named refs and
-          # full 40-char SHAs. Setting 0 fetches full history so
-          # operators can paste short SHAs (e.g. `74b4f669`) into the
-          # dispatch input without it failing the fetch step.
-          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -93,7 +63,7 @@ jobs:
         working-directory: front
         run: pnpm prebuild
 
-      - name: Regenerate front types from new schema
+      - name: Regenerate front types from PR schema
         working-directory: front
         env:
           # graphql-codegen accepts file paths in its `schema:` field.


### PR DESCRIPTION
## Summary

Follow-up to #5435 / #5438. Reshapes the front compatibility workflow per a product/team decision: instead of a `workflow_dispatch`-only post-merge alert, surface schema-vs-front-typecheck issues directly on the lago-api PR that introduces them — but never block merge.

## Changes

`.github/workflows/front-compatibility.yml`:

- **Trigger**: `workflow_dispatch` → `pull_request` with `branches: [main]` and `paths: ['schema.graphql']`. Drops the manual dispatch UI and its `api_ref` / `front_ref` inputs.
- **Refs**: API checkout uses `${{ github.event.pull_request.head.sha }}` (PR head). Front checkout pinned to `main`.
- **Non-blocking**: added `continue-on-error: true` at the job level. A failure shows up as ❌ in the PR's checks panel (with full logs) but the workflow run itself reports success, so branch protection cannot gate merges on it.
- **Cleanup**: `fetch-depth: 0` on the front checkout was only needed to resolve short SHAs typed into the manual dispatch — dropped now that we always check `main`.

## Why this shape

- "Silently fail" → `continue-on-error: true` at job level. Failures stay visible to the author (informative) but cannot accidentally become a merge gate, even if someone later flips this check to required in branch protection.
- PR head SHA over default merge ref → matches "API branch should be the current one (PR)" and is more deterministic (no merge-conflict / base-drift flakiness on the merge ref).
- Path filter retained → most API PRs don't touch `schema.graphql`, so this stays cheap.

