### PR TITLE
perf(plans): Improve filter-heavy plan updates

### DIFF
--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -24,48 +24,36 @@ module ChargeFilters
       # We only care about order when you have less than 100 filters.
       @touch = filters_params.size < 100
 
-      # NOTE: PaperTrail's per-save Version Create plus version_limit COUNT is the
-      #       dominant DB cost for large filter batches (two queries per record save).
-      #       Skip per-filter audit rows for this operation — the parent Plan/Charge
-      #       still gets its own audit entry from their respective services.
-      PaperTrail.request.disable_model(ChargeFilter)
-      PaperTrail.request.disable_model(ChargeFilterValue)
+      ActiveRecord::Base.transaction do
+        @new_filter_rows = []
+        @new_filter_value_rows = []
+        @new_filter_ids = []
 
-      begin
-        ActiveRecord::Base.transaction do
-          @new_filter_rows = []
-          @new_filter_value_rows = []
-          @new_filter_ids = []
+        filters_params.each do |filter_param|
+          values_params = filter_param[:values].transform_keys(&:to_s)
 
-          filters_params.each do |filter_param|
-            values_params = filter_param[:values].transform_keys(&:to_s)
+          # NOTE: since a filter could be a refinement of another one, we have to make sure
+          #       that we are targeting the right one
+          existing_filter = filters_by_values_key[values_params.sort]
 
-            # NOTE: since a filter could be a refinement of another one, we have to make sure
-            #       that we are targeting the right one
-            existing_filter = filters_by_values_key[values_params.sort]
+          properties = ChargeModels::FilterPropertiesService.call(
+            chargeable: charge,
+            properties: filter_param[:properties]&.deep_symbolize_keys&.except(:presentation_group_keys)
+          ).properties
 
-            properties = ChargeModels::FilterPropertiesService.call(
-              chargeable: charge,
-              properties: filter_param[:properties]&.deep_symbolize_keys&.except(:presentation_group_keys)
-            ).properties
-
-            if existing_filter
-              update_existing_filter(existing_filter, filter_param, values_params, properties)
-            else
-              accumulate_new_filter(filter_param, values_params, properties)
-            end
-          end
-
-          bulk_insert_new_filters
-
-          # NOTE: remove old filters that were not created or updated
-          charge.filters.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
-            remove_filter(it)
+          if existing_filter
+            update_existing_filter(existing_filter, filter_param, values_params, properties)
+          else
+            accumulate_new_filter(filter_param, values_params, properties)
           end
         end
-      ensure
-        PaperTrail.request.enable_model(ChargeFilter)
-        PaperTrail.request.enable_model(ChargeFilterValue)
+
+        bulk_insert_new_filters
+
+        # NOTE: remove old filters that were not created or updated
+        charge.filters.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
+          remove_filter(it)
+        end
       end
 
       result
@@ -84,8 +72,10 @@ module ChargeFilters
 
       filter.save! if filter.changed?
 
+      PaperTrail.request.disable_model(filter.class)
       # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
       filter.touch if touch # rubocop:disable Rails/SkipsModelValidations
+      PaperTrail.request.enable_model(filter.class)
 
       values_params.each do |key, values|
         billable_metric_filter = billable_metric_filters_by_key[key]
@@ -100,7 +90,9 @@ module ChargeFilters
         filter_value.values = values
         filter_value.save! if filter_value.changed?
 
-        filter_value.touch if @touch # rubocop:disable Rails/SkipsModelValidations
+        PaperTrail.request.disable_model(filter_value.class)
+        filter_value.touch if touch # rubocop:disable Rails/SkipsModelValidations
+        PaperTrail.request.enable_model(filter_value.class)
       end
 
       result.filters << filter

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -38,6 +38,10 @@ module ChargeFilters
           #       it on every built/looked-up child.
           organization = charge.organization
 
+          new_filter_rows = []
+          new_filter_value_rows = []
+          new_filter_ids_in_order = []
+
           filters_params.each do |filter_param|
             # NOTE: callers pass either string-keyed (plan flow, via with_indifferent_access) or
             #       symbol-keyed (subscription override flow, via deep_symbolize_keys) values
@@ -46,49 +50,26 @@ module ChargeFilters
 
             # NOTE: since a filter could be a refinement of another one, we have to make sure
             #       that we are targeting the right one
-            filter = filters_by_values_key[values_params.sort]
-            matched_existing_filter = !filter.nil?
+            existing_filter = filters_by_values_key[values_params.sort]
 
