### PR TITLE
fix(payments): Use provider-reported amount in webhook-built Payments

### DIFF
--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -14,9 +14,9 @@ module Invoices
         super
       end
 
-      def update_payment_status(provider_payment_id:, status:, metadata: {})
+      def update_payment_status(provider_payment_id:, status:, amount_cents: nil, metadata: {})
         payment = if metadata[:payment_type] == "one-time"
-          create_payment(provider_payment_id:, metadata:)
+          create_payment(provider_payment_id:, amount_cents:, metadata:)
         else
           Payment.find_by(provider_payment_id:)
         end
@@ -67,7 +67,7 @@ module Invoices
 
       delegate :organization, :customer, to: :invoice
 
-      def create_payment(provider_payment_id:, metadata:)
+      def create_payment(provider_payment_id:, metadata:, amount_cents: nil)
         @invoice = Invoice.find(metadata[:lago_invoice_id])
 
         increment_payment_attempts
@@ -78,7 +78,7 @@ module Invoices
           customer:,
           payment_provider_id: adyen_payment_provider.id,
           payment_provider_customer_id: customer.adyen_customer.id,
-          amount_cents: invoice.total_due_amount_cents,
+          amount_cents: amount_cents || invoice.total_due_amount_cents,
           amount_currency: invoice.currency.upcase,
           provider_payment_id:
         )

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -13,9 +13,9 @@ module Invoices
         super
       end
 
-      def update_payment_status(organization_id:, status:, cashfree_payment:)
+      def update_payment_status(organization_id:, status:, cashfree_payment:, amount_cents: nil)
         payment = if cashfree_payment.metadata[:payment_type] == "one-time"
-          create_payment(cashfree_payment)
+          create_payment(cashfree_payment, amount_cents:)
         else
           Payment.find_by(provider_payment_id: cashfree_payment.id)
         end
@@ -57,7 +57,7 @@ module Invoices
 
       delegate :organization, :customer, to: :invoice
 
-      def create_payment(cashfree_payment)
+      def create_payment(cashfree_payment, amount_cents: nil)
         @invoice = Invoice.find_by(id: cashfree_payment.metadata[:lago_invoice_id])
 
         increment_payment_attempts
@@ -68,7 +68,7 @@ module Invoices
           customer:,
           payment_provider_id: cashfree_payment_provider.id,
           payment_provider_customer_id: customer.cashfree_customer.id,
-          amount_cents: @invoice.total_due_amount_cents,
+          amount_cents: amount_cents || @invoice.total_due_amount_cents,
           amount_currency: @invoice.currency,
           provider_payment_id: cashfree_payment.id
         )

--- a/app/services/invoices/payments/flutterwave_service.rb
+++ b/app/services/invoices/payments/flutterwave_service.rb
@@ -13,9 +13,9 @@ module Invoices
         super
       end
 
-      def update_payment_status(organization_id:, status:, flutterwave_payment:)
+      def update_payment_status(organization_id:, status:, flutterwave_payment:, amount_cents: nil)
         payment = if flutterwave_payment.metadata[:payment_type] == "one-time"
-          create_payment(flutterwave_payment)
+          create_payment(flutterwave_payment, amount_cents:)
         else
           Payment.find_by(provider_payment_id: flutterwave_payment.id)
         end
@@ -129,7 +129,7 @@ module Invoices
         @http_client ||= LagoHttpClient::Client.new("#{flutterwave_payment_provider.api_url}/payments")
       end
 
-      def create_payment(flutterwave_payment)
+      def create_payment(flutterwave_payment, amount_cents: nil)
         @invoice = Invoice.find_by(id: flutterwave_payment.metadata[:lago_invoice_id])
 
         increment_payment_attempts
@@ -140,7 +140,7 @@ module Invoices
           customer:,
           payment_provider_id: flutterwave_payment_provider.id,
           payment_provider_customer_id: customer.flutterwave_customer.id,
-          amount_cents: @invoice.total_due_amount_cents,
+          amount_cents: amount_cents || @invoice.total_due_amount_cents,
           amount_currency: @invoice.currency,
           provider_payment_id: flutterwave_payment.id
         )

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -11,12 +11,12 @@ module Invoices
         super(nil)
       end
 
-      def update_payment_status(organization_id:, provider_payment_id:, status:, metadata: {})
+      def update_payment_status(organization_id:, provider_payment_id:, status:, amount_cents: nil, metadata: {})
         payment_obj = Payment.find_or_initialize_by(provider_payment_id: provider_payment_id)
         payment = if payment_obj.persisted?
           payment_obj
         else
