### PR TITLE
ING-53 feat(wallets): Add billing_entity_id to GraphQL wallet creatio…

### DIFF
--- a/app/graphql/types/wallets/create_input.rb
+++ b/app/graphql/types/wallets/create_input.rb
@@ -5,6 +5,7 @@ module Types
     class CreateInput < Types::BaseInputObject
       description "Create Wallet Input"
 
+      argument :billing_entity_id, ID, required: false
       argument :code, String, required: false
       argument :currency, Types::CurrencyEnum, required: true
       argument :customer_id, ID, required: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -2878,6 +2878,7 @@ Create Wallet Input
 """
 input CreateCustomerWalletInput {
   appliesTo: AppliesToInput
+  billingEntityId: ID
 
   """
   A unique identifier for the client performing the mutation.

--- a/schema.json
+++ b/schema.json
@@ -12310,6 +12310,18 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "billingEntityId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "code",
               "description": null,
               "type": {

--- a/spec/graphql/types/wallets/create_input_spec.rb
+++ b/spec/graphql/types/wallets/create_input_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Wallets::CreateInput do
   subject { described_class }
 
   it do
+    expect(subject).to accept_argument(:billing_entity_id).of_type("ID")
     expect(subject).to accept_argument(:code).of_type("String")
     expect(subject).to accept_argument(:currency).of_type("CurrencyEnum!")
     expect(subject).to accept_argument(:customer_id).of_type("ID!")


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
  - Add optional `billingEntityId` argument to `CreateCustomerWalletInput` GraphQL type                                                                                                                              
  - Update schema files (`schema.graphql`, `schema.json`) to reflect the new field                                                                                                                                   
  - Add input spec coverage for the new argument            
                                          
  ## Test plan                                                                                                                                                                                                       
  - [x] GraphQL input spec verifies `billing_entity_id` is accepted as an optional `ID` type                                                                                                                         
  - [x] Existing service-level tests (from prior PRs) cover the billing entity resolution logic    