### PR TITLE
fix(invoice-preview): Include full credit note amount_cents when upgrading subscription

### DIFF
--- a/app/services/invoices/preview/credits_service.rb
+++ b/app/services/invoices/preview/credits_service.rb
@@ -54,6 +54,7 @@ module Invoices
         CreditNotes::CreateFromTermination.call!(
           subscription: terminated_subscription,
           reason: "order_cancellation",
+          upgrade: terminated_subscription.upgraded?,
           context: :preview
         ).credit_note
       end

--- a/spec/services/invoices/preview/credits_service_spec.rb
+++ b/spec/services/invoices/preview/credits_service_spec.rb
@@ -92,6 +92,15 @@ RSpec.describe Invoices::Preview::CreditsService do
       context "when subscription is being upgraded to a pricier plan" do
         let(:pay_in_advance) { true }
         let(:upgrade_plan) { create(:plan, organization:, pay_in_advance: true, amount_cents: 20_000) }
+        let(:expected_credits_from_subscription) do
+          # 14 days × (10_000 / 28) = 5000 cents (with the upgrade boundary day).
+          [
+            hash_including(
+              amount_cents: 5_000,
+              amount_currency: "EUR"
+            )
+          ]
+        end
 
         before do
           terminated_subscription.next_subscriptions.build(
@@ -106,16 +115,6 @@ RSpec.describe Invoices::Preview::CreditsService do
             started_at: Time.current,
             created_at: Time.current
           )
-        end
-
-        let(:expected_credits_from_subscription) do
-          # 14 days × (10_000 / 28) = 5000 cents (with the upgrade boundary day).
-          [
-            hash_including(
-              amount_cents: 5_000,
-              amount_currency: "EUR"
-            )
-          ]
         end
 
         it "credits the upgrade boundary day in addition to the remaining days" do

--- a/spec/services/invoices/preview/credits_service_spec.rb
+++ b/spec/services/invoices/preview/credits_service_spec.rb
@@ -88,6 +88,41 @@ RSpec.describe Invoices::Preview::CreditsService do
           expect(credits).to match_array expected_credits_from_customer
         end
       end
+
+      context "when subscription is being upgraded to a pricier plan" do
+        let(:pay_in_advance) { true }
+        let(:upgrade_plan) { create(:plan, organization:, pay_in_advance: true, amount_cents: 20_000) }
+
+        before do
+          terminated_subscription.next_subscriptions.build(
+            organization:,
+            customer:,
+            plan: upgrade_plan,
+            external_id: terminated_subscription.external_id,
+            subscription_at: terminated_subscription.subscription_at,
+            billing_time: terminated_subscription.billing_time,
+            previous_subscription_id: terminated_subscription.id,
+            status: :active,
+            started_at: Time.current,
+            created_at: Time.current
+          )
+        end
+
+        let(:expected_credits_from_subscription) do
+          # 14 days × (10_000 / 28) = 5000 cents (with the upgrade boundary day).
+          [
+            hash_including(
+              amount_cents: 5_000,
+              amount_currency: "EUR"
+            )
+          ]
+        end
+
+        it "credits the upgrade boundary day in addition to the remaining days" do
+          expect(result).to be_success
+          expect(credits).to match_array expected_credits_from_customer + expected_credits_from_subscription
+        end
+      end
     end
 
     context "when terminated_subscription is missing" do


### PR DESCRIPTION
## Context
When previewing a plan upgrade for a pay_in_advance subscription, the synthesized termination credit note is short by exactly one day's worth of the old plan's price.

## Description
Added `upgrade` flag to `CreditNotes::CreateFromTermination` call to match the real terminate-on-upgrade path (PlanUpgradeService → TerminateService), which rolls `billed_from` back one day to account for the new subscription taking over on the same calendar day.