### PR TITLE
Revert "misc(consumer): Temporary ignore organization id (#5487)"

### DIFF
--- a/app/consumers/events_charged_in_advance_consumer.rb
+++ b/app/consumers/events_charged_in_advance_consumer.rb
@@ -3,8 +3,6 @@
 class EventsChargedInAdvanceConsumer < ApplicationConsumer
   def consume
     messages.each do |message|
-      next if message.payload["organization_id"] == ENV["LAGO_SKIPPED_ORGANIZATION_ID"]
-
       Events::PayInAdvanceJob.set(wait: Events::Stores::ClickhouseStore::CLICKHOUSE_MERGE_DELAY).perform_later(message.payload)
     end
   end

--- a/spec/consumers/events_charged_in_advance_consumer_spec.rb
+++ b/spec/consumers/events_charged_in_advance_consumer_spec.rb
@@ -16,19 +16,4 @@ RSpec.describe EventsChargedInAdvanceConsumer do
         .at(Events::Stores::ClickhouseStore::CLICKHOUSE_MERGE_DELAY.from_now)
     end
   end
-
-  context "when the organization is skipped" do
-    let(:organization_id) { SecureRandom.uuid }
-    let(:event) { build(:common_event, organization_id: organization_id) }
-
-    around do |example|
-      ENV["LAGO_SKIPPED_ORGANIZATION_ID"] = organization_id
-      example.run
-      ENV.delete("LAGO_SKIPPED_ORGANIZATION_ID")
-    end
-
-    it "does not enqueue a pay in advance job" do
-      expect { consumer.consume }.not_to have_enqueued_job(Events::PayInAdvanceJob)
-    end
-  end
 end


### PR DESCRIPTION
Reverts temporary changes introduced at https://github.com/getlago/lago-api/pull/5487