### PR TITLE
ING-32 perf(events): Add index on (organization_id, transaction_id)

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -85,11 +85,12 @@ end
 #
 # Indexes
 #
-#  idx_events_billing_lookup                       (external_subscription_id,organization_id,code,timestamp) WHERE (deleted_at IS NULL)
-#  idx_events_for_distinct_codes                   (external_subscription_id,organization_id,timestamp) WHERE (deleted_at IS NULL)
-#  index_events_on_created_at                      (created_at) WHERE (deleted_at IS NULL)
-#  index_events_on_organization_id                 (organization_id)
-#  index_events_on_organization_id_and_code        (organization_id,code)
-#  index_events_on_organization_id_and_created_at  (organization_id,created_at DESC) WHERE (deleted_at IS NULL)
-#  index_unique_transaction_id                     (organization_id,external_subscription_id,transaction_id) UNIQUE
+#  idx_events_billing_lookup                           (external_subscription_id,organization_id,code,timestamp) WHERE (deleted_at IS NULL)
+#  idx_events_for_distinct_codes                       (external_subscription_id,organization_id,timestamp) WHERE (deleted_at IS NULL)
+#  index_events_on_created_at                          (created_at) WHERE (deleted_at IS NULL)
+#  index_events_on_organization_id                     (organization_id)
+#  index_events_on_organization_id_and_code            (organization_id,code)
+#  index_events_on_organization_id_and_created_at      (organization_id,created_at DESC) WHERE (deleted_at IS NULL)
+#  index_events_on_organization_id_and_transaction_id  (organization_id,transaction_id) WHERE (deleted_at IS NULL)
+#  index_unique_transaction_id                         (organization_id,external_subscription_id,transaction_id) UNIQUE
 #

--- a/db/migrate/20260504134804_add_events_organization_transaction_id_index.rb
+++ b/db/migrate/20260504134804_add_events_organization_transaction_id_index.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddEventsOrganizationTransactionIdIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :events,
+      [:organization_id, :transaction_id],
+      where: "deleted_at IS NULL",
+      name: "index_events_on_organization_id_and_transaction_id",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -587,6 +587,7 @@ DROP INDEX IF EXISTS public.index_fees_on_charge_filter_id;
 DROP INDEX IF EXISTS public.index_fees_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_fees_on_applied_add_on_id;
 DROP INDEX IF EXISTS public.index_fees_on_add_on_id;
+DROP INDEX IF EXISTS public.index_events_on_organization_id_and_transaction_id;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_created_at;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_events_on_organization_id;
@@ -7612,6 +7613,13 @@ CREATE INDEX index_events_on_organization_id_and_created_at ON public.events USI
 
 
 --
+-- Name: index_events_on_organization_id_and_transaction_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_on_organization_id_and_transaction_id ON public.events USING btree (organization_id, transaction_id) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: index_fees_on_add_on_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11851,6 +11859,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260504134804'),
 ('20260429133747'),
 ('20260429123434'),
 ('20260424170418'),


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                   
  - Add partial index `(organization_id, transaction_id) WHERE deleted_at IS NULL` on the events table                                                                                                               
  - Fixes `GET /api/v1/events/:id` taking 30+ seconds on Postgres-backed orgs with large event volumes                                                                                                             
  - Same index benefits the GraphQL `event(transactionId:)` resolver which uses the identical query pattern
                                              
  ## Test plan                            
                                                                                                                                                                                                                     
  - [ ] Run migration on staging and verify index creation with `\d events`                                                                                                                                          
  - [ ] EXPLAIN ANALYZE `SELECT * FROM events WHERE organization_id = '<org_id>' AND transaction_id = '<txn_id>' AND deleted_at IS NULL LIMIT 1` confirms index scan instead of sequential/filter scan               
  - [ ] `GET /api/v1/events/:id` responds in < 100ms for large PG-backed orgs