### PR TITLE
[ING-128] feat(invoice-grouping): Subscription consolidation

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -175,6 +175,7 @@ module Api
             :subscription_at,
             :ending_at,
             :progressive_billing_disabled,
+            :invoice_consolidation_enabled,
             invoice_custom_section: [
               :skip_invoice_custom_sections,
               {invoice_custom_section_codes: []}
@@ -199,6 +200,7 @@ module Api
           :progressive_billing_disabled,
           :billing_entity_id,
           :billing_entity_code,
+          :invoice_consolidation_enabled,
           activation_rules: [:type, :timeout_hours],
           invoice_custom_section: [
             :skip_invoice_custom_sections,

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -175,7 +175,7 @@ module Api
             :subscription_at,
             :ending_at,
             :progressive_billing_disabled,
-            :invoice_consolidation_enabled,
+            :consolidate_invoice,
             invoice_custom_section: [
               :skip_invoice_custom_sections,
               {invoice_custom_section_codes: []}
@@ -200,7 +200,7 @@ module Api
           :progressive_billing_disabled,
           :billing_entity_id,
           :billing_entity_code,
-          :invoice_consolidation_enabled,
+          :consolidate_invoice,
           activation_rules: [:type, :timeout_hours],
           invoice_custom_section: [
             :skip_invoice_custom_sections,

--- a/app/graphql/types/subscriptions/create_subscription_input.rb
+++ b/app/graphql/types/subscriptions/create_subscription_input.rb
@@ -19,8 +19,8 @@ module Types
 
       argument :activation_rules, [Types::Subscriptions::ActivationRuleInput], required: false
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
-      argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       argument :consolidate_invoice, Boolean, required: false
+      argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       argument :progressive_billing_disabled, Boolean, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
     end

--- a/app/graphql/types/subscriptions/create_subscription_input.rb
+++ b/app/graphql/types/subscriptions/create_subscription_input.rb
@@ -20,7 +20,7 @@ module Types
       argument :activation_rules, [Types::Subscriptions::ActivationRuleInput], required: false
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
-      argument :invoice_consolidation_enabled, Boolean, required: false
+      argument :consolidate_invoice, Boolean, required: false
       argument :progressive_billing_disabled, Boolean, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
     end

--- a/app/graphql/types/subscriptions/create_subscription_input.rb
+++ b/app/graphql/types/subscriptions/create_subscription_input.rb
@@ -20,6 +20,7 @@ module Types
       argument :activation_rules, [Types::Subscriptions::ActivationRuleInput], required: false
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
+      argument :invoice_consolidation_enabled, Boolean, required: false
       argument :progressive_billing_disabled, Boolean, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
     end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -54,7 +54,7 @@ module Types
       field :payment_method, Types::PaymentMethods::Object
       field :payment_method_type, Types::PaymentMethods::MethodTypeEnum
       field :progressive_billing_disabled, Boolean
-      field :invoice_consolidation_enabled, Boolean, null: false
+      field :consolidate_invoice, Boolean, null: false
 
       field :activated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :activation_rules, [Types::Subscriptions::ActivationRuleType], null: false

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -51,10 +51,10 @@ module Types
 
       field :usage_thresholds, [Types::UsageThresholds::Object], null: false
 
+      field :consolidate_invoice, Boolean, null: false
       field :payment_method, Types::PaymentMethods::Object
       field :payment_method_type, Types::PaymentMethods::MethodTypeEnum
       field :progressive_billing_disabled, Boolean
-      field :consolidate_invoice, Boolean, null: false
 
       field :activated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :activation_rules, [Types::Subscriptions::ActivationRuleType], null: false

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -54,6 +54,7 @@ module Types
       field :payment_method, Types::PaymentMethods::Object
       field :payment_method_type, Types::PaymentMethods::MethodTypeEnum
       field :progressive_billing_disabled, Boolean
+      field :invoice_consolidation_enabled, Boolean, null: false
 
       field :activated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :activation_rules, [Types::Subscriptions::ActivationRuleType], null: false

--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -10,6 +10,7 @@ module Types
       argument :activation_rules, [Types::Subscriptions::ActivationRuleInput], required: false
       argument :billing_entity_id, ID, required: false
       argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
+      argument :invoice_consolidation_enabled, Boolean, required: false
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :name, String, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false

--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -9,8 +9,8 @@ module Types
 
       argument :activation_rules, [Types::Subscriptions::ActivationRuleInput], required: false
       argument :billing_entity_id, ID, required: false
-      argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :consolidate_invoice, Boolean, required: false
+      argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :name, String, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false

--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -10,7 +10,7 @@ module Types
       argument :activation_rules, [Types::Subscriptions::ActivationRuleInput], required: false
       argument :billing_entity_id, ID, required: false
       argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
-      argument :invoice_consolidation_enabled, Boolean, required: false
+      argument :consolidate_invoice, Boolean, required: false
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :name, String, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false

--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -11,7 +11,6 @@ module Types
       argument :billing_entity_id, ID, required: false
       argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :consolidate_invoice, Boolean, required: false
-      argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :name, String, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false

--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -11,6 +11,7 @@ module Types
       argument :billing_entity_id, ID, required: false
       argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :consolidate_invoice, Boolean, required: false
+      argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :name, String, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -324,7 +324,6 @@ end
 #  canceled_at                   :datetime
 #  consolidate_invoice           :boolean          default(TRUE), not null
 #  ending_at                     :datetime
-#  invoice_consolidation_enabled :boolean          default(TRUE), not null
 #  last_received_event_on        :date
 #  name                          :string
 #  on_termination_credit_note    :enum

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -322,6 +322,7 @@ end
 #  billing_time                  :integer          default("calendar"), not null
 #  cancelation_reason            :enum
 #  canceled_at                   :datetime
+#  consolidate_invoice           :boolean          default(TRUE), not null
 #  ending_at                     :datetime
 #  invoice_consolidation_enabled :boolean          default(TRUE), not null
 #  last_received_event_on        :date

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -317,33 +317,34 @@ end
 # Table name: subscriptions
 # Database name: primary
 #
-#  id                           :uuid             not null, primary key
-#  activated_at                 :datetime
-#  billing_time                 :integer          default("calendar"), not null
-#  cancelation_reason           :enum
-#  canceled_at                  :datetime
-#  ending_at                    :datetime
-#  last_received_event_on       :date
-#  name                         :string
-#  on_termination_credit_note   :enum
-#  on_termination_invoice       :enum             default("generate"), not null
-#  payment_method_type          :enum             default("provider"), not null
-#  progressive_billing_disabled :boolean          default(FALSE), not null
-#  skip_invoice_custom_sections :boolean          default(FALSE), not null
-#  started_at                   :datetime
-#  status                       :integer          not null
-#  subscription_at              :datetime
-#  terminated_at                :datetime
-#  trial_ended_at               :datetime
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  billing_entity_id            :uuid
-#  customer_id                  :uuid             not null
-#  external_id                  :string           not null
-#  organization_id              :uuid             not null
-#  payment_method_id            :uuid
-#  plan_id                      :uuid             not null
-#  previous_subscription_id     :uuid
+#  id                            :uuid             not null, primary key
+#  activated_at                  :datetime
+#  billing_time                  :integer          default("calendar"), not null
+#  cancelation_reason            :enum
+#  canceled_at                   :datetime
+#  ending_at                     :datetime
+#  invoice_consolidation_enabled :boolean          default(TRUE), not null
+#  last_received_event_on        :date
+#  name                          :string
+#  on_termination_credit_note    :enum
+#  on_termination_invoice        :enum             default("generate"), not null
+#  payment_method_type           :enum             default("provider"), not null
+#  progressive_billing_disabled  :boolean          default(FALSE), not null
+#  skip_invoice_custom_sections  :boolean          default(FALSE), not null
+#  started_at                    :datetime
+#  status                        :integer          not null
+#  subscription_at               :datetime
+#  terminated_at                 :datetime
+#  trial_ended_at                :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  billing_entity_id             :uuid
+#  customer_id                   :uuid             not null
+#  external_id                   :string           not null
+#  organization_id               :uuid             not null
+#  payment_method_id             :uuid
+#  plan_id                       :uuid             not null
+#  previous_subscription_id      :uuid
 #
 # Indexes
 #

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -28,7 +28,8 @@ module V1
         current_billing_period_ending_at: dates_service.charges_to_datetime&.iso8601,
         on_termination_credit_note: model.on_termination_credit_note,
         on_termination_invoice: model.on_termination_invoice,
-        progressive_billing_disabled: model.progressive_billing_disabled
+        progressive_billing_disabled: model.progressive_billing_disabled,
+        invoice_consolidation_enabled: model.invoice_consolidation_enabled
       }
 
       payload = payload.merge(customer:) if include?(:customer)

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -29,7 +29,7 @@ module V1
         on_termination_credit_note: model.on_termination_credit_note,
         on_termination_invoice: model.on_termination_invoice,
         progressive_billing_disabled: model.progressive_billing_disabled,
-        invoice_consolidation_enabled: model.invoice_consolidation_enabled
+        consolidate_invoice: model.consolidate_invoice
       }
 
       payload = payload.merge(customer:) if include?(:customer)

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -130,7 +130,7 @@ module Subscriptions
         billing_time: billing_time || :calendar,
         ending_at: params[:ending_at],
         progressive_billing_disabled: params[:progressive_billing_disabled] || false,
-        invoice_consolidation_enabled: params.key?(:invoice_consolidation_enabled) ? params[:invoice_consolidation_enabled] : true,
+        consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : true,
         billing_entity: resolve_billing_entity
       )
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -130,6 +130,7 @@ module Subscriptions
         billing_time: billing_time || :calendar,
         ending_at: params[:ending_at],
         progressive_billing_disabled: params[:progressive_billing_disabled] || false,
+        invoice_consolidation_enabled: params.key?(:invoice_consolidation_enabled) ? params[:invoice_consolidation_enabled] : true,
         billing_entity: resolve_billing_entity
       )
 

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -29,6 +29,7 @@ module Subscriptions
         subscription_groups = group_by_payment_method(billing_subscriptions)
         subscription_groups = group_by_currency(subscription_groups)
         subscription_groups = group_by_billing_entity(subscription_groups)
