### PR TITLE
[ING-25] fix: patch fill history service

### DIFF
--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -17,7 +17,10 @@ module DailyUsages
       previous_daily_usage = nil
 
       (from..to).each do |date|
-        next if !sandbox && subscription.daily_usages.where(usage_date: date).exists?
+        if !sandbox && (existing_daily_usage = subscription.daily_usages.find_by(usage_date: date))
+          previous_daily_usage = existing_daily_usage
+          next
+        end
 
         datetime = date.in_time_zone(subscription.customer.applicable_timezone).beginning_of_day.utc
         datetime = date.beginning_of_day.utc if datetime < date # Handle last day for timezone with positive offset

--- a/spec/services/daily_usages/fill_history_service_spec.rb
+++ b/spec/services/daily_usages/fill_history_service_spec.rb
@@ -66,6 +66,53 @@ RSpec.describe DailyUsages::FillHistoryService do
         end
       end
     end
+
+    context "when an existing daily_usage covers a date in the middle of the range" do
+      let(:from_date) { Date.parse("2024-10-14") }
+      let(:to_date) { Date.parse("2024-10-16") }
+      let(:existing_daily_usage) do
+        create(
+          :daily_usage,
+          organization:,
+          customer:,
+          subscription:,
+          external_subscription_id: subscription.external_id,
+          usage_date: Date.parse("2024-10-15"),
+          from_datetime: Time.zone.parse("2024-10-01 00:00:00"),
+          to_datetime: Time.zone.parse("2024-10-31 23:59:59.999999"),
+          usage: {"amount_cents" => 0, "taxes_amount_cents" => 0, "total_amount_cents" => 0, "charges_usage" => []}
+        )
+      end
+
+      before do
+        create(:standard_charge, plan:, billable_metric:)
+        create(
+          :event,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp: Time.zone.parse("2024-10-14 10:00:00"),
+          created_at: Time.zone.parse("2024-10-14 10:00:00")
+        )
+        existing_daily_usage
+      end
+
+      it "uses the existing daily_usage as the baseline for the next iteration's diff" do
+        allow(DailyUsages::ComputeDiffService).to receive(:call).and_call_original
+
+        travel_to(Time.zone.parse("2024-10-17 12:00:00")) { call_service }
+
+        expect(DailyUsages::ComputeDiffService).to have_received(:call)
+          .with(hash_including(previous_daily_usage: existing_daily_usage))
+      end
+
+      it "does not overwrite the existing daily_usage" do
+        travel_to(Time.zone.parse("2024-10-17 12:00:00")) do
+          expect { call_service }.to change(DailyUsage, :count).by(2)
+        end
+        expect(DailyUsage.find_by(usage_date: Date.parse("2024-10-15"))).to eq(existing_daily_usage)
+      end
+    end
   end
 
   describe "#to" do


### PR DESCRIPTION
## Context

`DailyUsages::FillHistoryService` was skipping existing daily usages from the processing. However, in the loop, existing daily usage was not assigned properly to the temporary variable that calculate diff between current daily usage and previous daily usage. Running rake task on such use-case could lead to invalid daily usage calculation.

## Description

This PR handles described case and adds missing specs.
