### PR TITLE
feat(payment-gated-subs): Apply activation rules on downgrade of a subscription

### DIFF
--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -16,6 +16,7 @@ module Subscriptions
 
     def call
       if current_subscription.starting_in_the_future?
+        apply_activation_rules(current_subscription) if params[:activation_rules]
         update_pending_subscription
 
         result.subscription = current_subscription
@@ -39,6 +40,8 @@ module Subscriptions
           ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
           progressive_billing_disabled: params[:progressive_billing_disabled] || false
         )
+
+        apply_activation_rules(new_sub) if params[:activation_rules].present?
 
         if params.key?(:payment_method)
           new_sub.payment_method_type = params[:payment_method][:payment_method_type] if params[:payment_method].key?(:payment_method_type)
@@ -72,6 +75,13 @@ module Subscriptions
       if current_subscription.should_sync_hubspot_subscription?
         Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription: current_subscription)
       end
+    end
+
+    def apply_activation_rules(subscription)
+      Subscriptions::ActivationRules::ApplyService.call!(
+        subscription: subscription,
+        activation_rules: params[:activation_rules]
+      )
     end
 
     def override_plan

--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -17,15 +17,15 @@ module Subscriptions
     end
 
     def call
-      if current_subscription.starting_in_the_future?
-        apply_activation_rules(current_subscription) if params[:activation_rules]
-        update_pending_subscription
-
-        result.subscription = current_subscription
-        return result
-      end
-
       ActiveRecord::Base.transaction do
+        if current_subscription.starting_in_the_future?
+          apply_activation_rules(current_subscription) if params[:activation_rules]
+          update_pending_subscription
+
+          result.subscription = current_subscription
+          return result
+        end
+
         cancel_pending_subscription if pending_subscription?
 
         # NOTE: When downgrading a subscription, we keep the current one active

--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -79,7 +79,7 @@ module Subscriptions
 
     def apply_activation_rules(subscription)
       Subscriptions::ActivationRules::ApplyService.call!(
-        subscription: subscription,
+        subscription:,
         activation_rules: params[:activation_rules]
       )
     end

--- a/spec/services/subscriptions/plan_downgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_downgrade_service_spec.rb
@@ -149,6 +149,25 @@ RSpec.describe Subscriptions::PlanDowngradeService do
       end
     end
 
+    context "with activation_rules in params" do
+      let(:params) do
+        {
+          name: subscription_name,
+          activation_rules: [{type: "payment", timeout_hours: 48}]
+        }
+      end
+
+      it "applies the activation rules to the new pending next subscription" do
+        expect(result).to be_success
+
+        next_subscription = result.subscription.next_subscription
+        rules = next_subscription.activation_rules
+        expect(rules.count).to eq(1)
+        expect(rules.first).to be_inactive
+        expect(rules.first.timeout_hours).to eq(48)
+      end
+    end
+
     context "when current subscription is pending" do
       let(:subscription) do
         create(
@@ -184,6 +203,49 @@ RSpec.describe Subscriptions::PlanDowngradeService do
         it "does not enqueue the Hubspot update job" do
           result
           expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).not_to have_been_enqueued
+        end
+      end
+
+      context "with activation_rules in params" do
+        let(:params) do
+          {
+            name: subscription_name,
+            activation_rules: [{type: "payment", timeout_hours: 48}]
+          }
+        end
+
+        it "applies the activation rules to the current pending subscription" do
+          expect(result).to be_success
+
+          rules = subscription.reload.activation_rules
+          expect(rules.count).to eq(1)
+          expect(rules.first).to be_inactive
+          expect(rules.first.timeout_hours).to eq(48)
+        end
+
+        it "updates the pending subscription's plan and name" do
+          expect(result).to be_success
+          expect(result.subscription.id).to eq(subscription.id)
+          expect(result.subscription.plan_id).to eq(plan.id)
+          expect(result.subscription.name).to eq(subscription_name)
+        end
+      end
+
+      context "with an empty activation_rules array in params" do
+        let(:existing_rule) { create(:subscription_activation_rule, subscription:, organization:) }
+        let(:params) do
+          {
+            name: subscription_name,
+            activation_rules: []
+          }
+        end
+
+        before { existing_rule }
+
+        it "removes the activation rules from the current subscription" do
+          expect { result }
+            .to change { subscription.reload.activation_rules.count }
+            .from(1).to(0)
         end
       end
     end


### PR DESCRIPTION
## Context

Downgrades create (or mutate) a pending subscription, but `activation_rules` passed in the API params were being ignored on this path — only `CreateService` applied them. Closes that gap as part of payment-gated subs (Milestone 3), keeping behavior consistent with the create flow.

## Description

- `Subscriptions::PlanDowngradeService` now delegates to `Subscriptions::ActivationRules::ApplyService` when `activation_rules` is present in params.
- Applied on both branches: the newly created pending next subscription (downgrade from an active sub) and the current pending subscription (downgrade from a pending sub).