### PR TITLE
feat(multi-billing-entity): support billing entity on subscription upgrade

### DIFF
--- a/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
+++ b/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
@@ -7,18 +7,17 @@ module Subscriptions
 
       private
 
-      def resolve_billing_entity(customer:, params:, fallback_id: nil)
-        if customer.organization.feature_flag_enabled?(:multi_entity_billing)
-          attrs = if params[:billing_entity_id].present?
-            {id: params[:billing_entity_id]}
-          elsif params[:billing_entity_code].present?
-            {code: params[:billing_entity_code]}
-          end
+      def resolve_billing_entity(customer:, params:)
+        return unless customer.organization.feature_flag_enabled?(:multi_entity_billing)
 
-          return customer.organization.billing_entities.find_by!(attrs) if attrs
+        attrs = if params[:billing_entity_id].present?
+          {id: params[:billing_entity_id]}
+        elsif params[:billing_entity_code].present?
+          {code: params[:billing_entity_code]}
         end
+        return unless attrs
 
-        fallback_id && customer.organization.billing_entities.find_by(id: fallback_id)
+        customer.organization.billing_entities.find_by!(attrs)
       rescue ActiveRecord::RecordNotFound
         result.not_found_failure!(resource: "billing_entity").raise_if_error!
       end

--- a/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
+++ b/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
@@ -7,10 +7,6 @@ module Subscriptions
 
       private
 
-      # The fallback path is intentionally unconditional on the multi_entity_billing flag:
-      # carrying over a previous subscription's binding preserves an explicit choice made
-      # while the flag was on, even if it is later toggled off. On single-entity orgs the
-      # fallback FK is NULL for every subscription, so this branch is a no-op.
       def resolve_billing_entity(customer:, params:, fallback_id: nil)
         if customer.organization.feature_flag_enabled?(:multi_entity_billing)
           attrs = if params[:billing_entity_id].present?

--- a/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
+++ b/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module Concerns
+    module BillingEntityResolutionConcern
+      extend ActiveSupport::Concern
+
+      private
+
+      # The fallback path is intentionally unconditional on the multi_entity_billing flag:
+      # carrying over a previous subscription's binding preserves an explicit choice made
+      # while the flag was on, even if it is later toggled off. On single-entity orgs the
+      # fallback FK is NULL for every subscription, so this branch is a no-op.
+      def resolve_billing_entity(customer:, params:, fallback_id: nil)
+        if customer.organization.feature_flag_enabled?(:multi_entity_billing)
+          attrs = if params[:billing_entity_id].present?
+            {id: params[:billing_entity_id]}
+          elsif params[:billing_entity_code].present?
+            {code: params[:billing_entity_code]}
+          end
+
+          return customer.organization.billing_entities.find_by!(attrs) if attrs
+        end
+
+        fallback_id && customer.organization.billing_entities.find_by(id: fallback_id)
+      rescue ActiveRecord::RecordNotFound
+        result.not_found_failure!(resource: "billing_entity").raise_if_error!
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -2,6 +2,8 @@
 
 module Subscriptions
   class CreateService < BaseService
+    include Subscriptions::Concerns::BillingEntityResolutionConcern
+
     Result = BaseResult[:subscription, :payment_method]
 
     def initialize(customer:, plan:, params:)
@@ -131,7 +133,7 @@ module Subscriptions
         ending_at: params[:ending_at],
         progressive_billing_disabled: params[:progressive_billing_disabled] || false,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : true,
-        billing_entity: resolve_billing_entity
+        billing_entity: resolve_billing_entity(customer:, params:)
       )
 
       if params.key?(:payment_method)
@@ -234,22 +236,6 @@ module Subscriptions
       return nil if params[:payment_method].blank? || params[:payment_method][:payment_method_id].blank?
 
       @payment_method = PaymentMethod.find_by(id: params[:payment_method][:payment_method_id], organization_id: customer.organization_id)
