### PR TITLE
perf(billable_metrics): Add bulk update charge filters

### DIFF
--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -120,37 +120,24 @@ module BillableMetricFilters
     end
 
     def bulk_discard_emptied_charge_filters_for(filter_value_ids)
-      charge_filter_ids_to_discard = emptied_charge_filter_ids_for(filter_value_ids)
-      return if charge_filter_ids_to_discard.empty?
-
-      ChargeFilter
-        .where(id: charge_filter_ids_to_discard, deleted_at: nil)
-        .unscope(:order)
-        .update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-    end
-
-    def emptied_charge_filter_ids_for(filter_value_ids)
-      charge_filter_ids = charge_filter_ids_referenced_by(filter_value_ids)
-      return [] if charge_filter_ids.empty?
-
-      charge_filter_ids - charge_filter_ids_with_kept_values(charge_filter_ids)
-    end
-
-    def charge_filter_ids_referenced_by(filter_value_ids)
-      ChargeFilterValue
+      charge_filter_ids = ChargeFilterValue
         .with_discarded
         .where(id: filter_value_ids)
         .unscope(:order)
         .distinct
-        .pluck(:charge_filter_id)
-    end
+        .select(:charge_filter_id)
 
-    def charge_filter_ids_with_kept_values(charge_filter_ids)
-      ChargeFilterValue
-        .where(deleted_at: nil, charge_filter_id: charge_filter_ids)
+      return if charge_filter_ids.empty?
+
+      ChargeFilter
+        .where(id: charge_filter_ids, deleted_at: nil)
+        .where.not(
+          id: ChargeFilterValue
+            .where(deleted_at: nil, charge_filter_id: charge_filter_ids)
+            .select(:charge_filter_id)
+        )
         .unscope(:order)
-        .distinct
-        .pluck(:charge_filter_id)
+        .update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -2,6 +2,8 @@
 
 module BillableMetricFilters
   class CreateOrUpdateBatchService < BaseService
+    BATCH_SIZE = 1_000
+
     def initialize(billable_metric:, filters_params:)
       @billable_metric = billable_metric
       @filters_params = filters_params
@@ -17,6 +19,8 @@ module BillableMetricFilters
 
         return result
       end
+
+      return result.validation_failure!(errors: {values: ["value_is_mandatory"]}) if any_filter_params_values_blank?
 
       ActiveRecord::Base.transaction do
         filters_params.each do |filter_param|
@@ -35,7 +39,7 @@ module BillableMetricFilters
                   *deleted_values
                 )
 
-              filter_values.each { |filter_value| discard_filter_value(filter_value, new_values:) }
+              discard_filter_values_in_batches(filter_values, new_values:)
             end
           end
 
@@ -60,6 +64,12 @@ module BillableMetricFilters
 
     attr_reader :billable_metric, :filters_params
 
+    def any_filter_params_values_blank?
+      filters_params.any? do |filter_param|
+        filter_param[:values].blank?
+      end
+    end
+
     def discard_all_filters
       ActiveRecord::Base.transaction do
         billable_metric.filters.each { discard_filter(it) }
@@ -67,26 +77,80 @@ module BillableMetricFilters
     end
 
     def discard_filter(filter)
-      filter.filter_values.each { discard_filter_value(it) }
+      discard_filter_values_in_batches(filter.filter_values)
+
       filter.discard!
     end
 
-    def discard_filter_value(filter_value, new_values: [])
-      deleted_values = filter_value.values - new_values
+    def discard_filter_values_in_batches(filter_values, new_values: [])
+      filter_values.unscope(:order).in_batches(of: BATCH_SIZE) do |filter_value_batch|
+        values_to_trim, values_to_discard = filter_value_batch.partition { |fv| trimmable?(fv, new_values) }
 
-      if deleted_values.any?
-        values = filter_value.values - deleted_values
-
-        if values.any?
-          filter_value.update!(values:)
-          return
-        end
+        bulk_update_trimmed_filter_values(values_to_trim, new_values)
+        discard_filter_values_and_emptied_charge_filters(values_to_discard)
       end
