### PR TITLE
feat(presentation_group_keys): Fix validation of presentation group keys duplicated values

### DIFF
--- a/app/services/charges/validators/base_service.rb
+++ b/app/services/charges/validators/base_service.rb
@@ -59,6 +59,7 @@ module Charges
         raw_keys = properties["presentation_group_keys"]
         return if raw_keys.blank?
 
+        values = []
         valid_presentation_group_keys = raw_keys.is_a?(Array) && raw_keys.all? do |key|
           next false unless key.is_a?(Hash)
 
@@ -80,6 +81,8 @@ module Charges
             end
           end
 
+          values << key[:value] if value_valid
+
           keys_valid && value_key_present && value_valid && options_key_valid
         end
 
@@ -92,6 +95,10 @@ module Charges
 
         if raw_keys.size > 2
           add_error(field: "presentation_group_keys", error_code: "too_many_keys")
+        end
+
+        if values.size != values.uniq.size
+          add_error(field: "presentation_group_keys", error_code: "value_is_duplicated")
         end
       end
     end

--- a/spec/support/shared_examples/charges/presentation_group_keys_validation.rb
+++ b/spec/support/shared_examples/charges/presentation_group_keys_validation.rb
@@ -30,6 +30,17 @@ RSpec.shared_examples "presentation_group_keys property validation" do
     end
   end
 
+  context "when presentation_group_keys has duplicated values" do
+    let(:presentation_group_keys) { [{"value" => "country"}, {"value" => "country"}] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:presentation_group_keys)
+      expect(validation_service.result.error.messages[:presentation_group_keys]).to include("value_is_duplicated")
+    end
+  end
+
   context "when presentation_group_keys has options" do
     let(:presentation_group_keys) do
       [


### PR DESCRIPTION
This commit changes the validation of presentation group keys to avoid duplicated keys

The changes are quite simple, we're identifying when a value in presentation_group_keys
is duplicated and for this case we're returning a error `value_is_duplicated`.