### PR TITLE
feat(analytics): Group revenues by billing entity

### DIFF
--- a/app/graphql/types/analytics/gross_revenues/object.rb
+++ b/app/graphql/types/analytics/gross_revenues/object.rb
@@ -7,6 +7,7 @@ module Types
         graphql_name "GrossRevenue"
 
         field :amount_cents, GraphQL::Types::BigInt, null: true
+        field :billing_entity_id, ID, null: true
         field :currency, Types::CurrencyEnum, null: true
         field :invoices_count, GraphQL::Types::BigInt, null: false
         field :month, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/analytics/overdue_balances/object.rb
+++ b/app/graphql/types/analytics/overdue_balances/object.rb
@@ -7,6 +7,7 @@ module Types
         graphql_name "OverdueBalance"
 
         field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :billing_entity_id, ID, null: true
         field :currency, Types::CurrencyEnum, null: false
         field :lago_invoice_ids, [String], null: false
         field :month, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -8,6 +8,7 @@ module Analytics
       def query(organization_id, **args)
         if args[:billing_entity_id].present?
           and_billing_entity_id_sql = sanitize_sql(["AND i.billing_entity_id = :billing_entity_id", args[:billing_entity_id]])
+          and_fee_billing_entity_id_sql = sanitize_sql(["AND f.billing_entity_id = :billing_entity_id", args[:billing_entity_id]])
         end
 
         if args[:external_customer_id].present?
@@ -55,6 +56,7 @@ module Analytics
               i.issuing_date,
               i.total_amount_cents::float AS amount_cents,
               i.currency,
+              i.billing_entity_id,
               COALESCE(COUNT(DISTINCT i.id), 0) AS invoices_count,
               COALESCE(SUM(refund_amount_cents::float),0) AS total_refund_amount_cents
             FROM invoices i
@@ -66,7 +68,7 @@ module Analytics
             AND i.payment_dispute_lost_at IS NULL
             #{and_external_customer_id_sql}
             #{and_billing_entity_id_sql}
-            GROUP BY i.id, i.issuing_date, i.total_amount_cents, i.currency
+            GROUP BY i.id, i.issuing_date, i.total_amount_cents, i.currency, i.billing_entity_id
             ORDER BY i.issuing_date ASC
           ),
           instant_charges AS (
@@ -75,6 +77,7 @@ module Analytics
               f.created_at AS issuing_date,
               f.amount_cents AS amount_cents,
               f.amount_currency AS currency,
+              f.billing_entity_id,
               0 AS invoices_count,
               0 AS total_refund_amount_cents
             FROM fees f
@@ -84,11 +87,13 @@ module Analytics
             AND f.invoice_id IS NULL
             AND f.pay_in_advance IS TRUE
             #{and_external_customer_id_sql}
+            #{and_fee_billing_entity_id_sql}
           ),
           combined_data AS (
             SELECT
               DATE_TRUNC('month', issuing_date) AS month,
               currency,
+              billing_entity_id,
               COALESCE(SUM(invoices_count), 0) AS invoices_count,
               COALESCE(SUM(amount_cents), 0) AS amount_cents,
               COALESCE(SUM(total_refund_amount_cents), 0) AS total_refund_amount_cents
@@ -97,11 +102,12 @@ module Analytics
               UNION ALL
               SELECT * FROM instant_charges
             ) AS gross_revenue
-            GROUP BY month, currency, total_refund_amount_cents
+            GROUP BY month, currency, billing_entity_id, total_refund_amount_cents
           )
           SELECT
             am.month,
             #{select_currency_sql},
+            cd.billing_entity_id,
             COALESCE(SUM(invoices_count), 0) AS invoices_count,
             SUM(cd.amount_cents - cd.total_refund_amount_cents) AS amount_cents
           FROM all_months am
@@ -110,7 +116,7 @@ module Analytics
           #{and_months_sql}
           #{and_currency_sql}
           AND cd.amount_cents IS NOT NULL
