### PR TITLE
fix(specs): assert fee presence by lookup, not array position

### DIFF
--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Resolvers::InvoiceResolver do
       expect(data["customer"]["id"]).to eq(customer.id)
       expect(data["customer"]["name"]).to eq(customer.name)
       expect(data["invoiceSubscriptions"][0]["subscription"]["id"]).to eq(subscription.id)
-      expect(data["invoiceSubscriptions"][0]["fees"][0]["id"]).to eq(fee.id)
+      expect(data["invoiceSubscriptions"][0]["fees"]).to include(a_hash_including("id" => fee.id))
     end
   end
 
@@ -380,11 +380,12 @@ RSpec.describe Resolvers::InvoiceResolver do
       expect(data["status"]).to eq(invoice.status)
       expect(data["customer"]["id"]).to eq(customer.id)
       expect(data["customer"]["name"]).to eq(customer.name)
-      expect(data["fees"].first).to include(
+      add_on_fee = data["fees"].find { |f| f["itemType"] == "add_on" }
+      expect(add_on_fee).to include(
         "itemCode" => add_on.code,
         "itemName" => add_on.name
       )
-      expect(data["fees"].first["presentationBreakdowns"]).to eq([
+      expect(add_on_fee["presentationBreakdowns"]).to eq([
         {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
       ])
     end
@@ -411,12 +412,12 @@ RSpec.describe Resolvers::InvoiceResolver do
         expect(data["status"]).to eq(invoice.status)
         expect(data["customer"]["id"]).to eq(customer.id)
         expect(data["customer"]["name"]).to eq(customer.name)
-        expect(data["fees"].first).to include(
-          "itemType" => "add_on",
+        add_on_fee = data["fees"].find { |f| f["itemType"] == "add_on" }
+        expect(add_on_fee).to include(
           "itemCode" => add_on.code,
           "itemName" => add_on.name
         )
-        expect(data["fees"].first["presentationBreakdowns"]).to eq([
+        expect(add_on_fee["presentationBreakdowns"]).to eq([
           {"presentationBy" => {"department" => "engineering"}, "units" => "60.0"}
         ])
       end


### PR DESCRIPTION
## Context

`spec/graphql/resolvers/invoice_resolver_spec.rb` has been quietly flaky since PR #4740 (2026-01-13) introduced a top-level `before` block that creates **three fees** on every invoice (`fee`, `charge_fee`, `fixed_charge_fee`). Three pre-existing assertions in that file kept reading `data["fees"].first` / `data["fees"][0]`, which only worked while Postgres happened to return rows in insertion order. `Invoice#fees` has no explicit `ORDER BY`, so the assumption was never guaranteed.

The flake surfaced on a recent CI run on PR #5469 where the `fixed_charge_fee` came back at index 0 instead of the `add_on_fee`, failing this assertion:

```
expected #{...} to include {"itemType" => "add_on", ...}
got      "itemType" => "fixed_charge"
```

## Description

Three positional fee accesses replaced with lookups that express what the test actually means:

- `"with an add on invoice"` (line 364) and `"with a deleted add_on"` (line 395): `data["fees"].first` → `data["fees"].find { |f| f["itemType"] == "add_on" }`. The tests are about the add-on fee specifically — pick it by type.
- `"with a deleted billable metric"` (line 327): `data["invoiceSubscriptions"][0]["fees"][0]["id"]` → `include(a_hash_including("id" => fee.id))`. The test is asserting the deleted-charge-filter fee is *present* in the response, not at any particular position.

No production code changes — entirely a spec correction. The bug is in the test's assertion shape, not in the model or the resolver.