### PR TITLE
fix(netsuite-integration): wait 5 minutes between Net::ReadTimeout retries for invoices

### DIFF
--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -6,19 +6,43 @@ module Integrations
       class CreateJob < ApplicationJob
         include ConcurrencyThrottlable
 
+        # NOTE: NetSuite waits longer to avoid racing in-flight Nango calls; others use polynomial backoff.
+        READ_TIMEOUT_WAIT_BY_PROVIDER_KEY = {
+          "netsuite" => 5.minutes
+        }.freeze
+
         queue_as "integrations"
 
         unique :until_executed, on_conflict: :log
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-        retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 6
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
         retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
         discard_on BaseService::NonRetryableFailure
 
+        rescue_from(Net::ReadTimeout) do |error|
+          attempts = 6
+          executions_count = executions_for([Net::ReadTimeout])
+          raise error if executions_count >= attempts
+
+          wait_strategy = READ_TIMEOUT_WAIT_BY_PROVIDER_KEY.fetch(integration_provider_key, :polynomially_longer)
+
+          retry_job(
+            wait: determine_delay(seconds_or_duration_or_algorithm: wait_strategy, executions: executions_count),
+            error: error
+          )
+        end
+
         def perform(invoice:)
+          @invoice = invoice
           result = Integrations::Aggregator::Invoices::CreateService.call(invoice:)
           result.raise_if_error!
+        end
+
+        private
+
+        def integration_provider_key
+          @invoice&.customer&.integration_customers&.accounting_kind&.first&.integration&.provider_key
         end
       end
     end

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -8,7 +8,7 @@ module Integrations
 
         # NOTE: NetSuite waits longer to avoid racing in-flight Nango calls; others use polynomial backoff.
         # 6 minutes covers Nango's 5-minute upstream NetSuite action timeout with a safety margin.
-        READ_TIMEOUT_WAIT_BY_PROVIDER_KEY = {
+        DELAY_BY_PROVIDER_KEY = {
           "netsuite" => 6.minutes
         }.freeze
 
@@ -33,7 +33,7 @@ module Integrations
             raise
           end
 
-          wait_strategy = READ_TIMEOUT_WAIT_BY_PROVIDER_KEY.fetch(integration_provider_key, :polynomially_longer)
+          wait_strategy = DELAY_BY_PROVIDER_KEY.fetch(integration_provider_key, :polynomially_longer)
 
           retry_job(
             wait: determine_delay(seconds_or_duration_or_algorithm: wait_strategy, executions: executions_count),

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -7,8 +7,9 @@ module Integrations
         include ConcurrencyThrottlable
 
         # NOTE: NetSuite waits longer to avoid racing in-flight Nango calls; others use polynomial backoff.
+        # 6 minutes covers Nango's 5-minute upstream NetSuite action timeout with a safety margin.
         READ_TIMEOUT_WAIT_BY_PROVIDER_KEY = {
-          "netsuite" => 5.minutes
+          "netsuite" => 6.minutes
         }.freeze
 
         queue_as "integrations"
@@ -20,10 +21,17 @@ module Integrations
         retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
         discard_on BaseService::NonRetryableFailure
 
+        # NOTE: `executions_for` and `determine_delay` are ActiveJob internals used by `retry_on`,
+        # not part of its public API. We reuse them so the per-exception execution counter and jitter
+        # behave identically to a normal `retry_on`. Revisit this block on Rails upgrades.
         rescue_from(Net::ReadTimeout) do |error|
           attempts = 6
           executions_count = executions_for([Net::ReadTimeout])
-          raise error if executions_count >= attempts
+
+          if executions_count >= attempts
+            instrument :retry_stopped, error:
+            raise
+          end
 
           wait_strategy = READ_TIMEOUT_WAIT_BY_PROVIDER_KEY.fetch(integration_provider_key, :polynomially_longer)
 
@@ -34,7 +42,6 @@ module Integrations
         end
 
         def perform(invoice:)
-          @invoice = invoice
           result = Integrations::Aggregator::Invoices::CreateService.call(invoice:)
           result.raise_if_error!
         end
@@ -42,7 +49,8 @@ module Integrations
         private
 
         def integration_provider_key
-          @invoice&.customer&.integration_customers&.accounting_kind&.first&.integration&.provider_key
+          invoice = arguments.first[:invoice]
+          invoice&.customer&.integration_customers&.accounting_kind&.first&.integration&.provider_key
         end
       end
     end

--- a/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
@@ -5,7 +5,9 @@ require "rails_helper"
 RSpec.describe Integrations::Aggregator::Invoices::CreateJob do
   subject(:create_job) { described_class }
 
-  let(:invoice) { create(:invoice) }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
   let(:result) { BaseService::Result.new }
 
   before do
@@ -16,5 +18,43 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateJob do
     described_class.perform_now(invoice:)
 
     expect(Integrations::Aggregator::Invoices::CreateService).to have_received(:call)
+  end
+
+  describe "Net::ReadTimeout retry" do
+    before do
+      allow(Integrations::Aggregator::Invoices::CreateService).to receive(:call).and_raise(Net::ReadTimeout.new)
+    end
+
+    context "when the invoice is for a NetSuite integration" do
+      let(:integration) { create(:netsuite_integration, organization:) }
+
+      before { create(:netsuite_customer, integration:, customer:) }
+
+      it "schedules the next attempt at least 5 minutes later" do
+        freeze_time do
+          described_class.perform_now(invoice:)
+
+          retry_at = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:at]
+          # NOTE: Tolerance covers ActiveJob's 15% retry jitter (up to ~45s on a 5-minute wait).
+          expect(retry_at).to be_within(50.seconds).of(5.minutes.from_now.to_f)
+        end
+      end
+    end
+
+    context "when the invoice is for a non-NetSuite integration" do
+      let(:integration) { create(:xero_integration, organization:) }
+
+      before { create(:xero_customer, integration:, customer:) }
+
+      it "schedules the next attempt with polynomial backoff" do
+        freeze_time do
+          described_class.perform_now(invoice:)
+
+          retry_at = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:at]
+          # NOTE: First polynomial retry is ~3s (1**4 + 2) plus up to 15% jitter; well under a minute.
+          expect(retry_at).to be < 1.minute.from_now.to_f
+        end
+      end
+    end
   end
 end

