### PR TITLE
[ING-48] feat(wallets): filter by billing entity

### DIFF
--- a/app/controllers/api/v1/customers/wallets_controller.rb
+++ b/app/controllers/api/v1/customers/wallets_controller.rb
@@ -29,7 +29,12 @@ module Api
         end
 
         def index
-          wallet_index(external_customer_id: customer.external_id, currency: params[:currency])
+          permitted_params = params.permit(:currency, billing_entity_codes: [])
+          wallet_index(
+            external_customer_id: customer.external_id,
+            currency: permitted_params[:currency],
+            billing_entity_codes: permitted_params[:billing_entity_codes]
+          )
         end
 
         private

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -28,11 +28,12 @@ module Api
       end
 
       def index
-        permitted_params = params.permit(:external_customer_id, :currency)
+        permitted_params = params.permit(:external_customer_id, :currency, billing_entity_codes: [])
         external_customer_id = permitted_params[:external_customer_id]
         currency = permitted_params[:currency]
+        billing_entity_codes = permitted_params[:billing_entity_codes]
 
-        wallet_index(external_customer_id:, currency:)
+        wallet_index(external_customer_id:, currency:, billing_entity_codes:)
       end
 
       private

--- a/app/controllers/concerns/wallet_actions.rb
+++ b/app/controllers/concerns/wallet_actions.rb
@@ -47,14 +47,23 @@ module WalletActions
     render_wallet(wallet)
   end
 
-  def wallet_index(external_customer_id:, currency:)
+  def wallet_index(external_customer_id:, currency:, billing_entity_codes: nil)
+    if billing_entity_codes.present?
+      billing_entities = current_organization.all_billing_entities.where(code: billing_entity_codes)
+      return not_found_error(resource: "billing_entity") if billing_entities.count != billing_entity_codes.uniq.count
+    end
+
     result = WalletsQuery.call(
       organization: current_organization,
       pagination: {
         page: params[:page],
         limit: params[:per_page] || PER_PAGE
       },
-      filters: {external_customer_id: external_customer_id, currency:}
+      filters: {
+        external_customer_id: external_customer_id,
+        currency:,
+        billing_entity_ids: billing_entities&.ids
+      }.compact
     )
 
     if result.success?

--- a/app/queries/wallets_query.rb
+++ b/app/queries/wallets_query.rb
@@ -2,7 +2,7 @@
 
 class WalletsQuery < BaseQuery
   Result = BaseResult[:wallets]
-  Filters = BaseFilters[:external_customer_id, :currency]
+  Filters = BaseFilters[:external_customer_id, :currency, :billing_entity_ids]
 
   def call
     validate_filters
@@ -12,6 +12,7 @@ class WalletsQuery < BaseQuery
 
     wallets = with_external_customer_id(wallets) if filters.external_customer_id
     wallets = with_currency(wallets) if filters.currency
+    wallets = with_billing_entity_ids(wallets) if filters.billing_entity_ids.present?
 
     wallets = paginate(wallets)
     wallets = apply_consistent_ordering(wallets)
@@ -32,6 +33,13 @@ class WalletsQuery < BaseQuery
 
   def with_currency(scope)
     scope.where(balance_currency: filters.currency)
+  end
+
+  def with_billing_entity_ids(scope)
+    scope.joins(:customer).where(
+      "COALESCE(wallets.billing_entity_id, customers.billing_entity_id) IN (?)",
+      filters.billing_entity_ids
+    )
   end
 
   def validate_filters

--- a/spec/queries/wallets_query_spec.rb
+++ b/spec/queries/wallets_query_spec.rb
@@ -108,4 +108,56 @@ RSpec.describe WalletsQuery do
       end
     end
   end
