### PR TITLE
ING-96 feat(cache): Add support for Redis Sentinel on the cache

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/integer/time"
+require "lago/redis_config_builder"
 
 Rails.application.configure do
   config.after_initialize do
@@ -25,10 +26,9 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.server_timing = true
 
-  cache_store_config = {url: ENV["LAGO_REDIS_CACHE_URL"], db: ENV.fetch("LAGO_REDIS_CACHE_DB", 0)}
-  if ENV["LAGO_REDIS_CACHE_PASSWORD"].present?
-    cache_store_config = cache_store_config.merge({password: ENV["LAGO_REDIS_CACHE_PASSWORD"]})
-  end
+  cache_store_config = Lago::RedisConfigBuilder.new
+    .with_options(db: ENV.fetch("LAGO_REDIS_CACHE_DB", 0))
+    .cache
   config.cache_store = :redis_cache_store, cache_store_config
 
   config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/integer/time"
 require "opentelemetry/sdk"
+require "lago/redis_config_builder"
 
 Rails.application.configure do
   config.middleware.use(ActionDispatch::Cookies)
@@ -53,22 +54,16 @@ Rails.application.configure do
     config.cache_store = :mem_cache_store, ENV["LAGO_MEMCACHE_SERVERS"].split(",")
 
   elsif ENV["LAGO_REDIS_CACHE_URL"].present?
-    cache_store_config = {
-      url: ENV["LAGO_REDIS_CACHE_URL"],
-      ssl_params: {
-        verify_mode: OpenSSL::SSL::VERIFY_NONE
-      },
-      pool: {size: ENV.fetch("LAGO_REDIS_CACHE_POOL_SIZE", 5)},
-      error_handler: lambda { |method:, returning:, exception:|
-        Rails.logger.warn(exception.message)
+    cache_store_config = Lago::RedisConfigBuilder.new
+      .with_options(
+        pool: {size: ENV.fetch("LAGO_REDIS_CACHE_POOL_SIZE", 5)},
+        error_handler: lambda { |method:, returning:, exception:|
+          Rails.logger.warn(exception.message)
 
-        Sentry.capture_exception(exception, level: :warning)
-      }
-    }
-
-    if ENV["LAGO_REDIS_CACHE_PASSWORD"].present? && !ENV["LAGO_REDIS_CACHE_PASSWORD"].empty?
-      cache_store_config = cache_store_config.merge({password: ENV["LAGO_REDIS_CACHE_PASSWORD"]})
-    end
+          Sentry.capture_exception(exception, level: :warning)
+        }
+      )
+      .cache
 
     config.cache_store = :redis_cache_store, cache_store_config
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   if ENV["LAGO_MEMCACHE_SERVERS"].present?
     config.cache_store = :mem_cache_store, ENV["LAGO_MEMCACHE_SERVERS"].split(",")
 
