### PR TITLE
[ING-46] feat(multi-billing-entity): update payment request flow for billing entity

### DIFF
--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -63,6 +63,7 @@ module PaymentRequests
       # - there are no invoices
       # - the invoices are not overdue
       # - the invoices have different currencies
+      # - the invoices have different billing entities
       # - the invoices are not ready for payment processing
 
       return result.forbidden_failure! unless License.premium?
@@ -75,6 +76,10 @@ module PaymentRequests
 
       if invoices.pluck(:currency).uniq.size > 1
         return result.not_allowed_failure!(code: "invoices_have_different_currencies")
+      end
+
+      if invoices.pluck(:billing_entity_id).uniq.size > 1
+        return result.not_allowed_failure!(code: "invoices_have_different_billing_entities")
       end
 
       if invoices.exists?(ready_for_payment_processing: false)

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -92,6 +92,20 @@ RSpec.describe PaymentRequests::CreateService, :premium do
       end
     end
 
+    context "when invoices have different billing entities" do
+      let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+      before { second_invoice.update!(billing_entity: other_billing_entity) }
+
+      it "returns not allowed failure" do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoices_have_different_billing_entities")
+      end
+    end
+
     context "when invoices are not ready for payment processing" do
       before { first_invoice.update!(ready_for_payment_processing: false) }
 


### PR DESCRIPTION
## Context

Currently, one customer can be assigned to only one billing entity. With `multi-billing-entities` feature, it will be possible to assign any billing entity to customer's billing object, like subscription or wallet.

## Description

This PR reject payment request if invoices belong to different billing entity.
