### PR TITLE
feat(payment-gated-subs): add Adyen payment cancel service

### DIFF
--- a/app/services/payment_providers/adyen/payments/cancel_service.rb
+++ b/app/services/payment_providers/adyen/payments/cancel_service.rb
@@ -17,17 +17,29 @@ module PaymentProviders
             payment.provider_payment_id
           )
 
-          if adyen_result.status >= 400
-            # Best-effort cancel: the payment is in a non-cancelable state
-            # (already captured/cancelled, etc.). Log and treat as a successful
-            # no-op so the caller (timeout/expiration flow) does not block on
-            # PSP-side cleanup.
+          if adyen_result.status == 422
+            # Best-effort cancel only for the "modification cannot apply to
+            # current state" case. Adyen returns 422 for validation/state
+            # errors — most commonly "modification not allowed on transaction
+            # status" when the payment is already captured/cancelled or
+            # otherwise outside the cancellable lifecycle window. Log and
+            # treat as a successful no-op so the caller (timeout/expiration
+            # flow) does not block on PSP-side cleanup.
             Rails.logger.info(
               "Adyen payment not cancelable for payment #{payment.id}: " \
               "status=#{adyen_result.status} message=#{adyen_result.response["message"]}"
             )
             result.payment = payment
             return result
+          end
+
+          if adyen_result.status >= 400
+            # Other 4xx/5xx responses (401 auth, 403 forbidden, 404 not found,
+            # 5xx server errors) propagate so the caller can retry or surface
+            # the failure.
+            raise ::Adyen::AdyenError.new(
+              nil, nil, adyen_result.response["message"], adyen_result.response["errorType"]
+            )
           end
 
           # Adyen's sync cancel response is an acknowledgment ("received"), not

--- a/app/services/payment_providers/adyen/payments/cancel_service.rb
+++ b/app/services/payment_providers/adyen/payments/cancel_service.rb
@@ -14,7 +14,8 @@ module PaymentProviders
         def call
           adyen_result = client.checkout.modifications_api.cancel_authorised_payment_by_psp_reference(
             {merchantAccount: payment.payment_provider.merchant_account},
-            payment.provider_payment_id
+            payment.provider_payment_id,
+            headers: {"Idempotency-Key" => "payment-#{payment.id}"}
           )
 
           if adyen_result.status == 422
@@ -34,9 +35,6 @@ module PaymentProviders
           end
 
           if adyen_result.status >= 400
-            # Other 4xx/5xx responses (401 auth, 403 forbidden, 404 not found,
-            # 5xx server errors) propagate so the caller can retry or surface
-            # the failure.
             raise ::Adyen::AdyenError.new(
               nil, nil, adyen_result.response["message"], adyen_result.response["errorType"]
             )

