### PR TITLE
fix(subscriptions): update existing charge on overridden plan in place (#5549)

### DIFF
--- a/app/services/subscriptions/update_or_override_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_charge_service.rb
@@ -39,6 +39,15 @@ module Subscriptions
     attr_reader :subscription, :charge, :params
 
     def find_or_update_charge_override(target_plan)
+      # If the resolved charge already lives on the overridden plan, update
+      # it in place. Without this short-circuit, a charge created directly
+      # on the overridden plan by `Plans::UpdateService#process_charges`
+      # (the legacy `plan_overrides` PATCH path, where `parent_id` is nil)
+      # would end up with a SECOND override layered on top via
+      # `Charges::OverrideService` — same `billable_metric_id`, same `code` —
+      # and both charges would generate fees over the same events.
+      return update_charge_override(charge) if charge.plan_id == target_plan.id
+
       parent_charge = find_parent_charge
       existing_override = target_plan.charges.find_by(parent_id: parent_charge.id)
 

--- a/app/services/subscriptions/update_or_override_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_charge_service.rb
@@ -39,13 +39,7 @@ module Subscriptions
     attr_reader :subscription, :charge, :params
 
     def find_or_update_charge_override(target_plan)
-      # If the resolved charge already lives on the overridden plan, update
-      # it in place. Without this short-circuit, a charge created directly
-      # on the overridden plan by `Plans::UpdateService#process_charges`
-      # (the legacy `plan_overrides` PATCH path, where `parent_id` is nil)
-      # would end up with a SECOND override layered on top via
-      # `Charges::OverrideService` — same `billable_metric_id`, same `code` —
-      # and both charges would generate fees over the same events.
+      # NOTE: If the resolved charge already lives on the overridden plan, update it in place.
       return update_charge_override(charge) if charge.plan_id == target_plan.id
 
       parent_charge = find_parent_charge

--- a/spec/services/subscriptions/update_or_override_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_charge_service_spec.rb
@@ -127,13 +127,6 @@ RSpec.describe Subscriptions::UpdateOrOverrideChargeService do
       end
 
       context "when the charge passed lives directly on the overridden plan with parent_id: nil" do
-        # Reproduces the state left by `Plans::UpdateService#process_charges`
-        # (the legacy `plan_overrides` PATCH path): a top-level charge sits
-        # directly on the overridden plan with no parent, alongside the
-        # subscription's overridden plan. The service must update this charge
-        # in place rather than layering a second override on top of it,
-        # which would produce two charges with the same `billable_metric_id`
-        # and `code` — both contributing fees over the same events.
         let(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
         let!(:charge) do

--- a/spec/services/subscriptions/update_or_override_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_charge_service_spec.rb
@@ -126,6 +126,44 @@ RSpec.describe Subscriptions::UpdateOrOverrideChargeService do
         end
       end
 
+      context "when the charge passed lives directly on the overridden plan with parent_id: nil" do
+        # Reproduces the state left by `Plans::UpdateService#process_charges`
+        # (the legacy `plan_overrides` PATCH path): a top-level charge sits
+        # directly on the overridden plan with no parent, alongside the
+        # subscription's overridden plan. The service must update this charge
+        # in place rather than layering a second override on top of it,
+        # which would produce two charges with the same `billable_metric_id`
+        # and `code` — both contributing fees over the same events.
+        let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+        let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
+        let!(:charge) do
+          create(:standard_charge, plan: overridden_plan, organization:, billable_metric:)
+        end
+
+        it "does not create a second override charge" do
+          expect { service.call }.not_to change(Charge, :count)
+        end
+
+        it "updates the existing top-level charge in place" do
+          result = service.call
+
+          expect(result.charge.id).to eq(charge.id)
+          expect(result.charge.parent_id).to be_nil
+          expect(result.charge.plan_id).to eq(overridden_plan.id)
+          expect(result.charge.invoice_display_name).to eq("Overridden Charge")
+          expect(result.charge.min_amount_cents).to eq(500)
+          expect(result.charge.properties).to eq({"amount" => "150"})
+        end
+
+        it "does not create a duplicate charge for the same billable metric on the overridden plan" do
+          service.call
+
+          charges_for_metric = overridden_plan.charges.where(billable_metric_id: billable_metric.id)
+          expect(charges_for_metric.count).to eq(1)
+          expect(charges_for_metric.first.id).to eq(charge.id)
+        end
+      end
+
       context "with tax_codes" do
         let(:tax) { create(:tax, organization:) }
         let(:params) do


### PR DESCRIPTION
## Context

Closes #5549.

When a subscription has been updated through the legacy `PATCH /subscriptions/{external_id}` `plan_overrides` path and is later updated through the new per-charge `PUT /subscriptions/{external_id}/charges/{code}` endpoint, the overridden plan ends up holding two charges with the same `billable_metric_id` and `code`. Both are enumerated by the canonical fee-creation path (`app/services/invoices/calculate_fees_service.rb#create_charges_fees`) with no de-duplication, so each event produces two `Fee` rows. The full source trace and a reproduction sequence on `api.eu.getlago.com` are in #5549.

Implements **option 2** from the issue, per @rsempe's [suggestion](https://github.com/getlago/lago-api/issues/5549#issuecomment-4508815865):

> `Subscriptions::UpdateOrOverrideChargeService` will detect when the resolved charge is already on the overridden plan and update it in place rather than creating a duplicate.

## Change

In `Subscriptions::UpdateOrOverrideChargeService#find_or_update_charge_override(target_plan)`, short-circuit when the resolved charge already lives on the overridden plan — update it in place rather than walking up to `find_parent_charge` and creating a new override on top.

```ruby
def find_or_update_charge_override(target_plan)
  return update_charge_override(charge) if charge.plan_id == target_plan.id

  parent_charge = find_parent_charge
  existing_override = target_plan.charges.find_by(parent_id: parent_charge.id)

  if existing_override
    update_charge_override(existing_override)
  else
    create_charge_override(parent_charge, target_plan)
  end
end
```

## Behaviour across the three scenarios

| Subscription state | Resolved `charge.plan_id` vs. `target_plan.id` | Behaviour |
| --- | --- | --- |
| Fresh — on the base plan, no overridden plan yet | `base_plan.id != overridden_plan.id` | Short-circuit doesn't fire. `ensure_plan_override` creates the overridden plan and populates it via `Charges::OverrideService`. Existing branch finds the freshly-created override via `parent_id` match and updates it. **Unchanged.** |
| Already overridden via per-charge PUT — `parent_id` points at base-plan charge | `overridden_plan.id == overridden_plan.id` | Short-circuit fires → updates the override in place. **Same effective behaviour as before**, different code path. |
| Already overridden via legacy `plan_overrides` PATCH — `parent_id: nil`, charge sits directly on the overridden plan via `Plans::UpdateService#process_charges` | `overridden_plan.id == overridden_plan.id` | Short-circuit fires → updates the legacy charge in place. **No second override created. Bug fixed.** |

## Tests

Existing spec contexts in `spec/services/subscriptions/update_or_override_charge_service_spec.rb` continue to pass; new context `"when the charge passed lives directly on the overridden plan with parent_id: nil"` covers scenario 3 explicitly:

- Asserts `Charge.count` does not change (no second override).
- Asserts the existing charge is updated in place (`parent_id` still nil, same `plan_id`, override params applied).
- Asserts the overridden plan has exactly one charge for the `billable_metric` after the call.

## Out of scope

- Cleanup of already-affected production subscriptions. That stays a Lago-side concern (DB / support ticket); this fix only prevents new duplicates from forming.
- The full `DELETE /subscriptions/{external_id}/charges/{code}` endpoint (option 1 from the issue). Left for a follow-up.

cc @rsempe — thanks for the quick triage on #5549.