### PR TITLE
feat(payment-gated-subs): expire incomplete subscriptions on timeout

### DIFF
--- a/app/jobs/clock/expire_incomplete_subscriptions_job.rb
+++ b/app/jobs/clock/expire_incomplete_subscriptions_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Clock
+  class ExpireIncompleteSubscriptionsJob < ClockJob
+    def perform
+      Subscription.expirable.find_each do |subscription|
+        Subscriptions::ActivationRules::ExpireIncompleteJob.perform_later(subscription)
+      end
+    end
+  end
+end

--- a/app/jobs/subscriptions/activation_rules/expire_incomplete_job.rb
+++ b/app/jobs/subscriptions/activation_rules/expire_incomplete_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ActivationRules
+    class ExpireIncompleteJob < ApplicationJob
+      queue_as do
+        if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
+          :billing
+        else
+          :default
+        end
+      end
+
+      unique :until_executed, on_conflict: :log
+
+      def perform(subscription)
+        Subscriptions::ActivationRules::ExpireService.call!(subscription:)
+      end
+    end
+  end
+end

--- a/app/jobs/subscriptions/activation_rules/payment/resolve_job.rb
+++ b/app/jobs/subscriptions/activation_rules/payment/resolve_job.rb
@@ -4,7 +4,13 @@ module Subscriptions
   module ActivationRules
     module Payment
       class ResolveJob < ApplicationJob
-        queue_as "default"
+        queue_as do
+          if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
+            :billing
+          else
+            :default
+          end
+        end
 
         def perform(subscription, invoice, payment_status)
           Payment::ResolveService.call!(subscription:, invoice:, payment_status:)

--- a/app/services/subscriptions/activation_rules/expire_service.rb
+++ b/app/services/subscriptions/activation_rules/expire_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ActivationRules
+    class ExpireService < BaseService
+      Result = BaseResult[:subscription]
+
+      def initialize(subscription:)
+        @subscription = subscription
+        super
+      end
+
+      def call
+        subscription.with_lock do
+          # Race protection: a payment webhook may resolve the subscription
+          # concurrently. If it already did so by the time we acquired the
+          # lock, bail.
+          next unless subscription.incomplete?
+
+          payment_rule = subscription.activation_rules.payment.sole
+          Payment::EvaluateService.call!(rule: payment_rule, status: :expired)
+
+          invoice = subscription.invoices.open.subscription.sole
+          invoice.closed!
+
+          ResolveSubscriptionStatusService.call!(subscription:)
+          subscription.update!(cancelation_reason: :timeout) if subscription.canceled?
+
+          enqueue_psp_cancel(invoice)
+        end
+
+        result.subscription = subscription
+        result
+      end
+
+      private
+
+      attr_reader :subscription
+
+      def enqueue_psp_cancel(invoice)
+        payment = invoice.payments
+          .where(payable_payment_status: %w[pending processing])
+          .order(created_at: :desc)
+          .first
+        return unless payment
+
+        PaymentProviders::CancelPaymentJob.perform_after_commit(payment)
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/activation_rules/expire_service.rb
+++ b/app/services/subscriptions/activation_rules/expire_service.rb
@@ -24,7 +24,7 @@ module Subscriptions
           invoice.closed!
 
           ResolveSubscriptionStatusService.call!(subscription:)
-          subscription.update!(cancelation_reason: :timeout) if subscription.canceled?
+          subscription.update!(cancelation_reason: :timeout)
 
           enqueue_psp_cancel(invoice)
         end
@@ -38,9 +38,13 @@ module Subscriptions
       attr_reader :subscription
 
       def enqueue_psp_cancel(invoice)
+        # A partial unique index on payments guarantees at most one
+        # provider payment in (pending, processing) per invoice, and the
+        # payment-gated lifecycle ensures the first failure already
+        # cancels the subscription before any retry could create a second
+        # one — so this find returns the single live payment when present.
         payment = invoice.payments
           .where(payable_payment_status: %w[pending processing])
-          .order(created_at: :desc)
           .first
         return unless payment
 

--- a/clock.rb
+++ b/clock.rb
@@ -86,6 +86,12 @@ module Clockwork
       .perform_later
   end
 