+    end
 
-      filter_value.discard!
-      return if filter_value.charge_filter.values.where.not(id: filter_value.id).exists?
+    def trimmable?(filter_value, new_values)
+      filter_value.values.intersect?(new_values)
+    end
 
-      filter_value.charge_filter.discard! unless filter_value.charge_filter.discarded?
+    def bulk_update_trimmed_filter_values(filter_values, new_values)
+      return if filter_values.empty?
+
+      filter_values.group_by { |fv| fv.values & new_values }.each do |result_values, group|
+        ChargeFilterValue.where(id: group.map(&:id)).update_all( # rubocop:disable Rails/SkipsModelValidations
+          values: result_values, updated_at: Time.current
+        )
+      end
+    end
+
+    def discard_filter_values_and_emptied_charge_filters(filter_values)
+      return if filter_values.empty?
+
+      filter_value_ids = filter_values.map(&:id)
+      bulk_discard_filter_values(filter_value_ids)
+      bulk_discard_emptied_charge_filters_for(filter_value_ids)
+    end
+
+    def bulk_discard_filter_values(filter_value_ids)
+      ChargeFilterValue
+        .where(id: filter_value_ids)
+        .update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    def bulk_discard_emptied_charge_filters_for(filter_value_ids)
+      charge_filter_ids_to_discard = emptied_charge_filter_ids_for(filter_value_ids)
+      return if charge_filter_ids_to_discard.empty?
+
+      ChargeFilter
+        .where(id: charge_filter_ids_to_discard, deleted_at: nil)
+        .unscope(:order)
+        .update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    def emptied_charge_filter_ids_for(filter_value_ids)
+      charge_filter_ids = charge_filter_ids_referenced_by(filter_value_ids)
+      return [] if charge_filter_ids.empty?
+
+      charge_filter_ids - charge_filter_ids_with_kept_values(charge_filter_ids)
+    end
+
+    def charge_filter_ids_referenced_by(filter_value_ids)
+      ChargeFilterValue
+        .with_discarded
+        .where(id: filter_value_ids)
+        .unscope(:order)
+        .distinct
+        .pluck(:charge_filter_id)
+    end
+
+    def charge_filter_ids_with_kept_values(charge_filter_ids)
+      ChargeFilterValue
+        .where(deleted_at: nil, charge_filter_id: charge_filter_ids)
+        .unscope(:order)
+        .distinct
+        .pluck(:charge_filter_id)
     end
   end
 end

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
 
     context "when there are existing filters" do
       let(:filter) { create(:billable_metric_filter, billable_metric:, key: "region") }
-      let!(:filter_without_values) { create(:billable_metric_filter, billable_metric:, key: "cloud") }
 
       let(:charge) { create(:standard_charge, billable_metric:) }
       let(:charge_filter) { create(:charge_filter, charge:) }
@@ -33,7 +32,10 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         )
       end
 
-      before { filter_value }
+      before do
+        create(:billable_metric_filter, billable_metric:, key: "cloud")
+        filter_value
+      end
 
       it "discards all filters and the related values" do
         expect { service }.to change { BillableMetricFilter.with_discarded.discarded.count }.from(0).to(2)
@@ -43,7 +45,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
 
       context "when a charge_filter has filter_values from multiple billable_metric_filters" do
         let(:other_filter) { create(:billable_metric_filter, billable_metric:, key: "cloud") }
-        let!(:other_filter_value) do
+        let(:other_filter_value) do
           create(
             :charge_filter_value,
             charge_filter:,
@@ -51,6 +53,8 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
             values: [other_filter.values.first]
           )
         end
+
+        before { other_filter_value }
 
         it "discards all filters, all filter_values, and the shared charge_filter" do
           expect { service }.to change { BillableMetricFilter.with_discarded.discarded.count }.from(0).to(3)

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -14,8 +14,13 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
       expect { service }.not_to change(BillableMetricFilter, :count)
     end
 
