### PR TITLE
POC(fixed-charges): feature skip plan override on units-only update

### DIFF
--- a/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
+++ b/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
@@ -19,7 +19,8 @@ module Api
               ::V1::FixedChargeSerializer,
               collection_name: "fixed_charges",
               meta: pagination_metadata(fixed_charges),
-              includes: %i[taxes]
+              includes: %i[taxes],
+              subscription: subscription
             )
           )
         end
@@ -29,7 +30,8 @@ module Api
             json: ::V1::FixedChargeSerializer.new(
               fixed_charge,
               root_name: "fixed_charge",
-              includes: %i[taxes]
+              includes: %i[taxes],
+              subscription: subscription
             )
           )
         end
@@ -46,7 +48,8 @@ module Api
               json: ::V1::FixedChargeSerializer.new(
                 result.fixed_charge,
                 root_name: "fixed_charge",
-                includes: %i[taxes]
+                includes: %i[taxes],
+                subscription: subscription
               )
             )
           else

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -111,6 +111,7 @@ module Types
         object.plan.fixed_charges
           .includes(:add_on, :taxes)
           .order(created_at: :asc)
+          .map { |fc| FixedChargeForSubscription.new(fc, object) }
       end
 
       def dates_service

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -51,6 +51,10 @@ class FixedCharge < ApplicationRecord
       units == fixed_charge.units
   end
 
+  def units_for(subscription)
+    subscription_units_overrides.find_by(subscription_id: subscription.id)&.units || units
+  end
+
   # When upgrading a subscription with fixed_charges paid_in_advance,
   # this exact charge might have already been paid at the beginning of billing period.
   # in case of prorating, we need to deduct the prorated amount (remaining of the billing_period)

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -17,6 +17,7 @@ class FixedCharge < ApplicationRecord
   has_many :taxes, through: :applied_taxes
   has_many :fees
   has_many :events, class_name: "FixedChargeEvent", dependent: :destroy
+  has_many :subscription_units_overrides, class_name: "SubscriptionFixedChargeUnitsOverride"
 
   has_many :applied_taxes, class_name: "FixedCharge::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -52,6 +52,8 @@ class FixedCharge < ApplicationRecord
   end
 
   def units_for(subscription)
+    return units unless subscription
+
     subscription_units_overrides.find_by(subscription_id: subscription.id)&.units || units
   end
 

--- a/app/models/fixed_charge_for_subscription.rb
+++ b/app/models/fixed_charge_for_subscription.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Lightweight wrapper that exposes a FixedCharge with its units overridden
+# by any per-subscription override (SubscriptionFixedChargeUnitsOverride).
+# Used at presentation/serialization time when a subscription context is
+# available — primarily by the GraphQL Subscription type's `fixed_charges`
+# resolver. Every method other than `units` is delegated to the underlying
+# FixedCharge record.
+class FixedChargeForSubscription < SimpleDelegator
+  attr_reader :subscription
+
+  def initialize(fixed_charge, subscription)
+    super(fixed_charge)
+    @subscription = subscription
+  end
+
+  def units
+    __getobj__.units_for(subscription)
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -25,6 +25,7 @@ class Subscription < ApplicationRecord
   has_many :entitlement_removals, class_name: "Entitlement::SubscriptionFeatureRemoval"
   has_many :fixed_charges, -> { kept }, through: :plan
   has_many :fixed_charge_events
+  has_many :fixed_charge_units_overrides, class_name: "SubscriptionFixedChargeUnitsOverride"
   has_many :add_ons, through: :fixed_charges
   has_many :activity_logs,
     -> { order(logged_at: :desc) },

--- a/app/models/subscription_fixed_charge_units_override.rb
+++ b/app/models/subscription_fixed_charge_units_override.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class SubscriptionFixedChargeUnitsOverride < ApplicationRecord
+  include Discard::Model
+  include PaperTrailTraceable
+
+  self.discard_column = :deleted_at
+  default_scope -> { kept }
+
+  belongs_to :organization
+  belongs_to :billing_entity
+  belongs_to :subscription
+  belongs_to :fixed_charge
+
+  validates :units, presence: true, numericality: {greater_than_or_equal_to: 0}
+end
+
+# == Schema Information
+#
+# Table name: subscription_fixed_charge_units_overrides
+# Database name: primary
+#
+#  id                :uuid             not null, primary key
+#  deleted_at        :datetime
+#  units             :decimal(30, 10)  default(0.0), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  billing_entity_id :uuid             not null
+#  fixed_charge_id   :uuid             not null
+#  organization_id   :uuid             not null
+#  subscription_id   :uuid             not null
+#
+# Indexes
+#
+#  idx_on_billing_entity_id_ba78f5f5a5                            (billing_entity_id)
+#  idx_on_fixed_charge_id_06503ae1a5                              (fixed_charge_id)
+#  idx_on_organization_id_e742f77454                              (organization_id)
+#  idx_on_subscription_id_bd763c5aa3                              (subscription_id)
+#  idx_on_subscription_id_fixed_charge_id_d85b30a9bf              (subscription_id,fixed_charge_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_subscription_fixed_charge_units_overrides_on_deleted_at  (deleted_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (billing_entity_id => billing_entities.id)
+#  fk_rails_...  (fixed_charge_id => fixed_charges.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (subscription_id => subscriptions.id)
+#

