### PR TITLE
fix(database): opt-in statement/idle/lock timeouts via env vars (ING-97)

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,9 @@
 default: &default
   adapter: postgresql
+  variables:
+    statement_timeout: <%= ENV["LAGO_DATABASE_STATEMENT_TIMEOUT"] %>
+    idle_in_transaction_session_timeout: <%= ENV["LAGO_DATABASE_IDLE_TX_TIMEOUT"] %>
+    lock_timeout: <%= ENV["LAGO_DATABASE_LOCK_TIMEOUT"] %>
 
 development:
   primary:


### PR DESCRIPTION
## Summary

Adds three opt-in PostgreSQL session variables to the shared `default` block of `config/database.yml`, applied to every Rails connection (primary + events; ClickHouse is unaffected):

- `LAGO_DATABASE_STATEMENT_TIMEOUT` → `statement_timeout`
- `LAGO_DATABASE_IDLE_TX_TIMEOUT` → `idle_in_transaction_session_timeout`
- `LAGO_DATABASE_LOCK_TIMEOUT` → `lock_timeout`

[Public doc PR](https://github.com/getlago/lago-doc/pull/581)

## Why opt-in rather than baked-in defaults

The ticket suggested a code-level default of `30 s` for web and `0` (unlimited) for Sidekiq, gated by an `ENV.fetch(..., 30_000)` fallback. I deliberately **did not** go that route, for two reasons:

1. **No surprise behavior change on next deploy.** With code-level defaults, the cap kicks in the moment the change merges, regardless of whether infra has tuned it per deploy target. A query that legitimately runs 45 s today would start failing in production on the next deploy, which is not the rollout shape we want.
2. **Process discrimination belongs at the deploy boundary, not in `database.yml`.** Whether a given pod is "web", "clock worker", "events consumer", or "karafka" is best expressed in the deploy config that already differentiates the entrypoint scripts.

## Rollout

Each deploy target will be given sensible values for the three env vars via the infra config (not in this PR):

| Deploy target          | `LAGO_DATABASE_STATEMENT_TIMEOUT` | `LAGO_DATABASE_IDLE_TX_TIMEOUT` | `LAGO_DATABASE_LOCK_TIMEOUT` |
| ---------------------- | ---------------------- | -------------------- | ----------------- |
| API (Puma)             | `30000` (30 s)         | `60000` (1 min)      | `5000` (5 s)      |
| Sidekiq workers        | unset (no cap)         | unset                | unset             |
| Clock / Karafka        | unset                  | unset                | unset             |
| Rake / migrations      | unset                  | unset                | unset             |

Values can be tuned per env without touching the code. Setting any of them to `0` explicitly disables that specific cap.

## Test plan

Verified locally inside the api container:

- [x] No env vars set → `SHOW statement_timeout` / `idle_in_transaction_session_timeout` / `lock_timeout` all return `0`
- [x] All three env vars set (`30000` / `60000` / `5000`) → PG reports `30s` / `1min` / `5s`.
- [x] Only `LAGO_DATABASE_STATEMENT_TIMEOUT=5000` set → PG reports `5s` for statement timeout; the other two remain at `0`.
- [x] End-to-end: with `LAGO_DATABASE_STATEMENT_TIMEOUT=1000`, `SELECT pg_sleep(5)` raises `PG::QueryCanceled` at ~1.01 s.

Verified on preview app:

Instrumenting an `idle_in_transaction_timeout`

<img width="1581" height="229" alt="Capture d’écran 2026-05-12 à 15 32 15" src="https://github.com/user-attachments/assets/f22476a4-cc92-4020-9b55-6cc9c4f30d61" />

## Follow-ups (not in this PR)

- Infra change to set the three env vars on the API deploy target.
- Watch Sentry for `PG::QueryCanceled` for 24–48 h after rollout; tune the cap or add per-query `SET LOCAL` overrides where the cancellations are legitimate slow paths (likely candidates: GraphQL `events` query referenced in ING-16).

Closes ING-98