### PR TITLE
perf(invoices): Improvements for InvoicesQuery and InvoicesResolver

### DIFF
--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -84,7 +84,15 @@ module Resolvers
 
       return result_error(result) unless result.success?
 
-      Invoice.preload_offset_amounts(result.invoices)
+      Invoice.preload_offset_amounts(
+        result.invoices.preload(
+          :fees,
+          :regenerated_invoice,
+          :error_details,
+          :billing_entity,
+          {customer: :billing_entity}
+        )
+      )
     end
   end
 end

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -27,7 +27,7 @@ class InvoicesQuery < BaseQuery
   def call
     return result unless validate_filters.success?
 
-    invoices = base_scope.result.includes(:customer, file_attachment: :blob, xml_file_attachment: :blob)
+    invoices = base_scope.result.includes(:customer).preload(file_attachment: :blob, xml_file_attachment: :blob)
     invoices = with_customers_filter(invoices)
 
     invoices = with_billing_entity_ids(invoices) if filters.billing_entity_ids.present?
@@ -81,7 +81,9 @@ class InvoicesQuery < BaseQuery
   end
 
   def with_customers_filter(scope)
-    return scope if search_term.blank? || filters.customer_id.present?
+    return scope if search_term.blank?
+    return scope if filters.customer_id.present?
+    return scope if filters.customer_external_id.present?
 
     matching_customer_ids = organization.customers
       .ransack(

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -728,4 +728,80 @@ RSpec.describe Resolvers::InvoicesResolver do
       end
     end
   end
+
+  context "with N+1 query detection on associations", bullet: {unused_eager_loading: false} do
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(limit: 5) {
+            collection {
+              id
+              status
+              taxStatus
+              paymentStatus
+              paymentOverdue
+              number
+              issuingDate
+              totalAmountCents
+              totalDueAmountCents
+              totalPaidAmountCents
+              currency
+              voidable
+              paymentDisputeLostAt
+              taxProviderVoidable
+              invoiceType
+              creditableAmountCents
+              refundableAmountCents
+              offsettableAmountCents
+              associatedActiveWalletPresent
+              voidedInvoiceId
+              regeneratedInvoiceId
+              customer {
+                id
+                externalId
+                name
+                displayName
+                applicableTimezone
+                paymentProvider
+                hasActiveWallet
+                email
+                deletedAt
+                __typename
+              }
+              errorDetails {
+                errorCode
+                errorDetails
+                __typename
+              }
+              billingEntity {
+                id
+                name
+                code
+                email
+                einvoicing
+                emailSettings
+                __typename
+              }
+              payments {
+                createdAt
+                paymentMethodId
+                __typename
+              }
+            }
+          }
+        }
+      GQL
+    end
+
+    it "does not trigger N+1 queries on associations" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      expect(result["data"]["invoices"]["collection"].count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Context
Invoices page is pretty slow to load, especially for orgs with lots of invoices.

## Description
This PR adds a few improvements to `InvoicesQuery` and `InvoicesResolver` to speed up the invoices GraphQL query:

1. Preloads associations in `InvoicesResolver` to avoid most of the N+1 queries
2. Skips the `search_term` filter in the customers subquery when `customer_external_id` is present
3. Replaces `includes` with `preloads` for `file_attachment` and `xml_file_attachment` to avoid unnecessary left joins when searching by `customer_external_id`