+    it "does not enqueue the refresh draft invoices job" do
+      expect { service }.not_to have_enqueued_job(BillableMetricFilters::RefreshDraftInvoicesJob)
+    end
+
     context "when there are existing filters" do
-      let(:filter) { create(:billable_metric_filter, billable_metric:) }
+      let(:filter) { create(:billable_metric_filter, billable_metric:, key: "region") }
+      let!(:filter_without_values) { create(:billable_metric_filter, billable_metric:, key: "cloud") }
 
       let(:charge) { create(:standard_charge, billable_metric:) }
       let(:charge_filter) { create(:charge_filter, charge:) }
@@ -32,8 +37,29 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
 
       it "discards all filters and the related values" do
         expect { service }.to change { filter.reload.discarded? }.to(true)
+          .and change { filter_without_values.reload.discarded? }.to(true)
           .and change { filter_value.reload.discarded? }.to(true)
           .and change { charge_filter.reload.discarded? }.to(true)
+      end
+
+      context "when a charge_filter has filter_values from multiple billable_metric_filters" do
+        let(:other_filter) { create(:billable_metric_filter, billable_metric:, key: "cloud") }
+        let!(:other_filter_value) do
+          create(
+            :charge_filter_value,
+            charge_filter:,
+            billable_metric_filter: other_filter,
+            values: [other_filter.values.first]
+          )
+        end
+
+        it "discards both filters, all filter_values, and the shared charge_filter" do
+          expect { service }.to change { filter.reload.discarded? }.to(true)
+            .and change { other_filter.reload.discarded? }.to(true)
+            .and change { filter_value.reload.discarded? }.to(true)
+            .and change { other_filter_value.reload.discarded? }.to(true)
+            .and change { charge_filter.reload.discarded? }.to(true)
+        end
       end
     end
   end
@@ -72,6 +98,42 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         values: %w[aws gcp]
       )
     end
+
+    context "when filter param has duplicate values" do
+      let(:filters_params) do
+        [{key: "region", values: %w[US US Europe Europe]}]
+      end
+
+      it "stores deduplicated values" do
+        service
+
+        expect(billable_metric.filters.find_by(key: "region").values).to eq(%w[US Europe])
+      end
+    end
+
+    context "when any of multiple filter params has blank values" do
+      let(:filters_params) do
+        [
+          {key: "region", values: %w[US]},
+          {key: "cloud", values: []}
+        ]
+      end
+
+      it "returns a validation failure" do
+        result = service
+
+        expect(result).not_to be_success
+        expect(result.error.messages[:values]).to eq(["value_is_mandatory"])
+      end
+
+      it "does not persist the valid filter" do
+        expect { service }.not_to change(BillableMetricFilter, :count)
+      end
+
+      it "does not enqueue the refresh draft invoices job" do
+        expect { service }.not_to have_enqueued_job(BillableMetricFilters::RefreshDraftInvoicesJob)
+      end
+    end
   end
 
   context "with existing filters" do
@@ -95,6 +157,17 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         key: "region",
         values: %w[Europe US Asia Africa]
       )
+    end
+
+    context "when filter_param has the same values as the existing filter" do
+      let(:filters_params) do
+        [{key: "region", values: %w[Europe US Asia]}]
+      end
+
+      it "leaves the filter values unchanged" do
+        expect { service }.not_to change(BillableMetricFilter, :count)
+        expect(filter.reload.values).to eq(%w[Europe US Asia])
+      end
     end
 
     context "when a value is removed" do
@@ -124,6 +197,64 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         )
 
         expect(filter_value.reload).to be_discarded
