### PR TITLE
[ING-44] feat: add core logic for supporting passed billing entity in one-off flow

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -13,7 +13,8 @@ module Api
           timestamp: Time.current.to_i,
           skip_psp: create_params[:skip_psp],
           invoice_custom_section: create_params[:invoice_custom_section] || {},
-          payment_method_params: create_params[:payment_method]
+          payment_method_params: create_params[:payment_method],
+          billing_entity_code: create_params[:billing_entity_code]
         )
 
         if result.success?
@@ -275,6 +276,7 @@ module Api
               :external_customer_id,
               :currency,
               :skip_psp,
+              :billing_entity_code,
               fees: [
                 :add_on_code,
                 :invoice_display_name,

--- a/app/graphql/mutations/invoices/create.rb
+++ b/app/graphql/mutations/invoices/create.rb
@@ -25,7 +25,8 @@ module Mutations
           timestamp: Time.current.to_i,
           voided_invoice_id: args[:voided_invoice_id],
           payment_method_params: args[:payment_method]&.to_h,
-          invoice_custom_section: args[:invoice_custom_section]
+          invoice_custom_section: args[:invoice_custom_section],
+          billing_entity_id: args[:billing_entity_id]
         )
 
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/types/invoices/create_invoice_input.rb
+++ b/app/graphql/types/invoices/create_invoice_input.rb
@@ -5,6 +5,7 @@ module Types
     class CreateInvoiceInput < BaseInputObject
       description "Create Invoice input arguments"
 
+      argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
       argument :customer_id, ID, required: true
       argument :fees, [Types::Invoices::FeeInput], required: true

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -2,7 +2,7 @@
 
 module Invoices
   class CreateGeneratingService < BaseService
-    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false, skip_charges: false, invoice_id: nil, invoicing_reason: nil, subscription_gated: false) # rubocop:disable Metrics/ParameterLists
+    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false, skip_charges: false, invoice_id: nil, invoicing_reason: nil, subscription_gated: false, billing_entity: nil) # rubocop:disable Metrics/ParameterLists
       @customer = customer
       @invoice_type = invoice_type
       @currency = currency
@@ -12,6 +12,7 @@ module Invoices
       @invoice_id = invoice_id
       @recurring = invoicing_reason&.to_sym == :subscription_periodic
       @subscription_gated = subscription_gated
+      @billing_entity = billing_entity
 
       super
     end
@@ -23,7 +24,7 @@ module Invoices
         invoice = Invoice.create!(
           id: invoice_id || SecureRandom.uuid,
           organization:,
-          billing_entity: customer.billing_entity,
+          billing_entity: billing_entity || customer.billing_entity,
           customer:,
           invoice_type:,
           currency:,
@@ -46,7 +47,7 @@ module Invoices
 
     private
 
-    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance, :skip_charges, :invoice_id, :recurring, :subscription_gated
+    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance, :skip_charges, :invoice_id, :recurring, :subscription_gated, :billing_entity
 
     delegate :organization, to: :customer
 

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -2,7 +2,7 @@
 
 module Invoices
   class CreateOneOffService < BaseService
-    def initialize(customer:, currency:, fees:, timestamp:, skip_psp: false, voided_invoice_id: nil, payment_method_params: nil, invoice_custom_section: {})
+    def initialize(customer:, currency:, fees:, timestamp:, skip_psp: false, voided_invoice_id: nil, payment_method_params: nil, invoice_custom_section: {}, billing_entity_id: nil, billing_entity_code: nil)
       @customer = customer
       @currency = currency || customer&.currency
       @fees = fees
@@ -11,6 +11,8 @@ module Invoices
       @voided_invoice_id = voided_invoice_id
       @payment_method_params = payment_method_params
       @invoice_custom_section = invoice_custom_section
+      @billing_entity_id = billing_entity_id
+      @billing_entity_code = billing_entity_code
 
       super(nil)
     end
@@ -26,6 +28,9 @@ module Invoices
       return result.not_found_failure!(resource: "fees") if fees.blank?
       return result.not_found_failure!(resource: "add_on") unless add_ons.count == add_on_identifiers.count
       return result unless valid_payment_method?
+
+      resolve_billing_entity
+      return result if result.failure?
 
       tax_deferred = false
 
@@ -88,17 +93,33 @@ module Invoices
     private
 
     attr_accessor :timestamp, :currency, :customer, :fees, :invoice, :skip_psp, :voided_invoice_id, :payment_method_params, :invoice_custom_section
+    attr_reader :billing_entity_id, :billing_entity_code, :billing_entity
 
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
         customer:,
         invoice_type: :one_off,
         currency:,
-        datetime: Time.zone.at(timestamp)
+        datetime: Time.zone.at(timestamp),
+        billing_entity:
       )
       invoice_result.raise_if_error!
 
       @invoice = invoice_result.invoice