-    end
-
-    # nil here means "inherit from customer.billing_entity at billing time"
-    def resolve_billing_entity
-      return unless customer.organization.feature_flag_enabled?(:multi_entity_billing)
-
-      attrs = if params[:billing_entity_id].present?
-        {id: params[:billing_entity_id]}
-      elsif params[:billing_entity_code].present?
-        {code: params[:billing_entity_code]}
-      end
-      return unless attrs
-
-      customer.organization.billing_entities.find_by!(attrs)
-    rescue ActiveRecord::RecordNotFound
-      result.not_found_failure!(resource: "billing_entity").raise_if_error!
     end
   end
 end

--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -2,6 +2,8 @@
 
 module Subscriptions
   class PlanDowngradeService < BaseService
+    include Subscriptions::Concerns::BillingEntityResolutionConcern
+
     Result = BaseResult[:subscription]
 
     def initialize(customer:, current_subscription:, plan:, params:)
@@ -38,8 +40,14 @@ module Subscriptions
           billing_time: current_subscription.billing_time,
           ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
           progressive_billing_disabled: params[:progressive_billing_disabled] || false,
-          consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice
+          consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
+          billing_entity_id: current_subscription.billing_entity_id
         )
+
+        if params[:billing_entity_id].present? || params[:billing_entity_code].present?
+          override_entity = resolve_billing_entity(customer:, params:)
+          new_sub.update!(billing_entity: override_entity) if override_entity
+        end
 
         if params.key?(:payment_method)
           new_sub.payment_method_type = params[:payment_method][:payment_method_type] if params[:payment_method].key?(:payment_method_type)
@@ -68,6 +76,10 @@ module Subscriptions
     def update_pending_subscription
       current_subscription.plan = plan
       current_subscription.name = name if name.present?
+      if params[:billing_entity_id].present? || params[:billing_entity_code].present?
+        override_entity = resolve_billing_entity(customer:, params:)
+        current_subscription.billing_entity = override_entity if override_entity
+      end
       current_subscription.save!
 
       if current_subscription.should_sync_hubspot_subscription?

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -2,6 +2,8 @@
 
 module Subscriptions
   class PlanUpgradeService < BaseService
+    include Subscriptions::Concerns::BillingEntityResolutionConcern
+
     Result = BaseResult[:subscription]
 
     def initialize(current_subscription:, plan:, params:)
@@ -73,7 +75,14 @@ module Subscriptions
         subscription_at: current_subscription.subscription_at,
         billing_time: current_subscription.billing_time,
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
-        consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice
+        consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
+        # fallback_id uses the raw FK column, not Subscription#billing_entity (which would
+        # materialize customer.billing_entity, collapsing the "inherit at billing time" intent).
+        billing_entity: resolve_billing_entity(
+          customer: current_subscription.customer,
+          params:,
+          fallback_id: current_subscription.billing_entity_id
+        )
       )
 
       if params.key?(:payment_method)

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -76,8 +76,6 @@ module Subscriptions
         billing_time: current_subscription.billing_time,
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
-        # fallback_id uses the raw FK column, not Subscription#billing_entity (which would
-        # materialize customer.billing_entity, collapsing the "inherit at billing time" intent).
         billing_entity: resolve_billing_entity(
           customer: current_subscription.customer,
           params:,

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -65,6 +65,7 @@ module Subscriptions
     attr_reader :current_subscription, :plan, :params, :name
 
     def new_subscription_with_overrides
+      resolved_entity = resolve_billing_entity(customer: current_subscription.customer, params:)
       new_subscription = Subscription.new(
         organization_id: current_subscription.customer.organization_id,
         customer: current_subscription.customer,
@@ -76,11 +77,7 @@ module Subscriptions
         billing_time: current_subscription.billing_time,
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
-        billing_entity: resolve_billing_entity(
-          customer: current_subscription.customer,
-          params:,
-          fallback_id: current_subscription.billing_entity_id
-        )
+        billing_entity_id: resolved_entity&.id || current_subscription.billing_entity_id
       )
 
       if params.key?(:payment_method)

--- a/spec/services/plans/update_amount_service_spec.rb
+++ b/spec/services/plans/update_amount_service_spec.rb
@@ -92,5 +92,38 @@ RSpec.describe Plans::UpdateAmountService do
         end
       end
     end
+
+    context "when pending-promotion preserves billing entity from previous subscription" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:original_plan) { create(:plan, organization:, amount_cents: expected_amount_cents) }
+      let(:customer) { create(:customer, organization:) }
+      let(:original_active_sub) do
+        create(
+          :subscription,
+          plan: original_plan,
+          customer:,
+          status: :active,
+          billing_entity:,
+          subscription_at: Time.current,
+          started_at: Time.current
+        )
+      end
+      let(:pending_subscription) do
+        create(:subscription, plan:, status: :pending, previous_subscription_id: original_active_sub.id, customer:)
+      end
+
+      before do
+        original_active_sub
+        pending_subscription
+      end
+
+      it "carries the previous subscription's billing_entity onto the new active subscription" do
+        update_service.call
+
+        new_active_sub = Subscription.where(previous_subscription_id: original_active_sub.id, status: :active).first
+        expect(new_active_sub).to be_present
+        expect(new_active_sub.billing_entity_id).to eq(billing_entity.id)
+      end
+    end
   end
 end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -498,6 +498,49 @@ RSpec.describe Plans::UpdateService do
       end
     end
 