+
+  context "when filtering by billing_entity_ids" do
+    let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
+    let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
+
+    let(:customer_eu) { create(:customer, organization:, billing_entity: billing_entity_eu) }
+    let(:customer_us) { create(:customer, organization:, billing_entity: billing_entity_us) }
+
+    let(:wallet_eu_direct) { create(:wallet, customer: customer_us, billing_entity: billing_entity_eu) }
+    let(:wallet_eu_fallback) { create(:wallet, customer: customer_eu, billing_entity: nil) }
+    let(:wallet_us_direct) { create(:wallet, customer: customer_eu, billing_entity: billing_entity_us) }
+    let(:wallet_us_fallback) { create(:wallet, customer: customer_us, billing_entity: nil) }
+
+    let(:filters) { {billing_entity_ids: [billing_entity_eu.id]} }
+
+    before do
+      wallet_eu_direct
+      wallet_eu_fallback
+      wallet_us_direct
+      wallet_us_fallback
+    end
+
+    it "returns wallets directly stamped with the billing entity" do
+      expect(result).to be_success
+      expect(returned_ids).to include(wallet_eu_direct.id)
+    end
+
+    it "returns wallets with NULL billing_entity_id whose customer matches" do
+      expect(returned_ids).to include(wallet_eu_fallback.id)
+    end
+
+    it "excludes wallets stamped under a different billing entity" do
+      expect(returned_ids).not_to include(wallet_us_direct.id)
+    end
+
+    it "excludes wallets that fall back to a different billing entity via customer" do
+      expect(returned_ids).not_to include(wallet_us_fallback.id)
+    end
+
+    context "with multiple billing_entity_ids" do
+      let(:filters) { {billing_entity_ids: [billing_entity_eu.id, billing_entity_us.id]} }
+
+      it "returns wallets matching any of the provided ids" do
+        expect(returned_ids).to match_array([
+          wallet_eu_direct.id,
+          wallet_eu_fallback.id,
+          wallet_us_direct.id,
+          wallet_us_fallback.id
+        ])
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -82,5 +82,41 @@ RSpec.describe Api::V1::WalletsController do
         end
       end
     end
+
+    context "when filtering by billing_entity_codes" do
+      let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
+      let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
+      let(:wallet_eu) { create(:wallet, customer:, billing_entity: billing_entity_eu) }
+      let(:wallet_us) { create(:wallet, customer:, billing_entity: billing_entity_us) }
+
+      before do
+        wallet_eu
+        wallet_us
+      end
+
+      it "returns only wallets under the requested billing entity" do
+        get_with_token(organization, "/api/v1/wallets?billing_entity_codes[]=EU")
+
+        expect(response).to have_http_status(:success)
+        expect(json[:wallets].map { |w| w[:lago_id] }).to contain_exactly(wallet_eu.id)
+      end
+
+      context "when filtering by multiple billing_entity_codes" do
+        it "returns wallets matching any of the provided codes" do
+          get_with_token(organization, "/api/v1/wallets?billing_entity_codes[]=EU&billing_entity_codes[]=US")
+
+          expect(response).to have_http_status(:success)
+          expect(json[:wallets].map { |w| w[:lago_id] }).to contain_exactly(wallet_eu.id, wallet_us.id)
+        end
+      end
+
+      context "when one of the billing_entity_codes is unknown" do
+        it "returns a not found error" do
+          get_with_token(organization, "/api/v1/wallets?billing_entity_codes[]=EU&billing_entity_codes[]=BOGUS")
+
+          expect(response).to be_not_found_error("billing_entity")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Multi-entity customers need to scope the wallets list to a specific
billing entity. The `/customers` and `/invoices` list endpoints already
support a `billing_entity_codes` filter; this brings `/wallets` in line.

## Description

Adds an optional `billing_entity_codes` array filter to:

- `GET /api/v1/wallets`
- `GET /api/v1/customers/:external_id/wallets`

Behavior:

- Codes are resolved to IDs against `current_organization.all_billing_entities`. Unknown codes return `404 billing_entity_not_found` — matching the pattern used by `/customers` and `/invoices`.
- The query matches wallets directly stamped with a `billing_entity_id` **and** wallets that inherit it from their customer, preserving `Wallet#billing_entity`'s fallback semantics.
- Backwards compatible: the filter is optional and existing callers see no change.
- Side effect: wallet filters are now compacted before being passed to `WalletsQuery`, so calling `/api/v1/wallets` without `external_customer_id` no longer trips the `customer_not_found` validation.

## How to test

```
GET /api/v1/wallets?billing_entity_codes[]=EU
GET /api/v1/wallets?billing_entity_codes[]=EU&billing_entity_codes[]=US
GET /api/v1/wallets?billing_entity_codes[]=BOGUS   # → 404 billing_entity_not_found
```

Automated:

```
lago exec api bundle exec rspec \
  spec/queries/wallets_query_spec.rb \
  spec/requests/api/v1/wallets_controller_spec.rb \
  spec/requests/api/v1/customers/wallets_controller_spec.rb
```
