### PR TITLE
feat(multi-billing-entity): expose billing entity on graphql subscription create

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -167,6 +167,8 @@ module Api
           .permit(
             :external_customer_id,
             :plan_code,
+            :billing_entity_code,
+            :billing_entity_id,
             :name,
             :external_id,
             :billing_time,

--- a/app/graphql/types/subscriptions/create_subscription_input.rb
+++ b/app/graphql/types/subscriptions/create_subscription_input.rb
@@ -10,6 +10,7 @@ module Types
       argument :name, String, required: false
       argument :subscription_id, ID, required: false
 
+      argument :billing_entity_id, ID, required: false
       argument :customer_id, ID, required: true
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :plan_id, ID, required: true

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -129,7 +129,8 @@ module Subscriptions
         external_id:,
         billing_time: billing_time || :calendar,
         ending_at: params[:ending_at],
-        progressive_billing_disabled: params[:progressive_billing_disabled] || false
+        progressive_billing_disabled: params[:progressive_billing_disabled] || false,
+        billing_entity: resolve_billing_entity
       )
 
       if params.key?(:payment_method)
@@ -284,6 +285,22 @@ module Subscriptions
       return nil if params[:payment_method].blank? || params[:payment_method][:payment_method_id].blank?
 
       @payment_method = PaymentMethod.find_by(id: params[:payment_method][:payment_method_id], organization_id: customer.organization_id)
+    end
+
+    # nil here means "inherit from customer.billing_entity at billing time"
+    def resolve_billing_entity
+      return unless customer.organization.feature_flag_enabled?(:multi_entity_billing)
+
+      attrs = if params[:billing_entity_id].present?
+        {id: params[:billing_entity_id]}
+      elsif params[:billing_entity_code].present?
+        {code: params[:billing_entity_code]}
+      end
+      return unless attrs
+
+      customer.organization.billing_entities.find_by!(attrs)
+    rescue ActiveRecord::RecordNotFound
+      result.not_found_failure!(resource: "billing_entity").raise_if_error!
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3353,6 +3353,7 @@ Create Subscription input arguments
 """
 input CreateSubscriptionInput {
   activationRules: [SubscriptionActivationRuleInput!]
+  billingEntityId: ID
   billingTime: BillingTimeEnum!
 
   """

--- a/schema.json
+++ b/schema.json
@@ -15578,6 +15578,18 @@
               "deprecationReason": null
             },
             {
+              "name": "billingEntityId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "customerId",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -126,6 +126,90 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
     )
   end
 
+  context "with billing entity binding" do
+    let(:billing_entity) { create(:billing_entity, organization:) }
+    let(:mutation) do
+      <<~GQL
+        mutation($input: CreateSubscriptionInput!) {
+          createSubscription(input: $input) {
+            id
+            externalId
+          }
+        }
+      GQL
+    end
+
+    context "when multi_entity_billing flag is enabled" do
+      before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+      it "binds the subscription to the resolved entity" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {
+            input: {
+              customerId: customer.id,
+              planId: plan.id,
+              billingTime: "anniversary",
+              billingEntityId: billing_entity.id
+            }
+          }
+        )
+
+        external_id = result["data"]["createSubscription"]["externalId"]
+        subscription = Subscription.find_by(external_id:)
+        expect(subscription.billing_entity_id).to eq(billing_entity.id)
+      end
+
+      it "returns a not_found error when billing_entity_id is unknown" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {
+            input: {
+              customerId: customer.id,
+              planId: plan.id,
+              billingTime: "anniversary",
+              billingEntityId: SecureRandom.uuid
+            }
+          }
+        )
+
+        expect(result["errors"].first["extensions"]).to include(
+          "code" => "not_found",
+          "details" => {"billingEntity" => ["not_found"]}
+        )
+      end
+    end
+
+    context "when multi_entity_billing flag is disabled" do
+      it "ignores the billing entity binding" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {
+            input: {
+              customerId: customer.id,
+              planId: plan.id,
+              billingTime: "anniversary",
+              billingEntityId: billing_entity.id
+            }
+          }
+        )
+
+        external_id = result["data"]["createSubscription"]["externalId"]
+        subscription = Subscription.find_by(external_id:)
+        expect(subscription.billing_entity_id).to be_nil
+      end
+    end
+  end
+
   context "with activation rules" do
     let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
 

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -316,6 +316,82 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       end
     end
 