+    context "when pending-promotion preserves billing entity from previous subscription" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:original_plan) { create(:plan, organization:, amount_cents: 150) }
+      let(:new_customer) { create(:customer, organization:) }
+      let(:original_active_sub) do
+        create(
+          :subscription,
+          plan: original_plan,
+          customer: new_customer,
+          status: :active,
+          billing_entity:,
+          subscription_at: Time.current,
+          started_at: Time.current
+        )
+      end
+      let(:pending_subscription) do
+        create(:subscription, plan:, status: :pending, previous_subscription_id: original_active_sub.id, customer: new_customer)
+      end
+      let(:update_args) do
+        {
+          name: plan_name,
+          code: "new_plan",
+          interval: "monthly",
+          pay_in_advance: false,
+          amount_cents: 200,
+          amount_currency: "EUR"
+        }
+      end
+
+      before do
+        original_active_sub
+        pending_subscription
+      end
+
+      it "carries the previous subscription's billing_entity onto the new active subscription" do
+        plans_service.call
+
+        new_active_sub = Subscription.where(previous_subscription_id: original_active_sub.id, status: :active).first
+        expect(new_active_sub).to be_present
+        expect(new_active_sub.billing_entity_id).to eq(billing_entity.id)
+      end
+    end
+
     context "when plan is not found" do
       let(:applied_tax) { nil }
       let(:plan) { nil }

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1838,5 +1838,163 @@ RSpec.describe Subscriptions::CreateService do
         end
       end
     end
+
+    describe "billing entity binding on downgrade" do
+      let(:current_entity) { create(:billing_entity, organization:, code: "entity-x") }
+      let(:target_entity) { create(:billing_entity, organization:, code: "entity-y") }
+      let(:old_plan) { create(:plan, amount_cents: 100, organization:) }
+      let(:plan) { create(:plan, amount_cents: 50, organization:) }
+
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: old_plan,
+          status: :active,
+          subscription_at: Time.current,
+          started_at: Time.current,
+          external_id:,
+          billing_entity: current_entity
+        )
+      end
+
+      before { CurrentContext.source = "api" }
+
+      context "when multi_entity_billing flag is OFF" do
+        before { subscription.mark_as_active! }
+
+        it "carries over current_subscription.billing_entity_id to the pending subscription" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(current_entity.id)
+        end
+
+        it "carries over NULL when current_subscription is not bound to any entity" do
+          subscription.update!(billing_entity_id: nil)
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to be_nil
+        end
+
+        it "ignores billing_entity_code param and still carries over from current_subscription" do
+          params[:billing_entity_code] = target_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(current_entity.id)
+        end
+      end
+
+      context "when multi_entity_billing flag is ON" do
+        before do
+          subscription.mark_as_active!
+          organization.enable_feature_flag!(:multi_entity_billing)
+        end
+
+        it "carries over current_subscription.billing_entity_id when no param is provided" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(current_entity.id)
+        end
+
+        it "persists NULL when current_subscription is not bound and no param is provided" do
+          subscription.update!(billing_entity_id: nil)
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to be_nil
+        end
+
+        it "binds the pending subscription to the entity matched by billing_entity_code" do
+          params[:billing_entity_code] = target_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(target_entity.id)
+        end
+
+        it "leaves the current subscription bound to its original entity when the param overrides it" do
+          params[:billing_entity_code] = target_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.reload.billing_entity_id).to eq(current_entity.id)
+        end
+
+        it "binds the pending subscription to the entity matched by billing_entity_id" do
+          params[:billing_entity_id] = target_entity.id
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(target_entity.id)
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_code is unknown" do
+          params[:billing_entity_code] = "unknown-entity-code"
+
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_id is unknown" do
+          params[:billing_entity_id] = SecureRandom.uuid
+
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+      end
+
+      context "when re-downgrading a starting_in_the_future subscription" do
+        let(:subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan: old_plan,
+            status: :pending,
+            subscription_at: 1.day.from_now,
+            external_id:,
+            billing_entity: current_entity
+          )
+        end
+
+        before do
+          subscription
+          organization.enable_feature_flag!(:multi_entity_billing)
+        end
+
+        it "re-binds the pending subscription when billing_entity_code is provided" do
+          params[:billing_entity_code] = target_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.id).to eq(subscription.id)
+          expect(result.subscription.reload.billing_entity_id).to eq(target_entity.id)
+        end
+
+        it "leaves the pending subscription's billing entity untouched when no param is provided" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.id).to eq(subscription.id)
+          expect(result.subscription.reload.billing_entity_id).to eq(current_entity.id)
+        end
+      end
+    end
   end
 end

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -323,5 +323,117 @@ RSpec.describe Subscriptions::PlanUpgradeService do
         expect(next_subscription.reload).to be_canceled
       end
     end
