### PR TITLE
fix(charge-filters): Cascade filter changes via `ChargeFilters::CascadeJob` on bulk updates

### DIFF
--- a/app/services/charge_filters/cascade_dispatcher.rb
+++ b/app/services/charge_filters/cascade_dispatcher.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  module CascadeDispatcher
+    module_function
+
+    # Diffs `before` against `after` and enqueues one ChargeFilters::CascadeJob
+    # per change. `before` and `after` are arrays of:
+    #   { values: {"key" => [...]}, properties: {...} | nil, invoice_display_name: "..." }
+    # `values` and `properties` must be string-keyed.
+    def call(charge:, before:, after:)
+      before_by_values = before.index_by { |f| f[:values] }
+
+      after.each do |new_filter|
+        existing = before_by_values.delete(new_filter[:values])
+
+        next if existing &&
+          existing[:properties] == new_filter[:properties] &&
+          existing[:invoice_display_name] == new_filter[:invoice_display_name]
+
+        ChargeFilters::CascadeJob.perform_later(
+          charge.id,
+          existing ? "update" : "create",
+          new_filter[:values],
+          existing&.dig(:properties),
+          new_filter[:properties],
+          new_filter[:invoice_display_name]
+        )
+      end
+
+      before_by_values.each_value do |old|
+        ChargeFilters::CascadeJob.perform_later(
+          charge.id,
+          "destroy",
+          old[:values],
+          old[:properties],
+          nil,
+          old[:invoice_display_name]
+        )
+      end
+    end
+  end
+end

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -2,6 +2,7 @@
 
 module ChargeFilters
   class CreateOrUpdateBatchService < BaseService
+    # TODO: drop `cascade_options` after Sidekiq drain — filter cascade goes through ChargeFilters::CascadeJob now.
     def initialize(charge:, filters_params:, cascade_options: {})
       @charge = charge
       @filters_params = filters_params

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -2,7 +2,7 @@
 
 module ChargeFilters
   class CreateOrUpdateBatchService < BaseService
-    # TODO: drop `cascade_options` after Sidekiq drain — filter cascade goes through ChargeFilters::CascadeJob now.
+    # TODO: drop `cascade_options` — filter cascade goes through ChargeFilters::CascadeJob
     def initialize(charge:, filters_params:, cascade_options: {})
       @charge = charge
       @filters_params = filters_params

--- a/app/services/charges/cascade_updatable.rb
+++ b/app/services/charges/cascade_updatable.rb
@@ -10,31 +10,62 @@ module Charges
       return unless cascade_updates
       return unless charge.children.exists?
 
+      # Charge-level cascade only — filters are stripped from `params` and
+      # cascaded individually below via per-filter jobs that don't contend
+      # for the parent-level advisory lock.
+      # TODO: drop `old_parent_filters_attrs:` after Sidekiq drain — dead, filter cascade goes through ChargeFilters::CascadeJob now.
       Charges::UpdateChildrenJob.perform_later(
         params: build_cascade_params.deep_stringify_keys,
         old_parent_attrs: old_parent_attrs || charge.attributes,
-        old_parent_filters_attrs: old_filters_attrs.map(&:deep_stringify_keys),
+        old_parent_filters_attrs: old_filters_attrs.map { |f| f.slice(:id, :properties).deep_stringify_keys },
         old_parent_applied_pricing_unit_attrs: old_applied_pricing_unit_attrs || charge.applied_pricing_unit&.attributes
       )
+
+      cascade_filter_changes(old_filters_attrs)
+    end
+
+    def cascade_filter_changes(old_filters_attrs)
+      old_by_values = old_filters_attrs.index_by { |f| f[:values] }
+
+      charge.filters.reset
+      charge.filters.includes(values: :billable_metric_filter).each do |filter|
+        values = filter.to_h
+        old = old_by_values.delete(values)
+
+        ChargeFilters::CascadeJob.perform_later(
+          charge.id,
+          old ? "update" : "create",
+          values.deep_stringify_keys,
+          old&.dig(:properties)&.deep_stringify_keys,
+          filter.properties.deep_stringify_keys,
+          filter.invoice_display_name
+        )
+      end
+
+      old_by_values.each_value do |old|
+        ChargeFilters::CascadeJob.perform_later(
+          charge.id,
+          "destroy",
+          old[:values].deep_stringify_keys,
+          old[:properties]&.deep_stringify_keys,
+          nil,
+          old[:invoice_display_name]
+        )
+      end
     end
 
     def build_cascade_params
       {
         code: charge.code,
         charge_model: charge.charge_model,
-        properties: charge.properties,
-        filters: charge.filters.reload.map do |f|
-          {
-            invoice_display_name: f.invoice_display_name,
-            properties: f.properties,
-            values: f.to_h
-          }
-        end
+        properties: charge.properties
       }
     end
 
     def capture_old_filters_attrs