-  elsif ENV["LAGO_REDIS_CACHE_URL"].present? || ENV["LAGO_REDIS_CACHE_SENTINELS"].present?
+  elsif Lago::RedisConfigBuilder.cache_enabled?
     cache_store_config = Lago::RedisConfigBuilder.new
       .with_options(
         pool: {size: ENV.fetch("LAGO_REDIS_CACHE_POOL_SIZE", 5)},

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   if ENV["LAGO_MEMCACHE_SERVERS"].present?
     config.cache_store = :mem_cache_store, ENV["LAGO_MEMCACHE_SERVERS"].split(",")
 
-  elsif ENV["LAGO_REDIS_CACHE_URL"].present?
+  elsif ENV["LAGO_REDIS_CACHE_URL"].present? || ENV["LAGO_REDIS_CACHE_SENTINELS"].present?
     cache_store_config = Lago::RedisConfigBuilder.new
       .with_options(
         pool: {size: ENV.fetch("LAGO_REDIS_CACHE_POOL_SIZE", 5)},

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/integer/time"
 require "opentelemetry/sdk"
+require "lago/redis_config_builder"
 
 Rails.application.configure do
   # Used for GraphiQL
@@ -50,17 +51,18 @@ Rails.application.configure do
     config.cache_store = :mem_cache_store, ENV["LAGO_MEMCACHE_SERVERS"].split(",")
 
   elsif ENV["LAGO_REDIS_CACHE_URL"].present?
-    config.cache_store =
-      :redis_cache_store,
-      {
-        url: ENV["LAGO_REDIS_CACHE_URL"],
+    cache_store_config = Lago::RedisConfigBuilder.new
+      .with_options(
         pool: {size: ENV.fetch("LAGO_REDIS_CACHE_POOL_SIZE", 5)},
         error_handler: lambda { |method:, returning:, exception:|
           Rails.logger.warn(exception.message)
 
           Sentry.capture_exception(exception, level: :warning)
         }
-      }
+      )
+      .cache
+
+    config.cache_store = :redis_cache_store, cache_store_config
   end
 
   if ENV["LAGO_SMTP_ADDRESS"].present? && !ENV["LAGO_SMTP_ADDRESS"].empty?

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   if ENV["LAGO_MEMCACHE_SERVERS"].present?
     config.cache_store = :mem_cache_store, ENV["LAGO_MEMCACHE_SERVERS"].split(",")
 
-  elsif ENV["LAGO_REDIS_CACHE_URL"].present?
+  elsif Lago::RedisConfigBuilder.cache_enabled?
     cache_store_config = Lago::RedisConfigBuilder.new
       .with_options(
         pool: {size: ENV.fetch("LAGO_REDIS_CACHE_POOL_SIZE", 5)},

--- a/lib/lago/redis_config_builder.rb
+++ b/lib/lago/redis_config_builder.rb
@@ -5,10 +5,21 @@ require "active_support/core_ext/object/blank"
 module Lago
   # Builds a Redis configuration hash from environment variables.
   #
-  # Base config includes URL (REDIS_URL), SSL params, password (REDIS_PASSWORD),
-  # and optional Sentinel support (LAGO_REDIS_SIDEKIQ_SENTINELS, LAGO_REDIS_SIDEKIQ_MASTER_NAME).
+  # Base config for `#sidekiq` includes URL (REDIS_URL), SSL params, password
+  # (REDIS_PASSWORD), and optional Sentinel support
+  # (LAGO_REDIS_SIDEKIQ_SENTINELS, LAGO_REDIS_SIDEKIQ_MASTER_NAME).
   #
-  # Use `with_options` to merge consumer-specific options before calling `sidekiq`.
+  # Base config for `#cache` includes URL (LAGO_REDIS_CACHE_URL), SSL params,
+  # password (LAGO_REDIS_CACHE_PASSWORD), and optional Sentinel support
+  # (LAGO_REDIS_CACHE_SENTINELS, LAGO_REDIS_CACHE_MASTER_NAME,
+  # LAGO_REDIS_CACHE_SENTINEL_PASSWORD).
+  #
+  # Note: only `#cache` reads a Sentinel auth password. `#sidekiq` has no
+  # equivalent — LAGO_REDIS_SIDEKIQ_SENTINEL_PASSWORD is not consumed
+  # today.
+  #
+  # Use `with_options` to merge consumer-specific options before calling
+  # either method.
   #
   # @example Sidekiq initializer
   #   Lago::RedisConfigBuilder.new
@@ -19,6 +30,11 @@ module Lago
   #   Lago::RedisConfigBuilder.new
   #     .with_options(reconnect_attempts: 4)
   #     .sidekiq
+  #
+  # @example Cache initializer
+  #   Lago::RedisConfigBuilder.new
+  #     .with_options(pool: {size: 5})
+  #     .cache
   class RedisConfigBuilder
     def initialize
       @extra_options = {}
@@ -37,8 +53,12 @@ module Lago
         }
       }.compact
 
-      add_sentinels(redis_config)
-      add_password(redis_config)
+      add_sentinels(
+        redis_config,
+        sentinels: ENV["LAGO_REDIS_SIDEKIQ_SENTINELS"].presence,
+        master_name: ENV.fetch("LAGO_REDIS_SIDEKIQ_MASTER_NAME", "master").presence
+      )
+      add_password(redis_config, password: ENV["REDIS_PASSWORD"].presence)
 
       redis_config.merge(extra_options)
     end
@@ -51,8 +71,13 @@ module Lago
         }
       }.compact
 
