### PR TITLE
fix(charges): Defer cascade enqueue until transaction commit

### DIFF
--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -144,25 +144,30 @@ module Plans
 
       old_parent_attrs = charge.attributes
       old_parent_applied_pricing_unit_attrs = charge.applied_pricing_unit&.attributes
+      before_filters = capture_filters(charge) if payload_charge.key?(:filters)
 
-      Charges::UpdateChildrenJob.perform_later(
-        params: payload_charge.except(:filters).deep_stringify_keys,
-        old_parent_attrs:,
-        old_parent_applied_pricing_unit_attrs:
-      )
+      after_commit do
+        Charges::UpdateChildrenJob.perform_later(
+          params: payload_charge.except(:filters).deep_stringify_keys,
+          old_parent_attrs:,
+          old_parent_applied_pricing_unit_attrs:
+        )
 
-      cascade_filter_changes(charge, payload_charge[:filters]) if payload_charge.key?(:filters)
+        cascade_filter_changes(charge, before_filters, payload_charge[:filters]) if before_filters
+      end
     end
 
-    def cascade_filter_changes(charge, payload_filters)
-      before = charge.filters.includes(values: :billable_metric_filter).map do |f|
+    def capture_filters(charge)
+      charge.filters.includes(values: :billable_metric_filter).map do |f|
         {
           values: f.to_h.deep_stringify_keys,
           properties: f.properties,
           invoice_display_name: f.invoice_display_name
         }
       end
+    end
 
+    def cascade_filter_changes(charge, before, payload_filters)
       after = (payload_filters || []).map do |fp|
         {
           values: (fp[:values] || {}).deep_stringify_keys,

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -247,6 +247,37 @@ RSpec.describe Plans::UpdateService do
           end.not_to have_enqueued_job(Plans::UpdateAmountJob)
         end
       end
+
+      context "when an in-transaction failure follows a charge update" do
+        let(:existing_charge) { create(:standard_charge, plan:, billable_metric:) }
+        let(:update_args) do
+          {
+            charges: [
+              {
+                id: existing_charge.id,
+                billable_metric_id: billable_metric.id,
+                charge_model: "standard",
+                properties: {amount: "0"}
+              },
+              {
+                billable_metric_id: billable_metric.id,
+                charge_model: "standard"
+              }
+            ]
+          }
+        end
+
+        before do
+          existing_charge
+          allow(Charges::CreateService).to receive(:call!).and_raise(
+            ActiveRecord::RecordInvalid.new(Charge.new.tap { |c| c.errors.add(:base, "boom") })
+          )
+        end
+
+        it "does not enqueue Charges::UpdateChildrenJob" do
+          expect { plans_service.call }.not_to have_enqueued_job(Charges::UpdateChildrenJob)
+        end
+      end
     end
 
     context "when thresholds are present" do


### PR DESCRIPTION
Wrap the `Charges::UpdateChildrenJob.perform_later` and `ChargeFilters::CascadeDispatcher.call` invocations inside `cascade_charge_update` in an `after_commit { ... }` block