### PR TITLE
[ING-62] feat(multi-billing-entity): resolve invoice billing entity across the codebase

### DIFF
--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -133,7 +133,8 @@ module Invoices
         invoice_type: :advance_charges,
         currency:,
         datetime: billing_at, # this is an int we need to convert it
-        skip_charges: true
+        skip_charges: true,
+        billing_entity: initial_subscriptions.first&.billing_entity || customer.billing_entity
       ) do |invoice|
         Invoices::CreateAdvanceChargesInvoiceSubscriptionService.call!(
           invoice:,

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -82,7 +82,6 @@ module Invoices
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
         customer:,
-        billing_entity: subscription.billing_entity,
         invoice_type: :subscription,
         currency: subscription.plan_amount_currency,
         datetime: Time.zone.at(timestamp),

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -87,7 +87,8 @@ module Invoices
         currency: subscription.plan_amount_currency,
         datetime: Time.zone.at(timestamp),
         charge_in_advance: true,
-        invoice_id: result.invoice_id
+        invoice_id: result.invoice_id,
+        billing_entity: subscription.billing_entity || customer.billing_entity
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions: [subscription], timestamp:, invoicing_reason: :in_advance_charge)
@@ -113,7 +114,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && customer.billing_entity.email_settings.include?("invoice.finalized")
+      License.premium? && invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def should_create_applied_prepaid_credit?

--- a/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
+++ b/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
@@ -133,7 +133,8 @@ module Invoices
         invoice_type: :subscription,
         currency: subscription.plan_amount_currency,
         datetime: Time.zone.at(timestamp),
-        charge_in_advance: true
+        charge_in_advance: true,
+        billing_entity: subscription.billing_entity || customer.billing_entity
       ) do |inv|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice: inv, subscriptions: [subscription], timestamp:, invoicing_reason: :in_advance_charge)
@@ -154,7 +155,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && customer.billing_entity.email_settings.include?("invoice.finalized")
+      License.premium? && invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def wallets

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -66,7 +66,8 @@ module Invoices
         customer:,
         invoice_type: :credit,
         currency:,
-        datetime: Time.zone.at(timestamp)
+        datetime: Time.zone.at(timestamp),
+        billing_entity: wallet_transaction.wallet.billing_entity || customer.billing_entity
       )
       invoice_result.raise_if_error!
 
@@ -99,7 +100,7 @@ module Invoices
 
     def should_deliver_email?
       License.premium? &&
-        customer.billing_entity.email_settings.include?("invoice.finalized")
+        invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
   end
 end

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -78,7 +78,8 @@ module Invoices
         customer: subscription.customer,
         invoice_type: :progressive_billing,
         currency: subscription.plan.amount_currency,
-        datetime: Time.zone.at(timestamp)
+        datetime: Time.zone.at(timestamp),
+        billing_entity: subscription.billing_entity || subscription.customer.billing_entity
       ) do |invoice|
         CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions: [subscription], timestamp:, invoicing_reason: :progressive_billing)
@@ -145,7 +146,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && subscription.billing_entity.email_settings.include?("invoice.finalized")
+      License.premium? && invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def create_credit_note_credit

--- a/app/services/invoices/regenerate_from_voided_service.rb
+++ b/app/services/invoices/regenerate_from_voided_service.rb
@@ -266,7 +266,8 @@ module Invoices
         customer: voided_invoice.customer,
         invoice_type: voided_invoice.invoice_type,
         currency: voided_invoice.currency,
-        datetime: voided_invoice.created_at
+        datetime: voided_invoice.created_at,
+        billing_entity: voided_invoice.billing_entity
       ).invoice.tap do |invoice|
         invoice.update!(voided_invoice_id: voided_invoice.id)
       end
@@ -285,7 +286,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && customer.billing_entity.email_settings.include?("invoice.finalized")
+      License.premium? && regenerated_invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
   end
 end

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -152,7 +152,8 @@ module Invoices
         invoicing_reason:,
         currency:,
         datetime: Time.zone.at(timestamp),
-        skip_charges:
+        skip_charges:,
+        billing_entity: subscriptions.first&.billing_entity || customer.billing_entity
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions:, timestamp:, invoicing_reason:)
@@ -186,7 +187,7 @@ module Invoices
 
     def should_deliver_finalized_email?
       License.premium? &&
-        customer.billing_entity.email_settings.include?("invoice.finalized")
+        invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def flag_lifetime_usage_for_refresh

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -152,8 +152,7 @@ module Invoices
         invoicing_reason:,
         currency:,
         datetime: Time.zone.at(timestamp),
