### PR TITLE
feat: extend customer invoice numbering with billing entity support

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -124,8 +124,8 @@ class Invoice < ApplicationRecord
     end
   end
 
-  sequenced scope: ->(invoice) { invoice.customer.invoices },
-    lock_key: ->(invoice) { invoice.customer_id }
+  sequenced scope: ->(invoice) { invoice.customer.invoices.where(billing_entity_id: invoice.billing_entity_id) },
+    lock_key: ->(invoice) { "#{invoice.customer_id}-#{invoice.billing_entity_id}" }
 
   scope :visible, -> { where(status: VISIBLE_STATUS.keys) }
   scope :invisible, -> { where(status: INVISIBLE_STATUS.keys) }
@@ -739,7 +739,7 @@ end
 #  idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655  (billing_entity_id,billing_entity_sequential_id DESC)
 #  idx_on_organization_id_organization_sequential_id_2387146f54    (organization_id,organization_sequential_id DESC)
 #  index_invoices_by_cursor                                        (organization_id,issuing_date DESC,created_at DESC,id)
-#  index_invoices_on_customer_id_and_sequential_id                 (customer_id,sequential_id) UNIQUE
+#  index_invoices_on_customer_billing_entity_sequential            (customer_id,billing_entity_id,sequential_id) UNIQUE
 #  index_invoices_on_number                                        (number)
 #  index_invoices_on_organization_id_and_customer_id               (customer_id,organization_id)
 #  index_invoices_on_organization_id_number_gin_trgm_ops           (organization_id,number) USING gin

--- a/db/migrate/20260520134318_swap_invoices_sequential_unique_index.rb
+++ b/db/migrate/20260520134318_swap_invoices_sequential_unique_index.rb
@@ -8,8 +8,9 @@ class SwapInvoicesSequentialUniqueIndex < ActiveRecord::Migration[8.0]
       unique: true,
       algorithm: :concurrently,
       name: "index_invoices_on_customer_billing_entity_sequential"
-    remove_index :invoices,
-      name: "index_invoices_on_customer_id_and_sequential_id",
-      algorithm: :concurrently
+    remove_index :invoices, [:customer_id, :sequential_id],
+      unique: true,
+      algorithm: :concurrently,
+      name: "index_invoices_on_customer_id_and_sequential_id"
   end
 end

--- a/db/migrate/20260520134318_swap_invoices_sequential_unique_index.rb
+++ b/db/migrate/20260520134318_swap_invoices_sequential_unique_index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SwapInvoicesSequentialUniqueIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :invoices, [:customer_id, :billing_entity_id, :sequential_id],
+      unique: true,
+      algorithm: :concurrently,
+      name: "index_invoices_on_customer_billing_entity_sequential"
+    remove_index :invoices,
+      name: "index_invoices_on_customer_id_and_sequential_id",
+      algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -544,7 +544,7 @@ DROP INDEX IF EXISTS public.index_invoices_on_payment_due_date;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_number_gin_trgm_ops;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_and_customer_id;
 DROP INDEX IF EXISTS public.index_invoices_on_number;
