### PR TITLE
fix(invoices): skip MarkOverdueService when invoice is already overdue

### DIFF
--- a/app/services/invoices/payments/mark_overdue_service.rb
+++ b/app/services/invoices/payments/mark_overdue_service.rb
@@ -20,6 +20,7 @@ module Invoices
         return result.not_allowed_failure!(code: "invoice_payment_already_succeeded") if invoice.payment_succeeded?
         return result.not_allowed_failure!(code: "invoice_due_date_in_future") if invoice.payment_due_date > Time.current
         return result.not_allowed_failure!(code: "invoice_dispute_lost") if invoice.payment_dispute_lost_at
+        return result.not_allowed_failure!(code: "invoice_already_overdue") if invoice.payment_overdue?
 
         invoice.update!(payment_overdue: true)
 

--- a/spec/services/invoices/payments/mark_overdue_service_spec.rb
+++ b/spec/services/invoices/payments/mark_overdue_service_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe Invoices::Payments::MarkOverdueService do
       payment_due_date: invoice_due_date,
       status: invoice_status,
       payment_status: invoice_payment_status,
-      payment_dispute_lost_at: invoice_dispute_lost_at)
+      payment_dispute_lost_at: invoice_dispute_lost_at,
+      payment_overdue: invoice_payment_overdue)
   end
   let(:invoice_payment_status) { :pending }
   let(:invoice_due_date) { 1.day.ago }
   let(:invoice_status) { :finalized }
   let(:invoice_dispute_lost_at) { nil }
+  let(:invoice_payment_overdue) { false }
 
   describe "#call" do
     it "mark the invoice as payment_overdue" do
@@ -80,6 +82,16 @@ RSpec.describe Invoices::Payments::MarkOverdueService do
         expect(result.success?).to be(false)
         expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
         expect(result.error.code).to eq("invoice_dispute_lost")
+      end
+    end
+
+    context "when invoice is already overdue" do
+      let(:invoice_payment_overdue) { true }
+
+      it "returns not allowed failure" do
+        expect(result.success?).to be(false)
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoice_already_overdue")
       end
     end
   end


### PR DESCRIPTION
This commits add an extra guard clause to MarkOverdueService.

We're adding an extra guard clause on MarkOverdueService to avoid mark the invoice
payment_overdue to true when is already done. 
Having this, we're preventing redundant updates and duplicate invoice.payment_overdue webhook deliveries.
