### PR TITLE
[ING-123] fix(flat_filters): update flat_filters view to improve performances

### DIFF
--- a/db/migrate/20260512142543_update_flat_filters_to_version_5.rb
+++ b/db/migrate/20260512142543_update_flat_filters_to_version_5.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateFlatFiltersToVersion5 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :flat_filters, version: 5, revert_to_version: 4
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -313,7 +313,6 @@ SELECT
     NULL::uuid AS charge_filter_id,
     NULL::timestamp(6) without time zone AS charge_filter_updated_at,
     NULL::jsonb AS filters,
-    NULL::jsonb AS properties,
     NULL::jsonb AS pricing_group_keys,
     NULL::boolean AS pay_in_advance,
     NULL::boolean AS accepts_target_wallet;
@@ -4315,7 +4314,6 @@ SELECT
     NULL::uuid AS charge_filter_id,
     NULL::timestamp(6) without time zone AS charge_filter_updated_at,
     NULL::jsonb AS filters,
-    NULL::jsonb AS properties,
     NULL::jsonb AS pricing_group_keys,
     NULL::boolean AS pay_in_advance,
     NULL::boolean AS accepts_target_wallet;
@@ -9848,16 +9846,15 @@ CREATE OR REPLACE VIEW public.flat_filters AS
             END)
             ELSE NULL::jsonb
         END AS filters,
-    COALESCE(charge_filters.properties, charges.properties) AS properties,
     (COALESCE(charge_filters.properties, charges.properties) -> 'pricing_group_keys'::text) AS pricing_group_keys,
     charges.pay_in_advance,
     charges.accepts_target_wallet
    FROM ((((public.billable_metrics
      JOIN public.charges ON ((charges.billable_metric_id = billable_metrics.id)))
-     LEFT JOIN public.charge_filters ON ((charge_filters.charge_id = charges.id)))
-     LEFT JOIN public.charge_filter_values ON ((charge_filter_values.charge_filter_id = charge_filters.id)))
-     LEFT JOIN public.billable_metric_filters ON ((billable_metric_filters.id = charge_filter_values.billable_metric_filter_id)))
-  WHERE ((billable_metrics.deleted_at IS NULL) AND (charges.deleted_at IS NULL) AND (charge_filters.deleted_at IS NULL) AND (charge_filter_values.deleted_at IS NULL) AND (billable_metric_filters.deleted_at IS NULL))
+     LEFT JOIN public.charge_filters ON (((charge_filters.charge_id = charges.id) AND (charge_filters.deleted_at IS NULL))))
+     LEFT JOIN public.charge_filter_values ON (((charge_filter_values.charge_filter_id = charge_filters.id) AND (charge_filter_values.deleted_at IS NULL))))
+     LEFT JOIN public.billable_metric_filters ON (((billable_metric_filters.id = charge_filter_values.billable_metric_filter_id) AND (billable_metric_filters.deleted_at IS NULL))))
+  WHERE ((billable_metrics.deleted_at IS NULL) AND (charges.deleted_at IS NULL))
   GROUP BY billable_metrics.organization_id, billable_metrics.code, charges.plan_id, charges.id, charges.updated_at, charge_filters.id, charge_filters.updated_at;
 
 
@@ -12219,6 +12216,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260517101105'),
+('20260512142543'),
 ('20260504134804'),
 ('20260430102814'),
 ('20260430102813'),
@@ -13216,3 +13214,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/db/views/flat_filters_v05.sql
+++ b/db/views/flat_filters_v05.sql
@@ -1,0 +1,41 @@
+-- This view is used on events_processor side to check filters matching on events received for organization using the Clickhouse store
+-- It then allows us to expire the usage chage directly within the events events_processor service
+SELECT
+  billable_metrics.organization_id AS organization_id,
+  billable_metrics.code AS billable_metric_code,
+  charges.plan_id AS plan_id,
+  charges.id AS charge_id,
+  charges.updated_at AS charge_updated_at,
+  charge_filters.id AS charge_filter_id,
+  charge_filters.updated_at AS charge_filter_updated_at,
+  CASE WHEN charge_filters.id IS NOT NULL
+  THEN
+	  jsonb_object_agg(
+	    COALESCE(billable_metric_filters.key, ''),
+	    CASE
+	      WHEN charge_filter_values.values::text[] && ARRAY['__ALL_FILTER_VALUES__']
+	      THEN billable_metric_filters.values
+	      ELSE charge_filter_values.values
+	    end
+	  )
+	  ELSE NULL
+  END AS filters,
+  COALESCE(charge_filters.properties, charges.properties)->'pricing_group_keys' AS pricing_group_keys,
+  charges.pay_in_advance AS pay_in_advance,
+  charges.accepts_target_wallet AS accepts_target_wallet
+FROM billable_metrics
+  INNER JOIN charges ON charges.billable_metric_id = billable_metrics.id
+  LEFT JOIN charge_filters ON charge_filters.charge_id = charges.id AND charge_filters.deleted_at IS NULL
+  LEFT JOIN charge_filter_values ON charge_filter_values.charge_filter_id = charge_filters.id AND charge_filter_values.deleted_at IS NULL
+  LEFT JOIN billable_metric_filters ON billable_metric_filters.id = charge_filter_values.billable_metric_filter_id AND billable_metric_filters.deleted_at IS NULL
+WHERE
+  billable_metrics.deleted_at IS NULL
+  AND charges.deleted_at IS NULL
+GROUP BY
+  billable_metrics.organization_id,
+  billable_metrics.code,
+  charges.plan_id,
+  charges.id,
+  charges.updated_at,
+  charge_filters.id,
+  charge_filters.updated_at


### PR DESCRIPTION
## Context

Related to https://github.com/getlago/lago/pull/738

After some analysis, it appears that the queries used in the events-processor to fetch the flat_filters (aggregated filter keys/values) is not performant enough under heavy write load on the database.

## Description

This PR improves the query by:
- moving the `where deleted_at is null` filtering on left join itself rather than in the condition
- removing the `properties` select as it is not used by the events-processor
