### PR TITLE
[ING-45] feat(multi-billing-entity): support custom billing entity for the invoice preview

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -250,8 +250,7 @@ module Api
         result = Invoices::PreviewService.call(
           customer: result.customer,
           subscriptions: result.subscriptions,
-          applied_coupons: result.applied_coupons,
-          billing_entity_code: params[:billing_entity_code]
+          applied_coupons: result.applied_coupons
         )
         if result.success?
           render(

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -250,7 +250,8 @@ module Api
         result = Invoices::PreviewService.call(
           customer: result.customer,
           subscriptions: result.subscriptions,
-          applied_coupons: result.applied_coupons
+          applied_coupons: result.applied_coupons,
+          billing_entity_code: params[:billing_entity_code]
         )
         if result.success?
           render(

--- a/app/services/invoices/preview/build_subscription_service.rb
+++ b/app/services/invoices/preview/build_subscription_service.rb
@@ -5,9 +5,10 @@ module Invoices
     class BuildSubscriptionService < BaseService
       Result = BaseResult[:subscriptions]
 
-      def initialize(customer:, params:)
+      def initialize(customer:, params:, billing_entity: nil)
         @customer = customer
         @params = params.presence || {}
+        @billing_entity = billing_entity
         super
       end
 
@@ -21,7 +22,7 @@ module Invoices
 
       private
 
-      attr_reader :customer, :params
+      attr_reader :customer, :params, :billing_entity
 
       delegate :organization, to: :customer
 
@@ -30,12 +31,20 @@ module Invoices
           organization_id: organization.id,
           customer:,
           plan:,
+          billing_entity: effective_billing_entity,
           subscription_at: params[:subscription_at].presence || Time.current,
           started_at: params[:subscription_at].presence || Time.current,
           billing_time:,
           created_at: params[:subscription_at].presence || Time.current,
           updated_at: Time.current
         )
+      end
+
+      def effective_billing_entity
+        return nil unless organization.feature_flag_enabled?(:multi_entity_billing)
+        return nil if billing_entity.nil? || billing_entity == customer.billing_entity
+
+        billing_entity
       end
 
       def billing_time

--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -48,7 +48,7 @@ module Invoices
           BuildSubscriptionService.call(
             customer:,
             params:,
-            billing_entity: @billing_entity
+            billing_entity:
           )
         when :projection
           FindSubscriptionsService.call(
@@ -59,7 +59,7 @@ module Invoices
 
       private
 
-      attr_reader :params, :organization, :customer
+      attr_reader :params, :organization, :customer, :billing_entity
 
       def context
         return @context if defined?(@context)

--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -5,10 +5,11 @@ module Invoices
     class SubscriptionsService < BaseService
       Result = BaseResult[:subscriptions]
 
-      def initialize(organization:, customer:, params:)
+      def initialize(organization:, customer:, params:, billing_entity: nil)
         @organization = organization
         @customer = customer
         @params = params
+        @billing_entity = billing_entity
         super
       end
 
@@ -46,7 +47,8 @@ module Invoices
         when :proposal
           BuildSubscriptionService.call(
             customer:,
-            params:
+            params:,
+            billing_entity: @billing_entity
           )
         when :projection
           FindSubscriptionsService.call(

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -18,7 +18,8 @@ module Invoices
       subscriptions_service = ::Invoices::Preview::SubscriptionsService.call(
         organization: organization,
         customer: result.customer,
-        params: subscription_params
+        params: subscription_params,
+        billing_entity: billing_entity
       )
 
       if subscriptions_service.success?

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -42,13 +42,25 @@ module Invoices
       params.slice(:billing_time, :plan_code, :subscription_at, :subscriptions)
     end
 
+    def new_customer_billing_entity
+      if organization.feature_flag_enabled?(:multi_entity_billing)
+        organization.default_billing_entity
+      else
+        billing_entity
+      end
+    end
+
     def find_or_build_customer
       customer_params = params[:customer] || {}
 
       customer = if customer_params.key?(:external_id)
         organization.customers.find_by!(external_id: customer_params[:external_id])
       else
-        organization.customers.new(created_at: Time.current, updated_at: Time.current, billing_entity:)
+        organization.customers.new(
+          created_at: Time.current,
+          updated_at: Time.current,
+          billing_entity: new_customer_billing_entity
+        )
       end
 
       customer.assign_attributes(

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -4,11 +4,10 @@ module Invoices
   class PreviewService < BaseService
     Result = BaseResult[:subscriptions, :invoice, :fees_taxes]
 
-    def initialize(customer:, subscriptions:, applied_coupons: [], billing_entity_code: nil)
+    def initialize(customer:, subscriptions:, applied_coupons: [])
       @customer = customer
       @subscriptions = subscriptions
       @applied_coupons = applied_coupons
-      @billing_entity_code = billing_entity_code
       @first_subscription = subscriptions.first
       @persisted_subscriptions = subscriptions.any?(&:persisted?)
       @subscription_context = fetch_context
@@ -21,10 +20,6 @@ module Invoices
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "subscription") if subscriptions.empty?
       return result.not_allowed_failure!(code: "premium_integration_missing") if persisted_subscriptions && !organization.preview_enabled?
-
-      resolve_billing_entity
-      return result unless result.success?
-
       return result unless currencies_aligned?
       return result unless billing_times_aligned?
       return result unless billing_entities_aligned?
@@ -58,17 +53,13 @@ module Invoices
     private
 
     attr_accessor :customer, :subscriptions, :invoice, :applied_coupons, :first_subscription, :persisted_subscriptions, :subscription_context
-    attr_reader :billing_entity, :billing_entity_code
     delegate :organization, to: :customer
 
-    def resolve_billing_entity
-      return @billing_entity = customer.billing_entity unless multi_entity_billing_enabled?
-
-      if billing_entity_code.present?
-        @billing_entity = organization.billing_entities.find_by(code: billing_entity_code)
-        result.not_found_failure!(resource: "billing_entity") if @billing_entity.nil?
+    def billing_entity
+      @billing_entity ||= if multi_entity_billing_enabled?
+        first_subscription.billing_entity || customer.billing_entity
       else
-        @billing_entity = first_subscription&.billing_entity || customer.billing_entity
+        customer.billing_entity
       end
     end
 
@@ -79,7 +70,7 @@ module Invoices
       effective_entity_ids = subscriptions.map { |s| s.billing_entity_id || customer.billing_entity_id }.uniq
 
       if effective_entity_ids.size > 1
-        result.single_validation_failure!(error_code: "subscription_billing_entities_does_not_match")
+        result.single_validation_failure!(error_code: "subscription_billing_entities_do_not_match")
         return false
       end
 

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -4,10 +4,11 @@ module Invoices
   class PreviewService < BaseService
     Result = BaseResult[:subscriptions, :invoice, :fees_taxes]
 
-    def initialize(customer:, subscriptions:, applied_coupons: [])
+    def initialize(customer:, subscriptions:, applied_coupons: [], billing_entity_code: nil)
       @customer = customer
       @subscriptions = subscriptions
       @applied_coupons = applied_coupons
+      @billing_entity_code = billing_entity_code
       @first_subscription = subscriptions.first
       @persisted_subscriptions = subscriptions.any?(&:persisted?)
       @subscription_context = fetch_context
@@ -20,8 +21,13 @@ module Invoices
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "subscription") if subscriptions.empty?
       return result.not_allowed_failure!(code: "premium_integration_missing") if persisted_subscriptions && !organization.preview_enabled?
+
+      resolve_billing_entity
+      return result unless result.success?
+
       return result unless currencies_aligned?
       return result unless billing_times_aligned?
+      return result unless billing_entities_aligned?
 
       @invoice = Invoice.new(
         organization:,
@@ -52,8 +58,37 @@ module Invoices
     private
 
     attr_accessor :customer, :subscriptions, :invoice, :applied_coupons, :first_subscription, :persisted_subscriptions, :subscription_context
+    attr_reader :billing_entity, :billing_entity_code
     delegate :organization, to: :customer
-    delegate :billing_entity, to: :customer
+
+    def resolve_billing_entity
+      return @billing_entity = customer.billing_entity unless multi_entity_billing_enabled?
+
+      if billing_entity_code.present?
+        @billing_entity = organization.billing_entities.find_by(code: billing_entity_code)
+        result.not_found_failure!(resource: "billing_entity") if @billing_entity.nil?
+      else
+        @billing_entity = first_subscription&.billing_entity || customer.billing_entity
+      end
+    end
+
+    def billing_entities_aligned?
+      return true unless multi_entity_billing_enabled?
+      return true if subscriptions.size <= 1
+
+      effective_entity_ids = subscriptions.map { |s| s.billing_entity_id || customer.billing_entity_id }.uniq
+
+      if effective_entity_ids.size > 1
+        result.single_validation_failure!(error_code: "subscription_billing_entities_does_not_match")
+        return false
+      end
+
+      true
+    end
+
+    def multi_entity_billing_enabled?
+      organization.feature_flag_enabled?(:multi_entity_billing)
+    end
 
     def fetch_context
       return :terminated if subscriptions.any?(&:terminated?)

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1141,6 +1141,30 @@ RSpec.describe Api::V1::InvoicesController do
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context "when previewing a new subscription for an existing customer with multi_entity_billing enabled" do
+        let(:existing_customer) { create(:customer, organization:, currency: "EUR") }
+        let(:preview_params) do
+          {
+            customer: {external_id: existing_customer.external_id},
+            plan_code: plan.code,
+            billing_time: "anniversary",
+            billing_entity_code: billing_entity.code
+          }
+        end
+
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "creates a preview invoice under the requested billing entity" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoice]).to include(
+            billing_entity_code: billing_entity.code,
+            invoice_type: "subscription"
+          )
+        end
+      end
     end
 
     context "when subscriptions are persisted" do

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1165,6 +1165,33 @@ RSpec.describe Api::V1::InvoicesController do
           )
         end
       end
