### PR TITLE
test(fixed-charges): repro subscription endpoint billing bug

### DIFF
--- a/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
+++ b/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
@@ -1403,4 +1403,81 @@ describe "Pay in advance fixed charge units change mid-period", :premium do
       end
     end
   end
+
+  # Bug repro: hitting the dedicated subscription-scoped endpoint
+  # PUT /api/v1/subscriptions/:external_id/fixed_charges/:code with
+  # apply_units_immediately: true silently skips the mid-period delta invoice.
+  # The plan-level endpoint and the plan_overrides path both dispatch
+  # Invoices::CreatePayInAdvanceFixedChargesJob; this one doesn't.
+  describe "when updating subscription fixed charge via the dedicated endpoint" do
+    let(:subscription_date) { DateTime.new(2024, 12, 1) }
+    let(:subscription) { customer.subscriptions.first }
+
+    before do
+      fixed_charge
+
+      travel_to subscription_date do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: "sub_endpoint_#{customer.external_id}",
+            plan_code: plan.code,
+            billing_time: "calendar",
+            subscription_at: subscription_date.iso8601
+          }
+        )
+        perform_all_enqueued_jobs
+      end
+    end
+
+    context "when increasing units to 15 with apply_units_immediately: true" do
+      before do
+        travel_to subscription_date + 1.hour do
+          update_subscription_fixed_charge(
+            subscription,
+            fixed_charge.code,
+            {
+              units: "15",
+              apply_units_immediately: true
+            }
+          )
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it "creates a plan override with the new units" do
+        child_plan = subscription.reload.plan
+        expect(child_plan.parent_id).to eq(plan.id)
+
+        child_fixed_charge = child_plan.fixed_charges.first
+        expect(child_fixed_charge.parent_id).to eq(fixed_charge.id)
+        expect(child_fixed_charge.units).to eq(15)
+      end
+
+      it "generates a mid-period delta invoice for 5 units (15 - 10)" do
+        invoices = subscription.reload.invoices.order(:created_at)
+
+        # Expected behaviour (matches the plan-level endpoint and the
+        # plan_overrides path on Subscriptions::UpdateService):
+        # 1. Initial invoice (10 units, $100)
+        # 2. Mid-period delta invoice (5 units, $50)
+        #
+        # Current behaviour on main: only the initial invoice exists
+        # because UpdateOrOverrideFixedChargeService never dispatches
+        # Invoices::CreatePayInAdvanceFixedChargesJob.
+        expect(invoices.count).to eq(2)
+
+        initial_invoice = invoices.first
+        expect(initial_invoice.fees.fixed_charge.first.units).to eq(10)
+        expect(initial_invoice.fees.fixed_charge.first.amount_cents).to eq(10_000)
+
+        delta_invoice = invoices.last
+        expect(delta_invoice.fees.fixed_charge.count).to eq(1)
+
+        delta_fee = delta_invoice.fees.fixed_charge.first
+        expect(delta_fee.units).to eq(5)
+        expect(delta_fee.amount_cents).to eq(5_000)
+      end
+    end
+  end
 end

--- a/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
+++ b/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
@@ -1454,6 +1454,26 @@ describe "Pay in advance fixed charge units change mid-period", :premium do
         expect(child_fixed_charge.units).to eq(15)
       end
 
+      it "creates a single FixedChargeEvent on the override with units=15 at the update time" do
+        child_fixed_charge = subscription.reload.plan.fixed_charges.first
+        events = FixedChargeEvent.where(subscription:, fixed_charge: child_fixed_charge).order(:created_at)
+
+        # Expectation: one event on the child fixed_charge with the new
+        # 15 units, anchored at "now" (apply_units_immediately: true).
+        #
+        # Observed on main: TWO events on the child fixed_charge:
+        #   1. units=10 anchored at the next-period boundary, created by
+        #      Plans::OverrideService cloning fixed_charges with
+        #      apply_units_immediately defaulting to false.
+        #   2. units=15 anchored at "now", created by the subsequent
+        #      update_fixed_charge_override step.
+        # The stale units=10 event at the next-period boundary is what
+        # the aggregation reads for the next billing cycle.
+        expect(events.count).to eq(1)
+        expect(events.first.units).to eq(15)
+        expect(events.first.timestamp).to be_within(5.seconds).of(subscription_date + 1.hour)
+      end
+
       it "generates a mid-period delta invoice for 5 units (15 - 10)" do
         invoices = subscription.reload.invoices.order(:created_at)
 