--- a/app/serializers/v1/fixed_charge_serializer.rb
+++ b/app/serializers/v1/fixed_charge_serializer.rb
@@ -14,7 +14,7 @@ module V1
         pay_in_advance: model.pay_in_advance,
         prorated: model.prorated,
         properties: model.properties,
-        units: model.units,
+        units: subscription_aware_units,
         lago_parent_id: model.parent_id
       }
 
@@ -24,6 +24,13 @@ module V1
     end
 
     private
+
+    def subscription_aware_units
+      subscription = options[:subscription]
+      return model.units unless subscription
+
+      model.units_for(subscription)
+    end
 
     def taxes
       ::CollectionSerializer.new(

--- a/app/services/fixed_charge_events/create_service.rb
+++ b/app/services/fixed_charge_events/create_service.rb
@@ -17,7 +17,7 @@ module FixedChargeEvents
         organization:,
         subscription:,
         fixed_charge:,
-        units: fixed_charge.units,
+        units: fixed_charge.units_for(subscription),
         timestamp:
       )
 

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -47,6 +47,9 @@ module Subscriptions
     end
 
     def override_units_only
+      apply_units_immediately = !!params[:apply_units_immediately]
+      timestamp = Time.current.to_i
+
       ActiveRecord::Base.transaction do
         parent_fixed_charge = find_parent_fixed_charge
         override = SubscriptionFixedChargeUnitsOverride.find_or_initialize_by(
@@ -61,8 +64,15 @@ module Subscriptions
         FixedCharges::EmitEventsService.call!(
           fixed_charge: parent_fixed_charge,
           subscription:,
-          apply_units_immediately: !!params[:apply_units_immediately]
+          apply_units_immediately:,
+          timestamp:
         )
+
+        if apply_units_immediately && parent_fixed_charge.pay_in_advance?
+          after_commit do
+            Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+          end
+        end
 
         result.fixed_charge = parent_fixed_charge
       end

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -6,6 +6,8 @@ module Subscriptions
 
     Result = BaseResult[:fixed_charge]
 
+    UNITS_ONLY_PARAM_KEYS = %i[units apply_units_immediately].freeze
+
     def initialize(subscription:, fixed_charge:, params:)
       @subscription = subscription
       @fixed_charge = fixed_charge
@@ -19,11 +21,10 @@ module Subscriptions
       return result.not_found_failure!(resource: "subscription") unless subscription
       return result.not_found_failure!(resource: "fixed_charge") unless fixed_charge
 
-      ActiveRecord::Base.transaction do
-        target_plan = ensure_plan_override
-        target_fixed_charge = find_or_create_fixed_charge_override(target_plan)
-
-        result.fixed_charge = target_fixed_charge
+      if units_only_change?
+        override_units_only
+      else
+        override_via_plan
       end
 
       result
@@ -36,6 +37,45 @@ module Subscriptions
     private
 
     attr_reader :subscription, :fixed_charge, :params
+
+    def units_only_change?
+      return false unless params.key?(:units)
+      return false if subscription.plan.parent_id
+
+      param_keys = params.keys.map(&:to_sym)
+      (param_keys - UNITS_ONLY_PARAM_KEYS).empty?
+    end
+
+    def override_units_only
+      ActiveRecord::Base.transaction do
+        parent_fixed_charge = find_parent_fixed_charge
+        override = SubscriptionFixedChargeUnitsOverride.find_or_initialize_by(
+          subscription:,
+          fixed_charge: parent_fixed_charge
+        )
+        override.organization = subscription.organization
+        override.billing_entity = subscription.billing_entity
+        override.units = params[:units]
+        override.save!
+
+        FixedCharges::EmitEventsService.call!(
+          fixed_charge: parent_fixed_charge,
+          subscription:,
+          apply_units_immediately: !!params[:apply_units_immediately]
+        )
+
+        result.fixed_charge = parent_fixed_charge
+      end
+    end
+
+    def override_via_plan
+      ActiveRecord::Base.transaction do
+        target_plan = ensure_plan_override
+        target_fixed_charge = find_or_create_fixed_charge_override(target_plan)
+
+        result.fixed_charge = target_fixed_charge
+      end
+    end
 
     def find_or_create_fixed_charge_override(target_plan)
       parent_fixed_charge = find_parent_fixed_charge

--- a/db/migrate/20260513125234_recreate_subscription_fixed_charge_units_overrides.rb
+++ b/db/migrate/20260513125234_recreate_subscription_fixed_charge_units_overrides.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RecreateSubscriptionFixedChargeUnitsOverrides < ActiveRecord::Migration[8.0]
+  def change
+    create_table :subscription_fixed_charge_units_overrides, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :billing_entity, null: false, foreign_key: true, type: :uuid
+      t.references :subscription, null: false, foreign_key: true, type: :uuid
+      t.references :fixed_charge, null: false, foreign_key: true, type: :uuid
+
+      t.decimal :units, precision: 30, scale: 10, null: false, default: 0.0
+      t.datetime :deleted_at, index: true
+
+      t.index [:subscription_id, :fixed_charge_id],
+        unique: true,
+        where: "deleted_at IS NULL"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -54,6 +54,7 @@ ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_d9ea200904;
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_d9448a540b;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_d9342a8ca7;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_d72a9877be;
 ALTER TABLE IF EXISTS ONLY public.entitlement_privileges DROP CONSTRAINT IF EXISTS fk_rails_d648e28d9f;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_d53f825a88;
 ALTER TABLE IF EXISTS ONLY public.idempotency_records DROP CONSTRAINT IF EXISTS fk_rails_d4f02c82b2;
@@ -63,6 +64,7 @@ ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS fk_ra
 ALTER TABLE IF EXISTS ONLY public.item_metadata DROP CONSTRAINT IF EXISTS fk_rails_d0b1714507;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_d07bc24ce3;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ce2c63d69f;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_cdaf36dc89;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS fk_rails_cd99351ee3;
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_cc318ad1ff;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS fk_rails_cbf700aeb8;
@@ -119,6 +121,7 @@ ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_94cc21031f;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_91802dc891;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_90fd72ac8f;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_90d93bd016;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_909197908c;
 ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS fk_rails_90302b3ca3;
@@ -297,6 +300,7 @@ ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CO
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_085d1cc97b;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXISTS fk_rails_07b21049f2;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_06b7046ec3;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_0480ef4ad3;
 ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS fk_rails_04388258ff;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_01a4c0c7db;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS fk_rails_019e2289e5;
@@ -403,6 +407,7 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_on_subscription_id;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_on_organization_id;
+DROP INDEX IF EXISTS public.index_subscription_fixed_charge_units_overrides_on_deleted_at;
 DROP INDEX IF EXISTS public.index_subscription_activation_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_search_quantified_events;
 DROP INDEX IF EXISTS public.index_rtr_invoice_custom_sections_unique;
@@ -788,6 +793,8 @@ DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_recurring_756a2a370
 DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_78eb24d06c;
 DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_4290c95dec;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_type_8feb7b9623;
+DROP INDEX IF EXISTS public.idx_on_subscription_id_fixed_charge_id_d85b30a9bf;
+DROP INDEX IF EXISTS public.idx_on_subscription_id_bd763c5aa3;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_b41afd08e0;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_295edd8bb3;
 DROP INDEX IF EXISTS public.idx_on_recurring_transaction_rule_id_fba3d39cca;
@@ -795,6 +802,7 @@ DROP INDEX IF EXISTS public.idx_on_plan_id_billable_metric_id_pay_in_advance_4a2
 DROP INDEX IF EXISTS public.idx_on_outbound_wallet_transaction_id_cf6ff733c6;
 DROP INDEX IF EXISTS public.idx_on_organization_id_organization_sequential_id_2387146f54;
 DROP INDEX IF EXISTS public.idx_on_organization_id_external_subscription_id_df3a30d96d;
+DROP INDEX IF EXISTS public.idx_on_organization_id_e742f77454;
 DROP INDEX IF EXISTS public.idx_on_organization_id_e73219f079;
 DROP INDEX IF EXISTS public.idx_on_organization_id_deleted_at_225e3f789d;
 DROP INDEX IF EXISTS public.idx_on_organization_id_ccdf05cbfe;
@@ -810,6 +818,7 @@ DROP INDEX IF EXISTS public.idx_on_invoice_custom_section_id_aca4661c33;
 DROP INDEX IF EXISTS public.idx_on_invoice_custom_section_id_5f37496c8c;
 DROP INDEX IF EXISTS public.idx_on_invoice_custom_section_id_50c2a2e7c0;
 DROP INDEX IF EXISTS public.idx_on_inbound_wallet_transaction_id_e54d00758d;
+DROP INDEX IF EXISTS public.idx_on_fixed_charge_id_06503ae1a5;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_entitlement_entitle_9d0542eb1a;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_9946ccf514;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_6a228dc433;
@@ -820,6 +829,7 @@ DROP INDEX IF EXISTS public.idx_on_dunning_campaign_id_currency_fbf233b2ae;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_invoice_custom_section_id_bd78c547d3;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_customer_id_invoice_custom_e7aada65cb;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655;
+DROP INDEX IF EXISTS public.idx_on_billing_entity_id_ba78f5f5a5;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_724373e5ae;
 DROP INDEX IF EXISTS public.idx_invoices_organization_id_status;
 DROP INDEX IF EXISTS public.idx_invoice_subscriptions_on_subscription_with_timestamps;
@@ -857,6 +867,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.taxes DROP CONSTRAINT IF EXISTS taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS subscriptions_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscriptions_invoice_custom_sections DROP CONSTRAINT IF EXISTS subscriptions_invoice_custom_sections_pkey;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS subscription_fixed_charge_units_overrides_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS subscription_activation_rules_pkey;
 ALTER TABLE IF EXISTS ONLY public.schema_migrations DROP CONSTRAINT IF EXISTS schema_migrations_pkey;
 ALTER TABLE IF EXISTS ONLY public.roles DROP CONSTRAINT IF EXISTS roles_pkey;
@@ -976,6 +987,7 @@ DROP SEQUENCE IF EXISTS public.usage_monitoring_subscription_activities_id_seq;
 DROP TABLE IF EXISTS public.usage_monitoring_subscription_activities;
 DROP TABLE IF EXISTS public.usage_monitoring_alerts;
 DROP TABLE IF EXISTS public.subscriptions_invoice_custom_sections;
+DROP TABLE IF EXISTS public.subscription_fixed_charge_units_overrides;
 DROP TABLE IF EXISTS public.subscription_activation_rules;
 DROP TABLE IF EXISTS public.schema_migrations;
 DROP TABLE IF EXISTS public.roles;
@@ -1509,11 +1521,11 @@ CREATE TYPE public.usage_monitoring_alert_types AS ENUM (
     'billable_metric_current_usage_amount',
     'billable_metric_current_usage_units',
     'lifetime_usage_amount',
+    'billable_metric_lifetime_usage_units',
     'wallet_balance_amount',
     'wallet_credits_balance',
     'wallet_ongoing_balance_amount',
-    'wallet_credits_ongoing_balance',
-    'billable_metric_lifetime_usage_units'
+    'wallet_credits_ongoing_balance'
 );
 
 
@@ -4957,6 +4969,23 @@ CREATE TABLE public.subscription_activation_rules (
 
 
 --
+-- Name: subscription_fixed_charge_units_overrides; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.subscription_fixed_charge_units_overrides (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    billing_entity_id uuid NOT NULL,
+    subscription_id uuid NOT NULL,
+    fixed_charge_id uuid NOT NULL,
+    units numeric(30,10) DEFAULT 0.0 NOT NULL,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: subscriptions_invoice_custom_sections; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6027,6 +6056,14 @@ ALTER TABLE ONLY public.subscription_activation_rules
 
 
 --
+-- Name: subscription_fixed_charge_units_overrides subscription_fixed_charge_units_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT subscription_fixed_charge_units_overrides_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: subscriptions_invoice_custom_sections subscriptions_invoice_custom_sections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6333,6 +6370,13 @@ CREATE INDEX idx_on_billing_entity_id_724373e5ae ON public.billing_entities_invo
 
 
 --
+-- Name: idx_on_billing_entity_id_ba78f5f5a5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_billing_entity_id_ba78f5f5a5 ON public.subscription_fixed_charge_units_overrides USING btree (billing_entity_id);
+
+
+--
 -- Name: idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6400,6 +6444,13 @@ CREATE INDEX idx_on_entitlement_privilege_id_9946ccf514 ON public.entitlement_su
 --
 
 CREATE UNIQUE INDEX idx_on_entitlement_privilege_id_entitlement_entitle_9d0542eb1a ON public.entitlement_entitlement_values USING btree (entitlement_privilege_id, entitlement_entitlement_id) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: idx_on_fixed_charge_id_06503ae1a5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_fixed_charge_id_06503ae1a5 ON public.subscription_fixed_charge_units_overrides USING btree (fixed_charge_id);
 
 
 --
@@ -6508,6 +6559,13 @@ CREATE INDEX idx_on_organization_id_e73219f079 ON public.recurring_transaction_r
 
 
 --
+-- Name: idx_on_organization_id_e742f77454; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_organization_id_e742f77454 ON public.subscription_fixed_charge_units_overrides USING btree (organization_id);
+
+
+--
 -- Name: idx_on_organization_id_external_subscription_id_df3a30d96d; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6554,6 +6612,20 @@ CREATE INDEX idx_on_subscription_id_295edd8bb3 ON public.entitlement_subscriptio
 --
 
 CREATE INDEX idx_on_subscription_id_b41afd08e0 ON public.enriched_store_subscription_migrations USING btree (subscription_id);
+
+
+--
+-- Name: idx_on_subscription_id_bd763c5aa3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_subscription_id_bd763c5aa3 ON public.subscription_fixed_charge_units_overrides USING btree (subscription_id);
+
+
+--
+-- Name: idx_on_subscription_id_fixed_charge_id_d85b30a9bf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_on_subscription_id_fixed_charge_id_d85b30a9bf ON public.subscription_fixed_charge_units_overrides USING btree (subscription_id, fixed_charge_id) WHERE (deleted_at IS NULL);
 
 
 --
@@ -9256,6 +9328,13 @@ CREATE INDEX index_subscription_activation_rules_on_organization_id ON public.su
 
 
 --
+-- Name: index_subscription_fixed_charge_units_overrides_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscription_fixed_charge_units_overrides_on_deleted_at ON public.subscription_fixed_charge_units_overrides USING btree (deleted_at);
+
+
+--
 -- Name: index_subscriptions_invoice_custom_sections_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9902,6 +9981,14 @@ ALTER TABLE ONLY public.wallet_transactions
 
 ALTER TABLE ONLY public.invoice_settlements
     ADD CONSTRAINT fk_rails_04388258ff FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: subscription_fixed_charge_units_overrides fk_rails_0480ef4ad3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT fk_rails_0480ef4ad3 FOREIGN KEY (fixed_charge_id) REFERENCES public.fixed_charges(id);
 
 
 --
@@ -11329,6 +11416,14 @@ ALTER TABLE ONLY public.invoice_subscriptions
 
 
 --
+-- Name: subscription_fixed_charge_units_overrides fk_rails_90fd72ac8f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT fk_rails_90fd72ac8f FOREIGN KEY (billing_entity_id) REFERENCES public.billing_entities(id);
+
+
+--
 -- Name: adjusted_fees fk_rails_91802dc891; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11777,6 +11872,14 @@ ALTER TABLE ONLY public.pricing_units
 
 
 --
+-- Name: subscription_fixed_charge_units_overrides fk_rails_cdaf36dc89; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT fk_rails_cdaf36dc89 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: integration_customers fk_rails_ce2c63d69f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11846,6 +11949,14 @@ ALTER TABLE ONLY public.entitlement_entitlements
 
 ALTER TABLE ONLY public.entitlement_privileges
     ADD CONSTRAINT fk_rails_d648e28d9f FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: subscription_fixed_charge_units_overrides fk_rails_d72a9877be; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT fk_rails_d72a9877be FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
 
 
 --
@@ -12215,6 +12326,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260513125234'),
 ('20260504134804'),
 ('20260430102814'),
 ('20260430102813'),
@@ -13210,3 +13322,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/spec/factories/subscription_fixed_charge_units_overrides.rb
+++ b/spec/factories/subscription_fixed_charge_units_overrides.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subscription_fixed_charge_units_override do
+    organization { subscription&.organization || association(:organization) }
+    billing_entity { subscription&.billing_entity || association(:billing_entity) }
+    subscription
+    fixed_charge
+    units { Faker::Number.between(from: 0, to: 100) }
+  end
+end

--- a/spec/models/fixed_charge_for_subscription_spec.rb
+++ b/spec/models/fixed_charge_for_subscription_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FixedChargeForSubscription do
+  subject(:presenter) { described_class.new(fixed_charge, subscription) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 10) }
+  let(:subscription) { create(:subscription, plan:, customer:) }
+
+  describe "#units" do
+    context "without a per-subscription override" do
+      it "returns the plan-level units from the wrapped FixedCharge" do
+        expect(presenter.units).to eq(fixed_charge.units)
+      end
+    end
+
+    context "with a per-subscription override" do
+      before do
+        create(:subscription_fixed_charge_units_override,
+          subscription:,
+          fixed_charge:,
+          organization:,
+          billing_entity: customer.billing_entity,
+          units: 42)
+      end
+
+      it "returns the overridden units" do
+        expect(presenter.units).to eq(42)
+      end
+    end
+  end
+
+  describe "delegation" do
+    it "delegates other attribute reads to the wrapped FixedCharge" do
+      expect(presenter.id).to eq(fixed_charge.id)
+      expect(presenter.code).to eq(fixed_charge.code)
+      expect(presenter.charge_model).to eq(fixed_charge.charge_model)
+      expect(presenter.pay_in_advance).to eq(fixed_charge.pay_in_advance)
+      expect(presenter.add_on_id).to eq(fixed_charge.add_on_id)
+    end
+  end
+end

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe FixedCharge do
   it { is_expected.to have_many(:taxes).through(:applied_taxes) }
   it { is_expected.to have_many(:fees) }
   it { is_expected.to have_many(:events).class_name("FixedChargeEvent").dependent(:destroy) }
+  it { is_expected.to have_many(:subscription_units_overrides).class_name("SubscriptionFixedChargeUnitsOverride") }
 
   it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_presence_of(:charge_model) }

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -369,4 +369,43 @@ RSpec.describe FixedCharge do
       end
     end
   end
+
+  describe "#units_for" do
+    subject(:units_for) { fixed_charge.units_for(subscription) }
+
+    let(:fixed_charge) { create(:fixed_charge, units: 7) }
+    let(:subscription) { create(:subscription, plan: fixed_charge.plan) }
+
+    context "when no override exists" do
+      it { is_expected.to eq(7) }
+    end
+
+    context "when an override exists for the (subscription, fixed_charge) pair" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 42)
+      end
+
+      it { is_expected.to eq(42) }
+    end
+
+    context "when the override has been discarded" do
+      before do
+        override = create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 42)
+        override.discard!
+      end
+
+      it "falls back to the fixed charge units" do
+        expect(units_for).to eq(7)
+      end
+    end
+
+    context "when an override exists for a different subscription" do
+      before do
+        other_subscription = create(:subscription, plan: fixed_charge.plan)
+        create(:subscription_fixed_charge_units_override, subscription: other_subscription, fixed_charge:, units: 42)
+      end
+
+      it { is_expected.to eq(7) }
+    end
+  end
 end

