### PR TITLE
feat: add billable_metric.{created,updated,deleted} webhooks

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -15,6 +15,9 @@ class SendWebhookJob < ApplicationJob
 
   WEBHOOK_SERVICES = {
     "alert.triggered" => Webhooks::UsageMonitoring::AlertTriggeredService,
+    "billable_metric.created" => Webhooks::BillableMetrics::CreatedService,
+    "billable_metric.updated" => Webhooks::BillableMetrics::UpdatedService,
+    "billable_metric.deleted" => Webhooks::BillableMetrics::DeletedService,
     "dunning_campaign.finished" => Webhooks::DunningCampaigns::FinishedService,
     "invoice.created" => Webhooks::Invoices::CreatedService,
     "invoice.one_off_created" => Webhooks::Invoices::OneOffCreatedService,

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -44,6 +44,8 @@ module BillableMetrics
         result.billable_metric = metric
         track_billable_metric_created(metric)
       end
+
+      SendWebhookJob.perform_after_commit("billable_metric.created", result.billable_metric) if result.billable_metric
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -36,6 +36,8 @@ module BillableMetrics
       BillableMetrics::DeleteEventsJob.perform_later(metric)
       BillableMetricFilters::DestroyAllJob.perform_later(metric.id)
 
+      SendWebhookJob.perform_after_commit("billable_metric.deleted", metric)
+
       result.billable_metric = metric
       result
     end

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -55,6 +55,8 @@ module BillableMetrics
 
       billable_metric.save!
 
+      SendWebhookJob.perform_after_commit("billable_metric.updated", billable_metric)
+
       result.billable_metric = billable_metric
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/webhooks/billable_metrics/created_service.rb
+++ b/app/services/webhooks/billable_metrics/created_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module BillableMetrics
+    class CreatedService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::BillableMetricSerializer.new(
+          object,
+          root_name: "billable_metric"
+        )
+      end
+
+      def webhook_type
+        "billable_metric.created"
+      end
+
+      def object_type
+        "billable_metric"
+      end
+    end
+  end
+end

--- a/app/services/webhooks/billable_metrics/deleted_service.rb
+++ b/app/services/webhooks/billable_metrics/deleted_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module BillableMetrics
+    class DeletedService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::BillableMetricSerializer.new(
+          object,
+          root_name: "billable_metric"
+        )
+      end
+
+      def webhook_type
+        "billable_metric.deleted"
+      end
+
+      def object_type
+        "billable_metric"
+      end
+    end
+  end
+end

--- a/app/services/webhooks/billable_metrics/updated_service.rb
+++ b/app/services/webhooks/billable_metrics/updated_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module BillableMetrics
+    class UpdatedService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::BillableMetricSerializer.new(
+          object,
+          root_name: "billable_metric"
+        )
+      end
+
+      def webhook_type
+        "billable_metric.updated"
+      end
+
+      def object_type
+        "billable_metric"
+      end
+    end
+  end
+end

--- a/config/webhook_event_types.yml
+++ b/config/webhook_event_types.yml
@@ -3,6 +3,21 @@ alert_triggered:
   description: One or more thresholds defined in the alert were crossed
   category: Alerts
   deprecated: false
+billable_metric_created:
+  name: billable_metric.created
+  description: A new billable metric has been created
+  category: Billable Metrics
+  deprecated: false
+billable_metric_updated:
+  name: billable_metric.updated
+  description: A billable metric has been updated
+  category: Billable Metrics
+  deprecated: false
+billable_metric_deleted:
+  name: billable_metric.deleted
+  description: A billable metric has been deleted
+  category: Billable Metrics
+  deprecated: false
 customer_created:
   name: customer.created
   description: A new customer has been created

--- a/schema.graphql
+++ b/schema.graphql
@@ -5703,6 +5703,7 @@ type Event {
 
 enum EventCategoryEnum {
   ALERTS
+  BILLABLE_METRICS
   CREDIT_NOTES
   CUSTOMERS
   DUNNING_CAMPAIGNS
@@ -5735,6 +5736,9 @@ type EventCollection {
 enum EventTypeEnum {
   alert_triggered
   all
+  billable_metric_created
+  billable_metric_deleted
+  billable_metric_updated
   credit_note_created
   credit_note_generated
   credit_note_provider_refund_failure

--- a/schema.json
+++ b/schema.json
@@ -27648,6 +27648,12 @@
               "deprecationReason": null
             },
             {
+              "name": "BILLABLE_METRICS",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "CUSTOMERS",
               "description": null,
               "isDeprecated": false,
@@ -27783,6 +27789,24 @@
           "enumValues": [
             {
               "name": "alert_triggered",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billable_metric_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billable_metric_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billable_metric_deleted",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -726,6 +726,22 @@ RSpec.describe SendWebhookJob do
       end
     end
 
+    context "with billable metric webhooks" do
+      let(:object) { create(:billable_metric, organization:) }
+
+      it_behaves_like "a webhook service",
+        "billable_metric.created",
+        Webhooks::BillableMetrics::CreatedService
+
+      it_behaves_like "a webhook service",
+        "billable_metric.updated",
+        Webhooks::BillableMetrics::UpdatedService
+
+      it_behaves_like "a webhook service",
+        "billable_metric.deleted",
+        Webhooks::BillableMetrics::DeletedService
+    end
+
     context "when webhook_type is dunning_campaign.finished" do
       let(:webhook_service) { instance_double(Webhooks::DunningCampaigns::FinishedService) }
       let(:customer) { create(:customer) }

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe BillableMetrics::CreateService do
         .to change(BillableMetric, :count).by(1)
     end
 
+    it "enqueues a billable_metric.created webhook" do
+      result = described_class.call(create_args)
+
+      expect(SendWebhookJob).to have_been_enqueued.with("billable_metric.created", result.billable_metric)
+    end
+
     context "with code already used by a deleted metric" do
       it "creates a billable metric with the same code" do
         create(:billable_metric, organization:, code: "new_metric", deleted_at: Time.current)

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe BillableMetrics::DestroyService do
       end.to have_enqueued_job(BillableMetrics::DeleteEventsJob).with(billable_metric)
     end
 
+    it "enqueues a billable_metric.deleted webhook" do
+      destroy_service.call
+
+      expect(SendWebhookJob).to have_been_enqueued.with("billable_metric.deleted", billable_metric)
+    end
+
     it "marks invoice as ready to be refreshed" do
       invoice = create(:invoice, :draft)
       create(:invoice_subscription, subscription:, invoice:)

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe BillableMetrics::UpdateService do
       expect(Utils::ActivityLog).to have_produced("billable_metric.updated").after_commit.with(billable_metric)
     end
 
+    it "enqueues a billable_metric.updated webhook" do
+      described_class.call(billable_metric:, params:)
+
+      expect(SendWebhookJob).to have_been_enqueued.with("billable_metric.updated", billable_metric)
+    end
+
     context "with filters arguments" do
       let(:filters) do
         [

--- a/spec/services/webhooks/billable_metrics/created_service_spec.rb
+++ b/spec/services/webhooks/billable_metrics/created_service_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::BillableMetrics::CreatedService do
+  subject(:webhook_service) { described_class.new(object: billable_metric) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "billable_metric.created", "billable_metric", {
+      "lago_id" => String,
+      "name" => String,
+      "code" => String,
+      "aggregation_type" => String,
+      "recurring" => false,
+      "filters" => Array
+    }
+  end
+end

--- a/spec/services/webhooks/billable_metrics/deleted_service_spec.rb
+++ b/spec/services/webhooks/billable_metrics/deleted_service_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::BillableMetrics::DeletedService do
+  subject(:webhook_service) { described_class.new(object: billable_metric) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "billable_metric.deleted", "billable_metric"
+  end
+end

--- a/spec/services/webhooks/billable_metrics/updated_service_spec.rb
+++ b/spec/services/webhooks/billable_metrics/updated_service_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::BillableMetrics::UpdatedService do
+  subject(:webhook_service) { described_class.new(object: billable_metric) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "billable_metric.updated", "billable_metric", {
+      "lago_id" => String,
+      "name" => String,
+      "code" => String,
+      "aggregation_type" => String,
+      "recurring" => false,
+      "filters" => Array
+    }
+  end
+end


### PR DESCRIPTION
Emit webhook events when a billable metric is created, updated or deleted, reaching parity with plans and features.

- New Webhooks::BillableMetrics::{Created,Updated,Deleted}Service reusing V1::BillableMetricSerializer.
- BillableMetrics::CreateService / UpdateService / DestroyService now fire SendWebhookJob.perform_after_commit with the matching event.
- Register the three event types in WEBHOOK_SERVICES and in the webhook_event_types.yml config under a new 'Billable Metrics' category — which auto-flows into the GraphQL EventTypeEnum and EventCategoryEnum used by the frontend webhook subscription UI.
- schema.graphql / schema.json regenerated for the new enum values.
- Specs added for the three webhook services and for the routing in SendWebhookJob; CreateService / UpdateService / DestroyService specs now assert SendWebhookJob is enqueued.