### PR TITLE
misc(clickhouse): Define primary key for events_enriched table

### DIFF
--- a/app/models/clickhouse/events_enriched.rb
+++ b/app/models/clickhouse/events_enriched.rb
@@ -3,6 +3,7 @@
 module Clickhouse
   class EventsEnriched < BaseRecord
     self.table_name = "events_enriched"
+    self.primary_key = [:organization_id, :code, :external_subscription_id, :timestamp]
   end
 end
 

--- a/app/models/clickhouse/events_enriched_expanded.rb
+++ b/app/models/clickhouse/events_enriched_expanded.rb
@@ -3,6 +3,14 @@
 module Clickhouse
   class EventsEnrichedExpanded < BaseRecord
     self.table_name = "events_enriched_expanded"
+    self.primary_key = [
+      :organization_id,
+      :code,
+      :external_subscription_id,
+      :charge_id,
+      :charge_filter_id,
+      :timestamp
+    ]
   end
 end
 

--- a/spec/models/clickhouse/events_enriched_expanded_spec.rb
+++ b/spec/models/clickhouse/events_enriched_expanded_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Clickhouse::EventsEnrichedExpanded, clickhouse: true do
+  subject(:events_enriched_expanded) { create(:clickhouse_events_enriched_expanded) }
+
+  it "persists a record via the factory" do
+    expect(events_enriched_expanded).to be_persisted
+  end
+
+  describe ".table_name" do
+    it "is events_enriched_expanded" do
+      expect(described_class.table_name).to eq("events_enriched_expanded")
+    end
+  end
+
+  describe ".primary_key" do
+    it "matches the ClickHouse table primary key" do
+      expect(described_class.primary_key).to eq(
+        ["organization_id", "code", "external_subscription_id", "charge_id", "charge_filter_id", "timestamp"]
+      )
+    end
+  end
+end

--- a/spec/models/clickhouse/events_enriched_spec.rb
+++ b/spec/models/clickhouse/events_enriched_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Clickhouse::EventsEnriched, clickhouse: true do
+  subject(:events_enriched) { create(:clickhouse_events_enriched) }
+
+  it "persists a record via the factory" do
+    expect(events_enriched).to be_persisted
+  end
+
+  describe ".table_name" do
+    it "is events_enriched" do
+      expect(described_class.table_name).to eq("events_enriched")
+    end
+  end
+
+  describe ".primary_key" do
+    it "matches the ClickHouse table primary key" do
+      expect(described_class.primary_key).to eq(
+        ["organization_id", "code", "external_subscription_id", "timestamp"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR sets the `primary_key` attribute for `events_enriched` and `events_enriched_expanded` tables.
These two tables does not define a primary key and this change allows us to use `in_batch` AR method with a `cursor` to loop over rows.