### PR TITLE
ING-42 feat(wallets): Support billing_entity_code on wallet creation

### DIFF
--- a/app/controllers/concerns/wallet_actions.rb
+++ b/app/controllers/concerns/wallet_actions.rb
@@ -96,6 +96,7 @@ module WalletActions
       :ignore_paid_top_up_limits_on_creation,
       :transaction_name,
       :transaction_priority,
+      :billing_entity_code,
       metadata: {},
       transaction_metadata: [
         :key,

--- a/app/controllers/concerns/wallet_actions.rb
+++ b/app/controllers/concerns/wallet_actions.rb
@@ -97,6 +97,7 @@ module WalletActions
       :transaction_name,
       :transaction_priority,
       :billing_entity_code,
+      :billing_entity_id,
       metadata: {},
       transaction_metadata: [
         :key,

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -206,10 +206,11 @@ module Wallets
     def billing_entity
       return @billing_entity if defined? @billing_entity
 
+      scope = customer.organization.billing_entities
       @billing_entity = if params[:billing_entity_id].present?
-        BillingEntity.find_by(id: params[:billing_entity_id])
+        scope.find_by(id: params[:billing_entity_id])
       elsif params[:billing_entity_code].present?
-        BillingEntity.find_by(code: params[:billing_entity_code])
+        scope.find_by(code: params[:billing_entity_code])
       else
         customer.billing_entity
       end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -206,7 +206,9 @@ module Wallets
     def billing_entity
       return @billing_entity if defined? @billing_entity
 
-      @billing_entity = if params[:billing_entity_code].present?
+      @billing_entity = if params[:billing_entity_id].present?
+        BillingEntity.find_by(id: params[:billing_entity_id])
+      elsif params[:billing_entity_code].present?
         BillingEntity.find_by(code: params[:billing_entity_code])
       else
         customer.billing_entity

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -58,14 +58,20 @@ module Wallets
         attributes[:payment_method_id] = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
       end
 
+      if organization_flag_enabled?(:multi_entity_billing)
+        return result.not_found_failure!(resource: "billing_entity") unless billing_entity
+
+        attributes[:billing_entity_id] = billing_entity.id
+      end
+
       wallet = Wallet.new(attributes)
 
       ActiveRecord::Base.transaction do
-        if currency.present? && (!multi_currency_enabled? || customer.currency.blank?)
+        if currency.present? && (!organization_flag_enabled?(:multi_currency) || customer.currency.blank?)
           Customers::UpdateCurrencyService.call!(customer: customer, currency:)
         end
 
-        wallet.currency = multi_currency_enabled? ? (currency || wallet.customer.currency) : wallet.customer.currency
+        wallet.currency = organization_flag_enabled?(:multi_currency) ? (currency || wallet.customer.currency) : wallet.customer.currency
         wallet.save!
 
         validate_wallet_initial_amount! wallet
@@ -144,8 +150,8 @@ module Wallets
       params[:currency]
     end
 
-    def multi_currency_enabled?
-      customer.organization.feature_flag_enabled?(:multi_currency)
+    def organization_flag_enabled?(flag)
+      customer.organization.feature_flag_enabled?(flag)
     end
 
     def valid?
@@ -195,6 +201,16 @@ module Wallets
       return nil if params[:payment_method].blank? || params[:payment_method][:payment_method_id].blank?
 
       @payment_method = PaymentMethod.find_by(id: params[:payment_method][:payment_method_id], organization_id:)
+    end
+
+    def billing_entity
+      return @billing_entity if defined? @billing_entity
+
+      @billing_entity = if params[:billing_entity_code].present?
+        BillingEntity.find_by(code: params[:billing_entity_code])
+      else
+        customer.billing_entity
+      end
     end
 
     def create_metadata(wallet, metadata_value)

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -58,7 +58,7 @@ module Wallets
         attributes[:payment_method_id] = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
       end
 
-      if organization_flag_enabled?(:multi_entity_billing)
+      if organization_flag_enabled?(:multi_entity_billing) && (params[:billing_entity_id].present? || params[:billing_entity_code].present?)
         return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 
         attributes[:billing_entity_id] = billing_entity.id
@@ -211,8 +211,6 @@ module Wallets
         scope.find_by(id: params[:billing_entity_id])
       elsif params[:billing_entity_code].present?
         scope.find_by(code: params[:billing_entity_code])
-      else
-        customer.billing_entity
       end
     end
 

--- a/spec/requests/api/v1/customers/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/customers/wallets_controller_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe Api::V1::Customers::WalletsController do
         end
       end
     end
+
+    it_behaves_like "a wallet create endpoint with billing_entity_id" do
+      subject do
+        post_with_token(organization, "/api/v1/customers/#{external_id}/wallets", {wallet: create_params})
+      end
+    end
   end
 
   describe "PUT /api/v1/customers/:customer_external_id/wallets/:code" do

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe Api::V1::WalletsController do
         end
       end
     end
+
+    it_behaves_like "a wallet create endpoint with billing_entity_id" do
+      subject do
+        post_with_token(organization, "/api/v1/wallets", {wallet: create_params})
+      end
+    end
   end
 
   describe "PUT /api/v1/wallets/:id" do

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -1018,6 +1018,28 @@ RSpec.describe Wallets::CreateService do
         end
       end
 
+      context "when billing_entity_id is provided" do
+        let(:params) do
+          {
+            name: "New Wallet",
+            customer:,
+            organization_id: organization.id,
+            currency: "EUR",
+            rate_amount: "1.00",
+            paid_credits: "0.00",
+            granted_credits: "0.00",
+            billing_entity_id: billing_entity.id
+          }
+        end
+
+        it "assigns the billing entity to the wallet" do
+          expect(service_result).to be_success
+
+          wallet = service_result.wallet
+          expect(wallet.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+
       context "when billing_entity_code is not provided" do
         it "falls back to the customer billing entity" do
           expect(service_result).to be_success
@@ -1045,6 +1067,52 @@ RSpec.describe Wallets::CreateService do
           expect(service_result).not_to be_success
           expect(service_result.error).to be_a(BaseService::NotFoundFailure)
           expect(service_result.error.resource).to eq("billing_entity")
+        end
+      end
+
+      context "when billing_entity_id does not match any entity" do
+        let(:params) do
+          {
+            name: "New Wallet",
+            customer:,
+            organization_id: organization.id,
+            currency: "EUR",
+            rate_amount: "1.00",
+            paid_credits: "0.00",
+            granted_credits: "0.00",
+            billing_entity_id: SecureRandom.uuid
+          }
+        end
+
+        it "returns a not found error" do
+          expect(service_result).not_to be_success
+          expect(service_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(service_result.error.resource).to eq("billing_entity")
+        end
+      end
+
+      context "when both billing_entity_id and billing_entity_code are provided" do
+        let!(:other_billing_entity) { create(:billing_entity, organization:, code: "other_be") }
+
+        let(:params) do
+          {
+            name: "New Wallet",
+            customer:,
+            organization_id: organization.id,
+            currency: "EUR",
+            rate_amount: "1.00",
+            paid_credits: "0.00",
+            granted_credits: "0.00",
+            billing_entity_id: billing_entity.id,
+            billing_entity_code: other_billing_entity.code
+          }
+        end
+
+        it "billing_entity_id takes precedence" do
+          expect(service_result).to be_success
+
+          wallet = service_result.wallet
+          expect(wallet.billing_entity_id).to eq(billing_entity.id)
         end
       end
     end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -1070,6 +1070,56 @@ RSpec.describe Wallets::CreateService do
         end
       end
 
+      context "when billing_entity_id belongs to another organization" do
+        let(:other_organization) { create(:organization) }
+        let!(:other_billing_entity) { create(:billing_entity, organization: other_organization) }
+
+        let(:params) do
+          {
+            name: "New Wallet",
+            customer:,
+            organization_id: organization.id,
+            currency: "EUR",
+            rate_amount: "1.00",
+            paid_credits: "0.00",
+            granted_credits: "0.00",
+            billing_entity_id: other_billing_entity.id
+          }
+        end
+
+        it "returns a not found error" do
+          expect(service_result).not_to be_success
+          expect(service_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(service_result.error.resource).to eq("billing_entity")
+        end
+      end
+
+      context "when billing_entity_code belongs to another organization" do
+        let(:other_organization) { create(:organization) }
+        let!(:other_billing_entity) { create(:billing_entity, organization: other_organization, code: "other_org_be") }
+
+        let(:params) do
+          {
+            name: "New Wallet",
+            customer:,
+            organization_id: organization.id,
+            currency: "EUR",
+            rate_amount: "1.00",
+            paid_credits: "0.00",
+            granted_credits: "0.00",
+            billing_entity_code: "other_org_be"
+          }
+        end
+
+        before { other_billing_entity }
+
+        it "returns a not found error" do
+          expect(service_result).not_to be_success
+          expect(service_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(service_result.error.resource).to eq("billing_entity")
+        end
+      end
+
       context "when billing_entity_id does not match any entity" do
         let(:params) do
           {

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -989,6 +989,92 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
+    context "when multi_entity_billing is enabled" do
+      let!(:billing_entity) { create(:billing_entity, organization:, code: "be_code") }
+
+      before do
+        organization.update!(feature_flags: ["multi_entity_billing"])
+      end
+
+      context "when billing_entity_code is provided" do
+        let(:params) do
+          {
+            name: "New Wallet",
+            customer:,
+            organization_id: organization.id,
+            currency: "EUR",
+            rate_amount: "1.00",
+            paid_credits: "0.00",
+            granted_credits: "0.00",
+            billing_entity_code: "be_code"
+          }
+        end
+
+        it "assigns the billing entity to the wallet" do
+          expect(service_result).to be_success
+
+          wallet = service_result.wallet
+          expect(wallet.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+
+      context "when billing_entity_code is not provided" do
+        it "falls back to the customer billing entity" do
+          expect(service_result).to be_success
+
+          wallet = service_result.wallet
+          expect(wallet.billing_entity_id).to eq(customer.billing_entity.id)
+        end
+      end
+
+      context "when billing_entity_code does not match any entity" do
+        let(:params) do
+          {
+            name: "New Wallet",
+            customer:,
+            organization_id: organization.id,
+            currency: "EUR",
+            rate_amount: "1.00",
+            paid_credits: "0.00",
+            granted_credits: "0.00",
+            billing_entity_code: "nonexistent"
+          }
+        end
+
+        it "returns a not found error" do
+          expect(service_result).not_to be_success
+          expect(service_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(service_result.error.resource).to eq("billing_entity")
+        end
+      end
+    end
+
+    context "when multi_entity_billing is not enabled" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "be_code") }
+
+      let(:params) do
+        {
+          name: "New Wallet",
+          customer:,
+          organization_id: organization.id,
+          currency: "EUR",
+          rate_amount: "1.00",
+          paid_credits: "0.00",
+          granted_credits: "0.00",
+          billing_entity_code: "be_code"
+        }
+      end
+
+      before { billing_entity }
+
+      it "does not assign the billing entity even if code is provided" do
+        expect(service_result).to be_success
+
+        wallet = service_result.wallet
+        expect(wallet.billing_entity_id).to be_nil
+      end
+    end
+
     context "when neither code nor name is provided" do
       let(:params) do
         {

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -1040,12 +1040,12 @@ RSpec.describe Wallets::CreateService do
         end
       end
 
-      context "when billing_entity_code is not provided" do
-        it "falls back to the customer billing entity" do
+      context "when neither billing_entity_code nor billing_entity_id is provided" do
+        it "creates the wallet without a billing entity" do
           expect(service_result).to be_success
 
           wallet = service_result.wallet
-          expect(wallet.billing_entity_id).to eq(customer.billing_entity.id)
+          expect(wallet.billing_entity_id).to be_nil
         end
       end
 

--- a/spec/support/shared_examples/wallet_actions.rb
+++ b/spec/support/shared_examples/wallet_actions.rb
@@ -621,14 +621,14 @@ RSpec.shared_examples "a wallet create endpoint" do
       end
     end
 
-    context "when billing_entity_code is not provided" do
-      it "falls back to the customer billing entity" do
+    context "when neither billing_entity_code nor billing_entity_id is provided" do
+      it "creates the wallet without a billing entity" do
         subject
 
         expect(response).to have_http_status(:success)
 
         wallet = Wallet.find(json[:wallet][:lago_id])
-        expect(wallet.billing_entity_id).to eq(customer.billing_entity.id)
+        expect(wallet.billing_entity_id).to be_nil
       end
     end
 

--- a/spec/support/shared_examples/wallet_actions.rb
+++ b/spec/support/shared_examples/wallet_actions.rb
@@ -602,6 +602,63 @@ RSpec.shared_examples "a wallet create endpoint" do
       expect(json[:wallet][:applied_invoice_custom_sections].count).to eq(wallet.applied_invoice_custom_sections.count)
     end
   end
+
+  context "when multi_entity_billing is enabled" do
+    before { organization.update!(feature_flags: ["multi_entity_billing"]) }
+
+    context "when billing_entity_code is provided" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "be_wallet") }
+
+      before { create_params[:billing_entity_code] = billing_entity.code }
+
+      it "assigns the billing entity to the wallet" do
+        subject
+
+        expect(response).to have_http_status(:success)
+
+        wallet = Wallet.find(json[:wallet][:lago_id])
+        expect(wallet.billing_entity_id).to eq(billing_entity.id)
+      end
+    end
+
+    context "when billing_entity_code is not provided" do
+      it "falls back to the customer billing entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+
+        wallet = Wallet.find(json[:wallet][:lago_id])
+        expect(wallet.billing_entity_id).to eq(customer.billing_entity.id)
+      end
+    end
+
+    context "when billing_entity_code does not match any entity" do
+      before { create_params[:billing_entity_code] = "nonexistent" }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context "when multi_entity_billing is not enabled" do
+    context "when billing_entity_code is provided" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "be_wallet") }
+
+      before { create_params[:billing_entity_code] = billing_entity.code }
+
+      it "does not assign a billing entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+
+        wallet = Wallet.find(json[:wallet][:lago_id])
+        expect(wallet.billing_entity_id).to be_nil
+      end
+    end
+  end
 end
 
 RSpec.shared_examples "a wallet update endpoint" do

--- a/spec/support/shared_examples/wallet_actions.rb
+++ b/spec/support/shared_examples/wallet_actions.rb
@@ -661,6 +661,63 @@ RSpec.shared_examples "a wallet create endpoint" do
   end
 end
 
+RSpec.shared_examples "a wallet create endpoint with billing_entity_id" do
+  let(:create_params) do
+    {
+      external_customer_id: customer.external_id,
+      rate_amount: "1",
+      name: "Wallet1",
+      currency: "EUR"
+    }
+  end
+
+  context "when multi_entity_billing is enabled" do
+    before { organization.update!(feature_flags: ["multi_entity_billing"]) }
+
+    context "when billing_entity_id is provided" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+
+      before { create_params[:billing_entity_id] = billing_entity.id }
+
+      it "assigns the billing entity to the wallet" do
+        subject
+
+        expect(response).to have_http_status(:success)
+
+        wallet = Wallet.find(json[:wallet][:lago_id])
+        expect(wallet.billing_entity_id).to eq(billing_entity.id)
+      end
+    end
+
+    context "when billing_entity_id does not match any entity" do
+      before { create_params[:billing_entity_id] = SecureRandom.uuid }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context "when multi_entity_billing is not enabled" do
+    context "when billing_entity_id is provided" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+
+      before { create_params[:billing_entity_id] = billing_entity.id }
+
+      it "does not assign a billing entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+
+        wallet = Wallet.find(json[:wallet][:lago_id])
+        expect(wallet.billing_entity_id).to be_nil
+      end
+    end
+  end
+end
+
 RSpec.shared_examples "a wallet update endpoint" do
   let(:wallet) { create(:wallet, customer:) }
   let(:expiration_at) { (Time.current + 1.year).iso8601 }


### PR DESCRIPTION
  ## Summary
  - Accept `billing_entity_code` and `billing_entity_id` params on wallet creation to assign a billing entity when the `multi_entity_billing` feature flag is enabled                                                
  - `billing_entity_id` takes precedence over `billing_entity_code` when both are provided
  - Returns `not_found` error for unknown billing entity code or ID; falls back to the customer's billing entity when neither is provided
  - Billing entity assignment is skipped entirely when the feature flag is disabled
  - Billing entity lookups are scoped to the current organization, preventing cross-organization assignment                                                                                                          
                                              
  ## Test plan                                                                                                                                                                                                       
  - [x] Service tests cover lookup by code, by ID, unknown code, unknown ID, precedence of ID over code, fallback to customer, and flag-disabled scenarios                                                           
  - [x] Service tests verify that billing entities from other organizations are rejected with not_found                                                                                                              
  - [x] Controller shared examples cover both `Api::V1::WalletsController` and `Api::V1::Customers::WalletsController` for `billing_entity_code` and `billing_entity_id` 