+
+      context "when previewing for an anonymous customer with multi_entity_billing enabled" do
+        let(:preview_params) do
+          {
+            customer: {
+              name: "test 1",
+              currency: "EUR",
+              tax_identification_number: "123456789"
+            },
+            plan_code: plan.code,
+            billing_time: "anniversary",
+            billing_entity_code: billing_entity.code
+          }
+        end
+
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "stamps the invoice with the requested billing entity" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoice]).to include(
+            billing_entity_code: billing_entity.code,
+            invoice_type: "subscription"
+          )
+        end
+      end
     end
 
     context "when subscriptions are persisted" do

--- a/spec/services/invoices/preview/build_subscription_service_spec.rb
+++ b/spec/services/invoices/preview/build_subscription_service_spec.rb
@@ -112,6 +112,45 @@ RSpec.describe Invoices::Preview::BuildSubscriptionService do
           expect { subject }.not_to change(Subscription, :count)
         end
       end
+
+      context "when a billing_entity is provided" do
+        subject(:result) { described_class.call(customer:, params:, billing_entity:) }
+
+        let(:plan) { create(:plan, organization: customer.organization) }
+        let(:other_billing_entity) { create(:billing_entity, organization: customer.organization) }
+        let(:params) { {plan_code: plan.code} }
+
+        context "when multi_entity_billing flag is disabled" do
+          let(:billing_entity) { other_billing_entity }
+
+          it "does not assign an explicit billing entity on the subscription" do
+            expect(result).to be_success
+            expect(subscriptions.first.billing_entity_id).to be_nil
+          end
+        end
+
+        context "when multi_entity_billing flag is enabled" do
+          before { customer.organization.enable_feature_flag!(:multi_entity_billing) }
+
+          context "when the billing entity differs from the customer default" do
+            let(:billing_entity) { other_billing_entity }
+
+            it "assigns the billing entity on the subscription" do
+              expect(result).to be_success
+              expect(subscriptions.first.billing_entity_id).to eq(other_billing_entity.id)
+            end
+          end
+
+          context "when the billing entity matches the customer default" do
+            let(:billing_entity) { customer.billing_entity }
+
+            it "leaves the subscription's billing_entity_id nil so it inherits at billing time" do
+              expect(result).to be_success
+              expect(subscriptions.first.billing_entity_id).to be_nil
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -373,6 +373,43 @@ RSpec.describe Invoices::Preview::SubscriptionsService do
               )
           end
         end