-          GROUP BY am.month, cd.currency
+          GROUP BY am.month, cd.currency, cd.billing_entity_id
           ORDER BY am.month;
         SQL
 

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -59,8 +59,9 @@ module Analytics
             SELECT
               DATE_TRUNC('month', payment_due_date) AS month,
               i.currency,
+              i.billing_entity_id,
               COALESCE(SUM(
-                i.total_amount_cents - 
+                i.total_amount_cents -
                 i.total_paid_amount_cents -
                 COALESCE(cn.offset_amount_cents_sum, 0)
                ), 0) AS total_amount_cents,
@@ -80,12 +81,13 @@ module Analytics
             #{and_external_customer_id_sql}
             #{and_billing_entity_id_sql}
             #{and_billing_entity_code_sql}
-            GROUP BY month, i.currency, total_amount_cents
+            GROUP BY month, i.currency, i.billing_entity_id, total_amount_cents
             ORDER BY month ASC
           )
           SELECT
             am.month,
             #{select_currency_sql},
+            invs.billing_entity_id,
             SUM(invs.total_amount_cents) AS amount_cents,
             jsonb_agg(DISTINCT invs.ids) AS lago_invoice_ids
           FROM all_months am
@@ -94,7 +96,7 @@ module Analytics
           #{and_months_sql}
           #{and_currency_sql}
           AND invs.total_amount_cents IS NOT NULL
-          GROUP BY am.month, invs.currency
+          GROUP BY am.month, invs.currency, invs.billing_entity_id
           ORDER BY am.month;
         SQL
 

--- a/app/serializers/v1/analytics/gross_revenue_serializer.rb
+++ b/app/serializers/v1/analytics/gross_revenue_serializer.rb
@@ -8,7 +8,8 @@ module V1
           month: model["month"],
           amount_cents: model["amount_cents"],
           currency: model["currency"],
-          invoices_count: model["invoices_count"]
+          invoices_count: model["invoices_count"],
+          billing_entity_id: model["billing_entity_id"]
         }
       end
     end

--- a/app/serializers/v1/analytics/overdue_balance_serializer.rb
+++ b/app/serializers/v1/analytics/overdue_balance_serializer.rb
@@ -8,7 +8,8 @@ module V1
           month: model["month"],
           amount_cents: model["amount_cents"],
           currency: model["currency"],
