### PR TITLE
feat(payment-gated-subs): Apply activation rules on plan upgrades

### DIFF
--- a/app/services/plans/update_amount_service.rb
+++ b/app/services/plans/update_amount_service.rb
@@ -41,10 +41,18 @@ module Plans
         next unless subscription.previous_subscription
 
         if plan.yearly_amount_cents >= subscription.previous_subscription.plan.yearly_amount_cents
+          upgrade_params = {name: subscription.name}
+
+          if subscription.activation_rules.any?
+            upgrade_params[:activation_rules] = subscription.activation_rules.map do |rule|
+              {type: rule.type, timeout_hours: rule.timeout_hours}
+            end
+          end
+
           Subscriptions::PlanUpgradeService.call(
             current_subscription: subscription.previous_subscription,
             plan: plan,
-            params: {name: subscription.name}
+            params: upgrade_params
           ).raise_if_error!
         end
       end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -345,10 +345,18 @@ module Plans
         next unless subscription.previous_subscription
 
         if plan.yearly_amount_cents >= subscription.previous_subscription.plan.yearly_amount_cents
+          upgrade_params = {name: subscription.name}
+
+          if subscription.activation_rules.any?
+            upgrade_params[:activation_rules] = subscription.activation_rules.map do |rule|
+              {type: rule.type, timeout_hours: rule.timeout_hours}
+            end
+          end
+
           Subscriptions::PlanUpgradeService.call(
             current_subscription: subscription.previous_subscription,
             plan: plan,
-            params: {name: subscription.name}
+            params: upgrade_params
           ).raise_if_error!
         end
       end

--- a/spec/services/plans/update_amount_service_spec.rb
+++ b/spec/services/plans/update_amount_service_spec.rb
@@ -61,7 +61,30 @@ RSpec.describe Plans::UpdateAmountService do
       it "upgrades subscription plan" do
         update_service.call
 
-        expect(Subscriptions::PlanUpgradeService).to have_received(:call)
+        expect(Subscriptions::PlanUpgradeService).to have_received(:call).with(
+          current_subscription: subscription,
+          plan: plan,
+          params: {name: pending_subscription.name}
+        )
+      end
+
+      context "when the pending subscription has activation rules" do
+        before do
+          create(:subscription_activation_rule, subscription: pending_subscription, organization:, timeout_hours: 24)
+        end
+
+        it "forwards the activation_rules to the plan upgrade" do
+          update_service.call
+
+          expect(Subscriptions::PlanUpgradeService).to have_received(:call).with(
+            current_subscription: subscription,
+            plan: plan,
+            params: {
+              name: pending_subscription.name,
+              activation_rules: [{type: "payment", timeout_hours: 24}]
+            }
+          )
+        end
       end
 
       context "when pending subscription does not have a previous one" do

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -458,7 +458,11 @@ RSpec.describe Plans::UpdateService do
         it "upgrades subscription plan" do
           plans_service.call
 
-          expect(Subscriptions::PlanUpgradeService).to have_received(:call)
+          expect(Subscriptions::PlanUpgradeService).to have_received(:call).with(
+            current_subscription: subscription,
+            plan: plan,
+            params: {name: pending_subscription.name}
+          )
         end
 
         it "updates the plan" do
@@ -466,6 +470,25 @@ RSpec.describe Plans::UpdateService do
 
           expect(result.plan.name).to eq("Updated plan name")
           expect(result.plan.amount_cents).to eq(200)
+        end
+
+        context "when the pending subscription has activation rules" do
+          before do
+            create(:subscription_activation_rule, subscription: pending_subscription, organization:, timeout_hours: 24)
+          end
+
+          it "forwards the activation_rules to the plan upgrade" do
+            plans_service.call
+
+            expect(Subscriptions::PlanUpgradeService).to have_received(:call).with(
+              current_subscription: subscription,
+              plan: plan,
+              params: {
+                name: pending_subscription.name,
+                activation_rules: [{type: "payment", timeout_hours: 24}]
+              }
+            )
+          end
         end
 
         context "when pending subscription does not have a previous one" do


### PR DESCRIPTION
## Context

When a plan's amount is updated and a pending upgrade subscription exists, `Plans::UpdateService` and `Plans::UpdateAmountService` trigger `Subscriptions::PlanUpgradeService` to create a new active subscription. The activation rules attached to the pending subscription were dropped in this flow, so payment-gated upgrades silently lost their rules.

## Description

`process_pending_subscriptions` in both services now serializes the pending subscription's `activation_rules` into the `{type:, timeout_hours:}` shape and forwards them via the `params` of `Subscriptions::PlanUpgradeService`, which re-applies them to the new subscription through `Subscriptions::ActivationRules::ApplyService`.