### PR TITLE
feat(payment-gated-subs): activate gated subs on zero-amount invoice

### DIFF
--- a/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
+++ b/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
@@ -47,6 +47,8 @@ module Invoices
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
         Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
+        skip_payment_gating_for_zero_amount if subscription.gated? && invoice.total_amount_cents.zero?
+
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         Invoices::TransitionToFinalStatusService.call(invoice:)
         invoice.save!
@@ -84,6 +86,14 @@ module Invoices
 
     attr_reader :subscription, :timestamp, :customer, :organization
     attr_accessor :invoice
+
+    def skip_payment_gating_for_zero_amount
+      Subscriptions::ActivationRules::Payment::EvaluateService.call!(
+        rule: subscription.activation_rules.payment.sole,
+        status: :satisfied
+      )
+      Subscriptions::ActivationRules::ResolveSubscriptionStatusService.call!(subscription:)
+    end
 
     def fixed_charge_events
       @fixed_charge_events ||= subscription

--- a/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
+++ b/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
@@ -47,7 +47,7 @@ module Invoices
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
         Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
-        skip_payment_gating_for_zero_amount if subscription.gated? && invoice.total_amount_cents.zero?
+        skip_payment_gating_for_zero_amount if subscription.payment_gated? && invoice.total_amount_cents.zero?
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         Invoices::TransitionToFinalStatusService.call(invoice:)

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -36,6 +36,8 @@ module Invoices
         )
         Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
+        skip_payment_gating_for_zero_amount if subscription_gated? && invoice.total_amount_cents.zero?
+
         set_invoice_generated_status unless invoice.pending?
         invoice.save!
 
@@ -120,7 +122,16 @@ module Invoices
     end
 
     def subscription_gated?
-      @subscription_gated ||= subscriptions.any?(&:gated?)
+      subscriptions.any?(&:gated?)
+    end
+
+    def skip_payment_gating_for_zero_amount
+      gated = subscriptions.find(&:gated?)
+      Subscriptions::ActivationRules::Payment::EvaluateService.call!(
+        rule: gated.activation_rules.payment.sole,
+        status: :satisfied
+      )
+      Subscriptions::ActivationRules::ResolveSubscriptionStatusService.call!(subscription: gated)
     end
 
     def create_generating_invoice

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -36,7 +36,7 @@ module Invoices
         )
         Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
-        skip_payment_gating_for_zero_amount if subscription_gated? && invoice.total_amount_cents.zero?
+        skip_payment_gating_for_zero_amount if subscription_payment_gated? && invoice.total_amount_cents.zero?
 
         set_invoice_generated_status unless invoice.pending?
         invoice.save!
@@ -125,8 +125,12 @@ module Invoices
       subscriptions.any?(&:gated?)
     end
 
+    def subscription_payment_gated?
+      subscriptions.any?(&:payment_gated?)
+    end
+
     def skip_payment_gating_for_zero_amount
-      gated = subscriptions.find(&:gated?)
+      gated = subscriptions.find(&:payment_gated?)
       Subscriptions::ActivationRules::Payment::EvaluateService.call!(
         rule: gated.activation_rules.payment.sole,
         status: :satisfied

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -176,6 +176,26 @@ describe "Payment Gated Subscription Activation Scenarios" do
     end
   end
 
+  describe "zero-amount gated invoice (no charge to collect)" do
+    let(:plan) do
+      create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 0)
+    end
+
+    it "marks the rule satisfied and activates without going through the payment chain" do
+      create_subscription(subscription_params)
+      perform_all_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_active
+      expect(subscription.activation_rules.sole).to be_satisfied
+
+      invoice = subscription.invoices.sole
+      expect(invoice).to be_finalized
+      expect(invoice.total_amount_cents).to eq(0)
+      expect(invoice.payment_status).to eq("succeeded")
+    end
+  end
+
   describe "pay-in-arrears plan with pay-in-advance fixed charges" do
     let(:plan) do
       create(:plan, organization:, interval: "monthly", pay_in_advance: false, amount_cents: 1000)

--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -696,6 +696,26 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
 
         expect(Invoices::Payments::CreateService).to have_received(:call_async)
       end
+
+      context "when invoice total is zero" do
+        let(:fixed_charge_event) do
+          create(:fixed_charge_event, subscription:, fixed_charge:, units: 0,
+            timestamp: Time.zone.at(timestamp))
+        end
+        let(:rule) { subscription.activation_rules.payment.sole }
+
+        it "marks the payment activation rule as satisfied" do
+          invoice_service.call
+
+          expect(rule.reload).to be_satisfied
+        end
+
+        it "activates the subscription" do
+          invoice_service.call
+
+          expect(subscription.reload).to be_active
+        end
+      end
     end
   end
 end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -613,6 +613,23 @@ RSpec.describe Invoices::SubscriptionService do
 
         expect(Invoices::Payments::CreateService).to have_received(:call_async)
       end
+
+      context "when invoice total is zero" do
+        let(:plan) { create(:plan, interval: "monthly", pay_in_advance: true, amount_cents: 0) }
+        let(:rule) { subscription.activation_rules.payment.sole }
+
+        it "marks the payment activation rule as satisfied" do
+          invoice_service.call
+
+          expect(rule.reload).to be_satisfied
+        end
+
+        it "activates the subscription" do
+          invoice_service.call
+
+          expect(subscription.reload).to be_active
+        end
+      end
     end
 
     context "when an error occurs" do


### PR DESCRIPTION
 ## Context

When a payment-gated subscription's invoice ends up with zero total_amount_cents (e.g. a 100% coupon, or a zero-priced plan), the payment activation rule cannot be resolved by collecting payment — there is nothing to charge. Without a shortcut, the subscription stays incomplete indefinitely because no payment webhook ever arrives.

 ## Description

Add a shortcut in Invoices::SubscriptionService and Invoices::CreatePayInAdvanceFixedChargesService that runs after fees are calculated. When the invoice is gated and totals to zero, mark the payment rule as satisfied via Payment::EvaluateService and delegate to ResolveSubscriptionStatusService, which activates the subscription through the standard ActivateService.activate_from_incomplete branch. After this, the subscription is no longer gated and the invoice proceeds through the regular non-gated zero-amount finalization, fires the standard side effects, and the no-op Payments::CreateService.call_async that already short-circuits for zero-amount invoices.

Drop the memoization on subscription_gated? in SubscriptionService so the predicate reflects the post-shortcut state when re-evaluated later in the call.

Add scenario coverage for end-to-end activation without any Stripe interaction, plus service-level tests asserting the rule satisfies and the subscription activates.