### PR TITLE
fix(wallets): Refresh ongoing balances on lifecycle changes

### DIFF
--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -83,6 +83,8 @@ module Wallets
         end
 
         create_metadata(wallet, params[:metadata]) if !params[:metadata].nil?
+
+        customer.flag_wallets_for_refresh
       end
 
       result.wallet = wallet
@@ -90,8 +92,6 @@ module Wallets
       SendWebhookJob.perform_after_commit("wallet.created", wallet)
 
       schedule_top_up(wallet)
-
-      customer.flag_wallets_for_refresh
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -91,6 +91,8 @@ module Wallets
 
       schedule_top_up(wallet)
 
+      customer.flag_wallets_for_refresh
+
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/wallets/terminate_service.rb
+++ b/app/services/wallets/terminate_service.rb
@@ -19,6 +19,8 @@ module Wallets
           end
           SendWebhookJob.perform_later("wallet.terminated", wallet)
         end
+
+        wallet.customer.flag_wallets_for_refresh
       end
 
       result.wallet = wallet

--- a/app/services/wallets/terminate_service.rb
+++ b/app/services/wallets/terminate_service.rb
@@ -17,10 +17,9 @@ module Wallets
           wallet.recurring_transaction_rules.find_each do |recurring_transaction_rule|
             Wallets::RecurringTransactionRules::TerminateService.call(recurring_transaction_rule: recurring_transaction_rule)
           end
-          SendWebhookJob.perform_later("wallet.terminated", wallet)
+          wallet.customer.flag_wallets_for_refresh
+          SendWebhookJob.perform_after_commit("wallet.terminated", wallet)
         end
-
-        wallet.customer.flag_wallets_for_refresh
       end
 
       result.wallet = wallet

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe Wallets::CreateService do
       expect(Utils::ActivityLog).to have_produced("wallet.created").after_commit.with(wallet)
     end
 