-          create_payment(provider_payment_id:, metadata:)
+          create_payment(provider_payment_id:, amount_cents:, metadata:)
         end
 
         return handle_missing_payment(organization_id, metadata) unless payment
@@ -94,20 +94,22 @@ module Invoices
         invoice.update!(payment_attempts: invoice.payment_attempts + 1)
       end
 
-      def create_payment(provider_payment_id:, metadata:)
+      def create_payment(provider_payment_id:, metadata:, amount_cents: nil)
         @invoice ||= Invoice.find_by(id: metadata["lago_payable_id"])
         unless @invoice
           result.not_found_failure!(resource: "invoice")
           return
         end
+
         increment_payment_attempts
+
         Payment.new(
           organization_id: @invoice.organization_id,
           payable: invoice,
           customer:,
           payment_provider_id: moneyhash_payment_provider.id,
           payment_provider_customer_id: customer.moneyhash_customer.id,
-          amount_cents: invoice.total_amount_cents,
+          amount_cents: amount_cents || invoice.total_amount_cents,
           amount_currency: invoice.currency&.upcase,
           provider_payment_id:
         )

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -13,12 +13,12 @@ module Invoices
         super
       end
 
-      def update_payment_status(organization_id:, status:, stripe_payment:)
+      def update_payment_status(organization_id:, status:, stripe_payment:, amount_cents: nil)
         payment = Payment.find_by(provider_payment_id: stripe_payment.id)
         return result if payment&.payable&.organization_id.present? && payment.payable.organization_id != organization_id
 
         if !payment && stripe_payment.metadata[:payment_type] == "one-time"
-          payment = create_payment(stripe_payment)
+          payment = create_payment(stripe_payment, amount_cents:)
         end
 
         unless payment
@@ -82,7 +82,7 @@ module Invoices
 
       delegate :organization, :customer, to: :invoice
 
-      def create_payment(stripe_payment, invoice: nil)
+      def create_payment(stripe_payment, invoice: nil, amount_cents: nil)
         @invoice = invoice || Invoice.find_by(id: stripe_payment.metadata[:lago_invoice_id])
         unless @invoice
           result.not_found_failure!(resource: "invoice")
@@ -97,7 +97,7 @@ module Invoices
           customer:,
           payment_provider_id: stripe_payment_provider.id,
           payment_provider_customer_id: customer.stripe_customer.id,
-          amount_cents: @invoice.total_due_amount_cents,
+          amount_cents: amount_cents || @invoice.total_due_amount_cents,
           amount_currency: @invoice.currency,
           status: "pending"
         )

--- a/app/services/payment_providers/adyen/handle_event_service.rb
+++ b/app/services/payment_providers/adyen/handle_event_service.rb
@@ -100,8 +100,12 @@ module PaymentProviders
           lago_payable_type: event.dig("additionalData", "metadata.lago_payable_type")
         }
 
-        payment_service_klass(metadata)
-          .new.update_payment_status(provider_payment_id:, status:, metadata:)
+        payment_service_klass(metadata).new.update_payment_status(
+          provider_payment_id:,
+          status:,
+          amount_cents: event.dig("amount", "value"),
+          metadata:
+        )
       end
 
       def payment_service_klass(metadata)