+
+    describe "billing entity binding" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:other_entity) { create(:billing_entity, organization:) }
+
+      context "when multi_entity_billing flag is OFF" do
+        it "carries over the current subscription's billing_entity_id even without params" do
+          subscription.update!(billing_entity:)
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        it "ignores billing_entity_code in params but still carries over" do
+          subscription.update!(billing_entity:)
+          params[:billing_entity_code] = other_entity.code
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        it "persists nil when current subscription has no billing entity binding" do
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to be_nil
+        end
+      end
+
+      context "when multi_entity_billing flag is ON" do
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "carries over the current subscription's billing_entity_id when no param is provided" do
+          subscription.update!(billing_entity:)
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+
+        it "persists nil when no param and current subscription is unbound" do
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to be_nil
+        end
+
+        it "binds to billing_entity_code from params over the current binding" do
+          subscription.update!(billing_entity:)
+          params[:billing_entity_code] = other_entity.code
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(other_entity.id)
+        end
+
+        it "binds to billing_entity_id from params over the current binding" do
+          subscription.update!(billing_entity:)
+          params[:billing_entity_id] = other_entity.id
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(other_entity.id)
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_id is unknown" do
+          params[:billing_entity_id] = SecureRandom.uuid
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_code is unknown" do
+          params[:billing_entity_code] = "unknown-entity-code"
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+
+        it "prefers billing_entity_id over billing_entity_code when both are provided" do
+          params[:billing_entity_id] = billing_entity.id
+          params[:billing_entity_code] = other_entity.code
+
+          expect(result).to be_success
+          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+
+      context "when bill_subscriptions runs after the upgrade" do
+        let(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true) }
+
+        before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+        it "carries the current subscription's entity into termination and new-period billing context" do
+          subscription.update!(billing_entity:)
+
+          new_subscription = result.subscription
+
+          expect(subscription.reload.billing_entity_id).to eq(billing_entity.id)
+          expect(new_subscription.billing_entity_id).to eq(billing_entity.id)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription, new_subscription], kind_of(Integer), invoicing_reason: :upgrading)
+        end
+
+        it "routes the new-period billing to the override entity when params specify one" do
+          subscription.update!(billing_entity:)
+          params[:billing_entity_code] = other_entity.code
+
+          new_subscription = result.subscription
+
+          expect(subscription.reload.billing_entity_id).to eq(billing_entity.id)
+          expect(new_subscription.billing_entity_id).to eq(other_entity.id)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription, new_subscription], kind_of(Integer), invoicing_reason: :upgrading)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Multi-billing-entity support has been rolling out across the API a slice at a time. Subscription create landed in #5467 and wallets in #5471. The upgrade path was the next obvious gap: if you'd explicitly bound a subscription to a non-default entity (say `eu` instead of the customer's default `us`), upgrading the plan silently dropped that binding. The new subscription ended up with `billing_entity_id` NULL and quietly inherited the customer's default at billing time. The `billing_entity_id` and `billing_entity_code` params that already work on create were silently ignored on upgrade, so operators couldn't re-bind during an upgrade either.