--- a/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
@@ -30,13 +30,14 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateJob do
 
       before { create(:netsuite_customer, integration:, customer:) }
 
-      it "schedules the next attempt at least 5 minutes later" do
+      it "schedules the next attempt at least 6 minutes later" do
         freeze_time do
           described_class.perform_now(invoice:)
 
           retry_at = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:at]
-          # NOTE: Tolerance covers ActiveJob's 15% retry jitter (up to ~45s on a 5-minute wait).
-          expect(retry_at).to be_within(50.seconds).of(5.minutes.from_now.to_f)
+          # NOTE: ActiveJob applies up to 15% positive jitter on top of the configured wait,
+          # so the retry lands in [6 minutes, 6 minutes + 15%] from now.
+          expect(retry_at).to be_between(6.minutes.from_now.to_f, 7.minutes.from_now.to_f)
         end
       end
     end


### PR DESCRIPTION
## Context

`Integrations::Aggregator::Invoices::CreateJob` POSTs to Nango to create the NetSuite invoice. Lago's HTTP client has a 60-second read timeout, while Nango's NetSuite action can take longer than that to commit. When `Net::ReadTimeout` fires on Lago's side, the upstream Nango call keeps running and may still create the NetSuite invoice.

ActiveJob's `:polynomially_longer` then schedules the first retry only ~3-5 seconds after the timeout. That retry POSTs to Nango while the original write is still committing in NetSuite, the optimistic lock raises `RCRD_HAS_BEEN_CHANGED` (HTTP 424), retries exhaust, and the job dies. Lago never reaches the response-handling path that would persist an `IntegrationResource`, so the invoice can exist in NetSuite with no link in Lago.

Nango's NetSuite action times out upstream at 5 minutes. Waiting 5 minutes between retries guarantees the original call has settled (succeeded or definitively failed) before we retry, which eliminates the in-flight race that produces `RCRD_HAS_BEEN_CHANGED`.

## Description

- Replace `retry_on Net::ReadTimeout` with a custom `rescue_from(Net::ReadTimeout)` block. ActiveJob's `wait:` Proc receives only `executions`, not the job instance, so a Proc cannot branch on which integration the invoice belongs to. `rescue_from` is the canonical workaround when the retry decision depends on the job's instance state.
- Add `READ_TIMEOUT_WAIT_BY_PROVIDER_KEY` mapping each provider key to its wait strategy. NetSuite waits 5 minutes (matching Nango's upstream action timeout); other integrations that reach this job (Xero, via `accounting_kind`) fall through to `:polynomially_longer`.
- Reuse `executions_for` and `determine_delay` so the per-exception execution counter, attempts limit, and jitter behave identically to a normal `retry_on`.
- Cover both branches in specs: a NetSuite invoice schedules the next attempt within ~5 minutes (jitter tolerance), a Xero invoice schedules the first retry under one minute (polynomial backoff).

The durable fix is idempotent find-or-create on the Nango RESTlet, planned separately. With idempotency in place, retries against an already-committed record return success instead of `RCRD_HAS_BEEN_CHANGED`. This PR is the in-Lago mitigation until that ships.