### PR TITLE
ING-139 feat(payments): Filter payments by currency

### DIFF
--- a/app/graphql/resolvers/payments_resolver.rb
+++ b/app/graphql/resolvers/payments_resolver.rb
@@ -9,6 +9,7 @@ module Resolvers
 
     description "Query payments of an organization"
 
+    argument :currency, String, required: false
     argument :external_customer_id, ID, required: false
     argument :invoice_id, ID, required: false
     argument :limit, Integer, required: false
@@ -17,12 +18,13 @@ module Resolvers
 
     type Types::Payments::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil, invoice_id: nil, external_customer_id: nil, search_term: nil)
+    def resolve(currency: nil, page: nil, limit: nil, invoice_id: nil, external_customer_id: nil, search_term: nil)
       result = PaymentsQuery.call(
         organization: current_organization,
         filters: {
           invoice_id:,
-          external_customer_id:
+          external_customer_id:,
+          currency:
         },
         search_term:,
         pagination: {

--- a/app/graphql/resolvers/payments_resolver.rb
+++ b/app/graphql/resolvers/payments_resolver.rb
@@ -9,7 +9,7 @@ module Resolvers
 
     description "Query payments of an organization"
 
-    argument :currency, String, required: false
+    argument :currency, Types::CurrencyEnum, required: false
     argument :external_customer_id, ID, required: false
     argument :invoice_id, ID, required: false
     argument :limit, Integer, required: false

--- a/app/queries/payments_query.rb
+++ b/app/queries/payments_query.rb
@@ -2,7 +2,7 @@
 
 class PaymentsQuery < BaseQuery
   Result = BaseResult[:payments]
-  Filters = BaseFilters[:invoice_id, :external_customer_id]
+  Filters = BaseFilters[:invoice_id, :external_customer_id, :currency]
 
   def call
     return result unless validate_filters.success?
@@ -82,6 +82,7 @@ class PaymentsQuery < BaseQuery
   def apply_filters(scope)
     scope = filter_by_invoice(scope) if filters.invoice_id.present?
     scope = filter_by_customer(scope) if filters.external_customer_id.present?
+    scope = filter_by_currency(scope) if filters.currency.present?
     scope
   end
 
@@ -104,5 +105,9 @@ class PaymentsQuery < BaseQuery
         "OR invoices_payment_requests.invoice_id = :invoice_id",
         invoice_id:
       )
+  end
+
+  def filter_by_currency(scope)
+    scope.where(amount_currency: filters.currency)
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -10482,7 +10482,7 @@ type Query {
   """
   Query payments of an organization
   """
-  payments(currency: String, externalCustomerId: ID, invoiceId: ID, limit: Int, page: Int, searchTerm: String): PaymentCollection!
+  payments(currency: CurrencyEnum, externalCustomerId: ID, invoiceId: ID, limit: Int, page: Int, searchTerm: String): PaymentCollection!
 
   """
   Query a single plan of an organization

--- a/schema.graphql
+++ b/schema.graphql
@@ -10482,7 +10482,7 @@ type Query {
   """
   Query payments of an organization
   """
-  payments(externalCustomerId: ID, invoiceId: ID, limit: Int, page: Int, searchTerm: String): PaymentCollection!
+  payments(currency: String, externalCustomerId: ID, invoiceId: ID, limit: Int, page: Int, searchTerm: String): PaymentCollection!
 
   """
   Query a single plan of an organization

--- a/schema.json
+++ b/schema.json
@@ -56171,8 +56171,8 @@
                   "name": "currency",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -56168,6 +56168,18 @@
               "description": "Query payments of an organization",
               "args": [
                 {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "externalCustomerId",
                   "description": null,
                   "type": {

--- a/spec/graphql/resolvers/payments_resolver_spec.rb
+++ b/spec/graphql/resolvers/payments_resolver_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Resolvers::PaymentsResolver do
   context "when currency is present" do
     let(:query) do
       <<~GQL
-        query($currency: String!) {
+        query($currency: CurrencyEnum!) {
           payments(currency: $currency, limit: 5) {
             collection { id }
             metadata { currentPage, totalCount }

--- a/spec/graphql/resolvers/payments_resolver_spec.rb
+++ b/spec/graphql/resolvers/payments_resolver_spec.rb
@@ -104,4 +104,33 @@ RSpec.describe Resolvers::PaymentsResolver do
         .to contain_exactly(invoice1.id, invoice2.id)
     end
   end
+
+  context "when currency is present" do
+    let(:query) do
+      <<~GQL
+        query($currency: String!) {
+          payments(currency: $currency, limit: 5) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    let(:usd_invoice) { create(:invoice, customer:, organization:, currency: "USD") }
+    let!(:usd_payment) { create(:payment, payable: usd_invoice, amount_currency: "USD") }
+
+    it "returns only payments matching the currency" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {currency: "USD"}
+      )
+
+      ids = result["data"]["payments"]["collection"].map { |p| p["id"] }
+      expect(ids).to contain_exactly(usd_payment.id)
+    end
+  end
 end

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -188,6 +188,26 @@ RSpec.describe PaymentsQuery do
     end
   end
 
+  context "when filtering by currency" do
+    let(:filters) { {currency: "USD"} }
+    let(:usd_invoice) { create(:invoice, organization:, currency: "USD") }
+    let!(:usd_payment) { create(:payment, payable: usd_invoice, amount_currency: "USD") }
+
+    it "returns only payments matching the currency" do
+      expect(result).to be_success
+      expect(returned_ids).to contain_exactly(usd_payment.id)
+    end
+  end
+
+  context "when filtering by a currency that matches no payments" do
+    let(:filters) { {currency: "GBP"} }
+
+    it "returns an empty result set" do
+      expect(result).to be_success
+      expect(returned_ids).to be_empty
+    end
+  end
+
   context "when filtering with an invalid invoice_id" do
     let(:filters) { {invoice_id: "invalid-uuid"} }
 


### PR DESCRIPTION
The payments listing in the front-end needs to be filterable by currency, but the GraphQL `payments` query and the underlying `PaymentsQuery` had no such filter. This PR adds it at both layers.

The change is mechanical: a `currency` argument on `Resolvers::PaymentsResolver`, a `currency` entry in `PaymentsQuery::Filters`, and a `filter_by_currency` helper that scopes the query to `where(amount_currency: filters.currency)`. The resolver's `resolve` method defaults `currency:` to `nil` so existing callers that don't pass it continue to work unchanged. The generated `schema.graphql` and `schema.json` are regenerated to reflect the new argument.

## Before and after

|  | Before | After |
| --- | --- | --- |
| Filter payments by currency through GraphQL | No | `payments(currency: "USD") { ... }` |
| `PaymentsQuery::Filters` shape | `[:invoice_id, :external_customer_id]` | `[:invoice_id, :external_customer_id, :currency]` |
| Existing filters (invoice, external customer, search) | Worked | Unchanged |

## Test plan

- [ ] `bundle exec rspec spec/queries/payments_query_spec.rb`
- [ ] `bundle exec rspec spec/graphql/resolvers/payments_resolver_spec.rb`
- [ ] Manual via GraphiQL: `payments(currency: "USD") { collection { id } }` returns only payments whose `amount_currency = "USD"`.

## Migration

None. The new argument is optional and not gated — existing callers see no change.

## Follow-up worth opening

`app/contracts/queries/payments_query_filters_contract.rb` lists `invoice_id` and `external_customer_id` but not `currency`. Adding `optional(:currency).maybe(:string)` would reject malformed currency strings at the validation layer instead of silently returning empty results. Skipped here to keep the PR focused.