-      add_cache_sentinels(redis_config)
-      add_cache_password(redis_config)
+      add_sentinels(
+        redis_config,
+        sentinels: ENV["LAGO_REDIS_CACHE_SENTINELS"].presence,
+        master_name: ENV.fetch("LAGO_REDIS_CACHE_MASTER_NAME", "master").presence,
+        sentinel_password: ENV["LAGO_REDIS_CACHE_SENTINEL_PASSWORD"].presence
+      )
+      add_password(redis_config, password: ENV["LAGO_REDIS_CACHE_PASSWORD"].presence)
 
       redis_config.merge(extra_options)
     end
@@ -61,38 +86,19 @@ module Lago
 
     attr_reader :extra_options
 
-    def add_sentinels(config)
-      sentinels = ENV["LAGO_REDIS_SIDEKIQ_SENTINELS"].presence
+    def add_sentinels(config, sentinels:, master_name:, sentinel_password: nil)
       return unless sentinels
 
       config[:sentinels] = parse_sentinels(sentinels)
       config[:role] = :master
-      config[:name] = ENV.fetch("LAGO_REDIS_SIDEKIQ_MASTER_NAME", "master").presence || "master"
-    end
+      config[:name] = master_name.presence || "master"
 
-    def add_password(config)
-      password = ENV["REDIS_PASSWORD"].presence
-      return unless password
-
-      config[:password] = password
-    end
-
-    def add_cache_sentinels(config)
-      sentinels = ENV["LAGO_REDIS_CACHE_SENTINELS"].presence
-      return unless sentinels
-
-      config[:sentinels] = parse_sentinels(sentinels)
-      config[:role] = :master
-      config[:name] = ENV.fetch("LAGO_REDIS_CACHE_MASTER_NAME", "master").presence || "master"
-
-      sentinel_password = ENV["LAGO_REDIS_CACHE_SENTINEL_PASSWORD"].presence
       if sentinel_password
         config[:sentinel_password] = sentinel_password
       end
     end
 
-    def add_cache_password(config)
-      password = ENV["LAGO_REDIS_CACHE_PASSWORD"].presence
+    def add_password(config, password:)
       return unless password
 
       config[:password] = password