+    end
+
+    def resolve_billing_entity
+      multi_entity_enabled = customer.organization.feature_flag_enabled?(:multi_entity_billing)
+
+      if multi_entity_enabled && billing_entity_id.present?
+        @billing_entity = customer.organization.billing_entities.find_by(id: billing_entity_id)
+        result.not_found_failure!(resource: "billing_entity") if @billing_entity.nil?
+      elsif multi_entity_enabled && billing_entity_code.present?
+        @billing_entity = customer.organization.billing_entities.find_by(code: billing_entity_code)
+        result.not_found_failure!(resource: "billing_entity") if @billing_entity.nil?
+      else
+        @billing_entity = customer.billing_entity
+      end
     end
 
     def create_one_off_fees(invoice)
@@ -106,7 +127,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && customer.billing_entity.email_settings.include?("invoice.finalized")
+      License.premium? && invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def add_ons

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -30,7 +30,7 @@ module Invoices
       return result unless valid_payment_method?
 
       resolve_billing_entity
-      return result if result.failure?
+      return result unless result.success?
 
       tax_deferred = false
 
@@ -109,17 +109,19 @@ module Invoices
     end
 
     def resolve_billing_entity
-      multi_entity_enabled = customer.organization.feature_flag_enabled?(:multi_entity_billing)
-
-      if multi_entity_enabled && billing_entity_id.present?
+      if multi_entity_enabled? && billing_entity_id.present?
         @billing_entity = customer.organization.billing_entities.find_by(id: billing_entity_id)
         result.not_found_failure!(resource: "billing_entity") if @billing_entity.nil?
-      elsif multi_entity_enabled && billing_entity_code.present?
+      elsif multi_entity_enabled? && billing_entity_code.present?
         @billing_entity = customer.organization.billing_entities.find_by(code: billing_entity_code)
         result.not_found_failure!(resource: "billing_entity") if @billing_entity.nil?
       else
         @billing_entity = customer.billing_entity
       end
+    end
+
+    def multi_entity_enabled?
+      customer.organization.feature_flag_enabled?(:multi_entity_billing)
     end
 
     def create_one_off_fees(invoice)