+
+        context "when a billing_entity is provided" do
+          let(:result) { described_class.call(organization:, customer:, params:, billing_entity:) }
+          let(:customer) { create(:customer, organization:) }
+          let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+          context "when multi_entity_billing flag is enabled" do
+            before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+            context "when the billing entity differs from the customer default" do
+              let(:billing_entity) { other_billing_entity }
+
+              it "forwards it to the built subscription" do
+                expect(result).to be_success
+                expect(subject.first.billing_entity_id).to eq(other_billing_entity.id)
+              end
+            end
+
+            context "when the billing entity matches the customer default" do
+              let(:billing_entity) { customer.billing_entity }
+
+              it "leaves the built subscription's billing_entity_id nil" do
+                expect(result).to be_success
+                expect(subject.first.billing_entity_id).to be_nil
+              end
+            end
+          end
+
+          context "when multi_entity_billing flag is disabled" do
+            let(:billing_entity) { other_billing_entity }
+
+            it "leaves the built subscription's billing_entity_id nil" do
+              expect(result).to be_success
+              expect(subject.first.billing_entity_id).to be_nil
+            end
+          end
+        end
       end
     end
   end

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -175,6 +175,38 @@ RSpec.describe Invoices::PreviewContextService do
           expect(subject).to be_nil
         end
       end
