### PR TITLE
fix(invoices): Prevent duplicate PullTaxesAndApplyJob

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -5,6 +5,8 @@ module Invoices
     class PullTaxesAndApplyJob < ApplicationJob
       queue_as "providers"
 
+      unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+
       retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 6
       retry_on OpenSSL::SSL::SSLError, wait: :polynomially_longer, attempts: 6

--- a/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob do
 
   let(:result) { BaseService::Result.new }
 
+  it_behaves_like "a unique job" do
+    let(:job_args) { [{invoice:}] }
+  end
+
   before do
     allow(Invoices::ProviderTaxes::PullTaxesAndApplyService).to receive(:call)
       .with(invoice:)


### PR DESCRIPTION
## Context

PullTaxesAndApplyJob had no uniqueness lock, causing duplicated tax rows for the same invoice and invoice number shift.

## Description

Added uniqueness for Invoices::ProviderTaxes::PullTaxesAndApplyJob
