### PR TITLE
feat(payment-gated-subs): tax-pending guards and tax-service shortcuts

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -412,6 +412,10 @@ class Invoice < ApplicationRecord
     open? && subscriptions.any?(&:gated?)
   end
 
+  def subscription_payment_gated?
+    open? && subscriptions.any?(&:payment_gated?)
+  end
+
   def voidable?
     if payment_dispute_lost_at? || total_paid_amount_cents > 0 || credit_notes.where.not(credit_status: :voided).any?
       return false

--- a/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
+++ b/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
@@ -47,7 +47,7 @@ module Invoices
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
         Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
-        skip_payment_gating_for_zero_amount if subscription.payment_gated? && invoice.total_amount_cents.zero?
+        skip_payment_gating_for_zero_amount if subscription.payment_gated? && invoice.total_amount_cents.zero? && !invoice.tax_pending?
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         Invoices::TransitionToFinalStatusService.call(invoice:)

--- a/app/services/invoices/finalize_pending_vies_invoice_service.rb
+++ b/app/services/invoices/finalize_pending_vies_invoice_service.rb
@@ -29,6 +29,9 @@ module Invoices
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         invoice.tax_status = "succeeded"
+
+        skip_payment_gating_for_zero_amount if invoice.subscription_gated? && invoice.total_amount_cents.zero?
+
         Invoices::TransitionToFinalStatusService.call(invoice:)
 
         invoice.save!
@@ -59,6 +62,17 @@ module Invoices
     private
 
     attr_reader :invoice
+
+    def skip_payment_gating_for_zero_amount
+      gated = invoice.subscriptions.find(&:gated?)
+      return unless gated
+
+      Subscriptions::ActivationRules::Payment::EvaluateService.call!(
+        rule: gated.activation_rules.payment.sole,
+        status: :satisfied
+      )
+      Subscriptions::ActivationRules::ResolveSubscriptionStatusService.call!(subscription: gated)
+    end
 
     def customer
       @customer ||= invoice.customer

--- a/app/services/invoices/finalize_pending_vies_invoice_service.rb
+++ b/app/services/invoices/finalize_pending_vies_invoice_service.rb
@@ -30,7 +30,7 @@ module Invoices
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         invoice.tax_status = "succeeded"
 
-        skip_payment_gating_for_zero_amount if invoice.subscription_gated? && invoice.total_amount_cents.zero?
+        skip_payment_gating_for_zero_amount if invoice.subscription_payment_gated? && invoice.total_amount_cents.zero?
 
         Invoices::TransitionToFinalStatusService.call(invoice:)
 
@@ -64,7 +64,7 @@ module Invoices
     attr_reader :invoice
 
     def skip_payment_gating_for_zero_amount
