### PR TITLE
feat(multi-billing-entity): allow setting subscription billing entity

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -167,6 +167,8 @@ module Api
           .permit(
             :external_customer_id,
             :plan_code,
+            :billing_entity_code,
+            :billing_entity_id,
             :name,
             :external_id,
             :billing_time,

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -129,7 +129,8 @@ module Subscriptions
         external_id:,
         billing_time: billing_time || :calendar,
         ending_at: params[:ending_at],
-        progressive_billing_disabled: params[:progressive_billing_disabled] || false
+        progressive_billing_disabled: params[:progressive_billing_disabled] || false,
+        billing_entity: resolve_billing_entity
       )
 
       if params.key?(:payment_method)
@@ -284,6 +285,22 @@ module Subscriptions
       return nil if params[:payment_method].blank? || params[:payment_method][:payment_method_id].blank?
 
       @payment_method = PaymentMethod.find_by(id: params[:payment_method][:payment_method_id], organization_id: customer.organization_id)
+    end
+
+    # nil here means "inherit from customer.billing_entity at billing time"
+    def resolve_billing_entity
+      return unless customer.organization.feature_flag_enabled?(:multi_entity_billing)
+
+      attrs = if params[:billing_entity_id].present?
+        {id: params[:billing_entity_id]}
+      elsif params[:billing_entity_code].present?
+        {code: params[:billing_entity_code]}
+      end
+      return unless attrs
+
+      customer.organization.billing_entities.find_by!(attrs)
+    rescue ActiveRecord::RecordNotFound
+      result.not_found_failure!(resource: "billing_entity").raise_if_error!
     end
   end
 end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -316,6 +316,82 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       end
     end
 
+    context "when binding the subscription to an explicit billing entity" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          billing_time: "anniversary",
+          billing_entity_code: billing_entity.code
+        }
+      end
+
+      context "when multi_entity_billing flag is enabled" do
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "binds the subscription to the resolved billing entity" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          subscription = Subscription.find_by(external_id: params[:external_id])
+          expect(subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        context "when binding via billing_entity_id instead of code" do
+          let(:params) do
+            {
+              external_customer_id: customer.external_id,
+              plan_code:,
+              external_id: SecureRandom.uuid,
+              billing_time: "anniversary",
+              billing_entity_id: billing_entity.id
+            }
+          end
+
+          it "binds the subscription to the resolved billing entity" do
+            subject
+
+            expect(response).to have_http_status(:ok)
+            subscription = Subscription.find_by(external_id: params[:external_id])
+            expect(subscription.billing_entity_id).to eq(billing_entity.id)
+          end
+        end
+      end
+
+      context "when multi_entity_billing flag is disabled" do
+        it "ignores the param and persists subscription with no explicit billing entity" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          subscription = Subscription.find_by(external_id: params[:external_id])
+          expect(subscription.billing_entity_id).to be_nil
+        end
+      end
+
+      context "without billing_entity_code" do
+        let(:params) do
+          {
+            external_customer_id: customer.external_id,
+            plan_code:,
+            external_id: SecureRandom.uuid,
+            billing_time: "anniversary"
+          }
+        end
+
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "persists subscription with no explicit billing entity" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          subscription = Subscription.find_by(external_id: params[:external_id])
+          expect(subscription.billing_entity_id).to be_nil
+        end
+      end
+    end
+
     context "with invalid plan code" do
       let(:plan_code) { "#{plan.code}-invalid" }
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1623,5 +1623,89 @@ RSpec.describe Subscriptions::CreateService do
         expect(result.subscription.activation_rules.count).to eq(0)
       end
     end
+
+    describe "billing entity binding" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+
+      context "when multi_entity_billing flag is OFF" do
+        it "ignores billing_entity_code and persists nil" do
+          params[:billing_entity_code] = billing_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to be_nil
+        end
+
+        it "ignores billing_entity_id and persists nil" do
+          params[:billing_entity_id] = billing_entity.id
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to be_nil
+        end
+      end
+
+      context "when multi_entity_billing flag is ON" do
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "persists nil when no billing entity reference is provided" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to be_nil
+        end
+
+        it "binds the subscription to the entity matched by billing_entity_id" do
+          params[:billing_entity_id] = billing_entity.id
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        it "binds the subscription to the entity matched by billing_entity_code" do
+          params[:billing_entity_code] = billing_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_id is unknown" do
+          params[:billing_entity_id] = SecureRandom.uuid
+
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_code is unknown" do
+          params[:billing_entity_code] = "unknown-entity-code"
+
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+
+        it "prefers billing_entity_id over billing_entity_code when both are provided" do
+          other_entity = create(:billing_entity, organization:)
+          params[:billing_entity_id] = billing_entity.id
+          params[:billing_entity_code] = other_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Today every new subscription inherits its billing entity from the customer record, with no way to override it on a per-subscription basis. Multi-entity workflows need an explicit binding so that the same logical customer can hold subscriptions across different billing entities, each invoiced under its own legal identity.

This change teaches `Subscriptions::CreateService` to accept an explicit billing entity reference: `billing_entity_id` on the GraphQL path and `billing_entity_code` on the REST path. When neither is provided, the new `subscriptions.billing_entity_id` column persists as `NULL`, which is the load-bearing semantic for "no explicit binding, inherit from `customer.billing_entity` at billing time"; this preserves the property that later changes to a customer's default flow through to any subscription that never bound explicitly. When a reference is provided but unknown, the service fails with `not_found_failure!(resource: "billing_entity")`.

The REST permit list now allows `billing_entity_code` on `POST /api/v1/subscriptions` so the value reaches the service. The whole behavior is gated behind the `multi_entity_billing` feature flag; with the flag off the param is silently ignored, which keeps the surface forward-compatible for clients that start sending it before the rollout completes.

The service contract intentionally accepts both shapes already, so the GraphQL input addition can ship as a small follow-up PR with no further service changes.

## Try it locally

1. Pick an organization in your dev environment and enable the flag:
   ```ruby
   org = Organization.find_by(name: "...")
   org.enable_feature_flag!(:multi_entity_billing)
   ```
2. Create a second billing entity on that org so you have something to point at:
   ```ruby
   FactoryBot.create(:billing_entity, organization: org, code: "acme_eu")
   ```
3. Create a subscription bound to that entity via REST:
   ```bash
   curl -X POST http://localhost:3000/api/v1/subscriptions \
     -H "Authorization: Bearer <api_key>" \
     -H "Content-Type: application/json" \
     -d '{"subscription":{"external_customer_id":"<existing>","plan_code":"<existing>","external_id":"sub_eu_1","billing_entity_code":"acme_eu"}}'
   ```
   Expect the response to succeed and `Subscription.find_by(external_id: "sub_eu_1").billing_entity.code` to return `"acme_eu"`.
4. Repeat step 3 without `billing_entity_code` (use `external_id: "sub_inherit_1"`) and verify `billing_entity_id` persists as `NULL`.
5. Repeat step 3 with `billing_entity_code: "does_not_exist"` and expect a 404 response with `code: "billing_entity_not_found"`.
6. Disable the flag (`org.disable_feature_flag!(:multi_entity_billing)`), POST again with a valid `billing_entity_code`, and verify the column persists as `NULL` (param silently ignored).