+        subscription_groups = split_consolidation_opted_out(subscription_groups)
 
         subscription_groups.each do |subscriptions|
           BillSubscriptionJob.perform_later(
@@ -528,6 +529,18 @@ module Subscriptions
 
       subscription_groups.flat_map do |subscriptions|
         subscriptions.group_by { |sub| sub.plan.amount_currency }.values
+      end
+    end
+
+    # NOTE: Any subscription with `invoice_consolidation_enabled = false` must be billed
+    #       on its own invoice, regardless of the other grouping criteria. Split it out
+    #       of its current group into a one-element group.
+    def split_consolidation_opted_out(subscription_groups)
+      subscription_groups.flat_map do |subscriptions|
+        opted_out, consolidated = subscriptions.partition { |sub| !sub.invoice_consolidation_enabled }
+        groups = opted_out.map { |sub| [sub] }
+        groups << consolidated if consolidated.any?
+        groups
       end
     end
 

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -37,9 +37,9 @@ module Subscriptions
             today.to_i,
             invoicing_reason: :subscription_periodic
           )
-        end
 
-        BillNonInvoiceableFeesJob.perform_later(billing_subscriptions, today)
+          BillNonInvoiceableFeesJob.perform_later(subscriptions, today)
+        end
       end
 
       result

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -532,12 +532,12 @@ module Subscriptions
       end
     end
 
-    # NOTE: Any subscription with `invoice_consolidation_enabled = false` must be billed
+    # NOTE: Any subscription with `consolidate_invoice = false` must be billed
     #       on its own invoice, regardless of the other grouping criteria. Split it out
     #       of its current group into a one-element group.
     def split_consolidation_opted_out(subscription_groups)
       subscription_groups.flat_map do |subscriptions|
-        opted_out, consolidated = subscriptions.partition { |sub| !sub.invoice_consolidation_enabled }
+        opted_out, consolidated = subscriptions.partition { |sub| !sub.consolidate_invoice }
         groups = opted_out.map { |sub| [sub] }
         groups << consolidated if consolidated.any?
         groups