-        skip_charges:,
-        billing_entity: subscriptions.first&.billing_entity || customer.billing_entity
+        skip_charges:
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions:, timestamp:, invoicing_reason:)

--- a/app/services/invoices/transition_to_final_status_service.rb
+++ b/app/services/invoices/transition_to_final_status_service.rb
@@ -5,7 +5,7 @@ module Invoices
     def initialize(invoice:)
       @invoice = invoice
       @customer = @invoice.customer
-      @billing_entity = @customer.billing_entity
+      @billing_entity = @invoice.billing_entity
       super
     end
 

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -125,6 +125,26 @@ RSpec.describe Invoices::AdvanceChargesService do
             }
           )
       end
+
+      context "billing_entity resolution" do
+        it "stamps the customer's billing_entity when subscription has none" do
+          invoice = invoice_service.call.invoice
+
+          expect(invoice.billing_entity).to eq(customer.billing_entity)
+        end
+
+        context "when subscription has its own billing_entity" do
+          let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+          before { subscription.update!(billing_entity: other_billing_entity) }
+
+          it "stamps the subscription's billing_entity on the invoice" do
+            invoice = invoice_service.call.invoice
+
+            expect(invoice.billing_entity).to eq(other_billing_entity)
+          end
+        end
+      end
     end
 
     context "without any standalone fees" do

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Invoices::AdvanceChargesService do
           )
       end
 
-      context "billing_entity resolution" do
+      context "with billing entity resolution" do
         it "stamps the customer's billing_entity when subscription has none" do
           invoice = invoice_service.call.invoice
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -119,6 +119,26 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService do
       expect { invoice_service.call.invoice }.to change(InvoiceSubscription, :count).by(1)
     end
 
+    context "billing_entity resolution" do
+      it "stamps the customer's billing_entity when subscription has none" do
+        invoice = invoice_service.call.invoice
+
+        expect(invoice.billing_entity).to eq(customer.billing_entity)
+      end
+
+      context "when subscription has its own billing_entity" do
+        let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+        before { subscription.update!(billing_entity: other_billing_entity) }
+
+        it "stamps the subscription's billing_entity on the invoice" do
+          invoice = invoice_service.call.invoice
+
+          expect(invoice.billing_entity).to eq(other_billing_entity)
+        end
+      end
+    end
+
     it "calls SegmentTrackJob" do
       invoice = invoice_service.call.invoice
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService do
       expect { invoice_service.call.invoice }.to change(InvoiceSubscription, :count).by(1)
     end
 
-    context "billing_entity resolution" do
+    context "with billing entity resolution" do
       it "stamps the customer's billing_entity when subscription has none" do
         invoice = invoice_service.call.invoice
 

--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
       expect { invoice_service.call }.to change(InvoiceSubscription, :count).by(1)
     end
 
-    context "billing_entity resolution" do
+    context "with billing entity resolution" do
       it "stamps the customer's billing_entity when subscription has none" do
         invoice = invoice_service.call.invoice
 

--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
       expect { invoice_service.call }.to change(InvoiceSubscription, :count).by(1)
     end
 
+    context "billing_entity resolution" do
+      it "stamps the customer's billing_entity when subscription has none" do
+        invoice = invoice_service.call.invoice
+
+        expect(invoice.billing_entity).to eq(customer.billing_entity)
+      end
+
+      context "when subscription has its own billing_entity" do
+        let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+        before { subscription.update!(billing_entity: other_billing_entity) }
+
+        it "stamps the subscription's billing_entity on the invoice" do
+          invoice = invoice_service.call.invoice
+
+          expect(invoice.billing_entity).to eq(other_billing_entity)
+        end
+      end
+    end
+
     it "calls SegmentTrackJob" do
       invoice = invoice_service.call.invoice
 

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Invoices::PaidCreditService do
         .to change(wallet_transaction, :invoice).from(nil).to(Invoice)
     end
 
-    context "billing_entity resolution" do
+    context "with billing entity resolution" do
       it "stamps the customer's billing_entity when wallet has none" do
         invoice = invoice_service.call.invoice
 

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -56,6 +56,26 @@ RSpec.describe Invoices::PaidCreditService do
         .to change(wallet_transaction, :invoice).from(nil).to(Invoice)
     end
 
