### PR TITLE
fix(subscriptions): Validate pending taxes on termination

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -302,6 +302,10 @@ class Subscription < ApplicationRecord
 
     usage_thresholds.presence || plan.usage_thresholds.presence || plan.applicable_usage_thresholds
   end
+
+  def last_subscription_fee
+    fees.subscription.order(created_at: :desc).first
+  end
 end
 
 # == Schema Information

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -81,7 +81,7 @@ module CreditNotes
     end
 
     def last_subscription_fee
-      @last_subscription_fee ||= subscription.fees.subscription.order(created_at: :desc).first
+      @last_subscription_fee ||= subscription.last_subscription_fee
     end
 
     def calculate_base_unused_amount

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -43,7 +43,7 @@ module CreditNotes
           reason:,
           description:,
           credit_status: "available",
-          status: invoice.voided? ? "finalized" : invoice.status # credit notes dont have void state
+          status: credit_note_status
         )
 
         if metadata_value
@@ -161,6 +161,15 @@ module CreditNotes
 
     def non_offset_amounts_present?
       credit_amount_cents.positive? || refund_amount_cents.positive?
+    end
+
+    # NOTE: credit notes only support draft/finalized; voided invoices map to
+    #       finalized, and previews are never persisted so finalized is safe.
+    def credit_note_status
+      return "finalized" if invoice.voided?
+      return "finalized" if context == :preview
+
+      invoice.status
     end
 
     # NOTE: issuing_date must be in customer time zone (accounting date)

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -41,6 +41,11 @@ module Subscriptions
             #       Depending on the termination behaviour, we will optionally refund the portion of the unconsumed
             #       subscription that was already paid.
 
+            if blocked_by_pending_taxes?
+              result.not_allowed_failure!(code: "cannot_terminate_with_pending_taxes")
+              result.raise_if_error!
+            end
+
             CreditNotes::CreateFromTermination.call!(
               subscription:,
               reason: "order_cancellation",
@@ -223,6 +228,10 @@ module Subscriptions
       return if params.empty?
 
       Subscriptions::UpdateService.call!(subscription:, params:)
+    end
+
+    def blocked_by_pending_taxes?
+      subscription.last_subscription_fee&.invoice&.tax_pending?
     end
   end
 end

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -231,7 +231,7 @@ module Subscriptions
     end
 
     def blocked_by_pending_taxes?
-      subscription.last_subscription_fee&.invoice&.tax_pending?
+      subscription.last_subscription_fee&.invoice&.tax_pending? || false
     end
   end
 end

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -1173,5 +1173,21 @@ RSpec.describe CreditNotes::CreateFromTermination do
         expect { create_service.call }.not_to change(CreditNoteItem, :count)
       end
     end
+
+    context "when invoice is tax_pending and context is :preview" do
+      # NOTE: Real termination is blocked upstream by Subscriptions::TerminateService.
+      #       Preview is exempt so the dashboard can still render the credit note;
+      #       CreditNotes::CreateService#credit_note_status forces :finalized in that case.
+      let(:context) { :preview }
+
+      before { invoice.update!(status: :pending, tax_status: :pending) }
+
+      it "builds a credit note without error" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.credit_note).to be_a(CreditNote).and be_new_record
+      end
+    end
   end
 end

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -296,6 +296,27 @@ RSpec.describe Subscriptions::TerminateService do
           expect { subject }.not_to change(CreditNote, :count)
         end
       end
+
+      context "when last subscription fee invoice has pending taxes" do
+        let(:on_termination_credit_note) { "credit" }
+
+        before { invoice.update!(status: :pending, tax_status: :pending) }
+
+        it "returns a cannot_terminate_with_pending_taxes failure" do
+          expect(result).to be_failure
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq("cannot_terminate_with_pending_taxes")
+        end
+
+        it "does not mark the subscription as terminated" do
+          subject
+          expect(subscription.reload).not_to be_terminated
+        end
+
+        it "does not create a credit note" do
+          expect { subject }.not_to change(CreditNote, :count)
+        end
+      end
     end
 
     context "when subscription is pay in arrears" do


### PR DESCRIPTION
## Context
Terminating a pay-in-advance subscription whose latest invoice was stuck in tax-pending state (provider tax check or VIES validation) crashed with `ArgumentError ('pending' is not a valid status)`. The credit-note creation inherits the invoice status, but `CreditNote.status` only accepts `[draft, finalized]`.

## Description
- Added validation for pending taxes on subscription termination.
- Unblocked invoice preview endpoint by setting "finalized" credit note status.

NOTE: This is a targeted fix for this specific case. The root cause affects multiple areas and needs to be addressed with a comprehensive change.