### PR TITLE
feat(multi-billing-entity): support billing entity on subscription downgrade

### DIFF
--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -2,6 +2,8 @@
 
 module Subscriptions
   class PlanDowngradeService < BaseService
+    include Subscriptions::Concerns::BillingEntityResolutionConcern
+
     Result = BaseResult[:subscription]
 
     def initialize(customer:, current_subscription:, plan:, params:)
@@ -38,8 +40,14 @@ module Subscriptions
           billing_time: current_subscription.billing_time,
           ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
           progressive_billing_disabled: params[:progressive_billing_disabled] || false,
-          consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice
+          consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
+          billing_entity_id: current_subscription.billing_entity_id
         )
+
+        if params[:billing_entity_id].present? || params[:billing_entity_code].present?
+          override_entity = resolve_billing_entity(customer:, params:)
+          new_sub.update!(billing_entity: override_entity) if override_entity
+        end
 
         if params.key?(:payment_method)
           new_sub.payment_method_type = params[:payment_method][:payment_method_type] if params[:payment_method].key?(:payment_method_type)
@@ -68,6 +76,10 @@ module Subscriptions
     def update_pending_subscription
       current_subscription.plan = plan
       current_subscription.name = name if name.present?
+      if params[:billing_entity_id].present? || params[:billing_entity_code].present?
+        override_entity = resolve_billing_entity(customer:, params:)
+        current_subscription.billing_entity = override_entity if override_entity
+      end
       current_subscription.save!
 
       if current_subscription.should_sync_hubspot_subscription?

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1838,5 +1838,163 @@ RSpec.describe Subscriptions::CreateService do
         end
       end
     end