-          lago_invoice_ids: JSON.parse(model["lago_invoice_ids"]).flatten
+          lago_invoice_ids: JSON.parse(model["lago_invoice_ids"]).flatten,
+          billing_entity_id: model["billing_entity_id"]
         }
       end
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6315,6 +6315,7 @@ type GraphqlSubscription {
 
 type GrossRevenue {
   amountCents: BigInt
+  billingEntityId: ID
   currency: CurrencyEnum
   invoicesCount: BigInt!
   month: ISO8601DateTime!
@@ -9073,6 +9074,7 @@ input OrganizationBillingConfigurationInput {
 
 type OverdueBalance {
   amountCents: BigInt!
+  billingEntityId: ID
   currency: CurrencyEnum!
   lagoInvoiceIds: [String!]!
   month: ISO8601DateTime!

--- a/schema.json
+++ b/schema.json
@@ -32104,6 +32104,18 @@
               "deprecationReason": null
             },
             {
+              "name": "billingEntityId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "currency",
               "description": null,
               "args": [],
@@ -43528,6 +43540,18 @@
                   "name": "BigInt",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingEntityId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/types/analytics/gross_revenues/object_spec.rb
+++ b/spec/graphql/types/analytics/gross_revenues/object_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Analytics::GrossRevenues::Object do
   it do
     expect(subject).to have_field(:month).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:amount_cents).of_type("BigInt")
+    expect(subject).to have_field(:billing_entity_id).of_type("ID")
     expect(subject).to have_field(:currency).of_type("CurrencyEnum")
   end
 end

--- a/spec/graphql/types/analytics/overdue_balances/object_spec.rb
+++ b/spec/graphql/types/analytics/overdue_balances/object_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Types::Analytics::OverdueBalances::Object do
 
   it do
     expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:billing_entity_id).of_type("ID")
     expect(subject).to have_field(:currency).of_type("CurrencyEnum!")
     expect(subject).to have_field(:lago_invoice_ids).of_type("[String!]!")
     expect(subject).to have_field(:month).of_type("ISO8601DateTime!")

--- a/spec/models/analytics/gross_revenue_spec.rb
+++ b/spec/models/analytics/gross_revenue_spec.rb
@@ -96,17 +96,31 @@ RSpec.describe Analytics::GrossRevenue do
     context "when no filters passed" do
       let(:args) { {} }
 
-      it "returns all gross revenues" do
+      it "returns gross revenues split per (month, currency, billing_entity_id)" do
         expect(gross_revenues).to match_array([hash_including({
           "month" => Time.current.beginning_of_month - 2.months,
           "currency" => "EUR",
-          "invoices_count" => 2,
-          "amount_cents" => 7000.0
+          "billing_entity_id" => billing_entity1.id,
+          "invoices_count" => 1,
+          "amount_cents" => 3000.0
+        }), hash_including({
+          "month" => Time.current.beginning_of_month - 2.months,
+          "currency" => "EUR",
+          "billing_entity_id" => billing_entity2.id,
+          "invoices_count" => 1,
+          "amount_cents" => 4000.0
         }), hash_including({
           "month" => Time.current.beginning_of_month - 1.month,
           "currency" => "EUR",
-          "invoices_count" => 2,
-          "amount_cents" => 3000.0
+          "billing_entity_id" => billing_entity1.id,
+          "invoices_count" => 1,
+          "amount_cents" => 1000.0
+        }), hash_including({
+          "month" => Time.current.beginning_of_month - 1.month,
+          "currency" => "EUR",
+          "billing_entity_id" => billing_entity2.id,
+          "invoices_count" => 1,
+          "amount_cents" => 2000.0
         })])
       end
 
@@ -120,27 +134,57 @@ RSpec.describe Analytics::GrossRevenue do
           ]
         }
 
-        it "returns gross revenues grouped by currencies" do
+        it "returns gross revenues grouped by currencies and billing entities" do
           expect(gross_revenues).to match_array([hash_including({
             "month" => Time.current.beginning_of_month - 1.month,
             "currency" => "USD",
+            "billing_entity_id" => billing_entity1.id,
             "invoices_count" => 1,
             "amount_cents" => 1000.0
           }), hash_including({
             "month" => Time.current.beginning_of_month - 1.month,
             "currency" => "EUR",
+            "billing_entity_id" => billing_entity2.id,
             "invoices_count" => 1,
             "amount_cents" => 2000.0
           }), hash_including({
             "month" => Time.current.beginning_of_month - 2.months,
             "currency" => "USD",
+            "billing_entity_id" => billing_entity1.id,
             "invoices_count" => 1,
             "amount_cents" => 3000.0
           }), hash_including({
             "month" => Time.current.beginning_of_month - 2.months,
             "currency" => "EUR",
+            "billing_entity_id" => billing_entity2.id,
             "invoices_count" => 1,
             "amount_cents" => 4000.0
+          })])
+        end
+      end
+
+      context "when a customer has invoices across multiple billing entities in the same month and currency" do
+        let(:customer) { create(:customer, organization:) }
+        let(:invoices) {
+          [
+            create(:invoice, organization:, customer:, total_amount_cents: 1000, issuing_date: 1.month.ago, billing_entity: billing_entity1),
+            create(:invoice, organization:, customer:, total_amount_cents: 2000, issuing_date: 1.month.ago, billing_entity: billing_entity2)
+          ]
+        }
+
+        it "emits one row per billing entity for the same (month, currency) bucket" do
+          expect(gross_revenues).to match_array([hash_including({
+            "month" => Time.current.beginning_of_month - 1.month,
+            "currency" => "EUR",
+            "billing_entity_id" => billing_entity1.id,
+            "invoices_count" => 1,
+            "amount_cents" => 1000.0
+          }), hash_including({
+            "month" => Time.current.beginning_of_month - 1.month,
+            "currency" => "EUR",
+            "billing_entity_id" => billing_entity2.id,
+            "invoices_count" => 1,
+            "amount_cents" => 2000.0
           })])
         end
       end
