### PR TITLE
fix: prevent double-charge via expired payment URLs across providers

### DIFF
--- a/app/jobs/payment_intents/expire_open_checkout_urls_job.rb
+++ b/app/jobs/payment_intents/expire_open_checkout_urls_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PaymentIntents
+  class ExpireOpenCheckoutUrlsJob < ApplicationJob
+    queue_as "default"
+
+    # Provider transient failures are wrapped as Lago errors inside each
+    # Invoices::Payments::<provider>Service#expire_checkout_session. Mirrors
+    # the retry shape used by Invoices::Payments::CreateJob.
+    retry_on Invoices::Payments::ConnectionError, wait: :polynomially_longer, attempts: 6
+    retry_on Invoices::Payments::RateLimitError, wait: :polynomially_longer, attempts: 6
+
+    def perform(invoice)
+      PaymentIntents::ExpireOpenCheckoutUrlsService.call!(invoice:)
+    end
+  end
+end

--- a/app/jobs/payment_intents/expire_open_checkout_urls_job.rb
+++ b/app/jobs/payment_intents/expire_open_checkout_urls_job.rb
@@ -4,9 +4,6 @@ module PaymentIntents
   class ExpireOpenCheckoutUrlsJob < ApplicationJob
     queue_as "default"
 
-    # Provider transient failures are wrapped as Lago errors inside each
-    # Invoices::Payments::<provider>Service#expire_checkout_session. Mirrors
-    # the retry shape used by Invoices::Payments::CreateJob.
     retry_on Invoices::Payments::ConnectionError, wait: :polynomially_longer, attempts: 6
     retry_on Invoices::Payments::RateLimitError, wait: :polynomially_longer, attempts: 6
 

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -22,18 +22,20 @@ end
 # Table name: payment_intents
 # Database name: primary
 #
-#  id              :uuid             not null, primary key
-#  expires_at      :datetime         not null
-#  payment_url     :string
-#  status          :integer          default("active"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  invoice_id      :uuid             not null
-#  organization_id :uuid             not null
+#  id                  :uuid             not null, primary key
+#  expires_at          :datetime         not null
+#  payment_url         :string
+#  status              :integer          default("active"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  invoice_id          :uuid             not null
+#  organization_id     :uuid             not null
+#  provider_session_id :string
 #
 # Indexes
 #
 #  index_payment_intents_on_invoice_id             (invoice_id)
 #  index_payment_intents_on_invoice_id_and_status  (invoice_id,status) UNIQUE WHERE (status = 0)
 #  index_payment_intents_on_organization_id        (organization_id)
+#  index_payment_intents_on_provider_session_id    (provider_session_id)
 #

--- a/app/models/payment_providers/adyen_provider.rb
+++ b/app/models/payment_providers/adyen_provider.rb
@@ -11,6 +11,13 @@ module PaymentProviders
     SUCCESS_STATUSES = %w[Authorised SentForSettle SettleScheduled Settled Refunded].freeze
     FAILED_STATUSES = %w[Cancelled CaptureFailed Error Expired Refused].freeze
 
+    # Payment-link states where the customer either completed payment or
+    # is mid-payment in an async flow. Distinct from the payment-level
+    # SUCCESS_STATUSES above — Adyen's payment-link API exposes its own
+    # enum. Used by Invoices::Payments::AdyenService to keep auto-charges
+    # from racing a hosted-link payment.
+    CHECKOUT_COMPLETED_STATUSES = %w[completed paymentPending].freeze
+
     validates :api_key, :merchant_account, presence: true
     validates :success_redirect_url, adyen_url: true, allow_nil: true, length: {maximum: 1024}
 

--- a/app/models/payment_providers/cashfree_provider.rb
+++ b/app/models/payment_providers/cashfree_provider.rb
@@ -12,6 +12,11 @@ module PaymentProviders
     SUCCESS_STATUSES = %w[PAID].freeze
     FAILED_STATUSES = %w[EXPIRED CANCELLED].freeze
 
+    # Payment-link states where the URL has captured funds (in part or in
+    # full) and Cashfree is settling. Used by Invoices::Payments::CashfreeService
+    # to keep auto-charges from racing a hosted-link payment.
+    CHECKOUT_COMPLETED_STATUSES = (SUCCESS_STATUSES + PROCESSING_STATUSES).freeze
+
     validates :client_id, presence: true
     validates :client_secret, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: {maximum: 1024}

--- a/app/models/payment_providers/flutterwave_provider.rb
+++ b/app/models/payment_providers/flutterwave_provider.rb
@@ -10,6 +10,13 @@ module PaymentProviders
     PROCESSING_STATUSES = %w[pending].freeze
     SUCCESS_STATUSES = %w[successful].freeze
     FAILED_STATUSES = %w[failed cancelled].freeze
+
+    # Transaction states where the hosted-link has settled funds.
+    # Aliases SUCCESS_STATUSES — Flutterwave's link verification API
+    # exposes the same enum as the transaction level. Used by
+    # Invoices::Payments::FlutterwaveService to keep auto-charges from
+    # racing a hosted-link payment.
+    CHECKOUT_COMPLETED_STATUSES = SUCCESS_STATUSES
     validates :secret_key, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: {maximum: 1024}
 

--- a/app/models/payment_providers/flutterwave_provider.rb
+++ b/app/models/payment_providers/flutterwave_provider.rb
@@ -10,13 +10,6 @@ module PaymentProviders
     PROCESSING_STATUSES = %w[pending].freeze
     SUCCESS_STATUSES = %w[successful].freeze
     FAILED_STATUSES = %w[failed cancelled].freeze
-
-    # Transaction states where the hosted-link has settled funds.
-    # Aliases SUCCESS_STATUSES — Flutterwave's link verification API
-    # exposes the same enum as the transaction level. Used by
-    # Invoices::Payments::FlutterwaveService to keep auto-charges from
-    # racing a hosted-link payment.
-    CHECKOUT_COMPLETED_STATUSES = SUCCESS_STATUSES
     validates :secret_key, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: {maximum: 1024}
 

--- a/app/models/payment_providers/moneyhash_provider.rb
+++ b/app/models/payment_providers/moneyhash_provider.rb
@@ -9,12 +9,6 @@ module PaymentProviders
     SUCCESS_STATUSES = %w[SUCCESSFUL PROCESSED].freeze
     FAILED_STATUSES = %w[FAILED].freeze
 
