### PR TITLE
[ING-25] fix(daily-usage): create daily usage based on ingested units and not based on zero amount cents

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -260,6 +260,10 @@ class Fee < ApplicationRecord
     charge&.filters&.any?
   end
 
+  def non_zero?
+    units.positive? || amount_cents.positive? || events_count.to_i.positive?
+  end
+
   def date_boundaries
     if charge? && !pay_in_advance? && charge.pay_in_advance?
       timestamp = invoice.invoice_subscription(subscription.id).timestamp

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -19,9 +19,9 @@ module DailyUsages
         return result
       end
 
-      if current_usage.total_amount_cents.positive?
-        current_usage.fees = current_usage.fees.select { |f| f.units.positive? }
+      current_usage.fees = current_usage.fees.select { |f| non_empty_fee?(f) }
 
+      if current_usage.fees.any?
         daily_usage = DailyUsage.new(
           organization: subscription.organization,
           customer: subscription.customer,
@@ -94,6 +94,10 @@ module DailyUsages
 
     def usage_date
       @usage_date ||= date_in_timezone - 1.day
+    end
+
+    def non_empty_fee?(fee)
+      fee.units.positive? || fee.amount_cents.positive? || fee.events_count.to_i.positive?
     end
   end
 end

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -19,7 +19,7 @@ module DailyUsages
         return result
       end
 
-      current_usage.fees = current_usage.fees.select { |f| non_empty_fee?(f) }
+      current_usage.fees = current_usage.fees.select(&:non_zero?)
 
       if current_usage.fees.any?
         daily_usage = DailyUsage.new(
@@ -94,10 +94,6 @@ module DailyUsages
 
     def usage_date
       @usage_date ||= date_in_timezone - 1.day
-    end
-
-    def non_empty_fee?(fee)
-      fee.units.positive? || fee.amount_cents.positive? || fee.events_count.to_i.positive?
     end
   end
 end

--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -40,7 +40,7 @@ module DailyUsages
             previous_daily_usage = nil
           end
 
-          usage.fees = usage.fees.select { |f| non_empty_fee?(f) }
+          usage.fees = usage.fees.select(&:non_zero?)
 
           if usage.fees.any?
             daily_usage = DailyUsage.new(
@@ -104,10 +104,6 @@ module DailyUsages
 
     def timezone
       @timezone ||= subscription.customer.applicable_timezone
-    end
-
-    def non_empty_fee?(fee)
-      fee.units.positive? || fee.amount_cents.positive? || fee.events_count.to_i.positive?
     end
   end
 end

--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -40,9 +40,9 @@ module DailyUsages
             previous_daily_usage = nil
           end
 
-          if usage.total_amount_cents.positive?
-            usage.fees = usage.fees.select { |f| f.units.positive? }
+          usage.fees = usage.fees.select { |f| non_empty_fee?(f) }
 
+          if usage.fees.any?
             daily_usage = DailyUsage.new(
               organization:,
               customer: subscription.customer,
@@ -104,6 +104,10 @@ module DailyUsages
 
     def timezone
       @timezone ||= subscription.customer.applicable_timezone
+    end
+
+    def non_empty_fee?(fee)
+      fee.units.positive? || fee.amount_cents.positive? || fee.events_count.to_i.positive?
     end
   end
 end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -598,6 +598,43 @@ RSpec.describe Fee do
     end
   end
 
+  describe "#non_zero?" do
+    subject { fee.non_zero? }
+
+    let(:fee) { build(:fee, units:, amount_cents:, events_count:) }
+    let(:units) { 0 }
+    let(:amount_cents) { 0 }
+    let(:events_count) { 0 }
+
+    context "when units, amount_cents and events_count are all zero" do
+      it { is_expected.to be false }
+    end
+
+    context "when only units are positive" do
+      let(:units) { 5 }
+
+      it { is_expected.to be true }
+    end
+
+    context "when only amount_cents are positive" do
+      let(:amount_cents) { 100 }
+
+      it { is_expected.to be true }
+    end
+
+    context "when only events_count is positive" do
+      let(:events_count) { 3 }
+
+      it { is_expected.to be true }
+    end
+
+    context "when events_count is nil" do
+      let(:events_count) { nil }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe "#has_charge_filter?" do
     subject(:fee) { create(:add_on_fee) }
 

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe DailyUsages::ComputeService do
         end
       end
 
+      context "when the only consumed charge is free (zero amount)" do
+        let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "0"}) }
+
+        it "creates a daily usage based on consumed units" do
+          travel_to(timestamp) do
+            expect { compute_service.call }.to change(DailyUsage, :count).by(1)
+
+            daily_usage = DailyUsage.order(created_at: :asc).last
+            expect(daily_usage.usage["charges_usage"].count).to eq(1)
+            expect(daily_usage.usage["amount_cents"]).to eq(0)
+          end
+        end
+      end
+
       it "creates a daily usage" do
         travel_to(timestamp) do
           expect { compute_service.call }.to change(DailyUsage, :count).by(1)

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe DailyUsages::ComputeService do
     context "when there is usage" do
       before { event }
 
-      context "when usage contains charges usage with 0 units due to filters" do
-        it "does not include fees with 0 units" do
+      context "when usage contains charges with no consumption due to filters" do
+        it "does not include fees with no consumption" do
           billable_metric_filter = create(:billable_metric_filter, billable_metric:)
           charge_filter = create(:charge_filter, charge:, properties: {amount: "10"})
           create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: [billable_metric_filter.values.first])

