### PR TITLE
[ING-68] feat/multi-entity): adapt dunning campaign flow for multi entity billing

### DIFF
--- a/app/jobs/dunning_campaigns/process_attempt_job.rb
+++ b/app/jobs/dunning_campaigns/process_attempt_job.rb
@@ -4,9 +4,9 @@ module DunningCampaigns
   class ProcessAttemptJob < ApplicationJob
     queue_as :default
 
-    def perform(customer:, dunning_campaign_threshold:)
+    def perform(customer:, dunning_campaign_threshold:, billing_entity:)
       DunningCampaigns::ProcessAttemptService
-        .call(customer:, dunning_campaign_threshold:)
+        .call(customer:, dunning_campaign_threshold:, billing_entity:)
         .raise_if_error!
     end
   end

--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -43,7 +43,13 @@ module DunningCampaigns
         increment_per_currency_attempts(thresholds)
 
         thresholds.each do |threshold|
-          DunningCampaigns::ProcessAttemptJob.perform_later(customer:, dunning_campaign_threshold: threshold)
+          overdue_billing_entities_for(threshold.currency).each do |entity|
+            DunningCampaigns::ProcessAttemptJob.perform_later(
+              customer:,
+              dunning_campaign_threshold: threshold,
+              billing_entity: entity
+            )
+          end
         end
 
         if all_dunned_currencies_max_attempts_reached?
@@ -75,6 +81,12 @@ module DunningCampaigns
             .where(currency:)
             .find_by("amount_cents <= ?", amount_cents)
         end
+      end
+
+      def overdue_billing_entities_for(currency)
+        entity_ids = customer.invoices.non_self_billed.payment_overdue
+          .where(currency: currency).distinct.pluck(:billing_entity_id)
+        customer.organization.billing_entities.where(id: entity_ids)
       end
 
       def increment_per_currency_attempts(thresholds)

--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -84,8 +84,14 @@ module DunningCampaigns
       end
 
       def overdue_billing_entities_for(currency)
-        entity_ids = customer.invoices.non_self_billed.payment_overdue
-          .where(currency: currency).distinct.pluck(:billing_entity_id)
+        entity_ids = customer
+          .invoices
+          .non_self_billed
+          .payment_overdue
+          .where(currency: currency)
+          .where(ready_for_payment_processing: true)
+          .distinct
+          .pluck(:billing_entity_id)
         customer.organization.billing_entities.where(id: entity_ids)
       end
 

--- a/app/services/dunning_campaigns/process_attempt_service.rb
+++ b/app/services/dunning_campaigns/process_attempt_service.rb
@@ -44,6 +44,7 @@ module DunningCampaigns
       return false if customer.exclude_from_dunning_campaign?
 
       custom_campaign = customer.applied_dunning_campaign
+      # Dunning campaign is resolved at the customer level (from their own billing entity), not from the invoice's BE.
       default_campaign = customer.billing_entity.applied_dunning_campaign
 
       custom_campaign == dunning_campaign || (!custom_campaign && default_campaign == dunning_campaign)
@@ -54,8 +55,9 @@ module DunningCampaigns
     end
 
     def overdue_invoices_in_currency
-      customer
+      @overdue_invoices_in_currency ||= customer
         .invoices
+        .non_self_billed
         .payment_overdue
         .where(ready_for_payment_processing: true)
         .where(currency: dunning_campaign_threshold.currency)

--- a/app/services/dunning_campaigns/process_attempt_service.rb
+++ b/app/services/dunning_campaigns/process_attempt_service.rb
@@ -2,12 +2,12 @@
 
 module DunningCampaigns
   class ProcessAttemptService < BaseService
-    def initialize(customer:, dunning_campaign_threshold:)
+    def initialize(customer:, dunning_campaign_threshold:, billing_entity:)
       @customer = customer
       @dunning_campaign_threshold = dunning_campaign_threshold
       @dunning_campaign = dunning_campaign_threshold.dunning_campaign
       @organization = customer.organization
-      @billing_entity = customer.billing_entity
+      @billing_entity = billing_entity
 
       super
     end
@@ -44,21 +44,25 @@ module DunningCampaigns
       return false if customer.exclude_from_dunning_campaign?
 
       custom_campaign = customer.applied_dunning_campaign