-    # Intent states where the URL has been used and Moneyhash is settling.
-    # Aliases SUCCESS_STATUSES — the intent endpoint surfaces the same enum
-    # Lago already normalizes through. Used by Invoices::Payments::MoneyhashService
-    # to keep auto-charges from racing a hosted-link payment.
-    CHECKOUT_COMPLETED_STATUSES = SUCCESS_STATUSES
-
     # MoneyHash payment status -> Lago payable_payment_status mapping
     PAYABLE_PAYMENT_STATUS_MAP = {
       "PENDING" => "pending",

--- a/app/models/payment_providers/moneyhash_provider.rb
+++ b/app/models/payment_providers/moneyhash_provider.rb
@@ -9,6 +9,12 @@ module PaymentProviders
     SUCCESS_STATUSES = %w[SUCCESSFUL PROCESSED].freeze
     FAILED_STATUSES = %w[FAILED].freeze
 
+    # Intent states where the URL has been used and Moneyhash is settling.
+    # Aliases SUCCESS_STATUSES — the intent endpoint surfaces the same enum
+    # Lago already normalizes through. Used by Invoices::Payments::MoneyhashService
+    # to keep auto-charges from racing a hosted-link payment.
+    CHECKOUT_COMPLETED_STATUSES = SUCCESS_STATUSES
+
     # MoneyHash payment status -> Lago payable_payment_status mapping
     PAYABLE_PAYMENT_STATUS_MAP = {
       "PENDING" => "pending",

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -5,6 +5,11 @@ module PaymentProviders
     AMOUNT_TOO_SMALL_ERROR_CODE = "amount_too_small"
     NEED_3DS_ERROR_CODE = "authentication_required"
 
+    # Checkout Session states that mean the customer paid via the hosted
+    # URL. Used by Invoices::Payments::StripeService to keep auto-charges
+    # from racing a Checkout Session payment.
+    CHECKOUT_COMPLETED_STATUSES = %w[complete].freeze
+
     StripePayment = Data.define(:id, :status, :metadata, :error_code)
 
     SUCCESS_REDIRECT_URL = "https://stripe.com/"

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -49,7 +49,7 @@ module Invoices
 
         res = client.checkout.payment_links_api.get_payment_link(payment_intent.provider_session_id)
         %w[completed paymentPending].include?(res.response["status"])
-      rescue StandardError
+      rescue
         false
       end
 
@@ -62,6 +62,9 @@ module Invoices
         )
       rescue Faraday::ConnectionFailed => e
         raise Invoices::Payments::ConnectionError, e
+      rescue Adyen::AdyenError => e
+        raise Invoices::Payments::RateLimitError, e if e.code.to_i == 429
+        raise
       end
 
       def generate_payment_url(payment_intent)

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -8,10 +8,6 @@ module Invoices
 
       PROVIDER_NAME = "Adyen"
 
-      # Adyen payment-link states that mean an auto-charge MUST NOT run:
-      # the URL is past the open stage and the provider is settling it.
-      COMPLETED_PAYMENT_LINK_STATUSES = %w[completed paymentPending].freeze
-
       def initialize(invoice = nil)
         @invoice = invoice
 
@@ -52,7 +48,7 @@ module Invoices
         return false if payment_intent.provider_session_id.blank?
 
         res = client.checkout.payment_links_api.get_payment_link(payment_intent.provider_session_id)
-        COMPLETED_PAYMENT_LINK_STATUSES.include?(res.response["status"])
+        ::PaymentProviders::AdyenProvider::CHECKOUT_COMPLETED_STATUSES.include?(res.response["status"])
       rescue
         false
       end

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -43,6 +43,26 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      def checkout_session_already_completed?(payment_intent)
+        return false if payment_intent.provider_session_id.blank?
+
+        res = client.checkout.payment_links_api.get_payment_link(payment_intent.provider_session_id)
+        %w[completed paymentPending].include?(res.response["status"])
+      rescue Adyen::AdyenError
+        false
+      end
+
+      def expire_checkout_session(payment_intent)
+        return if payment_intent.provider_session_id.blank?
+
+        client.checkout.payment_links_api.update_payment_link(
+          {status: "expired"},
+          payment_intent.provider_session_id
+        )
+      rescue Adyen::AdyenError
+        nil
+      end
+
       def generate_payment_url(payment_intent)
         res = client.checkout.payment_links_api.payment_links(
           Lago::Adyen::Params.new(payment_url_params(payment_intent)).to_h,

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -55,6 +55,7 @@ module Invoices
         return result unless result.success?
 
         result.payment_url = res.response["url"]
+        result.provider_session_id = res.response["id"]
 
         result
       rescue Adyen::AdyenError => e

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -43,12 +43,13 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      # Best-effort: any error returns false so we never block auto-charge.
       def checkout_session_already_completed?(payment_intent)
         return false if payment_intent.provider_session_id.blank?
 
         res = client.checkout.payment_links_api.get_payment_link(payment_intent.provider_session_id)
         %w[completed paymentPending].include?(res.response["status"])
-      rescue Adyen::AdyenError
+      rescue StandardError
         false
       end
 

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -8,6 +8,10 @@ module Invoices
 
       PROVIDER_NAME = "Adyen"
 
+      # Adyen payment-link states that mean an auto-charge MUST NOT run:
+      # the URL is past the open stage and the provider is settling it.
+      COMPLETED_PAYMENT_LINK_STATUSES = %w[completed paymentPending].freeze
+
       def initialize(invoice = nil)
         @invoice = invoice
 
@@ -48,7 +52,7 @@ module Invoices
         return false if payment_intent.provider_session_id.blank?
 
         res = client.checkout.payment_links_api.get_payment_link(payment_intent.provider_session_id)
-        %w[completed paymentPending].include?(res.response["status"])
+        COMPLETED_PAYMENT_LINK_STATUSES.include?(res.response["status"])
       rescue
         false
       end

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -59,8 +59,8 @@ module Invoices
           {status: "expired"},
           payment_intent.provider_session_id
         )
-      rescue Adyen::AdyenError
-        nil
+      rescue Faraday::ConnectionFailed => e
+        raise Invoices::Payments::ConnectionError, e
       end
 
       def generate_payment_url(payment_intent)

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -7,6 +7,11 @@ module Invoices
 
       PROVIDER_NAME = "Cashfree"
 
+      # Cashfree link states that mean an auto-charge MUST NOT run:
+      # the URL has captured funds (in part or in full) and the provider
+      # is settling them.
+      COMPLETED_LINK_STATUSES = %w[PAID PARTIALLY_PAID].freeze
+
       def initialize(invoice = nil)
         @invoice = invoice
 
@@ -48,7 +53,7 @@ module Invoices
 
         response = link_client(payment_intent.provider_session_id).get(headers: cashfree_headers)
         link_status = JSON.parse(response.body)["link_status"]
-        %w[PAID PARTIALLY_PAID].include?(link_status)
+        COMPLETED_LINK_STATUSES.include?(link_status)
       rescue
         false
       end

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -57,9 +57,15 @@ module Invoices
 
         link_client("#{payment_intent.provider_session_id}/cancel")
           .post_with_response({}, cashfree_headers)
-      rescue LagoHttpClient::HttpError
-        # 409 if the link isn't in ACTIVE status anymore - benign
-        nil
+      rescue LagoHttpClient::HttpError => e
+        status = e.error_code.to_i
+        # 429 -> let the job back off as a rate-limit retry.
+        raise Invoices::Payments::RateLimitError, e if status == 429
+        # 4xx (other) -> link no longer in ACTIVE / not found, idempotent success.
+        return if (400..499).cover?(status)
+
+        # 5xx -> transient provider issue, retry.
+        raise Invoices::Payments::ConnectionError, e
       end
 
       def generate_payment_url(payment_intent)

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -44,7 +44,9 @@ module Invoices
 
       def generate_payment_url(payment_intent)
         payment_link_response = create_payment_link(payment_url_params(payment_intent))
-        result.payment_url = JSON.parse(payment_link_response.body)["link_url"]
+        parsed_response = JSON.parse(payment_link_response.body)
+        result.payment_url = parsed_response["link_url"]
+        result.provider_session_id = parsed_response["link_id"]
 
         result
       rescue LagoHttpClient::HttpError => e

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -7,11 +7,6 @@ module Invoices
 
       PROVIDER_NAME = "Cashfree"
 
-      # Cashfree link states that mean an auto-charge MUST NOT run:
-      # the URL has captured funds (in part or in full) and the provider
-      # is settling them.
-      COMPLETED_LINK_STATUSES = %w[PAID PARTIALLY_PAID].freeze
-
       def initialize(invoice = nil)
         @invoice = invoice
 
@@ -53,7 +48,7 @@ module Invoices
 
         response = link_client(payment_intent.provider_session_id).get(headers: cashfree_headers)
         link_status = JSON.parse(response.body)["link_status"]
-        COMPLETED_LINK_STATUSES.include?(link_status)
+        ::PaymentProviders::CashfreeProvider::CHECKOUT_COMPLETED_STATUSES.include?(link_status)
       rescue
         false
       end

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -42,13 +42,14 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      # Best-effort: any error returns false so we never block auto-charge.
       def checkout_session_already_completed?(payment_intent)
         return false if payment_intent.provider_session_id.blank?
 
         response = link_client(payment_intent.provider_session_id).get(headers: cashfree_headers)
         link_status = JSON.parse(response.body)["link_status"]
         %w[PAID PARTIALLY_PAID].include?(link_status)
-      rescue LagoHttpClient::HttpError
+      rescue StandardError
         false
       end
 

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -42,6 +42,26 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      def checkout_session_already_completed?(payment_intent)
+        return false if payment_intent.provider_session_id.blank?
+
+        response = link_client(payment_intent.provider_session_id).get(headers: cashfree_headers)
+        link_status = JSON.parse(response.body)["link_status"]
+        %w[PAID PARTIALLY_PAID].include?(link_status)
+      rescue LagoHttpClient::HttpError
+        false
+      end
+
+      def expire_checkout_session(payment_intent)
+        return if payment_intent.provider_session_id.blank?
+
+        link_client("#{payment_intent.provider_session_id}/cancel")
+          .post_with_response({}, cashfree_headers)
+      rescue LagoHttpClient::HttpError
+        # 409 if the link isn't in ACTIVE status anymore - benign
+        nil
+      end
+
       def generate_payment_url(payment_intent)
         payment_link_response = create_payment_link(payment_url_params(payment_intent))
         parsed_response = JSON.parse(payment_link_response.body)
@@ -85,13 +105,21 @@ module Invoices
       end
 
       def create_payment_link(body)
-        client.post_with_response(body, {
+        client.post_with_response(body, cashfree_headers)
+      end
+
+      def cashfree_headers
+        {
           "accept" => "application/json",
           "content-type" => "application/json",
           "x-client-id" => cashfree_payment_provider.client_id,
           "x-client-secret" => cashfree_payment_provider.client_secret,
           "x-api-version" => ::PaymentProviders::CashfreeProvider::API_VERSION
-        })
+        }
+      end
+
+      def link_client(suffix)
+        LagoHttpClient::Client.new("#{::PaymentProviders::CashfreeProvider::BASE_URL}/#{suffix}")
       end
 
       def success_redirect_url

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -49,7 +49,7 @@ module Invoices
         response = link_client(payment_intent.provider_session_id).get(headers: cashfree_headers)
         link_status = JSON.parse(response.body)["link_status"]
         %w[PAID PARTIALLY_PAID].include?(link_status)
-      rescue StandardError
+      rescue
         false
       end
 

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -29,6 +29,13 @@ module Invoices
           return result
         end
 
+        reconciliation = PaymentIntents::ReconcileOpenCheckoutUrlsService.call(invoice:)
+        if reconciliation.already_paid_via_checkout
+          # The customer paid via the hosted URL before this auto-charge could
+          # run. Stand down; the URL's webhook will finalize the invoice.
+          return result
+        end
+
         invoice.update!(payment_attempts: invoice.payment_attempts + 1)
 
         payment ||= Payment.create_with(

--- a/app/services/invoices/payments/flutterwave_service.rb
+++ b/app/services/invoices/payments/flutterwave_service.rb
@@ -7,10 +7,6 @@ module Invoices
 
       PROVIDER_NAME = "Flutterwave"
 
-      # Flutterwave transaction state that means an auto-charge MUST NOT
-      # run: the URL was used and the provider settled the funds.
-      COMPLETED_TRANSACTION_STATUS = "successful"
-
       def initialize(invoice = nil)
         @invoice = invoice
 
@@ -54,7 +50,8 @@ module Invoices
           headers: headers,
           params: {tx_ref: payment_intent.provider_session_id}
         )
-        JSON.parse(response.body).dig("data", "status") == COMPLETED_TRANSACTION_STATUS
+        ::PaymentProviders::FlutterwaveProvider::CHECKOUT_COMPLETED_STATUSES
+          .include?(JSON.parse(response.body).dig("data", "status"))
       rescue
         false
       end

--- a/app/services/invoices/payments/flutterwave_service.rb
+++ b/app/services/invoices/payments/flutterwave_service.rb
@@ -44,6 +44,9 @@ module Invoices
 
       def generate_payment_url(payment_intent)
         result.payment_url = payment_url
+        # Flutterwave's hosted-link API exposes no separate session id; the
+        # transaction is identified by tx_ref (= invoice.id) on verify.
+        result.provider_session_id = invoice.id
         result
       rescue LagoHttpClient::HttpError => e
         result.third_party_failure!(third_party: PROVIDER_NAME, error_code: e.error_code, error_message: e.error_body)

--- a/app/services/invoices/payments/flutterwave_service.rb
+++ b/app/services/invoices/payments/flutterwave_service.rb
@@ -42,6 +42,7 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      # Best-effort: any error returns false so we never block auto-charge.
       def checkout_session_already_completed?(payment_intent)
         return false if payment_intent.provider_session_id.blank?
 
@@ -50,7 +51,7 @@ module Invoices
           params: {tx_ref: payment_intent.provider_session_id}
         )
         JSON.parse(response.body).dig("data", "status") == "successful"
