### PR TITLE
feat(multi-billing-entity): expose billing_entity_id on update mutation

### DIFF
--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -8,6 +8,7 @@ module Types
       argument :id, ID, required: true
 
       argument :activation_rules, [Types::Subscriptions::ActivationRuleInput], required: false
+      argument :billing_entity_id, ID, required: false
       argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :name, String, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -13256,6 +13256,7 @@ Update Subscription input arguments
 """
 input UpdateSubscriptionInput {
   activationRules: [SubscriptionActivationRuleInput!]
+  billingEntityId: ID
 
   """
   A unique identifier for the client performing the mutation.

--- a/schema.json
+++ b/schema.json
@@ -70367,6 +70367,18 @@
               "deprecationReason": null
             },
             {
+              "name": "billingEntityId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "endingAt",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -256,4 +256,47 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
       end
     end
   end
+
+  context "when moving to a different billing entity" do
+    let(:subscription) { create(:subscription, organization:, plan:) }
+    let(:new_billing_entity) { create(:billing_entity, organization:) }
+
+    let(:query) do
+      <<~GQL
+        mutation($input: UpdateSubscriptionInput!) {
+          updateSubscription(input: $input) {
+            id
+            billingEntityId
+          }
+        }
+      GQL
+    end
+
+    let(:input) { {id: subscription.id, billingEntityId: new_billing_entity.id} }
+
+    before { organization.update!(feature_flags: ["multi_entity_billing"]) }
+
+    it "rebinds the subscription to the new billing entity" do
+      result = subject
+
+      result_data = result["data"]["updateSubscription"]
+
+      expect(result_data["billingEntityId"]).to eq(new_billing_entity.id)
+      expect(subscription.reload.billing_entity_id).to eq(new_billing_entity.id)
+    end
+
+    context "when billing_entity_id does not exist" do
+      let(:input) { {id: subscription.id, billingEntityId: SecureRandom.uuid} }
+
+      it "returns a not_found error" do
+        result = subject
+
+        expect(result["data"]["updateSubscription"]).to be_nil
+        expect(result["errors"].first["extensions"]).to include(
+          "code" => "not_found",
+          "details" => {"billingEntity" => ["not_found"]}
+        )
+      end
+    end
+  end
 end

--- a/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
@@ -13,5 +13,6 @@ RSpec.describe Types::Subscriptions::UpdateSubscriptionInput do
     expect(subject).to accept_argument(:plan_overrides).of_type("PlanOverridesInput")
     expect(subject).to accept_argument(:subscription_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:activation_rules).of_type("[SubscriptionActivationRuleInput!]")
+    expect(subject).to accept_argument(:billing_entity_id).of_type("ID")
   end
 end


### PR DESCRIPTION
## Summary

The service-level support for moving an active subscription between billing entities shipped in #5498 — `Subscriptions::UpdateService` now accepts `billing_entity_id`, gates it behind the `multi_entity_billing` feature flag, returns 404 on unknown ids, and silently no-ops when the flag is off. The GraphQL `updateSubscription` mutation, however, did not expose the field, so operators driving the admin UI through GraphQL could not move a subscription between entities without dropping to REST. This PR closes the gap with a single new input argument on `UpdateSubscriptionInput`, mirroring the field that already lives on `CreateSubscriptionInput`.

No mutation resolver change is needed: `Mutations::Subscriptions::Update#resolve` already forwards every input argument verbatim as `params:` to the service, so adding the field to the input type is the entire surface change. Validation, feature-flag gating, and the 404 behaviour are inherited from the existing service code path. The schema dumps (`schema.graphql`, `schema.json`) are regenerated to keep the `LagoApiSchema` contract test green.

## Test plan

- [ ] Seed a premium organization with `feature_flags: ["multi_entity_billing"]`, plus two billing entities `us` (default) and `eu`. Seed a customer under `us` and an active subscription on a monthly plan.
- [ ] Open GraphiQL and run `mutation { updateSubscription(input: { id: "<sub_id>", billingEntityId: "<eu_id>" }) { id billingEntityId } }`. Expect the response to return `billingEntityId` set to `eu`'s id; verify the `subscriptions` row in the database also shows the new id.
- [ ] Run the mutation again with `billingEntityId: "<random-uuid>"`. Expect a GraphQL `errors` entry with `extensions.code = "not_found"` and `extensions.details = { billingEntity: ["not_found"] }`; the row stays on `eu`.
- [ ] Toggle `multi_entity_billing` off on the organization. Run the mutation with `billingEntityId: "<us_id>"`. Expect a 200 response and no row change (matches the create-side "silently ignored" convention).