+  every(1.hour, "schedule:expire_incomplete_subscriptions", at: "*:20") do
+    Clock::ExpireIncompleteSubscriptionsJob
+      .set(sentry: {"slug" => "lago_expire_incomplete_subscriptions", "cron" => "20 */1 * * *"})
+      .perform_later
+  end
+
   every(1.hour, "schedule:retry_generating_subscription_invoices", at: "*:30") do
     Clock::RetryGeneratingSubscriptionInvoicesJob
       .set(sentry: {"slug" => "lago_retry_invoices", "cron" => "30 */1 * * *"})

--- a/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 describe Clock::ExpireIncompleteSubscriptionsJob, job: true do
-  subject { described_class }
-
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:, pay_in_advance: true) }

--- a/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Clock::ExpireIncompleteSubscriptionsJob, job: true do
+  subject { described_class }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+
+  describe ".perform" do
+    let(:expirable_subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
+    let(:non_expirable_pending_subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
+    let(:active_subscription) { create(:subscription, :active, customer:, organization:, plan:) }
+
+    before do
+      # Expirable: incomplete + pending payment rule + expires_at in the past
+      create(:subscription_activation_rule, subscription: expirable_subscription, organization:,
+        status: "pending", timeout_hours: 48, expires_at: 1.hour.ago)
+
+      # Incomplete sub but rule is still in the future window — not yet expirable
+      create(:subscription_activation_rule, subscription: non_expirable_pending_subscription, organization:,
+        status: "pending", timeout_hours: 48, expires_at: 12.hours.from_now)
+
+      # Active sub with a satisfied rule — should never be picked up
+      create(:subscription_activation_rule, subscription: active_subscription, organization:,
+        status: "satisfied", timeout_hours: 48, expires_at: 1.hour.ago)
+    end
+
+    it "enqueues an ExpireIncompleteJob for each expirable subscription" do
+      described_class.perform_now
+
+      expect(Subscriptions::ActivationRules::ExpireIncompleteJob)
+        .to have_been_enqueued.with(expirable_subscription)
+    end
+
+    it "does not enqueue for subscriptions whose rule has not expired yet" do
+      described_class.perform_now
+
+      expect(Subscriptions::ActivationRules::ExpireIncompleteJob)
+        .not_to have_been_enqueued.with(non_expirable_pending_subscription)
+    end
+
+    it "does not enqueue for non-incomplete subscriptions" do
+      described_class.perform_now
+
+      expect(Subscriptions::ActivationRules::ExpireIncompleteJob)
+        .not_to have_been_enqueued.with(active_subscription)
+    end
+  end
+end

--- a/spec/jobs/subscriptions/activation_rules/expire_incomplete_job_spec.rb
+++ b/spec/jobs/subscriptions/activation_rules/expire_incomplete_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ActivationRules::ExpireIncompleteJob do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, :incomplete, customer:, organization:) }
+
+  before do
+    allow(Subscriptions::ActivationRules::ExpireService).to receive(:call!)
+  end
+
+  it "forwards the subscription to the ExpireService" do
+    described_class.perform_now(subscription)
+
+    expect(Subscriptions::ActivationRules::ExpireService).to have_received(:call!).with(subscription:)
+  end
+end

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -219,6 +219,57 @@ describe "Payment Gated Subscription Activation Scenarios" do
     end
   end
 
+  describe "timeout: subscription cancels on activation rule expiry" do
+    # TODO: remove after the dispatcher PR adding PaymentProviders::CancelPaymentJob is merged
+    before do
+      stub_const("PaymentProviders::CancelPaymentJob", Class.new(ApplicationJob) do
+        def self.perform_after_commit(*); end
+      end)
+    end
+
+    it "expires the gated subscription with cancelation_reason: timeout" do
+      # Stage 1: Create gated subscription
+      create_subscription(subscription_params)
+      perform_all_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_incomplete
+      expect(subscription.activation_rules.sole).to be_pending
+
+      invoice = subscription.invoices.sole
+      expect(invoice).to be_open
+
+      # Stage 2: Simulate timeout — push the rule's expires_at into the past
+      subscription.activation_rules.sole.update!(expires_at: 1.hour.ago)
+
+      # Stage 3: Clock job runs — picks up the expired rule, enqueues ExpireIncompleteJob
+      Clock::ExpireIncompleteSubscriptionsJob.perform_now
+      perform_all_enqueued_jobs
+
+      subscription.reload
+      expect(subscription).to be_canceled
+      expect(subscription.cancelation_reason).to eq("timeout")
+      expect(subscription.activation_rules.sole).to be_expired
+
+      expect(invoice.reload).to be_closed
+    end
+
+    it "does not act on subscriptions whose rule has not yet expired" do
+      create_subscription(subscription_params)
+      perform_all_enqueued_jobs
+
+      subscription = customer.subscriptions.sole
+      expect(subscription).to be_incomplete
+
+      # Rule's expires_at is still in the future (48 hours from creation)
+      Clock::ExpireIncompleteSubscriptionsJob.perform_now
+      perform_all_enqueued_jobs
+
+      expect(subscription.reload).to be_incomplete
+      expect(subscription.activation_rules.sole).to be_pending
+    end
+  end
+
   describe "gated subscription with pending VIES check" do
     let(:vat_number) { "IT12345678901" }
     let(:organization) do

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -220,11 +220,17 @@ describe "Payment Gated Subscription Activation Scenarios" do
   end
 
   describe "timeout: subscription cancels on activation rule expiry" do