--- a/app/services/payment_providers/cashfree/webhooks/payment_link_event_service.rb
+++ b/app/services/payment_providers/cashfree/webhooks/payment_link_event_service.rb
@@ -18,6 +18,7 @@ module PaymentProviders
           payment_service_class.new.update_payment_status(
             organization_id: organization.id,
             status: link_status,
+            amount_cents: link_amount_paid_cents,
             cashfree_payment: PaymentProviders::CashfreeProvider::CashfreePayment.new(
               id: provider_payment_id,
               status: link_status,
@@ -44,6 +45,14 @@ module PaymentProviders
 
         def payable_type
           @payable_type ||= event.dig("data", "link_notes", "lago_payable_type")
+        end
+
+        def link_amount_paid_cents
+          raw = event.dig("data", "link_amount_paid")
+          currency = event.dig("data", "link_currency")
+          return nil if raw.nil? || currency.nil?
+
+          Money.from_amount(raw.to_d, currency).cents
         end
       end
     end

--- a/app/services/payment_providers/flutterwave/webhooks/charge_completed_service.rb
+++ b/app/services/payment_providers/flutterwave/webhooks/charge_completed_service.rb
@@ -33,6 +33,7 @@ module PaymentProviders
           payment_service_class.new(payable:).update_payment_status(
             organization_id:,
             status: verified_transaction[:status],
+            amount_cents: verified_amount_cents(verified_transaction),
             flutterwave_payment: PaymentProviders::FlutterwaveProvider::FlutterwavePayment.new(
               id: provider_payment_id,
               status: verified_transaction[:status],
@@ -133,6 +134,14 @@ module PaymentProviders
             currency: verified_transaction[:currency],
             payment_type: "one-time"
           }
+        end
+
+        def verified_amount_cents(verified_transaction)
+          amount = verified_transaction[:amount]
+          currency = verified_transaction[:currency]
+          return nil if amount.nil? || currency.nil?
+
+          Money.from_amount(amount.to_d, currency).cents
         end
 
         def headers(payment_provider)

--- a/app/services/payment_providers/moneyhash/handle_event_service.rb
+++ b/app/services/payment_providers/moneyhash/handle_event_service.rb
@@ -66,6 +66,10 @@ module PaymentProviders
               organization_id: @organization.id,
               provider_payment_id: @event_json.dig("data", "intent_id"),
               status: event_to_payment_status(event_code),
+              amount_cents: intent_amount_cents(
+                @event_json.dig("data", "intent", "amount"),
+                @event_json.dig("data", "intent", "amount_currency")
+              ),
               metadata: @event_json.dig("data", "intent", "custom_fields")
             ).raise_if_error!
         end
@@ -78,9 +82,29 @@ module PaymentProviders
               organization_id: @organization.id,
               provider_payment_id: @event_json.dig("intent", "id"),
               status: event_to_payment_status(event_code),
+              amount_cents: intent_amount_cents(@event_json.dig("intent", "amount"), nil),
               metadata: @event_json.dig("intent", "custom_fields")
             ).raise_if_error!
         end
+      end
+
+      # Intent events expose `data.intent.amount` as a scalar (e.g. 5 or "5.00"),
+      # with `data.intent.amount_currency` as a sibling field.
+      # Transaction events expose `intent.amount` as a hash
+      # `{"value" => 7.1, "currency" => "USD"}` — currency lives inside.
+      def intent_amount_cents(raw, currency_fallback)
+        return nil if raw.nil?
+
+        if raw.is_a?(Hash)
+          value = raw["value"]
+          currency = raw["currency"]
+        else
+          value = raw
+          currency = currency_fallback
+        end
+        return nil if value.nil? || currency.nil?
+
+        Money.from_amount(value.to_d, currency).cents
       end
 
       def handle_card_event

--- a/app/services/payment_providers/stripe/webhooks/base_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/base_service.rb
@@ -63,6 +63,7 @@ module PaymentProviders
           payment_service_klass.new.update_payment_status(
             organization_id: organization.id,
             status:,
+            amount_cents: event.data.object.try(:amount),
             stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
               id: event.data.object.id,
               status: event.data.object.status,

--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -30,7 +30,7 @@ module PaymentRequests
         result.third_party_failure!(third_party: PROVIDER_NAME, error_code: e.code, error_message: e.msg)
       end
 
-      def update_payment_status(provider_payment_id:, status:, metadata: {})
+      def update_payment_status(provider_payment_id:, status:, amount_cents: nil, metadata: {})
         payment = if metadata[:payment_type] == "one-time"
           create_payment(provider_payment_id:, metadata:)
         else

--- a/app/services/payment_requests/payments/cashfree_service.rb
+++ b/app/services/payment_requests/payments/cashfree_service.rb
@@ -27,7 +27,7 @@ module PaymentRequests
         result.third_party_failure!(third_party: PROVIDER_NAME, error_code: e.error_code, error_message: e.error_body)
       end
 
-      def update_payment_status(organization_id:, status:, cashfree_payment:)
+      def update_payment_status(organization_id:, status:, cashfree_payment:, amount_cents: nil)
         payment = if cashfree_payment.metadata[:payment_type] == "one-time"
           create_payment(cashfree_payment)
         else

--- a/app/services/payment_requests/payments/flutterwave_service.rb
+++ b/app/services/payment_requests/payments/flutterwave_service.rb
@@ -21,7 +21,7 @@ module PaymentRequests
         result.service_failure!(code: "action_script_runtime_error", message: e.message)
       end
 
-      def update_payment_status(organization_id:, status:, flutterwave_payment:)
+      def update_payment_status(organization_id:, status:, flutterwave_payment:, amount_cents: nil)
         payment = if flutterwave_payment.metadata[:payment_type] == "one-time"
           create_payment(flutterwave_payment)
         else

--- a/app/services/payment_requests/payments/moneyhash_service.rb
+++ b/app/services/payment_requests/payments/moneyhash_service.rb
@@ -57,7 +57,7 @@ module PaymentRequests
         result
       end
 
-      def update_payment_status(organization_id:, provider_payment_id:, status:, metadata: {})
+      def update_payment_status(organization_id:, provider_payment_id:, status:, amount_cents: nil, metadata: {})
         payment_obj = Payment.find_or_initialize_by(provider_payment_id: provider_payment_id)
         payment = if payment_obj.persisted?
           payment_obj

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -29,7 +29,7 @@ module PaymentRequests
         result.third_party_failure!(third_party: PROVIDER_NAME, error_code: e.code, error_message: e.message)
       end
 
-      def update_payment_status(organization_id:, status:, stripe_payment:)
+      def update_payment_status(organization_id:, status:, stripe_payment:, amount_cents: nil)
         payment = Payment.find_by(provider_payment_id: stripe_payment.id)
         return result if payment&.payable&.organization_id.present? && payment.payable.organization_id != organization_id
 

--- a/spec/services/invoices/payments/moneyhash_service_spec.rb
+++ b/spec/services/invoices/payments/moneyhash_service_spec.rb
@@ -52,6 +52,33 @@ RSpec.describe Invoices::Payments::MoneyhashService do
         )
       end.to have_enqueued_job(SendWebhookJob).with("payment.succeeded", Payment)
     end
+
+    context "when amount_cents kwarg is provided" do
+      it "records the Payment with that amount, not the invoice total" do
+        result = moneyhash_service.update_payment_status(
+          organization_id: organization.id,
+          provider_payment_id: intent_processed_json.dig("data", "intent_id"),
+          status: "SUCCESSFUL",
+          amount_cents: 4242,
+          metadata: intent_processed_json.dig("data", "intent", "custom_fields")
+        ).raise_if_error!
+
+        expect(result.payment.amount_cents).to eq(4242)
+      end
+    end
+
+    context "when amount_cents kwarg is not provided" do
+      it "falls back to the invoice's total amount" do
+        result = moneyhash_service.update_payment_status(
+          organization_id: organization.id,
+          provider_payment_id: intent_processed_json.dig("data", "intent_id"),
+          status: "SUCCESSFUL",
+          metadata: intent_processed_json.dig("data", "intent", "custom_fields")
+        ).raise_if_error!
+
+        expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
+      end
+    end
   end
 
   describe "#generate_payment_url" do

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -294,6 +294,31 @@ RSpec.describe Invoices::Payments::StripeService do
         )
       end
 
