### PR TITLE
fix(invoices): race condition on void calls

### DIFF
--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -18,7 +18,6 @@ module Invoices
 
     def call
       return result.not_found_failure!(resource: "invoice") unless invoice
-      return result.not_allowed_failure!(code: "not_voidable") if invoice.voided?
       return result.forbidden_failure! unless generate_credit_note_allowed?
       unless valid_credit_note_amounts?
         return result.single_validation_failure!(
@@ -27,7 +26,9 @@ module Invoices
         )
       end
 
-      ActiveRecord::Base.transaction do
+      invoice.with_lock do
+        return result.not_allowed_failure!(code: "not_voidable") if invoice.voided?
+
         invoice.void!
         flag_lifetime_usage_for_refresh
 

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -217,5 +217,47 @@ RSpec.describe Invoices::VoidService do
         end
       end
     end
+
+    describe "guard against concurrent calls" do
+      let(:invoice) { create(:invoice, status: :finalized) }
+
+      context "with two threads racing on the same invoice", transaction: false do
+        # Separate in-memory instances of the same database record
+        let!(:invoice_instances) do
+          Array.new(2) do
+            inv = Invoice.find(invoice.id)
+
+            allow(inv).to receive(:void!).and_wrap_original do |original, *args|
+              sleep(0.05)
+              original.call(*args)
+            end
+
+            inv
+          end
+        end
+
+        it "voids the invoice exactly once and rejects other attempts" do
+          allow(LifetimeUsages::FlagRefreshFromInvoiceService).to receive(:call).and_call_original
+
+          results = Concurrent::Array.new
+
+          threads = invoice_instances.map do |inv|
+            Thread.new do
+              results << described_class.new(invoice: inv).call
+            end
+          end
+
+          threads.each(&:join)
+
+          successes = results.count(&:success?)
+          rejections = results.count { |r| !r.success? && r.error.code == "not_voidable" }
+
+          expect(successes).to eq(1)
+          expect(rejections).to eq(1)
+          expect(invoice.reload).to be_voided
+          expect(LifetimeUsages::FlagRefreshFromInvoiceService).to have_received(:call).once
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Two concurrent `POST /invoices/:id/void` requests could both pass the initial in-memory `invoice.voided?` check before either had committed, causing the full void path to run twice on the same invoice.

## Description

This fix wraps the void path in `invoice.with_lock` and moves the `invoice.voided?` check inside this lock.

The first request runs normally.

Any concurrent request reloads the row after acquiring the lock, sees it's already voided, and returns `not_voidable` without running side effects.