-            filter ||= charge.filters.new(organization_id: charge.organization_id)
-            filter.charge = charge
-            filter.organization = organization
-
-            filter.invoice_display_name = filter_param[:invoice_display_name]
-            filter.properties = ChargeModels::FilterPropertiesService.call(
+            properties = ChargeModels::FilterPropertiesService.call(
               chargeable: charge,
               properties: filter_param[:properties]&.deep_symbolize_keys&.except(:presentation_group_keys)
             ).properties
 
-            filter.save! if filter.changed?
-
-            # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
-            filter.touch if touch # rubocop:disable Rails/SkipsModelValidations
-
-            # NOTE: Create or update the filter values
-            values_params.each do |key, values|
-              billable_metric_filter = billable_metric_filters_by_key[key]
-
-              # NOTE: only look up an existing filter_value if the parent filter came from
-              #       the preloaded set. For freshly-created filters, the values collection
-              #       is provably empty — querying it on a now-persisted record issues a
-              #       wasted SELECT per filter.
-              filter_value = if matched_existing_filter
-                filter.values.to_a.find { |v| v.billable_metric_filter_id == billable_metric_filter&.id }
-              end
-              filter_value ||= filter.values.build(organization_id: charge.organization_id)
-              filter_value.charge_filter = filter
-              filter_value.billable_metric_filter = billable_metric_filter
-              filter_value.organization = organization
-
-              filter_value.values = values
-              filter_value.save! if filter_value.changed?
-
-              # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
-              filter_value.touch if touch # rubocop:disable Rails/SkipsModelValidations
+            if existing_filter
+              update_existing_filter(
+                existing_filter, organization, filter_param, values_params, properties, touch
+              )
+            else
+              accumulate_new_filter(
+                organization, filter_param, values_params, properties,
+                new_filter_rows, new_filter_value_rows, new_filter_ids_in_order
+              )
             end
-
-            result.filters << filter
           end
+
+          bulk_insert_new_filters(new_filter_rows, new_filter_value_rows, new_filter_ids_in_order)
 
           # NOTE: remove old filters that were not created or updated
           charge.filters.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
@@ -106,6 +87,121 @@ module ChargeFilters
     private
 
     attr_reader :charge, :filters_params
+
+    def update_existing_filter(filter, organization, filter_param, values_params, properties, touch)
+      filter.charge = charge
+      filter.organization = organization
+
+      filter.invoice_display_name = filter_param[:invoice_display_name]
+      filter.properties = properties
+
+      filter.save! if filter.changed?
+
+      # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
+      filter.touch if touch # rubocop:disable Rails/SkipsModelValidations
+
+      values_params.each do |key, values|
+        billable_metric_filter = billable_metric_filters_by_key[key]
+
+        # NOTE: existing filter was preloaded with values, so this in-memory find avoids a SELECT.
+        filter_value = filter.values.to_a.find { |v| v.billable_metric_filter_id == billable_metric_filter&.id }
+        filter_value ||= filter.values.build(organization_id: charge.organization_id)
+        filter_value.charge_filter = filter
+        filter_value.billable_metric_filter = billable_metric_filter
+        filter_value.organization = organization
+
+        filter_value.values = values
+        filter_value.save! if filter_value.changed?
+
+        filter_value.touch if touch # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      result.filters << filter
+    end
+
+    def accumulate_new_filter(organization, filter_param, values_params, properties,
+      new_filter_rows, new_filter_value_rows, new_filter_ids_in_order)
+      # NOTE: pre-generate the UUID so we can wire ChargeFilterValue rows to their parent
+      #       without a round-trip after the ChargeFilter insert_all.
+      filter_id = SecureRandom.uuid
+
+      # NOTE: build an in-memory AR instance only to run validations — we drop it after
+      #       capturing the row hash. Use a standalone ChargeFilter.new (not
+      #       `charge.filters.new`) so the unsaved instance is not appended to the
+      #       parent's in-memory collection, which can interfere with later charge.save!
+      #       in callers like Charges::CreateService.
+      filter_instance = ChargeFilter.new(
+        id: filter_id,
+        charge_id: charge.id,
+        organization_id: charge.organization_id,
+        invoice_display_name: filter_param[:invoice_display_name],
+        properties: properties
+      )
+      filter_instance.charge = charge
+      filter_instance.organization = organization
+      filter_instance.validate!
+
+      new_filter_rows << {
+        id: filter_id,
+        charge_id: charge.id,
+        organization_id: charge.organization_id,
+        invoice_display_name: filter_param[:invoice_display_name],
+        properties: properties
+      }
+      new_filter_ids_in_order << filter_id
+
+      values_params.each do |key, values|
+        billable_metric_filter = billable_metric_filters_by_key[key]
+
+        value_instance = ChargeFilterValue.new(
+          organization_id: charge.organization_id,
+          values: values
+        )
+        value_instance.charge_filter = filter_instance
+        value_instance.billable_metric_filter = billable_metric_filter
+        value_instance.organization = organization
+        value_instance.validate!
+
+        new_filter_value_rows << {
+          charge_filter_id: filter_id,
+          billable_metric_filter_id: billable_metric_filter&.id,
+          organization_id: charge.organization_id,
+          values: values
+        }
+      end
+    end
+
+    def bulk_insert_new_filters(new_filter_rows, new_filter_value_rows, new_filter_ids_in_order)
+      return if new_filter_rows.empty?
+
+      # NOTE: insert_all skips AR callbacks (and therefore updated_at handling), so set
+      #       monotonically-increasing timestamps to preserve the request order under the
+      #       model's `order(updated_at: :asc)` default scope.
+      now = Time.current
+      new_filter_rows.each_with_index do |row, idx|
+        ts = now + (idx / 1_000_000.0)
+        row[:created_at] = ts
+        row[:updated_at] = ts
+      end
+      ChargeFilter.insert_all!(new_filter_rows) # rubocop:disable Rails/SkipsModelValidations
+
+      if new_filter_value_rows.any?
+        new_filter_value_rows.each_with_index do |row, idx|
+          ts = now + (idx / 1_000_000.0)
+          row[:created_at] = ts
+          row[:updated_at] = ts
+        end
+        ChargeFilterValue.insert_all!(new_filter_value_rows) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      # NOTE: re-fetch the inserted filters with their values so callers iterating over
+      #       result.filters see fully-hydrated records.
+      inserted = charge.filters
+        .where(id: new_filter_ids_in_order)
+        .includes(values: :billable_metric_filter)
+        .index_by(&:id)
+      new_filter_ids_in_order.each { |id| result.filters << inserted[id] }
+    end
 
     def filters
       @filters ||= charge.filters.includes(values: :billable_metric_filter)

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -93,8 +93,8 @@ module ChargeFilters
         filter_value.save! if filter_value.changed?
 
         if @touch
-          # NOTE: Make sure update_at is touched even if not changed to keep the right order
           PaperTrail.request.disable_model(filter_value.class)
+          # NOTE: Make sure update_at is touched even if not changed to keep the right order
           filter_value.touch # rubocop:disable Rails/SkipsModelValidations
           PaperTrail.request.enable_model(filter_value.class)
         end

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -41,7 +41,10 @@ module ChargeFilters
             chargeable: charge,
             properties: filter_param[:properties]&.deep_symbolize_keys&.except(:presentation_group_keys)
           ).properties
-          if filter.save! && touch && !filter.changed?
+
+          filter.save! if filter.changed?
+
+          if touch
             PaperTrail.request.disable_model(filter.class)
             # NOTE: Make sure update_at is touched even if not changed to keep the right order
             filter.touch # rubocop:disable Rails/SkipsModelValidations
@@ -57,7 +60,9 @@ module ChargeFilters
             ) { it.organization_id = charge.organization_id }
 
             filter_value.values = values
-            if filter_value.save! && touch && !filter_value.changed?
+            filter_value.save! if filter_value.changed?
+
+            if touch
               PaperTrail.request.disable_model(filter_value.class)
               # NOTE: Make sure update_at is touched even if not changed to keep the right order
               filter_value.touch # rubocop:disable Rails/SkipsModelValidations

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -23,74 +23,81 @@ module ChargeFilters
       # We only care about order when you have less than 100 filters.
       touch = filters_params.size < 100
 