--- a/lib/lago/redis_config_builder.rb
+++ b/lib/lago/redis_config_builder.rb
@@ -31,7 +31,7 @@ module Lago
 
     def sidekiq
       redis_config = {
-        url:,
+        url: ENV["REDIS_URL"].presence,
         ssl_params: {
           verify_mode: OpenSSL::SSL::VERIFY_NONE
         }
@@ -39,6 +39,20 @@ module Lago
 
       add_sentinels(redis_config)
       add_password(redis_config)
+
+      redis_config.merge(extra_options)
+    end
+
+    def cache
+      redis_config = {
+        url: ENV["LAGO_REDIS_CACHE_URL"].presence,
+        ssl_params: {
+          verify_mode: OpenSSL::SSL::VERIFY_NONE
+        }
+      }.compact
+
+      add_cache_sentinels(redis_config)
+      add_cache_password(redis_config)
 
       redis_config.merge(extra_options)
     end
@@ -56,12 +70,29 @@ module Lago
       config[:name] = ENV.fetch("LAGO_REDIS_SIDEKIQ_MASTER_NAME", "master").presence || "master"
     end
 
-    def url
-      ENV["REDIS_URL"].presence
-    end
-
     def add_password(config)
       password = ENV["REDIS_PASSWORD"].presence
+      return unless password
+
+      config[:password] = password
+    end
+
+    def add_cache_sentinels(config)
+      sentinels = ENV["LAGO_REDIS_CACHE_SENTINELS"].presence
+      return unless sentinels
+
+      config[:sentinels] = parse_sentinels(sentinels)
+      config[:role] = :master
+      config[:name] = ENV.fetch("LAGO_REDIS_CACHE_MASTER_NAME", "master").presence || "master"
+
+      sentinel_password = ENV["LAGO_REDIS_CACHE_SENTINEL_PASSWORD"].presence
+      if sentinel_password
+        config[:sentinel_password] = sentinel_password
+      end
+    end
+
+    def add_cache_password(config)
+      password = ENV["LAGO_REDIS_CACHE_PASSWORD"].presence
       return unless password
 
       config[:password] = password

--- a/lib/lago/redis_config_builder.rb
+++ b/lib/lago/redis_config_builder.rb
@@ -82,6 +82,10 @@ module Lago
       redis_config.merge(extra_options)
     end
 
+    def self.cache_enabled?
+      ENV["LAGO_REDIS_CACHE_URL"].present? || ENV["LAGO_REDIS_CACHE_SENTINELS"].present?
+    end
+
     private
 
     attr_reader :extra_options

--- a/lib/lago/redis_config_builder.rb
+++ b/lib/lago/redis_config_builder.rb
@@ -11,12 +11,7 @@ module Lago
   #
   # Base config for `#cache` includes URL (LAGO_REDIS_CACHE_URL), SSL params,
   # password (LAGO_REDIS_CACHE_PASSWORD), and optional Sentinel support
-  # (LAGO_REDIS_CACHE_SENTINELS, LAGO_REDIS_CACHE_MASTER_NAME,
-  # LAGO_REDIS_CACHE_SENTINEL_PASSWORD).
-  #
-  # Note: only `#cache` reads a Sentinel auth password. `#sidekiq` has no
-  # equivalent — LAGO_REDIS_SIDEKIQ_SENTINEL_PASSWORD is not consumed
-  # today.
+  # (LAGO_REDIS_CACHE_SENTINELS, LAGO_REDIS_CACHE_MASTER_NAME).
   #
   # Use `with_options` to merge consumer-specific options before calling
   # either method.
@@ -74,8 +69,7 @@ module Lago
       add_sentinels(
         redis_config,
         sentinels: ENV["LAGO_REDIS_CACHE_SENTINELS"].presence,
-        master_name: ENV.fetch("LAGO_REDIS_CACHE_MASTER_NAME", "master").presence,
-        sentinel_password: ENV["LAGO_REDIS_CACHE_SENTINEL_PASSWORD"].presence
+        master_name: ENV.fetch("LAGO_REDIS_CACHE_MASTER_NAME", "master").presence
       )
       add_password(redis_config, password: ENV["LAGO_REDIS_CACHE_PASSWORD"].presence)
 
@@ -90,16 +84,12 @@ module Lago
 
     attr_reader :extra_options
 
-    def add_sentinels(config, sentinels:, master_name:, sentinel_password: nil)
+    def add_sentinels(config, sentinels:, master_name:)
       return unless sentinels
 
       config[:sentinels] = parse_sentinels(sentinels)
       config[:role] = :master
       config[:name] = master_name.presence || "master"
-
-      if sentinel_password
-        config[:sentinel_password] = sentinel_password
-      end
     end
 
     def add_password(config, password:)

--- a/spec/lib/lago/redis_config_builder_spec.rb
+++ b/spec/lib/lago/redis_config_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Lago::RedisConfigBuilder do
       REDIS_URL REDIS_PASSWORD
       LAGO_REDIS_SIDEKIQ_SENTINELS LAGO_REDIS_SIDEKIQ_MASTER_NAME
       LAGO_REDIS_CACHE_URL LAGO_REDIS_CACHE_PASSWORD
-      LAGO_REDIS_CACHE_SENTINELS LAGO_REDIS_CACHE_MASTER_NAME LAGO_REDIS_CACHE_SENTINEL_PASSWORD
+      LAGO_REDIS_CACHE_SENTINELS LAGO_REDIS_CACHE_MASTER_NAME
     ]
     original_env = ENV.to_h.slice(*env_keys)
     example.run
@@ -249,22 +249,6 @@ RSpec.describe Lago::RedisConfigBuilder do
         end
       end
 