--- a/spec/models/subscription_fixed_charge_units_override_spec.rb
+++ b/spec/models/subscription_fixed_charge_units_override_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubscriptionFixedChargeUnitsOverride, type: :model do
+  subject { build(:subscription_fixed_charge_units_override) }
+
+  it_behaves_like "paper_trail traceable"
+
+  it { expect(described_class).to be_soft_deletable }
+
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:billing_entity)
+      expect(subject).to belong_to(:subscription)
+      expect(subject).to belong_to(:fixed_charge)
+    end
+  end
+
+  describe "validations" do
+    it do
+      expect(subject).to validate_presence_of(:units)
+      expect(subject).to validate_numericality_of(:units).is_greater_than_or_equal_to(0)
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Subscription do
       expect(subject).to have_many(:usage_thresholds)
       expect(subject).to have_many(:fixed_charges).through(:plan)
       expect(subject).to have_many(:fixed_charge_events)
+      expect(subject).to have_many(:fixed_charge_units_overrides).class_name("SubscriptionFixedChargeUnitsOverride")
       expect(subject).to have_many(:add_ons).through(:fixed_charges)
       expect(subject).to have_one(:lifetime_usage).autosave(true)
       expect(subject).to have_one(:subscription_activity).class_name("UsageMonitoring::SubscriptionActivity")