+    it "flags the customer for ongoing balance refresh" do
+      expect { service_result }.to change { customer.reload.awaiting_wallet_refresh }.from(false).to(true)
+    end
+
     it "enqueues the WalletTransaction::CreateJob" do
       expect { service_result }.to have_enqueued_job_after_commit(WalletTransactions::CreateJob).with({
         organization_id: organization.id,

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -28,6 +28,21 @@ RSpec.describe Wallets::TerminateService do
       expect { terminate_service.call }.to have_enqueued_job(SendWebhookJob).with("wallet.terminated", Wallet)
     end
 
+    context "when the customer has another active wallet" do
+      before { create(:wallet, customer:, organization:) }
+
+      it "flags the customer for ongoing balance refresh" do
+        expect { terminate_service.call }.to change { customer.reload.awaiting_wallet_refresh }.from(false).to(true)
+      end
+    end
+
+    context "when terminating the customer's last active wallet" do
+      it "does not raise and leaves the flag untouched" do
+        expect { terminate_service.call }.not_to change { customer.reload.awaiting_wallet_refresh }
+        expect(customer.reload.awaiting_wallet_refresh).to be(false)
+      end
+    end
+
     context "when wallet has recurring transaction rules" do
       let(:recurring_transaction_rule) { create(:recurring_transaction_rule, wallet:) }
       let(:another_rule) { create(:recurring_transaction_rule, wallet:) }
@@ -61,6 +76,10 @@ RSpec.describe Wallets::TerminateService do
 
       it "does not send the `wallet.terminated` webhook" do
         expect { terminate_service.call }.not_to have_enqueued_job(SendWebhookJob)
+      end
+
+      it "does not flag the customer for ongoing balance refresh" do
+        expect { terminate_service.call }.not_to change { customer.reload.awaiting_wallet_refresh }
       end
     end
   end

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Wallets::TerminateService do
     end
 
     it "sends a `wallet.terminated` webhook" do
-      expect { terminate_service.call }.to have_enqueued_job(SendWebhookJob).with("wallet.terminated", Wallet)
+      expect { terminate_service.call }.to have_enqueued_job_after_commit(SendWebhookJob).with("wallet.terminated", Wallet)
     end
 
     context "when the customer has another active wallet" do


### PR DESCRIPTION
## Context

Customers reported that newly-created wallets showed an ongoing usage balance of zero even when the subscription had accumulated usage. Manually topping up the wallet "unstuck" it. Topping up doesn't fix the math: it just happens to trigger the same refresh path the customer was waiting on.

The root cause is a missing trigger. `Customer#flag_wallets_for_refresh` sets `awaiting_wallet_refresh = true`, and `Clock::RefreshWalletsOngoingBalanceJob` only picks up customers where that flag is true. The flag is currently set from four places: usage event ingestion, subscription flagging, draft invoice refresh, and grace-period invoice generation. None of them fire on wallet lifecycle changes.

So in two scenarios the clock job silently skips the customer:

- **Create flow:** a new wallet on a customer with no recent events sits at zero ongoing balance until the next event arrives. Worst case, that's never if the customer is between billing cycles.
- **Terminate flow:** when one wallet is terminated, any other active wallets should recompute their ongoing balance, since the terminated wallet may have been allocating usage. Without a flag, the customer is skipped entirely.

The customer in the support thread hit both: the trial wallet auto-expired, the primary wallet was created at zero, and the ongoing balance never updated until they manually added credits.

## Description

Two surgical edits, plus tests. No new abstractions.

`Wallets::CreateService` now calls `customer.flag_wallets_for_refresh` after the wallet has been saved and committed. The call sits after `schedule_top_up`, so even zero-credit wallets (which don't enqueue a top-up job) still flag the customer.

`Wallets::TerminateService` now calls `wallet.customer.flag_wallets_for_refresh` after the transaction block, but only inside the `unless wallet.terminated?` branch. That keeps idempotent re-calls of the service from pointlessly re-flagging the customer. The existing `wallets.active.exists?` guard inside `flag_wallets_for_refresh` naturally handles the "terminated the customer's last active wallet" case as a no-op: there's nothing to refresh, so no flag.

To prove the tests pin down the actual bug rather than just covering existing behavior, the new specs were run against the unfixed code. The two positive-case tests fail without the fix and pass with it; the two negative-case tests are regression guards.

| Test | Old code (no fix) | New code (with fix) |
|------|-------------------|---------------------|
| `CreateService#call flags the customer for ongoing balance refresh` | FAIL: flag stays `false` | PASS |
| `TerminateService#call when the customer has another active wallet flags the customer for ongoing balance refresh` | FAIL: flag stays `false` | PASS |
| `TerminateService#call when terminating the customer's last active wallet does not raise and leaves the flag untouched` | pass (regression guard) | PASS |
| `TerminateService#call when wallet is already terminated does not flag the customer for ongoing balance refresh` | pass (regression guard) | PASS |

## How to try locally

Run the targeted specs:

```
lago exec api bundle exec rspec spec/services/wallets/create_service_spec.rb spec/services/wallets/terminate_service_spec.rb
```

Manual end-to-end repro of the original bug, before vs. after this PR:

1. Create a trial wallet on a customer with a usage-based subscription. Grant it 5000 credits.
2. Send some usage events. Wait, then check the trial wallet's ongoing balance: it decreases as expected.
3. Terminate the trial wallet from the UI.
4. Create a second wallet with zero initial credits.
5. Without this PR: the second wallet's ongoing usage balance shows 0 indefinitely. With this PR: the customer is flagged on the second wallet's creation; the next `Clock::RefreshWalletsOngoingBalanceJob` tick (or `Clock::RefreshWalletsOngoingBalanceJob.new.perform` from `rails console`) recomputes the correct ongoing balance.

Optional sanity check: `git grep -n flag_wallets_for_refresh app spec` should now show six production callers (four pre-existing plus the two added here).