### PR TITLE
fix(wallets): Don't refresh wallets when there is no need to

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -41,6 +41,8 @@ class Wallet < ApplicationRecord
 
   LOWEST_PRIORITY = 50
 
+  REFRESH_RELEVANT_ATTRIBUTES = %w[code priority allowed_fee_types].freeze
+
   validates :rate_amount, numericality: {greater_than: 0}
   validates :currency, inclusion: {in: currency_list}
   validates :invoice_requires_successful_payment, exclusion: [nil]

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -58,7 +58,7 @@ module Wallets
 
       InvoiceCustomSections::AttachToResourceService.call(resource: wallet, params:)
       SendWebhookJob.perform_later("wallet.updated", wallet)
-      Customers::RefreshWalletsService.call(customer: wallet.customer)
+      Customers::RefreshWalletsService.call(customer: wallet.customer) if needs_refresh?
 
       result.wallet = wallet
       result
@@ -121,6 +121,7 @@ module Wallets
         next if existing_wallet_billable_metric_ids.include?(bm.id)
 
         WalletTarget.create!(wallet:, billable_metric: bm, organization_id: wallet.organization_id)
+        @wallet_targets_changed = true
       end
 
       sanitize_wallet_billable_metrics(existing_wallet_billable_metric_ids) if existing_wallet_billable_metric_ids.present?
@@ -129,8 +130,18 @@ module Wallets
     def sanitize_wallet_billable_metrics(existing_wallet_billable_metric_ids)
       not_needed_wallet_target_ids = existing_wallet_billable_metric_ids - billable_metrics.pluck(:id)
       not_needed_wallet_target_ids.each do |wallet_billable_metric_id|
-        WalletTarget.find_by(wallet:, billable_metric_id: wallet_billable_metric_id, organization: wallet.organization)&.destroy!
+        target = WalletTarget.find_by(wallet:, billable_metric_id: wallet_billable_metric_id, organization: wallet.organization)
+        next unless target
+
+        target.destroy!
+        @wallet_targets_changed = true
       end
+    end
+
+    def needs_refresh?
+      return true if @wallet_targets_changed
+
+      (wallet.saved_changes.keys & Wallet::REFRESH_RELEVANT_ATTRIBUTES).any?
     end
 
     def billable_metric_identifiers

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -251,4 +251,51 @@ RSpec.describe Wallet do
       expect(wallet.paid_top_up_max_credits).to be_nil
     end
   end
+
+  describe "REFRESH_RELEVANT_ATTRIBUTES" do
+    # If this list changes, you MUST decide whether the new/removed column
+    # should trigger Customers::RefreshWalletsService and update
+    # Wallet::REFRESH_RELEVANT_ATTRIBUTES accordingly.
+    non_refresh_relevant_attributes = %w[
+      id
+      balance_cents
+      balance_currency
+      consumed_amount_cents
+      consumed_amount_currency
+      consumed_credits
+      credits_balance
+      credits_ongoing_balance
+      credits_ongoing_usage_balance
+      depleted_ongoing_balance
+      expiration_at
+      invoice_requires_successful_payment
+      last_balance_sync_at
+      last_consumed_credit_at
+      last_ongoing_balance_sync_at
+      lock_version
+      name
+      ongoing_balance_cents
+      ongoing_usage_balance_cents
+      paid_top_up_max_amount_cents
+      paid_top_up_min_amount_cents
+      payment_method_type
+      rate_amount
+      ready_to_be_refreshed
+      skip_invoice_custom_sections
+      status
+      terminated_at
+      traceable
+      created_at
+      updated_at
+      billing_entity_id
+      customer_id
+      organization_id
+      payment_method_id
+    ].freeze
+
+    it "covers every column that does not need to trigger a refresh" do
+      expect(described_class.column_names - described_class::REFRESH_RELEVANT_ATTRIBUTES)
+        .to match_array(non_refresh_relevant_attributes)
+    end
+  end
 end

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -53,6 +53,126 @@ RSpec.describe Wallets::UpdateService do
       expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
     end
 
