### PR TITLE
Fix(finalization): fix double invoice finalization

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -21,6 +21,7 @@ class SendWebhookJob < ApplicationJob
     "invoice.paid_credit_added" => Webhooks::Invoices::PaidCreditAddedService,
     "invoice.generated" => Webhooks::Invoices::GeneratedService,
     "invoice.drafted" => Webhooks::Invoices::DraftedService,
+    "invoice.ready_to_finalize" => Webhooks::Invoices::ReadyToFinalizeService,
     "invoice.voided" => Webhooks::Invoices::VoidedService,
     "invoice.payment_dispute_lost" => Webhooks::Invoices::PaymentDisputeLostService,
     "invoice.payment_status_updated" => Webhooks::Invoices::PaymentStatusUpdatedService,

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -50,6 +50,7 @@ module Clickhouse
       customer_updated: "customer.updated",
       customer_deleted: "customer.deleted",
       invoice_drafted: "invoice.drafted",
+      invoice_ready_to_finalize: "invoice.ready_to_finalize",
       invoice_failed: "invoice.failed",
       invoice_created: "invoice.created",
       invoice_one_off_created: "invoice.one_off_created",

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -28,6 +28,7 @@ module Invoices
           invoice.status = "failed" unless invoice.draft?
           invoice.save!
 
+          notify_ready_to_finalize
           return result
         end
 
@@ -70,6 +71,8 @@ module Invoices
           Integrations::Aggregator::Invoices::Hubspot::CreateJob.perform_later(invoice:) if invoice.should_sync_hubspot_invoice?
           Invoices::Payments::CreateService.call_async(invoice:)
           Utils::SegmentTrack.invoice_created(invoice)
+        elsif invoice.draft?
+          notify_ready_to_finalize
         end
 
         result
@@ -86,6 +89,12 @@ module Invoices
       private
 
       attr_accessor :invoice
+
+      def notify_ready_to_finalize
+        return unless invoice.draft?
+        SendWebhookJob.perform_later("invoice.ready_to_finalize", invoice)
+        Utils::ActivityLog.produce(invoice, "invoice.ready_to_finalize")
+      end
 
       def skip_payment_gating_for_zero_amount
         gated = invoice.subscriptions.find(&:payment_gated?)

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -10,7 +10,9 @@ module Invoices
     def call
       return result.not_found_failure!(resource: "invoice") if invoice.nil?
       return result.forbidden_failure! unless invoice.subscription?
+
       return result unless invoice.draft?
+      return result.forbidden_failure!(code: "cannot_finalize_with_pending_taxes") if invoice.tax_pending?
       drafted_issuing_date = invoice.issuing_date
 
       ActiveRecord::Base.transaction do

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -66,6 +66,7 @@ module Invoices
         if grace_period?
           SendWebhookJob.perform_after_commit("invoice.drafted", invoice)
           Utils::ActivityLog.produce_after_commit(invoice, "invoice.drafted")
+          notify_ready_to_finalize unless invoice.tax_pending?
         end
 
         return result
@@ -76,10 +77,7 @@ module Invoices
       elsif grace_period?
         SendWebhookJob.perform_after_commit("invoice.drafted", invoice)
         Utils::ActivityLog.produce_after_commit(invoice, "invoice.drafted")
-        unless invoice.tax_pending?
-          SendWebhookJob.perform_after_commit("invoice.ready_to_finalize", invoice)
-          Utils::ActivityLog.produce_after_commit(invoice, "invoice.ready_to_finalize")
-        end
+        notify_ready_to_finalize unless invoice.tax_pending?
       else
         unless invoice.closed? # we dont need to send the webhooks if the invoice was closed ( skip 0 invoice setting )
           SendWebhookJob.perform_after_commit("invoice.created", invoice)
@@ -201,6 +199,11 @@ module Invoices
       after_commit do
         DailyUsages::FillFromInvoiceJob.perform_later(invoice:, subscriptions:)
       end
+    end
+
+    def notify_ready_to_finalize
+      SendWebhookJob.perform_after_commit("invoice.ready_to_finalize", invoice)
+      Utils::ActivityLog.produce_after_commit(invoice, "invoice.ready_to_finalize")
     end
   end
 end

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -76,6 +76,10 @@ module Invoices
       elsif grace_period?
         SendWebhookJob.perform_after_commit("invoice.drafted", invoice)
         Utils::ActivityLog.produce_after_commit(invoice, "invoice.drafted")
+        unless invoice.tax_pending?
+          SendWebhookJob.perform_after_commit("invoice.ready_to_finalize", invoice)
+          Utils::ActivityLog.produce_after_commit(invoice, "invoice.ready_to_finalize")
+        end
       else
         unless invoice.closed? # we dont need to send the webhooks if the invoice was closed ( skip 0 invoice setting )
           SendWebhookJob.perform_after_commit("invoice.created", invoice)