-DROP INDEX IF EXISTS public.index_invoices_on_customer_id_and_sequential_id;
+DROP INDEX IF EXISTS public.index_invoices_on_customer_billing_entity_sequential;
 DROP INDEX IF EXISTS public.index_invoices_by_cursor;
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_subscription_id;
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_regenerated_invoice_id;
@@ -8816,10 +8816,10 @@ CREATE INDEX index_invoices_by_cursor ON public.invoices USING btree (organizati
 
 
 --
--- Name: index_invoices_on_customer_id_and_sequential_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_invoices_on_customer_billing_entity_sequential; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_invoices_on_customer_id_and_sequential_id ON public.invoices USING btree (customer_id, sequential_id);
+CREATE UNIQUE INDEX index_invoices_on_customer_billing_entity_sequential ON public.invoices USING btree (customer_id, billing_entity_id, sequential_id);
 
 
 --
@@ -12811,6 +12811,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260526142247'),
 ('20260526131452'),
 ('20260525102114'),
+('20260520134318'),
 ('20260520075420'),
 ('20260518152858'),
 ('20260517101105'),

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -198,6 +198,36 @@ RSpec.describe Invoice do
       end
     end
 
+    context "when the same customer has invoices across multiple billing entities" do
+      let(:billing_entity_2) { create(:billing_entity, organization:) }
+
+      before do
+        create(:invoice, customer:, organization:, billing_entity:, sequential_id: 1, billing_entity_sequential_id: 1, organization_sequential_id: 0)
+        create(:invoice, customer:, organization:, billing_entity:, sequential_id: 2, billing_entity_sequential_id: 2, organization_sequential_id: 0)
+        create(:invoice, customer:, organization:, billing_entity: billing_entity_2, sequential_id: 1, billing_entity_sequential_id: 1, organization_sequential_id: 0)
+      end
+
+      it "scopes sequential_id per (customer, billing_entity)" do
+        invoice_in_entity_2 = build(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity: billing_entity_2,
+          billing_entity_sequential_id: nil,
+          organization_sequential_id: 0,
+          status: :generating
+        )
+        invoice_in_entity_2.save!
+        invoice_in_entity_2.finalized!
+
+        invoice.save!
+        invoice.finalized!
+
+        expect(invoice_in_entity_2.sequential_id).to eq(2)
+        expect(invoice.sequential_id).to eq(3)
+      end
+    end
+
     context "with invoices on other organization" do
       before do
         create(:invoice, sequential_id: 1, organization_sequential_id: 0)

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -1141,4 +1141,106 @@ describe "Invoice Numbering Scenario", transaction: false do
       end
     end
   end
+
+  context "with a single customer billed across multiple billing entities" do
+    let(:organization) do
+      create(
+        :organization,
+        document_numbering: "per_customer",
+        webhook_url: nil,
+        billing_entities: [billing_entity_first, billing_entity_second]
+      )
+    end
+
+    let(:billing_entity_first) do
+      create(:billing_entity, document_numbering: "per_customer", document_number_prefix: "BENT-1")
+    end
+
+    let(:billing_entity_second) do
+      create(:billing_entity, document_numbering: "per_customer", document_number_prefix: "BENT-2")
+    end
+
+    let(:customer) { create(:customer, organization:, billing_entity: billing_entity_first) }
+    let(:subscription_under_first_external_id) { "sub-under-first" }
+    let(:subscription_under_second_external_id) { "sub-under-second" }
+
+    before { organization.enable_feature_flag!(:multi_entity_billing) }
+
+    it "numbers invoices gaplessly per (customer, billing_entity)" do
+      # NOTE: Jul 19th: create two subscriptions for the same customer, one per billing entity
+      travel_to(subscription_at) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: subscription_under_first_external_id,
+            plan_code: monthly_plan.code,
+            billing_time: "anniversary",
+            subscription_at: subscription_at.iso8601
+          }
+        )
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: subscription_under_second_external_id,
+            plan_code: monthly_plan.code,
+            billing_time: "anniversary",
+            subscription_at: subscription_at.iso8601,
+            billing_entity_code: billing_entity_second.code
+          }
+        )
+
+        invoices = customer.reload.invoices.order(created_at: :asc)
+
+        expect(invoices.pluck(:billing_entity_id))
+          .to eq([billing_entity_first.id, billing_entity_second.id])
+        expect(invoices.pluck(:sequential_id)).to eq([1, 1])
+        expect(invoices.pluck(:number))
+          .to match_array(%w[BENT-1-001-001 BENT-2-001-001])
+      end
+
+      # NOTE: August 19th: second billing cycle
+      travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
+        perform_billing
+
+        invoices = customer.reload.invoices.order(created_at: :asc)
+
+        expect(invoices.where(billing_entity: billing_entity_first).pluck(:sequential_id))
+          .to eq([1, 2])
+        expect(invoices.where(billing_entity: billing_entity_second).pluck(:sequential_id))
+          .to eq([1, 2])
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              BENT-1-001-001
+              BENT-2-001-001
+              BENT-1-001-002
+              BENT-2-001-002
+            ]
+          )
+      end
+
+      # NOTE: September 19th: third billing cycle — sequences stay gapless and independent per entity
+      travel_to(DateTime.new(2023, 9, 19, 12, 12)) do
+        perform_billing
+
+        invoices = customer.reload.invoices.order(created_at: :asc)
+
+        expect(invoices.where(billing_entity: billing_entity_first).pluck(:sequential_id))
+          .to eq([1, 2, 3])
+        expect(invoices.where(billing_entity: billing_entity_second).pluck(:sequential_id))
+          .to eq([1, 2, 3])
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              BENT-1-001-001
+              BENT-2-001-001
+              BENT-1-001-002
+              BENT-2-001-002
+              BENT-1-001-003
+              BENT-2-001-003
+            ]
+          )
+      end
+    end
+  end
 end

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -1189,11 +1189,10 @@ describe "Invoice Numbering Scenario", transaction: false do
           }
         )
 
-        invoices = customer.reload.invoices.order(created_at: :asc)
+        invoices = customer.reload.invoices
 
-        expect(invoices.pluck(:billing_entity_id))
-          .to eq([billing_entity_first.id, billing_entity_second.id])
-        expect(invoices.pluck(:sequential_id)).to eq([1, 1])
+        expect(invoices.where(billing_entity: billing_entity_first).pluck(:sequential_id)).to eq([1])
+        expect(invoices.where(billing_entity: billing_entity_second).pluck(:sequential_id)).to eq([1])
         expect(invoices.pluck(:number))
           .to match_array(%w[BENT-1-001-001 BENT-2-001-001])
       end


### PR DESCRIPTION
## Context

Currently, one customer can be assigned to only one billing entity. With `multi-billing-entities` feature, it will be possible to assign any billing entity to customer's billing object, like subscription or wallet.

## Description

This PR changes `per_customer` invoice numbering. Currently all invoices belong to the same billing entity. However, with new initiative, we need to increase sequential ID per billing entity. The change is backward compatible.