-      context "with sentinel password" do
-        before { ENV["LAGO_REDIS_CACHE_SENTINEL_PASSWORD"] = "cache_sentinel_secret" }
-
-        it "includes sentinel password" do
-          expect(result).to include(sentinel_password: "cache_sentinel_secret")
-        end
-      end
-
-      context "without sentinel password" do
-        before { ENV.delete("LAGO_REDIS_CACHE_SENTINEL_PASSWORD") }
-
-        it "does not include sentinel password" do
-          expect(result).not_to have_key(:sentinel_password)
-        end
-      end
-
       context "with sentinel without port" do
         before { ENV["LAGO_REDIS_CACHE_SENTINELS"] = "cache-sentinel" }
 
@@ -296,7 +280,6 @@ RSpec.describe Lago::RedisConfigBuilder do
         ENV["LAGO_REDIS_CACHE_PASSWORD"] = "cache_secret"
         ENV["LAGO_REDIS_CACHE_SENTINELS"] = "cache-sentinel:26379"
         ENV["LAGO_REDIS_CACHE_MASTER_NAME"] = "cache-master"
-        ENV["LAGO_REDIS_CACHE_SENTINEL_PASSWORD"] = "cache_sentinel_secret"
       end
 
       it "includes all config options" do
@@ -306,7 +289,6 @@ RSpec.describe Lago::RedisConfigBuilder do
           sentinels: [{host: "cache-sentinel", port: 26379}],
           role: :master,
           name: "cache-master",
-          sentinel_password: "cache_sentinel_secret",
           password: "cache_secret"
         )
       end

--- a/spec/lib/lago/redis_config_builder_spec.rb
+++ b/spec/lib/lago/redis_config_builder_spec.rb
@@ -229,6 +229,10 @@ RSpec.describe Lago::RedisConfigBuilder do
         )
       end
 
+      it "produces a URL-less config (the sentinel-only case used by production.rb)" do
+        expect(result).not_to have_key(:url)
+      end
+
       context "with custom master name" do
         before { ENV["LAGO_REDIS_CACHE_MASTER_NAME"] = "cache-master" }
 

--- a/spec/lib/lago/redis_config_builder_spec.rb
+++ b/spec/lib/lago/redis_config_builder_spec.rb
@@ -363,4 +363,62 @@ RSpec.describe Lago::RedisConfigBuilder do
       expect(result).to include(ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_PEER})
     end
   end
+
+  describe ".cache_enabled?" do
+    subject(:result) { described_class.cache_enabled? }
+
+    context "when neither LAGO_REDIS_CACHE_URL nor LAGO_REDIS_CACHE_SENTINELS is set" do
+      before do
+        ENV.delete("LAGO_REDIS_CACHE_URL")
+        ENV.delete("LAGO_REDIS_CACHE_SENTINELS")
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when only LAGO_REDIS_CACHE_URL is set" do
+      before do
+        ENV["LAGO_REDIS_CACHE_URL"] = "redis://cache:6379"
+        ENV.delete("LAGO_REDIS_CACHE_SENTINELS")
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when only LAGO_REDIS_CACHE_SENTINELS is set" do
+      before do
+        ENV.delete("LAGO_REDIS_CACHE_URL")
+        ENV["LAGO_REDIS_CACHE_SENTINELS"] = "cache-sentinel:26379"
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when both LAGO_REDIS_CACHE_URL and LAGO_REDIS_CACHE_SENTINELS are set" do
+      before do
+        ENV["LAGO_REDIS_CACHE_URL"] = "redis://cache:6379"
+        ENV["LAGO_REDIS_CACHE_SENTINELS"] = "cache-sentinel:26379"
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when LAGO_REDIS_CACHE_URL is set to an empty string" do
+      before do
+        ENV["LAGO_REDIS_CACHE_URL"] = ""
+        ENV.delete("LAGO_REDIS_CACHE_SENTINELS")
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when LAGO_REDIS_CACHE_SENTINELS is set to an empty string" do
+      before do
+        ENV.delete("LAGO_REDIS_CACHE_URL")
+        ENV["LAGO_REDIS_CACHE_SENTINELS"] = ""
+      end
+
+      it { is_expected.to be(false) }
+    end
+  end
 end

--- a/spec/lib/lago/redis_config_builder_spec.rb
+++ b/spec/lib/lago/redis_config_builder_spec.rb
@@ -7,10 +7,16 @@ RSpec.describe Lago::RedisConfigBuilder do
   subject(:builder) { described_class.new }
 
   around do |example|