-      gated = invoice.subscriptions.find(&:gated?)
+      gated = invoice.subscriptions.find(&:payment_gated?)
       return unless gated
 
       Subscriptions::ActivationRules::Payment::EvaluateService.call!(

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -49,6 +49,9 @@ module Invoices
 
           invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
           invoice.tax_status = "succeeded"
+
+          skip_payment_gating_for_zero_amount if invoice.subscription_gated? && invoice.total_amount_cents.zero?
+
           Invoices::TransitionToFinalStatusService.call(invoice:) unless invoice.draft?
 
           invoice.save!
@@ -83,6 +86,17 @@ module Invoices
       private
 
       attr_accessor :invoice
+
+      def skip_payment_gating_for_zero_amount
+        gated = invoice.subscriptions.find(&:gated?)
+        return unless gated
+
+        Subscriptions::ActivationRules::Payment::EvaluateService.call!(
+          rule: gated.activation_rules.payment.sole,
+          status: :satisfied
+        )
+        Subscriptions::ActivationRules::ResolveSubscriptionStatusService.call!(subscription: gated)
+      end
 
       def should_deliver_email?
         License.premium? &&

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -50,7 +50,7 @@ module Invoices
           invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
           invoice.tax_status = "succeeded"
 
-          skip_payment_gating_for_zero_amount if invoice.subscription_gated? && invoice.total_amount_cents.zero?
+          skip_payment_gating_for_zero_amount if invoice.subscription_payment_gated? && invoice.total_amount_cents.zero?
 
           Invoices::TransitionToFinalStatusService.call(invoice:) unless invoice.draft?
 
@@ -88,7 +88,7 @@ module Invoices
       attr_accessor :invoice
 
       def skip_payment_gating_for_zero_amount
-        gated = invoice.subscriptions.find(&:gated?)
+        gated = invoice.subscriptions.find(&:payment_gated?)
         return unless gated
 
         Subscriptions::ActivationRules::Payment::EvaluateService.call!(

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -36,7 +36,7 @@ module Invoices
         )
         Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
-        skip_payment_gating_for_zero_amount if subscription_payment_gated? && invoice.total_amount_cents.zero?
+        skip_payment_gating_for_zero_amount if subscription_payment_gated? && invoice.total_amount_cents.zero? && !invoice.tax_pending?
 
         set_invoice_generated_status unless invoice.pending?
         invoice.save!

--- a/app/services/invoices/transition_to_final_status_service.rb
+++ b/app/services/invoices/transition_to_final_status_service.rb
@@ -12,8 +12,10 @@ module Invoices
     def call
       result.invoice = invoice
 
-      # Keep open for payment-gated invoices awaiting payment resolution
-      return result if invoice.subscription_gated? && invoice.total_amount_cents.positive?
+      # Keep open for payment-gated invoices awaiting payment or tax resolution.
+      # Tax pending matters because totals are not yet computed — falling through
+      # would treat the invoice as zero-amount and finalize it prematurely.
+      return result if invoice.subscription_gated? && (invoice.total_amount_cents.positive? || invoice.tax_pending?)
 
       if should_finalize_invoice?
         Invoices::FinalizeService.call!(invoice: invoice)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1153,6 +1153,47 @@ RSpec.describe Invoice do
     end
   end
 
+  describe "#subscription_payment_gated?" do
+    subject(:subscription_payment_gated?) { invoice.subscription_payment_gated? }
+
+    before { invoice }
+
+    context "when invoice is not open" do
+      let(:invoice) { create(:invoice) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when invoice is open" do
+      let(:invoice) do
+        create(
+          :invoice,
+          :open,
+          :with_subscriptions,
+          subscriptions: [subscription],
+          organization: subscription.organization,
+          customer: subscription.customer
+        )
+      end
+
+      context "when subscription is payment-gated" do
+        let(:subscription) { create(:subscription, :incomplete) }
+
+        before do
+          create(:subscription_activation_rule, subscription:, status: "pending")
+        end
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when subscription is not gated" do
+        let(:subscription) { create(:subscription, :incomplete) }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
   describe "#voidable?" do
     subject(:voidable) { invoice.voidable? }
 

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -220,16 +220,50 @@ describe "Payment Gated Subscription Activation Scenarios" do
   end
 
   describe "gated subscription with pending VIES check" do
-    it "completes the flow: gated → VIES pending → VIES resolved → payment → activation" do
-      pending "requires CreateService integration with ActivateService gated path (PR #5370)"
+    let(:vat_number) { "IT12345678901" }
+    let(:organization) do
+      create(:organization, country: "FR", webhook_url: nil, eu_tax_management: true,
+        billing_entities: [create(:billing_entity, country: "FR", eu_tax_management: true)])
+    end
+    let(:billing_entity) { organization.billing_entities.first }
+    let(:customer) do
+      create(:customer, organization:, billing_entity:, country: "IT", currency: "EUR",
+        tax_identification_number: vat_number)
+    end
 
-      # 1. Create subscription with payment gating + customer has pending VIES check
-      # 2. Invoice created as open, tax_status: pending (VIES blocks tax calculation)
-      # 3. No payment triggered yet (can't pay without taxes)
-      # 4. VIES resolves → ViesCheckJob picks up the open invoice
-      # 5. FinalizePendingViesInvoiceService applies taxes, triggers payment only
-      # 6. Payment succeeds → subscription activates, invoice finalized
-      raise "not implemented"
+    before do
+      create(:pending_vies_check, customer:, tax_identification_number: vat_number)
+    end
+
+    it "stays gated until VIES resolves, then activates on payment success" do
+      # Stage 1: Create subscription — invoice goes :open with tax_status :pending (VIES blocks taxes)
+      create_subscription(subscription_params)
+      perform_all_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_incomplete
+      expect(subscription.activation_rules.sole).to be_pending
+
+      invoice = subscription.invoices.sole
+      expect(invoice).to be_open
+      expect(invoice.tax_status).to eq("pending")
+
+      # Stage 2: VIES resolves — FinalizePendingViesInvoiceService applies taxes and triggers payment
+      mock_vies_check!(vat_number)
+      Customers::ViesCheckJob.perform_now(customer)
+      perform_all_enqueued_jobs
+
+      invoice.reload
+      expect(invoice.tax_status).to eq("succeeded")
+      expect(invoice).to be_open
+
+      # Stage 3: Stripe webhook — payment succeeded, subscription activates
+      simulate_stripe_webhook(status: "succeeded")
+
+      subscription.reload
+      expect(subscription).to be_active
+      expect(subscription.activation_rules.sole).to be_satisfied
+      expect(invoice.reload).to be_finalized
     end
   end
 

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -310,7 +310,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
       expect(invoice.tax_status).to eq("failed")
 
       # Stage 2: Re-stub Anrok to succeed, then retry. Invoice goes :open with taxes
-      # applied; FinalizePendingViesInvoiceService triggers payment for the gated case.
+      # applied; PullTaxesAndApplyService triggers payment for the gated case.
       stub_anrok_response(success_body_for(invoice))
       Invoices::RetryService.call!(invoice:)
       perform_all_enqueued_jobs

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -268,15 +268,64 @@ describe "Payment Gated Subscription Activation Scenarios" do
   end
 
   describe "gated subscription with provider tax failure" do
-    it "completes the flow: gated → tax failure → retry → payment → activation" do
-      pending "requires CreateService integration with ActivateService gated path (PR #5370)"
+    let(:tax_integration) { create(:anrok_integration, organization:) }
+    let(:tax_integration_customer) { create(:anrok_customer, integration: tax_integration, customer:) }
+    let(:anrok_client) { instance_double(LagoHttpClient::Client) }
+    let(:anrok_finalized_endpoint) { "https://api.nango.dev/v1/anrok/finalized_invoices" }
+    let(:anrok_draft_endpoint) { "https://api.nango.dev/v1/anrok/draft_invoices" }
+    let(:failure_body) { File.read(Rails.root.join("spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json")) }
+    let(:success_body_template) { JSON.parse(File.read(Rails.root.join("spec/fixtures/integration_aggregator/taxes/invoices/success_response.json"))) }
 
-      # 1. Create subscription with payment gating + customer has tax provider
-      # 2. Invoice created as open, tax provider fails → invoice status: failed
-      # 3. User retries → RetryService sets status back to open (not pending)
-      # 4. PullTaxesAndApplyService succeeds → triggers payment only
-      # 5. Payment succeeds → subscription activates, invoice finalized
-      raise "not implemented"
+    before do
+      tax_integration_customer
+      allow(LagoHttpClient::Client).to receive(:new).and_call_original
+      allow(LagoHttpClient::Client).to receive(:new).with(anrok_finalized_endpoint, anything).and_return(anrok_client)
+      allow(LagoHttpClient::Client).to receive(:new).with(anrok_draft_endpoint, anything).and_return(anrok_client)
+      stub_anrok_response(failure_body)
+    end
+
+    def stub_anrok_response(body)
+      response = instance_double(Net::HTTPOK)
+      allow(response).to receive(:body).and_return(body)
+      allow(anrok_client).to receive(:post_with_response).and_return(response)
+    end
+
+    def success_body_for(invoice)
+      body = success_body_template.deep_dup
+      body["succeededInvoices"].first["fees"].first["item_id"] = invoice.fees.first.id
+      body.to_json
+    end
+
+    it "fails on tax error, retries successfully, then activates on payment success" do
+      # Stage 1: Create subscription — Anrok fails → invoice :failed
+      create_subscription(subscription_params)
+      perform_all_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_incomplete
+      expect(subscription.activation_rules.sole).to be_pending
+
+      invoice = subscription.invoices.sole
+      expect(invoice).to be_failed
+      expect(invoice.tax_status).to eq("failed")
+
+      # Stage 2: Re-stub Anrok to succeed, then retry. Invoice goes :open with taxes
+      # applied; FinalizePendingViesInvoiceService triggers payment for the gated case.
+      stub_anrok_response(success_body_for(invoice))
+      Invoices::RetryService.call!(invoice:)
+      perform_all_enqueued_jobs
+
+      invoice.reload
+      expect(invoice).to be_open
+      expect(invoice.tax_status).to eq("succeeded")
+
+      # Stage 3: Stripe webhook — payment succeeded, subscription activates
+      simulate_stripe_webhook(status: "succeeded")
+
+      subscription.reload
+      expect(subscription).to be_active
+      expect(subscription.activation_rules.sole).to be_satisfied
+      expect(invoice.reload).to be_finalized
     end
   end
 end

--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -716,6 +716,27 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
           expect(subscription.reload).to be_active
         end
       end
+
+      context "when tax is pending" do
+        let(:integration) { create(:anrok_integration, organization:) }
+        let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+        let(:rule) { subscription.activation_rules.payment.sole }
+
+        before { integration_customer }
+
+        it "does not fire the zero-amount activation shortcut" do
+          invoice_service.call
+
+          expect(rule.reload).to be_pending
+          expect(subscription.reload).to be_incomplete
+        end
+
+        it "keeps the invoice open" do
+          result = invoice_service.call
+
+          expect(result.invoice).to be_open
+        end
+      end
     end
   end
 end

--- a/spec/services/invoices/finalize_pending_vies_invoice_service_spec.rb
+++ b/spec/services/invoices/finalize_pending_vies_invoice_service_spec.rb
@@ -555,6 +555,28 @@ RSpec.describe Invoices::FinalizePendingViesInvoiceService do
         expect(Invoices::Payments::CreateService).to have_received(:call_async)
         expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
       end
+
+      context "when invoice total is zero after tax computation" do
+        let(:rule) { subscription.activation_rules.payment.sole }
+        let(:fee_subscription) do
+          create(:fee, invoice:, subscription:, fee_type: :subscription, amount_cents: 0)
+        end
+        let(:fee_charge) do
+          create(:fee, invoice:, charge:, fee_type: :charge, total_aggregated_units: 0, amount_cents: 0)
+        end
+
+        it "marks the payment activation rule as satisfied" do
+          finalize_service.call
+
+          expect(rule.reload).to be_satisfied
+        end
+
+        it "activates the subscription" do
+          finalize_service.call
+
+          expect(subscription.reload).to be_active
+        end
+      end
     end
   end
 end

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -555,6 +555,44 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
         expect(Invoices::Payments::CreateService).to have_received(:call_async)
         expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
       end
+
+      context "when invoice total is zero after tax computation" do
+        let(:rule) { subscription.activation_rules.payment.sole }
+        let(:fee_subscription) do
+          create(:fee, invoice:, subscription:, fee_type: :subscription, amount_cents: 0)
+        end
+        let(:fee_charge) do
+          create(:fee, invoice:, charge:, fee_type: :charge, total_aggregated_units: 0, amount_cents: 0)
+        end
+        let(:body) do
+          {
+            succeededInvoices: [{
+              id: invoice.id,
+              issuing_date: Time.current.to_date.iso8601,
+              sub_total_excluding_taxes: 0,
+              taxes_amount_cents: 0,
+              currency: "EUR",
+              fees: [
+                {item_id: fee_subscription.id, amount_cents: 0, tax_amount_cents: 0, tax_breakdown: []},
+                {item_id: fee_charge.id, amount_cents: 0, tax_amount_cents: 0, tax_breakdown: []}
+              ]
+            }],
+            failedInvoices: []
+          }.to_json
+        end
+
+        it "marks the payment activation rule as satisfied" do
+          pull_taxes_service.call
+
+          expect(rule.reload).to be_satisfied
+        end
+
+        it "activates the subscription" do
+          pull_taxes_service.call
+
+          expect(subscription.reload).to be_active
+        end
+      end
     end
   end
 end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -630,6 +630,28 @@ RSpec.describe Invoices::SubscriptionService do
           expect(subscription.reload).to be_active
         end
       end
+
+      context "when tax is pending" do
+        let(:integration) { create(:anrok_integration, organization:) }
+        let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+        let(:rule) { subscription.activation_rules.payment.sole }
+
+        before { integration_customer }
+
+        it "does not fire the zero-amount activation shortcut" do
+          invoice_service.call
+
+          expect(rule.reload).to be_pending
+          expect(subscription.reload).to be_incomplete
+        end
+
+        it "keeps the invoice open with tax_status pending" do
+          result = invoice_service.call
+
+          expect(result.invoice).to be_open
+          expect(result.invoice.tax_status).to eq("pending")
+        end
+      end
     end
 
     context "when an error occurs" do

--- a/spec/services/invoices/transition_to_final_status_service_spec.rb
+++ b/spec/services/invoices/transition_to_final_status_service_spec.rb
@@ -101,6 +101,37 @@ RSpec.describe Invoices::TransitionToFinalStatusService do
     end
   end
 
+  context "when invoice is subscription_gated with tax pending" do
+    let(:fees_amount_cents) { 100 }
+    let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+    let(:subscription) do
+      create(:subscription, :incomplete, :with_activation_rules,
+        activation_rules_config: [{type: "payment", timeout_hours: 48, status: "pending"}],
+        organization:, customer:, plan:)
+    end
+    let(:invoice) do
+      create(
+        :invoice,
+        organization:,
+        currency: "EUR",
+        fees_amount_cents:,
+        total_amount_cents: 0,
+        tax_status: :pending,
+        issuing_date: Time.zone.now.beginning_of_month,
+        customer:,
+        status: :open
+      )
+    end
+
+    before { create(:invoice_subscription, invoice:, subscription:) }
+
+    it "keeps the invoice as open while waiting for tax resolution" do
+      result
+
+      expect(invoice.status).to eq("open")
+    end
+  end
+
   context "when invoice fees_amount_cents is zero" do
     let(:fees_amount_cents) { 0 }
 


### PR DESCRIPTION
## Context

Built on top of #5461 (zero-amount activation shortcut for SubscriptionService and CreatePayInAdvanceFixedChargesService). Two loose ends from that work plus two scenarios that have been pending since #5375 needed closing:

1. The gated invoice guards in TransitionToFinalStatusService and the zero-amount activation shortcut both treat `total_amount_cents` as "the invoice is zero" without distinguishing between "tax has computed and the result is zero" and "tax is still pending and totals haven't been computed yet". With Anrok or VIES in the mix, the second case happens regularly, and the literal 0 reading would either prematurely finalize a gated invoice or fire the activation shortcut while the tax flow was still in progress.
2. The same zero-amount activation shortcut needed to be applied in PullTaxesAndApplyService and FinalizePendingViesInvoiceService for parity. A free / coupon-zeroed gated subscription with a tax provider integration (Anrok) or pending VIES check would otherwise wait on the payment chain to resolve a payment that will never come.
3. The VIES and provider-tax-failure end-to-end scenarios for gated subscriptions were placeholders since #5375 — `pending` blocks with `raise "not implemented"` — and could now be implemented since the prerequisite wiring is in place.

## Description

**Tax-pending guards**

- `TransitionToFinalStatusService`: extend the gated guard to also keep the invoice `:open` when `tax_pending?`. Totals are not yet computed in that state — falling through to the standard finalize path would treat the invoice as zero-amount and finalize prematurely.
- `Invoices::SubscriptionService` and `Invoices::CreatePayInAdvanceFixedChargesService`: add `!tax_pending?` to the zero-amount activation shortcut condition. The shortcut is meant for invoices whose total is genuinely zero after tax computation, not for invoices waiting on tax resolution.

**Zero-amount activation shortcut in tax services**

- `Invoices::ProviderTaxes::PullTaxesAndApplyService`: after taxes are applied, if the resulting total is zero on a gated invoice, mark the payment activation rule as satisfied and resolve the subscription status. Subscription transitions to active before `TransitionToFinalStatusService` runs, so the invoice falls through to the standard zero-amount finalize/close path — same pattern as in the other invoice services.
- `Invoices::FinalizePendingViesInvoiceService`: same shortcut applied after VIES resolution and tax application.

**End-to-end scenarios**

- Gated subscription with pending VIES check: customer with a pending VIES record → invoice goes `:open` with `tax_status: :pending` → VIES resolves via `ViesCheckJob` → `FinalizePendingViesInvoiceService` applies taxes and triggers payment for the gated case → Stripe success webhook activates the subscription.
- Gated subscription with provider tax failure: Anrok stub returns the failure response → invoice goes `:failed` → `Invoices::RetryService` resets to `:open` and re-enqueues the tax fetch → Anrok stub re-stubbed to succeed → taxes applied, payment triggered → Stripe success webhook activates.

## Tests

- `transition_to_final_status_service_spec.rb`: new context covering gated + tax_pending → keeps `:open`.
- `subscription_service_spec.rb` and `create_pay_in_advance_fixed_charges_service_spec.rb`: new contexts inside the existing gated blocks asserting the zero-amount shortcut does not fire while tax is pending and the invoice stays `:open`.
- `pull_taxes_and_apply_service_spec.rb` and `finalize_pending_vies_invoice_service_spec.rb`: new contexts inside the existing gated blocks constructing zero-amount fees (and a zero-tax Anrok body for the provider tax case) so the shortcut fires through the real flow. Assert rule satisfied + subscription active.
- `payment_gated_activation_spec.rb`: the two `pending` placeholders from #5375 are replaced with full implementations.

## Out of scope

- Late payment refund routing in `Payment::ResolveService` (deferred to comming PR alongside the timeout/expire mechanism it depends on).