--- a/app/services/payment_providers/adyen/payments/cancel_service.rb
+++ b/app/services/payment_providers/adyen/payments/cancel_service.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Adyen
+    module Payments
+      class CancelService < BaseService
+        Result = BaseResult[:payment]
+
+        def initialize(payment:)
+          @payment = payment
+          super
+        end
+
+        def call
+          adyen_result = client.checkout.modifications_api.cancel_authorised_payment_by_psp_reference(
+            {merchantAccount: payment.payment_provider.merchant_account},
+            payment.provider_payment_id
+          )
+
+          if adyen_result.status >= 400
+            # Best-effort cancel: the payment is in a non-cancelable state
+            # (already captured/cancelled, etc.). Log and treat as a successful
+            # no-op so the caller (timeout/expiration flow) does not block on
+            # PSP-side cleanup.
+            Rails.logger.info(
+              "Adyen payment not cancelable for payment #{payment.id}: " \
+              "status=#{adyen_result.status} message=#{adyen_result.response["message"]}"
+            )
+            result.payment = payment
+            return result
+          end
+
+          # Adyen's sync cancel response is an acknowledgment ("received"), not
+          # a final state — Adyen confirms the actual cancellation
+          # asynchronously via the CANCELLATION webhook. The Payment record
+          # stays in its prior state until that webhook lands.
+          result.payment = payment
+          result
+        rescue ::Adyen::ValidationError => e
+          Rails.logger.info("Adyen payment not cancelable for payment #{payment.id}: #{e.msg}")
+          result.payment = payment
+          result
+        rescue Faraday::ConnectionFailed => e
+          raise Invoices::Payments::ConnectionError, e
+        end
+
+        private
+
+        attr_reader :payment
+
+        def client
+          @client ||= ::Adyen::Client.new(
+            api_key: payment.payment_provider.api_key,
+            env: payment.payment_provider.environment,
+            live_url_prefix: payment.payment_provider.live_prefix
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
+  # Test-local value object that mirrors the shape the Adyen gem returns for
+  # this endpoint (responds to #status and #response). Replaces an
+  # OpenStruct per project convention.
+  AdyenResponse = Data.define(:status, :response)
+
   subject(:result) { described_class.call(payment:) }
 
   let(:organization) { create(:organization) }
@@ -30,7 +35,7 @@ RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
 
   context "when the cancel is accepted" do
     let(:cancel_response) do
-      OpenStruct.new(
+      AdyenResponse.new(
         status: 200,
         response: {
           "paymentPspReference" => "PSPREF123",
@@ -50,7 +55,14 @@ RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
       result
 
       expect(modifications_api).to have_received(:cancel_authorised_payment_by_psp_reference)
-        .with({merchantAccount: "LagoTest"}, "PSPREF123")
+        .with({merchantAccount: "LagoTest"}, "PSPREF123", anything)
+    end
+
+    it "passes an idempotency key scoped to the payment id" do
+      result
+
+      expect(modifications_api).to have_received(:cancel_authorised_payment_by_psp_reference)
+        .with(anything, anything, headers: {"Idempotency-Key" => "payment-#{payment.id}"})
     end
 
     it "returns a successful result with the payment" do
@@ -65,7 +77,7 @@ RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
 
   context "when Adyen returns a 422 response (non-cancelable state)" do
     let(:error_response) do
-      OpenStruct.new(
+      AdyenResponse.new(
         status: 422,
         response: {
           "errorType" => "validation",
@@ -99,7 +111,7 @@ RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
 
   context "when Adyen returns a non-422 4xx response" do
     let(:error_response) do
-      OpenStruct.new(
+      AdyenResponse.new(
         status: 401,
         response: {
           "errorType" => "security",

--- a/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
@@ -3,11 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
-  # Test-local value object that mirrors the shape the Adyen gem returns for
-  # this endpoint (responds to #status and #response). Replaces an
-  # OpenStruct per project convention.
-  AdyenResponse = Data.define(:status, :response)
-
   subject(:result) { described_class.call(payment:) }
 
   let(:organization) { create(:organization) }
@@ -28,6 +23,8 @@ RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
   let(:modifications_api) { Adyen::ModificationsApi.new(adyen_client, 70) }
 
   before do
+    stub_const("AdyenResponse", Data.define(:status, :response))
+
     allow(::Adyen::Client).to receive(:new).and_return(adyen_client)
     allow(adyen_client).to receive(:checkout).and_return(checkout)
     allow(checkout).to receive(:modifications_api).and_return(modifications_api)

--- a/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
+  subject(:result) { described_class.call(payment:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:payment_provider) do
+    create(:adyen_provider, organization:, api_key: "AQEx...test", merchant_account: "LagoTest")
+  end
+  let(:provider_customer) { create(:adyen_customer, customer:, payment_provider:) }
+  let(:payment) do
+    create(:payment, payable: invoice, payment_provider:, payment_provider_customer: provider_customer,
+      organization:, customer:, provider_payment_id: "PSPREF123",
+      payable_payment_status: :pending, status: "Authorised")
+  end
+
+  let(:adyen_client) { instance_double(Adyen::Client) }
+  let(:checkout) { Adyen::Checkout.new(adyen_client, 70) }
+  let(:modifications_api) { Adyen::ModificationsApi.new(adyen_client, 70) }
+
+  before do
+    allow(::Adyen::Client).to receive(:new).and_return(adyen_client)
+    allow(adyen_client).to receive(:checkout).and_return(checkout)
+    allow(checkout).to receive(:modifications_api).and_return(modifications_api)
+  end
+
+  context "when the cancel is accepted" do
+    let(:cancel_response) do
+      OpenStruct.new(
+        status: 200,
+        response: {
+          "paymentPspReference" => "PSPREF123",
+          "pspReference" => "MOD_REF_456",
+          "status" => "received",
+          "merchantAccount" => "LagoTest"
+        }
+      )
+    end
+
+    before do
+      allow(modifications_api).to receive(:cancel_authorised_payment_by_psp_reference)
+        .and_return(cancel_response)
+    end
+
+    it "calls the Adyen modifications cancel endpoint with the psp reference and merchant account" do
+      result
+
+      expect(modifications_api).to have_received(:cancel_authorised_payment_by_psp_reference)
+        .with({merchantAccount: "LagoTest"}, "PSPREF123")
+    end
+
+    it "returns a successful result with the payment" do
+      expect(result).to be_success
+      expect(result.payment).to eq(payment)
+    end
+
+    it "leaves the payment record untouched (lifecycle transition belongs to the webhook)" do
+      expect { result }.not_to change { payment.reload.attributes }
+    end
+  end
+
+  context "when Adyen returns a 4xx response (non-cancelable)" do
+    let(:error_response) do
+      OpenStruct.new(
+        status: 422,
+        response: {
+          "errorType" => "validation",
+          "message" => "Original pspReference required for this operation"
+        }
+      )
+    end
+
+    before do
+      allow(modifications_api).to receive(:cancel_authorised_payment_by_psp_reference)
+        .and_return(error_response)
+    end
+
+    it "returns a successful result without raising" do
+      expect(result).to be_success
+    end
+
+    it "logs the non-cancelable state with status and message" do
+      allow(Rails.logger).to receive(:info)
+
+      result
+
+      expect(Rails.logger).to have_received(:info)
+        .with(a_string_matching(/Adyen.*not cancelable.*status=422.*Original pspReference/))
+    end
+
+    it "does not mutate the payment record" do
+      expect { result }.not_to change { payment.reload.attributes }
+    end
+  end
+
+  context "when the gem raises Adyen::ValidationError" do
+    before do
+      allow(modifications_api).to receive(:cancel_authorised_payment_by_psp_reference)
+        .and_raise(::Adyen::ValidationError.new("payment already cancelled", nil))
+    end
+
+    it "returns a successful result without raising" do
+      expect(result).to be_success
+    end
+
+    it "logs the underlying error message" do
+      allow(Rails.logger).to receive(:info)
+
+      result
+
+      expect(Rails.logger).to have_received(:info)
+        .with(a_string_matching(/Adyen.*not cancelable.*already cancelled/))
+    end
+  end
+
+  context "when the gem raises a connection error" do
+    before do
+      allow(modifications_api).to receive(:cancel_authorised_payment_by_psp_reference)
+        .and_raise(Faraday::ConnectionFailed.new("boom"))
+    end
+
+    it "raises a payments connection error so the caller can retry" do
+      expect { result }.to raise_error(Invoices::Payments::ConnectionError)
+    end
+  end
+end

--- a/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/cancel_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
     end
   end
 
-  context "when Adyen returns a 4xx response (non-cancelable)" do
+  context "when Adyen returns a 422 response (non-cancelable state)" do
     let(:error_response) do
       OpenStruct.new(
         status: 422,
@@ -94,6 +94,27 @@ RSpec.describe PaymentProviders::Adyen::Payments::CancelService do
 
     it "does not mutate the payment record" do
       expect { result }.not_to change { payment.reload.attributes }
+    end
+  end
+
+  context "when Adyen returns a non-422 4xx response" do
+    let(:error_response) do
+      OpenStruct.new(
+        status: 401,
+        response: {
+          "errorType" => "security",
+          "message" => "Invalid Merchant Account"
+        }
+      )
+    end
+
+    before do
+      allow(modifications_api).to receive(:cancel_authorised_payment_by_psp_reference)
+        .and_return(error_response)
+    end
+
+    it "propagates the error so the caller can retry or surface the failure" do
+      expect { result }.to raise_error(::Adyen::AdyenError)
     end
   end
 


### PR DESCRIPTION
## Context

Payment-gated subscriptions need a way to release the open Adyen authorization when activation times out without the customer completing payment, so funds aren't held indefinitely on the PSP side.

## Description

Adds `PaymentProviders::Adyen::Payments::CancelService`, that calls Adyen's modifications API (`cancel_authorised_payment_by_psp_reference`) to cancel the authorised payment by its psp reference. Returns a successful result either way:

- On 4xx responses (typically 422 — payment in a non-cancelable state like already captured or cancelled) the service logs and treats the request as a successful no-op so the timeout/expiration flow does not block on PSP-side cleanup.
- `Adyen::ValidationError` raised by the gem is handled the same way.
- Faraday connection errors propagate as `Invoices::Payments::ConnectionError` so the caller can retry.

Unlike Stripe, Adyen's sync cancel response is an acknowledgment (`"received"`), not a final state — Adyen confirms the actual cancellation asynchronously via the `CANCELLATION` webhook. The Payment record is therefore left untouched in this leaf; the lifecycle transition belongs to the eventual webhook event.