+      end
+
+      context "when a filter_value has both kept and removed values" do
+        let!(:partial_filter_value) do
+          create(
+            :charge_filter_value,
+            billable_metric_filter: filter,
+            values: %w[US Europe]
+          )
+        end
+
+        it "trims the partial filter_value and discards the fully-removed one in the same batch" do
+          service
+
+          expect(partial_filter_value.reload).not_to be_discarded
+          expect(partial_filter_value.values).to eq(%w[Europe])
+
+          expect(filter_value.reload).to be_discarded
+        end
+      end
+
+      context "when the discarded filter_value's charge_filter has a kept filter_value from another filter" do
+        let(:other_filter) { create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp]) }
+        let(:charge) { create(:standard_charge, billable_metric:) }
+        let(:shared_charge_filter) { create(:charge_filter, charge:) }
+
+        let!(:shared_cfv_region) do
+          create(
+            :charge_filter_value,
+            charge_filter: shared_charge_filter,
+            billable_metric_filter: filter,
+            values: %w[US]
+          )
+        end
+
+        let!(:shared_cfv_cloud) do
+          create(
+            :charge_filter_value,
+            charge_filter: shared_charge_filter,
+            billable_metric_filter: other_filter,
+            values: %w[aws]
+          )
+        end
+
+        let(:filters_params) do
+          [
+            {key: "region", values: %w[Europe]},
+            {key: "cloud", values: %w[aws gcp]}
+          ]
+        end
+
+        it "discards the filter_value but keeps the shared charge_filter" do
+          service
+
+          expect(shared_cfv_region.reload).to be_discarded
+          expect(shared_cfv_cloud.reload).not_to be_discarded
+          expect(shared_charge_filter.reload).not_to be_discarded
+        end
       end
 
       context "when removing all values" do
@@ -173,6 +304,148 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         expect { service }.not_to change(BillableMetricFilter, :count)
 
         expect(filter.reload).to be_discarded
