### PR TITLE
feat(payment-gated-subs): add Stripe payment cancel service

### DIFF
--- a/app/services/payment_providers/stripe/payments/cancel_service.rb
+++ b/app/services/payment_providers/stripe/payments/cancel_service.rb
@@ -4,7 +4,7 @@ module PaymentProviders
   module Stripe
     module Payments
       class CancelService < BaseService
-        Result = BaseResult
+        Result = BaseResult[:payment]
 
         def initialize(payment:)
           @payment = payment
@@ -12,18 +12,24 @@ module PaymentProviders
         end
 
         def call
-          ::Stripe::PaymentIntent.cancel(
+          stripe_result = ::Stripe::PaymentIntent.cancel(
             payment.provider_payment_id,
             {cancellation_reason: :abandoned},
             {api_key: payment.payment_provider.secret_key}
           )
 
+          payment.status = stripe_result.status
+          payment.payable_payment_status = payment.payment_provider.determine_payment_status(payment.status)
+          payment.save!
+
+          result.payment = payment
           result
         rescue ::Stripe::InvalidRequestError => e
           # Best-effort cancel: the payment intent has advanced to a non-cancelable
           # state (succeeded, processing, already canceled, etc.). Log and treat as
           # a successful no-op — the caller (timeout/expiration flow) should not
-          # block on PSP-side cleanup.
+          # block on PSP-side cleanup. The Payment record is left untouched; the
+          # webhook for the prior state transition will land its true state.
           Rails.logger.info("Stripe payment intent not cancelable for payment #{payment.id}: #{e.message}")
           result
         end

--- a/app/services/payment_providers/stripe/payments/cancel_service.rb
+++ b/app/services/payment_providers/stripe/payments/cancel_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    module Payments
+      class CancelService < BaseService
+        Result = BaseResult
+
+        def initialize(payment:)
+          @payment = payment
+          super
+        end
+
+        def call
+          ::Stripe::PaymentIntent.cancel(
+            payment.provider_payment_id,
+            {cancellation_reason: :abandoned},
+            {api_key: payment.payment_provider.secret_key}
+          )
+
+          result
+        rescue ::Stripe::InvalidRequestError => e
+          # Best-effort cancel: the payment intent has advanced to a non-cancelable
+          # state (succeeded, processing, already canceled, etc.). Log and treat as
+          # a successful no-op — the caller (timeout/expiration flow) should not
+          # block on PSP-side cleanup.
+          Rails.logger.info("Stripe payment intent not cancelable for payment #{payment.id}: #{e.message}")
+          result
+        end
+
+        private
+
+        attr_reader :payment
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/payments/cancel_service.rb
+++ b/app/services/payment_providers/stripe/payments/cancel_service.rb
@@ -25,11 +25,18 @@ module PaymentProviders
           result.payment = payment
           result
         rescue ::Stripe::InvalidRequestError => e
-          # Best-effort cancel: the payment intent has advanced to a non-cancelable
-          # state (succeeded, processing, already canceled, etc.). Log and treat as
-          # a successful no-op — the caller (timeout/expiration flow) should not
-          # block on PSP-side cleanup. The Payment record is left untouched; the
-          # webhook for the prior state transition will land its true state.
+          # Best-effort cancel only for the "intent in a non-cancelable state"
+          # case (succeeded, processing, already canceled, etc.). Log and treat
+          # as a successful no-op — the caller (timeout/expiration flow) should
+          # not block on PSP-side cleanup. The Payment record is left
+          # untouched; the webhook for the prior state transition will land its
+          # true state.
+          #
+          # Other InvalidRequestError codes (bad params, missing resource,
+          # idempotency conflicts, etc.) propagate so the caller can retry or
+          # surface the failure.
+          raise unless e.code == "payment_intent_unexpected_state"
+
           Rails.logger.info("Stripe payment intent not cancelable for payment #{payment.id}: #{e.message}")
           result
         end

--- a/spec/services/payment_providers/stripe/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/cancel_service_spec.rb
@@ -63,7 +63,11 @@ RSpec.describe PaymentProviders::Stripe::Payments::CancelService do
       stub_request(:post, "https://api.stripe.com/v1/payment_intents/pi_test_123/cancel")
         .to_return(
           status: 400,
-          body: {error: {type: "invalid_request_error", message: "You cannot cancel this PaymentIntent because it has a status of succeeded."}}.to_json
+          body: {error: {
+            type: "invalid_request_error",
+            code: "payment_intent_unexpected_state",
+            message: "You cannot cancel this PaymentIntent because it has a status of succeeded."
+          }}.to_json
         )
     end
 
@@ -81,6 +85,24 @@ RSpec.describe PaymentProviders::Stripe::Payments::CancelService do
 
     it "does not mutate the payment record" do
       expect { result }.not_to change { payment.reload.attributes }
+    end
+  end
+
+  context "when Stripe returns an InvalidRequestError with a different code" do
+    before do
+      stub_request(:post, "https://api.stripe.com/v1/payment_intents/pi_test_123/cancel")
+        .to_return(
+          status: 400,
+          body: {error: {
+            type: "invalid_request_error",
+            code: "parameter_invalid_empty",
+            message: "Missing required param: amount."
+          }}.to_json
+        )
+    end
+
+    it "propagates the error so the caller can retry or surface the failure" do
+      expect { result }.to raise_error(::Stripe::InvalidRequestError)
     end
   end
 

--- a/spec/services/payment_providers/stripe/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/cancel_service_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Stripe::Payments::CancelService do
+  subject(:result) { described_class.call(payment:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:payment_provider) { create(:stripe_provider, organization:, secret_key: "sk_test_123") }
+  let(:payment) do
+    create(:payment, payable: invoice, payment_provider:, organization:, customer:,
+      provider_payment_id: "pi_test_123", payable_payment_status: :pending)
+  end
+
+  context "when the payment intent is cancelable" do
+    before do
+      stub_request(:post, "https://api.stripe.com/v1/payment_intents/pi_test_123/cancel")
+        .to_return(status: 200, body: {id: "pi_test_123", status: "canceled"}.to_json)
+    end
+
+    it "calls the Stripe cancel endpoint" do
+      result
+
+      expect(WebMock).to have_requested(:post, "https://api.stripe.com/v1/payment_intents/pi_test_123/cancel")
+    end
+
+    it "uses the provider's secret key" do
+      result
+
+      expect(WebMock).to have_requested(:post, "https://api.stripe.com/v1/payment_intents/pi_test_123/cancel")
+        .with(headers: {"Authorization" => "Bearer sk_test_123"})
+    end
+
+    it "passes cancellation_reason: abandoned" do
+      result
+
+      expect(WebMock).to have_requested(:post, "https://api.stripe.com/v1/payment_intents/pi_test_123/cancel")
+        .with(body: hash_including("cancellation_reason" => "abandoned"))
+    end
+
+    it "returns a successful result" do
+      expect(result).to be_success
+    end
+  end
+
+  context "when the payment intent is no longer cancelable" do
+    before do
+      stub_request(:post, "https://api.stripe.com/v1/payment_intents/pi_test_123/cancel")
+        .to_return(
+          status: 400,
+          body: {error: {type: "invalid_request_error", message: "You cannot cancel this PaymentIntent because it has a status of succeeded."}}.to_json
+        )
+    end
+
+    it "returns a successful result without raising" do
+      expect(result).to be_success
+    end
+
+    it "logs the non-cancelable state" do
+      allow(Rails.logger).to receive(:info)
+
+      result
+
+      expect(Rails.logger).to have_received(:info).with(a_string_matching(/Stripe.*not cancelable.*succeeded/))
+    end
+  end
+
+  context "when Stripe returns a different error" do
+    before do
+      stub_request(:post, "https://api.stripe.com/v1/payment_intents/pi_test_123/cancel")
+        .to_return(status: 401, body: {error: {type: "authentication_error", message: "Invalid API key."}}.to_json)
+    end
+
+    it "propagates the error so the caller can retry" do
+      expect { result }.to raise_error(::Stripe::AuthenticationError)
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/cancel_service_spec.rb
@@ -40,8 +40,21 @@ RSpec.describe PaymentProviders::Stripe::Payments::CancelService do
         .with(body: hash_including("cancellation_reason" => "abandoned"))
     end
 
-    it "returns a successful result" do
+    it "returns a successful result with the payment" do
       expect(result).to be_success
+      expect(result.payment).to eq(payment)
+    end
+
+    it "writes the canceled status from the Stripe response onto the payment" do
+      result
+
+      expect(payment.reload.status).to eq("canceled")
+    end
+
+    it "maps the canceled status to a failed payable_payment_status" do
+      result
+
+      expect(payment.reload.payable_payment_status).to eq("failed")
     end
   end
 
@@ -64,6 +77,10 @@ RSpec.describe PaymentProviders::Stripe::Payments::CancelService do
       result
 
       expect(Rails.logger).to have_received(:info).with(a_string_matching(/Stripe.*not cancelable.*succeeded/))
+    end
+
+    it "does not mutate the payment record" do
+      expect { result }.not_to change { payment.reload.attributes }
     end
   end
 


### PR DESCRIPTION
## Context

Milestone 2 introduces a timeout cleanup path for incomplete gated subscriptions. When the activation timeout expires, the gated payment authorization needs a best-effort cancellation against the PSP so the customer is not charged for a subscription that never activated. Stripe payment intents in cancelable states (requires_capture, requires_action, requires_payment_method, requires_confirmation) need a corresponding cancel call; intents that have advanced to non-cancelable states should be tolerated, not raise.

## Description

Add PaymentProviders::Stripe::Payments::CancelService following the established payment_providers/<name>/payments/ service convention. The service calls Stripe::PaymentIntent.cancel with the provider's secret key and cancellation_reason: :abandoned so Stripe's dashboard records the timeout-driven origin of the cancellation. It rescues Stripe::InvalidRequestError when the intent has already moved past a cancelable state (logged and swallowed), and propagates other Stripe errors so the caller (the async cancel job) can retry via Sidekiq.

The service stands alone in this PR — the dispatcher (Payments::CancelService) and async wrapper (Payments::CancelJob) that will route to it land in a follow-up PR after the parallel Adyen and GoCardless leaf services are in place.