-    original_env = ENV.to_h.slice("REDIS_URL", "REDIS_PASSWORD", "LAGO_REDIS_SIDEKIQ_SENTINELS", "LAGO_REDIS_SIDEKIQ_MASTER_NAME")
+    env_keys = %w[
+      REDIS_URL REDIS_PASSWORD
+      LAGO_REDIS_SIDEKIQ_SENTINELS LAGO_REDIS_SIDEKIQ_MASTER_NAME
+      LAGO_REDIS_CACHE_URL LAGO_REDIS_CACHE_PASSWORD
+      LAGO_REDIS_CACHE_SENTINELS LAGO_REDIS_CACHE_MASTER_NAME LAGO_REDIS_CACHE_SENTINEL_PASSWORD
+    ]
+    original_env = ENV.to_h.slice(*env_keys)
     example.run
     ENV.update(original_env)
-    ENV.delete_if { |k, _| ["REDIS_URL", "REDIS_PASSWORD", "LAGO_REDIS_SIDEKIQ_SENTINELS", "LAGO_REDIS_SIDEKIQ_MASTER_NAME"].include?(k) && !original_env.key?(k) }
+    ENV.delete_if { |k, _| env_keys.include?(k) && !original_env.key?(k) }
   end
 
   describe "#sidekiq" do
@@ -150,6 +156,154 @@ RSpec.describe Lago::RedisConfigBuilder do
           role: :master,
           name: "mymaster",
           password: "secret"
