### PR TITLE
[ING-49] feat(payment-requests): filter by entity

### DIFF
--- a/app/controllers/concerns/payment_request_index.rb
+++ b/app/controllers/concerns/payment_request_index.rb
@@ -5,7 +5,16 @@ module PaymentRequestIndex
   extend ActiveSupport::Concern
 
   def payment_request_index(external_customer_id:)
-    filters = params.permit(:payment_status, :currency)
+    filters = params.permit(:payment_status, :currency, billing_entity_codes: []).to_h
+    billing_entity_codes = filters.delete(:billing_entity_codes)
+
+    if billing_entity_codes.present?
+      billing_entities = current_organization.all_billing_entities.where(code: billing_entity_codes)
+      return not_found_error(resource: "billing_entity") if billing_entities.count != billing_entity_codes.uniq.count
+
+      filters[:billing_entity_ids] = billing_entities.ids
+    end
+
     filters[:external_customer_id] = external_customer_id
     result = PaymentRequestsQuery.call(
       organization: current_organization,

--- a/app/queries/payment_requests_query.rb
+++ b/app/queries/payment_requests_query.rb
@@ -2,11 +2,12 @@
 
 class PaymentRequestsQuery < BaseQuery
   Result = BaseResult[:payment_requests]
-  Filters = BaseFilters[:external_customer_id, :payment_status, :currency]
+  Filters = BaseFilters[:external_customer_id, :payment_status, :currency, :billing_entity_ids]
 
   def call
     payment_requests = PaymentRequest.where(organization:)
 
+    payment_requests = with_billing_entity_ids(payment_requests) if filters.billing_entity_ids.present?
     payment_requests = with_external_customer(payment_requests) if filters.external_customer_id
     payment_requests = with_payment_status(payment_requests) if filters.payment_status
     payment_requests = with_currency(payment_requests) if filters.currency
@@ -18,6 +19,10 @@ class PaymentRequestsQuery < BaseQuery
   end
 
   private
+
+  def with_billing_entity_ids(scope)
+    scope.joins(:customer).where(customers: {billing_entity_id: filters.billing_entity_ids})
+  end
 
   def with_external_customer(scope)
     scope.joins(:customer).where(customers: {external_id: filters.external_customer_id})

--- a/app/queries/payment_requests_query.rb
+++ b/app/queries/payment_requests_query.rb
@@ -21,7 +21,11 @@ class PaymentRequestsQuery < BaseQuery
   private
 
   def with_billing_entity_ids(scope)
-    scope.joins(:customer).where(customers: {billing_entity_id: filters.billing_entity_ids})
+    scope.where(
+      id: PaymentRequest.joins(:invoices)
+        .where(invoices: {billing_entity_id: filters.billing_entity_ids})
+        .select(:id)
+    )
   end
 
   def with_external_customer(scope)

--- a/spec/queries/payment_requests_query_spec.rb
+++ b/spec/queries/payment_requests_query_spec.rb
@@ -96,6 +96,44 @@ RSpec.describe PaymentRequestsQuery do
     end
   end
 
+  context "when filtering by billing_entity_ids" do
+    let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
+    let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
+
+    let(:customer_eu) { create(:customer, organization:, billing_entity: billing_entity_eu) }
+    let(:customer_us) { create(:customer, organization:, billing_entity: billing_entity_us) }
+
+    let(:payment_request_first) { create(:payment_request, organization:, customer: customer_eu) }
+    let(:payment_request_second) { create(:payment_request, organization:, customer: customer_us) }
+
+    let(:filters) { {billing_entity_ids: [billing_entity_eu.id]} }
+
+    it "returns payment requests whose customer belongs to the billing entity" do
+      expect(result).to be_success
+      expect(returned_ids).to contain_exactly(payment_request_first.id)
+    end
+
+    context "with multiple billing_entity_ids" do
+      let(:filters) { {billing_entity_ids: [billing_entity_eu.id, billing_entity_us.id]} }
+
+      it "returns payment requests matching any of the provided ids" do
+        expect(returned_ids).to contain_exactly(
+          payment_request_first.id,
+          payment_request_second.id
+        )
+      end
+    end
+
+    context "when no payment request matches the billing entity" do
+      let(:filters) { {billing_entity_ids: [create(:billing_entity, organization:).id]} }
+
+      it "returns no payment requests" do
+        expect(result).to be_success
+        expect(returned_ids).to be_empty
+      end
+    end
+  end
+
   context "when filtering by payment_status" do
     context "when pending status" do
       let(:filters) { {payment_status: :pending} }

--- a/spec/queries/payment_requests_query_spec.rb
+++ b/spec/queries/payment_requests_query_spec.rb
@@ -100,15 +100,22 @@ RSpec.describe PaymentRequestsQuery do
     let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
     let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
 
-    let(:customer_eu) { create(:customer, organization:, billing_entity: billing_entity_eu) }
-    let(:customer_us) { create(:customer, organization:, billing_entity: billing_entity_us) }
+    let(:customer_first) { create(:customer, organization:) }
+    let(:customer_second) { create(:customer, organization:) }
 
-    let(:payment_request_first) { create(:payment_request, organization:, customer: customer_eu) }
-    let(:payment_request_second) { create(:payment_request, organization:, customer: customer_us) }
+    let(:invoice_eu) { create(:invoice, organization:, customer: customer_first, billing_entity: billing_entity_eu) }
+    let(:invoice_us) { create(:invoice, organization:, customer: customer_second, billing_entity: billing_entity_us) }
+
+    let(:payment_request_first) do
+      create(:payment_request, organization:, customer: customer_first, invoices: [invoice_eu])
+    end
+    let(:payment_request_second) do
+      create(:payment_request, organization:, customer: customer_second, invoices: [invoice_us])
+    end
 
     let(:filters) { {billing_entity_ids: [billing_entity_eu.id]} }
 
-    it "returns payment requests whose customer belongs to the billing entity" do
+    it "returns payment requests whose invoices belong to the billing entity" do
       expect(result).to be_success
       expect(returned_ids).to contain_exactly(payment_request_first.id)
     end
@@ -121,6 +128,24 @@ RSpec.describe PaymentRequestsQuery do
           payment_request_first.id,
           payment_request_second.id
         )