-      ActiveRecord::Base.transaction do
-        # NOTE: the `with_discarded` scope on the belongs_to associations below defeats
-        #       Rails' automatic inverse_of, so every save would otherwise re-SELECT the
-        #       parent records during validation. Load each parent once and pre-assign
-        #       it on every built/looked-up child.
-        organization = charge.organization
+      # NOTE: PaperTrail's per-save Version Create plus version_limit COUNT is the
+      #       dominant DB cost for large filter batches (two queries per record save).
+      #       Skip per-filter audit rows for this operation — the parent Plan/Charge
+      #       still gets its own audit entry from their respective services.
+      PaperTrail.request.disable_model(ChargeFilter)
+      PaperTrail.request.disable_model(ChargeFilterValue)
 
-        filters_params.each do |filter_param|
-          # NOTE: callers pass either string-keyed (plan flow, via with_indifferent_access) or
-          #       symbol-keyed (subscription override flow, via deep_symbolize_keys) values
-          #       hashes. Normalize so the in-memory indexes below match regardless.
-          values_params = filter_param[:values].transform_keys(&:to_s)
+      begin
+        ActiveRecord::Base.transaction do
+          # NOTE: the `with_discarded` scope on the belongs_to associations below defeats
+          #       Rails' automatic inverse_of, so every save would otherwise re-SELECT the
+          #       parent records during validation. Load each parent once and pre-assign
+          #       it on every built/looked-up child.
+          organization = charge.organization
 
-          # NOTE: since a filter could be a refinement of another one, we have to make sure
-          #       that we are targeting the right one
-          filter = filters_by_values_key[values_params.sort]
+          filters_params.each do |filter_param|
+            # NOTE: callers pass either string-keyed (plan flow, via with_indifferent_access) or
+            #       symbol-keyed (subscription override flow, via deep_symbolize_keys) values
+            #       hashes. Normalize so the in-memory indexes below match regardless.
+            values_params = filter_param[:values].transform_keys(&:to_s)
 
-          filter ||= charge.filters.new(organization_id: charge.organization_id)
-          filter.charge = charge
-          filter.organization = organization
+            # NOTE: since a filter could be a refinement of another one, we have to make sure
+            #       that we are targeting the right one
+            filter = filters_by_values_key[values_params.sort]
+            matched_existing_filter = !filter.nil?
 
-          filter.invoice_display_name = filter_param[:invoice_display_name]
-          filter.properties = ChargeModels::FilterPropertiesService.call(
-            chargeable: charge,
-            properties: filter_param[:properties]&.deep_symbolize_keys&.except(:presentation_group_keys)
-          ).properties
+            filter ||= charge.filters.new(organization_id: charge.organization_id)
+            filter.charge = charge
+            filter.organization = organization
 
-          filter.save! if filter.changed?
+            filter.invoice_display_name = filter_param[:invoice_display_name]
+            filter.properties = ChargeModels::FilterPropertiesService.call(
+              chargeable: charge,
+              properties: filter_param[:properties]&.deep_symbolize_keys&.except(:presentation_group_keys)
+            ).properties
 
-          if touch
-            PaperTrail.request.disable_model(filter.class)
-            # NOTE: Make sure update_at is touched even if not changed to keep the right order
-            filter.touch # rubocop:disable Rails/SkipsModelValidations
-            PaperTrail.request.enable_model(filter.class)
-          end
+            filter.save! if filter.changed?
 
-          # NOTE: Create or update the filter values
-          values_params.each do |key, values|
-            billable_metric_filter = billable_metric_filters_by_key[key]
+            # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
+            filter.touch if touch # rubocop:disable Rails/SkipsModelValidations
 
-            # NOTE: look up against the preloaded values collection in memory so we don't
-            #       re-query charge_filter_values; pre-assign the parents below so the
-            #       belongs_to validations and validate_values callback use cached
-            #       associations instead of issuing a SELECT.
-            filter_value = filter.values.to_a.find { |v| v.billable_metric_filter_id == billable_metric_filter&.id }
-            filter_value ||= filter.values.build(organization_id: charge.organization_id)
-            filter_value.charge_filter = filter
-            filter_value.billable_metric_filter = billable_metric_filter
-            filter_value.organization = organization
+            # NOTE: Create or update the filter values
+            values_params.each do |key, values|
+              billable_metric_filter = billable_metric_filters_by_key[key]
 
-            filter_value.values = values
-            filter_value.save! if filter_value.changed?
+              # NOTE: only look up an existing filter_value if the parent filter came from
+              #       the preloaded set. For freshly-created filters, the values collection
+              #       is provably empty — querying it on a now-persisted record issues a
+              #       wasted SELECT per filter.
+              filter_value = if matched_existing_filter
+                filter.values.to_a.find { |v| v.billable_metric_filter_id == billable_metric_filter&.id }
+              end
+              filter_value ||= filter.values.build(organization_id: charge.organization_id)
+              filter_value.charge_filter = filter
+              filter_value.billable_metric_filter = billable_metric_filter
+              filter_value.organization = organization
 
-            if touch
-              PaperTrail.request.disable_model(filter_value.class)
-              # NOTE: Make sure update_at is touched even if not changed to keep the right order
-              filter_value.touch # rubocop:disable Rails/SkipsModelValidations
-              PaperTrail.request.enable_model(filter_value.class)
+              filter_value.values = values
+              filter_value.save! if filter_value.changed?
+
+              # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
+              filter_value.touch if touch # rubocop:disable Rails/SkipsModelValidations
             end
+
+            result.filters << filter
           end
 
-          result.filters << filter
+          # NOTE: remove old filters that were not created or updated
+          charge.filters.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
+            remove_filter(it)
+          end
         end
-
-        # NOTE: remove old filters that were not created or updated
-        charge.filters.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
-          remove_filter(it)
-        end
+      ensure
+        PaperTrail.request.enable_model(ChargeFilter)
+        PaperTrail.request.enable_model(ChargeFilterValue)
       end
 
       result

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -55,9 +55,12 @@ module ChargeFilters
           values_params.each do |key, values|
             billable_metric_filter = billable_metric_filters_by_key[key]
 
-            filter_value = filter.values.find_or_initialize_by(
-              billable_metric_filter_id: billable_metric_filter&.id
-            ) { it.organization_id = charge.organization_id }
+            # NOTE: look up against the preloaded values collection in memory so we don't
+            #       re-query charge_filter_values; pre-assign billable_metric_filter so the
+            #       validate_values callback uses the cached association instead of a SELECT.
+            filter_value = filter.values.to_a.find { |v| v.billable_metric_filter_id == billable_metric_filter&.id }
+            filter_value ||= filter.values.build(organization_id: charge.organization_id)
+            filter_value.billable_metric_filter = billable_metric_filter
 
             filter_value.values = values
             filter_value.save! if filter_value.changed?

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -61,7 +61,7 @@ module ChargeFilters
 
     private
 