--- a/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
@@ -66,6 +66,26 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
       end
     end
 
+    context "when a per-subscription units override exists" do
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 10) }
+
+      before do
+        create(:subscription_fixed_charge_units_override,
+          subscription:,
+          fixed_charge:,
+          organization:,
+          billing_entity: customer.billing_entity,
+          units: 42)
+      end
+
+      it "returns the overridden units" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:fixed_charges].first[:units]).to eq("42.0")
+      end
+    end
+
     context "when fixed charges have applied taxes" do
       let(:fixed_charge) { create(:fixed_charge, :with_applied_taxes, plan:, organization:) }
 
@@ -140,6 +160,26 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
         expect(response).to have_http_status(:success)
         expect(json[:fixed_charge][:lago_id]).to eq(overridden_fixed_charge.id)
         expect(json[:fixed_charge][:lago_parent_id]).to eq(fixed_charge.id)
+      end
+    end
+
+    context "when a per-subscription units override exists" do
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 10) }
+
+      before do
+        create(:subscription_fixed_charge_units_override,
+          subscription:,
+          fixed_charge:,
+          organization:,
+          billing_entity: customer.billing_entity,
+          units: 99)
+      end
+
+      it "returns the overridden units" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:fixed_charge][:units]).to eq("99.0")
       end
     end
   end