+    context "billing_entity resolution" do
+      it "stamps the customer's billing_entity when wallet has none" do
+        invoice = invoice_service.call.invoice
+
+        expect(invoice.billing_entity).to eq(customer.billing_entity)
+      end
+
+      context "when wallet has its own billing_entity" do
+        let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+        before { wallet.update!(billing_entity: other_billing_entity) }
+
+        it "stamps the wallet's billing_entity on the invoice" do
+          invoice = invoice_service.call.invoice
+
+          expect(invoice.billing_entity).to eq(other_billing_entity)
+        end
+      end
+    end
+
     it "enqueues a SendWebhookJob" do
       expect do
         invoice_service.call

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Invoices::ProgressiveBillingService, transaction: false do
       expect(result2).not_to be_success
     end
 
-    context "billing_entity resolution" do
+    context "with billing entity resolution" do
       it "stamps the customer's billing_entity when subscription has none" do
         invoice = create_service.call.invoice
 

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -76,6 +76,26 @@ RSpec.describe Invoices::ProgressiveBillingService, transaction: false do
       expect(result2).not_to be_success
     end
 
+    context "billing_entity resolution" do
+      it "stamps the customer's billing_entity when subscription has none" do
+        invoice = create_service.call.invoice
+
+        expect(invoice.billing_entity).to eq(customer.billing_entity)
+      end
+
+      context "when subscription has its own billing_entity" do
+        let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+        before { subscription.update!(billing_entity: other_billing_entity) }
+
+        it "stamps the subscription's billing_entity on the invoice" do
+          invoice = create_service.call.invoice
+
+          expect(invoice.billing_entity).to eq(other_billing_entity)
+        end
+      end
+    end
+
     context "when there is tax provider integration" do
       let(:integration) { create(:anrok_integration, organization:) }
       let(:integration_customer) { create(:anrok_customer, integration:, customer:) }

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -60,7 +60,7 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
       expect(regenerated_fee.amount_cents).to eq 10 * 5050
     end
 
-    context "billing_entity resolution" do
+    context "with billing entity resolution" do
       it "carries the voided invoice's billing_entity to the regenerated invoice" do
         other_billing_entity = create(:billing_entity, organization:)
         voided_invoice.update!(billing_entity: other_billing_entity)

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -60,6 +60,15 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
       expect(regenerated_fee.amount_cents).to eq 10 * 5050
     end
 
+    context "billing_entity resolution" do
+      it "carries the voided invoice's billing_entity to the regenerated invoice" do
+        other_billing_entity = create(:billing_entity, organization:)
+        voided_invoice.update!(billing_entity: other_billing_entity)
+
+        expect(regenerate_result.invoice.billing_entity).to eq(other_billing_entity)
+      end
+    end
+
     context "when voided fee has pay_in_advance_event_transaction_id" do
       before do
         original_fee.update!(pay_in_advance_event_transaction_id: "txn_123", pay_in_advance: true)

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Invoices::SubscriptionService do
       expect(Utils::ActivityLog).to have_produced("invoice.created").after_commit.with(invoice)
     end
 
-    context "billing_entity resolution" do
+    context "with billingentity resolution" do
       it "stamps the customer's billing_entity when subscription has none" do
         invoice = invoice_service.call.invoice
 

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -260,6 +260,26 @@ RSpec.describe Invoices::SubscriptionService do
       expect(Utils::ActivityLog).to have_produced("invoice.created").after_commit.with(invoice)
     end
 
+    context "billing_entity resolution" do
+      it "stamps the customer's billing_entity when subscription has none" do
+        invoice = invoice_service.call.invoice
+
+        expect(invoice.billing_entity).to eq(customer.billing_entity)
+      end
+
+      context "when subscription has its own billing_entity" do
+        let(:other_billing_entity) { create(:billing_entity, organization:) }
+
+        before { subscription.update!(billing_entity: other_billing_entity) }
+
+        it "stamps the subscription's billing_entity on the invoice" do
+          invoice = invoice_service.call.invoice
+
+          expect(invoice.billing_entity).to eq(other_billing_entity)
+        end
+      end
+    end
+
     it "enqueues GenerateDocumentsJob with email false" do
       expect do
         invoice_service.call

--- a/spec/services/invoices/transition_to_final_status_service_spec.rb
+++ b/spec/services/invoices/transition_to_final_status_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Invoices::TransitionToFinalStatusService do
     create(
       :invoice,
       organization:,
+      billing_entity:,
       currency: "EUR",
       fees_amount_cents:,
       issuing_date: Time.zone.now.beginning_of_month,


### PR DESCRIPTION
## Context

Currently, one customer can be assigned to only one billing entity. With `multi-billing-entities` feature, it will be possible to assign any billing entity to customer's billing object, like subscription or wallet.

## Description

This PR resolve all occurrences of `customer.billing_entity` when creating an invoice. With the new behaviour, invoice needs to write billing entity from subscription or wallet that is relevant for such an invoice. Customer's billing entity serves as a fallback.
