### PR TITLE
ING-84 feat(wallets): Accept billingEntityId on updateCustomerWallet

### DIFF
--- a/app/graphql/types/wallets/update_input.rb
+++ b/app/graphql/types/wallets/update_input.rb
@@ -5,6 +5,7 @@ module Types
     class UpdateInput < Types::BaseInputObject
       description "Update Wallet Input"
 
+      argument :billing_entity_id, ID, required: false
       argument :code, String, required: false
       argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :id, ID, required: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -12727,6 +12727,7 @@ Update Wallet Input
 """
 input UpdateCustomerWalletInput {
   appliesTo: AppliesToInput
+  billingEntityId: ID
 
   """
   A unique identifier for the client performing the mutation.

--- a/schema.json
+++ b/schema.json
@@ -66700,6 +66700,18 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "billingEntityId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "code",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -224,4 +224,31 @@ RSpec.describe Mutations::Wallets::Update, :premium do
       expect_unprocessable_entity(result, details: {code: ["value_already_exist"]})
     end
   end
+
+  context "when updating billing_entity_id with multi_entity_billing enabled" do
+    let(:billing_entity) { create(:billing_entity, organization:) }
+
+    before do
+      organization.update!(feature_flags: ["multi_entity_billing"])
+    end
+
+    it "updates the wallet's billing entity" do
+      result = execute_graphql(
+        current_organization: organization,
+        current_user: membership.user,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: wallet.id,
+            billingEntityId: billing_entity.id,
+            priority: 22
+          }
+        }
+      )
+
+      expect(result["data"]["updateCustomerWallet"]["id"]).to eq(wallet.id)
+      expect(wallet.reload.billing_entity_id).to eq(billing_entity.id)
+    end
+  end
 end

--- a/spec/graphql/types/wallets/update_input_spec.rb
+++ b/spec/graphql/types/wallets/update_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Wallets::UpdateInput do
   it do
     expect(subject).to accept_argument(:expiration_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:id).of_type("ID!")
+    expect(subject).to accept_argument(:billing_entity_id).of_type("ID")
     expect(subject).to accept_argument(:code).of_type("String")
     expect(subject).to accept_argument(:invoice_requires_successful_payment).of_type("Boolean")
     expect(subject).to accept_argument(:name).of_type("String")


### PR DESCRIPTION
ING-43 made `Wallets::UpdateService` accept `billing_entity_id` and `billing_entity_code` behind the `multi_entity_billing` feature flag, but the GraphQL `updateCustomerWallet` mutation did not expose `billingEntityId` as an input argument. That meant REST callers could move a wallet between entities while GraphQL callers could not — the frontend had no way to drive the flow. This PR closes the gap.

The change is minimal: a single `argument :billing_entity_id, ID, required: false` added to `Types::Wallets::UpdateInput`, matching the placement that already exists on `CreateInput`. The mutation resolver at `Mutations::Wallets::Update#resolve` forwards `**args` straight to `Wallets::UpdateService`, so no handler change is needed — the new argument flows through automatically and is gated by the same feature flag as the REST path. Behavior is unchanged for any caller that does not supply `billingEntityId`, and the generated `schema.graphql` / `schema.json` are updated to reflect the new input.

## Before and after

|  | Before | After |
| --- | --- | --- |
| `updateCustomerWallet` accepts `billingEntityId` | No | Yes, optional |
| Frontend can move a wallet between entities | Not without REST | Yes |
| Service-layer wiring | Already in place (ING-43) | Unchanged |
| Feature gating | n/a | `multi_entity_billing` (inherited from the service) |

## Test plan

- [ ] `bundle exec rspec spec/graphql/types/wallets/update_input_spec.rb` — type spec asserts the new argument is accepted as `ID`.
- [ ] `bundle exec rspec spec/graphql/mutations/wallets/update_spec.rb` — new context "when updating billing_entity_id with multi_entity_billing enabled" turns the flag on, calls the mutation with `billingEntityId`, and asserts the wallet row is updated.
- [ ] Manual: with `multi_entity_billing` enabled on an organization, run the mutation through GraphiQL and confirm the wallet's `billing_entity_id` changes.

## Migration

None. The new argument is optional and inherits the existing `multi_entity_billing` feature gate — operators with the flag off see no change; operators with the flag on gain the GraphQL surface automatically.

## Out of scope

Only `billing_entity_id` is exposed, mirroring `CreateInput`. The REST API accepts `billing_entity_code` as well, but GraphQL inputs keep to the `id`-only convention.
