### PR TITLE
feat(customers): filter credit notes scalars

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -81,7 +81,10 @@ module Types
       field :credit_notes_balance_amount_cents,
         GraphQL::Types::BigInt,
         null: false,
-        description: "Credit notes credits balance available per customer"
+        description: "Credit notes credits balance available per customer" do
+        argument :billing_entity_id, ID, required: false
+        argument :currency, Types::CurrencyEnum, required: false
+      end
       field :credit_notes_balances,
         [Types::Customers::CreditNotesBalance],
         null: false,
@@ -89,7 +92,10 @@ module Types
       field :credit_notes_credits_available_count,
         Integer,
         null: false,
-        description: "Number of available credits from credit notes per customer"
+        description: "Number of available credits from credit notes per customer" do
+        argument :billing_entity_id, ID, required: false
+        argument :currency, Types::CurrencyEnum, required: false
+      end
       field :has_active_wallet, Boolean, null: false, description: "Define if a customer has an active wallet"
       field :has_credit_notes, Boolean, null: false, description: "Define if a customer has any credit note"
       field :has_overdue_invoices, Boolean, null: false, description: "Define if a customer has overdue invoices"
@@ -157,12 +163,15 @@ module Types
         end
       end
 
-      def credit_notes_credits_available_count
-        object.credit_notes.finalized.where("credit_notes.credit_amount_cents > 0").count
+      def credit_notes_credits_available_count(currency: nil, billing_entity_id: nil)
+        filtered_credit_notes(currency:, billing_entity_id:)
+          .where("credit_notes.credit_amount_cents > 0")
+          .count
       end
 
-      def credit_notes_balance_amount_cents
-        object.credit_notes.finalized.sum("credit_notes.balance_amount_cents")
+      def credit_notes_balance_amount_cents(currency: nil, billing_entity_id: nil)
+        filtered_credit_notes(currency:, billing_entity_id:)
+          .sum("credit_notes.balance_amount_cents")
       end
 
       def credit_notes_balances
@@ -185,6 +194,15 @@ module Types
 
       def has_overwritten_invoice_custom_sections_selection
         !object.skip_invoice_custom_sections && object.manual_selected_invoice_custom_sections.any?