+
+      context "when an explicit billing_entity is passed for a brand-new customer" do
+        let(:billing_entity) { create(:billing_entity, organization:) }
+        let(:params) do
+          {
+            customer: {
+              name: "Mislav M",
+              currency: "EUR"
+            }
+          }
+        end
+
+        context "when multi_entity_billing flag is disabled" do
+          it "builds the customer with the passed billing entity" do
+            expect(subject)
+              .to be_present
+              .and be_new_record
+              .and have_attributes(billing_entity_id: billing_entity.id)
+          end
+        end
+
+        context "when multi_entity_billing flag is enabled" do
+          before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+          it "builds the customer with the organization's default billing entity" do
+            expect(subject)
+              .to be_present
+              .and be_new_record
+              .and have_attributes(billing_entity_id: organization.default_billing_entity.id)
+          end
+        end
+      end
     end
   end
 

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -90,11 +90,20 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
         let(:other_billing_entity) { create(:billing_entity, organization:) }
 
         context "when multi_entity_billing flag is disabled" do
-          subject(:preview_service) do
-            described_class.new(customer:, subscriptions:, billing_entity_code: other_billing_entity.code)
+          let(:subscription) do
+            build(
+              :subscription,
+              customer:,
+              plan:,
+              billing_entity: other_billing_entity,
+              billing_time:,
+              subscription_at: timestamp,
+              started_at: timestamp,
+              created_at: timestamp
+            )
           end
 
-          it "ignores billing_entity_code and uses customer's entity" do
+          it "ignores the subscription's billing entity and uses the customer's entity" do
             travel_to(timestamp) do
               result = preview_service.call
 
@@ -107,12 +116,21 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
         context "when multi_entity_billing flag is enabled" do
           before { organization.enable_feature_flag!(:multi_entity_billing) }
 
-          context "when billing_entity_code is provided" do
-            subject(:preview_service) do
-              described_class.new(customer:, subscriptions:, billing_entity_code: other_billing_entity.code)
+          context "when the subscription has its own billing entity" do
+            let(:subscription) do
+              build(
+                :subscription,
+                customer:,
+                plan:,
+                billing_entity: other_billing_entity,
+                billing_time:,
+                subscription_at: timestamp,
+                started_at: timestamp,
+                created_at: timestamp
+              )
             end
 
-            it "uses the explicit billing entity for the invoice" do
+            it "uses the subscription's billing entity" do
               travel_to(timestamp) do
                 result = preview_service.call
 
@@ -122,53 +140,13 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
             end
           end
 
-          context "when billing_entity_code is unknown" do
-            subject(:preview_service) do
-              described_class.new(customer:, subscriptions:, billing_entity_code: "unknown")
-            end
+          context "when the subscription has no explicit billing entity" do
+            it "falls back to the customer's billing entity" do
+              travel_to(timestamp) do
+                result = preview_service.call
 
-            it "returns a not found failure" do
-              result = preview_service.call
-
-              expect(result).not_to be_success
-              expect(result.error).to be_a(BaseService::NotFoundFailure)
-              expect(result.error.resource).to eq("billing_entity")
-            end
-          end
-
-          context "when no billing entity param is provided" do
-            context "when the subscription has its own billing entity" do
-              let(:subscription) do
-                build(
-                  :subscription,
-                  customer:,
-                  plan:,
-                  billing_entity: other_billing_entity,
-                  billing_time:,
-                  subscription_at: timestamp,
-                  started_at: timestamp,
-                  created_at: timestamp
-                )
-              end
-
-              it "uses the subscription's billing entity" do
-                travel_to(timestamp) do
-                  result = preview_service.call
-
-                  expect(result).to be_success
-                  expect(result.invoice.billing_entity).to eq(other_billing_entity)
-                end
-              end
-            end
-
-            context "when the subscription has no explicit billing entity" do
-              it "falls back to the customer's billing entity" do
-                travel_to(timestamp) do
-                  result = preview_service.call
-
-                  expect(result).to be_success
-                  expect(result.invoice.billing_entity).to eq(billing_entity)
-                end
+                expect(result).to be_success
+                expect(result.invoice.billing_entity).to eq(billing_entity)
               end
             end
           end