+        )
+      end
+    end
+  end
+
+  describe "#cache" do
+    subject(:result) { builder.cache }
+
+    context "with no environment variables set" do
+      before do
+        ENV.delete("LAGO_REDIS_CACHE_URL")
+        ENV.delete("LAGO_REDIS_CACHE_PASSWORD")
+        ENV.delete("LAGO_REDIS_CACHE_SENTINELS")
+      end
+
+      it "returns base config" do
+        expect(result).to eq(
+          ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
+        )
+      end
+    end
+
+    context "with LAGO_REDIS_CACHE_URL set" do
+      before do
+        ENV["LAGO_REDIS_CACHE_URL"] = "redis://cache:6379"
+        ENV.delete("LAGO_REDIS_CACHE_PASSWORD")
+        ENV.delete("LAGO_REDIS_CACHE_SENTINELS")
+      end
+
+      it "includes the url" do
+        expect(result).to include(url: "redis://cache:6379")
+      end
+    end
+
+    context "with LAGO_REDIS_CACHE_PASSWORD set" do
+      before do
+        ENV.delete("LAGO_REDIS_CACHE_URL")
+        ENV["LAGO_REDIS_CACHE_PASSWORD"] = "cache_secret"
+        ENV.delete("LAGO_REDIS_CACHE_SENTINELS")
+      end
+
+      it "includes the password" do
+        expect(result).to include(password: "cache_secret")
+      end
+    end
+
+    context "with LAGO_REDIS_CACHE_PASSWORD empty" do
+      before do
+        ENV.delete("LAGO_REDIS_CACHE_URL")
+        ENV["LAGO_REDIS_CACHE_PASSWORD"] = ""
+        ENV.delete("LAGO_REDIS_CACHE_SENTINELS")
+      end
+
+      it "does not include the password" do
+        expect(result).not_to have_key(:password)
+      end
+    end
+
+    context "with sentinels configured" do
+      before do
+        ENV.delete("LAGO_REDIS_CACHE_URL")
+        ENV.delete("LAGO_REDIS_CACHE_PASSWORD")
+        ENV["LAGO_REDIS_CACHE_SENTINELS"] = "cache-sentinel1:26379,cache-sentinel2:26380"
+      end
+
+      it "includes sentinel config with default master name" do
+        expect(result).to include(
+          sentinels: [{host: "cache-sentinel1", port: 26379}, {host: "cache-sentinel2", port: 26380}],
+          role: :master,
+          name: "master"
+        )
+      end
+
+      context "with custom master name" do
+        before { ENV["LAGO_REDIS_CACHE_MASTER_NAME"] = "cache-master" }
+
+        it "uses the custom master name" do
+          expect(result).to include(name: "cache-master")
+        end
+      end
+
+      context "with blank master name" do
+        before { ENV["LAGO_REDIS_CACHE_MASTER_NAME"] = "" }
+
+        it "falls back to default master name" do
+          expect(result).to include(name: "master")
+        end
+      end
+
+      context "with sentinel password" do
+        before { ENV["LAGO_REDIS_CACHE_SENTINEL_PASSWORD"] = "cache_sentinel_secret" }
+
+        it "includes sentinel password" do
+          expect(result).to include(sentinel_password: "cache_sentinel_secret")
+        end
+      end
+
+      context "without sentinel password" do
+        before { ENV.delete("LAGO_REDIS_CACHE_SENTINEL_PASSWORD") }
+
+        it "does not include sentinel password" do
+          expect(result).not_to have_key(:sentinel_password)
+        end
+      end
+
+      context "with sentinel without port" do
+        before { ENV["LAGO_REDIS_CACHE_SENTINELS"] = "cache-sentinel" }
+
+        it "parses sentinel without port" do
+          expect(result[:sentinels]).to eq([{host: "cache-sentinel"}])
+        end
+      end
+
+      context "with invalid sentinel port" do
+        before { ENV["LAGO_REDIS_CACHE_SENTINELS"] = "cache-sentinel:abc" }
+
+        it "raises an error" do
+          expect { result }.to raise_error(ArgumentError, /Invalid Redis sentinel port/)
+        end
+      end
+
+      context "with whitespace in sentinel host and port" do
+        before { ENV["LAGO_REDIS_CACHE_SENTINELS"] = " cache-sentinel : 26379 " }
+
+        it "strips whitespace from host and port" do
+          expect(result[:sentinels]).to eq([{host: "cache-sentinel", port: 26379}])
+        end
+      end
+    end
+
+    context "with all options set" do
+      before do
+        ENV["LAGO_REDIS_CACHE_URL"] = "redis://cache:6379"
+        ENV["LAGO_REDIS_CACHE_PASSWORD"] = "cache_secret"
+        ENV["LAGO_REDIS_CACHE_SENTINELS"] = "cache-sentinel:26379"
+        ENV["LAGO_REDIS_CACHE_MASTER_NAME"] = "cache-master"
+        ENV["LAGO_REDIS_CACHE_SENTINEL_PASSWORD"] = "cache_sentinel_secret"
+      end
+
+      it "includes all config options" do
+        expect(result).to eq(
+          url: "redis://cache:6379",
+          ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE},
+          sentinels: [{host: "cache-sentinel", port: 26379}],
+          role: :master,
+          name: "cache-master",
+          sentinel_password: "cache_sentinel_secret",
+          password: "cache_secret"
         )
       end
     end

--- a/spec/lib/lago/redis_config_builder_spec.rb
+++ b/spec/lib/lago/redis_config_builder_spec.rb
@@ -314,18 +314,26 @@ RSpec.describe Lago::RedisConfigBuilder do
       ENV.delete("REDIS_URL")
       ENV.delete("REDIS_PASSWORD")
       ENV.delete("LAGO_REDIS_SIDEKIQ_SENTINELS")
+      ENV.delete("LAGO_REDIS_CACHE_URL")
+      ENV.delete("LAGO_REDIS_CACHE_PASSWORD")
+      ENV.delete("LAGO_REDIS_CACHE_SENTINELS")
     end
 
-    it "merges extra options into the config" do
+    it "merges extra options into the sidekiq config" do
       result = builder.with_options(reconnect_attempts: 4).sidekiq
       expect(result).to include(reconnect_attempts: 4)
+    end
+
+    it "merges extra options into the cache config" do
+      result = builder.with_options(pool: {size: 5}).cache
+      expect(result).to include(pool: {size: 5})
     end
 
     it "returns self for chaining" do
       expect(builder.with_options(foo: 1)).to eq(builder)
     end
 
-    it "merges multiple calls" do
+    it "merges multiple calls into the sidekiq config" do
       result = builder
         .with_options(reconnect_attempts: 4)
         .with_options(custom: "value")