-      rescue LagoHttpClient::HttpError
+      rescue StandardError
         false
       end
 

--- a/app/services/invoices/payments/flutterwave_service.rb
+++ b/app/services/invoices/payments/flutterwave_service.rb
@@ -7,6 +7,10 @@ module Invoices
 
       PROVIDER_NAME = "Flutterwave"
 
+      # Flutterwave transaction state that means an auto-charge MUST NOT
+      # run: the URL was used and the provider settled the funds.
+      COMPLETED_TRANSACTION_STATUS = "successful"
+
       def initialize(invoice = nil)
         @invoice = invoice
 
@@ -50,7 +54,7 @@ module Invoices
           headers: headers,
           params: {tx_ref: payment_intent.provider_session_id}
         )
-        JSON.parse(response.body).dig("data", "status") == "successful"
+        JSON.parse(response.body).dig("data", "status") == COMPLETED_TRANSACTION_STATUS
       rescue
         false
       end

--- a/app/services/invoices/payments/flutterwave_service.rb
+++ b/app/services/invoices/payments/flutterwave_service.rb
@@ -51,7 +51,7 @@ module Invoices
           params: {tx_ref: payment_intent.provider_session_id}
         )
         JSON.parse(response.body).dig("data", "status") == "successful"
-      rescue StandardError
+      rescue
         false
       end
 

--- a/app/services/invoices/payments/flutterwave_service.rb
+++ b/app/services/invoices/payments/flutterwave_service.rb
@@ -50,7 +50,7 @@ module Invoices
           headers: headers,
           params: {tx_ref: payment_intent.provider_session_id}
         )
-        ::PaymentProviders::FlutterwaveProvider::CHECKOUT_COMPLETED_STATUSES
+        ::PaymentProviders::FlutterwaveProvider::SUCCESS_STATUSES
           .include?(JSON.parse(response.body).dig("data", "status"))
       rescue
         false

--- a/app/services/invoices/payments/flutterwave_service.rb
+++ b/app/services/invoices/payments/flutterwave_service.rb
@@ -42,6 +42,26 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      def checkout_session_already_completed?(payment_intent)
+        return false if payment_intent.provider_session_id.blank?
+
+        response = verify_client.get(
+          headers: headers,
+          params: {tx_ref: payment_intent.provider_session_id}
+        )
+        JSON.parse(response.body).dig("data", "status") == "successful"
+      rescue LagoHttpClient::HttpError
+        false
+      end
+
+      # Flutterwave Standard has no per-transaction expire API. The
+      # `session_duration` set at create time is the only timeout knob.
+      # We rely on the local PaymentIntent.expired! + invoice.payment_succeeded?
+      # short-circuit downstream.
+      def expire_checkout_session(_payment_intent)
+        nil
+      end
+
       def generate_payment_url(payment_intent)
         result.payment_url = payment_url
         # Flutterwave's hosted-link API exposes no separate session id; the
@@ -130,6 +150,10 @@ module Invoices
 
       def http_client
         @http_client ||= LagoHttpClient::Client.new("#{flutterwave_payment_provider.api_url}/payments")
+      end
+
+      def verify_client
+        LagoHttpClient::Client.new("#{flutterwave_payment_provider.api_url}/transactions/verify_by_reference")
       end
 
       def create_payment(flutterwave_payment)

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -45,7 +45,7 @@ module Invoices
 
         response = intent_client(payment_intent.provider_session_id).get(headers: headers)
         status = JSON.parse(response.body).dig("data", "status")
-        ::PaymentProviders::MoneyhashProvider::CHECKOUT_COMPLETED_STATUSES.include?(status)
+        ::PaymentProviders::MoneyhashProvider::SUCCESS_STATUSES.include?(status)
       rescue
         false
       end

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -46,7 +46,7 @@ module Invoices
         response = intent_client(payment_intent.provider_session_id).get(headers: headers)
         status = JSON.parse(response.body).dig("data", "status")
         %w[PROCESSED SUCCESSFUL].include?(status)
-      rescue StandardError
+      rescue
         false
       end
 

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -39,6 +39,26 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      def checkout_session_already_completed?(payment_intent)
+        return false if payment_intent.provider_session_id.blank?
+
+        response = intent_client(payment_intent.provider_session_id).get(headers: headers)
+        status = JSON.parse(response.body).dig("data", "status")
+        %w[PROCESSED SUCCESSFUL].include?(status)
+      rescue LagoHttpClient::HttpError
+        false
+      end
+
+      def expire_checkout_session(payment_intent)
+        return if payment_intent.provider_session_id.blank?
+
+        intent_client("#{payment_intent.provider_session_id}/close")
+          .post_with_response({}, headers)
+      rescue LagoHttpClient::HttpError
+        # MoneyHash rejects close on PROCESSED intents - benign
+        nil
+      end
+
       def generate_payment_url(payment_intent)
         return result unless should_process_payment?
 
@@ -123,6 +143,10 @@ module Invoices
 
       def client
         @client || LagoHttpClient::Client.new("#{::PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/")
+      end
+
+      def intent_client(suffix)
+        LagoHttpClient::Client.new("#{::PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/#{suffix}/")
       end
 
       def headers

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -39,13 +39,14 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      # Best-effort: any error returns false so we never block auto-charge.
       def checkout_session_already_completed?(payment_intent)
         return false if payment_intent.provider_session_id.blank?
 
         response = intent_client(payment_intent.provider_session_id).get(headers: headers)
         status = JSON.parse(response.body).dig("data", "status")
         %w[PROCESSED SUCCESSFUL].include?(status)
-      rescue LagoHttpClient::HttpError
+      rescue StandardError
         false
       end
 

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -54,9 +54,13 @@ module Invoices
 
         intent_client("#{payment_intent.provider_session_id}/close")
           .post_with_response({}, headers)
-      rescue LagoHttpClient::HttpError
-        # MoneyHash rejects close on PROCESSED intents - benign
-        nil
+      rescue LagoHttpClient::HttpError => e
+        status = e.error_code.to_i
+        raise Invoices::Payments::RateLimitError, e if status == 429
+        # 4xx (other) -> intent already PROCESSED / not found, idempotent success.
+        return if (400..499).cover?(status)
+
+        raise Invoices::Payments::ConnectionError, e
       end
 
       def generate_payment_url(payment_intent)

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -5,6 +5,10 @@ module Invoices
     class MoneyhashService < BaseService
       include Customers::PaymentProviderFinder
 
+      # Moneyhash intent states that mean an auto-charge MUST NOT run:
+      # the URL has been used and the provider is settling it.
+      COMPLETED_INTENT_STATUSES = %w[PROCESSED SUCCESSFUL].freeze
+
       def initialize(invoice = nil)
         @invoice = invoice
 
@@ -45,7 +49,7 @@ module Invoices
 
         response = intent_client(payment_intent.provider_session_id).get(headers: headers)
         status = JSON.parse(response.body).dig("data", "status")
-        %w[PROCESSED SUCCESSFUL].include?(status)
+        COMPLETED_INTENT_STATUSES.include?(status)
       rescue
         false
       end

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -5,11 +5,6 @@ module Invoices
     class MoneyhashService < BaseService
       include Customers::PaymentProviderFinder
 
-      # Moneyhash intent states that mean an auto-charge MUST NOT run:
-      # the URL has been used and the provider is settling it. Aliases
-      # the canonical provider-model list so the two cannot drift.
-      COMPLETED_INTENT_STATUSES = ::PaymentProviders::MoneyhashProvider::SUCCESS_STATUSES
-
       def initialize(invoice = nil)
         @invoice = invoice
 
@@ -50,7 +45,7 @@ module Invoices
 
         response = intent_client(payment_intent.provider_session_id).get(headers: headers)
         status = JSON.parse(response.body).dig("data", "status")
-        COMPLETED_INTENT_STATUSES.include?(status)
+        ::PaymentProviders::MoneyhashProvider::CHECKOUT_COMPLETED_STATUSES.include?(status)
       rescue
         false
       end

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -52,6 +52,7 @@ module Invoices
 
         moneyhash_result_data = moneyhash_result["data"]
         result.payment_url = "#{moneyhash_result_data["embed_url"]}?lago_request=generate_payment_url"
+        result.provider_session_id = moneyhash_result_data["id"]
         result
       rescue LagoHttpClient::HttpError => e
         deliver_error_webhook(e)

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -6,8 +6,9 @@ module Invoices
       include Customers::PaymentProviderFinder
 
       # Moneyhash intent states that mean an auto-charge MUST NOT run:
-      # the URL has been used and the provider is settling it.
-      COMPLETED_INTENT_STATUSES = %w[PROCESSED SUCCESSFUL].freeze
+      # the URL has been used and the provider is settling it. Aliases
+      # the canonical provider-model list so the two cannot drift.
+      COMPLETED_INTENT_STATUSES = ::PaymentProviders::MoneyhashProvider::SUCCESS_STATUSES
 
       def initialize(invoice = nil)
         @invoice = invoice

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -75,9 +75,11 @@ module Invoices
         false
       end
 
-      # Best-effort: make the Checkout Session unusable. Idempotent — Stripe
-      # 400s on sessions that are not `open` (already expired/completed),
-      # which we treat as success.
+      # Best-effort: make the Checkout Session unusable.
+      # Terminal-but-idempotent errors (already paid, already expired,
+      # unknown id) are swallowed. Transient errors are re-raised as Lago
+      # wrappers so the job's retry_on triggers backoff. Mirrors the pattern
+      # in PaymentProviders::Stripe::Payments::CreateService.
       def expire_checkout_session(payment_intent)
         return if payment_intent.provider_session_id.blank?
 