@@ -230,6 +270,26 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
           expect(json[:fixed_charge][:taxes]).to be_present
           expect(json[:fixed_charge][:taxes].length).to eq(1)
           expect(json[:fixed_charge][:taxes].first[:code]).to eq(tax.code)
+        end
+      end
+
+      context "when only units are updated (units-only override path)" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 10) }
+        let(:update_params) { {units: "25"} }
+
+        it "creates a SubscriptionFixedChargeUnitsOverride instead of a plan override" do
+          expect { subject }
+            .to change(SubscriptionFixedChargeUnitsOverride, :count).by(1)
+            .and not_change(Plan, :count)
+            .and not_change(FixedCharge, :count)
+        end
+
+        it "returns the overridden units in the response body" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:fixed_charge][:lago_id]).to eq(fixed_charge.id)
+          expect(json[:fixed_charge][:units]).to eq("25.0")
         end
       end
     end

--- a/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
+++ b/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Subscription fixed charge units override via subscription endpoint", :premium do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, timezone: "UTC") }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      amount_cents: 0,
+      interval: "monthly",
+      pay_in_advance: true
+    )
+  end
+
+  let(:fixed_charge) do
+    create(
+      :fixed_charge,
+      plan:,
+      add_on:,
+      units: 10,
+      properties: {amount: "10"},
+      prorated: false,
+      pay_in_advance: true
+    )
+  end
+
+  let(:subscription_date) { DateTime.new(2024, 3, 1) }
+  let(:subscription) { customer.subscriptions.first }
+
+  before do
+    fixed_charge
+
+    travel_to subscription_date do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: "sub_#{customer.external_id}",
+          plan_code: plan.code,
+          billing_time: "calendar"
+        }
+      )
+    end
+
+    travel_to subscription_date + 1.minute do
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context "when units are updated through the subscription endpoint" do
+    let(:override) { subscription.fixed_charge_units_overrides.first }
+
+    before do
+      travel_to subscription_date + 5.days do
+        update_subscription_fixed_charge(
+          subscription,
+          fixed_charge.code,
+          {
+            units: 15,
+            apply_units_immediately: true
+          }
+        )
+
+        perform_all_enqueued_jobs
+      end
+    end
+
+    it "does not create a plan override" do
+      expect(subscription.reload.plan_id).to eq(plan.id)
+      expect(Plan.where(parent_id: plan.id)).to be_empty
+    end
+
+    it "does not create a fixed charge override" do
+      expect(FixedCharge.where(parent_id: fixed_charge.id)).to be_empty
+    end
+
+    it "creates a SubscriptionFixedChargeUnitsOverride for the pair" do
+      expect(subscription.fixed_charge_units_overrides.count).to eq(1)
+      expect(override.fixed_charge).to eq(fixed_charge)
+      expect(override.units).to eq(15)
+    end
+
+    it "emits a fixed charge event with the override units" do
+      events = FixedChargeEvent.where(subscription:, fixed_charge:).order(:created_at)
+      expect(events.count).to eq(2)
+      expect(events.last.units).to eq(15)
+    end
+  end
+end

