### PR TITLE
ING-47 feat(subscriptions): List by billing entity

### DIFF
--- a/app/controllers/concerns/subscription_index.rb
+++ b/app/controllers/concerns/subscription_index.rb
@@ -5,9 +5,13 @@ module SubscriptionIndex
   extend ActiveSupport::Concern
 
   def subscription_index(external_customer_id: nil)
+    billing_entities = current_organization.all_billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
+    return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count
+
     filters = params.permit(:plan_code, :overriden, :overridden, :currency, status: [])
     filters[:status] = ["active"] if filters[:status].blank?
     filters[:external_customer_id] = external_customer_id
+    filters[:billing_entity_ids] = billing_entities&.ids
     result = SubscriptionsQuery.call(
       organization: current_organization,
       pagination: {

--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -10,7 +10,8 @@ class SubscriptionsQuery < BaseQuery
     :overriden, # overriden is a legacy typo kept for backward compatibility
     :overridden,
     :exclude_next_subscriptions,
-    :currency
+    :currency,
+    :billing_entity_ids
   ]
 
   def call
@@ -27,6 +28,7 @@ class SubscriptionsQuery < BaseQuery
       SQL
     )
 
+    subscriptions = with_billing_entity_ids(subscriptions) if filters.billing_entity_ids.present?
     subscriptions = with_external_customer(subscriptions) if filters.external_customer_id
     subscriptions = with_plan_code(subscriptions) if filters.plan_code
     subscriptions = with_overridden(subscriptions) unless overridden_filter.nil?
@@ -95,6 +97,10 @@ class SubscriptionsQuery < BaseQuery
 
   def with_currency(scope)
     scope.joins(:plan).where(plans: {amount_currency: filters.currency})
+  end
+
+  def with_billing_entity_ids(scope)
+    scope.where(billing_entity_id: filters.billing_entity_ids)
   end
 
   def with_excluded_next_subscriptions(scope)

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -317,6 +317,46 @@ RSpec.describe SubscriptionsQuery do
     end
   end
 
+  context "with billing_entity_ids filter" do
+    let(:us_entity) { create(:billing_entity, organization:, code: "us") }
+    let(:eu_entity) { create(:billing_entity, organization:, code: "eu") }
+    let(:subscription) { create(:subscription, customer:, plan:, billing_entity: us_entity) }
+    let(:us_subscription) { subscription }
+    let(:eu_subscription) { create(:subscription, customer:, plan:, billing_entity: eu_entity) }
+
+    before do
+      us_subscription
+      eu_subscription
+    end
+
+    context "when filtering by a single billing_entity_id" do
+      let(:filters) { {billing_entity_ids: [eu_entity.id]} }
+
+      it "returns only subscriptions stamped under that entity" do
+        expect(result).to be_success
+        expect(result.subscriptions).to eq([eu_subscription])
+      end
+    end
+
+    context "when filtering by multiple billing_entity_ids" do
+      let(:filters) { {billing_entity_ids: [eu_entity.id, us_entity.id]} }
+
+      it "returns subscriptions stamped under any of the given entities" do
+        expect(result).to be_success
+        expect(result.subscriptions).to match_array([eu_subscription, us_subscription])
+      end
+    end
+
+    context "when billing_entity_ids is blank" do
+      let(:filters) { {billing_entity_ids: []} }
+
+      it "returns all subscriptions" do
+        expect(result).to be_success
+        expect(result.subscriptions).to match_array([eu_subscription, us_subscription])
+      end
+    end
+  end
+
   context "with currency filter" do
     let(:eur_plan) { create(:plan, organization:, amount_currency: "EUR") }
     let(:usd_plan) { create(:plan, organization:, amount_currency: "USD") }

--- a/spec/support/shared_examples/subscription_index.rb
+++ b/spec/support/shared_examples/subscription_index.rb
@@ -155,6 +155,45 @@ RSpec.shared_examples "a subscription index endpoint" do
     end
   end
 
+  context "with billing_entity_codes filter" do
+    let(:us_entity) { create(:billing_entity, organization:, code: "us") }
+    let(:eu_entity) { create(:billing_entity, organization:, code: "eu") }
+    let!(:eu_subscription) { create(:subscription, customer:, plan:, billing_entity: eu_entity) }
+    let!(:us_subscription) { create(:subscription, customer:, plan:, billing_entity: us_entity) }
+
+    context "when filtering by a single code" do
+      let(:params) { {billing_entity_codes: [eu_entity.code]} }
+
+      it "returns only subscriptions stamped under that entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscriptions].pluck(:lago_id)).to eq([eu_subscription.id])
+      end
+    end
+
+    context "when filtering by multiple codes" do
+      let(:params) { {billing_entity_codes: [eu_entity.code, us_entity.code]} }
+
+      it "returns subscriptions stamped under any of the given entities" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscriptions].pluck(:lago_id)).to match_array([eu_subscription.id, us_subscription.id])
+      end
+    end
+
+    context "when a code does not exist" do
+      let(:params) { {billing_entity_codes: ["unknown"]} }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("billing_entity")
+      end
+    end
+  end
+
   context "with N+1 query detection", bullet: {n_plus_one_query: true, unused_eager_loading: false} do
     before do
       create(:subscription, customer:, plan: create(:plan, organization:))


### PR DESCRIPTION
## Context

Multi-entity customers already filter `GET /api/v1/invoices` and `GET /api/v1/credit_notes` by billing entity through a `billing_entity_codes` list parameter — an array of codes that each endpoint resolves against the organization's billing entities and forwards to the matching query under `billing_entity_ids`. Subscriptions were the remaining gap from task T20 of the multi-entity dive-in (ING-47).

The ticket originally proposed a singular `billing_entity_code: String` parameter on `GET /api/v1/subscriptions`, but the two sibling list endpoints already use the plural array form, so I deliberately departed from the ticket wording and adopted the plural here too. Keeping the three list endpoints aligned avoids introducing a third style on the public REST surface and lets callers pass one or multiple codes from the same URL shape they already use for invoices and credit notes. The single-code path remains the typical case; the plural shape simply doesn't close off the multi-code case for free.

## Description

`SubscriptionIndex` now resolves `params[:billing_entity_codes]` against `current_organization.all_billing_entities` and returns a `billing_entity` not-found error if any code is unknown — the same handshake `InvoiceIndex` and `CreditNoteIndex` already use. The resolved IDs are forwarded to `SubscriptionsQuery` under a new `billing_entity_ids` filter, which applies `where(billing_entity_id: …)` directly against the `subscriptions` table. The query intentionally bypasses the `Subscription#billing_entity` reader's fallback to `customer.billing_entity`, so only subscriptions explicitly stamped under the requested entity are returned — matching the ticket's "stamped under EU" acceptance criterion.

The new parameter is optional, all existing filters keep their behaviour, and the change is purely additive. The shared example `"a subscription index endpoint"` covers single-code, multi-code, and unknown-code scenarios so both `GET /api/v1/subscriptions` and `GET /api/v1/customers/:id/subscriptions` exercise the new surface, and `SubscriptionsQuery` is covered directly at the query level with single-id, multi-id, and blank cases.

`Subscription.ransackable_attributes` is left untouched: the new filter is a direct column predicate, not a ransack search term.

## API surface

```
GET /api/v1/subscriptions?billing_entity_codes[]=EU
GET /api/v1/subscriptions?billing_entity_codes[]=EU&billing_entity_codes[]=US
GET /api/v1/customers/:external_id/subscriptions?billing_entity_codes[]=EU
```
