### PR TITLE
fix(invoices): Fix UUID search term

### DIFF
--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -4,6 +4,7 @@ class BaseQuery < BaseService
   # nil values force Kaminari to apply its default values for page and limit.
   DEFAULT_PAGINATION_PARAMS = {page: nil, limit: nil}
   DEFAULT_ORDER = {created_at: :desc}
+  UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
   Pagination = Struct.new(:page, :limit, keyword_init: true)
   Filters = BaseFilters

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -27,7 +27,7 @@ class InvoicesQuery < BaseQuery
   def call
     return result unless validate_filters.success?
 
-    invoices = base_scope.result.includes(:customer).preload(file_attachment: :blob, xml_file_attachment: :blob)
+    invoices = base_scope.includes(:customer).preload(file_attachment: :blob, xml_file_attachment: :blob)
     invoices = with_customers_filter(invoices)
 
     invoices = with_billing_entity_ids(invoices) if filters.billing_entity_ids.present?
@@ -67,17 +67,11 @@ class InvoicesQuery < BaseQuery
   end
 
   def base_scope
-    organization.invoices.ransack(search_params)
-  end
+    scope = organization.invoices
+    return scope if search_term.blank?
 
-  def search_params
-    return if search_term.blank?
-
-    {
-      m: "or",
-      id_cont: search_term,
-      number_cont: search_term
-    }
+    by_number = scope.ransack(number_cont: search_term).result
+    search_term.match?(BaseQuery::UUID_REGEX) ? by_number.or(scope.where(id: search_term)) : by_number
   end
 
   def with_customers_filter(scope)

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -399,16 +399,28 @@ RSpec.describe InvoicesQuery do
     end
   end
 
-  context "when searching for a part of an invoice id" do
-    let(:search_term) { invoice_fourth.id.scan(/.{10}/).first }
+  context "when searching for a full invoice id (UUID)" do
+    let(:search_term) { invoice_fourth.id }
 
-    it "returns 1 invoices" do
-      expect(returned_ids.count).to eq(1)
-      expect(returned_ids).not_to include(invoice_first.id)
-      expect(returned_ids).not_to include(invoice_second.id)
-      expect(returned_ids).not_to include(invoice_third.id)
-      expect(returned_ids).to include(invoice_fourth.id)
-      expect(returned_ids).not_to include(invoice_fifth.id)
+    it "returns the matching invoice" do
+      expect(returned_ids).to eq([invoice_fourth.id])
+    end
+  end
+
+  context "when searching for a partial UUID-like string" do
+    let(:search_term) { invoice_fourth.id.first(10) }
+
+    it "does not match by invoice id" do
+      expect(returned_ids).to be_empty
+    end
+  end
+
+  context "when searching for a non-UUID string that resembles part of an id" do
+    let(:search_term) { "abcdef12" }
+
+    it "does not raise and returns no id-matched invoices" do
+      expect { result }.not_to raise_error
+      expect(returned_ids).to be_empty
     end
   end
 


### PR DESCRIPTION
- Only applies `id` search term when search params is matching `UUID` regex.
- Using `id_cont` will do `uuid::varchar` casting under the hood. This leads to PG not using pkey index, degrading performances with a full table scan.