@@ -86,8 +88,12 @@ module Invoices
           {},
           {api_key: stripe_api_key}
         )
-      rescue ::Stripe::InvalidRequestError, ::Stripe::AuthenticationError, ::Stripe::PermissionError
+      rescue ::Stripe::InvalidRequestError
         nil
+      rescue ::Stripe::RateLimitError => e
+        raise Invoices::Payments::RateLimitError, e
+      rescue ::Stripe::APIConnectionError => e
+        raise Invoices::Payments::ConnectionError, e
       end
 
       def generate_payment_url(payment_intent)

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -70,6 +70,7 @@ module Invoices
         )
 
         result.payment_url = res["url"]
+        result.provider_session_id = res["id"]
 
         result
       rescue ::Stripe::CardError, ::Stripe::InvalidRequestError, ::Stripe::AuthenticationError, Stripe::PermissionError => e

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -63,6 +63,10 @@ module Invoices
       # Returns true if the Checkout Session was already paid on Stripe's side.
       # Used by the entry-sweep to bail out of an auto-charge that would
       # otherwise race a customer paying via the hosted URL.
+      #
+      # Best-effort: any error (terminal or transient) returns false so we
+      # never block the auto-charge on a flaky provider. The trailing-edge
+      # ExpireOpenCheckoutUrlsJob handles cleanup after the invoice settles.
       def checkout_session_already_completed?(payment_intent)
         return false if payment_intent.provider_session_id.blank?
 
@@ -71,7 +75,7 @@ module Invoices
           {api_key: stripe_api_key}
         )
         session["status"] == "complete" || session["payment_status"] == "paid"
-      rescue ::Stripe::InvalidRequestError, ::Stripe::AuthenticationError, ::Stripe::PermissionError
+      rescue StandardError
         false
       end
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -60,6 +60,36 @@ module Invoices
         result.fail_with_error!(e)
       end
 
+      # Returns true if the Checkout Session was already paid on Stripe's side.
+      # Used by the entry-sweep to bail out of an auto-charge that would
+      # otherwise race a customer paying via the hosted URL.
+      def checkout_session_already_completed?(payment_intent)
+        return false if payment_intent.provider_session_id.blank?
+
+        session = ::Stripe::Checkout::Session.retrieve(
+          payment_intent.provider_session_id,
+          {api_key: stripe_api_key}
+        )
+        session["status"] == "complete" || session["payment_status"] == "paid"
+      rescue ::Stripe::InvalidRequestError, ::Stripe::AuthenticationError, ::Stripe::PermissionError
+        false
+      end
+
+      # Best-effort: make the Checkout Session unusable. Idempotent — Stripe
+      # 400s on sessions that are not `open` (already expired/completed),
+      # which we treat as success.
+      def expire_checkout_session(payment_intent)
+        return if payment_intent.provider_session_id.blank?
+
+        ::Stripe::Checkout::Session.expire(
+          payment_intent.provider_session_id,
+          {},
+          {api_key: stripe_api_key}
+        )
+      rescue ::Stripe::InvalidRequestError, ::Stripe::AuthenticationError, ::Stripe::PermissionError
+        nil
+      end
+
       def generate_payment_url(payment_intent)
         res = ::Stripe::Checkout::Session.create(
           payment_url_payload(payment_intent),

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -75,7 +75,7 @@ module Invoices
           {api_key: stripe_api_key}
         )
         session["status"] == "complete" || session["payment_status"] == "paid"
-      rescue StandardError
+      rescue
         false
       end
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -74,7 +74,7 @@ module Invoices
           payment_intent.provider_session_id,
           {api_key: stripe_api_key}
         )
-        session["status"] == "complete" || session["payment_status"] == "paid"
+        ::PaymentProviders::StripeProvider::CHECKOUT_COMPLETED_STATUSES.include?(session["status"])
       rescue
         false
       end

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -78,8 +78,20 @@ module Invoices
           deliver_webhook
           log_activity
         end
+        expire_open_checkout_urls_on_success(old_payment_status)
       end
       update_hubspot_invoice if invoice.should_update_hubspot_invoice?
+    end
+
+    # Kills any hosted-URL still open at the provider once the invoice is
+    # paid, so a customer clicking the URL afterwards cannot double-charge.
+    # Covers URLs generated mid-auto-charge that the pre-charge reconciliation
+    # never saw.
+    def expire_open_checkout_urls_on_success(old_payment_status)
+      return unless invoice.payment_succeeded?
+      return if old_payment_status.to_s == "succeeded"
+
+      PaymentIntents::ExpireOpenCheckoutUrlsJob.perform_after_commit(invoice)
     end
 
     def update_fees_payment_status

--- a/app/services/payment_intents/expire_open_checkout_urls_service.rb
+++ b/app/services/payment_intents/expire_open_checkout_urls_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PaymentIntents
+  # Expires every open hosted-checkout URL for an invoice on the provider
+  # side and marks the matching PaymentIntent as expired locally.
+  #
+  # Used after the invoice has already been paid (auto-charge succeeded, or
+  # URL payment landed) to make sure no other open URL can be used to charge
+  # the customer a second time. Unlike ReconcileOpenCheckoutUrlsService, this
+  # does NOT check whether the URL was already paid first — the invoice is
+  # already settled, so the "already paid" branch is information we don't
+  # need to act on. Provider returns "not expirable" on already-paid URLs;
+  # the per-provider rescue swallows it.
+  class ExpireOpenCheckoutUrlsService < BaseService
+    def initialize(invoice:)
+      @invoice = invoice
+      super
+    end
+
+    def call
+      return result if invoice.blank?
+
+      open_intents = PaymentIntent.active.where(invoice:).where.not(provider_session_id: nil)
+      return result if open_intents.none?
+
+      provider = Invoices::Payments::PaymentProviders::Factory.new_instance(invoice:)
+
+      open_intents.find_each do |payment_intent|
+        provider.expire_checkout_session(payment_intent)
+        payment_intent.expired!
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :invoice
+  end
+end

--- a/app/services/payment_intents/expire_open_checkout_urls_service.rb
+++ b/app/services/payment_intents/expire_open_checkout_urls_service.rb
@@ -12,6 +12,8 @@ module PaymentIntents
   # need to act on. Provider returns "not expirable" on already-paid URLs;
   # the per-provider rescue swallows it.
   class ExpireOpenCheckoutUrlsService < BaseService
+    Result = BaseResult
+
     def initialize(invoice:)
       @invoice = invoice
       super

--- a/app/services/payment_intents/fetch_service.rb
+++ b/app/services/payment_intents/fetch_service.rb
@@ -26,7 +26,10 @@ module PaymentIntents
           return result.single_validation_failure!(error_code: "payment_provider_error")
         end
 
-        payment_intent.update!(payment_url: payment_url_result.payment_url)
+        payment_intent.update!(
+          payment_url: payment_url_result.payment_url,
+          provider_session_id: payment_url_result.provider_session_id
+        )
       end
 
       result.payment_intent = payment_intent

--- a/app/services/payment_intents/reconcile_open_checkout_urls_service.rb
+++ b/app/services/payment_intents/reconcile_open_checkout_urls_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module PaymentIntents
+  # Reconciles every open hosted-checkout URL for an invoice against the
+  # provider's view of it. Each URL ends up in one of two terminal states:
+  #
+  #   * customer already paid via the URL -> result.already_paid_via_checkout = true
+  #     (the caller must stand down; the URL's webhook will finalize the invoice)
+  #   * URL not paid -> expired locally and on the provider side
+  #
+  # Used by Invoices::Payments::CreateService before launching an automatic
+  # charge, so an auto-charge cannot race a customer paying via the URL.
+  class ReconcileOpenCheckoutUrlsService < BaseService
+    Result = BaseResult[:already_paid_via_checkout]
+
+    def initialize(invoice:)
+      @invoice = invoice
+      super
+    end
+
+    def call
+      result.already_paid_via_checkout = false
+      return result if invoice.blank?
+
+      open_intents = PaymentIntent.active.where(invoice:).where.not(provider_session_id: nil)
+      return result if open_intents.none?
+
+      provider = Invoices::Payments::PaymentProviders::Factory.new_instance(invoice:)
+
+      open_intents.find_each do |payment_intent|
+        if provider.checkout_session_already_completed?(payment_intent)
+          result.already_paid_via_checkout = true
+          return result
+        end
+
+        begin
+          provider.expire_checkout_session(payment_intent)
+          payment_intent.expired!
+        rescue => e
+          # Don't block the auto-charge on a flaky provider. The intent stays
+          # active so the trailing-edge ExpireOpenCheckoutUrlsJob (or the next
+          # reconcile run) can retry. We log so operators see the trend.
+          Rails.logger.warn(
+            "ReconcileOpenCheckoutUrlsService: expire failed for " \
+            "PaymentIntent #{payment_intent.id}: #{e.class}: #{e.message}"
+          )
+        end
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :invoice
+  end
+end

--- a/db/migrate/20260520154815_add_provider_session_id_to_payment_intents.rb
+++ b/db/migrate/20260520154815_add_provider_session_id_to_payment_intents.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddProviderSessionIdToPaymentIntents < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :payment_intents, :provider_session_id, :string
+    add_index :payment_intents, :provider_session_id, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -479,6 +479,7 @@ DROP INDEX IF EXISTS public.index_payment_methods_on_payment_provider_id;
 DROP INDEX IF EXISTS public.index_payment_methods_on_payment_provider_customer_id;
 DROP INDEX IF EXISTS public.index_payment_methods_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_methods_on_customer_id;
+DROP INDEX IF EXISTS public.index_payment_intents_on_provider_session_id;
 DROP INDEX IF EXISTS public.index_payment_intents_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_intents_on_invoice_id_and_status;
 DROP INDEX IF EXISTS public.index_payment_intents_on_invoice_id;
@@ -4617,7 +4618,8 @@ CREATE TABLE public.payment_intents (
     status integer DEFAULT 0 NOT NULL,
     expires_at timestamp(6) without time zone NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    provider_session_id character varying
 );
 
 