-      charge.filters.map { |f| {id: f.id, properties: f.properties} }
+      charge.filters.includes(values: :billable_metric_filter).map do |f|
+        {id: f.id, properties: f.properties, invoice_display_name: f.invoice_display_name, values: f.to_h}
+      end
     end
 
     def capture_old_applied_pricing_unit_attrs

--- a/app/services/charges/cascade_updatable.rb
+++ b/app/services/charges/cascade_updatable.rb
@@ -28,7 +28,7 @@ module Charges
       old_by_values = old_filters_attrs.index_by { |f| f[:values] }
 
       charge.filters.reset
-      charge.filters.includes(values: :billable_metric_filter).each do |filter|
+      charge.filters.includes(values: :billable_metric_filter).unscope(:order).find_each do |filter|
         values = filter.to_h
         old = old_by_values.delete(values)
 

--- a/app/services/charges/cascade_updatable.rb
+++ b/app/services/charges/cascade_updatable.rb
@@ -10,10 +10,7 @@ module Charges
       return unless cascade_updates
       return unless charge.children.exists?
 
-      # Charge-level cascade only — filters are stripped from `params` and
-      # cascaded individually below via per-filter jobs that don't contend
-      # for the parent-level advisory lock.
-      # TODO: drop `old_parent_filters_attrs:` after Sidekiq drain — dead, filter cascade goes through ChargeFilters::CascadeJob now.
+      # TODO: drop `old_parent_filters_attrs:` filter cascade goes through ChargeFilters::CascadeJob
       Charges::UpdateChildrenJob.perform_later(
         params: build_cascade_params.deep_stringify_keys,
         old_parent_attrs: old_parent_attrs || charge.attributes,
@@ -25,33 +22,24 @@ module Charges
     end
 
     def cascade_filter_changes(old_filters_attrs)
-      old_by_values = old_filters_attrs.index_by { |f| f[:values] }
+      before = old_filters_attrs.map do |f|
+        {
+          values: f[:values].deep_stringify_keys,
+          properties: f[:properties]&.deep_stringify_keys,
+          invoice_display_name: f[:invoice_display_name]
+        }
+      end
 
       charge.filters.reset
-      charge.filters.includes(values: :billable_metric_filter).unscope(:order).find_each do |filter|
-        values = filter.to_h
-        old = old_by_values.delete(values)
-
-        ChargeFilters::CascadeJob.perform_later(
-          charge.id,
-          old ? "update" : "create",
-          values.deep_stringify_keys,
-          old&.dig(:properties)&.deep_stringify_keys,
-          filter.properties.deep_stringify_keys,
-          filter.invoice_display_name
-        )
+      after = charge.filters.includes(values: :billable_metric_filter).unscope(:order).find_each.map do |filter|
+        {
+          values: filter.to_h.deep_stringify_keys,
+          properties: filter.properties.deep_stringify_keys,
+          invoice_display_name: filter.invoice_display_name
+        }
       end
 
-      old_by_values.each_value do |old|
-        ChargeFilters::CascadeJob.perform_later(
-          charge.id,
-          "destroy",
-          old[:values].deep_stringify_keys,
-          old[:properties]&.deep_stringify_keys,
-          nil,
-          old[:invoice_display_name]
-        )
-      end
+      ChargeFilters::CascadeDispatcher.call(charge:, before:, after:)
     end
 
     def build_cascade_params

--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -4,6 +4,7 @@ module Charges
   class UpdateChildrenService < BaseService
     Result = BaseResult[:charge]
 
+    # TODO: drop `old_parent_filters_attrs` / `parent_filters` after Sidekiq drain — dead, filter cascade goes through ChargeFilters::CascadeJob now.
     def initialize(charge:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, child_ids:)
       @charge = charge
       @params = params

--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -4,7 +4,7 @@ module Charges
   class UpdateChildrenService < BaseService
     Result = BaseResult[:charge]
 
-    # TODO: drop `old_parent_filters_attrs` / `parent_filters` after Sidekiq drain — dead, filter cascade goes through ChargeFilters::CascadeJob now.
+    # TODO: drop `old_parent_filters_attrs` / `parent_filters` — filter cascade goes through ChargeFilters::CascadeJob
     def initialize(charge:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, child_ids:)
       @charge = charge
       @params = params

--- a/app/services/charges/update_service.rb
+++ b/app/services/charges/update_service.rb
@@ -55,6 +55,7 @@ module Charges
 
         filters = params.delete(:filters)
         unless filters.nil?
+          # TODO: skip when `cascade` after Sidekiq drain — filter cascade goes through ChargeFilters::CascadeJob now.
           ChargeFilters::CreateOrUpdateBatchService.call(
             charge:,
             filters_params: filters.map(&:with_indifferent_access),

--- a/app/services/charges/update_service.rb
+++ b/app/services/charges/update_service.rb
@@ -55,7 +55,7 @@ module Charges
 
         filters = params.delete(:filters)
         unless filters.nil?
-          # TODO: skip when `cascade` after Sidekiq drain — filter cascade goes through ChargeFilters::CascadeJob now.
+          # TODO: skip when `cascade` — filter cascade goes through ChargeFilters::CascadeJob
           ChargeFilters::CreateOrUpdateBatchService.call(
             charge:,
             filters_params: filters.map(&:with_indifferent_access),

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -146,12 +146,45 @@ module Plans
       old_parent_filters_attrs = charge.filters.map(&:attributes)
       old_parent_applied_pricing_unit_attrs = charge.applied_pricing_unit&.attributes
 
+      # Filters are stripped from `params`; cascaded individually below.
+      # TODO: drop `old_parent_filters_attrs:` after Sidekiq drain — dead, filter cascade goes through ChargeFilters::CascadeJob now.
       Charges::UpdateChildrenJob.perform_later(
-        params: payload_charge.deep_stringify_keys,
+        params: payload_charge.except(:filters).deep_stringify_keys,
         old_parent_attrs:,
         old_parent_filters_attrs:,
         old_parent_applied_pricing_unit_attrs:
       )
+
+      cascade_filter_changes(charge, payload_charge[:filters]) if payload_charge.key?(:filters)
+    end
+
+    def cascade_filter_changes(charge, payload_filters)
+      current_by_values = charge.filters.includes(values: :billable_metric_filter).index_by(&:to_h)
+
+      (payload_filters || []).each do |fp|
+        values = (fp[:values] || {}).deep_stringify_keys
+        existing = current_by_values.delete(values)
+
+        ChargeFilters::CascadeJob.perform_later(
+          charge.id,
+          existing ? "update" : "create",
+          values,
+          existing&.properties,
+          fp[:properties]&.deep_stringify_keys,
+          fp[:invoice_display_name]
+        )
+      end
+
+      current_by_values.each_value do |existing|
+        ChargeFilters::CascadeJob.perform_later(
+          charge.id,
+          "destroy",
+          existing.to_h,
+          existing.properties,
+          nil,
+          existing.invoice_display_name
+        )
+      end
     end
 
     def cascade_fixed_charge_removal(fixed_charge)

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -164,13 +164,16 @@ module Plans
       (payload_filters || []).each do |fp|
         values = (fp[:values] || {}).deep_stringify_keys
         existing = current_by_values.delete(values)
+        new_properties = fp[:properties]&.deep_stringify_keys
+
+        next if existing && existing.properties == new_properties && existing.invoice_display_name == fp[:invoice_display_name]
 
         ChargeFilters::CascadeJob.perform_later(
           charge.id,
           existing ? "update" : "create",
           values,
           existing&.properties,
-          fp[:properties]&.deep_stringify_keys,
+          new_properties,
           fp[:invoice_display_name]
         )
       end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -146,8 +146,7 @@ module Plans
       old_parent_filters_attrs = charge.filters.map(&:attributes)
       old_parent_applied_pricing_unit_attrs = charge.applied_pricing_unit&.attributes
 
-      # Filters are stripped from `params`; cascaded individually below.
-      # TODO: drop `old_parent_filters_attrs:` after Sidekiq drain — dead, filter cascade goes through ChargeFilters::CascadeJob now.
+      # TODO: drop `old_parent_filters_attrs:` — filter cascade goes through ChargeFilters::CascadeJob
       Charges::UpdateChildrenJob.perform_later(
         params: payload_charge.except(:filters).deep_stringify_keys,
         old_parent_attrs:,
@@ -159,35 +158,23 @@ module Plans
     end
 
     def cascade_filter_changes(charge, payload_filters)
-      current_by_values = charge.filters.includes(values: :billable_metric_filter).index_by(&:to_h)
-
-      (payload_filters || []).each do |fp|
-        values = (fp[:values] || {}).deep_stringify_keys
-        existing = current_by_values.delete(values)
-        new_properties = fp[:properties]&.deep_stringify_keys
-
-        next if existing && existing.properties == new_properties && existing.invoice_display_name == fp[:invoice_display_name]
-
-        ChargeFilters::CascadeJob.perform_later(
-          charge.id,
-          existing ? "update" : "create",
-          values,
-          existing&.properties,
-          new_properties,
-          fp[:invoice_display_name]
-        )
+      before = charge.filters.includes(values: :billable_metric_filter).map do |f|
+        {
+          values: f.to_h.deep_stringify_keys,
+          properties: f.properties,
+          invoice_display_name: f.invoice_display_name
+        }
       end
 
-      current_by_values.each_value do |existing|
-        ChargeFilters::CascadeJob.perform_later(
-          charge.id,
-          "destroy",
-          existing.to_h,
-          existing.properties,
-          nil,
-          existing.invoice_display_name
-        )
+      after = (payload_filters || []).map do |fp|
+        {
+          values: (fp[:values] || {}).deep_stringify_keys,
+          properties: fp[:properties]&.deep_stringify_keys,
+          invoice_display_name: fp[:invoice_display_name]
+        }
       end
+
+      ChargeFilters::CascadeDispatcher.call(charge:, before:, after:)
     end
 
     def cascade_fixed_charge_removal(fixed_charge)

--- a/spec/scenarios/plans/cascade_bulk_filter_updates_spec.rb
+++ b/spec/scenarios/plans/cascade_bulk_filter_updates_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Tests filter-level cascade for the bulk plan update path
+# (PUT /api/v1/plans/:code, which goes through Plans::UpdateService).
+#
+# The plan-level update enqueues a charge-level cascade for non-filter changes
+# AND one ChargeFilters::CascadeJob per changed filter — avoiding the
+# advisory-lock contention of the legacy charge-level cascade.
+RSpec.describe "Cascade bulk filter updates via Plans::UpdateService", :premium do
+  include ScenariosHelper
+
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:billable_metric) { create(:billable_metric, organization:, code: "storage") }
+  let(:bm_filter) do
+    create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu asia])
+  end
+
+  before { bm_filter }
+
+  def setup_plan_with_subscription
+    create_plan({
+      name: "Enterprise",
+      code: "enterprise",
+      interval: "monthly",
+      amount_cents: 0,
+      amount_currency: "EUR",
+      pay_in_advance: false,
+      charges: [
+        {
+          billable_metric_id: billable_metric.id,
+          charge_model: "standard",
+          code: "storage_charge",
+          pay_in_advance: false,
+          properties: {amount: "0"},
+          filters: [
+            {
+              invoice_display_name: "US region",
+              properties: {amount: "10"},
+              values: {region: ["us"]}
+            },
+            {
+              invoice_display_name: "EU region",
+              properties: {amount: "20"},
+              values: {region: ["eu"]}
+            }
+          ]
+        }
+      ]
+    })
+
+    parent_plan = organization.plans.find_by(code: "enterprise")
+    parent_charge = parent_plan.charges.first
+
+    create_subscription({
+      external_customer_id: customer.external_id,
+      external_id: "sub_enterprise",
+      plan_code: "enterprise"
+    })
+
+    subscription = organization.subscriptions.find_by(external_id: "sub_enterprise")
+
+    update_subscription_charge(subscription, "storage_charge", {
+      invoice_display_name: "My storage",
+      properties: {amount: "0"}
+    })
+
+    subscription.reload
+    child_charge = subscription.plan.charges.find_by(code: "storage_charge")
+
+    {parent_plan:, parent_charge:, child_charge:}
+  end
+
+  def bulk_update_charge(parent_plan, parent_charge, filters_payload, **opts)
+    update_plan(parent_plan, {
+      cascade_updates: true,
+      charges: [
+        {
+          id: parent_charge.id,
+          billable_metric_id: parent_charge.billable_metric_id,
+          charge_model: parent_charge.charge_model,
+          properties: parent_charge.properties,
+          filters: filters_payload
+        }
+      ]
+    }, **opts)
+  end
+
+  it "enqueues one ChargeFilters::CascadeJob per changed filter (no shared advisory lock)" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+
+    expect do
+      bulk_update_charge(parent_plan, parent_charge, [
+        {
+          invoice_display_name: "US region",
+          properties: {amount: "15"},
+          values: {region: ["us"]}
+        },
+        {
+          invoice_display_name: "EU region",
+          properties: {amount: "25"},
+          values: {region: ["eu"]}
+        }
+      ], perform_jobs: false)
+    end.to have_enqueued_job(ChargeFilters::CascadeJob).twice
+  end
+
+  it "does not enqueue cascade jobs for unchanged filters" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+
+    expect do
+      bulk_update_charge(parent_plan, parent_charge, [
+        {
+          invoice_display_name: "US region",
+          properties: {amount: "15"}, # only US changes
+          values: {region: ["us"]}
+        },
+        {
+          invoice_display_name: "EU region",
+          properties: {amount: "20"}, # unchanged
+          values: {region: ["eu"]}
+        }
+      ], perform_jobs: false)
+    end.to have_enqueued_job(ChargeFilters::CascadeJob).once
+  end
+
+  it "cascades bulk filter updates to children when jobs run" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    bulk_update_charge(parent_plan, parent_charge, [
+      {
+        invoice_display_name: "US region",
+        properties: {amount: "15"},
+        values: {region: ["us"]}
+      },
+      {
+        invoice_display_name: "EU region",
+        properties: {amount: "25"},
+        values: {region: ["eu"]}
+      }
+    ])
+
+    child_filter_us = child_charge.filters.find_by(invoice_display_name: "US region")
+    child_filter_eu = child_charge.filters.find_by(invoice_display_name: "EU region")
+
+    expect(child_filter_us.properties).to eq({"amount" => "15"})
+    expect(child_filter_eu.properties).to eq({"amount" => "25"})
+  end
+
+  it "cascades a new filter added in a bulk update as a 'create' job" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    expect(child_charge.filters.count).to eq(2)
+
+    bulk_update_charge(parent_plan, parent_charge, [
+      {
+        invoice_display_name: "US region",
+        properties: {amount: "10"},
+        values: {region: ["us"]}
+      },
+      {
+        invoice_display_name: "EU region",
+        properties: {amount: "20"},
+        values: {region: ["eu"]}
+      },
+      {
+        invoice_display_name: "Asia region",
+        properties: {amount: "30"},
+        values: {region: ["asia"]}
+      }
+    ])
+
+    child_charge.reload
+    expect(child_charge.filters.count).to eq(3)
+
+    child_filter_asia = child_charge.filters.find_by(invoice_display_name: "Asia region")
+    expect(child_filter_asia.properties).to eq({"amount" => "30"})
+    expect(child_filter_asia.to_h).to eq({"region" => ["asia"]})
+  end
+
+  it "cascades a removed filter in a bulk update as a 'destroy' job" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    expect(child_charge.filters.count).to eq(2)
+
+    bulk_update_charge(parent_plan, parent_charge, [
+      {
+        invoice_display_name: "US region",
+        properties: {amount: "10"},
+        values: {region: ["us"]}
+      }
+    ])
+
+    child_charge.reload
+    expect(child_charge.filters.count).to eq(1)
+    expect(child_charge.filters.first.invoice_display_name).to eq("US region")
+  end
+end

--- a/spec/scenarios/plans/cascade_bulk_filter_updates_spec.rb
+++ b/spec/scenarios/plans/cascade_bulk_filter_updates_spec.rb
@@ -2,12 +2,6 @@
 
 require "rails_helper"
 
-# Tests filter-level cascade for the bulk plan update path
-# (PUT /api/v1/plans/:code, which goes through Plans::UpdateService).
-#
-# The plan-level update enqueues a charge-level cascade for non-filter changes
-# AND one ChargeFilters::CascadeJob per changed filter — avoiding the
-# advisory-lock contention of the legacy charge-level cascade.
 RSpec.describe "Cascade bulk filter updates via Plans::UpdateService", :premium do
   include ScenariosHelper
 

--- a/spec/services/charge_filters/cascade_dispatcher_spec.rb
+++ b/spec/services/charge_filters/cascade_dispatcher_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeFilters::CascadeDispatcher do
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+
+  let(:us_values) { {"region" => ["us"]} }
+  let(:eu_values) { {"region" => ["eu"]} }
+
+  describe ".call" do
+    context "when a filter is added" do
+      let(:before) { [] }
+      let(:after) do
+        [{values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"}]
+      end
+
+      it "enqueues a create cascade job" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "create", us_values, nil, {"amount" => "10"}, "US"
+        )
+      end
+    end
+
+    context "when a filter is removed" do
+      let(:before) do
+        [{values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"}]
+      end
+      let(:after) { [] }
+
+      it "enqueues a destroy cascade job" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "destroy", us_values, {"amount" => "10"}, nil, "US"
+        )
+      end
+    end
+
+    context "when a filter's properties change" do
+      let(:before) do
+        [{values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"}]
+      end
+      let(:after) do
+        [{values: us_values, properties: {"amount" => "15"}, invoice_display_name: "US"}]
+      end
+
+      it "enqueues an update cascade job carrying both old and new properties" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "15"}, "US"
+        )
+      end
+    end
+
+    context "when a filter's invoice_display_name changes" do
+      let(:before) do
+        [{values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"}]
+      end
+      let(:after) do
+        [{values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US region"}]
+      end
+
+      it "enqueues an update cascade job with the new display name" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "10"}, "US region"
+        )
+      end
+    end
+
+    context "when a filter is unchanged" do
+      let(:filter) { {values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"} }
+      let(:before) { [filter] }
+      let(:after) { [filter] }
+
+      it "does not enqueue any cascade job" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.not_to have_enqueued_job(ChargeFilters::CascadeJob)
+      end
+    end
+
+    context "with a mix of create, update, destroy and unchanged" do
+      let(:asia_values) { {"region" => ["asia"]} }
+      let(:ca_values) { {"region" => ["ca"]} }
+
+      let(:before) do
+        [
+          {values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"},
+          {values: eu_values, properties: {"amount" => "20"}, invoice_display_name: "EU"},
+          {values: asia_values, properties: {"amount" => "30"}, invoice_display_name: "Asia"}
+        ]
+      end
+
+      let(:after) do
+        [
+          {values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"},   # unchanged
+          {values: eu_values, properties: {"amount" => "25"}, invoice_display_name: "EU"},   # update
+          {values: ca_values, properties: {"amount" => "40"}, invoice_display_name: "CA"}    # create
+          # asia removed → destroy
+        ]
+      end
+
+      it "enqueues exactly one job per change and skips the unchanged filter" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).exactly(3).times
+      end
+
+      it "enqueues the update job for the modified filter" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "update", eu_values, {"amount" => "20"}, {"amount" => "25"}, "EU"
+        )
+      end
+
+      it "enqueues the create job for the new filter" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "create", ca_values, nil, {"amount" => "40"}, "CA"
+        )
+      end
+
+      it "enqueues the destroy job for the removed filter" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "destroy", asia_values, {"amount" => "30"}, nil, "Asia"
+        )
+      end
+    end
+  end
+end

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -413,15 +413,17 @@ RSpec.describe Charges::UpdateService do
           allow(Charges::UpdateChildrenJob).to receive(:perform_later)
         end
 
-        it "triggers cascade update via Charges::UpdateChildrenJob" do
+        it "triggers charge-level cascade via Charges::UpdateChildrenJob (without filters)" do
           subject
 
-          expect(Charges::UpdateChildrenJob).to have_received(:perform_later).with(
-            params: hash_including("charge_model", "properties", "filters"),
-            old_parent_attrs: hash_including("id" => charge.id),
-            old_parent_filters_attrs: array_including,
-            old_parent_applied_pricing_unit_attrs: anything
-          )
+          expect(Charges::UpdateChildrenJob).to have_received(:perform_later) do |args|
+            expect(args[:params]).to include("charge_model", "properties")
+            # Filters are cascaded via per-filter ChargeFilters::CascadeJob,
+            # not via the legacy lock-protected job.
+            expect(args[:params]).not_to have_key("filters")
+            expect(args[:old_parent_attrs]).to include("id" => charge.id)
+            expect(args[:old_parent_filters_attrs]).to be_an(Array)
+          end
         end
 
         context "when charge has no children" do

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -418,8 +418,6 @@ RSpec.describe Charges::UpdateService do
 
           expect(Charges::UpdateChildrenJob).to have_received(:perform_later) do |args|
             expect(args[:params]).to include("charge_model", "properties")
-            # Filters are cascaded via per-filter ChargeFilters::CascadeJob,
-            # not via the legacy lock-protected job.
             expect(args[:params]).not_to have_key("filters")
             expect(args[:old_parent_attrs]).to include("id" => charge.id)
             expect(args[:old_parent_filters_attrs]).to be_an(Array)


### PR DESCRIPTION
Extend the filter-level cascade introduced in #5357 to the bulk update paths: filters are stripped from the legacy job's params and dispatched individually via `ChargeFilters::CascadeJob`.