--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -37,7 +37,8 @@ module Subscriptions
           status: :pending,
           billing_time: current_subscription.billing_time,
           ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
-          progressive_billing_disabled: params[:progressive_billing_disabled] || false
+          progressive_billing_disabled: params[:progressive_billing_disabled] || false,
+          consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice
         )
 
         if params.key?(:payment_method)

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -72,7 +72,8 @@ module Subscriptions
         previous_subscription_id: current_subscription.id,
         subscription_at: current_subscription.subscription_at,
         billing_time: current_subscription.billing_time,
-        ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at
+        ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
+        invoice_consolidation_enabled: params.key?(:invoice_consolidation_enabled) ? params[:invoice_consolidation_enabled] : current_subscription.invoice_consolidation_enabled
       )
 
       if params.key?(:payment_method)

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -73,7 +73,7 @@ module Subscriptions
         subscription_at: current_subscription.subscription_at,
         billing_time: current_subscription.billing_time,
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
-        invoice_consolidation_enabled: params.key?(:invoice_consolidation_enabled) ? params[:invoice_consolidation_enabled] : current_subscription.invoice_consolidation_enabled
+        consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice
       )
 
       if params.key?(:payment_method)

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -50,6 +50,7 @@ module Subscriptions
         subscription.name = params[:name] if params.key?(:name)
         subscription.ending_at = params[:ending_at] if params.key?(:ending_at)
         subscription.progressive_billing_disabled = params[:progressive_billing_disabled] if params.key?(:progressive_billing_disabled)
+        subscription.invoice_consolidation_enabled = params[:invoice_consolidation_enabled] if params.key?(:invoice_consolidation_enabled)
 
         if pay_in_advance? && params.key?(:on_termination_credit_note)
           subscription.on_termination_credit_note = params[:on_termination_credit_note]

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -50,7 +50,7 @@ module Subscriptions
         subscription.name = params[:name] if params.key?(:name)
         subscription.ending_at = params[:ending_at] if params.key?(:ending_at)
         subscription.progressive_billing_disabled = params[:progressive_billing_disabled] if params.key?(:progressive_billing_disabled)
-        subscription.invoice_consolidation_enabled = params[:invoice_consolidation_enabled] if params.key?(:invoice_consolidation_enabled)
+        subscription.consolidate_invoice = params[:consolidate_invoice] if params.key?(:consolidate_invoice)
 
         if pay_in_advance? && params.key?(:on_termination_credit_note)
           subscription.on_termination_credit_note = params[:on_termination_credit_note]

--- a/db/migrate/20260513130417_add_invoice_consolidation_enabled_to_subscriptions.rb
+++ b/db/migrate/20260513130417_add_invoice_consolidation_enabled_to_subscriptions.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddInvoiceConsolidationEnabledToSubscriptions < ActiveRecord::Migration[8.0]
-  def change
-    add_column :subscriptions, :invoice_consolidation_enabled, :boolean, default: true, null: false
-  end
-end

--- a/db/migrate/20260513130417_add_invoice_consolidation_enabled_to_subscriptions.rb
+++ b/db/migrate/20260513130417_add_invoice_consolidation_enabled_to_subscriptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInvoiceConsolidationEnabledToSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :subscriptions, :invoice_consolidation_enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260513181544_add_consolidate_invoice_to_subscriptions.rb
+++ b/db/migrate/20260513181544_add_consolidate_invoice_to_subscriptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddConsolidateInvoiceToSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :subscriptions, :consolidate_invoice, :boolean, default: true, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3228,7 +3228,8 @@ CREATE TABLE public.subscriptions (
     incompleted_at timestamp(6) without time zone,
     activated_at timestamp(6) without time zone,
     billing_entity_id uuid,
-    invoice_consolidation_enabled boolean DEFAULT true NOT NULL
+    invoice_consolidation_enabled boolean DEFAULT true NOT NULL,
+    consolidate_invoice boolean DEFAULT true NOT NULL
 );
 
 
@@ -12217,7 +12218,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260520075420'),
 ('20260517101105'),