@@ -153,14 +197,37 @@ RSpec.describe Analytics::GrossRevenue do
         expect(gross_revenues).to match_array([hash_including({
           "month" => Time.current.beginning_of_month - 1.month,
           "currency" => "EUR",
+          "billing_entity_id" => billing_entity1.id,
           "invoices_count" => 1,
           "amount_cents" => 1000.0
         }), hash_including({
           "month" => Time.current.beginning_of_month - 2.months,
           "currency" => "EUR",
+          "billing_entity_id" => billing_entity1.id,
           "invoices_count" => 1,
           "amount_cents" => 3000.0
         })])
+      end
+
+      context "with pay_in_advance fees on other billing entities" do
+        let(:customer1) { create(:customer, organization:, billing_entity: billing_entity1) }
+        let(:customer2) { create(:customer, organization:, billing_entity: billing_entity2) }
+        let(:subscription1) { create(:subscription, customer: customer1) }
+        let(:subscription2) { create(:subscription, customer: customer2) }
+
+        before do
+          create(:fee, organization:, billing_entity: billing_entity1, subscription: subscription1,
+            invoice: nil, pay_in_advance: true, amount_cents: 500, amount_currency: "EUR",
+            created_at: 1.month.ago)
+          create(:fee, organization:, billing_entity: billing_entity2, subscription: subscription2,
+            invoice: nil, pay_in_advance: true, amount_cents: 9999, amount_currency: "EUR",
+            created_at: 1.month.ago)
+        end
+
+        it "excludes pay_in_advance fees from other billing entities" do
+          billing_entity_ids = gross_revenues.map { |r| r["billing_entity_id"] }.uniq
+          expect(billing_entity_ids).to eq([billing_entity1.id])
+        end
       end
     end
   end

--- a/spec/models/analytics/overdue_balance_spec.rb
+++ b/spec/models/analytics/overdue_balance_spec.rb
@@ -111,20 +111,50 @@ RSpec.describe Analytics::OverdueBalance do
     context "with no arguments" do
       let(:args) { {} }
 
-      it "returns the overdue balances" do
+      it "returns the overdue balances with billing_entity_id" do
         expect(overdue_balances).to match_array([
           hash_including({
             "month" => Time.current.beginning_of_month - 2.months,
             "currency" => "EUR",
+            "billing_entity_id" => billing_entity2.id,
             "amount_cents" => 400,
             "lago_invoice_ids" => "[[\"#{invoice4.id}\"]]"
           }), hash_including({
             "month" => Time.current.beginning_of_month - 1.month,
             "currency" => "EUR",
+            "billing_entity_id" => billing_entity1.id,
             "amount_cents" => 100,
             "lago_invoice_ids" => "[[\"#{invoice1.id}\"]]"
           })
         ])