+    describe "Customers::RefreshWalletsService gating" do
+      before { allow(Customers::RefreshWalletsService).to receive(:call) }
+
+      shared_examples "calls refresh" do
+        it "calls Customers::RefreshWalletsService" do
+          expect(result).to be_success
+          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:)
+        end
+      end
+
+      shared_examples "does not call refresh" do
+        it "does not call Customers::RefreshWalletsService" do
+          expect(result).to be_success
+          expect(Customers::RefreshWalletsService).not_to have_received(:call)
+        end
+      end
+
+      context "when code changes" do
+        let(:params) { {id: wallet.id, code: "new_code"} }
+
+        include_examples "calls refresh"
+      end
+
+      context "when priority changes" do
+        let(:params) { {id: wallet.id, priority: wallet.priority - 1} }
+
+        include_examples "calls refresh"
+      end
+
+      context "when allowed_fee_types change" do
+        let(:params) { {id: wallet.id, applies_to: {fee_types: %w[charge]}} }
+
+        include_examples "calls refresh"
+      end
+
+      context "when a wallet_target is added" do
+        let(:billable_metric) { create(:billable_metric, organization:) }
+        let(:params) { {id: wallet.id, applies_to: {billable_metric_ids: [billable_metric.id]}} }
+
+        before { CurrentContext.source = "graphql" }
+
+        include_examples "calls refresh"
+      end
+
+      context "when a wallet_target is removed" do
+        let(:billable_metric) { create(:billable_metric, organization:) }
+        let(:params) { {id: wallet.id, applies_to: {billable_metric_ids: []}} }
+
+        before do
+          CurrentContext.source = "graphql"
+          create(:wallet_target, wallet:, billable_metric:)
+        end
+
+        include_examples "calls refresh"
+      end
+
+      context "when only name changes" do
+        let(:params) { {id: wallet.id, name: "new name"} }
+
+        include_examples "does not call refresh"
+      end
+
+      context "when only expiration_at changes" do
+        let(:params) { {id: wallet.id, expiration_at: (Time.current + 1.year).iso8601} }
+
+        include_examples "does not call refresh"
+      end
+
+      context "when only paid_top_up_* change" do
+        let(:params) do
+          {
+            id: wallet.id,
+            paid_top_up_min_amount_cents: 1_00,
+            paid_top_up_max_amount_cents: 1_000_00
+          }
+        end
+
+        include_examples "does not call refresh"
+      end
+
+      context "when only payment_method changes" do
+        let(:payment_method) { create(:payment_method, organization:, customer:) }
+        let(:params) do
+          {
+            id: wallet.id,
+            payment_method: {payment_method_id: payment_method.id, payment_method_type: "provider"}
+          }
+        end
+
+        before { payment_method }
+
+        include_examples "does not call refresh"
+      end
+
+      context "when only recurring_transaction_rules change", :premium do
+        let(:params) do
+          {
+            id: wallet.id,
+            recurring_transaction_rules: [
+              {trigger: "interval", interval: "weekly", paid_credits: "105", granted_credits: "105"}
+            ]
+          }
+        end
+
+        include_examples "does not call refresh"
+      end
+
+      context "when only metadata changes" do
+        let(:params) { {id: wallet.id, metadata: {"foo" => "bar"}} }
+
+        include_examples "does not call refresh"
+      end
+
+      context "when client resends a refresh-relevant attribute with the same value (no-op)" do
+        let(:params) { {id: wallet.id, code: wallet.code, name: "new name"} }
+
+        include_examples "does not call refresh"
+      end
+    end
+
     context "when wallet is not found" do
       let(:wallet) { nil }
 


### PR DESCRIPTION
## Context

`Wallets::UpdateService` always calls `Customers::RefreshWalletsService` after a successful update. The refresh recomputes usage per active subscription, rebuilds allocation rules, and writes to every active wallet. Most update paths do not affect any meaningful attributes requiring a refresh, thus wasting time on useless computations.

## Description

Skip the refresh when the update did not touch any attribute or association the refresh actually reads.

The refresh-relevant wallet columns are listed in `Wallet::REFRESH_RELEVANT_ATTRIBUTES` (`code`, `priority`, `allowed_fee_types`).

`wallet_targets` mutations are tracked separately in the service via a `@wallet_targets_changed` flag since they are an association rather than a column. A private `needs_refresh?` method on `Wallets::UpdateService` checks for changes in any of them.

A spec on `Wallet` lists every column not "refresh-relevant" and asserts the diff against the constant matches, so any new column or change to the constant fails the test until someone makes a conscious decision.