### PR TITLE
ING-107 fix(wallet credits): Calculate granted credits the same way we calculate paid credits

### DIFF
--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -133,7 +133,7 @@ module WalletTransactions
     def handle_granted_credits(wallet:, credits_amount:, reset_consumed_credits: false, voided_invoice_id: nil)
       return if credits_amount.zero?
 
-      wallet_credit = WalletCredit.new(wallet:, credit_amount: credits_amount, invoiceable: false)
+      wallet_credit = WalletCredit.new(wallet:, credit_amount: credits_amount)
       ActiveRecord::Base.transaction do
         wallet_transaction = WalletTransactions::CreateService.call!(
           wallet:,

--- a/spec/scenarios/wallets/topup_with_rounding_spec.rb
+++ b/spec/scenarios/wallets/topup_with_rounding_spec.rb
@@ -59,7 +59,7 @@ describe "Wallet Transaction with rounding", :premium do
     expect(wallet.balance_cents).to eq 1797
   end
 
-  it "does not apply rounding handling granted_credits" do
+  it "does apply rounding handling granted_credits" do
     wallet = create_wallet({
       external_customer_id: customer.external_id,
       rate_amount: "1",
@@ -79,13 +79,13 @@ describe "Wallet Transaction with rounding", :premium do
     expect(wt.status).to eq "settled"
     expect(wt.transaction_status).to eq "granted"
     expect(wt.invoice_requires_successful_payment).to be false
-    expect(wt.credit_amount).to eq(17.96999)
+    expect(wt.credit_amount).to eq(17.97)
     expect(wt.amount).to eq(17.97)
 
     perform_all_enqueued_jobs
 
     wallet.reload
-    expect(wallet.credits_balance).to eq 17.96999
+    expect(wallet.credits_balance).to eq 17.97
     expect(wallet.balance.to_d).to eq 17.97
   end
 end

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -423,5 +423,15 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
         expect(applied_sections.first.invoice_custom_section.code).to eq("section_code_1")
       end
     end
+
+    context "when granted credits should be calculated using amount and wallet rate" do
+      let(:granted_credits) { "10.34567" }
+      let(:rate_amount) { 1.375 }
+
+      it "creates wallet transaction with expected credit amount" do
+        expect(result.wallet_transactions.find(&:granted?).credit_amount).to eq(10.34909) # 14.23/1.375
+        expect(result.wallet_transactions.find(&:granted?).amount).to eq(14.23) # 10.34567*1.375
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

During a top-up, paid credits go through a lossy conversion: credits are turned into an amount (rounded to cents), then back into credits. This keeps the transaction credits as close as possible to `amount / rate` and limits the drift between the wallet balance and the credit balance.

Granted credits skipped this conversion and kept their arbitrary decimals as-is. A single granted transaction could drift by -0.00342 credits, roughly 342x larger than the typical paid-credit drift (~0.00001).

## Description

`WalletCredit` already applies the round-trip conversion when `invoiceable` is true, which is its default. `handle_granted_credits` was building the credit with `invoiceable: false`, which bypassed it. Dropping that argument makes granted credits use the same conversion as paid credits.

The change is non-breaking. Only new granted transactions are affected, and existing transactions are left unchanged.

## Test plan

- The `topup_with_rounding_spec` scenario was updated to assert that granted credits now round to `17.97` (and `credits_balance` to `17.97`) instead of `17.96999`.
- A `create_from_params_service` spec was added for a granted top-up of `10.34567` credits at rate `1.375`, asserting the stored credit amount is `10.34909` and the amount is `14.23`.