+      end
+
+      context "when overdue invoices share the same (month, currency) across billing entities" do
+        let(:cross_entity_invoice) do
+          create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+            total_amount_cents: 500, billing_entity: billing_entity2, issuing_date: 1.month.ago)
+        end
+
+        before { cross_entity_invoice }
+
+        it "emits one row per billing entity for the same (month, currency) bucket" do
+          one_month_ago_rows = overdue_balances.select do |row|
+            row["month"] == Time.current.beginning_of_month - 1.month && row["currency"] == "EUR"
+          end
+
+          expect(one_month_ago_rows).to match_array([
+            hash_including({
+              "billing_entity_id" => billing_entity1.id,
+              "amount_cents" => 100,
+              "lago_invoice_ids" => "[[\"#{invoice1.id}\"]]"
+            }),
+            hash_including({
+              "billing_entity_id" => billing_entity2.id,
+              "amount_cents" => 500,
+              "lago_invoice_ids" => "[[\"#{cross_entity_invoice.id}\"]]"
+            })
+          ])
+        end
       end
     end
 
@@ -136,6 +166,7 @@ RSpec.describe Analytics::OverdueBalance do
           hash_including({
             "month" => Time.current.beginning_of_month - 1.month,
             "currency" => "EUR",
+            "billing_entity_id" => billing_entity1.id,
             "amount_cents" => 100,
             "lago_invoice_ids" => "[[\"#{invoice1.id}\"]]"
           })
@@ -151,6 +182,7 @@ RSpec.describe Analytics::OverdueBalance do
           hash_including({
             "month" => Time.current.beginning_of_month - 2.months,
             "currency" => "EUR",
+            "billing_entity_id" => billing_entity2.id,
             "amount_cents" => 400,
             "lago_invoice_ids" => "[[\"#{invoice4.id}\"]]"
           })

--- a/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
@@ -33,13 +33,15 @@ RSpec.describe Api::V1::Analytics::OverdueBalancesController do
               month: "2023-11-01T00:00:00.000Z",
               amount_cents: "1000.0",
               currency: "EUR",
-              lago_invoice_ids: [i1.id]
+              lago_invoice_ids: [i1.id],
+              billing_entity_id: organization.default_billing_entity.id
             },
             {
               month: "2024-01-01T00:00:00.000Z",
               amount_cents: "5000.0",
               currency: "EUR",
-              lago_invoice_ids: match_array([i2.id, i3.id])
+              lago_invoice_ids: match_array([i2.id, i3.id]),
+              billing_entity_id: organization.default_billing_entity.id
             }
           ]
         )

--- a/spec/serializers/v1/analytics/gross_revenue_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/gross_revenue_serializer_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe ::V1::Analytics::GrossRevenueSerializer do
       "month" => "2024-06-01T00:00:00Z",
       "amount_cents" => 100,
       "currency" => "EUR",
-      "invoices_count" => 1
+      "invoices_count" => 1,
+      "billing_entity_id" => "be-id-1"
     }
   end
 
@@ -22,7 +23,8 @@ RSpec.describe ::V1::Analytics::GrossRevenueSerializer do
         "month" => "2024-06-01T00:00:00Z",
         "amount_cents" => 100,
         "currency" => "EUR",
-        "invoices_count" => 1
+        "invoices_count" => 1,
+        "billing_entity_id" => "be-id-1"
       }
     )
   end

--- a/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe ::V1::Analytics::OverdueBalanceSerializer do
       "month" => "2024-06-01T00:00:00Z",
       "amount_cents" => 100,
       "currency" => "EUR",
-      "lago_invoice_ids" => "[\"1\", \"2\", \"3\"]"
+      "lago_invoice_ids" => "[\"1\", \"2\", \"3\"]",
+      "billing_entity_id" => "be-id-1"
     }
   end
 
@@ -22,7 +23,8 @@ RSpec.describe ::V1::Analytics::OverdueBalanceSerializer do
         "month" => "2024-06-01T00:00:00Z",
         "amount_cents" => 100,
         "currency" => "EUR",
-        "lago_invoice_ids" => ["1", "2", "3"]
+        "lago_invoice_ids" => ["1", "2", "3"],
+        "billing_entity_id" => "be-id-1"
       }
     )
   end


### PR DESCRIPTION
## Context

