### PR TITLE
[ING-39] feat(multi-billing-entity): allow editing customer billing entity

### DIFF
--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -97,7 +97,7 @@ module Customers
       #       external_id,
       #       account_type,
       #       billing_entity_id (gated by editable? unless multi_entity_billing flag is enabled)
-      if args.key?(:billing_entity_code) && (organization.feature_flag_enabled?(:multi_entity_billing) || customer.editable?)
+      if args.key?(:billing_entity_code) && allow_billing_entity_update?
         customer.billing_entity = billing_entity
       end
 
@@ -214,6 +214,10 @@ module Customers
       return true if metadata.count <= ::Metadata::CustomerMetadata::COUNT_PER_CUSTOMER
 
       false
+    end
+
+    def allow_billing_entity_update?
+      organization.feature_flag_enabled?(:multi_entity_billing) || customer.editable?
     end
 
     def assign_premium_attributes(customer, args)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -96,10 +96,13 @@ module Customers
       # NOTE: Some fields are not editable if customer is attached to subscriptions:
       #       external_id,
       #       account_type,
-      #       billing_entity_id
+      #       billing_entity_id (gated by editable? unless multi_entity_billing flag is enabled)
+      if args.key?(:billing_entity_code) && (organization.feature_flag_enabled?(:multi_entity_billing) || customer.editable?)
+        customer.billing_entity = billing_entity
+      end
+
       if customer.editable?
         customer.external_id = args[:external_id] if args.key?(:external_id)
-        customer.billing_entity = billing_entity if args.key?(:billing_entity_code)
 
         if organization.revenue_share_enabled?
           customer.account_type = args[:account_type] if args.key?(:account_type)

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -46,7 +46,9 @@ module Customers
       ActiveRecord::Base.transaction do
         original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
 
-        customer.billing_entity = billing_entity if new_customer || (customer.editable? && params.key?(:billing_entity_code))
+        if new_customer || (params.key?(:billing_entity_code) && (organization.feature_flag_enabled?(:multi_entity_billing) || customer.editable?))
+          customer.billing_entity = billing_entity
+        end
         customer.name = params[:name] if params.key?(:name)
         customer.country = params[:country]&.upcase if params.key?(:country)
         customer.address_line1 = params[:address_line1] if params.key?(:address_line1)

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -46,7 +46,7 @@ module Customers
       ActiveRecord::Base.transaction do
         original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
 
-        if new_customer || (params.key?(:billing_entity_code) && (organization.feature_flag_enabled?(:multi_entity_billing) || customer.editable?))
+        if new_customer || (params.key?(:billing_entity_code) && allow_billing_entity_update?(customer))
           customer.billing_entity = billing_entity
         end
         customer.name = params[:name] if params.key?(:name)
@@ -177,6 +177,10 @@ module Customers
       input_types = integration_customers&.map { |c| c.to_h.deep_symbolize_keys }&.map { |c| c[:integration_type] }
 
       input_types.length == input_types.uniq.length
+    end
+
+    def allow_billing_entity_update?(customer)
+      organization.feature_flag_enabled?(:multi_entity_billing) || customer.editable?
     end
 
     def create_metadata(customer:, args:)

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -122,6 +122,16 @@ RSpec.describe Customers::UpdateService do
           expect(result).to be_success
           expect(result.customer.billing_entity).to eq(billing_entity)
         end
+
+        context "when multi_entity_billing feature flag is enabled" do
+          before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+          it "updates the billing entity" do
+            result = customers_service.call
+            expect(result).to be_success
+            expect(result.customer.billing_entity).to eq(billing_entity_2)
+          end
+        end
       end
     end
 

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -285,6 +285,16 @@ RSpec.describe Customers::UpsertFromApiService do
         expect(result.customer).to eq(customer)
         expect(result.customer.billing_entity).to eq(billing_entity_2)
       end
+
+      context "when multi_entity_billing feature flag is enabled" do
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "updates the billing_entity of the customer" do
+          expect(result).to be_success
+          expect(result.customer).to eq(customer)
+          expect(result.customer.billing_entity).to eq(billing_entity)
+        end
+      end
     end
 
     context "when not sending billing_entity_code" do


### PR DESCRIPTION
## Context

Currently, a customer can be associated with only one billing entity.

## Description

The `multiple billing entity` feature allows customers to be associated with billing objects that belong to different billing entities.

This PR relaxes the rule for updating the billing entity on a customer. The billing entity on the customer is the default value, which can be overridden on a specific billing object such as a subscription or wallet. However, the goal is to allow users to edit this data at any time, which could potentially affect any future invoices.