+      end
+
+      private
+
+      def filtered_credit_notes(currency:, billing_entity_id:)
+        scope = object.credit_notes.finalized
+        scope = scope.where(total_amount_currency: currency) if currency
+        scope = scope.joins(:invoice).where(invoices: {billing_entity_id:}) if billing_entity_id
+        scope
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4359,7 +4359,7 @@ type Customer {
   """
   Credit notes credits balance available per customer
   """
-  creditNotesBalanceAmountCents: BigInt!
+  creditNotesBalanceAmountCents(billingEntityId: ID, currency: CurrencyEnum): BigInt!
 
   """
   Credit notes credits balance available per customer per currency
@@ -4369,7 +4369,7 @@ type Customer {
   """
   Number of available credits from credit notes per customer
   """
-  creditNotesCreditsAvailableCount: Int!
+  creditNotesCreditsAvailableCount(billingEntityId: ID, currency: CurrencyEnum): Int!
   currency: CurrencyEnum
   customerType: CustomerTypeEnum
   deletedAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -19318,7 +19318,32 @@
             {
               "name": "creditNotesBalanceAmountCents",
               "description": "Credit notes credits balance available per customer",
-              "args": [],
+              "args": [
+                {
+                  "name": "billingEntityId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -19358,7 +19383,32 @@
             {
               "name": "creditNotesCreditsAvailableCount",
               "description": "Number of available credits from credit notes per customer",
-              "args": [],
+              "args": [
+                {
+                  "name": "billingEntityId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -90,4 +90,92 @@ RSpec.describe Types::Customers::Object do
 
     expect(subject).to have_field(:error_details).of_type("[ErrorDetail!]")
   end
+
+  describe "credit notes scalar resolvers with filter arguments" do
+    let(:required_permission) { "customers:view" }
+    let(:membership) { create(:membership) }
+    let(:organization) { membership.organization }
+    let(:customer) { create(:customer, organization:, currency: "EUR") }
+    let(:billing_entity_a) { create(:billing_entity, organization:) }
+    let(:billing_entity_b) { create(:billing_entity, organization:) }
+
+    let(:query) do
+      <<~GQL
+        query($customerId: ID!, $currency: CurrencyEnum, $billingEntityId: ID) {
+          customer(id: $customerId) {
+            creditNotesBalanceAmountCents(currency: $currency, billingEntityId: $billingEntityId)
+            creditNotesCreditsAvailableCount(currency: $currency, billingEntityId: $billingEntityId)
+          }
+        }
+      GQL
+    end
+
+    before do
+      invoice_eur_a = create(:invoice, customer:, organization:, billing_entity: billing_entity_a)
+      invoice_usd_a = create(:invoice, customer:, organization:, billing_entity: billing_entity_a)
+      invoice_eur_b = create(:invoice, customer:, organization:, billing_entity: billing_entity_b)
+
+      create(:credit_note, customer:, organization:, invoice: invoice_eur_a,
+        total_amount_currency: "EUR", balance_amount_cents: 100, credit_amount_cents: 100)
+      create(:credit_note, customer:, organization:, invoice: invoice_usd_a,
+        total_amount_currency: "USD", balance_amount_cents: 200, credit_amount_cents: 200)
+      create(:credit_note, customer:, organization:, invoice: invoice_eur_b,
+        total_amount_currency: "EUR", balance_amount_cents: 400, credit_amount_cents: 400)
+    end
+
+    def execute_with(variables)
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: variables.merge(customerId: customer.id)
+      )
+      result["data"]["customer"]
+    end
+
+    context "without filter arguments" do
+      it "returns the legacy aggregate across all currencies and billing entities" do
+        data = execute_with({})
+        expect(data["creditNotesBalanceAmountCents"]).to eq("700")
+        expect(data["creditNotesCreditsAvailableCount"]).to eq(3)
+      end
+    end
+
+    context "with currency filter" do
+      it "returns only the EUR subtotal when filtered to EUR" do
+        data = execute_with(currency: "EUR")
+        expect(data["creditNotesBalanceAmountCents"]).to eq("500")
+        expect(data["creditNotesCreditsAvailableCount"]).to eq(2)
+      end
+
+      it "returns only the USD subtotal when filtered to USD (cross-currency regression)" do
+        data = execute_with(currency: "USD")
+        expect(data["creditNotesBalanceAmountCents"]).to eq("200")
+        expect(data["creditNotesCreditsAvailableCount"]).to eq(1)
+      end
+    end
+
+    context "with billing entity filter" do
+      it "returns only credit notes linked to invoices of that billing entity" do
+        data = execute_with(billingEntityId: billing_entity_a.id)
+        expect(data["creditNotesBalanceAmountCents"]).to eq("300")
+        expect(data["creditNotesCreditsAvailableCount"]).to eq(2)
+      end
+    end
+
+    context "with both filters combined" do
+      it "returns the intersection" do
+        data = execute_with(currency: "EUR", billingEntityId: billing_entity_a.id)
+        expect(data["creditNotesBalanceAmountCents"]).to eq("100")
+        expect(data["creditNotesCreditsAvailableCount"]).to eq(1)
+      end
+
+      it "returns zero when no credit note matches both filters" do
+        data = execute_with(currency: "USD", billingEntityId: billing_entity_b.id)
+        expect(data["creditNotesBalanceAmountCents"]).to eq("0")
+        expect(data["creditNotesCreditsAvailableCount"]).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

The customer detail page's "Total amount available" summary card is driven by currency and billing-entity filters that should also scope the card's totals. Today the two scalar fields on `Types::Customers::Object` backing that card cannot be filtered, and `credit_notes_balance_amount_cents` sums `balance_amount_cents` across every finalized credit note regardless of currency, producing a meaningless integer for any customer with credit notes in more than one currency.

## Description

Add optional `currency` and `billing_entity_id` GraphQL arguments to `credit_notes_balance_amount_cents` and `credit_notes_credits_available_count` on `Types::Customers::Object`. When provided, the resolver applies the filters before the aggregate. Defaults of `nil` preserve existing behavior so current callers continue to work unchanged. A private `filtered_credit_notes` helper extracts the shared filter chain so both resolvers stay in sync.

The cross-currency total is fixed at the call site, not the resolver default: the redesigned customer detail view always passes the customer's sticky default currency, so the displayed total is grouped by exactly one currency.

| Before | After |
|---|---|
| `creditNotesBalanceAmountCents` always sums across all currencies (EUR cents + USD cents added as raw integers) | `creditNotesBalanceAmountCents(currency: USD, billingEntityId: "...")` returns only the matching subset |
| `creditNotesCreditsAvailableCount` always counts across all currencies and billing entities | Same field can be filtered to a single currency, a single billing entity, or both |
| No way to scope the summary card to the active UI filters | Frontend can pass the same currency + billing-entity values that drive the credit-notes table |

## How to try locally

Seed a customer with credit notes in multiple currencies and billing entities, then exercise the GraphQL query:

```graphql
query($customerId: ID!, $currency: CurrencyEnum, $billingEntityId: ID) {
  customer(id: $customerId) {
    creditNotesBalanceAmountCents(currency: $currency, billingEntityId: $billingEntityId)
    creditNotesCreditsAvailableCount(currency: $currency, billingEntityId: $billingEntityId)
  }
}
```

Verify:
- No args: returns the existing unfiltered aggregate (legacy behavior preserved).
- `currency: USD`: returns only the USD subtotal.
- `billingEntityId`: returns only credit notes whose invoice belongs to that billing entity.
- Both combined: returns the intersection.

The new behavior is also covered by specs:

```
bundle exec rspec spec/graphql/types/customers/object_spec.rb
```