-('20260513130417'),
+('20260513181544'),
 ('20260513105210'),
 ('20260513105209'),
 ('20260512155310'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3228,7 +3228,6 @@ CREATE TABLE public.subscriptions (
     incompleted_at timestamp(6) without time zone,
     activated_at timestamp(6) without time zone,
     billing_entity_id uuid,
-    invoice_consolidation_enabled boolean DEFAULT true NOT NULL,
     consolidate_invoice boolean DEFAULT true NOT NULL
 );
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3227,7 +3227,8 @@ CREATE TABLE public.subscriptions (
     cancelation_reason public.subscription_cancelation_reasons,
     incompleted_at timestamp(6) without time zone,
     activated_at timestamp(6) without time zone,
-    billing_entity_id uuid
+    billing_entity_id uuid,
+    invoice_consolidation_enabled boolean DEFAULT true NOT NULL
 );
 
 
@@ -12216,6 +12217,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260520075420'),
 ('20260517101105'),
+('20260513130417'),
 ('20260513105210'),
 ('20260513105209'),
 ('20260512155310'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -3369,6 +3369,7 @@ input CreateSubscriptionInput {
   customerId: ID!
   endingAt: ISO8601DateTime
   externalId: String
+  invoiceConsolidationEnabled: Boolean
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
   name: String
   paymentMethod: PaymentMethodReferenceInput
@@ -11370,6 +11371,7 @@ type Subscription {
   fees: [Fee!]
   fixedCharges: [FixedCharge!]
   id: ID!
+  invoiceConsolidationEnabled: Boolean!
   lifetimeUsage: SubscriptionLifetimeUsage
   name: String
   nextName: String
@@ -13264,6 +13266,7 @@ input UpdateSubscriptionInput {
   clientMutationId: String
   endingAt: ISO8601DateTime
   id: ID!
+  invoiceConsolidationEnabled: Boolean
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
   name: String
   paymentMethod: PaymentMethodReferenceInput

--- a/schema.graphql
+++ b/schema.graphql
@@ -3366,10 +3366,10 @@ input CreateSubscriptionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  consolidateInvoice: Boolean
   customerId: ID!
   endingAt: ISO8601DateTime
   externalId: String
-  invoiceConsolidationEnabled: Boolean
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
   name: String
   paymentMethod: PaymentMethodReferenceInput
@@ -11361,6 +11361,7 @@ type Subscription {
   cancelationReason: CancelationReasonEnum
   canceledAt: ISO8601DateTime
   charges: [Charge!]
+  consolidateInvoice: Boolean!
   createdAt: ISO8601DateTime!
   currentBillingPeriodEndingAt: ISO8601DateTime
   currentBillingPeriodStartedAt: ISO8601DateTime
@@ -11371,7 +11372,6 @@ type Subscription {
   fees: [Fee!]
   fixedCharges: [FixedCharge!]
   id: ID!
-  invoiceConsolidationEnabled: Boolean!
   lifetimeUsage: SubscriptionLifetimeUsage
   name: String
   nextName: String
@@ -13264,9 +13264,9 @@ input UpdateSubscriptionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  consolidateInvoice: Boolean
   endingAt: ISO8601DateTime
   id: ID!
-  invoiceConsolidationEnabled: Boolean
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
   name: String
   paymentMethod: PaymentMethodReferenceInput

--- a/schema.json
+++ b/schema.json
@@ -15740,7 +15740,7 @@
               "deprecationReason": null
             },
             {
-              "name": "invoiceConsolidationEnabled",
+              "name": "consolidateInvoice",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -61261,6 +61261,22 @@
               "deprecationReason": null
             },
             {
+              "name": "consolidateInvoice",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createdAt",
               "description": null,
               "args": [],
@@ -61406,22 +61422,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "invoiceConsolidationEnabled",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
                   "ofType": null
                 }
               },
@@ -70419,7 +70419,7 @@
               "deprecationReason": null
             },
             {
-              "name": "invoiceConsolidationEnabled",
+              "name": "consolidateInvoice",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/schema.json
+++ b/schema.json
@@ -70407,11 +70407,11 @@
               "deprecationReason": null
             },
             {
-              "name": "endingAt",
+              "name": "consolidateInvoice",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "ISO8601DateTime",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,
@@ -70419,11 +70419,11 @@
               "deprecationReason": null
             },
             {
-              "name": "consolidateInvoice",
+              "name": "endingAt",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Boolean",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -15728,11 +15728,11 @@
               "deprecationReason": null
             },
             {
-              "name": "paymentMethod",
+              "name": "consolidateInvoice",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "PaymentMethodReferenceInput",
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,
@@ -15740,11 +15740,11 @@
               "deprecationReason": null
             },
             {
-              "name": "consolidateInvoice",
+              "name": "paymentMethod",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentMethodReferenceInput",
                 "ofType": null
               },
               "defaultValue": null,
@@ -70407,11 +70407,11 @@
               "deprecationReason": null
             },
             {
-              "name": "endingAt",
+              "name": "consolidateInvoice",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "ISO8601DateTime",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,
@@ -70419,11 +70419,11 @@
               "deprecationReason": null
             },
             {
-              "name": "consolidateInvoice",
+              "name": "endingAt",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Boolean",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -15740,6 +15740,18 @@
               "deprecationReason": null
             },
             {
+              "name": "invoiceConsolidationEnabled",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "progressiveBillingDisabled",
               "description": null,
               "type": {
@@ -61401,6 +61413,22 @@
               "deprecationReason": null
             },
             {
+              "name": "invoiceConsolidationEnabled",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "lifetimeUsage",
               "description": null,
               "args": [],
@@ -70384,6 +70412,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceConsolidationEnabled",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -70407,11 +70407,11 @@
               "deprecationReason": null
             },
             {
-              "name": "consolidateInvoice",
+              "name": "endingAt",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Boolean",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "defaultValue": null,
@@ -70419,11 +70419,11 @@
               "deprecationReason": null
             },
             {
-              "name": "endingAt",
+              "name": "consolidateInvoice",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "ISO8601DateTime",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe Types::Subscriptions::CreateSubscriptionInput do
     expect(subject).to accept_argument(:name).of_type("String")
     expect(subject).to accept_argument(:billing_time).of_type("BillingTimeEnum!")
     expect(subject).to accept_argument(:activation_rules).of_type("[SubscriptionActivationRuleInput!]")
-    expect(subject).to accept_argument(:invoice_consolidation_enabled).of_type("Boolean")
+    expect(subject).to accept_argument(:consolidate_invoice).of_type("Boolean")
   end
 end

--- a/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
@@ -17,5 +17,6 @@ RSpec.describe Types::Subscriptions::CreateSubscriptionInput do
     expect(subject).to accept_argument(:name).of_type("String")
     expect(subject).to accept_argument(:billing_time).of_type("BillingTimeEnum!")
     expect(subject).to accept_argument(:activation_rules).of_type("[SubscriptionActivationRuleInput!]")
+    expect(subject).to accept_argument(:invoice_consolidation_enabled).of_type("Boolean")
   end
 end

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Types::Subscriptions::Object do
 
     expect(subject).to have_field(:payment_method).of_type("PaymentMethod")
     expect(subject).to have_field(:payment_method_type).of_type("PaymentMethodTypeEnum")
+    expect(subject).to have_field(:invoice_consolidation_enabled).of_type("Boolean!")
 
     expect(subject).to have_field(:activated_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:activation_rules).of_type("[SubscriptionActivationRule!]!")

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Types::Subscriptions::Object do
 
     expect(subject).to have_field(:payment_method).of_type("PaymentMethod")
     expect(subject).to have_field(:payment_method_type).of_type("PaymentMethodTypeEnum")
-    expect(subject).to have_field(:invoice_consolidation_enabled).of_type("Boolean!")
+    expect(subject).to have_field(:consolidate_invoice).of_type("Boolean!")
 
     expect(subject).to have_field(:activated_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:activation_rules).of_type("[SubscriptionActivationRule!]!")

--- a/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe Types::Subscriptions::UpdateSubscriptionInput do
     expect(subject).to accept_argument(:subscription_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:activation_rules).of_type("[SubscriptionActivationRuleInput!]")
     expect(subject).to accept_argument(:billing_entity_id).of_type("ID")
-    expect(subject).to accept_argument(:invoice_consolidation_enabled).of_type("Boolean")
+    expect(subject).to accept_argument(:consolidate_invoice).of_type("Boolean")
   end
 end

--- a/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
@@ -14,5 +14,6 @@ RSpec.describe Types::Subscriptions::UpdateSubscriptionInput do
     expect(subject).to accept_argument(:subscription_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:activation_rules).of_type("[SubscriptionActivationRuleInput!]")
     expect(subject).to accept_argument(:billing_entity_id).of_type("ID")
+    expect(subject).to accept_argument(:invoice_consolidation_enabled).of_type("Boolean")
   end
 end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -688,6 +688,44 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       end
     end
 
+    context "with invoice_consolidation_enabled" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          invoice_consolidation_enabled: false
+        }
+      end
+
+      it "creates a subscription opted out of invoice consolidation" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:invoice_consolidation_enabled]).to be(false)
+
+        subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
+        expect(subscription.invoice_consolidation_enabled).to be(false)
+      end
+    end
+
+    context "when invoice_consolidation_enabled is omitted" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid
+        }
+      end
+
+      it "defaults invoice_consolidation_enabled to true" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:invoice_consolidation_enabled]).to be(true)
+      end
+    end
+
     context "with applied_invoice_custom_sections in response" do
       it "includes applied_invoice_custom_sections in the serialized response" do
         subject