--- a/app/services/webhooks/invoices/ready_to_finalize_service.rb
+++ b/app/services/webhooks/invoices/ready_to_finalize_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Invoices
+    class ReadyToFinalizeService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::InvoiceSerializer.new(
+          object,
+          root_name: "invoice",
+          includes: %i[customer subscriptions billing_periods fees credits applied_taxes error_details]
+        )
+      end
+
+      def webhook_type
+        "invoice.ready_to_finalize"
+      end
+
+      def object_type
+        "invoice"
+      end
+    end
+  end
+end

--- a/config/webhook_event_types.yml
+++ b/config/webhook_event_types.yml
@@ -138,6 +138,11 @@ invoice_drafted:
   description: A new draft invoice has been emitted
   category: Invoices
   deprecated: false
+invoice_ready_to_finalize:
+  name: invoice.ready_to_finalize
+  description: A draft invoice is ready to be finalized (taxes are resolved)
+  category: Invoices
+  deprecated: false
 invoice_voided:
   name: invoice.voided
   description: An invoice has been voided

--- a/schema.graphql
+++ b/schema.graphql
@@ -238,6 +238,11 @@ enum ActivityTypeEnum {
   invoice_payment_status_updated
 
   """
+  invoice.ready_to_finalize
+  """
+  invoice_ready_to_finalize
+
+  """
   invoice.regenerated
   """
   invoice_regenerated
@@ -5767,6 +5772,7 @@ enum EventTypeEnum {
   invoice_payment_failure
   invoice_payment_overdue
   invoice_payment_status_updated
+  invoice_ready_to_finalize
   invoice_resynced
   invoice_voided
   payment_provider_error

--- a/schema.json
+++ b/schema.json
@@ -559,6 +559,12 @@
               "deprecationReason": null
             },
             {
+              "name": "invoice_ready_to_finalize",
+              "description": "invoice.ready_to_finalize",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "invoice_failed",
               "description": "invoice.failed",
               "isDeprecated": false,
@@ -27945,6 +27951,12 @@
             },
             {
               "name": "invoice_drafted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_ready_to_finalize",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Types::ActivityLogs::ActivityTypeEnum do
         customer_updated
         customer_deleted
         invoice_drafted
+        invoice_ready_to_finalize
         invoice_failed
         invoice_one_off_created
         invoice_created

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -259,6 +259,12 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
         expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
       end
 
+      it "does not enqueue invoice.ready_to_finalize" do
+        expect do
+          pull_taxes_service.call
+        end.not_to have_enqueued_job(SendWebhookJob).with("invoice.ready_to_finalize", Invoice)
+      end
+
       it "enqueues GenerateDocumentsJob with email false" do
         expect do
           pull_taxes_service.call
@@ -395,6 +401,17 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
           end.not_to have_enqueued_job(SendWebhookJob).with("invoice.created", Invoice)
         end
 
+        it "enqueues a SendWebhookJob for invoice.ready_to_finalize" do
+          expect do
+            pull_taxes_service.call
+          end.to have_enqueued_job(SendWebhookJob).with("invoice.ready_to_finalize", Invoice)
+        end
+
+        it "produces an activity log for invoice.ready_to_finalize" do
+          pull_taxes_service.call
+          expect(Utils::ActivityLog).to have_produced("invoice.ready_to_finalize").with(invoice)
+        end
+
         it "does not create a payment" do
           allow(Invoices::Payments::CreateService).to receive(:call_async)
 
@@ -450,6 +467,12 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
         expect(invoice.error_details.tax_error.last.id).not_to eql(old_error_id)
         expect(invoice.error_details.tax_error.count).to be(1)
         expect(invoice.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
+      end
+
+      it "does not enqueue invoice.ready_to_finalize" do
+        expect do
+          pull_taxes_service.call
+        end.not_to have_enqueued_job(SendWebhookJob).with("invoice.ready_to_finalize", Invoice)
       end
 
       context "with api limit error" do
@@ -527,6 +550,17 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
             .to eq("action_script_failure")
           expect(invoice.error_details.tax_error.order(created_at: :asc).last.details["tax_error_message"])
             .to eq("Error starting integration 'netsuite-customer-create': {\n  \"name\": \"TRPCClientError\",\n  \"message\": \"fetch failed\"\n}")
+        end
+
+        it "enqueues a SendWebhookJob for invoice.ready_to_finalize" do
+          expect do
+            pull_taxes_service.call
+          end.to have_enqueued_job(SendWebhookJob).with("invoice.ready_to_finalize", Invoice)
+        end
+
+        it "produces an activity log for invoice.ready_to_finalize" do
+          pull_taxes_service.call
+          expect(Utils::ActivityLog).to have_produced("invoice.ready_to_finalize").with(invoice)
         end
       end
     end

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -346,6 +346,34 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService do
       end
     end
 
+    context "when invoice is a draft awaiting taxes" do
+      let(:invoice) do
+        create(
+          :invoice,
+          :draft,
+          :with_subscriptions,
+          organization:,
+          customer:,
+          subscriptions: [subscription],
+          currency: "EUR",
+          tax_status: :pending,
+          issuing_date: Time.zone.at(timestamp).to_date
+        )
+      end
+
+      it "returns a forbidden failure with cannot_finalize_with_pending_taxes code" do
+        result = finalize_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("cannot_finalize_with_pending_taxes")
+      end
+
+      it "does not change the invoice status" do
+        expect { finalize_service.call }.not_to change { invoice.reload.status }
+      end
+    end
+
     context "when invoice has invoice_generation_errors" do
       let(:backtrace) do
         [

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -292,6 +292,18 @@ RSpec.describe Invoices::SubscriptionService do
         expect(Utils::ActivityLog).to have_produced("invoice.drafted").after_commit.with(invoice)
       end
 
+      it "enqueues a SendWebhookJob for invoice.ready_to_finalize" do
+        expect do
+          invoice_service.call
+        end.to have_enqueued_job_after_commit(SendWebhookJob).with("invoice.ready_to_finalize", Invoice)
+      end
+
+      it "produces an activity log for invoice.ready_to_finalize" do
+        invoice = described_class.call(subscriptions:, timestamp: timestamp.to_i, invoicing_reason:).invoice
+
+        expect(Utils::ActivityLog).to have_produced("invoice.ready_to_finalize").after_commit.with(invoice)
+      end
+
       it "does not flag lifetime usage for refresh" do
         invoice_service.call
 
@@ -311,6 +323,39 @@ RSpec.describe Invoices::SubscriptionService do
           result = invoice_service.call
           expect(result).to be_success
           expect(result.invoice).to be_draft
+        end
+      end
+
+      context "when the invoice ends with pending taxes" do
+        let(:integration) { create(:anrok_integration, organization:) }
+        let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+
+        before { integration_customer }
+
+        it "creates a draft invoice with tax_status pending" do
+          result = invoice_service.call
+
+          expect(result).to be_success
+          expect(result.invoice).to be_draft
+          expect(result.invoice).to be_tax_pending
+        end
+
+        it "enqueues a SendWebhookJob for invoice.drafted" do
+          expect do
+            invoice_service.call
+          end.to have_enqueued_job_after_commit(SendWebhookJob).with("invoice.drafted", Invoice)
+        end
+
+        it "does not enqueue a SendWebhookJob for invoice.ready_to_finalize" do
+          expect do
+            invoice_service.call
+          end.not_to have_enqueued_job(SendWebhookJob).with("invoice.ready_to_finalize", Invoice)
+        end
+
+        it "does not produce an activity log for invoice.ready_to_finalize" do
+          invoice_service.call
+
+          expect(Utils::ActivityLog).not_to have_produced("invoice.ready_to_finalize")
         end
       end
     end

--- a/spec/services/webhooks/invoices/ready_to_finalize_service_spec.rb
+++ b/spec/services/webhooks/invoices/ready_to_finalize_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::Invoices::ReadyToFinalizeService do
+  subject(:webhook_service) { described_class.new(object: invoice) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+
+  before do
+    create_list(:fee, 1, invoice:)
+    create_list(:fee, 1, invoice:, presentation_breakdowns: [build(:presentation_breakdown)])
+    create_list(:credit, 2, invoice:)
+  end
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "invoice.ready_to_finalize", "invoice", {"fees" => Array, "credits" => Array}
+  end
+end


### PR DESCRIPTION
## Context

We have a case of race condition for pull_taxes_job:
drafted invoice schedules pull_taxes_and_apply_job
at the same time client schedules a finalization that refreshes invoice, moves invoices to pending schedules the job again

next, depending on the timing:
- if first taxes job gets back when draft invoice is refreshed, we're failing to delete applied taxes from the fees (because applied taxes were done in another thread), and fail to refresh draft invoice
- if the first job returns when invoice is already pending, it will progress the invoice status to finalized, but then second job will do the same - we result in double applied taxes and double progressed invoice number

## Description

- forbid to finalize invoice that is draft but pending taxes
- added a new webhook to identify that invoice is ready to be finalized
