### PR TITLE
fix(bullet): Fix Bullet ignoring N+1 in specs

### DIFF
--- a/app/graphql/resolvers/credit_notes_resolver.rb
+++ b/app/graphql/resolvers/credit_notes_resolver.rb
@@ -40,6 +40,7 @@ module Resolvers
       includes = [
         :customer,
         :error_details,
+        :metadata,
         {invoice: :billing_entity},
         items: {
           fee: [

--- a/spec/graphql/resolvers/credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes_resolver_spec.rb
@@ -345,66 +345,74 @@ RSpec.describe Resolvers::CreditNotesResolver do
     end
   end
 
-  it "does not trigger N+1 queries for metadata", bullet: {unused_eager_loading: false} do
-    credit_notes = create_list(:credit_note, 3, customer:)
-    credit_notes.each do |credit_note|
-      create(:item_metadata, owner: credit_note, organization:, value: {"foo" => "bar"})
+  context "with N+1 queries detection on metadata", bullet: {unused_eager_loading: false} do
+    before do
+      credit_notes = create_list(:credit_note, 3, customer:)
+      credit_notes.each do |credit_note|
+        create(:item_metadata, owner: credit_note, organization:, value: {"foo" => "bar"})
+      end
     end
 
-    execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      permissions: required_permission,
-      query: <<~GQL
-        query {
-          creditNotes(limit: 5) {
-            collection {
-              id
-              metadata { key value }
+    it "does not trigger N+1 queries for metadata" do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: <<~GQL
+          query {
+            creditNotes(limit: 5) {
+              collection {
+                id
+                metadata { key value }
+              }
             }
           }
-        }
-      GQL
-    )
+        GQL
+      )
+    end
   end
 
-  it "does not trigger N+1 queries for items and fees", bullet: {unused_eager_loading: false} do
-    subscription = create(:subscription, customer:, organization:)
+  context "with N+1 queries detection on items and fees", bullet: {unused_eager_loading: false} do
+    before do
+      subscription = create(:subscription, customer:, organization:)
 
-    3.times do
-      inv = create(:invoice, customer:, organization:)
-      sub_fee = create(:fee, invoice: inv, subscription:, organization:)
-      charge_fee = create(:charge_fee, invoice: inv, subscription:, organization:)
+      3.times do
+        inv = create(:invoice, customer:, organization:)
+        sub_fee = create(:fee, invoice: inv, subscription:, organization:)
+        charge_fee = create(:charge_fee, invoice: inv, subscription:, organization:)
 
-      cn = create(:credit_note, customer:, invoice: inv, organization:)
-      create(:credit_note_item, credit_note: cn, fee: sub_fee)
-      create(:credit_note_item, credit_note: cn, fee: charge_fee)
-      create(:credit_note_applied_tax, credit_note: cn, organization:)
+        cn = create(:credit_note, customer:, invoice: inv, organization:)
+        create(:credit_note_item, credit_note: cn, fee: sub_fee)
+        create(:credit_note_item, credit_note: cn, fee: charge_fee)
+        create(:credit_note_applied_tax, credit_note: cn, organization:)
+      end
     end
 
-    execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      permissions: required_permission,
-      query: <<~GQL
-        query {
-          creditNotes(limit: 5) {
-            collection {
-              id
-              appliedTaxes { id taxRate }
-              items {
+    it "does not trigger N+1 queries for items and fees" do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: <<~GQL
+          query {
+            creditNotes(limit: 5) {
+              collection {
                 id
-                fee {
+                appliedTaxes { id taxRate }
+                items {
                   id
-                  feeType
-                  subscription { id }
-                  charge { id }
+                  fee {
+                    id
+                    feeType
+                    subscription { id }
+                    charge { id }
+                  }
                 }
               }
             }
           }
-        }
-      GQL
-    )
+        GQL
+      )
+    end
   end
 end

--- a/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Resolvers::Entitlement::FeaturesResolver, :premium do
     expect(result["data"]["features"]["metadata"]["totalCount"]).to eq(2)
   end
 
-  it "does not trigger N+1 queries for privileges", :with_bullet do
+  it "does not trigger N+1 queries for privileges", :bullet do
     features = create_list(:feature, 3, organization:)
     features.each do |feature|
       create(:privilege, feature:)

--- a/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementsResolver, :premiu
     end
   end
 
-  it "does not trigger N+1 queries for privileges", :with_bullet do
+  it "does not trigger N+1 queries for privileges", :bullet do
     features = create_list(:feature, 3, organization:)
     features.each do |feature|
       privilege = create(:privilege, feature:)

--- a/spec/graphql/resolvers/subscriptions/alerts_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions/alerts_resolver_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Resolvers::Subscriptions::AlertsResolver do
   #     GQL
   #   end
   #
-  #   it "eager loads the relationships", with_bullet: true do
+  #   it "eager loads the relationships", :bullet do
   #     create_list(:billable_metric_current_usage_amount_alert, 3, organization:, subscription_external_id: subscription.external_id, thresholds: [10])
   #
   #     Bullet.start_request

--- a/spec/requests/api/v1/applied_coupons_controller_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::AppliedCouponsController, :with_bullet do
+RSpec.describe Api::V1::AppliedCouponsController, :bullet do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
-    context "with N+1 query detection on customer associations", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+    context "with N+1 query detection on customer associations", bullet: {n_plus_one_query: true, unused_eager_loading: false} do
       let(:other_billing_entity) { create(:billing_entity, organization:) }
 
       before do

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -1789,7 +1789,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       end
     end
 
-    context "with N+1 query detection", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+    context "with N+1 query detection", bullet: {n_plus_one_query: true, unused_eager_loading: false} do
       before do
         prev = create(:subscription, customer:, plan: create(:plan, organization:), status: :terminated)
         nxt = create(:subscription, customer:, plan: create(:plan, organization:), status: :pending)

--- a/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
@@ -304,6 +304,10 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService do
           entitlement_value3
         end
 
+        before do
+          allow(SendWebhookJob).to receive(:perform_after_commit)
+        end
+
         it "does not trigger N+1 queries when updating multiple features and privileges" do
           result
 

--- a/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
@@ -302,9 +302,7 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService do
           entitlement3
           entitlement_value2
           entitlement_value3
-        end
 
-        before do
           allow(SendWebhookJob).to receive(:perform_after_commit)
         end
 

--- a/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
@@ -253,6 +253,10 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService do
           entitlement_value3
         end
 
+        before do
+          allow(SendWebhookJob).to receive(:perform_after_commit)
+        end
+
         it "does not trigger N+1 queries when updating multiple features and privileges" do
           result
 

--- a/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
@@ -251,9 +251,7 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService do
           entitlement3
           entitlement_value2
           entitlement_value3
-        end
 
-        before do
           allow(SendWebhookJob).to receive(:perform_after_commit)
         end
 

--- a/spec/services/webhooks/credit_notes/created_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/created_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Webhooks::CreditNotes::CreatedService do
   let(:invoice) { create(:invoice, organization:, customer:) }
   let(:credit_note) { create(:credit_note, :with_metadata, customer:, invoice:) }
 
-  describe ".call", :with_bullet do
+  describe ".call", :bullet do
     it_behaves_like "creates webhook", "credit_note.created", "credit_note", {
       "customer" => Hash,
       "items" => [],

--- a/spec/services/webhooks/credit_notes/generated_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/generated_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Webhooks::CreditNotes::GeneratedService do
   let(:invoice) { create(:invoice, organization:, customer:) }
   let(:credit_note) { create(:credit_note, :with_metadata, customer:, invoice:) }
 
-  describe ".call", :with_bullet do
+  describe ".call", :bullet do
     it_behaves_like "creates webhook", "credit_note.generated", "credit_note", {
       "customer" => Hash,
       "metadata" => {"key" => "value"}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -159,14 +159,6 @@ RSpec.configure do |config|
       end
     end
 
-    if metadata[:with_bullet] || metadata[:bullet]
-      Bullet.enable = true
-      bullet_metadata = example.metadata[:bullet] || {}
-      Bullet.n_plus_one_query_enable = bullet_metadata.fetch(:n_plus_one_query, true)
-      Bullet.unused_eager_loading_enable = bullet_metadata.fetch(:unused_eager_loading, true)
-      Bullet.start_request
-    end
-
     if metadata[:cache]
       Rails.cache = if example.metadata[:cache].to_sym == :memory
         ActiveSupport::Cache.lookup_store(:memory_store)
@@ -178,14 +170,6 @@ RSpec.configure do |config|
         raise "Unknown cache store: #{example.metadata[:cache]}"
       end
     end
-  end
-
-  config.after do |example|
-    if example.metadata[:with_bullet] || example.metadata[:bullet]
-      Bullet.perform_out_of_channel_notifications if Bullet.notification?
-      Bullet.end_request
-    end
-    Bullet.enable = false
   end
 
   config.around do |example|
@@ -214,11 +198,26 @@ RSpec.configure do |config|
     end
   end
 
-  config.around do |example|
-    if example.metadata[:premium]
-      lago_premium!(&example)
-    else
-      example.run
+  config.around(:example, :premium) do |example|
+    lago_premium!(&example)
+  end
+
+  config.around(:example, :bullet) do |example|
+    bullet = example.metadata[:bullet].is_a?(Hash) ? example.metadata[:bullet] : {}
+
+    example.example_group.before do
+      Bullet.enable = true
+      Bullet.n_plus_one_query_enable = bullet.fetch(:n_plus_one_query, true)
+      Bullet.unused_eager_loading_enable = bullet.fetch(:unused_eager_loading, true)
+      Bullet.start_request
     end
+
+    example.example_group.after do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+      Bullet.enable = false
+    end
+
+    example.run
   end
 end

--- a/spec/support/shared_examples/credit_note_index.rb
+++ b/spec/support/shared_examples/credit_note_index.rb
@@ -374,7 +374,7 @@ RSpec.shared_examples "a credit note index endpoint" do
     end
   end
 
-  context "with credit notes containing all associations", :with_bullet do
+  context "with credit notes containing all associations", :bullet do
     before do
       # NOTE: Bullet cannot track ActiveStorage's internal blob access through the attachment proxy
       Bullet.add_safelist(type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :blob)
@@ -445,7 +445,7 @@ RSpec.shared_examples "a credit note index endpoint" do
       end
     end
 
-    it "returns metadata for each credit note", :with_bullet do
+    it "returns metadata for each credit note", :bullet do
       subject
 
       expect(response).to have_http_status(:success)

--- a/spec/support/shared_examples/invoice_index.rb
+++ b/spec/support/shared_examples/invoice_index.rb
@@ -450,7 +450,7 @@ RSpec.shared_examples "an invoice index endpoint" do
     end
   end
 
-  context "with N+1 query detection", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+  context "with N+1 query detection", bullet: {n_plus_one_query: true, unused_eager_loading: false} do
     let(:params) { {} }
     let(:other_billing_entity) { create(:billing_entity, organization:) }
 

--- a/spec/support/shared_examples/subscription_index.rb
+++ b/spec/support/shared_examples/subscription_index.rb
@@ -155,7 +155,7 @@ RSpec.shared_examples "a subscription index endpoint" do
     end
   end
 
-  context "with N+1 query detection", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+  context "with N+1 query detection", bullet: {n_plus_one_query: true, unused_eager_loading: false} do
     before do
       create(:subscription, customer:, plan: create(:plan, organization:))
 

--- a/spec/support/shared_examples/wallet_actions.rb
+++ b/spec/support/shared_examples/wallet_actions.rb
@@ -1184,7 +1184,7 @@ RSpec.shared_examples "a wallet index endpoint" do
     end
   end
 
-  context "with N+1 query detection", :with_bullet, bullet: {n_plus_one_query: true, unused_eager_loading: false} do
+  context "with N+1 query detection", bullet: {n_plus_one_query: true, unused_eager_loading: false} do
     let(:params) { {} }
 
     before do


### PR DESCRIPTION
## Context

Bullet ignores anything created after `Bullet.start_request` and flags it as "impossible." Because we register the Bullet hook at the config level and due to how RSpec orders hooks, it ends up at the very top.

Basically, anything created inside examples gets skipped, which makes the current Bullet tests kinda useless – they're not actually testing what they're supposed to:

```ruby
Config.before -> bullet
# Everything created after this gets ignored by Bullet
Parent.before
Example.before
```

For referrence: https://github.com/flyerhzm/bullet/issues/427

## Description

This PR moves the Bullet hook further down the chain, so it's registered at the example group level. That way, Bullet can actually see everything:

```ruby
Config.before
Parent.before
Example.before -> bullet
```

Also merged `:with_bullet` and `:bullet` into just `:bullet` to keep things simpler.

## Requests vs Resolvers specs

All the request specs with Bullet work as expected and raise an error if we remove associations from `includes`. But all the other specs using Bullet – like graphql resolvers or services – don't actually check anything and never raise errors.

### Requests specs
 Request specs are integration tests, so they go through the full Rails stack, including routing and middleware. That means they also go through the Bullet rack middleware, which turns Bullet on and properly tracks "possible" and "impossible" associations. If it detects an N+1 query, it raises an error directly in the controller before the execution even gets back to the spec, so all the `expect`s are skipped. 

This also means that Bullet settings configured on the RSpec level don't actually affect request specs.

You can see in the callstack for `invoices_request` specs that the error is raised on the Rails level:
```
...
# /usr/local/bundle/gems/bullet-8.1.0/lib/bullet.rb:210:in 'Bullet.perform_out_of_channel_notifications'
# /usr/local/bundle/gems/bullet-8.1.0/lib/bullet/rack.rb:45:in 'Bullet::Rack#call'
...
-> Here we start going through the rails stack
# ./spec/support/api_helper.rb:6:in 'ApiHelper#get_with_token'
# ./spec/requests/api/v1/invoices_controller_spec.rb:357:in 'block (4 levels) in <top (required)>'
```

### Resolvers & other specs

Resolver specs are more like unit tests and don't go through the Rails stack, so here the Bullet settings from `spec_helper` do take effect and all the things described in the PR happen. 

If Bullet is configured properly to catch N+1s in specs, you can see in the callstack that the error is raised from the Bullet after hook, while all the `expect`s in the test still run as normal:

```
...
# /usr/local/bundle/gems/bullet-8.1.0/lib/bullet.rb:210:in 'Bullet.perform_out_of_channel_notifications'
-> Here is where the bullet hooks are defined 
# ./spec/spec_helper.rb:216:in 'block (3 levels) in <top (required)>'
# ./spec/spec_helper.rb:221:in 'block (2 levels) in <top (required)>'
# ./spec/spec_helper.rb:197:in 'block (3 levels) in <top (required)>'
```