+      end
+
+      context "when the removed filter has filter_values and a charge_filter" do
+        let(:charge) { create(:standard_charge, billable_metric:) }
+        let(:charge_filter) { create(:charge_filter, charge:) }
+        let!(:filter_value) do
+          create(
+            :charge_filter_value,
+            charge_filter:,
+            billable_metric_filter: filter,
+            values: ["US"]
+          )
+        end
+
+        it "discards the filter, its filter_values, and the emptied charge_filter" do
+          service
+
+          expect(filter.reload).to be_discarded
+          expect(filter_value.reload).to be_discarded
+          expect(charge_filter.reload).to be_discarded
+        end
+      end
+    end
+
+    context "with new, existing, and removed filters together" do
+      let(:filters_params) do
+        [
+          {key: "region", values: %w[Europe US Asia Africa]},
+          {key: "cloud", values: %w[aws gcp]}
+        ]
+      end
+
+      let!(:filter_to_remove) do
+        create(:billable_metric_filter, billable_metric:, key: "country", values: %w[Australia])
+      end
+
+      it "creates new, updates existing, and discards missing filters" do
+        service
+
+        expect(filter.reload).to have_attributes(values: %w[Europe US Asia Africa])
+        expect(filter_to_remove.reload).to be_discarded
+        expect(billable_metric.filters.find_by(key: "cloud")).to have_attributes(values: %w[aws gcp])
+      end
+    end
+  end
+
+  context "with unrelated records present" do
+    let(:other_billable_metric) { create(:billable_metric) }
+    let!(:other_filter) { create(:billable_metric_filter, billable_metric: other_billable_metric, key: "region") }
+    let(:other_charge) { create(:standard_charge, billable_metric: other_billable_metric) }
+    let!(:other_charge_filter) { create(:charge_filter, charge: other_charge) }
+    let!(:other_filter_value) do
+      create(
+        :charge_filter_value,
+        charge_filter: other_charge_filter,
+        billable_metric_filter: other_filter,
+        values: [other_filter.values.first]
+      )
+    end
+
+    context "when discarding all filters of the billable_metric" do
+      let(:filters_params) { {} }
+
+      let(:filter) { create(:billable_metric_filter, billable_metric:) }
+      let(:charge) { create(:standard_charge, billable_metric:) }
+      let(:charge_filter) { create(:charge_filter, charge:) }
+      let(:filter_value) do
+        create(:charge_filter_value, charge_filter:, billable_metric_filter: filter, values: [filter.values.first])
+      end
+
+      before { filter_value }
+
+      it "discards exactly one of each: filter, filter_value, charge_filter" do
+        expect { service }.to change(BillableMetricFilter.kept, :count).by(-1)
+          .and change(ChargeFilterValue.kept, :count).by(-1)
+          .and change(ChargeFilter.kept, :count).by(-1)
+      end
+
+      it "leaves the other billable_metric's filter, filter_value and charge_filter untouched" do
+        service
+
+        expect(other_filter.reload).not_to be_discarded
+        expect(other_filter_value.reload).not_to be_discarded
+        expect(other_charge_filter.reload).not_to be_discarded
+      end
+    end
+
+    context "when removing values from one filter" do
+      let(:filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[US Europe]) }
+      let(:filters_params) { [{key: "region", values: %w[Europe]}] }
+
+      let(:cfv_to_discard) do
+        create(:charge_filter_value, billable_metric_filter: filter, values: %w[US])
+      end
+
+      let!(:cfv_unaffected) do
+        create(:charge_filter_value, billable_metric_filter: filter, values: %w[Europe])
+      end
+
+      let(:unrelated_charge) { create(:standard_charge, billable_metric:) }
+      let!(:unrelated_charge_filter) { create(:charge_filter, charge: unrelated_charge) }
+
+      let!(:already_discarded_cfv) do
+        create(:charge_filter_value, billable_metric_filter: filter, values: %w[US]).tap(&:discard!)
+      end
+
+      before do
+        filter
+        cfv_to_discard
+      end
+
+      it "discards only the filter_value whose values are being removed" do
+        expect { service }.to change(ChargeFilterValue.kept, :count).by(-1)
+      end
+
+      it "preserves filter_values whose values aren't being removed" do
+        service
+
+        expect(cfv_unaffected.reload).not_to be_discarded
+        expect(cfv_unaffected.values).to eq(%w[Europe])
+      end
+
+      it "does not touch charge_filters of unrelated charges in the same billable_metric" do
+        expect { service }.not_to change { unrelated_charge_filter.reload.discarded? }
+      end
+
+      it "does not modify deleted_at on already-discarded filter_values" do
+        original_deleted_at = already_discarded_cfv.deleted_at
+        service
+        expect(already_discarded_cfv.reload.deleted_at).to eq(original_deleted_at)
+      end
+
+      it "does not discard pre-existing emptied charge_filters unrelated to this run" do
+        expect { service }.not_to change { already_discarded_cfv.charge_filter.reload.discarded? }
+      end
+
+      it "leaves the other billable_metric's records untouched" do
+        service
+
+        expect(other_filter.reload).not_to be_discarded
+        expect(other_filter_value.reload).not_to be_discarded
+        expect(other_charge_filter.reload).not_to be_discarded
       end
     end
   end

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -36,10 +36,9 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
       before { filter_value }
 
       it "discards all filters and the related values" do
-        expect { service }.to change { filter.reload.discarded? }.to(true)
-          .and change { filter_without_values.reload.discarded? }.to(true)
-          .and change { filter_value.reload.discarded? }.to(true)
-          .and change { charge_filter.reload.discarded? }.to(true)
+        expect { service }.to change { BillableMetricFilter.with_discarded.discarded.count }.from(0).to(2)
+          .and change { ChargeFilterValue.with_discarded.discarded.count }.from(0).to(1)
+          .and change { ChargeFilter.with_discarded.discarded.count }.from(0).to(1)
       end
 
       context "when a charge_filter has filter_values from multiple billable_metric_filters" do
@@ -53,12 +52,10 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
           )
         end
 