--- a/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
+++ b/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
@@ -88,5 +88,17 @@ describe "Subscription fixed charge units override via subscription endpoint", :
       expect(events.count).to eq(2)
       expect(events.last.units).to eq(15)
     end
+
+    it "exposes the overridden units in the API response and on subsequent reads" do
+      expect(json[:fixed_charge][:units]).to eq("15.0")
+
+      travel_to subscription_date + 6.days do
+        get_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}/fixed_charges")
+        expect(json[:fixed_charges].first[:units]).to eq("15.0")
+
+        get_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}/fixed_charges/#{fixed_charge.code}")
+        expect(json[:fixed_charge][:units]).to eq("15.0")
+      end
+    end
   end
 end

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -33,4 +33,35 @@ RSpec.describe ::V1::FixedChargeSerializer do
       expect(result["fixed_charge"]["taxes"].map { |tax| tax["lago_id"] }).to match_array(taxes.map(&:id))
     end
   end
+
+  context "when a subscription option is provided" do
+    let(:serializer) do
+      described_class.new(fixed_charge, root_name: "fixed_charge", subscription: subscription)
+    end
+    let(:fixed_charge) { create(:fixed_charge, units: 10, properties:) }
+    let(:plan) { fixed_charge.plan }
+    let(:customer) { create(:customer, organization: plan.organization) }
+    let(:subscription) { create(:subscription, plan:, customer:) }
+
+    context "when there is no per-subscription units override" do
+      it "serializes the plan-level units" do
+        expect(result["fixed_charge"]["units"]).to eq("10.0")
+      end
+    end
+
+    context "when a per-subscription units override exists" do
+      before do
+        create(:subscription_fixed_charge_units_override,
+          subscription:,
+          fixed_charge:,
+          organization: plan.organization,
+          billing_entity: customer.billing_entity,
+          units: 25)
+      end
+
+      it "serializes the overridden units" do
+        expect(result["fixed_charge"]["units"]).to eq("25.0")
+      end
+    end
+  end
 end

