### PR TITLE
fix(subscriptions): preserve subscription_at on same-day activation

### DIFF
--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -51,7 +51,7 @@ module Subscriptions
     end
 
     def gate_subscription
-      subscription.mark_as_incomplete!
+      subscription.mark_as_incomplete!(timestamp)
 
       EmitFixedChargeEventsService.call!(
         subscriptions: [subscription],

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -160,7 +160,11 @@ module Subscriptions
     def handle_today_subscription(new_subscription)
       new_subscription.pending!
       apply_activation_rules(new_subscription)
-      ActivateService.call!(subscription: new_subscription, during_creation: true)
+      ActivateService.call!(
+        subscription: new_subscription,
+        timestamp: new_subscription.subscription_at,
+        during_creation: true
+      )
     end
 
     def handle_past_subscription(new_subscription)

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -729,6 +729,24 @@ RSpec.describe Subscriptions::CreateService do
       end
     end
 
+    context "when subscription_at is earlier today" do
+      let(:now) { Time.zone.local(2026, 5, 20, 14, 30) }
+      let(:subscription_at) { now.beginning_of_day }
+
+      around { |example| travel_to(now) { example.run } }
+
+      it "sets started_at to subscription_at so events in the gap are included in usage" do
+        result = create_service.call
+
+        expect(result).to be_success
+
+        subscription = result.subscription
+        expect(subscription).to be_active
+        expect(subscription.started_at).to eq(subscription_at)
+        expect(subscription.subscription_at).to eq(subscription_at)
+      end
+    end
+
     context "when billing_time is invalid" do
       let(:billing_time) { :foo }
 
@@ -1430,6 +1448,22 @@ RSpec.describe Subscriptions::CreateService do
 
           it "enqueues BillSubscriptionJob" do
             expect { create_service.call }.to have_enqueued_job(BillSubscriptionJob)
+          end
+
+          context "when subscription_at is earlier today" do
+            let(:now) { Time.zone.local(2026, 5, 20, 14, 30) }
+            let(:subscription_at) { now.beginning_of_day.iso8601 }
+
+            around { |example| travel_to(now) { example.run } }
+
+            it "sets started_at to subscription_at on the gated incomplete subscription" do
+              result = create_service.call
+
+              expect(result).to be_success
+              subscription = result.subscription
+              expect(subscription).to be_incomplete
+              expect(subscription.started_at).to eq(now.beginning_of_day)
+            end
           end
         end
 


### PR DESCRIPTION
## Context

Since PR #5441, same-day subscription creation routes through `Subscriptions::ActivateService`. The service was being called without forwarding `subscription_at`, so its `timestamp` defaulted to `Time.current` and `mark_as_active!` / `mark_as_incomplete!` set `started_at` to "now" instead of the provided `subscription_at`.

Any usage event ingested between `subscription_at` and the moment of creation was excluded from the subscription's usage because it fell before `started_at`. The past-day branch (`handle_past_subscription`) was untouched and continued to work correctly, so the regression was isolated to the same-day path.

Linear: [BIL-82](https://linear.app/getlago/issue/BIL-82/same-day-subscription-with-past-subscription-at-sets-started-at-to-now)
Regression introduced by: 499bef509a0ca0ef8b685237cc22e2f1dd02c3e1 (#5441)

## Description

`Subscriptions::CreateService#handle_today_subscription` now forwards `new_subscription.subscription_at` as the `timestamp:` argument to `ActivateService.call!`. This restores parity with `handle_past_subscription` and matches the pre-#5441 behavior.

`Subscriptions::ActivateService#gate_subscription` was also updated to use the configured `timestamp` when calling `mark_as_incomplete!`, so the fix applies to both the non-gated and the gated (activation-rules) paths. Without that change, the gated path would still set `started_at` to `Time.current` since `mark_as_incomplete!` defaults to `Time.current` when no argument is passed.

Two regression tests were added in `spec/services/subscriptions/create_service_spec.rb`, both using `travel_to` to lock the clock so that `subscription_at` is earlier than `Time.current` on the same day:

- A pay-in-arrears, no-activation-rules case asserts the resulting subscription is `active` with `started_at == subscription_at`.
- A pay-in-advance, activation-rules case asserts the resulting `incomplete` (gated) subscription also has `started_at == subscription_at`.

## Out of scope

A historical data backfill for subscriptions created with a "today" `subscription_at` since #5441 shipped is not part of this PR. If usage was lost for affected customers, that needs to be addressed separately.

## Test plan

- [x] `lago exec api bundle exec rspec spec/services/subscriptions/create_service_spec.rb spec/services/subscriptions/activate_service_spec.rb` — 139 examples, 0 failures
- [x] `lago exec api bundle exec rspec spec/services/subscriptions/` — 1405 examples, 0 failures
- [x] `lago exec api bundle exec rubocop app/services/subscriptions/create_service.rb app/services/subscriptions/activate_service.rb spec/services/subscriptions/create_service_spec.rb` — clean