-      default_campaign = billing_entity.applied_dunning_campaign
+      default_campaign = customer.billing_entity.applied_dunning_campaign
 
       custom_campaign == dunning_campaign || (!custom_campaign && default_campaign == dunning_campaign)
     end
 
     def dunning_campaign_threshold_reached?
-      overdue_invoices.sum(:total_amount_cents) >= dunning_campaign_threshold.amount_cents
+      overdue_invoices_in_currency.sum(:total_amount_cents) >= dunning_campaign_threshold.amount_cents
     end
 
-    def overdue_invoices
+    def overdue_invoices_in_currency
       customer
         .invoices
         .payment_overdue
         .where(ready_for_payment_processing: true)
         .where(currency: dunning_campaign_threshold.currency)
+    end
+
+    def overdue_invoices
+      overdue_invoices_in_currency.where(billing_entity_id: billing_entity.id)
     end
   end
 end

--- a/spec/jobs/dunning_campaigns/process_attempt_job_spec.rb
+++ b/spec/jobs/dunning_campaigns/process_attempt_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe DunningCampaigns::ProcessAttemptJob do
   let(:result) { BaseService::Result.new }
   let(:customer) { build :customer }
   let(:dunning_campaign_threshold) { build :dunning_campaign_threshold }
+  let(:billing_entity) { build :billing_entity }
 
   before do
     allow(DunningCampaigns::ProcessAttemptService)
@@ -14,10 +15,10 @@ RSpec.describe DunningCampaigns::ProcessAttemptJob do
   end
 
   it "calls DunningCampaigns::ProcessAttemptService" do
-    described_class.perform_now(customer:, dunning_campaign_threshold:)
+    described_class.perform_now(customer:, dunning_campaign_threshold:, billing_entity:)
 
     expect(DunningCampaigns::ProcessAttemptService)
       .to have_received(:call)
-      .with(customer:, dunning_campaign_threshold:)
+      .with(customer:, dunning_campaign_threshold:, billing_entity:)
   end
 end

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -94,9 +94,9 @@ describe "Dunning Campaign v1", :premium do
 
     # Create overdue invoices directly — multi-currency subscription API not yet shipped
     travel_to(DateTime.new(2025, 1, 1, 10)) do
