### PR TITLE
[ING-31] perf(events): add partial index on (organization_id, code, timestamp)

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -92,5 +92,6 @@ end
 #  index_events_on_organization_id_and_code            (organization_id,code)
 #  index_events_on_organization_id_and_created_at      (organization_id,created_at DESC) WHERE (deleted_at IS NULL)
 #  index_events_on_organization_id_and_transaction_id  (organization_id,transaction_id) WHERE (deleted_at IS NULL)
+#  index_events_on_organization_id_code_and_timestamp  (organization_id,code,timestamp DESC) WHERE (deleted_at IS NULL)
 #  index_unique_transaction_id                         (organization_id,external_subscription_id,transaction_id) UNIQUE
 #

--- a/db/migrate/20260506122830_add_events_organization_code_timestamp_index.rb
+++ b/db/migrate/20260506122830_add_events_organization_code_timestamp_index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddEventsOrganizationCodeTimestampIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :events,
+      [:organization_id, :code, :timestamp],
+      order: {timestamp: :desc},
+      where: "deleted_at IS NULL",
+      name: "index_events_on_organization_id_code_and_timestamp",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -642,6 +642,7 @@ DROP INDEX IF EXISTS public.index_fees_on_charge_filter_id;
 DROP INDEX IF EXISTS public.index_fees_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_fees_on_applied_add_on_id;
 DROP INDEX IF EXISTS public.index_fees_on_add_on_id;
+DROP INDEX IF EXISTS public.index_events_on_organization_id_code_and_timestamp;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_transaction_id;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_created_at;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_code;
@@ -8195,6 +8196,13 @@ CREATE INDEX index_events_on_organization_id_and_transaction_id ON public.events
 
 
 --
+-- Name: index_events_on_organization_id_code_and_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_on_organization_id_code_and_timestamp ON public.events USING btree (organization_id, code, "timestamp" DESC) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: index_fees_on_add_on_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12889,6 +12897,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260512155310'),
 ('20260512142543'),
 ('20260508134715'),
+('20260506122830'),
 ('20260504134804'),
 ('20260430102814'),
 ('20260430102813'),
@@ -13888,4 +13897,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
-


### PR DESCRIPTION
## Context

`GET /api/v1/events?code=...&per_page=100&page=1` against a Postgres-backed organization with a high-volume code degraded to roughly ten minutes per request, with ~99.998% of the time spent in the database.

None of the existing indexes on `events` covered the access path `(organization_id, code, ORDER BY timestamp DESC) WHERE deleted_at IS NULL`.

## Description

Add a partial composite index `(organization_id, code, timestamp DESC) WHERE deleted_at IS NULL` so the planner can satisfy both equality predicates and the ordering with a single backwards index scan. `LIMIT 100` returns after reading at most ~100 index tuples instead of sorting the full match set; the same predicate also speeds up the pagination `COUNT(*)` for that filter.

## Plans

Both plans were created with hot cache (almost 100% hits)

### Without the index introduced in this PR

<details>
<summary>Raw Plan</summary>

```
Limit  (cost=1490.32..1490.57 rows=100 width=373) (actual time=2.718..2.736 rows=100 loops=1)
   Output: id, organization_id, customer_id, transaction_id, code, properties, "timestamp", created_at, updated_at, metadata, subscription_id, deleted_at, external_customer_id, external_subscription_id, precise_total_amount_cents
   Buffers: shared hit=584
   ->  Sort  (cost=1490.32..1502.02 rows=4680 width=373) (actual time=2.716..2.724 rows=100 loops=1)
         Output: id, organization_id, customer_id, transaction_id, code, properties, "timestamp", created_at, updated_at, metadata, subscription_id, deleted_at, external_customer_id, external_subscription_id, precise_total_amount_cents
         Sort Key: events."timestamp" DESC
         Sort Method: top-N heapsort  Memory: 112kB
         Buffers: shared hit=584
         ->  Bitmap Heap Scan on public.events  (cost=68.26..1311.46 rows=4680 width=373) (actual time=0.231..1.954 rows=4680 loops=1)
               Output: id, organization_id, customer_id, transaction_id, code, properties, "timestamp", created_at, updated_at, metadata, subscription_id, deleted_at, external_customer_id, external_subscription_id, precise_total_amount_cents
               Recheck Cond: ((events.organization_id = '11111111-2222-3333-4444-555555555555'::uuid) AND ((events.code)::text = 'seed_count'::text))
               Filter: (events.deleted_at IS NULL)
               Heap Blocks: exact=579
               Buffers: shared hit=584
               ->  Bitmap Index Scan on index_events_on_organization_id_and_code  (cost=0.00..67.09 rows=4680 width=0) (actual time=0.153..0.154 rows=4680 loops=1)
                     Index Cond: ((events.organization_id = '11111111-2222-3333-4444-555555555555'::uuid) AND ((events.code)::text = 'seed_count'::text))
                     Buffers: shared hit=5
 Query Identifier: -510427802238512562
 Planning:
   Buffers: shared hit=10
 Planning Time: 0.234 ms
 Execution Time: 2.773 ms
```
</details>

<img width="488" height="944" alt="Capture d’écran 2026-05-06 à 14 39 29" src="https://github.com/user-attachments/assets/0c0390b6-cd29-4c52-9241-e5292ea43d4e" />

## With the index introduced in this PR

<details>
<summary>Raw Plan</summary>

```
Limit  (cost=0.41..50.80 rows=100 width=373) (actual time=0.033..0.168 rows=100 loops=1)
   Output: id, organization_id, customer_id, transaction_id, code, properties, "timestamp", created_at, updated_at, metadata, subscription_id, deleted_at, external_customer_id, external_subscription_id, precise_total_amount_cents
   Buffers: shared hit=100 read=3
   I/O Timings: shared read=0.009
   ->  Index Scan using index_events_on_organization_id_code_and_timestamp on public.events  (cost=0.41..2358.70 rows=4680 width=373) (actual time=0.032..0.156 rows=100 loops=1)
         Output: id, organization_id, customer_id, transaction_id, code, properties, "timestamp", created_at, updated_at, metadata, subscription_id, deleted_at, external_customer_id, external_subscription_id, precise_total_amount_cents
         Index Cond: ((events.organization_id = '11111111-2222-3333-4444-555555555555'::uuid) AND ((events.code)::text = 'seed_count'::text))
         Buffers: shared hit=100 read=3
         I/O Timings: shared read=0.009
 Query Identifier: -510427802238512562
 Planning:
   Buffers: shared hit=27 read=1
   I/O Timings: shared read=0.006
 Planning Time: 0.293 ms
 Execution Time: 0.193 ms
```
</details>

<img width="447" height="506" alt="Capture d’écran 2026-05-06 à 14 39 49" src="https://github.com/user-attachments/assets/744ae104-96ef-4854-adaa-09dba6a6af97" />