@@ -191,7 +169,7 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
               result = preview_service.call
 
               expect(result).not_to be_success
-              expect(result.error.messages[:base]).to include("subscription_billing_entities_does_not_match")
+              expect(result.error.messages[:base]).to include("subscription_billing_entities_do_not_match")
             end
           end
         end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -86,6 +86,117 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
         end
       end
 
+      context "with multi-entity billing" do
+        let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+        context "when multi_entity_billing flag is disabled" do
+          subject(:preview_service) do
+            described_class.new(customer:, subscriptions:, billing_entity_code: other_billing_entity.code)
+          end
+
+          it "ignores billing_entity_code and uses customer's entity" do
+            travel_to(timestamp) do
+              result = preview_service.call
+
+              expect(result).to be_success
+              expect(result.invoice.billing_entity).to eq(billing_entity)
+            end
+          end
+        end
+
+        context "when multi_entity_billing flag is enabled" do
+          before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+          context "when billing_entity_code is provided" do
+            subject(:preview_service) do
+              described_class.new(customer:, subscriptions:, billing_entity_code: other_billing_entity.code)
+            end
+
+            it "uses the explicit billing entity for the invoice" do
+              travel_to(timestamp) do
+                result = preview_service.call
+
+                expect(result).to be_success
+                expect(result.invoice.billing_entity).to eq(other_billing_entity)
+              end
+            end
+          end
+
+          context "when billing_entity_code is unknown" do
+            subject(:preview_service) do
+              described_class.new(customer:, subscriptions:, billing_entity_code: "unknown")
+            end
+
+            it "returns a not found failure" do
+              result = preview_service.call
+
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.resource).to eq("billing_entity")
+            end
+          end
+
+          context "when no billing entity param is provided" do
+            context "when the subscription has its own billing entity" do
+              let(:subscription) do
+                build(
+                  :subscription,
+                  customer:,
+                  plan:,
+                  billing_entity: other_billing_entity,
+                  billing_time:,
+                  subscription_at: timestamp,
+                  started_at: timestamp,
+                  created_at: timestamp
+                )
+              end
+
+              it "uses the subscription's billing entity" do
+                travel_to(timestamp) do
+                  result = preview_service.call
+
+                  expect(result).to be_success
+                  expect(result.invoice.billing_entity).to eq(other_billing_entity)
+                end
+              end
+            end
+
+            context "when the subscription has no explicit billing entity" do
+              it "falls back to the customer's billing entity" do
+                travel_to(timestamp) do
+                  result = preview_service.call
+
+                  expect(result).to be_success
+                  expect(result.invoice.billing_entity).to eq(billing_entity)
+                end
+              end
+            end
+          end
+
+          context "when subscriptions have mismatched effective billing entities" do
+            let(:customer) { create(:customer, organization:, billing_entity:) }
+            let(:plan1) { create(:plan, organization:, interval: "monthly") }
+            let(:plan2) { create(:plan, organization:, interval: "monthly") }
+            let(:subscriptions) { [subscription1, subscription2] }
+            let(:subscription1) do
+              create(:subscription, plan: plan1, customer:, billing_entity:, subscription_at: timestamp, billing_time: "calendar")
+            end
+            let(:subscription2) do
+              create(:subscription, plan: plan2, customer:, billing_entity: other_billing_entity, subscription_at: timestamp, billing_time: "calendar")
+            end
+
+            before { organization.update!(premium_integrations: ["preview"]) }
+
+            it "returns a validation error" do
+              result = preview_service.call
+
+              expect(result).not_to be_success
+              expect(result.error.messages[:base]).to include("subscription_billing_entities_does_not_match")
+            end
+          end
+        end
+      end
+
       context "when billing periods do not match" do
         let(:customer) { create(:customer, organization:, billing_entity:) }
         let(:plan1) { create(:plan, organization:, interval: "monthly") }


### PR DESCRIPTION
## Context

Currently, one customer can be assigned to only one billing entity. With `multi-billing-entities` feature, it will be possible to assign any billing entity to customer's billing object, like subscription or wallet.

## Description

This PR supports custom billing entity for the invoice preview flow.