+    context "when binding the subscription to an explicit billing entity" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          billing_time: "anniversary",
+          billing_entity_code: billing_entity.code
+        }
+      end
+
+      context "when multi_entity_billing flag is enabled" do
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "binds the subscription to the resolved billing entity" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          subscription = Subscription.find_by(external_id: params[:external_id])
+          expect(subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        context "when binding via billing_entity_id instead of code" do
+          let(:params) do
+            {
+              external_customer_id: customer.external_id,
+              plan_code:,
+              external_id: SecureRandom.uuid,
+              billing_time: "anniversary",
+              billing_entity_id: billing_entity.id
+            }
+          end
+
+          it "binds the subscription to the resolved billing entity" do
+            subject
+
+            expect(response).to have_http_status(:ok)
+            subscription = Subscription.find_by(external_id: params[:external_id])
+            expect(subscription.billing_entity_id).to eq(billing_entity.id)
+          end
+        end
+      end
+
+      context "when multi_entity_billing flag is disabled" do
+        it "ignores the param and persists subscription with no explicit billing entity" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          subscription = Subscription.find_by(external_id: params[:external_id])
+          expect(subscription.billing_entity_id).to be_nil
+        end
+      end
+
+      context "without billing_entity_code" do
+        let(:params) do
+          {
+            external_customer_id: customer.external_id,
+            plan_code:,
+            external_id: SecureRandom.uuid,
+            billing_time: "anniversary"
+          }
+        end
+
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "persists subscription with no explicit billing entity" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          subscription = Subscription.find_by(external_id: params[:external_id])
+          expect(subscription.billing_entity_id).to be_nil
+        end
+      end
+    end
+
     context "with invalid plan code" do
       let(:plan_code) { "#{plan.code}-invalid" }
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1623,5 +1623,89 @@ RSpec.describe Subscriptions::CreateService do
         expect(result.subscription.activation_rules.count).to eq(0)
       end
     end
+
+    describe "billing entity binding" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+
+      context "when multi_entity_billing flag is OFF" do
+        it "ignores billing_entity_code and persists nil" do
+          params[:billing_entity_code] = billing_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to be_nil
+        end
+
+        it "ignores billing_entity_id and persists nil" do
+          params[:billing_entity_id] = billing_entity.id
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to be_nil
+        end
+      end
+
+      context "when multi_entity_billing flag is ON" do
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "persists nil when no billing entity reference is provided" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to be_nil
+        end
+
+        it "binds the subscription to the entity matched by billing_entity_id" do
+          params[:billing_entity_id] = billing_entity.id
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        it "binds the subscription to the entity matched by billing_entity_code" do
+          params[:billing_entity_code] = billing_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_id is unknown" do
+          params[:billing_entity_id] = SecureRandom.uuid
+
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_code is unknown" do
+          params[:billing_entity_code] = "unknown-entity-code"
+
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+
+        it "prefers billing_entity_id over billing_entity_code when both are provided" do
+          other_entity = create(:billing_entity, organization:)
+          params[:billing_entity_id] = billing_entity.id
+          params[:billing_entity_code] = other_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Stacked on top of #5467, which already taught `Subscriptions::CreateService` to accept either `billing_entity_id` or `billing_entity_code` and persist the resulting binding on the subscription row. That work landed the dual-shape contract in the service layer but only wired the REST surface to it. This PR finishes the API exposure by adding the matching GraphQL input.

The change is a single argument on `Types::Subscriptions::CreateSubscriptionInput`: `argument :billing_entity_id, ID, required: false`. Because the existing mutation forwards `args.merge(...)` into the service `params:` hash, no resolver change is required; `params[:billing_entity_id]` reaches the resolver verbatim and triggers the same code path the REST flow already exercises through `billing_entity_code`. The committed schema dumps reflect the new argument so consumers regenerating their schema pick it up cleanly.

The same `multi_entity_billing` feature flag gates the behavior, so when the flag is off the input is accepted at the GraphQL layer and silently ignored downstream, matching the REST surface and keeping the contract forward-compatible.

## Try it locally

This PR depends on #5467; merge or rebase onto that branch first. Then:

1. Pick an organization and enable the flag:
   ```ruby
   org = Organization.find_by(name: "...")
   org.enable_feature_flag!(:multi_entity_billing)
   ```
2. Create a second billing entity to point at:
   ```ruby
   FactoryBot.create(:billing_entity, organization: org, code: "acme_eu")
   entity_id = org.billing_entities.find_by(code: "acme_eu").id
   ```
3. Run the GraphQL mutation against your dev server with `billingEntityId`:
   ```graphql
   mutation {
     createSubscription(input: {
       customerId: "<existing>",
       planId: "<existing>",
       billingTime: anniversary,
       billingEntityId: "<entity_id>"
     }) { id }
   }
   ```
   Expect success, and `Subscription.last.billing_entity_id` to match the chosen entity.
4. Repeat with `billingEntityId` set to a random UUID and expect a 404-shaped GraphQL error with `extensions.code = "not_found"` and `details: { billingEntity: ["not_found"] }`.
5. Disable the flag, repeat with the valid id, and verify the column persists as `NULL`.