### PR TITLE
Ing 43 move wallets billing entity

### DIFF
--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -24,6 +24,12 @@ module Wallets
       return result unless valid_limitations?
       return result unless valid_payment_method?
 
+      if organization_flag_enabled?(:multi_entity_billing) && (params[:billing_entity_id].present? || params[:billing_entity_code].present?)
+        return result.not_found_failure!(resource: "billing_entity") unless billing_entity
+
+        wallet.billing_entity_id = billing_entity.id
+      end
+
       ActiveRecord::Base.transaction do
         wallet.name = params[:name] if params.key?(:name)
         wallet.code = params[:code] if params[:code]
@@ -176,6 +182,21 @@ module Wallets
       return unless params.key?(:metadata)
 
       Metadata::UpdateItemService.call!(owner: wallet, value: params[:metadata], partial: partial_metadata.present?)
+    end
+
+    def organization_flag_enabled?(flag)
+      wallet.customer.organization.feature_flag_enabled?(flag)
+    end
+
+    def billing_entity
+      return @billing_entity if defined? @billing_entity
+
+      scope = wallet.customer.organization.billing_entities
+      @billing_entity = if params[:billing_entity_id].present?
+        scope.find_by(id: params[:billing_entity_id])
+      elsif params[:billing_entity_code].present?
+        scope.find_by(code: params[:billing_entity_code])
+      end
     end
   end
 end

--- a/spec/services/credits/applied_prepaid_credits_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credits_service_spec.rb
@@ -671,6 +671,42 @@ RSpec.describe Credits::AppliedPrepaidCreditsService do
       end
     end
 
+    context "when wallet and invoice belong to different billing entities" do
+      let(:wallet_billing_entity) { create(:billing_entity, organization: customer.organization, code: "be_a") }
+      let(:invoice_billing_entity) { create(:billing_entity, organization: customer.organization, code: "be_b") }
+
+      let(:wallets) { [cross_entity_wallet] }
+      let(:cross_entity_wallet) do
+        create(:wallet, :with_inbound_transaction,
+          name: "cross entity",
+          customer:,
+          billing_entity: wallet_billing_entity,
+          balance_cents: 1000,
+          credits_balance: 10.0)
+      end
+
+      let(:invoice) do
+        create(:invoice,
+          customer:,
+          billing_entity: invoice_billing_entity,
+          currency: "EUR",
+          total_amount_cents: amount_cents)
+      end
+
+      it "applies credits regardless of the billing entity mismatch" do
+        expect(result).to be_success
+        expect(result.wallet_transactions.count).to eq(1)
+        expect(result.wallet_transactions.first.wallet_id).to eq(cross_entity_wallet.id)
+        expect(result.prepaid_credit_amount_cents).to eq(100)
+        expect(invoice.prepaid_credit_amount_cents).to eq(100)
+      end
+
+      it "decrements the wallet balance even though entities differ" do
+        subject
+        expect(cross_entity_wallet.reload.balance_cents).to eq(900)
+      end
+    end
+
     context "when there is a concurrent lock" do
       before do
         stub_const("Customers::LockService::ACQUIRE_LOCK_TIMEOUT", 1.second)

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -881,5 +881,166 @@ RSpec.describe Wallets::UpdateService do
         end
       end
     end
