### PR TITLE
feat(multi-billing-entities): add logic to split periodic invoices per billing entity

### DIFF
--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -28,6 +28,7 @@ module Subscriptions
 
         subscription_groups = group_by_payment_method(billing_subscriptions)
         subscription_groups = group_by_currency(subscription_groups)
+        subscription_groups = group_by_billing_entity(subscription_groups)
 
         subscription_groups.each do |subscriptions|
           BillSubscriptionJob.perform_later(
@@ -527,6 +528,14 @@ module Subscriptions
 
       subscription_groups.flat_map do |subscriptions|
         subscriptions.group_by { |sub| sub.plan.amount_currency }.values
+      end
+    end
+
+    def group_by_billing_entity(subscription_groups)
+      return subscription_groups unless organization.feature_flag_enabled?(:multi_entity_billing)
+
+      subscription_groups.flat_map do |subscriptions|
+        subscriptions.group_by { |sub| sub.billing_entity_id || sub.customer.billing_entity_id }.values
       end
     end
 

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -919,5 +919,113 @@ RSpec.describe Subscriptions::OrganizationBillingService do
         end
       end
     end
+
+    context "when grouping subscriptions by billing entity" do
+      let(:organization) { create(:organization, feature_flags: ["multi_entity_billing"]) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:other_billing_entity) { create(:billing_entity, organization:) }
+      let(:interval) { :monthly }
+      let(:billing_time) { :anniversary }
+      let(:current_date) { subscription_at.next_month }
+
+      before { subscription.destroy }
+
+      context "when subscriptions have different billing entities" do
+        let(:subscription_default_entity) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:subscription_other_entity) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            billing_entity: other_billing_entity,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+
+        before do
+          subscription_default_entity
+          subscription_other_entity
+        end
+
+        it "produces separate billing jobs per billing entity" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription_default_entity], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription_other_entity], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+
+        context "without feature flag" do
+          let(:organization) { create(:organization) }
+
+          it "groups them into a single billing job" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with(
+                contain_exactly(subscription_default_entity, subscription_other_entity),
+                current_date.to_i,
+                invoicing_reason: :subscription_periodic
+              )
+          end
+        end
+      end
+
+      context "when subscriptions share the same effective billing entity" do
+        let(:subscription1) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:subscription2) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            billing_entity: customer.billing_entity,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+
+        before do
+          subscription1
+          subscription2
+        end
+
+        it "groups them into a single billing job" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(
+              contain_exactly(subscription1, subscription2),
+              current_date.to_i,
+              invoicing_reason: :subscription_periodic
+            )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently, one customer can be assigned to only one billing entity. With `multi-billing-entities` feature, it will be possible to assign any billing entity to customer's billing object, like subscription or wallet.

## Description

This PR adds new logic where periodic subscription invoices are grouped per billing entity, along with payment method or currency.