@@ -1477,6 +1497,25 @@ describe "Pay in advance fixed charge units change mid-period", :premium do
         delta_fee = delta_invoice.fees.fixed_charge.first
         expect(delta_fee.units).to eq(5)
         expect(delta_fee.amount_cents).to eq(5_000)
+      end
+
+      it "next regular billing cycle bills the new units (15), not the old (10)" do
+        expect {
+          travel_to subscription_date + 1.month + 1.minute do
+            perform_billing
+          end
+        }.to change { subscription.reload.invoices.count }.by(1)
+
+        next_period_invoice = subscription.reload.invoices.order(:created_at).last
+        next_period_fee = next_period_invoice.fees.fixed_charge.first
+
+        # The stale units=10 event sitting at the next-period boundary
+        # (see the FixedChargeEvent assertion above) is what the aggregation
+        # reads, so next-cycle billing also defaults to 10 units. The gap
+        # is broader than just the missing immediate-billing dispatch —
+        # subsequent periods also under-bill.
+        expect(next_period_fee.units).to eq(15)
+        expect(next_period_fee.amount_cents).to eq(15_000)
       end
     end
   end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -166,6 +166,14 @@ module ScenariosHelper
     end
   end
 
+  ### Subscription Fixed Charges
+
+  def update_subscription_fixed_charge(subscription, fixed_charge_code, params, **kwargs)
+    api_call(**kwargs) do
+      put_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}/fixed_charges/#{fixed_charge_code}", {fixed_charge: params})
+    end
+  end
+
   ### Subscription Charge Filters
 
   def create_subscription_charge_filter(subscription, charge_code, params, **kwargs)


### PR DESCRIPTION
## Summary

- Failing scenario tests that capture a broken billing flow on `PUT /api/v1/subscriptions/:external_id/fixed_charges/:code` with `apply_units_immediately: true`.
- **Intentionally failing — this PR does NOT include the fix.** It documents the bug as executable evidence so the fix can be scoped and validated.

## The bug

When the dedicated subscription endpoint is called with new units + `apply_units_immediately: true`:

1. A plan override is correctly created with the new units (e.g. 15). ✓
2. The request emits **TWO `FixedChargeEvent` rows** on the override fixed_charge:
   - `units = 10` anchored at the **next-period boundary** (created by `Plans::OverrideService` cloning fixed_charges with `apply_units_immediately` defaulting to false).
   - `units = 15` anchored at "now" (created by the subsequent `update_fixed_charge_override` step).
3. No `Invoices::CreatePayInAdvanceFixedChargesJob` is dispatched, so there's no mid-period delta invoice.
4. At the next regular billing cycle, the aggregation reads the **stale `units = 10` event** sitting at the period boundary instead of the `units = 15` value the merchant intended.

The plan-level endpoint (`PUT /api/v1/plans/:code/fixed_charges/:code`) and the `plan_overrides` path on `Subscriptions::UpdateService` both behave correctly — single `units = 15` event, immediate-billing job dispatched.

## Impact

- **Mid-period uplift never charged** (delta invoice missing).
- **Next billing cycle (and subsequent ones) silently under-bill** the new units.
- For pay-in-advance fixed charges this is direct lost revenue, not just delayed billing.

## Failing tests (3 of 4 in the new describe block)

Located at the end of `spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb`:

1. **`creates a single FixedChargeEvent on the override with units = 15 at the update time`** — proves the duplicate-event bug. Expected 1 event with units = 15 anchored at the update time; gets 2 events on the child fixed_charge (one stale at the next-period boundary).
2. **`generates a mid-period delta invoice for 5 units (15 - 10)`** — proves the missing immediate-billing dispatch. Expected 2 invoices (initial + delta); gets only the initial.
3. **`next regular billing cycle bills the new units (15), not the old (10)`** — proves the stale event corrupts next-cycle billing too. Expected next-period invoice at 15 units / \$150; gets 10 units / \$100.

The positive control test (`creates a plan override with the new units`) passes — confirming the override IS correctly applied at the plan/fixed_charge model level. Only the event emission and billing dispatch are broken.

## Test plan

- [ ] `lago exec api bundle exec rspec spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb -e "when updating subscription fixed charge via the dedicated endpoint"` reports **4 examples, 3 failures** with the assertions described above.
- [ ] Follow-up PR implements the fix and re-runs; expect 0 failures.