### PR TITLE
feat(payment-gated-subs): Apply activation rules on upgrade of a subscription starting in the future

### DIFF
--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -14,17 +14,17 @@ module Subscriptions
     end
 
     def call
-      if current_subscription.starting_in_the_future?
-        apply_activation_rules if params[:activation_rules]
-        update_pending_subscription
-
-        result.subscription = current_subscription
-        return result
-      end
-
-      new_subscription = new_subscription_with_overrides
-
       ActiveRecord::Base.transaction do
+        if current_subscription.starting_in_the_future?
+          apply_activation_rules if params[:activation_rules]
+          update_pending_subscription
+
+          result.subscription = current_subscription
+          return result
+        end
+
+        new_subscription = new_subscription_with_overrides
+
         cancel_pending_subscription if pending_subscription?
 
         # Group subscriptions for billing

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -15,6 +15,7 @@ module Subscriptions
 
     def call
       if current_subscription.starting_in_the_future?
+        apply_activation_rules if params[:activation_rules]
         update_pending_subscription
 
         result.subscription = current_subscription
@@ -91,6 +92,13 @@ module Subscriptions
       if current_subscription.should_sync_hubspot_subscription?
         Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription: current_subscription)
       end
+    end
+
+    def apply_activation_rules
+      Subscriptions::ActivationRules::ApplyService.call!(
+        subscription: current_subscription,
+        activation_rules: params[:activation_rules]
+      )
     end
 
     def override_plan

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -91,7 +91,7 @@ module Subscriptions
       current_subscription.save!
 
       if current_subscription.should_sync_hubspot_subscription?
-        Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription: current_subscription)
+        Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_after_commit(subscription: current_subscription)
       end
     end
 

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -43,6 +43,8 @@ module Subscriptions
           timestamp: new_subscription.started_at + 1.second
         )
 
+        result.subscription = new_subscription
+
         after_commit do
           SendWebhookJob.perform_later("subscription.started", new_subscription)
           Utils::ActivityLog.produce(new_subscription, "subscription.started")
@@ -51,7 +53,6 @@ module Subscriptions
         bill_subscriptions(billable_subscriptions) if billable_subscriptions.any?
       end
 
-      result.subscription = new_subscription
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -131,6 +131,49 @@ RSpec.describe Subscriptions::PlanUpgradeService do
         expect(result.subscription.plan_id).to eq(plan.id)
         expect(result.subscription.name).to eq(subscription_name)
       end
+
+      context "with activation_rules in params" do
+        let(:params) do
+          {
+            name: subscription_name,
+            activation_rules: [{type: "payment", timeout_hours: 48}]
+          }
+        end
+
+        it "applies the activation rules to the current subscription" do
+          expect(result).to be_success
+
+          rules = subscription.reload.activation_rules
+          expect(rules.count).to eq(1)
+          expect(rules.first).to be_inactive
+          expect(rules.first.timeout_hours).to eq(48)
+        end
+
+        it "still updates the pending subscription's plan and name" do
+          expect(result).to be_success
+          expect(result.subscription.id).to eq(subscription.id)
+          expect(result.subscription.plan_id).to eq(plan.id)
+          expect(result.subscription.name).to eq(subscription_name)
+        end
+      end
+
+      context "with an empty activation_rules array in params" do
+        let(:existing_rule) { create(:subscription_activation_rule, subscription:, organization:) }
+        let(:params) do
+          {
+            name: subscription_name,
+            activation_rules: []
+          }
+        end
+
+        before { existing_rule }
+
+        it "removes the activation rules from the current subscription" do
+          expect { result }
+            .to change { subscription.reload.activation_rules.count }
+            .from(1).to(0)
+        end
+      end
     end
 
     context "when old subscription is payed in arrear" do


### PR DESCRIPTION
## Context

First slice of Milestone 3 (Upgrade Path). `Subscriptions::PlanUpgradeService` currently ignores `params[:activation_rules]`; on an upgrade of a `starting_in_the_future?` subscription, rules should land on the pending subscription so `ActivateService` evaluates them when the activation date arrives — same lifecycle as a new subscription with rules.

## Description

- `Subscriptions::PlanUpgradeService` calls `Subscriptions::ActivationRules::ApplyService` against the current subscription in the `starting_in_the_future?` branch when `params[:activation_rules]` is provided.