+
+    context "when multi_entity_billing is enabled" do
+      let!(:billing_entity) { create(:billing_entity, organization:, code: "be_code") }
+
+      before do
+        organization.update!(feature_flags: ["multi_entity_billing"])
+      end
+
+      context "when billing_entity_code is provided" do
+        let(:params) do
+          {
+            id: wallet&.id,
+            billing_entity_code: "be_code"
+          }
+        end
+
+        it "assigns the billing entity to the wallet" do
+          expect(result).to be_success
+          expect(result.wallet.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+
+      context "when billing_entity_id is provided" do
+        let(:params) do
+          {
+            id: wallet&.id,
+            billing_entity_id: billing_entity.id
+          }
+        end
+
+        it "assigns the billing entity to the wallet" do
+          expect(result).to be_success
+          expect(result.wallet.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+
+      context "when neither billing_entity_code nor billing_entity_id is provided" do
+        let(:params) { {id: wallet&.id, name: "new name"} }
+
+        it "leaves the wallet's billing entity unchanged" do
+          expect(result).to be_success
+          expect(result.wallet.billing_entity_id).to be_nil
+        end
+      end
+
+      context "when the wallet already has a billing entity" do
+        let!(:initial_billing_entity) { create(:billing_entity, organization:, code: "initial_be") }
+        let(:wallet) { create(:wallet, customer:, billing_entity: initial_billing_entity, allowed_fee_types: []) }
+
+        let(:params) do
+          {
+            id: wallet&.id,
+            billing_entity_code: "be_code"
+          }
+        end
+
+        it "switches the wallet's billing entity" do
+          expect(result).to be_success
+          expect(result.wallet.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+
+      context "when billing_entity_code does not match any entity" do
+        let(:params) do
+          {
+            id: wallet&.id,
+            billing_entity_code: "nonexistent"
+          }
+        end
+
+        it "returns a not found error" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("billing_entity")
+        end
+      end
+
+      context "when billing_entity_id belongs to another organization" do
+        let(:other_organization) { create(:organization) }
+        let!(:other_billing_entity) { create(:billing_entity, organization: other_organization) }
+
+        let(:params) do
+          {
+            id: wallet&.id,
+            billing_entity_id: other_billing_entity.id
+          }
+        end
+
+        it "returns a not found error" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("billing_entity")
+        end
+      end
+
+      context "when billing_entity_code belongs to another organization" do
+        let(:other_organization) { create(:organization) }
+        let!(:other_billing_entity) { create(:billing_entity, organization: other_organization, code: "other_org_be") }
+
+        let(:params) do
+          {
+            id: wallet&.id,
+            billing_entity_code: "other_org_be"
+          }
+        end
+
+        it "returns a not found error" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("billing_entity")
+        end
+      end
+
+      context "when billing_entity_id does not match any entity" do
+        let(:params) do
+          {
+            id: wallet&.id,
+            billing_entity_id: SecureRandom.uuid
+          }
+        end
+
+        it "returns a not found error" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("billing_entity")
+        end
+      end
+
+      context "when both billing_entity_id and billing_entity_code are provided" do
+        let!(:other_billing_entity) { create(:billing_entity, organization:, code: "other_be") }
+
+        let(:params) do
+          {
+            id: wallet&.id,
+            billing_entity_id: billing_entity.id,
+            billing_entity_code: other_billing_entity.code
+          }
+        end
+
+        it "billing_entity_id takes precedence" do
+          expect(result).to be_success
+          expect(result.wallet.billing_entity_id).to eq(billing_entity.id)
+        end
+      end
+    end
+
+    context "when multi_entity_billing is not enabled" do
+      let!(:billing_entity) { create(:billing_entity, organization:, code: "be_code") }
+
+      let(:params) do
+        {
+          id: wallet&.id,
+          billing_entity_code: "be_code"
+        }
+      end
+
+      it "does not assign the billing entity even if code is provided" do
+        expect(result).to be_success
+        expect(result.wallet.billing_entity_id).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -978,7 +978,6 @@ RSpec.describe Wallets::UpdateService do
 
       context "when billing_entity_code belongs to another organization" do
         let(:other_organization) { create(:organization) }
-        let!(:other_billing_entity) { create(:billing_entity, organization: other_organization, code: "other_org_be") }
 
         let(:params) do
           {
@@ -986,6 +985,8 @@ RSpec.describe Wallets::UpdateService do
             billing_entity_code: "other_org_be"
           }
         end
+
+        before { create(:billing_entity, organization: other_organization, code: "other_org_be") }
 
         it "returns a not found error" do
           expect(result).not_to be_success
@@ -1028,14 +1029,14 @@ RSpec.describe Wallets::UpdateService do
     end
 
     context "when multi_entity_billing is not enabled" do
-      let!(:billing_entity) { create(:billing_entity, organization:, code: "be_code") }
-
       let(:params) do
         {
           id: wallet&.id,
           billing_entity_code: "be_code"
         }
       end
+
+      before { create(:billing_entity, organization:, code: "be_code") }
 
       it "does not assign the billing entity even if code is provided" do
         expect(result).to be_success


### PR DESCRIPTION
Dive-in decision 5.6 says a wallet's billing entity must be mutable through the API — once a customer's wallet is provisioned under entity A, an operator should be able to move it to entity B without tearing down and recreating the wallet. `Wallets::CreateService` already accepted `billing_entity_id` and `billing_entity_code` behind the `multi_entity_billing` feature flag, but `Wallets::UpdateService` did not, so the only way to change a wallet's billing entity was to terminate and recreate it.

This PR mirrors the create-side pattern in `Wallets::UpdateService`. When the `multi_entity_billing` flag is enabled on the wallet's organization and the caller provides `billing_entity_id` or `billing_entity_code`, the service resolves the target entity (scoped to the organization), fails with `not_found_failure!(resource: "billing_entity")` if the lookup misses, and otherwise assigns the new entity before the existing update transaction runs. When the flag is off, the params are silently ignored — exactly matching the create-side behavior. The two private helpers (`organization_flag_enabled?` and `billing_entity`) are copied from `CreateService`; the only difference is that they walk through `wallet.customer.organization` rather than going through `customer` directly.

A second commit covers T14 from the dive-in: verify that `Credits::AppliedPrepaidCreditsService` correctly applies credits when the wallet and invoice belong to different billing entities. An audit of the service confirmed it already supports cross-entity application by construction — the wallet query (`customer.wallets.active.with_positive_balance`, filtered by currency) does not reference `billing_entity_id`, and none of the downstream services it calls discriminate by billing entity either. No production code change is needed; the new regression context pins this behavior in place so a future change cannot quietly break it.

## Before and after

|  | Before | After |
| --- | --- | --- |
| `Wallets::UpdateService` accepts `billing_entity_id` / `billing_entity_code` | No | Yes, behind `multi_entity_billing` |
| Wallet's billing entity changeable via PATCH | No | Yes |
| Cross-entity prepaid credit application | Worked by construction, untested | Worked by construction, regression-covered |

## Test plan

- [ ] `bundle exec rspec spec/services/wallets/update_service_spec.rb`
- [ ] `bundle exec rspec spec/services/credits/applied_prepaid_credits_service_spec.rb`
- [ ] Manual: with `multi_entity_billing` enabled on an organization, PATCH a wallet with `billing_entity_code` set to another entity in the same organization and confirm the wallet row updates. With the flag off, confirm the param is silently ignored.
- [ ] Manual: PATCH a wallet with a `billing_entity_id` from a different organization and confirm the request fails with a `billing_entity` not-found error.

## QA scenarios

A wallet is tracked under entity US. Update it to entity EU. Pending transactions tied to the wallet still report US (transactions retain their original entity by virtue of not having a snapshot column today; only the wallet's own `billing_entity_id` changes). New transactions track EU.

## Out of scope

The matching front-end work is in the linked UI story (6.UI). This PR only covers the API and service layer.