@@ -8717,6 +8719,13 @@ CREATE INDEX index_payment_intents_on_organization_id ON public.payment_intents 
 
 
 --
+-- Name: index_payment_intents_on_provider_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_payment_intents_on_provider_session_id ON public.payment_intents USING btree (provider_session_id);
+
+
+--
 -- Name: index_payment_methods_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12214,6 +12223,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260520154815'),
 ('20260520075420'),
 ('20260517101105'),
 ('20260513105210'),
@@ -13217,3 +13227,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/spec/jobs/payment_intents/expire_open_checkout_urls_job_spec.rb
+++ b/spec/jobs/payment_intents/expire_open_checkout_urls_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentIntents::ExpireOpenCheckoutUrlsJob do
+  let(:invoice) { create(:invoice) }
+
+  describe "#perform" do
+    it "calls the expire service" do
+      allow(PaymentIntents::ExpireOpenCheckoutUrlsService).to receive(:call!)
+        .and_return(BaseService::Result.new)
+
+      described_class.new.perform(invoice)
+
+      expect(PaymentIntents::ExpireOpenCheckoutUrlsService).to have_received(:call!).with(invoice:)
+    end
+  end
+
+  describe "retry behavior" do
+    let(:registered_retry_classes) do
+      described_class.rescue_handlers.map { |klass_name, _| klass_name }
+    end
+
+    it "retries on Lago-wrapped transient provider failures" do
+      expect(registered_retry_classes).to include(
+        "Invoices::Payments::ConnectionError",
+        "Invoices::Payments::RateLimitError"
+      )
+    end
+  end
+end

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -296,6 +296,11 @@ RSpec.describe Invoices::Payments::AdyenService do
       allow(payment_links_api).to receive(:get_payment_link).and_raise(Adyen::AdyenError.new(nil, nil, "boom"))
       expect(adyen_service.checkout_session_already_completed?(payment_intent)).to be false
     end
+
+    it "swallows connection failures so auto-charge isn't blocked" do
+      allow(payment_links_api).to receive(:get_payment_link).and_raise(Faraday::ConnectionFailed.new("timeout"))
+      expect(adyen_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
   end
 
   describe "#expire_checkout_session" do

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -258,4 +258,74 @@ RSpec.describe Invoices::Payments::AdyenService do
       end
     end
   end
+
+  describe "#checkout_session_already_completed?" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "PL123") }
+    let(:get_response) { OpenStruct.new(response: {"status" => link_status}) }
+    let(:link_status) { "active" }
+
+    before do
+      adyen_payment_provider
+      adyen_customer
+      allow(Adyen::Client).to receive(:new).and_return(adyen_client)
+      allow(adyen_client).to receive(:checkout).and_return(checkout)
+      allow(checkout).to receive(:payment_links_api).and_return(payment_links_api)
+      allow(payment_links_api).to receive(:get_payment_link).and_return(get_response)
+    end
+
+    it "returns false for active links" do
+      expect(adyen_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    %w[completed paymentPending].each do |status|
+      context "when status is #{status}" do
+        let(:link_status) { status }
+
+        it "returns true" do
+          expect(adyen_service.checkout_session_already_completed?(payment_intent)).to be true
+        end
+      end
+    end
+
+    it "returns false when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      expect(adyen_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    it "swallows Adyen errors and returns false" do
+      allow(payment_links_api).to receive(:get_payment_link).and_raise(Adyen::AdyenError.new(nil, nil, "boom"))
+      expect(adyen_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+  end
+
+  describe "#expire_checkout_session" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "PL123") }
+
+    before do
+      adyen_payment_provider
+      adyen_customer
+      allow(Adyen::Client).to receive(:new).and_return(adyen_client)
+      allow(adyen_client).to receive(:checkout).and_return(checkout)
+      allow(checkout).to receive(:payment_links_api).and_return(payment_links_api)
+      allow(payment_links_api).to receive(:update_payment_link).and_return(OpenStruct.new(response: {}))
+    end
+
+    it "patches the link to expired" do
+      adyen_service.expire_checkout_session(payment_intent)
+
+      expect(payment_links_api).to have_received(:update_payment_link).with({status: "expired"}, "PL123")
+    end
+
+    it "does nothing when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      adyen_service.expire_checkout_session(payment_intent)
+
+      expect(payment_links_api).not_to have_received(:update_payment_link)
+    end
+
+    it "swallows Adyen errors" do
+      allow(payment_links_api).to receive(:update_payment_link).and_raise(Adyen::AdyenError.new(nil, nil, "boom"))
+      expect { adyen_service.expire_checkout_session(payment_intent) }.not_to raise_error
+    end
+  end
 end

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -340,5 +340,12 @@ RSpec.describe Invoices::Payments::AdyenService do
       expect { adyen_service.expire_checkout_session(payment_intent) }
         .to raise_error(Invoices::Payments::ConnectionError)
     end
+
+    it "wraps Adyen 429 errors as Invoices::Payments::RateLimitError" do
+      allow(payment_links_api).to receive(:update_payment_link)
+        .and_raise(Adyen::AdyenError.new(nil, nil, "rate limited", 429))
+      expect { adyen_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Invoices::Payments::RateLimitError)
+    end
   end
 end

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -323,9 +323,17 @@ RSpec.describe Invoices::Payments::AdyenService do
       expect(payment_links_api).not_to have_received(:update_payment_link)
     end
 
-    it "swallows Adyen errors" do
+    it "lets Adyen errors bubble up unwrapped (job will surface them)" do
       allow(payment_links_api).to receive(:update_payment_link).and_raise(Adyen::AdyenError.new(nil, nil, "boom"))
-      expect { adyen_service.expire_checkout_session(payment_intent) }.not_to raise_error
+      expect { adyen_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Adyen::AdyenError)
+    end
+
+    it "wraps Faraday connection failures as Invoices::Payments::ConnectionError" do
+      allow(payment_links_api).to receive(:update_payment_link)
+        .and_raise(Faraday::ConnectionFailed.new("timeout"))
+      expect { adyen_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Invoices::Payments::ConnectionError)
     end
   end
 end

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -235,6 +235,12 @@ RSpec.describe Invoices::Payments::AdyenService do
       expect(payment_links_api).to have_received(:payment_links)
     end
 
+    it "exposes the provider session id" do
+      result = adyen_service.generate_payment_url(payment_intent)
+
+      expect(result.provider_session_id).to eq(payment_links_response.response["id"])
+    end
+
     context "with an error on Adyen" do
       before do
         allow(payment_links_api).to receive(:payment_links)

--- a/spec/services/invoices/payments/cashfree_service_spec.rb
+++ b/spec/services/invoices/payments/cashfree_service_spec.rb
@@ -336,6 +336,11 @@ RSpec.describe Invoices::Payments::CashfreeService do
       allow(get_client).to receive(:get).and_raise(LagoHttpClient::HttpError.new(500, "boom", nil))
       expect(cashfree_service.checkout_session_already_completed?(payment_intent)).to be false
     end
