### PR TITLE
feat(presentation_group_keys): Change ClickhouseEnrichedStore to support presentation_by keys

### DIFF
--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -140,6 +140,16 @@ module Events
         @timezone ||= customer.applicable_timezone
       end
 
+      # NOTE: This method is used mainly for WeightedSumQuery and UniqueCountQuery.
+      #
+      # The idea is to identify when the grouped_by includes the presentation_by,
+      # so we decide when to use the sorted_grouped_by (only grouped_by from filters) or sorted_properties (grouped_by + presentation_by).
+      def with_presentation_by_in_grouped_by?
+        return false if grouped_by.blank?
+
+        filters[:presentation_by].present? && (grouped_by & filters[:presentation_by]).size.positive?
+      end
+
       attr_accessor :numeric_property, :aggregation_property, :use_from_boundary, :grouped_by, :charge_id, :charge_filter_id
 
       protected

--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -288,9 +288,12 @@ module Events
           :with_ctes,
           :charges_duration,
           :events_cte_queries,
-          :grouped_arel_columns,
           :operation_type_sql,
           to: :store
+
+        def grouped_arel_columns
+          store.grouped_arel_columns(store.grouped_by)
+        end
 
         def joined_group_names
           _, names = grouped_arel_columns

--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -289,11 +289,8 @@ module Events
           :charges_duration,
           :events_cte_queries,
           :operation_type_sql,
+          :grouped_arel_columns,
           to: :store
-
-        def grouped_arel_columns
-          store.grouped_arel_columns(store.grouped_by)
-        end
 
         def joined_group_names
           _, names = grouped_arel_columns

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -55,9 +55,12 @@ module Events
           :with_ctes,
           :charges_duration,
           :events_cte_queries,
-          :grouped_arel_columns,
           :grouped_by_columns,
           to: :store
+
+        def grouped_arel_columns
+          store.grouped_arel_columns(store.grouped_by)
+        end
 
         def group_names
           _, names = grouped_arel_columns
@@ -139,7 +142,7 @@ module Events
               arel_table[:timestamp].as("timestamp"),
               arel_table[:decimal_value].as("difference")
             ],
-            deduplicated_columns: %w[decimal_value]
+            deduplicated_columns: store.grouped_by.present? ? %w[decimal_value sorted_properties] : %w[decimal_value]
           )
 
           events_data = <<-SQL

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -56,11 +56,8 @@ module Events
           :charges_duration,
           :events_cte_queries,
           :grouped_by_columns,
+          :grouped_arel_columns,
           to: :store
-
-        def grouped_arel_columns
-          store.grouped_arel_columns(store.grouped_by)
-        end
 
         def group_names
           _, names = grouped_arel_columns
@@ -142,7 +139,7 @@ module Events
               arel_table[:timestamp].as("timestamp"),
               arel_table[:decimal_value].as("difference")
             ],
-            deduplicated_columns: store.grouped_by.present? ? %w[decimal_value sorted_properties] : %w[decimal_value]
+            deduplicated_columns: store.with_presentation_by_in_grouped_by? ? %w[decimal_value sorted_properties] : %w[decimal_value]
           )
 
           events_data = <<-SQL

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -266,15 +266,32 @@ module Events
         end
       end
 