+      end
+    end
+
+    context "when a payment request has multiple invoices in the same billing entity" do
+      let(:second_invoice_eu) do
+        create(:invoice, organization:, customer: customer_first, billing_entity: billing_entity_eu)
+      end
+      let(:payment_request_first) do
+        create(
+          :payment_request,
+          organization:,
+          customer: customer_first,
+          invoices: [invoice_eu, second_invoice_eu]
+        )
+      end
+
+      it "does not return duplicates" do
+        expect(returned_ids.count(payment_request_first.id)).to eq(1)
       end
     end
 

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -94,10 +94,16 @@ RSpec.describe Api::V1::PaymentRequestsController do
     context "when filtering by billing_entity_codes" do
       let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
       let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
-      let(:customer_eu) { create(:customer, organization:, billing_entity: billing_entity_eu) }
-      let(:customer_us) { create(:customer, organization:, billing_entity: billing_entity_us) }
-      let(:payment_request_eu) { create(:payment_request, organization:, customer: customer_eu) }
-      let(:payment_request_us) { create(:payment_request, organization:, customer: customer_us) }
+      let(:customer_eu) { create(:customer, organization:) }
+      let(:customer_us) { create(:customer, organization:) }
+      let(:invoice_eu) { create(:invoice, organization:, customer: customer_eu, billing_entity: billing_entity_eu) }
+      let(:invoice_us) { create(:invoice, organization:, customer: customer_us, billing_entity: billing_entity_us) }
+      let(:payment_request_eu) do
+        create(:payment_request, organization:, customer: customer_eu, invoices: [invoice_eu])
+      end
+      let(:payment_request_us) do
+        create(:payment_request, organization:, customer: customer_us, invoices: [invoice_us])
+      end
 
       before do
         payment_request_eu

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -90,6 +90,47 @@ RSpec.describe Api::V1::PaymentRequestsController do
         end
       end
     end
