### PR TITLE
fix(API-229): Fixes merge! with frozen hash

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -460,9 +460,10 @@ module Fees
         # when pricing group keys on a charge are "workspace" and "user", and filter_by_group is {"workspace" => ["A"]},
         # we want to remove the grouping keys "workspace", but keep the grouping key "user", so the usage will still be granular within the workspace
         usage_filters.filter_by_group.keys.each { |key| filters[:grouped_by]&.delete(key) }
-        filters[:matching_filters] ||= {}
+        # NOTE: filters[:matching_filters] may come from ChargeFilter#to_h_with_all_values
+        # which returns a frozen hash, so we must not mutate it in place.
         # expected matching_filters format is { "workspace" => ["A", "B"], "user" => ["U1", "U2"] }
-        filters[:matching_filters].merge!(usage_filters.filter_by_group)
+        filters[:matching_filters] = (filters[:matching_filters] || {}).merge(usage_filters.filter_by_group)
       end
 
       filters

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -4273,6 +4273,42 @@ RSpec.describe Fees::ChargeService, :premium do
           expect(gcp_fee).to have_attributes(units: 5)
         end
       end
+
+      context "when the charge also defines charge_filters" do
+        let(:charge) do
+          create(
+            :standard_charge,
+            plan: subscription.plan,
+            billable_metric:,
+            properties: {amount: "20", pricing_group_keys: %w[region cloud]}
+          )
+        end
+
+        let(:region_filter) do
+          create(:billable_metric_filter, billable_metric:, key: "region", values: %w[eu us])
+        end
+
+        let(:eu_filter) do
+          create(
+            :charge_filter,
+            charge:,
+            properties: {amount: "30", pricing_group_keys: %w[region cloud]}
+          )
+        end
+
+        before do
+          create(:charge_filter_value, charge_filter: eu_filter, billable_metric_filter: region_filter, values: ["eu"])
+        end
+
+        it "does not raise a FrozenError when merging filter_by_group into matching_filters" do
+          expect { charge_subscription_service.call }.not_to raise_error
+        end
+
+        it "still produces a successful result" do
+          result = charge_subscription_service.call
+          expect(result).to be_success
+        end
+      end
     end
 
     context "with filter_by_presentation" do


### PR DESCRIPTION
This commit fixes an issue in Fees::ChargeService where we're trying to mutate the filters[:matching_filters].

`matching_filters` are build in ChargeFilter and we have logic there that is freezing the hash.
Instead of changing the service, we're handling the logic in Fees::ChargeService to create a new hash instead.

Fixes sentry error API-229.