--- a/schema.graphql
+++ b/schema.graphql
@@ -3085,6 +3085,8 @@ input CreateInvoiceCustomSectionInput {
 Create Invoice input arguments
 """
 input CreateInvoiceInput {
+  billingEntityId: ID
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -5909,6 +5911,8 @@ enum FeeTypesEnum {
 Create Invoice input arguments
 """
 input FetchDraftInvoiceTaxesInput {
+  billingEntityId: ID
+
   """
   A unique identifier for the client performing the mutation.
   """

--- a/schema.json
+++ b/schema.json
@@ -13703,6 +13703,18 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "billingEntityId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "currency",
               "description": null,
               "type": {
@@ -29445,6 +29457,18 @@
           "description": "Create Invoice input arguments",
           "fields": null,
           "inputFields": [
+            {
+              "name": "billingEntityId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "currency",
               "description": null,

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -113,4 +113,98 @@ RSpec.describe Mutations::Invoices::Create do
     )
     expect(Invoice.one_off.order(created_at: :desc).first.applied_invoice_custom_sections.pluck(:code)).to eq([section_1.code])
   end
+
+  context "when multi_entity_billing feature flag is enabled" do
+    let(:other_billing_entity) { create(:billing_entity, organization:) }
+    let(:mutation) do
+      <<-GQL
+        mutation($input: CreateInvoiceInput!) {
+          createInvoice(input: $input) {
+            id
+            billingEntity { id code }
+          }
+        }
+      GQL
+    end
+
+    before do
+      organization.enable_feature_flag!(:multi_entity_billing)
+      create(:tax, :applied_to_billing_entity, billing_entity: other_billing_entity, organization:, rate: 20)
+    end
+
+    it "stamps the invoice with the resolved billing entity" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            currency:,
+            fees:,
+            billingEntityId: other_billing_entity.id
+          }
+        }
+      )
+
+      expect(result["data"]["createInvoice"]["billingEntity"]).to include(
+        "id" => other_billing_entity.id,
+        "code" => other_billing_entity.code
+      )
+    end
+
+    it "returns a not found error when billing entity is unknown" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            currency:,
+            fees:,
+            billingEntityId: SecureRandom.uuid
+          }
+        }
+      )
+
+      expect(result["errors"].first["extensions"]["code"]).to eq("not_found")
+      expect(result["errors"].first["extensions"]["details"]).to include("billingEntity" => ["not_found"])
+    end
+  end
+
+  context "when multi_entity_billing feature flag is disabled" do
+    let(:other_billing_entity) { create(:billing_entity, organization:) }
+    let(:mutation) do
+      <<-GQL
+        mutation($input: CreateInvoiceInput!) {
+          createInvoice(input: $input) {
+            id
+            billingEntity { id code }
+          }
+        }
+      GQL
+    end
+
+    it "ignores billingEntityId and falls back to the customer's billing entity" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            currency:,
+            fees:,
+            billingEntityId: other_billing_entity.id
+          }
+        }
+      )
+
+      expect(result["data"]["createInvoice"]["billingEntity"]["id"]).to eq(customer.billing_entity.id)
+    end
+  end
 end

--- a/spec/graphql/types/invoices/create_invoice_input_spec.rb
+++ b/spec/graphql/types/invoices/create_invoice_input_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Invoices::CreateInvoiceInput do
   subject { described_class }
 
   it "has the expected arguments with correct types" do
+    expect(subject).to accept_argument(:billing_entity_id).of_type("ID")
     expect(subject).to accept_argument(:currency).of_type("CurrencyEnum")
     expect(subject).to accept_argument(:customer_id).of_type("ID!")
     expect(subject).to accept_argument(:fees).of_type("[FeeInput!]!")

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -117,6 +117,86 @@ RSpec.describe Api::V1::InvoicesController do
         expect(response).to have_http_status(:success)
       end
     end
+
+    context "when multi_entity_billing feature flag is enabled" do
+      let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+      before do
+        organization.enable_feature_flag!(:multi_entity_billing)
+        create(:tax, :applied_to_billing_entity, billing_entity: other_billing_entity, organization:, rate: 20)
+      end
+
+      context "with a known billing_entity_code" do
+        let(:create_params) do
+          {
+            external_customer_id: customer_external_id,
+            currency: "EUR",
+            billing_entity_code: other_billing_entity.code,
+            fees: [{add_on_code: add_on_first.code, unit_amount_cents: 1200, units: 2}]
+          }
+        end
+
+        it "stamps the invoice with the resolved billing entity" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoice][:billing_entity_code]).to eq(other_billing_entity.code)
+        end
+      end
+
+      context "with an unknown billing_entity_code" do
+        let(:create_params) do
+          {
+            external_customer_id: customer_external_id,
+            currency: "EUR",
+            billing_entity_code: "unknown_code",
+            fees: [{add_on_code: add_on_first.code, unit_amount_cents: 1200, units: 2}]
+          }
+        end
+
+        it "returns a not found error" do
+          subject
+
+          expect(response).to be_not_found_error("billing_entity")
+        end
+      end
+
+      context "without billing_entity_code" do
+        let(:create_params) do
+          {
+            external_customer_id: customer_external_id,
+            currency: "EUR",
+            fees: [{add_on_code: add_on_first.code, unit_amount_cents: 1200, units: 2}]
+          }
+        end
+
+        it "stamps the invoice with the customer's billing entity" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoice][:billing_entity_code]).to eq(customer.billing_entity.code)
+        end
+      end
+    end
+
+    context "when multi_entity_billing feature flag is disabled" do
+      let(:other_billing_entity) { create(:billing_entity, organization:) }
+      let(:create_params) do
+        {
+          external_customer_id: customer_external_id,
+          currency: "EUR",
+          billing_entity_code: other_billing_entity.code,
+          fees: [{add_on_code: add_on_first.code, unit_amount_cents: 1200, units: 2}]
+        }
+      end
+
+      it "ignores billing_entity_code and falls back to the customer's billing entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoice][:billing_entity_code]).to eq(customer.billing_entity.code)
+      end
+    end
   end
 
   describe "PUT /api/v1/invoices/:id" do

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe Invoices::CreateGeneratingService do
       end
     end
 