--- a/spec/services/fixed_charge_events/create_service_spec.rb
+++ b/spec/services/fixed_charge_events/create_service_spec.rb
@@ -49,5 +49,18 @@ RSpec.describe FixedChargeEvents::CreateService do
         expect(result.error).to be_a(BaseService::ValidationFailure)
       end
     end
+
+    context "when a SubscriptionFixedChargeUnitsOverride exists for the pair" do
+      let(:fixed_charge) { create(:fixed_charge, organization:, plan:, add_on:, units: 3) }
+
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 25)
+      end
+
+      it "stores the override units on the event" do
+        expect(result).to be_success
+        expect(result.fixed_charge_event.units).to eq(25)
+      end
+    end
   end
 end

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -197,6 +197,100 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
           expect(result.fixed_charge.taxes).to include(tax)
         end
       end
+
+      context "when params only change units" do
+        let(:params) { {units: "10"} }
+
+        it "does not create a plan override" do
+          expect { service.call }.not_to change(Plan, :count)
+        end
+
+        it "does not create a fixed charge override" do
+          expect { service.call }.not_to change(FixedCharge, :count)
+        end
+
+        it "leaves the subscription on the original plan" do
+          service.call
+
+          expect(subscription.reload.plan_id).to eq(plan.id)
+        end
+
+        it "creates a SubscriptionFixedChargeUnitsOverride pointing at the parent fixed charge" do
+          expect { service.call }.to change(SubscriptionFixedChargeUnitsOverride, :count).by(1)
+
+          override = SubscriptionFixedChargeUnitsOverride.last
+          expect(override.subscription).to eq(subscription)
+          expect(override.fixed_charge).to eq(fixed_charge)
+          expect(override.units).to eq(10)
+          expect(override.organization).to eq(organization)
+        end
+
+        it "returns the parent fixed charge in the result" do
+          result = service.call
+
+          expect(result.fixed_charge).to eq(fixed_charge)
+        end
+
+        it "emits events for the parent fixed charge" do
+          allow(FixedCharges::EmitEventsService).to receive(:call!)
+
+          service.call
+
+          expect(FixedCharges::EmitEventsService).to have_received(:call!).with(
+            fixed_charge:,
+            subscription:,
+            apply_units_immediately: false
+          )
+        end
+
+        context "with apply_units_immediately" do
+          let(:params) { {units: "10", apply_units_immediately: true} }
+
+          it "forwards the flag to EmitEventsService" do
+            allow(FixedCharges::EmitEventsService).to receive(:call!)
+
+            service.call
+
+            expect(FixedCharges::EmitEventsService).to have_received(:call!).with(
+              fixed_charge:,
+              subscription:,
+              apply_units_immediately: true
+            )
+          end
+        end
+
+        context "when an override already exists for the pair" do
+          before do
+            create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 1)
+          end
+
+          it "updates the existing override instead of creating a new one" do
+            expect { service.call }.not_to change(SubscriptionFixedChargeUnitsOverride, :count)
+            expect(SubscriptionFixedChargeUnitsOverride.last.units).to eq(10)
+          end
+        end
+
+        context "when the subscription is already on a plan override" do
+          let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+          let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
+
+          it "does not create a SubscriptionFixedChargeUnitsOverride" do
+            expect { service.call }.not_to change(SubscriptionFixedChargeUnitsOverride, :count)
+          end
+
+          it "does not create a new plan override" do
+            expect { service.call }.not_to change(Plan, :count)
+          end
+
+          it "creates a fixed charge override on the existing plan override" do
+            expect { service.call }.to change(FixedCharge, :count).by(1)
+
+            new_fixed_charge = FixedCharge.where(parent_id: fixed_charge.id).first
+            expect(new_fixed_charge.plan_id).to eq(overridden_plan.id)
+            expect(new_fixed_charge.units).to eq(10)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -166,6 +166,12 @@ module ScenariosHelper
     end
   end
 