-        it "discards both filters, all filter_values, and the shared charge_filter" do
-          expect { service }.to change { filter.reload.discarded? }.to(true)
-            .and change { other_filter.reload.discarded? }.to(true)
-            .and change { filter_value.reload.discarded? }.to(true)
-            .and change { other_filter_value.reload.discarded? }.to(true)
-            .and change { charge_filter.reload.discarded? }.to(true)
+        it "discards all filters, all filter_values, and the shared charge_filter" do
+          expect { service }.to change { BillableMetricFilter.with_discarded.discarded.count }.from(0).to(3)
+            .and change { ChargeFilterValue.with_discarded.discarded.count }.from(0).to(2)
+            .and change { ChargeFilter.with_discarded.discarded.count }.from(0).to(1)
         end
       end
     end


### PR DESCRIPTION
## Context
The previous implementation discarded each `ChargeFilterValue` one row at a time via `discard!`, issued an existence check per row to decide whether to discard the parent `ChargeFilter`, and then discarded that parent per row when needed. Combined with PaperTrail audit inserts, that's roughly 3 SQL statements + 1 `versions` insert per cfv.

There is a performance issue on production when the organization has 48,952 plans, one billable_metric_filter with 16 values, and ~586,000 charge_filter_values. A single filter mutation could generate up to ~2.3M queries, timing out API request.

## Description
Replaced per-row `update!/discard!` with batched bulk SQL operations.

- **Batched charge_filter_values processing.** `discard_filter_values_in_batches` iterates affected `ChargeFilterValue`s via `in_batches(of: 1_000)`, partitioning each batch into "trim" (cfvs that retain at least one allowed value) and "discard" (cfvs whose values are entirely being removed).
- **Bulk trim.** `bulk_update_trimmed_filter_values` groups charge_filter_values by their resulting `values` array (the intersection with the new allowed set) and executes one `UPDATE … WHERE id IN (…)` per group.
- **Bulk discard charge_filter_values + emptied charge_filters.** `discard_filter_values_and_emptied_charge_filters` flips `deleted_at` on the cfv ids in one statement, then derives the affected `ChargeFilter` ids and discards those with no remaining kept cfvs via a second statement. The "which charge filters are now empty?" computation is done in Ruby with two small `pluck`s and set subtraction (`candidates - charge_filter_ids_with_kept_values`).
- **Pre-flight validation.** Added a guard that short-circuits with `validation_failure!(values: ["value_is_mandatory"])` when any `filter_param[:values]` is blank, preventing partial work that would have to rollback mid-transaction. This is consistent with the original behavior, where ActiveRecord::RecordInvalid was raised in a transaction, resulting in the same API response.

The trade-off matches the one already accepted in `BillableMetricFilters::DestroyAllService`, `ChargeFilters::DestroyService`, and `ChargeFilters::CascadeService`: bulk `update_all` skips PaperTrail callbacks, so individual cfv/cf discards no longer create `versions` rows. Audit history is retained for `BillableMetricFilter`.

## Tests

Expanded the spec from 8 to 27 examples, organized into:

- **Empty-params path** (discard everything): single filter, multiple filters, with/without dependent charge_filter_values, shared charge_filter across multiple BMFs.
- **New-filters path**: creation, refresh-job enqueue, deduplication of input values, validation failure on blank values (single param + one-of-many).
- **Existing-filters path**: value addition, no-op when same values, partial trim with cfvs that mix kept and removed values, mixed trim+discard in the same batch, charge_filter preservation when a sibling filter_value from another BMF is still kept, filter removal with cascade, mixed new/update/remove in one call.
- **Scoping isolation** (new top-level context): with a parallel `other_billable_metric` set up, asserts the bulk SQL doesn't touch records that are not related to the current batch.

## Performance testing
Preconditions:
- 1 billable metric
- 1 filter with 16 filter values
- N Plans using the billable metric.

Action: deleting 6 filter values via UI (GraphQL updateBillableMetric)

| Plans amount (N) | Original latency | Optimized latency | Reduction |
| ------------------ | --------------- | ------------------ | ---------- | 
| 200 | 14400ms (14.4s) | 339ms | 97.6% (42.5× faster) |
| 1000 | Timeout | 1s | N/A |