@@ -1666,6 +1704,21 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
 
         subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
         expect(subscription.progressive_billing_disabled).to be(true)
+      end
+    end
+
+    context "when updating invoice_consolidation_enabled" do
+      let(:update_params) { {invoice_consolidation_enabled: false} }
+      let(:subscription) { create(:subscription, customer:, plan:) }
+
+      it "updates invoice_consolidation_enabled" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:invoice_consolidation_enabled]).to be(false)
+
+        subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
+        expect(subscription.invoice_consolidation_enabled).to be(false)
       end
     end
 

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -688,13 +688,13 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       end
     end
 
-    context "with invoice_consolidation_enabled" do
+    context "with consolidate_invoice" do
       let(:params) do
         {
           external_customer_id: customer.external_id,
           plan_code:,
           external_id: SecureRandom.uuid,
-          invoice_consolidation_enabled: false
+          consolidate_invoice: false
         }
       end
 
@@ -702,14 +702,14 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         subject
 
         expect(response).to have_http_status(:success)
-        expect(json[:subscription][:invoice_consolidation_enabled]).to be(false)
+        expect(json[:subscription][:consolidate_invoice]).to be(false)
 
         subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
-        expect(subscription.invoice_consolidation_enabled).to be(false)
+        expect(subscription.consolidate_invoice).to be(false)
       end
     end
 
-    context "when invoice_consolidation_enabled is omitted" do
+    context "when consolidate_invoice is omitted" do
       let(:params) do
         {
           external_customer_id: customer.external_id,
@@ -718,11 +718,11 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         }
       end
 
-      it "defaults invoice_consolidation_enabled to true" do
+      it "defaults consolidate_invoice to true" do
         subject
 
         expect(response).to have_http_status(:success)
-        expect(json[:subscription][:invoice_consolidation_enabled]).to be(true)
+        expect(json[:subscription][:consolidate_invoice]).to be(true)
       end
     end
 
@@ -1707,18 +1707,18 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       end
     end
 
-    context "when updating invoice_consolidation_enabled" do
-      let(:update_params) { {invoice_consolidation_enabled: false} }
+    context "when updating consolidate_invoice" do
+      let(:update_params) { {consolidate_invoice: false} }
       let(:subscription) { create(:subscription, customer:, plan:) }
 
-      it "updates invoice_consolidation_enabled" do
+      it "updates consolidate_invoice" do
         subject
 
         expect(response).to have_http_status(:success)
-        expect(json[:subscription][:invoice_consolidation_enabled]).to be(false)
+        expect(json[:subscription][:consolidate_invoice]).to be(false)
 
         subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
-        expect(subscription.invoice_consolidation_enabled).to be(false)
+        expect(subscription.consolidate_invoice).to be(false)
       end
     end
 

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe ::V1::SubscriptionSerializer do
           "current_billing_period_started_at" => "2024-05-01T00:00:00Z",
           "current_billing_period_ending_at" => "2024-05-31T23:59:59Z",
           "progressive_billing_disabled" => false,
-          "invoice_consolidation_enabled" => true
+          "consolidate_invoice" => true
         )
 
         expect(result["subscription"]["customer"]["lago_id"]).to be_present

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -97,7 +97,8 @@ RSpec.describe ::V1::SubscriptionSerializer do
           "trial_ended_at" => nil,
           "current_billing_period_started_at" => "2024-05-01T00:00:00Z",
           "current_billing_period_ending_at" => "2024-05-31T23:59:59Z",
-          "progressive_billing_disabled" => false
+          "progressive_billing_disabled" => false,
+          "invoice_consolidation_enabled" => true
         )
 
         expect(result["subscription"]["customer"]["lago_id"]).to be_present

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -192,16 +192,16 @@ RSpec.describe Subscriptions::CreateService do
       end
     end
 
-    context "when invoice_consolidation_enabled is not passed" do
+    context "when consolidate_invoice is not passed" do
       it "defaults to true on the created subscription" do
         result = create_service.call
 
         expect(result).to be_success
-        expect(result.subscription.invoice_consolidation_enabled).to be(true)
+        expect(result.subscription.consolidate_invoice).to be(true)
       end
     end
 
-    context "when invoice_consolidation_enabled is passed as false" do
+    context "when consolidate_invoice is passed as false" do
       let(:params) do
         {
           external_customer_id:,
@@ -211,15 +211,15 @@ RSpec.describe Subscriptions::CreateService do
           billing_time:,
           subscription_at:,
           subscription_id:,
-          invoice_consolidation_enabled: false
+          consolidate_invoice: false
         }
       end
 
-      it "creates a subscription with invoice_consolidation_enabled set to false" do
+      it "creates a subscription with consolidate_invoice set to false" do
         result = create_service.call
 
         expect(result).to be_success