The same gap was hiding inside pending-subscription promotion: when an operator raised a plan's amount above the previous one (via `Plans::UpdateService` or `Plans::UpdateAmountService`), the pending subscription got promoted through `PlanUpgradeService`, and the binding was lost the same way.

## Description

There are two moving parts. The resolution rule (read params, gated by `multi_entity_billing`, scoped to the customer's organization, not-found error on unknown id/code) is the same one `CreateService` already had inline. I extracted it into a small shared concern, `Subscriptions::Concerns::BillingEntityResolutionConcern`, so create and upgrade now share a single source of truth.

The new behaviour on upgrade is straightforward: resolve the entity from params if the flag is on, else carry over `current_subscription.billing_entity_id`. The carry-over reads the raw FK column rather than the `Subscription#billing_entity` reader, because the reader would otherwise materialise the customer's current default and freeze it into the new row, collapsing the "inherit at billing time" semantic. The carry-over runs regardless of the feature flag, so an explicit binding made while the flag was on survives even if the flag is later toggled off; on single-entity orgs every FK is NULL, so this branch is a no-op for them.

The two pending-promotion paths (`Plans::UpdateService` and `Plans::UpdateAmountService`) needed no code change. They already call `PlanUpgradeService`, and once upgrade does the carry-over, those inherit the behaviour. Two new specs confirm it end-to-end.

### Behaviour by scenario

| Scenario | Before | After |
|---|---|---|
| Flag ON, no param, current sub bound to `eu` | new sub `billing_entity_id` = NULL (binding lost) | new sub bound to `eu` |
| Flag ON, no param, current sub NULL | NULL (inherit customer default at read time) | NULL (inherit customer default at read time) |
| Flag ON, `billing_entity_code: us`, current sub bound to `eu` | param ignored, new sub NULL | new sub bound to `us` |
| Flag ON, unknown `billing_entity_code` | param ignored, new sub NULL | `not_found_failure(resource: "billing_entity")` |
| Flag OFF, current sub bound to `eu` | new sub NULL (binding lost) | new sub bound to `eu` (carry-over independent of flag) |
| Pending-promotion via `Plans::UpdateService` / `UpdateAmountService` | new sub NULL | new sub keeps previous binding |

## How to try locally

Spin up a customer on an org with `multi_entity_billing` enabled and at least two billing entities. Call them `eu` and `us`.

1. Create a subscription bound to `eu`:
   ```bash
   curl -X POST http://localhost:3000/api/v1/subscriptions \
     -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
     -d '{"subscription":{"external_customer_id":"cust_1","external_id":"sub_1","plan_code":"starter","billing_entity_code":"eu"}}'
   ```
2. Upgrade the plan with no `billing_entity_*` in the body:
   ```bash
   curl -X POST http://localhost:3000/api/v1/subscriptions \
     -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
     -d '{"subscription":{"external_customer_id":"cust_1","external_id":"sub_1","plan_code":"growth"}}'
   ```
3. Check the new active subscription's `billing_entity_id`. It now matches the previous one. Before this change it would have been NULL, and the next invoice would have been numbered under the customer's default entity.

To exercise the explicit-override path, replace the second body with `"billing_entity_code":"us"`. The new subscription binds to `us`, and the termination invoice for the previous subscription stays under `eu`.

The full test suite for the change:
```
lago exec api bundle exec rspec \
  spec/services/subscriptions/plan_upgrade_service_spec.rb \
  spec/services/subscriptions/create_service_spec.rb \
  spec/services/plans/update_service_spec.rb \
  spec/services/plans/update_amount_service_spec.rb
```

226 examples, 0 failures.