+      context "when amount_cents kwarg is provided" do
+        it "records the Payment with the provider-reported amount, not the invoice due amount" do
+          result = stripe_service.update_payment_status(
+            organization_id: organization.id,
+            status: "succeeded",
+            amount_cents: 4242,
+            stripe_payment:
+          )
+
+          expect(result.payment.amount_cents).to eq(4242)
+        end
+      end
+
+      context "when amount_cents kwarg is not provided" do
+        it "falls back to the invoice's total due amount" do
+          result = stripe_service.update_payment_status(
+            organization_id: organization.id,
+            status: "succeeded",
+            stripe_payment:
+          )
+
+          expect(result.payment.amount_cents).to eq(invoice.total_due_amount_cents)
+        end
+      end
+
       context "when invoice is not found" do
         let(:stripe_payment) do
           PaymentProviders::StripeProvider::StripePayment.new(

--- a/spec/services/payment_providers/adyen/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_event_service_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
         expect(Invoices::Payments::AdyenService).to have_received(:new)
         expect(payment_service).to have_received(:update_payment_status)
       end
+
+      it "passes the amount value as a dedicated kwarg for the Payment row to use" do
+        event_service.call
+
+        expect(payment_service).to have_received(:update_payment_status).with(
+          hash_including(amount_cents: 71)
+        )
+      end
     end
 
     context "when succeeded authorisation event for processed one-time payment belonging to a Payment Request" do

--- a/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe PaymentProviders::Cashfree::Webhooks::PaymentLinkEventService do
         expect(Invoices::Payments::CashfreeService).to have_received(:new)
         expect(payment_service).to have_received(:update_payment_status)
       end
+
+      it "passes the paid amount converted from major units to cents as a dedicated kwarg" do
+        webhook_service.call
+
+        expect(payment_service).to have_received(:update_payment_status).with(
+          hash_including(amount_cents: 5500)
+        )
+      end
     end
 
     context "when succeeded payment_request event" do

--- a/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
@@ -129,6 +129,14 @@ RSpec.describe PaymentProviders::Flutterwave::Webhooks::ChargeCompletedService d
           expect(metadata[:flw_ref]).to eq("lago_invoice_12345")
         end
       end
+
+      it "passes amount_cents converted from major units as a dedicated kwarg" do
+        charge_completed_service.call
+
+        expect(payment_service).to have_received(:update_payment_status).with(
+          hash_including(amount_cents: 1_000_000)
+        )
+      end
     end
 
     context "when transaction status is not successful" do

--- a/spec/services/payment_providers/moneyhash/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/handle_event_service_spec.rb
@@ -110,6 +110,44 @@ RSpec.describe PaymentProviders::Moneyhash::HandleEventService do
     end
   end
 
+  describe "amount_cents handling in metadata" do
+    let(:payment_service) { instance_double(Invoices::Payments::MoneyhashService) }
+    let(:service_result) { BaseService::Result.new }
+
+    before do
+      allow(Invoices::Payments::MoneyhashService).to receive(:new).and_return(payment_service)
+      allow(payment_service).to receive(:update_payment_status).and_return(service_result)
+    end
+
+    context "when handling an intent event with a scalar amount in major units" do
+      let(:event_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/intent.processed.json"))) }
+
+      it "passes amount_cents converted to minor units as a dedicated kwarg" do
+        event_service.call
+
+        expect(payment_service).to have_received(:update_payment_status).with(
+          hash_including(amount_cents: 500)
+        )
+      end
+    end
+
+    context "when handling a transaction event whose amount is a hash with major-unit value" do
+      let(:event_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/transaction.purchase.successful.json"))) }
+
+      it "extracts the value from the amount hash and converts to cents" do
+        event_service.call
+
+        expect(payment_service).to have_received(:update_payment_status).with(
+          hash_including(amount_cents: 710)
+        )
+      end
+
+      it "does not raise when amount is a hash rather than a scalar" do
+        expect { event_service.call }.not_to raise_error
+      end
+    end
+  end
+
   # Card Token
   # handle event - card_token.created <-
   # handle event - card_token.updated <-

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedSer
           .with(
             organization_id: organization.id,
             status: "failed",
+            amount_cents: anything,
             stripe_payment: PaymentProviders::StripeProvider::StripePayment
           ).and_call_original
 
@@ -38,6 +39,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedSer
           .with(
             organization_id: organization.id,
             status: "failed",
+            amount_cents: anything,
             stripe_payment: PaymentProviders::StripeProvider::StripePayment
           ).and_call_original
 
@@ -64,6 +66,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedSer
           .with(
             organization_id: organization.id,
             status: "failed",
+            amount_cents: anything,
             stripe_payment: PaymentProviders::StripeProvider::StripePayment
           ).and_call_original
 
@@ -101,6 +104,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedSer
         .with(
           organization_id: organization.id,
           status: "failed",
+          amount_cents: anything,
           stripe_payment: PaymentProviders::StripeProvider::StripePayment
         ).and_call_original
 

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
           .with(
             organization_id: organization.id,
             status: "succeeded",
+            amount_cents: anything,
             stripe_payment: PaymentProviders::StripeProvider::StripePayment
           ).and_call_original
 
@@ -83,6 +84,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
             .with(
               organization_id: organization.id,
               status: "succeeded",
+              amount_cents: anything,
               stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
                 id: "pi_12345",
                 status: "succeeded",
@@ -111,6 +113,7 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
           .with(
             organization_id: organization.id,
             status: "succeeded",
+            amount_cents: anything,
             stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
               id: "pi_12345",
               status: "succeeded",


### PR DESCRIPTION
When a Stripe Checkout Session (or equivalent on Adyen, Cashfree, Flutterwave, MoneyHash) completes against an invoice that has already been settled by another path (typically off-session auto-pay), the webhook handler manufactures a Lago Payment for the incoming PaymentIntent. The Payment row was built using `invoice.total_due_amount_cents`, which at webhook time is 0 if the invoice is already paid.
