### PR TITLE
ING-142 feat(wallets): Add billingEntityId field

### DIFF
--- a/app/graphql/types/wallets/object.rb
+++ b/app/graphql/types/wallets/object.rb
@@ -8,6 +8,7 @@ module Types
 
       field :id, ID, null: false
 
+      field :billing_entity_id, ID, null: true
       field :customer, Types::Customers::Object
 
       field :code, String, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -13385,6 +13385,7 @@ type Wallet {
   activityLogs: [ActivityLog!]
   appliesTo: WalletAppliesTo
   balanceCents: BigInt!
+  billingEntityId: ID
   code: String
   consumedAmountCents: BigInt!
   consumedCredits: Float!

--- a/schema.json
+++ b/schema.json
@@ -71294,6 +71294,18 @@
               "deprecationReason": null
             },
             {
+              "name": "billingEntityId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "code",
               "description": null,
               "args": [],

--- a/spec/graphql/resolvers/wallet_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_resolver_spec.rb
@@ -97,4 +97,48 @@ RSpec.describe Resolvers::WalletResolver do
       expect_graphql_error(result:, message: "Resource not found")
     end
   end
+
+  context "with billing_entity_id field" do
+    let(:query) do
+      <<~GQL
+        query($id: ID!) {
+          wallet(id: $id) {
+            id
+            billingEntityId
+          }
+        }
+      GQL
+    end
+
+    context "when the wallet is bound to a billing entity" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:wallet) { create(:wallet, customer:, billing_entity:) }
+
+      it "returns the billing_entity_id" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          query:,
+          variables: {id: wallet.id}
+        )
+
+        expect(result["data"]["wallet"]["billingEntityId"]).to eq(billing_entity.id)
+      end
+    end
+
+    context "when the wallet has no billing entity (legacy row)" do
+      let(:wallet) { create(:wallet, customer:, billing_entity: nil) }
+
+      it "returns null" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          query:,
+          variables: {id: wallet.id}
+        )
+
+        expect(result["data"]["wallet"]["billingEntityId"]).to be_nil
+      end
+    end
+  end
 end

--- a/spec/graphql/types/wallets/object_spec.rb
+++ b/spec/graphql/types/wallets/object_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Wallets::Object do
   subject { described_class }
 
   it do
+    expect(subject).to have_field(:billing_entity_id).of_type("ID")
     expect(subject).to have_field(:customer).of_type("Customer")
 
     expect(subject).to have_field(:code).of_type("String")


### PR DESCRIPTION
The write side of multi-entity billing for wallets is already in place — ING-82 added `billingEntityId` to `CreateCustomerWalletInput` and ING-42 persists it on `wallets.billing_entity_id`. But the read side was missing: the Wallet GraphQL output type (`Types::Wallets::Object`) didn't expose the stored ID anywhere, so every wallet / wallets query came back without it. The frontend had no choice but to fall back to the customer's default billing entity for display, and operators couldn't tell which entity a wallet was actually bound to.

This PR adds the missing read path with a single new field on `Types::Wallets::Object`:

```ruby
field :billing_entity_id, ID, null: true
```

The default GraphQL resolver reads the column attribute directly. The field is nullable because `wallets.billing_entity_id` is nullable on legacy rows (created before the multi-entity billing work shipped). When the column is null, the frontend gets `null` back and can decide whether to render the customer's default; when it's set, the frontend sees exactly which entity the wallet is bound to.

## Before and after

|  | Before | After |
| --- | --- | --- |
| Read `billingEntityId` from a wallet via GraphQL | Not possible | `wallet(id: "...") { billingEntityId }` |
| Distinguish "wallet has its own entity" from "wallet uses customer's" | Not possible at the API level | `null` vs. UUID |
| Other Wallet fields | — | Unchanged |

## Test plan

- [ ] `bundle exec rspec spec/graphql/types/wallets/object_spec.rb` — type-spec assertion that the field exists with shape `ID`
- [ ] `bundle exec rspec spec/graphql/resolvers/wallet_resolver_spec.rb` — two scenarios: a wallet bound to a billing entity returns that UUID; a legacy wallet with `nil` returns null
- [ ] Manual via GraphiQL: create a wallet under a non-default billing entity and confirm `wallet(id: "...") { billingEntityId }` returns it.

## Migration

None. The new field is read-only and nullable. Existing GraphQL clients that don't query `billingEntityId` see no change in their responses; the only new behavior is that clients can now request it.

## Out of scope

- Exposing the full `BillingEntity` object on Wallet (would require a different shape — `billingEntity: BillingEntity` plus a custom resolver to bypass the Wallet model's `customer.billing_entity` fallback). Frontend only needs the ID for this round.
- `UpdateCustomerWalletInput.billingEntityId` (tracked separately under ING-84, currently in QA).
- Adding `billingEntityIds` as a filter argument on the `wallets` resolver (separate ticket under the F12 milestone).
