### PR TITLE
ING-140 feat(invoices): Add filters to customer invoices

### DIFF
--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -10,6 +10,8 @@ module Resolvers
 
       description "Query invoices of a customer"
 
+      argument :billing_entity_ids, [ID], required: false
+      argument :currency, Types::CurrencyEnum, required: false
       argument :customer_id, type: ID, required: true
       argument :limit, Integer, required: false
       argument :page, Integer, required: false
@@ -18,14 +20,16 @@ module Resolvers
 
       type Types::Invoices::Object.collection_type, null: false
 
-      def resolve(customer_id: nil, status: nil, page: nil, limit: nil, search_term: nil)
+      def resolve(customer_id: nil, status: nil, page: nil, limit: nil, search_term: nil, currency: nil, billing_entity_ids: nil)
         result = InvoicesQuery.call(
           organization: current_organization,
           pagination: {page:, limit:},
           search_term:,
           filters: {
             customer_id:,
-            status:
+            status:,
+            currency:,
+            billing_entity_ids:
           }
         )
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -10075,7 +10075,7 @@ type Query {
   """
   Query invoices of a customer
   """
-  customerInvoices(customerId: ID!, limit: Int, page: Int, searchTerm: String, status: [InvoiceStatusTypeEnum!]): InvoiceCollection!
+  customerInvoices(billingEntityIds: [ID!], currency: CurrencyEnum, customerId: ID!, limit: Int, page: Int, searchTerm: String, status: [InvoiceStatusTypeEnum!]): InvoiceCollection!
 
   """
   Query the projected usage of the customer on the current billing period

--- a/schema.json
+++ b/schema.json
@@ -52155,6 +52155,38 @@
               "description": "Query invoices of a customer",
               "args": [
                 {
+                  "name": "billingEntityIds",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "customerId",
                   "description": null,
                   "type": {

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -78,6 +78,118 @@ RSpec.describe Resolvers::Customers::InvoicesResolver do
     end
   end
 
+  context "with filter on currency" do
+    let(:query) do
+      <<~GQL
+        query($customerId: ID!, $currency: CurrencyEnum) {
+          customerInvoices(customerId: $customerId, currency: $currency) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    let!(:usd_invoice) { create(:invoice, customer:, organization:, currency: "USD") }
+
+    it "returns only invoices matching the currency" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customerId: customer.id, currency: "USD"}
+      )
+
+      invoices_response = result["data"]["customerInvoices"]
+
+      expect(invoices_response["collection"].pluck("id")).to contain_exactly(usd_invoice.id)
+    end
+  end
+
+  context "with filter on billing_entity_ids" do
+    let(:query) do
+      <<~GQL
+        query($customerId: ID!, $billingEntityIds: [ID!]) {
+          customerInvoices(customerId: $customerId, billingEntityIds: $billingEntityIds) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    let(:other_billing_entity) { create(:billing_entity, organization:) }
+    let!(:other_be_invoice) { create(:invoice, customer:, organization:, billing_entity: other_billing_entity) }
+
+    it "returns only invoices for the specified billing entities" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customerId: customer.id, billingEntityIds: [other_billing_entity.id]}
+      )
+
+      invoices_response = result["data"]["customerInvoices"]
+
+      expect(invoices_response["collection"].pluck("id")).to contain_exactly(other_be_invoice.id)
+    end
+  end
+
+  context "with combined currency, billing_entity_ids, and status filters" do
+    let(:query) do
+      <<~GQL
+        query(
+          $customerId: ID!,
+          $currency: CurrencyEnum,
+          $billingEntityIds: [ID!],
+          $status: [InvoiceStatusTypeEnum!]
+        ) {
+          customerInvoices(
+            customerId: $customerId,
+            currency: $currency,
+            billingEntityIds: $billingEntityIds,
+            status: $status
+          ) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    let(:target_billing_entity) { create(:billing_entity, organization:) }
+    let!(:target_invoice) do
+      create(:invoice, customer:, organization:, currency: "USD", billing_entity: target_billing_entity)
+    end
+
+    before do
+      create(:invoice, customer:, organization:, currency: "EUR", billing_entity: target_billing_entity)
+      create(:invoice, customer:, organization:, currency: "USD")
+      create(:invoice, :draft, customer:, organization:, currency: "USD", billing_entity: target_billing_entity)
+    end
+
+    it "returns only invoices matching all filters" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {
+          customerId: customer.id,
+          currency: "USD",
+          billingEntityIds: [target_billing_entity.id],
+          status: ["finalized"]
+        }
+      )
+
+      invoices_response = result["data"]["customerInvoices"]
+
+      expect(invoices_response["collection"].pluck("id")).to contain_exactly(target_invoice.id)
+    end
+  end
+
   context "when not member of the organization" do
     it "returns an error" do
       result = execute_graphql(


### PR DESCRIPTION
The customer invoices listing in lago-front (`/customer/<id>/invoices`) needs to be filterable by currency and billing entity — the same UX already shipped on customer Credit Notes and customer Usage. The frontend hits the top-level `customerInvoices(customerId: ...)` GraphQL field, which is backed by `Resolvers::Customers::InvoicesResolver`. That resolver only accepted `customer_id`, `limit`, `page`, `search_term`, and `status` — no way to narrow by currency or billing entity from the customer-scoped path.

The underlying `InvoicesQuery` already supported both filters (`:currency` and `:billing_entity_ids` are in its `Filters`, and `with_currency` / `with_billing_entity_ids` helpers exist), and the org-wide `Resolvers::InvoicesResolver` already exposed them. The customer-scoped resolver was the only piece missing. This PR closes that gap so lago-front can drive the same filtering from the customer page that the org-wide listing already offers.

The change is mechanical: two new arguments on the resolver (`currency`, `billing_entity_ids`), and the `resolve` method now forwards them into the filters hash passed to `InvoicesQuery.call`. Both arguments are optional and default to `nil`, so existing callers that omit them see no behavior change. The generated `schema.graphql` and `schema.json` are regenerated to expose the two arguments on the `customerInvoices` field.

## Before and after

|  | Before | After |
| --- | --- | --- |
| `customerInvoices` accepts `currency` | No | Yes, optional (`CurrencyEnum`) |
| `customerInvoices` accepts `billingEntityIds` | No | Yes, optional (`[ID]`) |
| Underlying `InvoicesQuery` wiring | Already in place | Unchanged |
| Org-wide `invoices` resolver | Already exposed both filters | Unchanged |
| Behavior for callers omitting the new args | n/a | Identical to today |

## Test plan

- [ ] `bundle exec rspec spec/graphql/resolvers/customers/invoices_resolver_spec.rb`
- [ ] Manual via GraphiQL: `customerInvoices(customerId: "<id>", currency: "USD") { collection { id } }` returns only invoices in USD.
- [ ] Manual: `customerInvoices(customerId: "<id>", billingEntityIds: ["<be-id>"]) { collection { id } }` returns only invoices on the named billing entity.
- [ ] Manual: combine `currency`, `billingEntityIds`, and `status` in one query and verify the intersection.

Spec coverage adds three resolver-spec contexts mirroring the existing `status` filter pattern: one for `currency` alone (a USD invoice singled out from the default EUR set), one for `billing_entity_ids` alone (an invoice on a second billing entity singled out), and one combining `currency`, `billing_entity_ids`, and `status` — seeded with four invoices where exactly one matches all three filters and the other three each miss a single filter.

## Migration

None. Both arguments are optional and the existing `customerInvoices` callers are fully backward-compatible.