-    attr_reader :charge, :filters_params, :organization, :touch
+    attr_reader :charge, :filters_params, :organization
 
     def update_existing_filter(filter, filter_param, values_params, properties)
       filter.charge = charge
@@ -72,7 +72,7 @@ module ChargeFilters
 
       filter.save! if filter.changed?
 
-      if touch
+      if @touch
         PaperTrail.request.disable_model(filter.class)
         # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
         filter.touch # rubocop:disable Rails/SkipsModelValidations
@@ -92,7 +92,7 @@ module ChargeFilters
         filter_value.values = values
         filter_value.save! if filter_value.changed?
 
-        if touch
+        if @touch
           # NOTE: Make sure update_at is touched even if not changed to keep the right order
           PaperTrail.request.disable_model(filter_value.class)
           filter_value.touch # rubocop:disable Rails/SkipsModelValidations

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -72,10 +72,12 @@ module ChargeFilters
 
       filter.save! if filter.changed?
 
-      PaperTrail.request.disable_model(filter.class)
-      # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
-      filter.touch if touch # rubocop:disable Rails/SkipsModelValidations
-      PaperTrail.request.enable_model(filter.class)
+      if touch
+        PaperTrail.request.disable_model(filter.class)
+        # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
+        filter.touch # rubocop:disable Rails/SkipsModelValidations
+        PaperTrail.request.enable_model(filter.class)
+      end
 
       values_params.each do |key, values|
         billable_metric_filter = billable_metric_filters_by_key[key]
@@ -90,9 +92,12 @@ module ChargeFilters
         filter_value.values = values
         filter_value.save! if filter_value.changed?
 
-        PaperTrail.request.disable_model(filter_value.class)
-        filter_value.touch if touch # rubocop:disable Rails/SkipsModelValidations
-        PaperTrail.request.enable_model(filter_value.class)
+        if touch
+          # NOTE: Make sure update_at is touched even if not changed to keep the right order
+          PaperTrail.request.disable_model(filter_value.class)
+          filter_value.touch # rubocop:disable Rails/SkipsModelValidations
+          PaperTrail.request.enable_model(filter_value.class)
+        end
       end
 
       result.filters << filter

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -6,6 +6,12 @@ module ChargeFilters
       @charge = charge
       @filters_params = filters_params
       @organization = charge.organization
+      @new_filter_rows = []
+      @new_filter_value_rows = []
+      @new_filter_ids = []
+
+      # We only care about order when you have less than 100 filters.
+      @should_touch = filters_params.size < 100
 
       super
     end
@@ -21,14 +27,7 @@ module ChargeFilters
 
       return result.single_validation_failure!(field: :values, error_code: "value_is_mandatory") if empty_filter_values?
 
-      # We only care about order when you have less than 100 filters.
-      @touch = filters_params.size < 100
-
       ActiveRecord::Base.transaction do
-        @new_filter_rows = []
-        @new_filter_value_rows = []
-        @new_filter_ids = []
-
         filters_params.each do |filter_param|
           values_params = filter_param[:values].transform_keys(&:to_s)
 
@@ -61,7 +60,7 @@ module ChargeFilters
 
     private
 
-    attr_reader :charge, :filters_params, :organization
+    attr_reader :charge, :filters_params, :organization, :should_touch, :new_filter_rows, :new_filter_value_rows, :new_filter_ids
 
     def update_existing_filter(filter, filter_param, values_params, properties)
       filter.charge = charge
@@ -72,18 +71,18 @@ module ChargeFilters
 
       filter.save! if filter.changed?
 
-      if @touch
+      if should_touch && !filter.saved_changes?
         PaperTrail.request.disable_model(filter.class)
         # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
         filter.touch # rubocop:disable Rails/SkipsModelValidations
         PaperTrail.request.enable_model(filter.class)
       end
 
+      filter_values_indexed = filter.values.index_by(&:billable_metric_filter_id)
+
       values_params.each do |key, values|
         billable_metric_filter = billable_metric_filters_by_key[key]
-
-        # NOTE: existing filter was preloaded with values, so this in-memory find avoids a SELECT.
-        filter_value = filter.values.to_a.find { |v| v.billable_metric_filter_id == billable_metric_filter&.id }
+        filter_value = filter_values_indexed[billable_metric_filter&.id]
         filter_value ||= filter.values.build
         filter_value.charge_filter = filter
         filter_value.billable_metric_filter = billable_metric_filter
@@ -92,7 +91,7 @@ module ChargeFilters
         filter_value.values = values
         filter_value.save! if filter_value.changed?
 
-        if @touch
+        if should_touch && !filter_value.saved_changes?
           PaperTrail.request.disable_model(filter_value.class)
           # NOTE: Make sure update_at is touched even if not changed to keep the right order
           filter_value.touch # rubocop:disable Rails/SkipsModelValidations
@@ -118,14 +117,14 @@ module ChargeFilters
       )
       filter_instance.validate!
 
-      @new_filter_rows << {
+      new_filter_rows << {
         id: filter_id,
         charge_id: charge.id,
         organization_id: organization.id,
         invoice_display_name: filter_param[:invoice_display_name],
         properties: properties
       }
-      @new_filter_ids << filter_id
+      new_filter_ids << filter_id
 
       values_params.each do |key, values|
         billable_metric_filter = billable_metric_filters_by_key[key]
@@ -138,7 +137,7 @@ module ChargeFilters
         )
         value_instance.validate!
 
