### PR TITLE
fix(api): Ability to use params without filter_by prefix to reflect the rest of the API

### DIFF
--- a/app/models/usage_filters.rb
+++ b/app/models/usage_filters.rb
@@ -14,7 +14,7 @@ class UsageFilters
   attr_reader :filter_by_charge_id, :filter_by_charge_code, :filter_by_metric_code, :filter_by_group, :filter_by_presentation, :skip_grouping, :full_usage
 
   def self.init_from_params(params)
-    group = params[:filter_by_group]
+    group = params[:group] || params[:filter_by_group]
     group = JSON.parse(group) if group.is_a?(String)
     group = group.to_unsafe_h if group.respond_to?(:to_unsafe_h)
 
@@ -23,9 +23,9 @@ class UsageFilters
     presentation = Array(presentation) if presentation.present?
 
     new(
-      filter_by_charge_id: params[:filter_by_charge_id],
-      filter_by_charge_code: params[:filter_by_charge_code],
-      filter_by_metric_code: params[:filter_by_metric_code],
+      filter_by_charge_id: params[:charge_id] || params[:filter_by_charge_id],
+      filter_by_charge_code: params[:charge_code] || params[:filter_by_charge_code],
+      filter_by_metric_code: params[:billable_metric_code] || params[:filter_by_metric_code],
       filter_by_group: group,
       filter_by_presentation: presentation,
       skip_grouping: ActiveModel::Type::Boolean.new.cast(params[:skip_grouping]),

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -430,6 +430,253 @@ RSpec.describe Api::V1::Customers::UsageController do
           end
         end
       end
+
+      context "when charge_code is provided" do
+        let(:params) { {external_subscription_id: subscription.external_id, charge_code: charge_a.code, apply_taxes: false} }
+
+        it "returns only the filtered charge with current period usage" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:customer_usage][:charges_usage].count).to eq(1)
+
+          charge_usage = json[:customer_usage][:charges_usage].first
+          expect(charge_usage[:billable_metric][:code]).to eq(metric_a.code)
+          expect(charge_usage[:units]).to eq("14.0")
+          expect(charge_usage[:amount_cents]).to eq(14_000)
+        end
+      end
+
+      context "when charge_code does not match any charge" do
+        let(:params) { {external_subscription_id: subscription.external_id, charge_code: "nonexistent"} }
+
+        it "returns not found" do
+          subject
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when charge_code belongs to another organization" do
+        let(:other_charge) { create(:standard_charge) }
+        let(:params) { {external_subscription_id: subscription.external_id, charge_code: other_charge.code} }
+
+        it "returns not found" do
+          subject
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when charge_id is provided" do
+        let(:params) { {external_subscription_id: subscription.external_id, charge_id: charge_a.id, apply_taxes: false} }
+
+        it "returns only the filtered charge with current period usage" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:customer_usage][:charges_usage].count).to eq(1)
+
+          charge_usage = json[:customer_usage][:charges_usage].first
+          expect(charge_usage[:billable_metric][:code]).to eq(metric_a.code)
+          expect(charge_usage[:units]).to eq("14.0")
+          expect(charge_usage[:amount_cents]).to eq(14_000)
+        end
+      end
+
+      context "when charge_id does not match any charge" do
+        let(:params) { {external_subscription_id: subscription.external_id, charge_id: SecureRandom.uuid} }
+
+        it "returns a not found error" do
+          subject
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when billable_metric_code is provided" do
+        let(:params) { {external_subscription_id: subscription.external_id, billable_metric_code: metric_a.code, apply_taxes: false} }
+
+        it "returns only charges for the given billable metric" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:customer_usage][:charges_usage].count).to eq(1)
+
+          charge_usage = json[:customer_usage][:charges_usage].first
+          expect(charge_usage[:billable_metric][:code]).to eq(metric_a.code)
+          expect(charge_usage[:units]).to eq("14.0")
+          expect(charge_usage[:amount_cents]).to eq(14_000)
+        end
+      end
+
+      context "when billable_metric_code matches multiple charges sharing the same metric" do
+        let(:charge_a2) do
+          create(
+            :standard_charge,
+            plan: subscription.plan,
+            billable_metric: metric_a,
+            organization:,
+            properties: {amount: "5", pricing_group_keys: []}
+          )
+        end
+
+        let(:params) { {external_subscription_id: subscription.external_id, billable_metric_code: metric_a.code, apply_taxes: false} }
+
+        before { charge_a2 }
+
+        it "returns all charges for the metric" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:customer_usage][:charges_usage].count).to eq(2)
+          expect(json[:customer_usage][:charges_usage].map { |c| c[:billable_metric][:code] }).to all(eq(metric_a.code))
+
+          amounts = json[:customer_usage][:charges_usage].map { |c| c[:amount_cents] }.sort
+          expect(amounts).to eq([7_000, 14_000])
+        end
+      end
+
+      context "when billable_metric_code does not match any charge" do
+        let(:params) { {external_subscription_id: subscription.external_id, billable_metric_code: "nonexistent_metric"} }
+
+        it "returns not found" do
+          subject
+
+          expect(response).to be_not_found_error("charge")
+        end
+      end
+
+      context "when billable_metric_code belongs to another organization" do
+        let(:other_metric) { create(:billable_metric) }
+        let(:params) { {external_subscription_id: subscription.external_id, billable_metric_code: other_metric.code} }
+
+        it "returns not found" do
+          subject
+
+          expect(response).to be_not_found_error("charge")
+        end
+      end
+
+      context "when full_usage is true with charge_code" do
+        let(:params) do
+          {
+            external_subscription_id: subscription.external_id,
+            charge_code: charge_a.code,
+            full_usage: true,
+            apply_taxes: false
+          }
+        end
+
+        it "returns method not allowed without premium integration" do
+          subject
+
+          expect(response).to have_http_status(:method_not_allowed)
+          expect(json[:code]).to eq("full_usage_not_allowed")
+        end
+
+        context "with granular_lifetime_usage premium integration", :premium do
+          before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+
+          it "returns usage aggregated from subscription start" do
+            subject
+
+            expect(response).to have_http_status(:success)
+            expect(json[:customer_usage][:charges_usage].count).to eq(1)
+
+            charge_usage = json[:customer_usage][:charges_usage].first
+            expect(charge_usage[:billable_metric][:code]).to eq(metric_a.code)
+            expect(charge_usage[:units]).to eq("26.0")
+            expect(charge_usage[:amount_cents]).to eq(26_000)
+          end
+        end
+      end
+
+      context "when full_usage is true with billable_metric_code" do
+        let(:params) do
+          {
+            external_subscription_id: subscription.external_id,
+            billable_metric_code: metric_a.code,
+            full_usage: true,
+            apply_taxes: false
+          }
+        end
+
+        it "returns method not allowed without premium integration" do
+          subject
+
+          expect(response).to have_http_status(:method_not_allowed)
+          expect(json[:code]).to eq("full_usage_not_allowed")
+        end
+
+        context "with granular_lifetime_usage premium integration", :premium do
+          before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+
+          it "returns usage aggregated from subscription start" do
+            subject
+
+            expect(response).to have_http_status(:success)
+            expect(json[:customer_usage][:charges_usage].count).to eq(1)
+
+            charge_usage = json[:customer_usage][:charges_usage].first
+            expect(charge_usage[:billable_metric][:code]).to eq(metric_a.code)
+            expect(charge_usage[:units]).to eq("26.0")
+            expect(charge_usage[:amount_cents]).to eq(26_000)
+          end
+        end
+      end
+
+      context "when group is provided" do
+        let(:params) do
+          {
+            external_subscription_id: subscription.external_id,
+            group: {cloud: "aws"},
+            apply_taxes: false
+          }
+        end
+
+        it "returns only usage matching the group filter for current period" do
+          subject
+
+          expect(response).to have_http_status(:success)
+
+          charge_usage = json[:customer_usage][:charges_usage].find { |c| c[:billable_metric][:code] == metric_a.code }
+          expect(charge_usage[:units]).to eq("8.0")
+          expect(charge_usage[:amount_cents]).to eq(8_000)
+        end
+      end
+
+      context "when group is provided with full_usage" do
+        let(:params) do
+          {
+            external_subscription_id: subscription.external_id,
+            group: {cloud: "aws"},
+            full_usage: true,
+            apply_taxes: false
+          }
+        end
+
+        it "returns method not allowed without premium integration" do
+          subject
+
+          expect(response).to have_http_status(:method_not_allowed)
+          expect(json[:code]).to eq("full_usage_not_allowed")
+        end
+
+        context "with granular_lifetime_usage premium integration", :premium do
+          before { organization.update!(premium_integrations: %w[granular_lifetime_usage]) }
+
+          it "returns group-filtered usage aggregated from subscription start" do
+            subject
+
+            expect(response).to have_http_status(:success)
+
+            charge_usage = json[:customer_usage][:charges_usage].find { |c| c[:billable_metric][:code] == metric_a.code }
+            expect(charge_usage[:units]).to eq("13.0")
+            expect(charge_usage[:amount_cents]).to eq(13_000)
+          end
+        end
+      end
     end
 
     context "with filters" do


### PR DESCRIPTION
## Context

We have different param naming convention in the `current_usage` endpoint. Some have the prefix `filter_by_`, not reflecting the pattern on the rest of the API. Add support for conventional ones, and mark the prefixed ones as deprecated.

## Description

Introduce unprefixed aliases for the `filter_by_*` query parameters on the `GET /customers/:customer_id/current_usage` endpoint (`charge_id, charge_code, billable_metric_code, group`), consistent with the naming convention used across the rest of the API.

The old `filter_by_*` names remain supported for backward compatibility.