--- a/spec/services/daily_usages/fill_history_service_spec.rb
+++ b/spec/services/daily_usages/fill_history_service_spec.rb
@@ -5,6 +5,69 @@ require "rails_helper"
 RSpec.describe DailyUsages::FillHistoryService do
   let(:service) { described_class.new(subscription:, from_date:, to_date:) }
 
+  describe "#call" do
+    subject(:call_service) { service.call }
+
+    let(:organization) { create(:organization) }
+    let(:billing_entity) { create(:billing_entity, organization:) }
+    let(:customer) { create(:customer, organization:, billing_entity:) }
+    let(:plan) { create(:plan, organization:) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:subscription_started_at) { Time.zone.parse("2024-10-01 00:00:00") }
+    let(:subscription) do
+      create(
+        :subscription,
+        :calendar,
+        customer:,
+        plan:,
+        started_at: subscription_started_at,
+        subscription_at: subscription_started_at
+      )
+    end
+    let(:from_date) { Date.parse("2024-10-15") }
+    let(:to_date) { Date.parse("2024-10-15") }
+
+    context "when the only consumed charge is free (zero amount)" do
+      before do
+        create(:standard_charge, plan:, billable_metric:, properties: {amount: "0"})
+        create(
+          :event,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp: Time.zone.parse("2024-10-15 10:00:00"),
+          created_at: Time.zone.parse("2024-10-15 10:00:00")
+        )
+      end
+
+      it "creates a daily usage based on consumed units" do
+        travel_to(Time.zone.parse("2024-10-16 12:00:00")) do
+          expect { call_service }.to change(DailyUsage, :count).by(1)
+
+          daily_usage = DailyUsage.order(created_at: :asc).last
+          expect(daily_usage).to have_attributes(
+            organization_id: organization.id,
+            customer_id: customer.id,
+            subscription_id: subscription.id,
+            usage_date: Date.parse("2024-10-15")
+          )
+          expect(daily_usage.usage["amount_cents"]).to eq(0)
+          expect(daily_usage.usage["charges_usage"].count).to eq(1)
+        end
+      end
+    end
+
+    context "when there is no usage at all" do
+      before { create(:standard_charge, plan:, billable_metric:) }
+
+      it "does not create a daily usage" do
+        travel_to(Time.zone.parse("2024-10-16 12:00:00")) do
+          expect { call_service }.not_to change(DailyUsage, :count)
+        end
+      end
+    end
+  end
+
   describe "#to" do
     subject(:to) { service.to }
 


### PR DESCRIPTION
## Context

Currently, the daily usage record is skipped if the current usage amount is zero. However, we should always generate a daily usage record if any usage has been ingested. The only use case where we don't want a daily usage record is when no usage has been ingested at all.

## Description

This PR handles the case described above.