-        expect(result.subscription.invoice_consolidation_enabled).to be(false)
+        expect(result.subscription.consolidate_invoice).to be(false)
       end
     end
 
@@ -1265,7 +1265,7 @@ RSpec.describe Subscriptions::CreateService do
             end
           end
 
-          context "when current subscription has invoice_consolidation_enabled disabled" do
+          context "when current subscription has consolidate_invoice disabled" do
             let(:subscription) do
               create(
                 :subscription,
@@ -1275,18 +1275,18 @@ RSpec.describe Subscriptions::CreateService do
                 subscription_at: Time.current,
                 started_at: Time.current,
                 external_id:,
-                invoice_consolidation_enabled: false
+                consolidate_invoice: false
               )
             end
 
-            it "preserves invoice_consolidation_enabled on the next subscription" do
+            it "preserves consolidate_invoice on the next subscription" do
               result = create_service.call
 
               expect(result).to be_success
-              expect(result.subscription.next_subscription.invoice_consolidation_enabled).to be(false)
+              expect(result.subscription.next_subscription.consolidate_invoice).to be(false)
             end
 
-            context "when params override invoice_consolidation_enabled to true" do
+            context "when params override consolidate_invoice to true" do
               let(:params) do
                 {
                   external_customer_id:,
@@ -1296,7 +1296,7 @@ RSpec.describe Subscriptions::CreateService do
                   billing_time:,
                   subscription_at:,
                   subscription_id:,
-                  invoice_consolidation_enabled: true
+                  consolidate_invoice: true
                 }
               end
 
@@ -1304,7 +1304,7 @@ RSpec.describe Subscriptions::CreateService do
                 result = create_service.call
 
                 expect(result).to be_success
-                expect(result.subscription.next_subscription.invoice_consolidation_enabled).to be(true)
+                expect(result.subscription.next_subscription.consolidate_invoice).to be(true)
               end
             end
           end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -192,6 +192,37 @@ RSpec.describe Subscriptions::CreateService do
       end
     end
 
+    context "when invoice_consolidation_enabled is not passed" do
+      it "defaults to true on the created subscription" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.subscription.invoice_consolidation_enabled).to be(true)
+      end
+    end
+
+    context "when invoice_consolidation_enabled is passed as false" do
+      let(:params) do
+        {
+          external_customer_id:,
+          plan_code:,
+          name:,
+          external_id:,
+          billing_time:,
+          subscription_at:,
+          subscription_id:,
+          invoice_consolidation_enabled: false
+        }
+      end
+
+      it "creates a subscription with invoice_consolidation_enabled set to false" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.subscription.invoice_consolidation_enabled).to be(false)
+      end
+    end
+
     context "when customer is invalid in an api context" do
       let(:customer) do
         build(:customer, organization:, currency: "EUR", external_id: nil)
@@ -1231,6 +1262,50 @@ RSpec.describe Subscriptions::CreateService do
               next_subscription = result.subscription.next_subscription.reload
               expect(next_subscription.applied_invoice_custom_sections.count).to be(1)
               expect(next_subscription.applied_invoice_custom_sections.pluck(:invoice_custom_section_id)).to include(section_1.id)
+            end
+          end
+
+          context "when current subscription has invoice_consolidation_enabled disabled" do
+            let(:subscription) do
+              create(
+                :subscription,
+                customer:,
+                plan: old_plan,
+                status: :active,
+                subscription_at: Time.current,
+                started_at: Time.current,
+                external_id:,
+                invoice_consolidation_enabled: false
+              )
+            end
+
+            it "preserves invoice_consolidation_enabled on the next subscription" do
+              result = create_service.call
+
+              expect(result).to be_success
+              expect(result.subscription.next_subscription.invoice_consolidation_enabled).to be(false)
+            end
+
+            context "when params override invoice_consolidation_enabled to true" do
+              let(:params) do
+                {
+                  external_customer_id:,
+                  plan_code:,
+                  name:,
+                  external_id:,
+                  billing_time:,
+                  subscription_at:,
+                  subscription_id:,
+                  invoice_consolidation_enabled: true
+                }
+              end
+
+              it "applies the override on the next subscription" do
+                result = create_service.call
+
+                expect(result).to be_success
+                expect(result.subscription.next_subscription.invoice_consolidation_enabled).to be(true)
+              end
             end
           end
 

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -1027,5 +1027,433 @@ RSpec.describe Subscriptions::OrganizationBillingService do
         end
       end
     end