-      create(:invoice, organization:, customer:, billing_entity:, currency: "EUR",
+      create(:invoice, organization:, customer:, currency: "EUR",
         payment_overdue: true, total_amount_cents: 149_00, ready_for_payment_processing: true)
-      create(:invoice, organization:, customer:, billing_entity:, currency: "USD",
+      create(:invoice, organization:, customer:, currency: "USD",
         payment_overdue: true, total_amount_cents: 120_00, ready_for_payment_processing: true)
     end
 
@@ -121,7 +121,7 @@ describe "Dunning Campaign v1", :premium do
 
     # Push EUR over threshold with another overdue invoice
     travel_to(DateTime.new(2025, 1, 5, 18)) do
-      create(:invoice, organization:, customer:, billing_entity:, currency: "EUR",
+      create(:invoice, organization:, customer:, currency: "EUR",
         payment_overdue: true, total_amount_cents: 10_00, ready_for_payment_processing: true)
     end
 

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -94,9 +94,9 @@ describe "Dunning Campaign v1", :premium do
 
     # Create overdue invoices directly — multi-currency subscription API not yet shipped
     travel_to(DateTime.new(2025, 1, 1, 10)) do
-      create(:invoice, organization:, customer:, currency: "EUR",
+      create(:invoice, organization:, customer:, billing_entity:, currency: "EUR",
         payment_overdue: true, total_amount_cents: 149_00, ready_for_payment_processing: true)
-      create(:invoice, organization:, customer:, currency: "USD",
+      create(:invoice, organization:, customer:, billing_entity:, currency: "USD",
         payment_overdue: true, total_amount_cents: 120_00, ready_for_payment_processing: true)
     end
 
@@ -121,7 +121,7 @@ describe "Dunning Campaign v1", :premium do
 
     # Push EUR over threshold with another overdue invoice
     travel_to(DateTime.new(2025, 1, 5, 18)) do
-      create(:invoice, organization:, customer:, currency: "EUR",
+      create(:invoice, organization:, customer:, billing_entity:, currency: "EUR",
         payment_overdue: true, total_amount_cents: 10_00, ready_for_payment_processing: true)
     end
 

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -62,10 +62,10 @@ RSpec.describe DunningCampaigns::BulkProcessService do
           expect(result).to be_success
           expect(DunningCampaigns::ProcessAttemptJob)
             .to have_been_enqueued
-            .with(customer:, dunning_campaign_threshold:)
+            .with(customer:, dunning_campaign_threshold:, billing_entity:)
         end
 
-        it "increments the per-currency attempt counter" do
+        it "increments the per-tuple attempt counter" do
           freeze_time do
             expect { result && customer.reload }
               .to change { customer.dunning_currency_attempts[currency] }.from(nil).to(1)
@@ -140,7 +140,7 @@ RSpec.describe DunningCampaigns::BulkProcessService do
             expect(result).to be_success
             expect(DunningCampaigns::ProcessAttemptJob)
               .to have_been_enqueued
-              .with(customer:, dunning_campaign_threshold:)
+              .with(customer:, dunning_campaign_threshold:, billing_entity:)
           end
         end
       end
@@ -214,7 +214,7 @@ RSpec.describe DunningCampaigns::BulkProcessService do
             expect(result).to be_success
             expect(DunningCampaigns::ProcessAttemptJob)
               .to have_been_enqueued
-              .with(customer:, dunning_campaign_threshold: customer_dunning_campaign_threshold)
+              .with(customer:, dunning_campaign_threshold: customer_dunning_campaign_threshold, billing_entity:)
           end
         end
 
@@ -321,7 +321,7 @@ RSpec.describe DunningCampaigns::BulkProcessService do
           expect(result).to be_success
           expect(DunningCampaigns::ProcessAttemptJob)
             .to have_been_enqueued
-            .with(customer:, dunning_campaign_threshold:)
+            .with(customer:, dunning_campaign_threshold:, billing_entity:)
         end
 
         context "when organization does not have auto_dunning feature enabled" do
@@ -391,7 +391,7 @@ RSpec.describe DunningCampaigns::BulkProcessService do
             expect(result).to be_success
             expect(DunningCampaigns::ProcessAttemptJob)
               .to have_been_enqueued
-              .with(customer:, dunning_campaign_threshold:)
+              .with(customer:, dunning_campaign_threshold:, billing_entity:)
           end
         end
       end
@@ -489,9 +489,9 @@ RSpec.describe DunningCampaigns::BulkProcessService do
         it "enqueues a ProcessAttemptJob for each currency" do
           result
           expect(DunningCampaigns::ProcessAttemptJob)
-            .to have_been_enqueued.with(customer:, dunning_campaign_threshold: usd_threshold)
+            .to have_been_enqueued.with(customer:, dunning_campaign_threshold: usd_threshold, billing_entity:)
           expect(DunningCampaigns::ProcessAttemptJob)
-            .to have_been_enqueued.with(customer:, dunning_campaign_threshold: eur_threshold)
+            .to have_been_enqueued.with(customer:, dunning_campaign_threshold: eur_threshold, billing_entity:)
         end
 
         it "increments per-currency counters independently" do
@@ -510,9 +510,9 @@ RSpec.describe DunningCampaigns::BulkProcessService do
         it "enqueues a ProcessAttemptJob only for the matching currency" do
           result
           expect(DunningCampaigns::ProcessAttemptJob)
-            .to have_been_enqueued.with(customer:, dunning_campaign_threshold: usd_threshold)
+            .to have_been_enqueued.with(customer:, dunning_campaign_threshold: usd_threshold, billing_entity:)
           expect(DunningCampaigns::ProcessAttemptJob)
-            .not_to have_been_enqueued.with(customer:, dunning_campaign_threshold: eur_threshold)
+            .not_to have_been_enqueued.with(customer:, dunning_campaign_threshold: eur_threshold, billing_entity:)
         end
       end
 
@@ -525,7 +525,7 @@ RSpec.describe DunningCampaigns::BulkProcessService do
         it "only enqueues for currencies with matching thresholds" do
           result
           expect(DunningCampaigns::ProcessAttemptJob)
-            .to have_been_enqueued.with(customer:, dunning_campaign_threshold: usd_threshold)
+            .to have_been_enqueued.with(customer:, dunning_campaign_threshold: usd_threshold, billing_entity:)
           expect(DunningCampaigns::ProcessAttemptJob)
             .to have_been_enqueued.once
         end
@@ -567,10 +567,10 @@ RSpec.describe DunningCampaigns::BulkProcessService do
 
       context "when all customers have overdue balances exceeding all thresholds" do
         before do
-          create(:invoice, organization:, customer: customer, currency:, payment_overdue: true, total_amount_cents: 100_00)
-          create(:invoice, organization:, customer: customer_1, currency:, payment_overdue: true, total_amount_cents: 60_00)
-          create(:invoice, organization:, customer: customer_2, currency:, payment_overdue: true, total_amount_cents: 51_00)
-          create(:invoice, organization:, customer: customer_3, currency:, payment_overdue: true, total_amount_cents: 51_00)
+          create(:invoice, organization:, customer:, billing_entity:, currency:, payment_overdue: true, total_amount_cents: 100_00)
+          create(:invoice, organization:, customer: customer_1, billing_entity: billing_entity_1, currency:, payment_overdue: true, total_amount_cents: 60_00)
+          create(:invoice, organization:, customer: customer_2, billing_entity: billing_entity_2, currency:, payment_overdue: true, total_amount_cents: 51_00)
+          create(:invoice, organization:, customer: customer_3, billing_entity:, currency:, payment_overdue: true, total_amount_cents: 51_00)
         end
 
         it "enqueues ProcessAttemptJob for both customers with their respective thresholds" do
@@ -578,11 +578,11 @@ RSpec.describe DunningCampaigns::BulkProcessService do
           expect(DunningCampaigns::ProcessAttemptJob)
             .not_to have_been_enqueued.with(hash_including(customer: customer))
           expect(DunningCampaigns::ProcessAttemptJob)
-            .to have_been_enqueued.with(customer: customer_1, dunning_campaign_threshold: dunning_campaign_threshold_1)
+            .to have_been_enqueued.with(customer: customer_1, dunning_campaign_threshold: dunning_campaign_threshold_1, billing_entity: billing_entity_1)
           expect(DunningCampaigns::ProcessAttemptJob)
-            .to have_been_enqueued.with(customer: customer_2, dunning_campaign_threshold: dunning_campaign_threshold_2)
+            .to have_been_enqueued.with(customer: customer_2, dunning_campaign_threshold: dunning_campaign_threshold_2, billing_entity: billing_entity_2)
           expect(DunningCampaigns::ProcessAttemptJob)
-            .to have_been_enqueued.with(customer: customer_3, dunning_campaign_threshold: dunning_campaign_threshold_1)
+            .to have_been_enqueued.with(customer: customer_3, dunning_campaign_threshold: dunning_campaign_threshold_1, billing_entity:)
         end
       end
     end
@@ -677,7 +677,7 @@ RSpec.describe DunningCampaigns::BulkProcessService do
       it "still enqueues the process attempt job" do
         result
         expect(DunningCampaigns::ProcessAttemptJob)
-          .to have_been_enqueued.with(customer:, dunning_campaign_threshold:)
+          .to have_been_enqueued.with(customer:, dunning_campaign_threshold:, billing_entity:)
       end
     end
 
@@ -708,9 +708,9 @@ RSpec.describe DunningCampaigns::BulkProcessService do
       it "only enqueues for the currency that has not reached max attempts" do
         result
         expect(DunningCampaigns::ProcessAttemptJob)
-          .not_to have_been_enqueued.with(customer:, dunning_campaign_threshold: usd_threshold)
+          .not_to have_been_enqueued.with(customer:, dunning_campaign_threshold: usd_threshold, billing_entity:)
         expect(DunningCampaigns::ProcessAttemptJob)
-          .to have_been_enqueued.with(customer:, dunning_campaign_threshold: eur_threshold)
+          .to have_been_enqueued.with(customer:, dunning_campaign_threshold: eur_threshold, billing_entity:)
       end
 
       it "only increments the non-maxed currency counter" do
@@ -798,6 +798,39 @@ RSpec.describe DunningCampaigns::BulkProcessService do
       it "does not enqueue any process attempt job" do
         result
         expect(DunningCampaigns::ProcessAttemptJob).not_to have_been_enqueued
+      end
+    end
+
+    context "when customer has overdue invoices across multiple billing entities" do
+      let(:other_billing_entity) { create :billing_entity, organization: }
+      let(:dunning_campaign) { create :dunning_campaign, organization:, max_attempts: 2 }
+      let(:dunning_campaign_threshold) do
+        create(:dunning_campaign_threshold, dunning_campaign:, currency:, amount_cents: 40_00)
+      end
+
+      before do
+        dunning_campaign_threshold
+        billing_entity.update!(applied_dunning_campaign: dunning_campaign)
+        create(:invoice, organization:, customer:, billing_entity:, currency:, payment_overdue: true, total_amount_cents: 50_00)
+        create(:invoice, organization:, customer:, billing_entity: other_billing_entity, currency:, payment_overdue: true, total_amount_cents: 60_00)
+      end
+
+      it "enqueues one ProcessAttemptJob per billing entity carrying overdue invoices in the currency" do
+        result
+        expect(DunningCampaigns::ProcessAttemptJob)
+          .to have_been_enqueued
+          .with(customer:, dunning_campaign_threshold:, billing_entity:)
+        expect(DunningCampaigns::ProcessAttemptJob)
+          .to have_been_enqueued
+          .with(customer:, dunning_campaign_threshold:, billing_entity: other_billing_entity)
+        expect(DunningCampaigns::ProcessAttemptJob)
+          .to have_been_enqueued.twice
+      end
+
+      it "increments the per-currency counter only once" do
+        result
+        customer.reload
+        expect(customer.dunning_currency_attempts).to eq(currency => 1)
       end
     end
 

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe DunningCampaigns::BulkProcessService do
             .with(customer:, dunning_campaign_threshold:, billing_entity:)
         end
 
-        it "increments the per-tuple attempt counter" do
+        it "increments the per-currency attempt counter" do
           freeze_time do
             expect { result && customer.reload }
               .to change { customer.dunning_currency_attempts[currency] }.from(nil).to(1)

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe DunningCampaigns::ProcessAttemptService do
-  subject(:result) { described_class.call(customer:, dunning_campaign_threshold:) }
+  subject(:result) { described_class.call(customer:, dunning_campaign_threshold:, billing_entity:) }
 
-  let(:customer) { create :customer, organization:, currency: }
+  let(:customer) { create :customer, organization:, currency:, billing_entity: }
   let(:organization) { create :organization }
   let(:billing_entity) { organization.default_billing_entity }
   let(:currency) { "EUR" }
@@ -151,6 +151,33 @@ RSpec.describe DunningCampaigns::ProcessAttemptService do
           expect(args[:params][:external_customer_id]).to eq(customer.external_id)
           expect(args[:params][:lago_invoice_ids]).to include(eur_invoice.id)
           expect(args[:params][:lago_invoice_ids]).not_to include(usd_invoice.id)
+        end
+      end
+    end
+
+    context "when the customer has overdue invoices across multiple billing entities" do
+      let(:other_billing_entity) { create :billing_entity, organization: }
+
+      let(:matching_invoice) do
+        create :invoice, organization:, customer:, billing_entity:, currency:,
+          payment_overdue: true, total_amount_cents: 99_00
+      end
+      let(:other_entity_invoice) do
+        create :invoice, organization:, customer:, billing_entity: other_billing_entity, currency:,
+          payment_overdue: true, total_amount_cents: 99_00
+      end
+
+      before do
+        matching_invoice
+        other_entity_invoice
+      end
+
+      it "scopes the payment request invoices to the provided billing entity" do
+        result
+
+        expect(PaymentRequests::CreateService).to have_received(:call) do |args|
+          expect(args[:params][:lago_invoice_ids]).to include(matching_invoice.id)
+          expect(args[:params][:lago_invoice_ids]).not_to include(other_entity_invoice.id)
         end
       end
     end


### PR DESCRIPTION
## Context

Currently, one customer can be assigned to only one billing entity. With `multi-billing-entities` feature, it will be possible to assign any billing entity to customer's billing object, like subscription or wallet.

## Description

This PR adapts dunning campaign flow for multi entity billing.
