### PR TITLE
feat(multi-billing-entity): move subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -197,6 +197,8 @@ module Api
           :on_termination_credit_note,
           :on_termination_invoice,
           :progressive_billing_disabled,
+          :billing_entity_id,
+          :billing_entity_code,
           activation_rules: [:type, :timeout_hours],
           invoice_custom_section: [
             :skip_invoice_custom_sections,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -107,6 +107,10 @@ class Subscription < ApplicationRecord
     super || customer&.billing_entity
   end
 
+  def applicable_billing_entity_id
+    billing_entity_id || customer&.billing_entity_id
+  end
+
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
     self.activated_at ||= timestamp

--- a/app/services/fees/build_pay_in_advance_fixed_charge_service.rb
+++ b/app/services/fees/build_pay_in_advance_fixed_charge_service.rb
@@ -98,7 +98,7 @@ module Fees
 
       Fee.new(
         organization:,
-        billing_entity_id: subscription.billing_entity_id || subscription.customer.billing_entity_id,
+        billing_entity_id: subscription.applicable_billing_entity_id,
         subscription:,
         fixed_charge:,
         amount_cents:,
@@ -141,7 +141,7 @@ module Fees
     def build_zero_amount_fee(boundaries)
       Fee.new(
         organization:,
-        billing_entity_id: subscription.billing_entity_id || subscription.customer.billing_entity_id,
+        billing_entity_id: subscription.applicable_billing_entity_id,
         subscription:,
         fixed_charge:,
         amount_cents: 0,

--- a/app/services/fees/build_pay_in_advance_fixed_charge_service.rb
+++ b/app/services/fees/build_pay_in_advance_fixed_charge_service.rb
@@ -98,7 +98,7 @@ module Fees
 
       Fee.new(
         organization:,
-        billing_entity_id: subscription.customer.billing_entity_id,
+        billing_entity_id: subscription.billing_entity_id || subscription.customer.billing_entity_id,
         subscription:,
         fixed_charge:,
         amount_cents:,
@@ -141,7 +141,7 @@ module Fees
     def build_zero_amount_fee(boundaries)
       Fee.new(
         organization:,
-        billing_entity_id: subscription.customer.billing_entity_id,
+        billing_entity_id: subscription.billing_entity_id || subscription.customer.billing_entity_id,
         subscription:,
         fixed_charge:,
         amount_cents: 0,

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -253,7 +253,7 @@ module Fees
       new_fee = Fee.new(
         invoice:,
         organization_id: organization.id,
-        billing_entity_id: subscription.billing_entity_id || subscription.customer.billing_entity_id,
+        billing_entity_id: subscription.applicable_billing_entity_id,
         subscription:,
         charge:,
         amount_cents:,

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -253,7 +253,7 @@ module Fees
       new_fee = Fee.new(
         invoice:,
         organization_id: organization.id,
-        billing_entity_id: subscription.customer.billing_entity_id,
+        billing_entity_id: subscription.billing_entity_id || subscription.customer.billing_entity_id,
         subscription:,
         charge:,
         amount_cents:,

--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -122,7 +122,7 @@ module Fees
       new_fee = Fee.new(
         invoice:,
         organization_id: organization.id,
-        billing_entity_id: subscription.billing_entity_id || subscription.customer.billing_entity_id,
+        billing_entity_id: subscription.applicable_billing_entity_id,
         subscription:,
         fixed_charge:,
         amount_cents:,

--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -122,7 +122,7 @@ module Fees
       new_fee = Fee.new(
         invoice:,
         organization_id: organization.id,
-        billing_entity_id: subscription.customer.billing_entity_id,
+        billing_entity_id: subscription.billing_entity_id || subscription.customer.billing_entity_id,
         subscription:,
         fixed_charge:,
         amount_cents:,

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -174,19 +174,8 @@ module Invoices
       subscriptions.first&.billing_entity || customer.billing_entity
     end
 
-    # Subscriptions batched into one invoice must resolve to the same billing
-    # entity. Pre-multi-entity this was guaranteed because all subscriptions
-    # inherited from customer.billing_entity. Now that subscription.billing_entity_id
-    # is mutable, an operator can move one of N subscriptions to a different
-    # entity and leave the rest. Refuse to invoice in that case rather than
-    # produce an invoice whose header and fees disagree. Upstream batching
-    # (OrganizationBillingService) is the right long-term home for the split.
     def mixed_billing_entities?
-      resolved_billing_entity_ids.uniq.size > 1
-    end
-
-    def resolved_billing_entity_ids
-      subscriptions.map { |s| s.billing_entity_id || s.customer.billing_entity_id }
+      subscriptions.map { |s| s.billing_entity_id || s.customer.billing_entity_id }.uniq.many?
     end
 
     def set_invoice_generated_status

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -23,6 +23,10 @@ module Invoices
     def call
       return result if active_subscriptions.empty? && recurring
 
+      if mixed_billing_entities?
+        return result.validation_failure!(errors: {billing_entity: ["mixed_billing_entities"]})
+      end
+
       create_generating_invoice unless invoice
       invoice.status = :open if subscription_gated?
       result.invoice = invoice
@@ -143,6 +147,7 @@ module Invoices
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
         customer:,
+        billing_entity: invoice_billing_entity,
         invoice_type: :subscription,
         invoicing_reason:,
         currency:,
@@ -163,6 +168,25 @@ module Invoices
       return false if subscription_gated?
 
       @grace_period ||= customer.applicable_invoice_grace_period.positive?
+    end
+
+    def invoice_billing_entity
+      subscriptions.first&.billing_entity || customer.billing_entity
+    end
+
+    # Subscriptions batched into one invoice must resolve to the same billing
+    # entity. Pre-multi-entity this was guaranteed because all subscriptions
+    # inherited from customer.billing_entity. Now that subscription.billing_entity_id
+    # is mutable, an operator can move one of N subscriptions to a different
+    # entity and leave the rest. Refuse to invoice in that case rather than
+    # produce an invoice whose header and fees disagree. Upstream batching
+    # (OrganizationBillingService) is the right long-term home for the split.
+    def mixed_billing_entities?
+      resolved_billing_entity_ids.uniq.size > 1
+    end
+
+    def resolved_billing_entity_ids
+      subscriptions.map { |s| s.billing_entity_id || s.customer.billing_entity_id }
     end
 
     def set_invoice_generated_status

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -175,7 +175,7 @@ module Invoices
     end
 
     def mixed_billing_entities?
-      subscriptions.map { |s| s.billing_entity_id || s.customer.billing_entity_id }.uniq.many?
+      subscriptions.map(&:applicable_billing_entity_id).uniq.many?
     end
 
     def set_invoice_generated_status

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -65,8 +65,8 @@ module Subscriptions
         end
 
         if params.key?(:billing_entity_id) || params.key?(:billing_entity_code)
-          resolved = resolve_billing_entity
-          subscription.billing_entity = resolved if resolved
+          new_billing_entity = resolve_billing_entity
+          subscription.billing_entity = new_billing_entity if new_billing_entity
         end
 
         subscription.plan = handle_plan_override.plan if params.key?(:plan_overrides)
@@ -158,14 +158,11 @@ module Subscriptions
     def resolve_billing_entity
       return nil unless subscription.organization.feature_flag_enabled?(:multi_entity_billing)
 
-      attrs = if params[:billing_entity_id].present?
-        {id: params[:billing_entity_id]}
+      if params[:billing_entity_id].present?
+        subscription.organization.billing_entities.find(params[:billing_entity_id])
       elsif params[:billing_entity_code].present?
-        {code: params[:billing_entity_code]}
+        subscription.organization.billing_entities.find_by!(code: params[:billing_entity_code])
       end
-      return nil unless attrs
-
-      subscription.organization.billing_entities.find_by!(attrs)
     rescue ActiveRecord::RecordNotFound
       result.not_found_failure!(resource: "billing_entity").raise_if_error!
     end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -64,6 +64,11 @@ module Subscriptions
           subscription.payment_method_id = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
         end
 
+        if params.key?(:billing_entity_id) || params.key?(:billing_entity_code)
+          resolved = resolve_billing_entity
+          subscription.billing_entity = resolved if resolved
+        end
+
         subscription.plan = handle_plan_override.plan if params.key?(:plan_overrides)
 
         if params.key?(:usage_thresholds)
@@ -148,6 +153,21 @@ module Subscriptions
           Invoices::CreatePayInAdvanceFixedChargesJob.perform_after_commit(subscription, subscription.started_at + 1.second)
         end
       end
+    end
+
+    def resolve_billing_entity
+      return nil unless subscription.organization.feature_flag_enabled?(:multi_entity_billing)
+
+      attrs = if params[:billing_entity_id].present?
+        {id: params[:billing_entity_id]}
+      elsif params[:billing_entity_code].present?
+        {code: params[:billing_entity_code]}
+      end
+      return nil unless attrs
+
+      subscription.organization.billing_entities.find_by!(attrs)
+    rescue ActiveRecord::RecordNotFound
+      result.not_found_failure!(resource: "billing_entity").raise_if_error!
     end
 
     def handle_plan_override

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -93,6 +93,28 @@ RSpec.describe Subscription do
     end
   end
 
+  describe "#applicable_billing_entity_id" do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    context "when subscription has a billing_entity_id" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:subscription) { create(:subscription, customer:, billing_entity:) }
+
+      it "returns the subscription's own billing_entity_id" do
+        expect(subscription.applicable_billing_entity_id).to eq(billing_entity.id)
+      end
+    end
+
+    context "when subscription has no billing_entity_id" do
+      let(:subscription) { create(:subscription, customer:, billing_entity: nil) }
+
+      it "falls back to the customer's billing_entity_id" do
+        expect(subscription.applicable_billing_entity_id).to eq(customer.billing_entity_id)
+      end
+    end
+  end
+
   describe "Scopes" do
     describe ".starting_in_the_future" do
       let(:organization) { create(:organization) }

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -1791,6 +1791,58 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           expect(json[:code]).to eq("subscription_incomplete")
         end
       end
+
+      context "when updating billing_entity" do
+        let(:subscription) { create(:subscription, customer:, plan:) }
+        let(:new_billing_entity) { create(:billing_entity, organization:) }
+
+        context "with multi_entity_billing feature flag enabled" do
+          before { organization.update!(feature_flags: ["multi_entity_billing"]) }
+
+          context "with billing_entity_code" do
+            let(:update_params) { {billing_entity_code: new_billing_entity.code} }
+
+            it "updates the subscription's billing entity" do
+              subject
+
+              expect(response).to have_http_status(:success)
+              expect(subscription.reload.billing_entity_id).to eq(new_billing_entity.id)
+            end
+          end
+
+          context "with billing_entity_id" do
+            let(:update_params) { {billing_entity_id: new_billing_entity.id} }
+
+            it "updates the subscription's billing entity" do
+              subject
+
+              expect(response).to have_http_status(:success)
+              expect(subscription.reload.billing_entity_id).to eq(new_billing_entity.id)
+            end
+          end
+
+          context "with an unknown billing_entity_code" do
+            let(:update_params) { {billing_entity_code: "does-not-exist"} }
+
+            it "returns a not found error" do
+              subject
+
+              expect(response).to be_not_found_error("billing_entity")
+            end
+          end
+        end
+
+        context "with multi_entity_billing feature flag disabled" do
+          let(:update_params) { {billing_entity_code: new_billing_entity.code} }
+
+          it "silently ignores billing_entity_code and returns success" do
+            subject
+
+            expect(response).to have_http_status(:success)
+            expect(subscription.reload.billing_entity_id).to be_nil
+          end
+        end
+      end
     end
   end
 

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -129,6 +129,39 @@ RSpec.describe Invoices::SubscriptionService do
       end
     end
 
+    context "when a subscription is moved between billing entities mid-lifecycle" do
+      let(:eu_entity) { create(:billing_entity, organization:) }
+
+      before { organization.update!(feature_flags: ["multi_entity_billing"]) }
+
+      it "stamps the past invoice with the original entity, then the next billing cycle with the new one" do
+        past_invoice = described_class.call(
+          subscriptions:,
+          timestamp: (timestamp - 1.month).to_i,
+          invoicing_reason: :subscription_periodic
+        ).invoice
+
+        expect(past_invoice.billing_entity_id).to eq(billing_entity.id)
+
+        update_result = Subscriptions::UpdateService.call(
+          subscription:,
+          params: {billing_entity_code: eu_entity.code}
+        )
+        expect(update_result).to be_success
+        expect(subscription.reload.billing_entity_id).to eq(eu_entity.id)
+
+        new_invoice = described_class.call(
+          subscriptions: [subscription],
+          timestamp: timestamp.to_i,
+          invoicing_reason: :subscription_periodic
+        ).invoice
+
+        expect(new_invoice.billing_entity_id).to eq(eu_entity.id)
+        expect(new_invoice.fees.subscription.first.billing_entity_id).to eq(eu_entity.id)
+        expect(past_invoice.reload.billing_entity_id).to eq(billing_entity.id)
+      end
+    end
+
     context "when batched subscriptions resolve to different billing entities" do
       let(:other_entity) { create(:billing_entity, organization:) }
       let(:other_subscription) do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -101,6 +101,58 @@ RSpec.describe Invoices::SubscriptionService do
       expect(result.invoice).to be_finalized
     end
 
+    context "when the subscription has its own billing_entity" do
+      let(:subscription_billing_entity) { create(:billing_entity, organization:) }
+      let(:subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          billing_entity: subscription_billing_entity,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at
+        )
+      end
+
+      it "stamps the generated invoice with the subscription's entity" do
+        result = invoice_service.call
+
+        expect(result).to be_success
+        expect(result.invoice.billing_entity_id).to eq(subscription_billing_entity.id)
+      end
+
+      it "stamps generated fees with the subscription's entity" do
+        result = invoice_service.call
+
+        expect(result.invoice.fees.subscription.first.billing_entity_id).to eq(subscription_billing_entity.id)
+      end
+    end
+
+    context "when batched subscriptions resolve to different billing entities" do
+      let(:other_entity) { create(:billing_entity, organization:) }
+      let(:other_subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          billing_entity: other_entity,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at
+        )
+      end
+      let(:subscriptions) { [subscription, other_subscription] }
+
+      it "returns a validation failure rather than producing a mixed-entity invoice" do
+        result = invoice_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:billing_entity]).to eq(["mixed_billing_entities"])
+      end
+    end
+
     it_behaves_like "syncs invoice" do
       let(:service_call) { invoice_service.call }
     end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1118,10 +1118,7 @@ RSpec.describe Subscriptions::UpdateService do
       let(:new_billing_entity) { create(:billing_entity, organization:) }
 
       context "with multi_entity_billing feature flag enabled" do
-        before do
-          organization.update!(feature_flags: ["multi_entity_billing"])
-          subscription.organization.reload
-        end
+        before { organization.update!(feature_flags: ["multi_entity_billing"]) }
 
         context "with billing_entity_id" do
           let(:params) { {billing_entity_id: new_billing_entity.id} }

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1109,5 +1109,111 @@ RSpec.describe Subscriptions::UpdateService do
         end
       end
     end
+
+    context "when updating billing_entity" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:subscription) { create(:subscription, customer:, plan:, organization:) }
+      let(:new_billing_entity) { create(:billing_entity, organization:) }
+
+      context "with multi_entity_billing feature flag enabled" do
+        before do
+          organization.update!(feature_flags: ["multi_entity_billing"])
+          subscription.organization.reload
+        end
+
+        context "with billing_entity_id" do
+          let(:params) { {billing_entity_id: new_billing_entity.id} }
+
+          it "assigns the new billing entity to the subscription" do
+            update_service.call
+
+            expect(subscription.reload.billing_entity_id).to eq(new_billing_entity.id)
+          end
+
+          it "sends subscription.updated webhook" do
+            expect { update_service.call }.to have_enqueued_job_after_commit(SendWebhookJob).with("subscription.updated", subscription)
+          end
+        end
+
+        context "with billing_entity_code" do
+          let(:params) { {billing_entity_code: new_billing_entity.code} }
+
+          it "assigns the new billing entity to the subscription" do
+            update_service.call
+
+            expect(subscription.reload.billing_entity_id).to eq(new_billing_entity.id)
+          end
+        end
+
+        context "with both billing_entity_id and billing_entity_code" do
+          let(:other_entity) { create(:billing_entity, organization:) }
+          let(:params) { {billing_entity_id: new_billing_entity.id, billing_entity_code: other_entity.code} }
+
+          it "prefers billing_entity_id over billing_entity_code" do
+            update_service.call
+
+            expect(subscription.reload.billing_entity_id).to eq(new_billing_entity.id)
+          end
+        end
+
+        context "with unknown billing_entity_id" do
+          let(:params) { {billing_entity_id: SecureRandom.uuid} }
+
+          it "returns not_found_failure for billing_entity" do
+            result = update_service.call
+
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.resource).to eq("billing_entity")
+          end
+
+          it "does not persist any change" do
+            expect { update_service.call }.not_to change { subscription.reload.attributes }
+          end
+        end
+
+        context "with unknown billing_entity_code" do
+          let(:params) { {billing_entity_code: "nonexistent"} }
+
+          it "returns not_found_failure for billing_entity" do
+            result = update_service.call
+
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.resource).to eq("billing_entity")
+          end
+        end
+
+        context "with a billing entity from another organization" do
+          let(:other_org) { create(:organization) }
+          let(:foreign_entity) { create(:billing_entity, organization: other_org) }
+          let(:params) { {billing_entity_id: foreign_entity.id} }
+
+          it "returns not_found_failure (scoping enforced)" do
+            result = update_service.call
+
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.resource).to eq("billing_entity")
+          end
+        end
+      end
+
+      context "with multi_entity_billing feature flag disabled" do
+        let(:params) { {billing_entity_id: new_billing_entity.id} }
+
+        it "silently ignores billing_entity_id" do
+          update_service.call
+
+          expect(subscription.reload.billing_entity_id).to be_nil
+        end
+
+        it "returns success" do
+          expect(update_service.call).to be_success
+        end
+      end
+    end
   end
 end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1169,6 +1169,10 @@ RSpec.describe Subscriptions::UpdateService do
           it "does not persist any change" do
             expect { update_service.call }.not_to change { subscription.reload.attributes }
           end
+
+          it "does not enqueue the subscription.updated webhook" do
+            expect { update_service.call }.not_to have_enqueued_job(SendWebhookJob).with("subscription.updated", subscription)
+          end
         end
 
         context "with unknown billing_entity_code" do


### PR DESCRIPTION
## Summary

Operators can now move an active subscription to a different billing entity through a normal `PATCH /api/v1/subscriptions/:external_id` request, instead of having to terminate and recreate it. From the next billing cycle on, invoices for that subscription land under the new entity (using its number prefix and sequence); invoices already generated stay where they were.

The change is gated behind the `multi_entity_billing` feature flag, so single-entity organizations see no behavior change at all.

## What changed

| Concern | Before | After |
|---|---|---|
| Moving a subscription to another billing entity | Terminate and recreate | `PATCH` with `billing_entity_id` or `billing_entity_code` |
| Where invoice rows read their billing entity from | `customer.billing_entity` | `subscription.billing_entity` (falls back to customer's) |
| Where fees read their billing entity from | `subscription.customer.billing_entity_id` | `subscription.billing_entity_id` (falls back to customer's) |
| Subscriptions with `NULL` `billing_entity_id` (every row in prod today) | Stamped with customer's entity | Same; the column fallback keeps stamping byte-identical |
| Customer with multiple subs on different entities billed together | Not reachable | Returns a `mixed_billing_entities` validation failure; never produces a mixed invoice |
| Feature flag off | Param wasn't accepted | Param is silently ignored, matching the create-side convention |

## How the resolver works

`Subscriptions::UpdateService` resolves the entity inline. It accepts either an id or a code on the same request; if both are sent, the id wins. Unknown values return a 404 with `billing_entity_not_found`. Cross-organization references resolve to "not found" because the lookup is scoped to the subscription's organization.

For the read side, every fee and invoice writer now prefers `subscription.billing_entity_id || subscription.customer.billing_entity_id`. Because every existing subscription row has a `NULL` override, the fallback path is taken and the behavior is identical to today. Once an operator flips the column, the next invoice and its fees follow.

The one read site that intentionally stays on `subscription.customer.billing_entity` is the previous-period proration lookup in `Fees::FixedChargeService`, because legacy paid fees were written against the customer's entity and the query needs to match them.

## Out of scope

The `subscription.updated` webhook payload doesn't surface the new `billing_entity_id` yet; that lives with the serializer and OpenAPI work. Batched billing across mixed-entity subscriptions returns a validation error today; the proper fix is to split the batch upstream in `OrganizationBillingService` and is deferred.

## Test plan

- [ ] Seed an organization with `multi_entity_billing` in `feature_flags`, plus two billing entities `us` (default) and `eu`. Seed a customer under `us` and an active subscription on a monthly recurring plan.
- [ ] `PATCH /api/v1/subscriptions/:external_id` with `{ subscription: { billing_entity_code: "eu" } }`. Expect `200` and verify the `subscriptions` row's `billing_entity_id` now points at `eu`; the `customers` row is unchanged.
- [ ] Force the next billing cycle (move the clock to the calendar boundary or invoke `BillSubscriptionJob` directly for the subscription). Verify the resulting invoice's `billing_entity_id` is `eu`, its number draws from `eu`'s sequence and prefix, and any previously-generated invoices are untouched.
- [ ] Toggle `multi_entity_billing` off on the organization. `PATCH` the subscription again with `billing_entity_code: "us"`. Expect `200` and no change to the row.
- [ ] Re-enable the flag. `PATCH` with `billing_entity_id` set to a random UUID. Expect `404` with `code: "billing_entity_not_found"`. `PATCH` with `billing_entity_id` referencing an entity from a different organization. Expect the same.
- [ ] Create a second subscription on the same customer and `PATCH` it to `eu`, leaving the original on `us`. Trigger their next billing day. Expect a validation failure with `billing_entity: ["mixed_billing_entities"]` rather than a mixed invoice.