+
+    it "swallows network timeouts so auto-charge isn't blocked" do
+      allow(get_client).to receive(:get).and_raise(Net::ReadTimeout)
+      expect(cashfree_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
   end
 
   describe "#expire_checkout_session" do

--- a/spec/services/invoices/payments/cashfree_service_spec.rb
+++ b/spec/services/invoices/payments/cashfree_service_spec.rb
@@ -296,4 +296,80 @@ RSpec.describe Invoices::Payments::CashfreeService do
       end
     end
   end
+
+  describe "#checkout_session_already_completed?" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "cf_link_123") }
+    let(:link_status) { "ACTIVE" }
+    let(:get_response) { instance_double(Net::HTTPResponse, body: {link_status:}.to_json) }
+    let(:get_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      cashfree_payment_provider
+      cashfree_customer
+
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with("#{::PaymentProviders::CashfreeProvider::BASE_URL}/cf_link_123")
+        .and_return(get_client)
+      allow(get_client).to receive(:get).and_return(get_response)
+    end
+
+    it "returns false when the link is active" do
+      expect(cashfree_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    %w[PAID PARTIALLY_PAID].each do |status|
+      context "when link_status is #{status}" do
+        let(:link_status) { status }
+
+        it "returns true" do
+          expect(cashfree_service.checkout_session_already_completed?(payment_intent)).to be true
+        end
+      end
+    end
+
+    it "returns false when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      expect(cashfree_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    it "swallows HTTP errors and returns false" do
+      allow(get_client).to receive(:get).and_raise(LagoHttpClient::HttpError.new(500, "boom", nil))
+      expect(cashfree_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+  end
+
+  describe "#expire_checkout_session" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "cf_link_123") }
+    let(:cancel_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      cashfree_payment_provider
+      cashfree_customer
+
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with("#{::PaymentProviders::CashfreeProvider::BASE_URL}/cf_link_123/cancel")
+        .and_return(cancel_client)
+      allow(cancel_client).to receive(:post_with_response).and_return(instance_double(Net::HTTPResponse))
+    end
+
+    it "POSTs to the cancel endpoint" do
+      cashfree_service.expire_checkout_session(payment_intent)
+      expect(cancel_client).to have_received(:post_with_response)
+    end
+
+    it "does nothing when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      allow(LagoHttpClient::Client).to receive(:new).and_return(cancel_client)
+
+      cashfree_service.expire_checkout_session(payment_intent)
+
+      expect(cancel_client).not_to have_received(:post_with_response)
+    end
+
+    it "swallows HTTP errors" do
+      allow(cancel_client).to receive(:post_with_response)
+        .and_raise(LagoHttpClient::HttpError.new(409, "not active", nil))
+      expect { cashfree_service.expire_checkout_session(payment_intent) }.not_to raise_error
+    end
+  end
 end

--- a/spec/services/invoices/payments/cashfree_service_spec.rb
+++ b/spec/services/invoices/payments/cashfree_service_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Invoices::Payments::CashfreeService do
     subject(:result) { cashfree_service.generate_payment_url(payment_intent) }
 
     let(:payment_links_response) { Net::HTTPResponse.new("1.0", "200", "OK") }
-    let(:payment_links_body) { {link_url: "https://payments-test.cashfree.com/links//U1mgll3c0e9g"}.to_json }
+    let(:payment_links_body) { {link_url: "https://payments-test.cashfree.com/links//U1mgll3c0e9g", link_id: "cf_link_123"}.to_json }
     let(:payment_intent) { create(:payment_intent) }
 
     before do
@@ -262,6 +262,10 @@ RSpec.describe Invoices::Payments::CashfreeService do
     it "generates payment url" do
       expect(result).to be_success
       expect(result.payment_url).to be_present
+    end
+
+    it "exposes the provider session id" do
+      expect(result.provider_session_id).to eq("cf_link_123")
     end
 
     context "when payment url failed to generate" do

--- a/spec/services/invoices/payments/cashfree_service_spec.rb
+++ b/spec/services/invoices/payments/cashfree_service_spec.rb
@@ -366,10 +366,24 @@ RSpec.describe Invoices::Payments::CashfreeService do
       expect(cancel_client).not_to have_received(:post_with_response)
     end
 
-    it "swallows HTTP errors" do
+    it "swallows 4xx HTTP errors (terminal: link not active / not found)" do
       allow(cancel_client).to receive(:post_with_response)
         .and_raise(LagoHttpClient::HttpError.new(409, "not active", nil))
       expect { cashfree_service.expire_checkout_session(payment_intent) }.not_to raise_error
+    end
+
+    it "wraps 5xx HTTP errors as Invoices::Payments::ConnectionError" do
+      allow(cancel_client).to receive(:post_with_response)
+        .and_raise(LagoHttpClient::HttpError.new(503, "service unavailable", nil))
+      expect { cashfree_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Invoices::Payments::ConnectionError)
+    end
+
+    it "wraps 429 HTTP errors as Invoices::Payments::RateLimitError" do
+      allow(cancel_client).to receive(:post_with_response)
+        .and_raise(LagoHttpClient::HttpError.new(429, "slow down", nil))
+      expect { cashfree_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Invoices::Payments::RateLimitError)
     end
   end
 end

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -435,6 +435,35 @@ RSpec.describe Invoices::Payments::CreateService do
       end
     end
 
+    context "when an open checkout URL was already paid on the provider side" do
+      before do
+        allow(PaymentIntents::ReconcileOpenCheckoutUrlsService)
+          .to receive(:call)
+          .with(invoice:)
+          .and_return(PaymentIntents::ReconcileOpenCheckoutUrlsService::Result.new.tap { |r| r.already_paid_via_checkout = true })
+      end
+
+      it "stands down without launching the auto-charge" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.payment).to be_nil
+        expect(invoice.reload.payment_attempts).to eq(0)
+        expect(provider_class).not_to have_received(:new)
+      end
+    end
+
+    context "when no open checkout URL was already paid" do
+      it "proceeds with the auto-charge after reconciliation" do
+        allow(PaymentIntents::ReconcileOpenCheckoutUrlsService).to receive(:call).and_call_original
+
+        create_service.call
+
+        expect(PaymentIntents::ReconcileOpenCheckoutUrlsService).to have_received(:call).with(invoice:)
+        expect(provider_class).to have_received(:new)
+      end
+    end
+
     it_behaves_like "syncs payment" do
       let(:service_call) { create_service.call }
     end

--- a/spec/services/invoices/payments/flutterwave_service_spec.rb
+++ b/spec/services/invoices/payments/flutterwave_service_spec.rb
@@ -317,6 +317,11 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
       allow(verify_client).to receive(:get).and_raise(LagoHttpClient::HttpError.new(500, "boom", nil))
       expect(flutterwave_service.checkout_session_already_completed?(payment_intent)).to be false
     end
+
+    it "swallows network timeouts so auto-charge isn't blocked" do
+      allow(verify_client).to receive(:get).and_raise(Net::ReadTimeout)
+      expect(flutterwave_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
   end
 
   describe "#expire_checkout_session" do

--- a/spec/services/invoices/payments/flutterwave_service_spec.rb
+++ b/spec/services/invoices/payments/flutterwave_service_spec.rb
@@ -222,6 +222,12 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
       expect(result.payment_url).to eq("https://checkout.flutterwave.com/v3/hosted/pay/test_link")
     end
 
+    it "exposes the invoice id as provider session id" do
+      result = flutterwave_service.generate_payment_url(payment_intent)
+
+      expect(result.provider_session_id).to eq(invoice.id)
+    end
+
     it "sends correct parameters to Flutterwave API" do
       flutterwave_service.generate_payment_url(payment_intent)
 

--- a/spec/services/invoices/payments/flutterwave_service_spec.rb
+++ b/spec/services/invoices/payments/flutterwave_service_spec.rb
@@ -227,6 +227,22 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
 
       expect(result.provider_session_id).to eq(invoice.id)
     end
+  end
+
+  describe "#generate_payment_url additional cases" do
+    let(:payment_intent) { double }
+    let(:http_client) { instance_double(LagoHttpClient::Client) }
+    let(:successful_response) do
+      instance_double("HTTPResponse", body: {
+        status: "success",
+        data: {link: "https://checkout.flutterwave.com/v3/hosted/pay/test_link"}
+      }.to_json)
+    end
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new).and_return(http_client)
+      allow(http_client).to receive(:post_with_response).and_return(successful_response)
+    end
 
     it "sends correct parameters to Flutterwave API" do
       flutterwave_service.generate_payment_url(payment_intent)
@@ -265,6 +281,49 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
         expect(result.error).to be_a(BaseService::ThirdPartyFailure)
         expect(result.error.third_party).to eq("Flutterwave")
       end
+    end
+  end
+
+  describe "#checkout_session_already_completed?" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: invoice.id) }
+    let(:verify_client) { instance_double(LagoHttpClient::Client) }
+    let(:verify_endpoint) { "#{flutterwave_provider.api_url}/transactions/verify_by_reference" }
+    let(:verify_status) { "pending" }
+    let(:verify_response) { instance_double("HTTPResponse", body: {data: {status: verify_status}}.to_json) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new).with(verify_endpoint).and_return(verify_client)
+      allow(verify_client).to receive(:get).and_return(verify_response)
+    end
+
+    it "returns false when the transaction is not successful" do
+      expect(flutterwave_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    context "when the transaction is successful" do
+      let(:verify_status) { "successful" }
+
+      it "returns true" do
+        expect(flutterwave_service.checkout_session_already_completed?(payment_intent)).to be true
+      end
+    end
+
+    it "returns false when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      expect(flutterwave_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    it "swallows HTTP errors and returns false" do
+      allow(verify_client).to receive(:get).and_raise(LagoHttpClient::HttpError.new(500, "boom", nil))
+      expect(flutterwave_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+  end
+
+  describe "#expire_checkout_session" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: invoice.id) }
+
+    it "is a no-op (Flutterwave has no per-transaction expire API)" do
+      expect { flutterwave_service.expire_checkout_session(payment_intent) }.not_to raise_error
     end
   end
 

--- a/spec/services/invoices/payments/moneyhash_service_spec.rb
+++ b/spec/services/invoices/payments/moneyhash_service_spec.rb
@@ -120,6 +120,11 @@ RSpec.describe Invoices::Payments::MoneyhashService do
       allow(intent_client).to receive(:get).and_raise(LagoHttpClient::HttpError.new(500, "boom", nil))
       expect(moneyhash_service.checkout_session_already_completed?(payment_intent)).to be false
     end