-        @new_filter_value_rows << {
+        new_filter_value_rows << {
           charge_filter_id: filter_id,
           billable_metric_filter_id: billable_metric_filter&.id,
           organization_id: organization.id,
@@ -148,35 +147,29 @@ module ChargeFilters
     end
 
     def bulk_insert_new_filters
-      return if @new_filter_rows.empty?
+      return if new_filter_rows.empty?
 
-      # NOTE: insert_all skips refreshing updated_at, so set
-      #       monotonically-increasing timestamps to preserve the request order under the
-      #       model's `order(updated_at: :asc)` default scope.
+      # NOTE: insert_all stamps every row with the same created_at/updated_at within
+      #       a single call. The model's default_scope orders by updated_at, so we
+      #       assign monotonically-increasing per-row offsets to preserve input order.
       now = Time.current
-      @new_filter_rows.each_with_index do |row, idx|
+      new_filter_rows.each_with_index do |row, idx|
         timestamp = now + (idx / 1_000_000.0)
         row[:created_at] = timestamp
         row[:updated_at] = timestamp
       end
-      ChargeFilter.insert_all!(@new_filter_rows) # rubocop:disable Rails/SkipsModelValidations
 
-      if @new_filter_value_rows.any?
-        @new_filter_value_rows.each_with_index do |row, idx|
+      returned = ChargeFilter.insert_all!(new_filter_rows, returning: ChargeFilter.column_names) # rubocop:disable Rails/SkipsModelValidations
+      returned.each { |attrs| result.filters << ChargeFilter.instantiate(attrs) }
+
+      if new_filter_value_rows.any?
+        new_filter_value_rows.each_with_index do |row, idx|
           timestamp = now + (idx / 1_000_000.0)
           row[:created_at] = timestamp
           row[:updated_at] = timestamp
         end
-        ChargeFilterValue.insert_all!(@new_filter_value_rows) # rubocop:disable Rails/SkipsModelValidations
+        ChargeFilterValue.insert_all!(new_filter_value_rows) # rubocop:disable Rails/SkipsModelValidations
       end
-
-      # NOTE: re-fetch the inserted filters with their values so callers iterating over
-      #       result.filters see fully-hydrated records.
-      inserted = charge.filters
-        .where(id: @new_filter_ids)
-        .includes(values: :billable_metric_filter)
-        .index_by(&:id)
-      @new_filter_ids.each { |id| result.filters << inserted[id] }
     end
 
     def filters

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -21,7 +21,7 @@ module ChargeFilters
       return result.single_validation_failure!(field: :values, error_code: "value_is_mandatory") if empty_filter_values?
 
       # We only care about order when you have less than 100 filters.
-      touch = filters_params.size < 100
+      @touch = filters_params.size < 100
 
       # NOTE: PaperTrail's per-save Version Create plus version_limit COUNT is the
       #       dominant DB cost for large filter batches (two queries per record save).
@@ -32,20 +32,12 @@ module ChargeFilters
 
       begin
         ActiveRecord::Base.transaction do
-          # NOTE: the `with_discarded` scope on the belongs_to associations below defeats
-          #       Rails' automatic inverse_of, so every save would otherwise re-SELECT the
-          #       parent records during validation. Load each parent once and pre-assign
-          #       it on every built/looked-up child.
-          organization = charge.organization
-
-          new_filter_rows = []
-          new_filter_value_rows = []
-          new_filter_ids_in_order = []
+          @organization = charge.organization
+          @new_filter_rows = []
+          @new_filter_value_rows = []
+          @new_filter_ids = []
 
           filters_params.each do |filter_param|
-            # NOTE: callers pass either string-keyed (plan flow, via with_indifferent_access) or
-            #       symbol-keyed (subscription override flow, via deep_symbolize_keys) values
-            #       hashes. Normalize so the in-memory indexes below match regardless.
             values_params = filter_param[:values].transform_keys(&:to_s)
 
             # NOTE: since a filter could be a refinement of another one, we have to make sure
@@ -58,18 +50,13 @@ module ChargeFilters
             ).properties
 
             if existing_filter
-              update_existing_filter(
-                existing_filter, organization, filter_param, values_params, properties, touch
-              )
+              update_existing_filter(existing_filter, filter_param, values_params, properties)
             else
-              accumulate_new_filter(
-                organization, filter_param, values_params, properties,
-                new_filter_rows, new_filter_value_rows, new_filter_ids_in_order
-              )
+              accumulate_new_filter(filter_param, values_params, properties)
             end
           end
 
-          bulk_insert_new_filters(new_filter_rows, new_filter_value_rows, new_filter_ids_in_order)
+          bulk_insert_new_filters
 
           # NOTE: remove old filters that were not created or updated
           charge.filters.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
@@ -88,9 +75,9 @@ module ChargeFilters
 
     attr_reader :charge, :filters_params
 
-    def update_existing_filter(filter, organization, filter_param, values_params, properties, touch)
+    def update_existing_filter(filter, filter_param, values_params, properties)
       filter.charge = charge
-      filter.organization = organization
+      filter.organization = @organization
 
       filter.invoice_display_name = filter_param[:invoice_display_name]
       filter.properties = properties
@@ -98,7 +85,7 @@ module ChargeFilters
       filter.save! if filter.changed?
 
       # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
-      filter.touch if touch # rubocop:disable Rails/SkipsModelValidations
+      filter.touch if @touch # rubocop:disable Rails/SkipsModelValidations
 
       values_params.each do |key, values|
         billable_metric_filter = billable_metric_filters_by_key[key]
@@ -108,28 +95,23 @@ module ChargeFilters
         filter_value ||= filter.values.build(organization_id: charge.organization_id)
         filter_value.charge_filter = filter
         filter_value.billable_metric_filter = billable_metric_filter
-        filter_value.organization = organization
+        filter_value.organization = @organization
 
         filter_value.values = values
         filter_value.save! if filter_value.changed?
 
-        filter_value.touch if touch # rubocop:disable Rails/SkipsModelValidations
+        filter_value.touch if @touch # rubocop:disable Rails/SkipsModelValidations
       end
 
       result.filters << filter
     end
 
-    def accumulate_new_filter(organization, filter_param, values_params, properties,
-      new_filter_rows, new_filter_value_rows, new_filter_ids_in_order)
+    def accumulate_new_filter(filter_param, values_params, properties)
       # NOTE: pre-generate the UUID so we can wire ChargeFilterValue rows to their parent
       #       without a round-trip after the ChargeFilter insert_all.
       filter_id = SecureRandom.uuid
 
-      # NOTE: build an in-memory AR instance only to run validations — we drop it after
-      #       capturing the row hash. Use a standalone ChargeFilter.new (not
-      #       `charge.filters.new`) so the unsaved instance is not appended to the
-      #       parent's in-memory collection, which can interfere with later charge.save!
-      #       in callers like Charges::CreateService.
+      # NOTE: build an in-memory AR instance only to run validations
       filter_instance = ChargeFilter.new(
         id: filter_id,
         charge_id: charge.id,
@@ -138,17 +120,17 @@ module ChargeFilters
         properties: properties
       )
       filter_instance.charge = charge
-      filter_instance.organization = organization
+      filter_instance.organization = @organization
       filter_instance.validate!
 
-      new_filter_rows << {
+      @new_filter_rows << {
         id: filter_id,
         charge_id: charge.id,
         organization_id: charge.organization_id,
         invoice_display_name: filter_param[:invoice_display_name],
         properties: properties
       }
-      new_filter_ids_in_order << filter_id
+      @new_filter_ids << filter_id
 
       values_params.each do |key, values|
         billable_metric_filter = billable_metric_filters_by_key[key]
@@ -159,10 +141,10 @@ module ChargeFilters
         )
         value_instance.charge_filter = filter_instance
         value_instance.billable_metric_filter = billable_metric_filter
-        value_instance.organization = organization
+        value_instance.organization = @organization
         value_instance.validate!
 
-        new_filter_value_rows << {
+        @new_filter_value_rows << {
           charge_filter_id: filter_id,
           billable_metric_filter_id: billable_metric_filter&.id,
           organization_id: charge.organization_id,
@@ -171,36 +153,36 @@ module ChargeFilters
       end
     end
 
-    def bulk_insert_new_filters(new_filter_rows, new_filter_value_rows, new_filter_ids_in_order)
-      return if new_filter_rows.empty?
+    def bulk_insert_new_filters
+      return if @new_filter_rows.empty?
 
-      # NOTE: insert_all skips AR callbacks (and therefore updated_at handling), so set
+      # NOTE: insert_all skips refreshing updated_at, so set
       #       monotonically-increasing timestamps to preserve the request order under the
       #       model's `order(updated_at: :asc)` default scope.
       now = Time.current
-      new_filter_rows.each_with_index do |row, idx|
-        ts = now + (idx / 1_000_000.0)
-        row[:created_at] = ts
-        row[:updated_at] = ts
+      @new_filter_rows.each_with_index do |row, idx|
+        timestamp = now + (idx / 1_000_000.0)
+        row[:created_at] = timestamp
+        row[:updated_at] = timestamp
       end
-      ChargeFilter.insert_all!(new_filter_rows) # rubocop:disable Rails/SkipsModelValidations
+      ChargeFilter.insert_all!(@new_filter_rows) # rubocop:disable Rails/SkipsModelValidations
 
-      if new_filter_value_rows.any?
-        new_filter_value_rows.each_with_index do |row, idx|
-          ts = now + (idx / 1_000_000.0)
-          row[:created_at] = ts
-          row[:updated_at] = ts
+      if @new_filter_value_rows.any?
+        @new_filter_value_rows.each_with_index do |row, idx|
+          timestamp = now + (idx / 1_000_000.0)
+          row[:created_at] = timestamp
+          row[:updated_at] = timestamp
         end
-        ChargeFilterValue.insert_all!(new_filter_value_rows) # rubocop:disable Rails/SkipsModelValidations
+        ChargeFilterValue.insert_all!(@new_filter_value_rows) # rubocop:disable Rails/SkipsModelValidations
       end
 
       # NOTE: re-fetch the inserted filters with their values so callers iterating over
       #       result.filters see fully-hydrated records.
       inserted = charge.filters
-        .where(id: new_filter_ids_in_order)
+        .where(id: @new_filter_ids)
         .includes(values: :billable_metric_filter)
         .index_by(&:id)
-      new_filter_ids_in_order.each { |id| result.filters << inserted[id] }
+      @new_filter_ids.each { |id| result.filters << inserted[id] }
     end
 
     def filters

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -27,9 +27,7 @@ module ChargeFilters
         filters_params.each do |filter_param|
           # NOTE: since a filter could be a refinement of another one, we have to make sure
           #       that we are targeting the right one
-          filter = filters.find do |f|
-            f.to_h.sort == filter_param[:values].sort
-          end
+          filter = filters_by_values_key[filter_param[:values].sort]
 
           filter ||= charge.filters.new(organization_id: charge.organization_id)
 
@@ -47,7 +45,7 @@ module ChargeFilters
 
           # NOTE: Create or update the filter values
           filter_param[:values].each do |key, values|
-            billable_metric_filter = charge.billable_metric.filters.find_by(key:)
+            billable_metric_filter = billable_metric_filters_by_key[key]
 
             filter_value = filter.values.find_or_initialize_by(
               billable_metric_filter_id: billable_metric_filter&.id
@@ -80,6 +78,14 @@ module ChargeFilters
 
     def filters
       @filters ||= charge.filters.includes(values: :billable_metric_filter)
+    end
+
+    def filters_by_values_key
+      @filters_by_values_key ||= filters.index_by { |f| f.to_h.sort }
+    end
+
+    def billable_metric_filters_by_key
+      @billable_metric_filters_by_key ||= charge.billable_metric.filters.index_by(&:key)
     end
 
     def remove_all

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -5,6 +5,7 @@ module ChargeFilters
     def initialize(charge:, filters_params:)
       @charge = charge
       @filters_params = filters_params
+      @organization = charge.organization
 
       super
     end
@@ -32,7 +33,6 @@ module ChargeFilters
 
       begin
         ActiveRecord::Base.transaction do
-          @organization = charge.organization
           @new_filter_rows = []
           @new_filter_value_rows = []
           @new_filter_ids = []
@@ -73,11 +73,11 @@ module ChargeFilters
 
     private
 
-    attr_reader :charge, :filters_params
+    attr_reader :charge, :filters_params, :organization, :touch
 
     def update_existing_filter(filter, filter_param, values_params, properties)
       filter.charge = charge
-      filter.organization = @organization
+      filter.organization = organization
 
       filter.invoice_display_name = filter_param[:invoice_display_name]
       filter.properties = properties
@@ -85,17 +85,17 @@ module ChargeFilters
       filter.save! if filter.changed?
 
       # NOTE: Make sure updated_at is touched even if not changed to keep the right order.
-      filter.touch if @touch # rubocop:disable Rails/SkipsModelValidations
+      filter.touch if touch # rubocop:disable Rails/SkipsModelValidations
 
       values_params.each do |key, values|
         billable_metric_filter = billable_metric_filters_by_key[key]
 
         # NOTE: existing filter was preloaded with values, so this in-memory find avoids a SELECT.
         filter_value = filter.values.to_a.find { |v| v.billable_metric_filter_id == billable_metric_filter&.id }
-        filter_value ||= filter.values.build(organization_id: charge.organization_id)
+        filter_value ||= filter.values.build
         filter_value.charge_filter = filter
         filter_value.billable_metric_filter = billable_metric_filter
-        filter_value.organization = @organization
+        filter_value.organization = organization
 
         filter_value.values = values
         filter_value.save! if filter_value.changed?
@@ -114,19 +114,17 @@ module ChargeFilters
       # NOTE: build an in-memory AR instance only to run validations
       filter_instance = ChargeFilter.new(
         id: filter_id,
-        charge_id: charge.id,
-        organization_id: charge.organization_id,
+        charge:,
+        organization:,
         invoice_display_name: filter_param[:invoice_display_name],
         properties: properties
       )
-      filter_instance.charge = charge
-      filter_instance.organization = @organization
       filter_instance.validate!
 
       @new_filter_rows << {
         id: filter_id,
         charge_id: charge.id,
-        organization_id: charge.organization_id,
+        organization_id: organization.id,
         invoice_display_name: filter_param[:invoice_display_name],
         properties: properties
       }
@@ -136,18 +134,17 @@ module ChargeFilters
         billable_metric_filter = billable_metric_filters_by_key[key]
 
         value_instance = ChargeFilterValue.new(
-          organization_id: charge.organization_id,
+          charge_filter: filter_instance,
+          billable_metric_filter:,
+          organization:,
           values: values
         )
-        value_instance.charge_filter = filter_instance
-        value_instance.billable_metric_filter = billable_metric_filter
-        value_instance.organization = @organization
         value_instance.validate!
 
         @new_filter_value_rows << {
           charge_filter_id: filter_id,
           billable_metric_filter_id: billable_metric_filter&.id,
-          organization_id: charge.organization_id,
+          organization_id: organization.id,
           values: values
         }
       end

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -25,9 +25,14 @@ module ChargeFilters
 
       ActiveRecord::Base.transaction do
         filters_params.each do |filter_param|
+          # NOTE: callers pass either string-keyed (plan flow, via with_indifferent_access) or
+          #       symbol-keyed (subscription override flow, via deep_symbolize_keys) values
+          #       hashes. Normalize so the in-memory indexes below match regardless.
+          values_params = filter_param[:values].transform_keys(&:to_s)
+
           # NOTE: since a filter could be a refinement of another one, we have to make sure
           #       that we are targeting the right one
-          filter = filters_by_values_key[filter_param[:values].sort]
+          filter = filters_by_values_key[values_params.sort]
 
           filter ||= charge.filters.new(organization_id: charge.organization_id)
 
@@ -44,7 +49,7 @@ module ChargeFilters
           end
 
           # NOTE: Create or update the filter values
-          filter_param[:values].each do |key, values|
+          values_params.each do |key, values|
             billable_metric_filter = billable_metric_filters_by_key[key]
 
             filter_value = filter.values.find_or_initialize_by(

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -24,6 +24,12 @@ module ChargeFilters
       touch = filters_params.size < 100
 
       ActiveRecord::Base.transaction do
+        # NOTE: the `with_discarded` scope on the belongs_to associations below defeats
+        #       Rails' automatic inverse_of, so every save would otherwise re-SELECT the
+        #       parent records during validation. Load each parent once and pre-assign
+        #       it on every built/looked-up child.
+        organization = charge.organization
+
         filters_params.each do |filter_param|
           # NOTE: callers pass either string-keyed (plan flow, via with_indifferent_access) or
           #       symbol-keyed (subscription override flow, via deep_symbolize_keys) values
@@ -35,6 +41,8 @@ module ChargeFilters
           filter = filters_by_values_key[values_params.sort]
 
           filter ||= charge.filters.new(organization_id: charge.organization_id)
+          filter.charge = charge
+          filter.organization = organization
 
           filter.invoice_display_name = filter_param[:invoice_display_name]
           filter.properties = ChargeModels::FilterPropertiesService.call(
@@ -56,11 +64,14 @@ module ChargeFilters
             billable_metric_filter = billable_metric_filters_by_key[key]
 
             # NOTE: look up against the preloaded values collection in memory so we don't
-            #       re-query charge_filter_values; pre-assign billable_metric_filter so the
-            #       validate_values callback uses the cached association instead of a SELECT.
+            #       re-query charge_filter_values; pre-assign the parents below so the
+            #       belongs_to validations and validate_values callback use cached
+            #       associations instead of issuing a SELECT.
             filter_value = filter.values.to_a.find { |v| v.billable_metric_filter_id == billable_metric_filter&.id }
             filter_value ||= filter.values.build(organization_id: charge.organization_id)
+            filter_value.charge_filter = filter
             filter_value.billable_metric_filter = billable_metric_filter
+            filter_value.organization = organization
 
             filter_value.values = values
             filter_value.save! if filter_value.changed?

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -270,6 +270,62 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
       expect(filter.values.pluck(:values).flatten).to match_array(%w[domestic visa])
     end
 
+    context "when the existing filter matches the request exactly" do
+      let(:filter) do
+        create(:charge_filter,
+          charge:,
+          invoice_display_name: "Same display name",
+          properties: {"amount" => "10"},
+          updated_at: 1.day.ago)
+      end
+
+      let(:filter_values) do
+        [
+          create(:charge_filter_value,
+            charge_filter: filter,
+            billable_metric_filter: card_location_filter,
+            values: ["domestic"],
+            updated_at: 1.day.ago),
+          create(:charge_filter_value,
+            charge_filter: filter,
+            billable_metric_filter: scheme_filter,
+            values: ["visa"],
+            updated_at: 1.day.ago)
+        ]
+      end
+
+      let(:filters_params) do
+        [
+          {
+            values: {
+              card_location_filter.key => ["domestic"],
+              scheme_filter.key => ["visa"]
+            },
+            invoice_display_name: "Same display name",
+            properties: {amount: "10"}
+          }
+        ]
+      end
+
+      it "touches the unchanged filter to preserve input order under updated_at ASC" do
+        previous_updated_at = filter.reload.updated_at
+
+        service
+
+        expect(filter.reload.updated_at).to be > previous_updated_at
+      end
+
+      it "touches each unchanged filter_value to preserve input order under updated_at ASC" do
+        previous_updated_ats = filter_values.map { it.reload.updated_at }
+
+        service
+
+        filter_values.zip(previous_updated_ats).each do |fv, previous_updated_at|
+          expect(fv.reload.updated_at).to be > previous_updated_at
+        end
+      end
+    end
+
     context "when changing filter values" do
       let(:filters_params) do
         [

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -59,6 +59,33 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
     end
   end
 
+  context "when only one of multiple filter_params has empty values" do
+    let(:filters_params) do
+      [
+        {
+          values: {card_location_filter.key => ["domestic"]},
+          invoice_display_name: "Valid filter",
+          properties: {amount: "10"}
+        },
+        {
+          values: {},
+          invoice_display_name: "Invalid filter",
+          properties: {amount: "20"}
+        }
+      ]
+    end
+
+    it "returns a validation failure" do
+      expect(service).not_to be_success
+      expect(service.error).to be_a(BaseService::ValidationFailure)
+      expect(service.error.messages[:values]).to eq(["value_is_mandatory"])
+    end
+
+    it "does not create any filters" do
+      expect { service }.not_to change(ChargeFilter, :count)
+    end
+  end
+
   context "when filter params is empty" do
     it "does not create any filters" do
       expect { service }.not_to change(ChargeFilter, :count)
@@ -167,6 +194,16 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
       end
     end
 
+    it "returns a successful result with filters ordered as in input params" do
+      result = service
+
+      expect(result).to be_success
+      expect(result.filters.count).to eq(2)
+      expect(result.filters.map(&:invoice_display_name)).to eq(
+        ["Visa domestic card payment", "Visa debit domestic card payment"]
+      )
+    end
+
     context "when filter properties contain presentation_group_keys" do
       let(:filters_params) do
         [
@@ -257,6 +294,12 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
         expect(new_filter.values.count).to eq(2)
         expect(new_filter.values.pluck(:values).flatten).to match_array(%w[international mastercard])
       end
+
+      it "soft-deletes the values of the removed filter" do
+        service
+
+        expect(filter_values.map { it.reload.discarded? }).to all(be true)
+      end
     end
 
     context "when adding a value into filter values" do
@@ -283,6 +326,66 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
         expect(new_filter.values.count).to eq(2)
         expect(new_filter.values.pluck(:values).flatten).to match_array(%w[domestic visa mastercard])
       end
+    end
+  end
+
+  context "with a mix of kept, new and removed filters" do
+    let(:filter_to_keep) { create(:charge_filter, charge:, invoice_display_name: "Old name") }
+    let(:filter_to_keep_value) do
+      create(
+        :charge_filter_value,
+        charge_filter: filter_to_keep,
+        billable_metric_filter: card_location_filter,
+        values: ["domestic"]
+      )
+    end
+
+    let(:filter_to_remove) { create(:charge_filter, charge:, invoice_display_name: "To remove") }
+    let(:filter_to_remove_value) do
+      create(
+        :charge_filter_value,
+        charge_filter: filter_to_remove,
+        billable_metric_filter: card_location_filter,
+        values: ["international"]
+      )
+    end
+
+    let(:filters_params) do
+      [
+        {
+          values: {card_location_filter.key => ["domestic"]},
+          invoice_display_name: "Updated name",
+          properties: {amount: "10"}
+        },
+        {
+          values: {scheme_filter.key => ["visa"]},
+          invoice_display_name: "Brand new filter",
+          properties: {amount: "20"}
+        }
+      ]
+    end
+
+    before do
+      filter_to_keep_value
+      filter_to_remove_value
+    end
+
+    it "updates matching filters, creates new ones and discards the rest" do
+      result = service
+
+      expect(result).to be_success
+      expect(result.filters.count).to eq(2)
+
+      expect(filter_to_keep.reload).not_to be_discarded
+      expect(filter_to_keep.invoice_display_name).to eq("Updated name")
+      expect(filter_to_keep.properties).to eq("amount" => "10")
+
+      expect(filter_to_remove.reload).to be_discarded
+      expect(filter_to_remove_value.reload).to be_discarded
+
+      new_filter = result.filters.find { it.invoice_display_name == "Brand new filter" }
+      expect(new_filter).not_to be_nil
+      expect(new_filter.values.pluck(:values).flatten).to eq(["visa"])
     end
   end
 end


### PR DESCRIPTION
## Context

PUT /api/v1/plans/:code is unusably slow when a plan has charges with hundreds of ChargeFilters. On prod, a payload with 8 charges and ~900 filters took ~18s in total with ~10s in the DB. The cost was dominated by per-record overhead inside ChargeFilters::CreateOrUpdateBatchService: redundant validation lookups, PaperTrail bookkeeping on every save, and 3,400+ individual INSERTs.

## Description

All changes are in ChargeFilters::CreateOrUpdateBatchService — the single hot spot of the request:

- **Preload the in-memory parents** on every built or looked-up ChargeFilter/ChargeFilterValue. The with_discarded scope on belongs_to :charge/:charge_filter/:billable_metric_filter defeats Rails automatic inverse_of, so every save was re-SELECTing those parents during presence validation.
- **Use the preloaded values collection instead of find_or_initialize_by**. Each (filter, key) pair was running `filter.values.find_or_initialize_by(...)`, which issues a SQL query per call. Since the values collection is already preloaded, this becomes an in-memory find.
- **Disable PaperTrail for ChargeFilter and ChargeFilterValue during the batch**. PaperTrail's per-save Version Create + the version_limit COUNT query was running thousands of times per request. The parent Plan/Charge still get their own audit entries from their respective services; per-filter granularity is intentionally dropped for this batch path.
- **Bulk-insert new filters via insert_all!**. Pre-generate filter UUIDs so child ChargeFilterValue rows can be wired without a round-trip. AR instances are still built once for validate! to preserve the existing validation contract (and the ActiveRecord::RecordInvalid propagation that callers rely on), but the actual write becomes one INSERT per charge for filters and one for filter values. Matched existing filters keep the per-record save! path.
- **Match existing filters via a hash index instead of a linear scan**. The lookup `filters.find { |f| f.to_h.sort == filter_param[:values].sort }` ran once per filter_param over the full preloaded set. Replaced with filters_by_values_key[values_params.sort], an index built once on the preloaded set.
- **Memoize the billable-metric-filter lookup**. Each pair was issuing `charge.billable_metric.filters.find_by(key:)` with one round-trip per call. Replaced with billable_metric_filters_by_key[key], a single `index_by(&:key)` over the already-loaded set.
- **Enhanced tests**: filter ordering after bulk insert, soft-delete of the removed filter's values, mixed kept/new/removed flow, partial validation failure across filter params.

Performance testing on staging env:
- 8 charges
- 972 filters

Create path (PUT with new charges).

| Metric| Original latency | Optimized latency |
| ------------------ | --------------- | ------------------ |
| total duration | ~36.2 s | ~2.6 s |
| DB time | ~22.0 s | ~1.0 s |
| Ruby allocations | ~8.8 M | ~2.25 M |

Update path (PUT with existing charges).
| Metric| Original latency | Optimized latency |
| ------------------ | --------------- | ------------------ |
| total duration | ~11.04 s| ~2.08 s |
| DB time | ~2.98 s | ~0.70 s |
| Ruby allocations | ~9.28 M| ~1.20 M |