-      def grouped_count(_columns = grouped_by)
+      def grouped_count(columns = grouped_by)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
-          sql = with_ctes(events_cte_queries(deduplicated_columns: %w[value], select: [arel_table[:sorted_grouped_by]]), <<-SQL)
-            SELECT
-              sorted_grouped_by as groups,
-              toDecimal32(count(), 0) as value
-            FROM events
-            GROUP BY sorted_grouped_by
-          SQL
+          if columns == grouped_by
+            sql = with_ctes(events_cte_queries(deduplicated_columns: %w[value], select: [arel_table[:sorted_grouped_by]]), <<-SQL)
+              SELECT
+                sorted_grouped_by as groups,
+                toDecimal32(count(), 0) as value
+              FROM events
+              GROUP BY sorted_grouped_by
+            SQL
+          else
+            map_args = columns.sort.flat_map do |col|
+              [
+                ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
+                ActiveRecord::Base.sanitize_sql_for_conditions(["events.sorted_properties[?]", col.to_s])
+              ]
+            end
+
+            sql = with_ctes(events_cte_queries(deduplicated_columns: %w[value sorted_properties]), <<-SQL)
+              SELECT
+                map(#{map_args.join(", ")}) as groups,
+                toDecimal32(count(), 0) as value
+              FROM events
+              GROUP BY #{map_args.each_slice(2).map(&:last).join(", ")}
+            SQL
+          end
 
           prepare_grouped_result(connection.select_all(sql))
         end

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -767,10 +767,10 @@ module Events
         @arel_table ||= ::Clickhouse::EventsEnrichedExpanded.arel_table
       end
 
-      def grouped_arel_columns(columns = nil)
-        return [[arel_table[:sorted_grouped_by].as("grouped_by")], group_names] if columns.blank?
+      def grouped_arel_columns
+        return [[arel_table[:sorted_grouped_by].as("grouped_by")], group_names] unless with_presentation_by_in_grouped_by?
 
-        map_args, = sorted_properties_map_args(columns, table: nil)
+        map_args, = sorted_properties_map_args(grouped_by, table: nil)
         map_sql = map_args.join(", ")
 
         grouped_by_node = Arel::Nodes::As.new(

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -475,15 +475,32 @@ module Events
         end
       end
 
-      def grouped_sum(_columns = grouped_by)
+      def grouped_sum(columns = grouped_by)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
-          sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
-            SELECT
-              sorted_grouped_by as groups,
-              sum(events.decimal_value) as value
-            FROM events
-            GROUP BY sorted_grouped_by
-          SQL
+          if columns == grouped_by
+            sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
+              SELECT
+                sorted_grouped_by as groups,
+                sum(events.decimal_value) as value
+              FROM events
+              GROUP BY sorted_grouped_by
+            SQL
+          else
+            map_args = columns.sort.flat_map do |col|
+              [
+                ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
+                ActiveRecord::Base.sanitize_sql_for_conditions(["events.sorted_properties[?]", col.to_s])
+              ]
+            end
+
+            sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
+              SELECT
+                map(#{map_args.join(", ")}) as groups,
+                sum(events.decimal_value) as value
+              FROM events
+              GROUP BY #{map_args.each_slice(2).map(&:last).join(", ")}
+            SQL
+          end
 
           prepare_grouped_result(connection.select_all(sql))
         end

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -711,13 +711,16 @@ module Events
         BigDecimal(result["aggregation"].presence || 0)
       end
 
-      def grouped_weighted_sum(_columns = grouped_by, initial_values: [])
+      def grouped_weighted_sum(columns = grouped_by, initial_values: [])
+        duplicated_weighted_sum_store = dup
+        duplicated_weighted_sum_store.grouped_by = columns
+
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
-          query = Clickhouse::WeightedSumQuery.new(store: self)
+          query = Clickhouse::WeightedSumQuery.new(store: duplicated_weighted_sum_store)
 
           # NOTE: build the list of initial values for each groups
           #       from the events in the period
-          formatted_initial_values = grouped_count.map do |group|
+          formatted_initial_values = grouped_count(columns).map do |group|
             value = 0
             previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
             value = previous_group[:value] if previous_group

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -367,9 +367,12 @@ module Events
         end
       end
 
-      def grouped_unique_count(_columns = grouped_by)
+      def grouped_unique_count(columns = grouped_by)
+        duplicated_unique_count_store = dup
+        duplicated_unique_count_store.grouped_by = columns
+
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
-          query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
+          query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: duplicated_unique_count_store)
           sql = ActiveRecord::Base.sanitize_sql_for_conditions(
             [
               sanitize_colon(query.grouped_query),
@@ -781,11 +784,22 @@ module Events
         @arel_table ||= ::Clickhouse::EventsEnrichedExpanded.arel_table
       end
 
-      def grouped_arel_columns
-        [
-          [arel_table[:sorted_grouped_by].as("grouped_by")],
-          group_names
-        ]
+      def grouped_arel_columns(columns = nil)
+        return [[arel_table[:sorted_grouped_by].as("grouped_by")], group_names] if columns.blank?
+
+        map_sql = columns.sort.flat_map do |col|
+          [
+            ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
+            ActiveRecord::Base.sanitize_sql_for_conditions(["sorted_properties[?]", col.to_s])
+          ]
+        end.join(", ")
+
+        grouped_by_node = Arel::Nodes::As.new(
+          Arel::Nodes::SqlLiteral.new("map(#{map_sql})"),
+          Arel::Nodes::SqlLiteral.new("grouped_by")
+        )
+
+        [[grouped_by_node], ["grouped_by"]]
       end
 
       def group_names

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -437,18 +437,35 @@ module Events
         end
       end
 
-      def grouped_max(_columns = grouped_by)
+      def grouped_max(columns = grouped_by)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
-          sql = with_ctes(events_cte_queries(
-            deduplicated_columns: %w[decimal_value],
-            select: [arel_table[:sorted_grouped_by], arel_table[:decimal_value]]
-          ), <<-SQL)
-            SELECT
-              sorted_grouped_by as groups,
-              MAX(events.decimal_value) as value
-            FROM events
-            GROUP BY sorted_grouped_by
-          SQL
+          if columns == grouped_by
+            sql = with_ctes(events_cte_queries(
+              deduplicated_columns: %w[decimal_value],
+              select: [arel_table[:sorted_grouped_by], arel_table[:decimal_value]]
+            ), <<-SQL)
+              SELECT
+                sorted_grouped_by as groups,
+                MAX(events.decimal_value) as value
+              FROM events
+              GROUP BY sorted_grouped_by
+            SQL
+          else
+            map_args = columns.sort.flat_map do |col|
+              [
+                ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
+                ActiveRecord::Base.sanitize_sql_for_conditions(["events.sorted_properties[?]", col.to_s])
+              ]
+            end
+
+            sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
+              SELECT
+                map(#{map_args.join(", ")}) as groups,
+                MAX(events.decimal_value) as value
+              FROM events
+              GROUP BY #{map_args.each_slice(2).map(&:last).join(", ")}
+            SQL
+          end
 
           prepare_grouped_result(connection.select_all(sql))
         end

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -467,15 +467,43 @@ module Events
         end
       end
 
-      def grouped_last(_columns = grouped_by)
+      def grouped_last(columns = grouped_by)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
-          sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
-            SELECT
-              DISTINCT ON (sorted_grouped_by) sorted_grouped_by as groups,
-              events.decimal_value as value
-            FROM events
-            ORDER BY sorted_grouped_by, timestamp DESC
-          SQL
+          if columns == grouped_by
+            sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
+              SELECT
+                DISTINCT ON (sorted_grouped_by) sorted_grouped_by as groups,
+                events.decimal_value as value
+              FROM events
+              ORDER BY sorted_grouped_by, timestamp DESC
+            SQL
+          else
+            map_args = columns.sort.flat_map do |col|
+              [
+                ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
+                ActiveRecord::Base.sanitize_sql_for_conditions(["events.sorted_properties[?]", col.to_s])
+              ]
+            end
+
+            sql = if grouped_by.blank?
+              with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
+                SELECT
+                  map(#{map_args.join(", ")}) as groups,
+                  events.decimal_value as value
+                FROM events
+                ORDER BY timestamp DESC
+                LIMIT 1
+              SQL
+            else
+              with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
+                SELECT
+                  DISTINCT ON (sorted_grouped_by) map(#{map_args.join(", ")}) as groups,
+                  events.decimal_value as value
+                FROM events
+                ORDER BY sorted_grouped_by, timestamp DESC
+              SQL
+            end
+          end
 
           prepare_grouped_result(connection.select_all(sql))
         end

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -277,19 +277,14 @@ module Events
               GROUP BY sorted_grouped_by
             SQL
           else
-            map_args = columns.sort.flat_map do |col|
-              [
-                ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
-                ActiveRecord::Base.sanitize_sql_for_conditions(["events.sorted_properties[?]", col.to_s])
-              ]
-            end
+            map_args, col_expressions = sorted_properties_map_args(columns)
 
             sql = with_ctes(events_cte_queries(deduplicated_columns: %w[value sorted_properties]), <<-SQL)
               SELECT
                 map(#{map_args.join(", ")}) as groups,
                 toDecimal32(count(), 0) as value
               FROM events
-              GROUP BY #{map_args.each_slice(2).map(&:last).join(", ")}
+              GROUP BY #{col_expressions.join(", ")}
             SQL
           end
 
@@ -454,19 +449,14 @@ module Events
               GROUP BY sorted_grouped_by
             SQL
           else
-            map_args = columns.sort.flat_map do |col|
-              [
-                ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
-                ActiveRecord::Base.sanitize_sql_for_conditions(["events.sorted_properties[?]", col.to_s])
-              ]
-            end
+            map_args, col_expressions = sorted_properties_map_args(columns)
 
             sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
               SELECT
                 map(#{map_args.join(", ")}) as groups,
                 MAX(events.decimal_value) as value
               FROM events
-              GROUP BY #{map_args.each_slice(2).map(&:last).join(", ")}
+              GROUP BY #{col_expressions.join(", ")}
             SQL
           end
 
@@ -498,12 +488,7 @@ module Events
               ORDER BY sorted_grouped_by, timestamp DESC
             SQL
           else
-            map_args = columns.sort.flat_map do |col|
-              [
-                ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
-                ActiveRecord::Base.sanitize_sql_for_conditions(["events.sorted_properties[?]", col.to_s])
-              ]
-            end
+            map_args, = sorted_properties_map_args(columns)
 
             sql = if grouped_by.blank?
               with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
@@ -551,19 +536,14 @@ module Events
               GROUP BY sorted_grouped_by
             SQL
           else
-            map_args = columns.sort.flat_map do |col|
-              [
-                ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
-                ActiveRecord::Base.sanitize_sql_for_conditions(["events.sorted_properties[?]", col.to_s])
-              ]
-            end
+            map_args, col_expressions = sorted_properties_map_args(columns)
 
             sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
               SELECT
                 map(#{map_args.join(", ")}) as groups,
                 sum(events.decimal_value) as value
               FROM events
-              GROUP BY #{map_args.each_slice(2).map(&:last).join(", ")}
+              GROUP BY #{col_expressions.join(", ")}
             SQL
           end
 
@@ -790,12 +770,8 @@ module Events
       def grouped_arel_columns(columns = nil)
         return [[arel_table[:sorted_grouped_by].as("grouped_by")], group_names] if columns.blank?
 
-        map_sql = columns.sort.flat_map do |col|
-          [
-            ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
-            ActiveRecord::Base.sanitize_sql_for_conditions(["sorted_properties[?]", col.to_s])
-          ]
-        end.join(", ")
+        map_args, = sorted_properties_map_args(columns, table: nil)
+        map_sql = map_args.join(", ")
 
         grouped_by_node = Arel::Nodes::As.new(
           Arel::Nodes::SqlLiteral.new("map(#{map_sql})"),
@@ -820,6 +796,19 @@ module Events
 
       def grouped_by_count
         1
+      end
+
+      def sorted_properties_map_args(columns, table: "events")
+        prefix = table ? "#{table}." : ""
+
+        map_args = columns.sort.flat_map do |col|
+          [
+            ActiveRecord::Base.sanitize_sql_for_conditions(["?", col.to_s]),
+            ActiveRecord::Base.sanitize_sql_for_conditions(["#{prefix}sorted_properties[?]", col.to_s])
+          ]
+        end
+
+        [map_args, map_args.each_slice(2).map(&:last)]
       end
 
       def operation_type_sql

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
 
   context "without deduplication" do
     it_behaves_like "an event store", with_event_duplication: false, excluding_features:
-      [:grouped_sum_breakdown, :grouped_count_breakdown, :grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+      [:grouped_count_breakdown, :grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 
   context "with deduplication" do
     it_behaves_like "an event store", with_event_duplication: true, excluding_features:
-      [:grouped_sum_breakdown, :grouped_count_breakdown, :grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+      [:grouped_count_breakdown, :grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 end

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
 
   context "without deduplication" do
     it_behaves_like "an event store", with_event_duplication: false, excluding_features:
-      [:grouped_count_breakdown, :grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+      [:grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 
   context "with deduplication" do
     it_behaves_like "an event store", with_event_duplication: true, excluding_features:
-      [:grouped_count_breakdown, :grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+      [:grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 end

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -47,4 +47,76 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
   context "with deduplication" do
     it_behaves_like "an event store", with_event_duplication: true
   end
+
+  describe "#grouped_arel_columns" do
+    subject(:event_store) do
+      described_class.new(
+        code: billable_metric.code,
+        subscription:,
+        boundaries:,
+        filters: {
+          grouped_by:,
+          presentation_by:
+        }
+      )
+    end
+
+    let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
+    let(:organization) { billable_metric.organization }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:) }
+    let(:boundaries) do
+      {
+        from_datetime: subscription.started_at.beginning_of_day,
+        to_datetime: subscription.started_at.end_of_month.end_of_day,
+        charges_duration: 31
+      }
+    end
+
+    context "when presentation_by is not included in grouped_by" do
+      let(:grouped_by) { ["cloud"] }
+      let(:presentation_by) { ["agent_name"] }
+
+      it "returns the precomputed sorted grouped by column" do
+        columns, names = event_store.grouped_arel_columns
+
+        expect(columns.count).to eq(1)
+        expect(columns.first.left.name).to eq("sorted_grouped_by")
+        expect(columns.first.right).to eq("grouped_by")
+        expect(names).to eq(["grouped_by"])
+      end
+    end
+
+    context "when presentation_by is included in grouped_by" do
+      let(:grouped_by) { ["cloud", "agent_name"] }
+      let(:presentation_by) { ["cloud"] }
+
+      it "returns a mapped grouped_by from the grouped properties" do
+        columns, names = event_store.grouped_arel_columns
+
+        expect(columns.count).to eq(1)
+        expect(columns.first.left.to_s).to eq("map('agent_name', sorted_properties['agent_name'], 'cloud', sorted_properties['cloud'])")
+        expect(columns.first.right.to_s).to eq("grouped_by")
+        expect(names).to eq(["grouped_by"])
+      end
+    end
+
+    context "when the store is duplicated with another grouped_by" do
+      let(:grouped_by) { ["cloud"] }
+      let(:presentation_by) { ["agent_name"] }
+
+      it "builds the mapped grouped_by from the duplicated grouped_by" do
+        duplicated_store = event_store.dup
+        duplicated_store.grouped_by = ["agent_name", "cloud"]
+
+        columns, names = duplicated_store.grouped_arel_columns
+
+        expect(event_store.grouped_by).to eq(["cloud"])
+        expect(columns.count).to eq(1)
+        expect(columns.first.left.to_s).to eq("map('agent_name', sorted_properties['agent_name'], 'cloud', sorted_properties['cloud'])")
+        expect(columns.first.right.to_s).to eq("grouped_by")
+        expect(names).to eq(["grouped_by"])
+      end
+    end
+  end
 end

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
 
   context "without deduplication" do
     it_behaves_like "an event store", with_event_duplication: false, excluding_features:
-      [:grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+      [:grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 
   context "with deduplication" do
     it_behaves_like "an event store", with_event_duplication: true, excluding_features:
-      [:grouped_last_breakdown, :grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+      [:grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 end

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
   end
 
   context "without deduplication" do
-    it_behaves_like "an event store", with_event_duplication: false, excluding_features: [:grouped_weighted_sum_breakdown]
+    it_behaves_like "an event store", with_event_duplication: false
   end
 
   context "with deduplication" do
-    it_behaves_like "an event store", with_event_duplication: true, excluding_features: [:grouped_weighted_sum_breakdown]
+    it_behaves_like "an event store", with_event_duplication: true
   end
 end

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
 
   context "without deduplication" do
     it_behaves_like "an event store", with_event_duplication: false, excluding_features:
-      [:grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+      [:grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 
   context "with deduplication" do
     it_behaves_like "an event store", with_event_duplication: true, excluding_features:
-      [:grouped_max_breakdown, :grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+      [:grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
   end
 end

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -41,12 +41,10 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
   end
 
   context "without deduplication" do
-    it_behaves_like "an event store", with_event_duplication: false, excluding_features:
-      [:grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+    it_behaves_like "an event store", with_event_duplication: false, excluding_features: [:grouped_weighted_sum_breakdown]
   end
 
   context "with deduplication" do
-    it_behaves_like "an event store", with_event_duplication: true, excluding_features:
-      [:grouped_unique_count_breakdown, :grouped_weighted_sum_breakdown]
+    it_behaves_like "an event store", with_event_duplication: true, excluding_features: [:grouped_weighted_sum_breakdown]
   end
 end


### PR DESCRIPTION
This commit changes the ClickhouseEnrichedStore to support presentation group keys

Continuing the development of presentation group keys, we're changing the last store ClickhouseEnriched to
also support presentation group keys.
The previous changes were done [in this PR](https://github.com/getlago/lago-api/pull/5401) we're passing it down the unique keys (pricing group keys + presentation group keys) and also changed the Postgres + Clickhouse Store and skipping the ClickhouseEnriched.

Since the enriched store rows in clickhouse are generated by event processor and requires an extra effort, we're making this change in two steps:

First, in this commit we're making the feature available to work with `sorted_properties` column where contains the grouped (pricing keys) and also the presentation group keys. Having this, we're making the feature available to customers that are using the presentation group keys with enriched store. 
We're making a fallback to use the sorted_grouped_by when the grouped_by doesn't contain the presentation group keys. With this, we're still taking advantage of the added column. When contains more columns, we go to `sorted_properties`. 

> The behaviour of deciding what column to use `sorted_grouped_by/sorted_properties` is not happening for `grouped_unique_count` and `grouped_weighted_sum`. To avoid adding more complexity, these queries are always using the `sorted_properties`. 


In a second step, we're going to change the flow of event processor to also enrich the event containing the presentation group keys and then rebuild the events. After this step is done, we're going to visit again the store and change to use the new column added, avoiding these extra conditionals to use or not the sorted_properties.