+
+    context "when filtering by billing_entity_codes" do
+      let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
+      let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
+      let(:customer_eu) { create(:customer, organization:, billing_entity: billing_entity_eu) }
+      let(:customer_us) { create(:customer, organization:, billing_entity: billing_entity_us) }
+      let(:payment_request_eu) { create(:payment_request, organization:, customer: customer_eu) }
+      let(:payment_request_us) { create(:payment_request, organization:, customer: customer_us) }
+
+      before do
+        payment_request_eu
+        payment_request_us
+      end
+
+      it "returns only payment requests under the requested billing entity" do
+        get_with_token(organization, "/api/v1/payment_requests?billing_entity_codes[]=EU")
+
+        expect(response).to have_http_status(:success)
+        expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(payment_request_eu.id)
+      end
+
+      context "when filtering by multiple billing_entity_codes" do
+        it "returns payment requests matching any of the provided codes" do
+          get_with_token(organization, "/api/v1/payment_requests?billing_entity_codes[]=EU&billing_entity_codes[]=US")
+
+          expect(response).to have_http_status(:success)
+          expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(
+            payment_request_eu.id,
+            payment_request_us.id
+          )
+        end
+      end
+
+      context "when one of the billing_entity_codes is unknown" do
+        it "returns a not found error" do
+          get_with_token(organization, "/api/v1/payment_requests?billing_entity_codes[]=EU&billing_entity_codes[]=BOGUS")
+
+          expect(response).to be_not_found_error("billing_entity")
+        end
+      end
+    end
   end
 
   describe "GET /api/v1/payment_requests/:id" do


### PR DESCRIPTION
## Context

Multi-entity customers need to scope the payment requests list to a specific billing entity. The `/customers`, `/invoices`, and `/wallets` list endpoints already support a `billing_entity_codes` filter; this brings `/payment_requests` in line.

## Description

Adds an optional `billing_entity_codes` array filter to:

- `GET /api/v1/payment_requests`
- `GET /api/v1/customers/:external_id/payment_requests`

Behavior:

- Codes are resolved to IDs against `current_organization.all_billing_entities`. Unknown codes return `404 billing_entity_not_found`, matching the pattern used by `/customers`, `/invoices`, and `/wallets`.
- The query filters via the PR's **invoices' `billing_entity_id`**, not via the customer's default. A payment request's effective billing entity is determined by the invoices it groups — multi-entity customers can have invoices under an entity that differs from the customer's default, so scoping through invoices is the correct semantic.
- Backwards compatible: the filter is optional and existing callers see no change.

### Why a subquery instead of `.joins(:invoices).distinct`?

```ruby
def with_billing_entity_ids(scope)
  scope.where(
    id: PaymentRequest.joins(:invoices)
      .where(invoices: {billing_entity_id: filters.billing_entity_ids})
      .select(:id)
  )
end
```

`DISTINCT` would collide with `apply_consistent_ordering`'s `ORDER BY` — Postgres rejects it with "ORDER BY expressions must appear in select list" when DISTINCT'd columns don't cover the order-by expressions. The subquery sidesteps that and naturally deduplicates payment requests whose multiple invoices fall under the same entity.

## How to test

Manual:

```
GET /api/v1/payment_requests?billing_entity_codes[]=EU
GET /api/v1/payment_requests?billing_entity_codes[]=EU&billing_entity_codes[]=US
GET /api/v1/payment_requests?billing_entity_codes[]=BOGUS   # → 404 billing_entity_not_found
```

A payment request appears in `?billing_entity_codes[]=EU` if **any** of its invoices is stamped under `EU`, regardless of the customer's default entity.

Automated:

```
lago exec api bundle exec rspec \
  spec/queries/payment_requests_query_spec.rb \
  spec/requests/api/v1/payment_requests_controller_spec.rb \
  spec/requests/api/v1/customers/payment_requests_controller_spec.rb
```

44 examples, 0 failures. Tests cover single-code, multi-code, unknown-code (404), and multi-invoice-no-duplicates scenarios.