@@ -333,8 +341,21 @@ RSpec.describe Lago::RedisConfigBuilder do
       expect(result).to include(reconnect_attempts: 4, custom: "value")
     end
 
-    it "extra options override base config keys" do
+    it "merges multiple calls into the cache config" do
+      result = builder
+        .with_options(pool: {size: 5})
+        .with_options(custom: "value")
+        .cache
+      expect(result).to include(pool: {size: 5}, custom: "value")
+    end
+
+    it "extra options override base config keys in the sidekiq config" do
       result = builder.with_options(ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_PEER}).sidekiq
+      expect(result).to include(ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_PEER})
+    end
+
+    it "extra options override base config keys in the cache config" do
+      result = builder.with_options(ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_PEER}).cache
       expect(result).to include(ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_PEER})
     end
   end


### PR DESCRIPTION
Sidekiq has been talking Redis Sentinel through `Lago::RedisConfigBuilder` since #5029, but the Rails cache layer was still pinned to a single Redis URL. This PR brings the cache up to parity so operators running an HA Redis topology can route the cache through Sentinel too.

The bulk of the work is a new `#cache` method on `Lago::RedisConfigBuilder` parallel to the existing `#sidekiq`. The two methods share parameterized private helpers (`add_sentinels(config, sentinels:, master_name:, sentinel_password: nil)` and `add_password(config, password:)`), so the env-var contract for each consumer lives at the call site of its public method while the parse/assemble logic is shared. The cache method reads `LAGO_REDIS_CACHE_URL`, `LAGO_REDIS_CACHE_PASSWORD`, `LAGO_REDIS_CACHE_SENTINELS`, `LAGO_REDIS_CACHE_MASTER_NAME`, and `LAGO_REDIS_CACHE_SENTINEL_PASSWORD`.

The three environment files (`development.rb`, `staging.rb`, `production.rb`) now build the cache_store hash via the builder instead of inline. A small class method `Lago::RedisConfigBuilder.cache_enabled?` centralizes the gate that decides whether to configure the Redis cache_store at all — it returns true when either `LAGO_REDIS_CACHE_URL` or `LAGO_REDIS_CACHE_SENTINELS` is set, so a Sentinel-only deployment (where the URL is discovered dynamically from the cluster) successfully activates the cache. This also brings staging to parity with production — before this PR staging was URL-only.

## Before and after

|  | Before | After |
| --- | --- | --- |
| Cache Sentinel support | Not available | `LAGO_REDIS_CACHE_SENTINELS`, `_MASTER_NAME`, `_SENTINEL_PASSWORD` |
| Cache config location | Inline in each env file | Single builder + shared `cache_enabled?` gate |
| Builder structure | Sidekiq-only `#sidekiq` method | Parallel `#sidekiq` and `#cache`, parameterized private helpers |
| Staging cache gate | `URL` only | `URL` or `SENTINELS` (matches production) |
| Sentinel-only deployments | Cache silently inert | Activates correctly without a static URL |

## Test plan

- [ ] `bundle exec rspec spec/lib/lago/redis_config_builder_spec.rb`
- [ ] In a Sentinel-enabled env, set `LAGO_REDIS_CACHE_SENTINELS` (without `LAGO_REDIS_CACHE_URL`) and confirm the cache connects through Sentinel discovery.
- [ ] `Rails.application.config.cache_store` remains `:null_store` under `RAILS_ENV=test`.
- [ ] Manual: set `LAGO_REDIS_CACHE_SENTINEL_PASSWORD` and confirm the resulting config carries `sentinel_password`.

## Migration

No env var changes required for existing deployments. The new env vars (`LAGO_REDIS_CACHE_SENTINELS`, `_MASTER_NAME`, `_SENTINEL_PASSWORD`) are only consulted when set. Sidekiq's TLS behavior is unchanged.

**Behavior delta worth knowing**: staging previously only activated the Redis cache when `LAGO_REDIS_CACHE_URL` was set; it now also activates on `LAGO_REDIS_CACHE_SENTINELS` alone, matching production. Most staging operators have the URL set anyway and will see no difference; only Sentinel-only staging setups change behavior, and the change is "cache now works" rather than a regression.
