### PR TITLE
[ING-121] feat(clickhouse): Make clickhouse the default event store when enabled

### DIFF
--- a/app/services/auth/google_service.rb
+++ b/app/services/auth/google_service.rb
@@ -110,8 +110,7 @@ module Auth
         result.user = User.create!(email:, password: SecureRandom.hex)
 
         result.organization = Organizations::CreateService
-          .call(name: organization_name, document_numbering: "per_organization")
-          .raise_if_error!
+          .call!(name: organization_name, document_numbering: "per_organization")
           .organization
 
         result.membership = Membership.create!(

--- a/app/services/organizations/create_service.rb
+++ b/app/services/organizations/create_service.rb
@@ -2,6 +2,8 @@
 
 module Organizations
   class CreateService < BaseService
+    Result = BaseResult[:organization]
+
     def initialize(params)
       @params = params
       super
@@ -11,6 +13,11 @@ module Organizations
       organization = Organization.new(
         params.slice(:name, :document_numbering, :premium_integrations)
       )
+
+      if ActiveModel::Type::Boolean.new.cast(ENV["LAGO_CLICKHOUSE_ENABLED"]) && ENV["LAGO_DEFAULT_EVENT_STORE"] == "clickhouse"
+        organization.clickhouse_events_store = true
+        organization.clickhouse_deduplication_enabled = true
+      end
 
       ActiveRecord::Base.transaction do
         # TODO: remove when we do not support document_numbering per organization

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -46,8 +46,7 @@ class UsersService < BaseService
       result.user = User.create!(email:, password:)
 
       result.organization = Organizations::CreateService
-        .call(name: organization_name, document_numbering: "per_organization")
-        .raise_if_error!
+        .call!(name: organization_name, document_numbering: "per_organization")
         .organization
 
       result.membership = Membership.create!(

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -104,8 +104,7 @@ Rails.application.console do
 
   def create_organization(org_name:, email:)
     organization = Organizations::CreateService
-      .call(name: org_name, document_numbering: "per_organization")
-      .raise_if_error!
+      .call!(name: org_name, document_numbering: "per_organization")
       .organization
 
     result = Invites::CreateService.call(

--- a/spec/services/organizations/create_service_spec.rb
+++ b/spec/services/organizations/create_service_spec.rb
@@ -35,6 +35,61 @@ RSpec.describe Organizations::CreateService do
         )
       end
 
+      context "when LAGO_CLICKHOUSE_ENABLED is set" do
+        around do |example|
+          previous_value = ENV["LAGO_CLICKHOUSE_ENABLED"]
+          ENV["LAGO_CLICKHOUSE_ENABLED"] = "true"
+          example.run
+        ensure
+          ENV["LAGO_CLICKHOUSE_ENABLED"] = previous_value
+        end
+
+        context "when LAGO_DEFAULT_EVENT_STORE is clickhouse" do
+          around do |example|
+            previous_value = ENV["LAGO_DEFAULT_EVENT_STORE"]
+            ENV["LAGO_DEFAULT_EVENT_STORE"] = "clickhouse"
+            example.run
+          ensure
+            ENV["LAGO_DEFAULT_EVENT_STORE"] = previous_value
+          end
+
+          it "enables clickhouse_events_store" do
+            expect(service_result.organization.reload.clickhouse_events_store).to be true
+            expect(service_result.organization.clickhouse_deduplication_enabled).to be true
+          end
+        end
+
+        context "when LAGO_DEFAULT_EVENT_STORE is not clickhouse" do
+          around do |example|
+            previous_value = ENV["LAGO_DEFAULT_EVENT_STORE"]
+            ENV["LAGO_DEFAULT_EVENT_STORE"] = "postgres"
+            example.run
+          ensure
+            ENV["LAGO_DEFAULT_EVENT_STORE"] = previous_value
+          end
+
+          it "leaves clickhouse_events_store disabled" do
+            expect(service_result.organization.reload.clickhouse_events_store).to be false
+            expect(service_result.organization.clickhouse_deduplication_enabled).to be false
+          end
+        end
+      end
+
+      context "when LAGO_CLICKHOUSE_ENABLED is not set" do
+        around do |example|
+          previous_value = ENV["LAGO_CLICKHOUSE_ENABLED"]
+          ENV.delete("LAGO_CLICKHOUSE_ENABLED")
+          example.run
+        ensure
+          ENV["LAGO_CLICKHOUSE_ENABLED"] = previous_value
+        end
+
+        it "leaves clickhouse_events_store disabled" do
+          expect(service_result.organization.reload.clickhouse_events_store).to be false
+          expect(service_result.organization.clickhouse_deduplication_enabled).to be false
+        end
+      end
+
       context "when document_numbering is per_customer" do
         let(:params) do
           {


### PR DESCRIPTION
## Description

This PR makes sure that every new organization created on an instance with `LAGO_CLICKHOUSE_ENABLED` env variable will set `clickhouse_events_store` to `true`.