+
+    context "when a subscription opts out of invoice consolidation" do
+      let(:interval) { :monthly }
+      let(:billing_time) { :anniversary }
+      let(:current_date) { subscription_at.next_month }
+
+      let(:consolidated_subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan:,
+          subscription_at:,
+          started_at: current_date - 10.days,
+          billing_time:,
+          created_at:
+        )
+      end
+      let(:opted_out_subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan:,
+          subscription_at:,
+          started_at: current_date - 10.days,
+          billing_time:,
+          created_at:,
+          invoice_consolidation_enabled: false
+        )
+      end
+
+      before do
+        subscription.destroy
+        consolidated_subscription
+        opted_out_subscription
+      end
+
+      it "bills the opted-out subscription on its own and consolidates the others" do
+        billing_service.call
+
+        expect(BillSubscriptionJob).to have_been_enqueued
+          .with([consolidated_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+        expect(BillSubscriptionJob).to have_been_enqueued
+          .with([opted_out_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+      end
+
+      context "when several subscriptions opt out" do
+        let(:other_opted_out_subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            invoice_consolidation_enabled: false
+          )
+        end
+
+        before { other_opted_out_subscription }
+
+        it "produces a dedicated billing job per opted-out subscription" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([opted_out_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([other_opted_out_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([consolidated_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+      end
+
+      context "when all subscriptions opt out" do
+        let(:consolidated_subscription) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            invoice_consolidation_enabled: false
+          )
+        end
+
+        it "produces a one-subscription billing job per subscription with no empty groups" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([consolidated_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([opted_out_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).not_to have_been_enqueued
+            .with([], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+      end
+
+      context "when combined with currency grouping" do
+        let(:organization) { create(:organization, feature_flags: ["multi_currency"]) }
+        let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }
+        let(:eur_plan) { create(:plan, organization:, interval:, amount_currency: "EUR") }
+
+        let(:usd_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:other_usd_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:eur_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan: eur_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:usd_opted_out) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            invoice_consolidation_enabled: false
+          )
+        end
+
+        before do
+          consolidated_subscription.destroy
+          opted_out_subscription.destroy
+          usd_consolidated
+          other_usd_consolidated
+          eur_consolidated
+          usd_opted_out
+        end
+
+        it "keeps currency groups together while splitting the opted-out subscription out" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(contain_exactly(usd_consolidated, other_usd_consolidated), current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([eur_consolidated], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([usd_opted_out], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+      end
+
+      context "when combined with billing entity grouping" do
+        let(:organization) { create(:organization, feature_flags: ["multi_entity_billing"]) }
+        let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+        let(:default_entity_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:other_default_entity_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:other_entity_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            billing_entity: other_billing_entity,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:
+          )
+        end
+        let(:other_entity_opted_out) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            billing_entity: other_billing_entity,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            invoice_consolidation_enabled: false
+          )
+        end
+
+        before do
+          consolidated_subscription.destroy
+          opted_out_subscription.destroy
+          default_entity_consolidated
+          other_default_entity_consolidated
+          other_entity_consolidated
+          other_entity_opted_out
+        end
+
+        it "keeps billing entity groups together while splitting the opted-out subscription out" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(contain_exactly(default_entity_consolidated, other_default_entity_consolidated), current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([other_entity_consolidated], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([other_entity_opted_out], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+      end
+
+      context "when combined with payment method grouping" do
+        let(:organization) { create(:organization, feature_flags: ["multiple_payment_methods"]) }
+
+        let(:provider_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider"
+          )
+        end
+        let(:other_provider_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider"
+          )
+        end
+        let(:manual_consolidated) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "manual"
+          )
+        end
+        let(:provider_opted_out) do
+          create(
+            :subscription,
+            customer:,
+            plan:,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider",
+            invoice_consolidation_enabled: false
+          )
+        end
+
+        before do
+          consolidated_subscription.destroy
+          opted_out_subscription.destroy
+          provider_consolidated
+          other_provider_consolidated
+          manual_consolidated
+          provider_opted_out
+        end
+
+        it "keeps payment method groups together while splitting the opted-out subscription out" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(contain_exactly(provider_consolidated, other_provider_consolidated), current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([manual_consolidated], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([provider_opted_out], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+      end
+
+      context "when combined with payment method, currency and billing entity grouping" do
+        let(:organization) do
+          create(:organization, feature_flags: %w[multi_currency multi_entity_billing multiple_payment_methods])
+        end
+        let(:other_billing_entity) { create(:billing_entity, organization:) }
+        let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }
+        let(:eur_plan) { create(:plan, organization:, interval:, amount_currency: "EUR") }
+
+        let(:default_usd_provider) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider"
+          )
+        end
+        let(:other_default_usd_provider) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider"
+          )
+        end
+        let(:default_eur_provider) do
+          create(
+            :subscription,
+            customer:,
+            plan: eur_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider"
+          )
+        end
+        let(:default_usd_manual) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "manual"
+          )
+        end
+        let(:other_entity_usd_provider) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            billing_entity: other_billing_entity,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider"
+          )
+        end
+        let(:default_usd_provider_opted_out) do
+          create(
+            :subscription,
+            customer:,
+            plan: usd_plan,
+            subscription_at:,
+            started_at: current_date - 10.days,
+            billing_time:,
+            created_at:,
+            payment_method_type: "provider",
+            invoice_consolidation_enabled: false
+          )
+        end
+
+        before do
+          consolidated_subscription.destroy
+          opted_out_subscription.destroy
+          default_usd_provider
+          other_default_usd_provider
+          default_eur_provider
+          default_usd_manual
+          other_entity_usd_provider
+          default_usd_provider_opted_out
+        end
+
+        it "splits the opted-out subscription out of its (default-entity, USD, provider) group" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(contain_exactly(default_usd_provider, other_default_usd_provider), current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([default_eur_provider], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([default_usd_manual], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([other_entity_usd_provider], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([default_usd_provider_opted_out], current_date.to_i, invoicing_reason: :subscription_periodic)
+        end
+      end
+    end
   end
 end

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -1053,7 +1053,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
           started_at: current_date - 10.days,
           billing_time:,
           created_at:,
-          invoice_consolidation_enabled: false
+          consolidate_invoice: false
         )
       end
 
@@ -1082,7 +1082,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             started_at: current_date - 10.days,
             billing_time:,
             created_at:,
-            invoice_consolidation_enabled: false
+            consolidate_invoice: false
           )
         end
 
@@ -1110,7 +1110,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             started_at: current_date - 10.days,
             billing_time:,
             created_at:,
-            invoice_consolidation_enabled: false
+            consolidate_invoice: false
           )
         end
 
@@ -1173,7 +1173,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             started_at: current_date - 10.days,
             billing_time:,
             created_at:,
-            invoice_consolidation_enabled: false
+            consolidate_invoice: false
           )
         end
 
@@ -1246,7 +1246,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             started_at: current_date - 10.days,
             billing_time:,
             created_at:,
-            invoice_consolidation_enabled: false
+            consolidate_invoice: false
           )
         end
 
@@ -1320,7 +1320,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             billing_time:,
             created_at:,
             payment_method_type: "provider",
-            invoice_consolidation_enabled: false
+            consolidate_invoice: false
           )
         end
 
@@ -1424,7 +1424,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             billing_time:,
             created_at:,
             payment_method_type: "provider",
-            invoice_consolidation_enabled: false
+            consolidate_invoice: false
           )
         end
 

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -489,6 +489,10 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             .with([usd_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([eur_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([usd_subscription], current_date)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([eur_subscription], current_date)
         end
 
         context "without feature flag" do
@@ -721,6 +725,10 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             .with([subscription1], current_date.to_i, invoicing_reason: :subscription_periodic)
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription2], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription1], current_date)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription2], current_date)
         end
 
         context "without feature flag" do
@@ -967,6 +975,10 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             .with([subscription_default_entity], current_date.to_i, invoicing_reason: :subscription_periodic)
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription_other_entity], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription_default_entity], current_date)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription_other_entity], current_date)
         end
 
         context "without feature flag" do
@@ -1070,6 +1082,10 @@ RSpec.describe Subscriptions::OrganizationBillingService do
           .with([consolidated_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         expect(BillSubscriptionJob).to have_been_enqueued
           .with([opted_out_subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+        expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+          .with([consolidated_subscription], current_date)
+        expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+          .with([opted_out_subscription], current_date)
       end
 
       context "when several subscriptions opt out" do
@@ -1452,6 +1468,17 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             .with([other_entity_usd_provider], current_date.to_i, invoicing_reason: :subscription_periodic)
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([default_usd_provider_opted_out], current_date.to_i, invoicing_reason: :subscription_periodic)
+
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with(contain_exactly(default_usd_provider, other_default_usd_provider), current_date)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([default_eur_provider], current_date)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([default_usd_manual], current_date)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([other_entity_usd_provider], current_date)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([default_usd_provider_opted_out], current_date)
         end
       end
     end

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -74,6 +74,35 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       expect(result.subscription.payment_method_type).to eq("provider")
     end
 
+    context "when subscription has invoice_consolidation_enabled disabled" do
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: old_plan,
+          status: :active,
+          subscription_at: Time.current,
+          started_at: Time.current,
+          external_id: SecureRandom.uuid,
+          invoice_consolidation_enabled: false
+        )
+      end
+
+      it "preserves invoice_consolidation_enabled on the new subscription" do
+        expect(result).to be_success
+        expect(result.subscription.invoice_consolidation_enabled).to be(false)
+      end
+
+      context "when params override invoice_consolidation_enabled to true" do
+        let(:params) { {name: subscription_name, invoice_consolidation_enabled: true} }
+
+        it "applies the override on the new subscription" do
+          expect(result).to be_success
+          expect(result.subscription.invoice_consolidation_enabled).to be(true)
+        end
+      end
+    end
+
     context "with payment method" do
       let(:payment_method) { create(:payment_method, organization: subscription.organization, customer: subscription.customer) }
       let(:params) do

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       expect(result.subscription.payment_method_type).to eq("provider")
     end
 
-    context "when subscription has invoice_consolidation_enabled disabled" do
+    context "when subscription has consolidate_invoice disabled" do
       let(:subscription) do
         create(
           :subscription,
@@ -84,21 +84,21 @@ RSpec.describe Subscriptions::PlanUpgradeService do
           subscription_at: Time.current,
           started_at: Time.current,
           external_id: SecureRandom.uuid,
-          invoice_consolidation_enabled: false
+          consolidate_invoice: false
         )
       end
 
-      it "preserves invoice_consolidation_enabled on the new subscription" do
+      it "preserves consolidate_invoice on the new subscription" do
         expect(result).to be_success
-        expect(result.subscription.invoice_consolidation_enabled).to be(false)
+        expect(result.subscription.consolidate_invoice).to be(false)
       end
 
-      context "when params override invoice_consolidation_enabled to true" do
-        let(:params) { {name: subscription_name, invoice_consolidation_enabled: true} }
+      context "when params override consolidate_invoice to true" do
+        let(:params) { {name: subscription_name, consolidate_invoice: true} }
 
         it "applies the override on the new subscription" do
           expect(result).to be_success
-          expect(result.subscription.invoice_consolidation_enabled).to be(true)
+          expect(result.subscription.consolidate_invoice).to be(true)
         end
       end
     end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -207,6 +207,29 @@ RSpec.describe Subscriptions::UpdateService do
         end
       end
 
+      context "when updating invoice_consolidation_enabled" do
+        let(:params) { {invoice_consolidation_enabled: false} }
+
+        it "updates invoice_consolidation_enabled to false" do
+          result = update_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.invoice_consolidation_enabled).to be(false)
+        end
+
+        context "when re-enabling consolidation" do
+          let(:subscription) { create(:subscription, invoice_consolidation_enabled: false) }
+          let(:params) { {invoice_consolidation_enabled: true} }
+
+          it "updates invoice_consolidation_enabled to true" do
+            result = update_service.call
+
+            expect(result).to be_success
+            expect(result.subscription.invoice_consolidation_enabled).to be(true)
+          end
+        end
+      end
+
       context "when updating payment method" do
         let(:payment_method) { create(:payment_method, organization: subscription.organization, customer: subscription.customer) }
         let(:params) { {payment_method: payment_method_params} }

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -207,25 +207,25 @@ RSpec.describe Subscriptions::UpdateService do
         end
       end
 
-      context "when updating invoice_consolidation_enabled" do
-        let(:params) { {invoice_consolidation_enabled: false} }
+      context "when updating consolidate_invoice" do
+        let(:params) { {consolidate_invoice: false} }
 
-        it "updates invoice_consolidation_enabled to false" do
+        it "updates consolidate_invoice to false" do
           result = update_service.call
 
           expect(result).to be_success
-          expect(result.subscription.invoice_consolidation_enabled).to be(false)
+          expect(result.subscription.consolidate_invoice).to be(false)
         end
 
         context "when re-enabling consolidation" do
-          let(:subscription) { create(:subscription, invoice_consolidation_enabled: false) }
-          let(:params) { {invoice_consolidation_enabled: true} }
+          let(:subscription) { create(:subscription, consolidate_invoice: false) }
+          let(:params) { {consolidate_invoice: true} }
 
-          it "updates invoice_consolidation_enabled to true" do
+          it "updates consolidate_invoice to true" do
             result = update_service.call
 
             expect(result).to be_success
-            expect(result.subscription.invoice_consolidation_enabled).to be(true)
+            expect(result.subscription.consolidate_invoice).to be(true)
           end
         end
       end


### PR DESCRIPTION
## Context

Currently customer subscriptions are grouped per payment method, billing entity and currency when creating recurring invoice.

## Description

We are adding `consolidate_invoice` flag on subscription so that users can define if certain subscription should be consolidated or excluded from consolidation.