+
+    it "swallows network timeouts so auto-charge isn't blocked" do
+      allow(intent_client).to receive(:get).and_raise(Net::ReadTimeout)
+      expect(moneyhash_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
   end
 
   describe "#expire_checkout_session" do

--- a/spec/services/invoices/payments/moneyhash_service_spec.rb
+++ b/spec/services/invoices/payments/moneyhash_service_spec.rb
@@ -80,4 +80,80 @@ RSpec.describe Invoices::Payments::MoneyhashService do
       expect(result.provider_session_id).to eq(payment_url_response.dig("data", "id"))
     end
   end
+
+  describe "#checkout_session_already_completed?" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "MH123") }
+    let(:base) { ::PaymentProviders::MoneyhashProvider.api_base_url }
+    let(:intent_endpoint) { "#{base}/api/v1.1/payments/intent/MH123/" }
+    let(:intent_client) { instance_double(LagoHttpClient::Client) }
+    let(:status) { "INITIATED" }
+    let(:get_response) { instance_double(Net::HTTPOK, body: {data: {status:}}.to_json) }
+
+    before do
+      moneyhash_provider
+      moneyhash_customer
+
+      allow(LagoHttpClient::Client).to receive(:new).with(intent_endpoint).and_return(intent_client)
+      allow(intent_client).to receive(:get).and_return(get_response)
+    end
+
+    it "returns false for non-paid intents" do
+      expect(moneyhash_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    %w[PROCESSED SUCCESSFUL].each do |s|
+      context "when status is #{s}" do
+        let(:status) { s }
+
+        it "returns true" do
+          expect(moneyhash_service.checkout_session_already_completed?(payment_intent)).to be true
+        end
+      end
+    end
+
+    it "returns false when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      expect(moneyhash_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    it "swallows HTTP errors and returns false" do
+      allow(intent_client).to receive(:get).and_raise(LagoHttpClient::HttpError.new(500, "boom", nil))
+      expect(moneyhash_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+  end
+
+  describe "#expire_checkout_session" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "MH123") }
+    let(:base) { ::PaymentProviders::MoneyhashProvider.api_base_url }
+    let(:close_endpoint) { "#{base}/api/v1.1/payments/intent/MH123/close/" }
+    let(:close_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      moneyhash_provider
+      moneyhash_customer
+
+      allow(LagoHttpClient::Client).to receive(:new).with(close_endpoint).and_return(close_client)
+      allow(close_client).to receive(:post_with_response).and_return(instance_double(Net::HTTPOK))
+    end
+
+    it "POSTs to the close endpoint" do
+      moneyhash_service.expire_checkout_session(payment_intent)
+      expect(close_client).to have_received(:post_with_response)
+    end
+
+    it "does nothing when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      allow(LagoHttpClient::Client).to receive(:new).and_return(close_client)
+
+      moneyhash_service.expire_checkout_session(payment_intent)
+
+      expect(close_client).not_to have_received(:post_with_response)
+    end
+
+    it "swallows HTTP errors" do
+      allow(close_client).to receive(:post_with_response)
+        .and_raise(LagoHttpClient::HttpError.new(400, "already processed", nil))
+      expect { moneyhash_service.expire_checkout_session(payment_intent) }.not_to raise_error
+    end
+  end
 end

--- a/spec/services/invoices/payments/moneyhash_service_spec.rb
+++ b/spec/services/invoices/payments/moneyhash_service_spec.rb
@@ -74,5 +74,10 @@ RSpec.describe Invoices::Payments::MoneyhashService do
       expect(result).to be_success
       expect(result.payment_url).to eq("#{payment_url_response.dig("data", "embed_url")}?lago_request=generate_payment_url")
     end
+
+    it "exposes the provider session id" do
+      result = moneyhash_service.generate_payment_url(payment_intent)
+      expect(result.provider_session_id).to eq(payment_url_response.dig("data", "id"))
+    end
   end
 end

--- a/spec/services/invoices/payments/moneyhash_service_spec.rb
+++ b/spec/services/invoices/payments/moneyhash_service_spec.rb
@@ -150,10 +150,24 @@ RSpec.describe Invoices::Payments::MoneyhashService do
       expect(close_client).not_to have_received(:post_with_response)
     end
 
-    it "swallows HTTP errors" do
+    it "swallows 4xx HTTP errors (terminal: intent processed / not found)" do
       allow(close_client).to receive(:post_with_response)
         .and_raise(LagoHttpClient::HttpError.new(400, "already processed", nil))
       expect { moneyhash_service.expire_checkout_session(payment_intent) }.not_to raise_error
+    end
+
+    it "wraps 5xx HTTP errors as Invoices::Payments::ConnectionError" do
+      allow(close_client).to receive(:post_with_response)
+        .and_raise(LagoHttpClient::HttpError.new(503, "service unavailable", nil))
+      expect { moneyhash_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Invoices::Payments::ConnectionError)
+    end
+
+    it "wraps 429 HTTP errors as Invoices::Payments::RateLimitError" do
+      allow(close_client).to receive(:post_with_response)
+        .and_raise(LagoHttpClient::HttpError.new(429, "slow down", nil))
+      expect { moneyhash_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Invoices::Payments::RateLimitError)
     end
   end
 end

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -148,13 +148,6 @@ RSpec.describe Invoices::Payments::StripeService do
       expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be true
     end
 
-    it "returns true when payment_status is paid" do
-      allow(::Stripe::Checkout::Session).to receive(:retrieve)
-        .and_return({"status" => "open", "payment_status" => "paid"})
-
-      expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be true
-    end
-
     it "returns false when the session is still open and unpaid" do
       allow(::Stripe::Checkout::Session).to receive(:retrieve)
         .and_return({"status" => "open", "payment_status" => "unpaid"})

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -133,6 +133,82 @@ RSpec.describe Invoices::Payments::StripeService do
     end
   end
 
+  describe "#checkout_session_already_completed?" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "cs_test_123") }
+
+    before do
+      stripe_payment_provider
+      stripe_customer
+    end
+
+    it "returns true when Stripe reports the session as complete" do
+      allow(::Stripe::Checkout::Session).to receive(:retrieve)
+        .and_return({"status" => "complete", "payment_status" => "paid"})
+
+      expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be true
+    end
+
+    it "returns true when payment_status is paid" do
+      allow(::Stripe::Checkout::Session).to receive(:retrieve)
+        .and_return({"status" => "open", "payment_status" => "paid"})
+
+      expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be true
+    end
+
+    it "returns false when the session is still open and unpaid" do
+      allow(::Stripe::Checkout::Session).to receive(:retrieve)
+        .and_return({"status" => "open", "payment_status" => "unpaid"})
+
+      expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    it "returns false when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+
+    it "swallows Stripe errors and returns false" do
+      allow(::Stripe::Checkout::Session).to receive(:retrieve)
+        .and_raise(::Stripe::InvalidRequestError.new("not found", {}))
+
+      expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
+  end
+
+  describe "#expire_checkout_session" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "cs_test_123") }
+
+    before do
+      stripe_payment_provider
+      stripe_customer
+    end
+
+    it "calls Stripe's expire endpoint with the session id" do
+      allow(::Stripe::Checkout::Session).to receive(:expire).and_return(nil)
+
+      stripe_service.expire_checkout_session(payment_intent)
+
+      expect(::Stripe::Checkout::Session).to have_received(:expire)
+        .with("cs_test_123", {}, hash_including(api_key: instance_of(String)))
+    end
+
+    it "does nothing when provider_session_id is missing" do
+      payment_intent.update!(provider_session_id: nil)
+      allow(::Stripe::Checkout::Session).to receive(:expire)
+
+      stripe_service.expire_checkout_session(payment_intent)
+
+      expect(::Stripe::Checkout::Session).not_to have_received(:expire)
+    end
+
+    it "swallows Stripe errors when the session is no longer expirable" do
+      allow(::Stripe::Checkout::Session).to receive(:expire)
+        .and_raise(::Stripe::InvalidRequestError.new("already completed", {}))
+
+      expect { stripe_service.expire_checkout_session(payment_intent) }.not_to raise_error
+    end
+  end
+
   describe "#update_payment_status" do
     let(:payment) do
       create(

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -201,11 +201,27 @@ RSpec.describe Invoices::Payments::StripeService do
       expect(::Stripe::Checkout::Session).not_to have_received(:expire)
     end
 
-    it "swallows Stripe errors when the session is no longer expirable" do
+    it "swallows InvalidRequestError when the session is no longer expirable" do
       allow(::Stripe::Checkout::Session).to receive(:expire)
         .and_raise(::Stripe::InvalidRequestError.new("already completed", {}))
 
       expect { stripe_service.expire_checkout_session(payment_intent) }.not_to raise_error
+    end
+
+    it "wraps connection errors as Invoices::Payments::ConnectionError" do
+      allow(::Stripe::Checkout::Session).to receive(:expire)
+        .and_raise(::Stripe::APIConnectionError.new("timeout"))
+
+      expect { stripe_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Invoices::Payments::ConnectionError)
+    end
+
+    it "wraps rate-limit errors as Invoices::Payments::RateLimitError" do
+      allow(::Stripe::Checkout::Session).to receive(:expire)
+        .and_raise(::Stripe::RateLimitError.new("slow down"))
+
+      expect { stripe_service.expire_checkout_session(payment_intent) }
+        .to raise_error(Invoices::Payments::RateLimitError)
     end
   end
 

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -33,13 +33,19 @@ RSpec.describe Invoices::Payments::StripeService do
       stripe_customer
 
       allow(::Stripe::Checkout::Session).to receive(:create)
-        .and_return({"url" => "https://example.com"})
+        .and_return({"url" => "https://example.com", "id" => "cs_test_123"})
     end
 
     it "generates payment url" do
       stripe_service.generate_payment_url(payment_intent)
 
       expect(::Stripe::Checkout::Session).to have_received(:create)
+    end
+
+    it "exposes the provider session id" do
+      result = stripe_service.generate_payment_url(payment_intent)
+
+      expect(result.provider_session_id).to eq("cs_test_123")
     end
 
     describe "#payment_url_payload" do

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -173,6 +173,13 @@ RSpec.describe Invoices::Payments::StripeService do
 
       expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be false
     end
+
+    it "swallows transient Stripe errors so auto-charge isn't blocked" do
+      allow(::Stripe::Checkout::Session).to receive(:retrieve)
+        .and_raise(::Stripe::APIConnectionError.new("timeout"))
+
+      expect(stripe_service.checkout_session_already_completed?(payment_intent)).to be false
+    end
   end
 
   describe "#expire_checkout_session" do

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -318,6 +318,34 @@ RSpec.describe Invoices::UpdateService do
       end
     end
 
+    context "post-success expire of open checkout URLs" do
+      context "when payment_status transitions to succeeded" do
+        let(:invoice) { create(:invoice, payment_status: :pending) }
+
+        it "enqueues ExpireOpenCheckoutUrlsJob" do
+          expect { result }
+            .to have_enqueued_job_after_commit(PaymentIntents::ExpireOpenCheckoutUrlsJob).with(invoice)
+        end
+      end
+
+      context "when payment_status was already succeeded" do
+        let(:invoice) { create(:invoice, payment_status: :succeeded) }
+
+        it "does not enqueue the job" do
+          expect { result }.not_to have_enqueued_job(PaymentIntents::ExpireOpenCheckoutUrlsJob)
+        end
+      end
+
+      context "when payment_status transitions to failed" do
+        let(:invoice) { create(:invoice, payment_status: :pending) }
+        let(:update_args) { {payment_status: "failed"} }
+
+        it "does not enqueue the job" do
+          expect { result }.not_to have_enqueued_job(PaymentIntents::ExpireOpenCheckoutUrlsJob)
+        end
+      end
+    end
+
     context "when invoice payment_status is invalid" do
       let(:update_args) do
         {

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Invoices::UpdateService do
       end
     end
 
-    context "post-success expire of open checkout URLs" do
+    context "when invoice payment_status transitions" do
       context "when payment_status transitions to succeeded" do
         let(:invoice) { create(:invoice, payment_status: :pending) }
 

--- a/spec/services/payment_intents/expire_open_checkout_urls_service_spec.rb
+++ b/spec/services/payment_intents/expire_open_checkout_urls_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentIntents::ExpireOpenCheckoutUrlsService do
+  subject(:result) { described_class.call(invoice:) }
+
+  let(:invoice) { create(:invoice) }
+  let(:provider_service) do
+    instance_double(Invoices::Payments::StripeService, expire_checkout_session: nil)
+  end
+
+  before do
+    allow(Invoices::Payments::PaymentProviders::Factory)
+      .to receive(:new_instance).with(invoice:).and_return(provider_service)
+  end
+
+  context "when the invoice is blank" do
+    let(:invoice) { nil }
+
+    it "returns a success result without contacting the provider" do
+      expect(result).to be_success
+      expect(Invoices::Payments::PaymentProviders::Factory).not_to have_received(:new_instance)
+    end
+  end
+
+  context "when there are no open intents with a provider_session_id" do
+    before { create(:payment_intent, invoice:, provider_session_id: nil) }
+
+    it "does not contact the provider" do
+      result
+      expect(Invoices::Payments::PaymentProviders::Factory).not_to have_received(:new_instance)
+    end
+  end
+
+  context "with an open intent that has a provider_session_id" do
+    let!(:payment_intent) do
+      create(:payment_intent, invoice:, provider_session_id: "cs_test_open")
+    end
+
+    it "expires the session on the provider" do
+      result
+      expect(provider_service).to have_received(:expire_checkout_session).with(payment_intent)
+    end
+
+    it "marks the intent expired locally" do
+      expect { result }.to change { payment_intent.reload.status }.from("active").to("expired")
+    end
+  end
+
+  context "when an intent's status is already expired" do
+    before { create(:payment_intent, :expired, invoice:, provider_session_id: "cs_old") }
+
+    it "skips it" do
+      result
+      expect(provider_service).not_to have_received(:expire_checkout_session)
+    end
+  end
+end

--- a/spec/services/payment_intents/fetch_service_spec.rb
+++ b/spec/services/payment_intents/fetch_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe PaymentIntents::FetchService do
       let(:invoice) { create(:invoice) }
       let(:payment_provider_service) { instance_double("PaymentProviderService") }
       let(:payment_url) { "https://example.com/payment" }
+      let(:provider_session_id) { "cs_test_abc" }
 
       before do
         allow(Invoices::Payments::PaymentProviders::Factory)
@@ -27,7 +28,12 @@ RSpec.describe PaymentIntents::FetchService do
         allow(payment_provider_service)
           .to receive(:generate_payment_url)
           .with(instance_of(PaymentIntent))
-          .and_return(BaseService::Result.new.tap { |r| r.payment_url = payment_url })
+          .and_return(
+            BaseService::Result.new.tap do |r|
+              r.payment_url = payment_url
+              r.provider_session_id = provider_session_id
+            end
+          )
       end
 
       context "when active payment intent exists" do
@@ -48,6 +54,10 @@ RSpec.describe PaymentIntents::FetchService do
           expect(result.payment_intent).to eq(payment_intent)
           expect(result.payment_intent.payment_url).to eq(payment_url)
           expect(payment_provider_service).to have_received(:generate_payment_url)
+        end
+
+        it "persists the provider session id" do
+          expect(result.payment_intent.provider_session_id).to eq(provider_session_id)
         end
       end
 

--- a/spec/services/payment_intents/reconcile_open_checkout_urls_service_spec.rb
+++ b/spec/services/payment_intents/reconcile_open_checkout_urls_service_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentIntents::ReconcileOpenCheckoutUrlsService do
+  subject(:result) { described_class.call(invoice:) }
+
+  let(:invoice) { create(:invoice) }
+  let(:provider_service) do
+    instance_double(
+      Invoices::Payments::StripeService,
+      checkout_session_already_completed?: completed,
+      expire_checkout_session: nil
+    )
+  end
+  let(:completed) { false }
+
+  before do
+    allow(Invoices::Payments::PaymentProviders::Factory)
+      .to receive(:new_instance).with(invoice:).and_return(provider_service)
+  end
+
+  context "when the invoice is blank" do
+    let(:invoice) { nil }
+
+    it "returns a success result with already_paid_via_checkout=false" do
+      expect(result).to be_success
+      expect(result.already_paid_via_checkout).to be false
+    end
+
+    it "does not contact the provider" do
+      result
+      expect(Invoices::Payments::PaymentProviders::Factory).not_to have_received(:new_instance)
+    end
+  end
+
+  context "when there are no open intents with a provider_session_id" do
+    before { create(:payment_intent, invoice:, provider_session_id: nil) }
+
+    it "returns already_paid_via_checkout=false without contacting the provider" do
+      expect(result.already_paid_via_checkout).to be false
+      expect(Invoices::Payments::PaymentProviders::Factory).not_to have_received(:new_instance)
+    end
+  end
+
+  context "when the open intent has not been paid via the URL" do
+    let!(:payment_intent) do
+      create(:payment_intent, invoice:, provider_session_id: "cs_test_open")
+    end
+
+    it "expires the intent locally" do
+      expect { result }.to change { payment_intent.reload.status }.from("active").to("expired")
+    end
+
+    it "expires the session on the provider" do
+      result
+      expect(provider_service).to have_received(:expire_checkout_session).with(payment_intent)
+    end
+
+    it "returns already_paid_via_checkout=false" do
+      expect(result.already_paid_via_checkout).to be false
+    end
+  end
+
+  context "when the URL was already paid on the provider side" do
+    let(:completed) { true }
+    let!(:payment_intent) do
+      create(:payment_intent, invoice:, provider_session_id: "cs_test_paid")
+    end
+
+    it "returns already_paid_via_checkout=true" do
+      expect(result.already_paid_via_checkout).to be true
+    end
+
+    it "does not expire the intent locally" do
+      expect { result }.not_to change { payment_intent.reload.status }
+    end
+
+    it "does not call expire_checkout_session" do
+      result
+      expect(provider_service).not_to have_received(:expire_checkout_session)
+    end
+  end
+
+  context "when expire raises a transient provider error" do
+    let!(:payment_intent) do
+      create(:payment_intent, invoice:, provider_session_id: "cs_test_open")
+    end
+
+    before do
+      allow(provider_service).to receive(:expire_checkout_session)
+        .and_raise(Invoices::Payments::ConnectionError.new(StandardError.new("boom")))
+    end
+
+    it "does not block the auto-charge" do
+      expect { result }.not_to raise_error
+    end
+
+    it "does not mark the intent expired locally (so retry can re-attempt)" do
+      expect { result }.not_to change { payment_intent.reload.status }
+    end
+
+    it "returns already_paid_via_checkout=false" do
+      expect(result.already_paid_via_checkout).to be false
+    end
+  end
+
+  context "when an intent's status is already expired" do
+    before { create(:payment_intent, :expired, invoice:, provider_session_id: "cs_old") }
+
+    it "does not reconsider it" do
+      result
+      expect(provider_service).not_to have_received(:checkout_session_already_completed?)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Lago has been seeing duplicate charges on invoices when an off-session auto-charge runs against the same invoice that has an active hosted-checkout URL (Stripe Checkout Session, Adyen Pay-by-Link, Cashfree Payment Link, Moneyhash Payment Intent, Flutterwave Standard checkout). Two race shapes were observed in the audit of 20 duplicate cases:

- **URL-first then auto-charge**: customer pays via the URL → ~5–300s later Lago's auto-charge fires and charges the saved card a second time.
- **Auto-charge mid-flight then URL paid**: auto-charge already running at the provider → customer clicks the still-live URL → second charge.

Today nothing inside `Invoices::Payments::CreateService` checks whether a hosted URL might already have been paid, and nothing kills open URLs after the invoice has been settled — so both sides of the race remain open.

## Description

Two coordinated entry points reconcile open hosted-checkout URLs with the provider's view of them.

### 1. Pre-auto-charge — `PaymentIntents::ReconcileOpenCheckoutUrlsService`

Called from `Invoices::Payments::CreateService#call` before the `Payment` row is created. For each active `PaymentIntent` carrying a `provider_session_id`:

- If the provider reports the URL was already paid → the auto-charge stands down (`already_paid_via_checkout = true`). The URL's webhook will finalize the invoice.
- Otherwise → the URL is expired on the provider side and the local `PaymentIntent` is marked `expired`.

Per-intent rescue keeps a flaky provider from blocking the auto-charge — the trailing-edge job handles cleanup.

### 2. Post-invoice-succeeded — `PaymentIntents::ExpireOpenCheckoutUrlsService` via `ExpireOpenCheckoutUrlsJob`

Hooked into `Invoices::UpdateService` on transition to `payment_status: :succeeded`. Closes URLs created mid-auto-charge that the pre-charge reconciliation never saw. Runs async to keep webhook latency low; uses Lago's standard retry pattern (`retry_on Invoices::Payments::ConnectionError, RateLimitError, attempts: 6, wait: :polynomially_longer`) — mirrors `Invoices::Payments::CreateJob`.

### Per-provider implementation

Each `Invoices::Payments::<Provider>Service` gets two new methods:

| Provider | `checkout_session_already_completed?` | `expire_checkout_session` |
|---|---|---|
| Stripe | `Checkout::Session.retrieve` → `status == "complete"` or `payment_status == "paid"` | `Checkout::Session.expire`; transient errors wrap as Lago `ConnectionError` / `RateLimitError` |
| Adyen | `payment_links_api.get_payment_link` → status in `[completed, paymentPending]` | `update_payment_link({status: "expired"})`; `Faraday::ConnectionFailed` and HTTP 429 wrap as Lago errors |
| Cashfree | `GET /pg/links/{id}` → `link_status` in `[PAID, PARTIALLY_PAID]` | `POST /pg/links/{id}/cancel`; 429 → `RateLimitError`, 5xx → `ConnectionError`, 4xx → idempotent success |
| Moneyhash | `GET /api/v1.1/payments/intent/{id}/` → status in `[PROCESSED, SUCCESSFUL]` | `POST /.../close/`; same status mapping as Cashfree |
| Flutterwave | `GET /v3/transactions/verify_by_reference?tx_ref=...` → `status == "successful"` | No-op (provider has no per-transaction expire API for Standard checkout) |

`checkout_session_already_completed?` is best-effort across all providers — any error returns `false` so a provider blip never blocks the auto-charge.

> [!IMPORTANT]
>  Flutterwave URLs cannot be expired at the provider — only locally. The `session_duration` set at create time is the only timeout knob there. Documented inline.