+
+    describe "billing entity binding on downgrade" do
+      let(:current_entity) { create(:billing_entity, organization:, code: "entity-x") }
+      let(:target_entity) { create(:billing_entity, organization:, code: "entity-y") }
+      let(:old_plan) { create(:plan, amount_cents: 100, organization:) }
+      let(:plan) { create(:plan, amount_cents: 50, organization:) }
+
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: old_plan,
+          status: :active,
+          subscription_at: Time.current,
+          started_at: Time.current,
+          external_id:,
+          billing_entity: current_entity
+        )
+      end
+
+      before { CurrentContext.source = "api" }
+
+      context "when multi_entity_billing flag is OFF" do
+        before { subscription.mark_as_active! }
+
+        it "carries over current_subscription.billing_entity_id to the pending subscription" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(current_entity.id)
+        end
+
+        it "carries over NULL when current_subscription is not bound to any entity" do
+          subscription.update!(billing_entity_id: nil)
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to be_nil
+        end
+
+        it "ignores billing_entity_code param and still carries over from current_subscription" do
+          params[:billing_entity_code] = target_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(current_entity.id)
+        end
+      end
+
+      context "when multi_entity_billing flag is ON" do
+        before do
+          subscription.mark_as_active!
+          organization.enable_feature_flag!(:multi_entity_billing)
+        end
+
+        it "carries over current_subscription.billing_entity_id when no param is provided" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(current_entity.id)
+        end
+
+        it "persists NULL when current_subscription is not bound and no param is provided" do
+          subscription.update!(billing_entity_id: nil)
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to be_nil
+        end
+
+        it "binds the pending subscription to the entity matched by billing_entity_code" do
+          params[:billing_entity_code] = target_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(target_entity.id)
+        end
+
+        it "leaves the current subscription bound to its original entity when the param overrides it" do
+          params[:billing_entity_code] = target_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.reload.billing_entity_id).to eq(current_entity.id)
+        end
+
+        it "binds the pending subscription to the entity matched by billing_entity_id" do
+          params[:billing_entity_id] = target_entity.id
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.billing_entity_id).to eq(target_entity.id)
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_code is unknown" do
+          params[:billing_entity_code] = "unknown-entity-code"
+
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+
+        it "fails with billing_entity_not_found when billing_entity_id is unknown" do
+          params[:billing_entity_id] = SecureRandom.uuid
+
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("billing_entity_not_found")
+        end
+      end
+
+      context "when re-downgrading a starting_in_the_future subscription" do
+        let(:subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan: old_plan,
+            status: :pending,
+            subscription_at: 1.day.from_now,
+            external_id:,
+            billing_entity: current_entity
+          )
+        end
+
+        before do
+          subscription
+          organization.enable_feature_flag!(:multi_entity_billing)
+        end
+
+        it "re-binds the pending subscription when billing_entity_code is provided" do
+          params[:billing_entity_code] = target_entity.code
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.id).to eq(subscription.id)
+          expect(result.subscription.reload.billing_entity_id).to eq(target_entity.id)
+        end
+
+        it "leaves the pending subscription's billing entity untouched when no param is provided" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.id).to eq(subscription.id)
+          expect(result.subscription.reload.billing_entity_id).to eq(current_entity.id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

The earlier feature work introduced support for binding a subscription to a non-default billing entity on creation, but the downgrade path was not part of that initial scope. A subscription explicitly bound to a non-default entity therefore loses that binding the moment a downgrade is requested: the pending row created for the next billing period is unbound, and the `billing_entity_id` / `billing_entity_code` params that work on the create endpoint are silently dropped on downgrade. Operators can neither preserve an existing binding nor re-bind a pending subscription to a different entity in one call.

## Description

This is the same rule the create path applies, transplanted onto the downgrade path. The resolution order is: explicit params win; otherwise carry the parent subscription's binding over to the pending row; otherwise persist `nil` so the customer's default fires at billing time. The same rule applies when re-downgrading a not-yet-active subscription via `update_pending_subscription`, which only touches the column when params explicitly carry an entity reference.

One nuance worth calling out: the carry-over from the parent subscription is not gated by the `multi_entity_billing` flag. That's deliberate. Single-entity customers all have `NULL` bindings today, so the carry-over is a no-op for them. For multi-entity organizations, it means an existing binding survives even if someone later disables the flag at the org level.

| Scenario | Before | After |
| :--- | :--- | :--- |
| Downgrade, no param, parent bound to X | Pending row unbound; re-resolves to `customer.billing_entity` at activation | Pending row bound to X |
| Downgrade, `billing_entity_code: Y`, parent bound to X | Param silently dropped; pending row unbound | Pending row bound to Y; parent keeps X until its terminal invoice |
| Downgrade, unknown entity code | Param silently dropped; pending row unbound | `404 billing_entity_not_found` |
| Re-downgrade of `starting_in_the_future` sub with `billing_entity_code: Y` | Param silently dropped; pending row keeps original entity | Pending row re-bound to Y |
| `multi_entity_billing` OFF, parent bound to X | Pending row unbound | Pending row bound to X (unconditional carry-over) |

Stacked on #5503, which extracted the resolution helper into the shared `Subscriptions::Concerns::BillingEntityResolutionConcern` reused here.

Two things worth flagging for the reviewer. Invoice numbering at activation (gapless per `(customer, billing_entity)`) is satisfied by construction: the pending row's `billing_entity_id` is now correctly set, and the existing invoice generation path reads `subscription.billing_entity || customer.billing_entity` at billing time, so no new invoice-level assertions were added here. Separately, `Subscriptions::PlanUpgradeService#update_pending_subscription` has the same gap on the upgrade side: it does not propagate `billing_entity` when an operator upgrades a not-yet-active pending subscription. That parity gap is out of scope here and worth a follow-up.

## How to try locally

Enable the `multi_entity_billing` feature flag on your test organization, then:

1. Create a non-default billing entity (`POST /api/v1/billing_entities` with `code: "eu"`).
2. Create a subscription against a higher-priced plan with `billing_entity_code: "eu"`. Confirm the subscription row has `billing_entity_id` set.
3. Downgrade to a cheaper plan without passing `billing_entity_*`. Confirm the pending `next_subscription` carries `billing_entity_id = eu`.
4. Downgrade that same pending sub again with `billing_entity_code: "us"`. Confirm the pending row now points to `us` (the `update_pending_subscription` branch).
5. Downgrade with an unknown code. Confirm `404 billing_entity_not_found`.

The tests for these scenarios live under `describe "billing entity binding on downgrade"` in `spec/services/subscriptions/create_service_spec.rb`:

```
bundle exec rspec spec/services/subscriptions/create_service_spec.rb -e "billing entity binding on downgrade"
```