+  def update_subscription_fixed_charge(subscription, fixed_charge_code, params, **kwargs)
+    api_call(**kwargs) do
+      put_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}/fixed_charges/#{fixed_charge_code}", {fixed_charge: params})
+    end
+  end
+
   ### Subscription Charge Filters
 
   def create_subscription_charge_filter(subscription, charge_code, params, **kwargs)


### PR DESCRIPTION
## Summary

- Reintroduce `subscription_fixed_charge_units_overrides` to record per-subscription units without cloning the plan (originally added in #4011, removed in #4318 and #4876 while waiting on the wider plan-override refactor).
- Branch `Subscriptions::UpdateOrOverrideFixedChargeService`: when the request only changes `units` (optionally with `apply_units_immediately`) **and** the subscription is not already on an overridden plan, write to the new table and skip the plan/fixed-charge override path. Any other field change, or a subscription already on an overridden plan, keeps the existing behaviour.
- Route `FixedChargeEvents::CreateService` through a new `FixedCharge#units_for(subscription)` accessor so emitted events carry the effective units.

## Background

Updating a fixed charge's units for one subscription today materialises a full plan override plus a fixed-charge override.

That's correct semantically but expensive in practice: organisations with many subscriptions on a shared plan accumulate one plan override per subscription, even though only `units` differs. This PoC offers a units-only fast path that avoids the plan override entirely while preserving the legacy path for any other field change.

## Out of scope for this PoC

Read sites still consume `fixed_charge.units` directly. They need to be switched to `fixed_charge.units_for(subscription)` in a follow-up before this can ship beyond PoC:
- `app/services/fees/fixed_charge_service.rb`
- `app/services/fees/build_pay_in_advance_fixed_charge_service.rb`
- `app/services/fees/init_from_adjusted_fixed_charge_fee_service.rb`
- `app/services/fixed_charge_events/aggregations/preview_aggregation_service.rb`

The scenario spec deliberately stops at the event level until those reads are wired.
