### PR TITLE
feat(LAGO-1462): add email to organization_registered Segment event

### DIFF
--- a/app/services/auth/google_service.rb
+++ b/app/services/auth/google_service.rb
@@ -142,7 +142,8 @@ module Auth
         event: "organization_registered",
         properties: {
           organization_name: organization.name,
-          organization_id: organization.id
+          organization_id: organization.id,
+          email: membership.user.email
         }
       )
     end

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -127,7 +127,8 @@ class UsersService < BaseService
       event: "organization_registered",
       properties: {
         organization_name: organization.name,
-        organization_id: organization.id
+        organization_id: organization.id,
+        email: membership.user.email
       }
     )
   end

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -29,14 +29,15 @@ RSpec.describe UsersService do
 
     it "calls SegmentTrackJob" do
       allow(SegmentTrackJob).to receive(:perform_later)
-      result = user_service.register("email", "password", "organization_name")
+      result = user_service.register("user@email.com", "password", "organization_name")
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: "membership/#{result.membership.id}",
         event: "organization_registered",
         properties: {
           organization_name: result.organization.name,
-          organization_id: result.organization.id
+          organization_id: result.organization.id,
+          email: result.user.email
         }
       )
     end


### PR DESCRIPTION
Adds the user's email to the properties payload of the \`organization_registered\` Segment event in both signup paths (email/password and Google OAuth)