The customer detail page (`/customer/<id>/invoices`) is being redesigned: the two global summary cards ("Gross revenue" + "Total overdue") are replaced by an "Invoice balances" table with one row per `(currency, billing_entity)`. Today the analytics resolvers backing those numbers already accept a `billing_entity_id` filter, but they aggregate strictly by `(month, currency)` and do not expose `billing_entity_id` in the returned objects, so the frontend cannot build per-entity rows from the existing data.

## Description

`Analytics::GrossRevenue` and `Analytics::OverdueBalance` now group by `billing_entity_id` in addition to `(month, currency)`. The column is threaded through every CTE, the final SELECT, and the outer GROUP BY. Volume of rows scanned is unchanged because `billing_entity_id` is already a column on `invoices` and `fees`; the aggregation bucket simply gains one dimension.

The corresponding GraphQL `GrossRevenue` and `OverdueBalance` object types expose a new nullable `billingEntityId: ID` field, and the V1 REST serializers expose `billing_entity_id` for parity. The `instant_charges` CTE in `GrossRevenue` (pay-in-advance fees) is also scoped by `billing_entity_id` when the filter is set, so filtered results no longer leak fees from other billing entities. Schema files regenerated.

| Before | After |
| --- | --- |
| One row per `(month, currency)` | One row per `(month, currency, billing_entity_id)` |
| `billingEntityId` not exposed on GraphQL/REST | `billingEntityId: ID` nullable on both |
| Filtered queries silently include other entities' pay-in-advance fees | `instant_charges` CTE honors the filter |

## Behavior change for API consumers

The response shape is additive (a new nullable field on each row), but the row count changes for organizations whose customers have invoices spanning multiple billing entities: where there was one row per `(month, currency)`, there are now N rows, one per billing entity. Consumers that map rows 1:1 to a `(month, currency)` slot (rather than aggregating with `SUM(amountCents)` and `SUM(invoicesCount)` across rows) will need to add the aggregation, or pass a `billingEntityId` filter to restore the prior shape.

Internal Lago consumers were verified: `CustomerOverview`, the analytics `Overview` and `Invoices` pages, and `PortalInvoicesList` already aggregate via `reduce`. The `Gross` chart (`front/src/components/graphs/utils.ts`) uses `.find` per month and needs a small follow-up in the front repo to aggregate by month before mapping; that fix ships separately.

The cache key already includes the `billing_entity_id` filter, so no cache poisoning across filtered/unfiltered queries.

## How to try locally

GraphQL:

```graphql
query GrossRevenuesForCustomer($externalCustomerId: String!) {
  grossRevenues(externalCustomerId: $externalCustomerId) {
    collection { month currency amountCents invoicesCount billingEntityId }
  }
}

query OverdueBalancesForCustomer($externalCustomerId: String!) {
  overdueBalances(externalCustomerId: $externalCustomerId) {
    collection { month currency amountCents lagoInvoiceIds billingEntityId }
  }
}
```

A customer with invoices spanning two billing entities should produce two rows per month/currency, each carrying its `billingEntityId`.

REST:

```bash
curl -H "Authorization: Bearer $LAGO_API_KEY" \
  "http://api.lago.dev/api/v1/analytics/gross_revenue?external_customer_id=cust_01"
curl -H "Authorization: Bearer $LAGO_API_KEY" \
  "http://api.lago.dev/api/v1/analytics/overdue_balance?external_customer_id=cust_01"
```

Each row in the response now includes `billing_entity_id`.

Specs:

```bash
lago exec api bundle exec rspec \
  spec/models/analytics/gross_revenue_spec.rb \
  spec/models/analytics/overdue_balance_spec.rb \
  spec/graphql/types/analytics/{gross_revenues,overdue_balances}/object_spec.rb \
  spec/serializers/v1/analytics/{gross_revenue,overdue_balance}_serializer_spec.rb \
  spec/requests/api/v1/analytics/
```