+    context "when an explicit billing_entity is passed" do
+      subject(:create_service) do
+        described_class.new(customer:, invoice_type:, currency:, datetime:, billing_entity:)
+      end
+
+      let(:billing_entity) { create(:billing_entity, organization: customer.organization) }
+
+      it "stamps the invoice with the provided billing entity" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.invoice.billing_entity).to eq(billing_entity)
+      end
+    end
+
     context "with applicable net payment term" do
       let(:customer) { create(:customer, net_payment_term: 3) }
 

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -407,6 +407,82 @@ RSpec.describe Invoices::CreateOneOffService do
       end
     end
 
+    context "when multi_entity_billing feature flag is enabled" do
+      let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+      before do
+        organization.enable_feature_flag!(:multi_entity_billing)
+        create(:tax, :applied_to_billing_entity, billing_entity: other_billing_entity, organization:, rate: 20)
+      end
+
+      context "when billing_entity_id is provided" do
+        let(:args) { {customer:, timestamp: timestamp.to_i, fees:, currency:, billing_entity_id: other_billing_entity.id} }
+
+        it "stamps the invoice with the resolved billing entity" do
+          result = described_class.call(**args)
+
+          expect(result).to be_success
+          expect(result.invoice.billing_entity).to eq(other_billing_entity)
+        end
+      end
+
+      context "when billing_entity_code is provided" do
+        let(:args) { {customer:, timestamp: timestamp.to_i, fees:, currency:, billing_entity_code: other_billing_entity.code} }
+
+        it "stamps the invoice with the resolved billing entity" do
+          result = described_class.call(**args)
+
+          expect(result).to be_success
+          expect(result.invoice.billing_entity).to eq(other_billing_entity)
+        end
+      end
+
+      context "when neither billing_entity_id nor billing_entity_code is provided" do
+        it "falls back to the customer's billing entity" do
+          result = described_class.call(**args)
+
+          expect(result).to be_success
+          expect(result.invoice.billing_entity).to eq(customer.billing_entity)
+        end
+      end
+
+      context "when billing_entity_id is unknown" do
+        let(:args) { {customer:, timestamp: timestamp.to_i, fees:, currency:, billing_entity_id: SecureRandom.uuid} }
+
+        it "returns a not found error" do
+          result = described_class.call(**args)
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq("billing_entity_not_found")
+        end
+      end
+
+      context "when billing_entity_code is unknown" do
+        let(:args) { {customer:, timestamp: timestamp.to_i, fees:, currency:, billing_entity_code: "unknown_code"} }
+
+        it "returns a not found error" do
+          result = described_class.call(**args)
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq("billing_entity_not_found")
+        end
+      end
+    end
+
+    context "when multi_entity_billing feature flag is disabled" do
+      let(:other_billing_entity) { create(:billing_entity, organization:) }
+      let(:args) { {customer:, timestamp: timestamp.to_i, fees:, currency:, billing_entity_id: other_billing_entity.id} }
+
+      it "ignores the billing_entity param and falls back to the customer's billing entity" do
+        result = described_class.call(**args)
+
+        expect(result).to be_success
+        expect(result.invoice.billing_entity).to eq(customer.billing_entity)
+      end
+    end
+
     context "when add_on_code is invalid" do
       let(:fees) do
         [


### PR DESCRIPTION
## Context

Currently, one customer can be assigned to only one billing entity. With `multi-billing-entities` feature, it will be possible to assign any billing entity to customer's billing object, like subscription or wallet.

## Description

This PR adds new logic which supports passing selected billing entity in one-off flow
