### PR TITLE
fix: set database timeouts variables to :default when the env variables are not set

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,9 +1,9 @@
 default: &default
   adapter: postgresql
   variables:
-    statement_timeout: <%= ENV["LAGO_DATABASE_STATEMENT_TIMEOUT"] %>
-    idle_in_transaction_session_timeout: <%= ENV["LAGO_DATABASE_IDLE_TX_TIMEOUT"] %>
-    lock_timeout: <%= ENV["LAGO_DATABASE_LOCK_TIMEOUT"] %>
+    statement_timeout: <%= ENV.fetch("LAGO_DATABASE_STATEMENT_TIMEOUT", ":default") %>
+    idle_in_transaction_session_timeout: <%= ENV.fetch("LAGO_DATABASE_IDLE_TX_TIMEOUT", ":default") %>
+    lock_timeout: <%= ENV.fetch("LAGO_DATABASE_LOCK_TIMEOUT", ":default") %>
 
 development:
   primary:


### PR DESCRIPTION
## Context

`rails dbconsole` does not filter out `nil` values in database `variables` configuration hash, returning:

```
psql: error: connection to server at "db" (172.18.0.6), port 5432 failed: FATAL:  invalid value for parameter "statement_timeout": ""
```

## Description

This PR uses the intended way to use `default` values when no env var is set for the db variable:

```
ENV.fetch("LAGO_DATABASE_STATEMENT_TIMEOUT", ":default")
```

[Source code showing this](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L73)