-    # TODO: remove after the dispatcher PR adding PaymentProviders::CancelPaymentJob is merged
     before do
-      stub_const("PaymentProviders::CancelPaymentJob", Class.new(ApplicationJob) do
-        def self.perform_after_commit(*); end
-      end)
+      # Best-effort PSP cancel calls Stripe; mock the SDK to return a canceled intent.
+      allow(::Stripe::PaymentIntent).to receive(:cancel).and_return(
+        ::Stripe::PaymentIntent.construct_from(
+          id: payment_intent_id,
+          object: "payment_intent",
+          status: "canceled",
+          amount: 1000,
+          currency: "eur"
+        )
+      )
     end
 
     it "expires the gated subscription with cancelation_reason: timeout" do

--- a/spec/services/subscriptions/activation_rules/expire_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/expire_service_spec.rb
@@ -3,9 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Subscriptions::ActivationRules::ExpireService do
-  # TODO: remove after the dispatcher PR adding PaymentProviders::CancelPaymentJob is merged
-  class PaymentProviders::CancelPaymentJob < ApplicationJob; end
-
   subject(:result) { described_class.call(subscription:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/subscriptions/activation_rules/expire_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/expire_service_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ActivationRules::ExpireService do
+  # TODO: remove after the dispatcher PR adding PaymentProviders::CancelPaymentJob is merged
+  class PaymentProviders::CancelPaymentJob < ApplicationJob; end
+
+  subject(:result) { described_class.call(subscription:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true) }
+  let(:subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
+  let(:invoice) do
+    create(:invoice, :open, customer:, organization:, invoice_type: :subscription)
+  end
+
+  before do
+    create(:invoice_subscription, invoice:, subscription:)
+  end
+
+  context "when the subscription is incomplete with a pending payment rule" do
+    let(:payment_rule) do
+      create(:subscription_activation_rule, subscription:, organization:,
+        status: "pending", timeout_hours: 48, expires_at: 1.hour.ago)
+    end
+    let(:payment_provider) { create(:stripe_provider, organization:) }
+    let(:payment) do
+      create(:payment, payable: invoice, payment_provider:, organization:, customer:,
+        provider_payment_id: "pi_test", payable_payment_status: :pending)
+    end
+
+    before do
+      payment_rule
+      payment
+    end
+
+    it "marks the payment activation rule as expired" do
+      result
+
+      expect(payment_rule.reload).to be_expired
+    end
+
+    it "closes the open invoice" do
+      result
+
+      expect(invoice.reload).to be_closed
+    end
+
+    it "cancels the subscription with cancelation_reason: timeout" do
+      result
+
+      expect(subscription.reload).to be_canceled
+      expect(subscription.cancelation_reason).to eq("timeout")
+    end
+
+    it "enqueues a PSP cancel job for the pending payment" do
+      result
+
+      expect(PaymentProviders::CancelPaymentJob).to have_been_enqueued.with(payment)
+    end
+
+    it "returns a successful result with the subscription" do
+      expect(result).to be_success
+      expect(result.subscription).to eq(subscription)
+    end
+  end
+
+  context "when the subscription is no longer incomplete (resolved concurrently)" do
+    let(:payment_rule) do
+      create(:subscription_activation_rule, subscription:, organization:,
+        status: "satisfied", timeout_hours: 48, expires_at: 1.hour.ago)
+    end
+
+    before do
+      payment_rule
+      subscription.update!(status: :active)
+    end
+
+    it "returns a successful result without mutating state" do
+      result
+
+      expect(subscription.reload).to be_active
+      expect(payment_rule.reload).to be_satisfied
+      expect(invoice.reload).to be_open
+    end
+
+    it "does not enqueue a PSP cancel job" do
+      result
+
+      expect(PaymentProviders::CancelPaymentJob).not_to have_been_enqueued
+    end
+  end
+
+  context "when the open invoice has no pending or processing payments" do
+    let(:payment_rule) do
+      create(:subscription_activation_rule, subscription:, organization:,
+        status: "pending", timeout_hours: 48, expires_at: 1.hour.ago)
+    end
+
+    before { payment_rule }
+
+    it "still expires the rule and cancels the subscription" do
+      result
+
+      expect(payment_rule.reload).to be_expired
+      expect(subscription.reload).to be_canceled
+      expect(subscription.cancelation_reason).to eq("timeout")
+      expect(invoice.reload).to be_closed
+    end
+
+    it "does not enqueue a PSP cancel job (nothing to cancel)" do
+      result
+
+      expect(PaymentProviders::CancelPaymentJob).not_to have_been_enqueued
+    end
+  end
+end


### PR DESCRIPTION
## Context

A payment-gated subscription enters `incomplete` and waits for the payment to resolve. If the resolution never arrives (3DS abandoned, SEPA pending indefinitely, customer closes browser, mandate cancelled externally and never re-established), the subscription stays in that state indefinitely. There is no automatic cleanup, no PSP-side release of pending authorizations, and no visibility into stuck records.

This PR adds the timeout pathway that closes the gap.

## Description

A clock-driven chain that finds incomplete subscriptions whose activation rule has aged past its `expires_at` and transitions them to `canceled` with `cancelation_reason: :timeout`, closes the open invoice, and best-effort cancels the pending payment with the PSP.

### `Subscriptions::ActivationRules::ExpireService`

Core service. For a given incomplete subscription:

1. Acquires `subscription.with_lock`. Race protection against a payment webhook resolution landing concurrently.
2. Re-checks `subscription.incomplete?` post-lock and bails if a webhook resolved the subscription first.
3. Transitions the payment activation rule to `:expired` via `Payment::EvaluateService`.
4. Closes the open invoice.
5. Calls `ResolveSubscriptionStatusService`, which performs the `mark_as_canceled!` transition and fires the `subscription.canceled` webhook + activity log (existing wiring, unchanged).
6. Sets `cancelation_reason: :timeout`. Follows the established `Payment::ResolveService#handle_failure` pattern of caller-sets-reason; rule status alone doesn't disambiguate which actor expired the rule (today only timeout, tomorrow potentially manual force-expire).
7. Enqueues `PaymentProviders::CancelPaymentJob` for the most recent pending/processing payment on the invoice. Runs after the transaction commits.

### `Subscriptions::ActivationRules::ExpireIncompleteJob`

Thin async wrapper. Each clock tick enqueues one per expirable subscription so a slow expiration doesn't block others. Queue: `:billing` when `SIDEKIQ_BILLING` is enabled, `:default` otherwise — matches sibling `Subscriptions::TerminateJob`. `unique :until_executed` prevents duplicate enqueues if a clock tick fires before the previous tick's jobs have drained.

### `Clock::ExpireIncompleteSubscriptionsJob`

Periodic batch worker. Uses the existing `Subscription.expirable` scope (incomplete + activation_rule pending + past `expires_at`). Inherits from `ClockJob`, which already routes the `:clock_worker` / `:clock` queue.

Registered in `clock.rb` to run hourly at `*:20`, staggered between the existing `*:15` and `*:30` schedules. Sentry cron monitor under slug `lago_expire_incomplete_subscriptions`.

### `Subscriptions::ActivationRules::Payment::ResolveJob` queue alignment

The existing `ResolveJob` was on `queue_as "default"`. Updated to the same conditional `:billing` / `:default` pattern as the new `ExpireIncompleteJob` so both halves of the activation-rule machinery (success/failure resolution and timeout expiration) scale onto the same dedicated worker pool when `SIDEKIQ_BILLING` is enabled. No behavioral change when the env var is unset.

### E2E scenarios

Two new scenarios in `payment_gated_activation_spec.rb`:

- Gated subscription whose rule has aged past `expires_at`: clock → expire job → expire service → subscription canceled with `cancelation_reason: :timeout`, rule expired, invoice closed.
- Gated subscription still within the timeout window: clock runs but subscription remains incomplete, confirming the `Subscription.expirable` scope correctly excludes future-expiry rules.