### PR TITLE
ING-110 fix(wallet): Use wallet_transactions's `amount_cents` to calculate wallet's `consumed_amount_cents`

### DIFF
--- a/app/services/wallets/balance/decrease_service.rb
+++ b/app/services/wallets/balance/decrease_service.rb
@@ -15,14 +15,13 @@ module Wallets
 
       def call
         transaction_credits_amount = wallet_transaction.credit_amount
-        currency = wallet.currency_for_balance
 
         wallet.update!(
           balance_cents: wallet.balance_cents - wallet_transaction.amount_cents,
           credits_balance: wallet.credits_balance - transaction_credits_amount,
           last_balance_sync_at: Time.zone.now,
           consumed_credits: wallet.consumed_credits + transaction_credits_amount,
-          consumed_amount_cents: ((wallet.consumed_credits + transaction_credits_amount) * wallet.rate_amount * currency.subunit_to_unit).floor,
+          consumed_amount_cents: wallet.consumed_amount_cents + wallet_transaction.amount_cents,
           last_consumed_credit_at: Time.current
         )
 

--- a/spec/services/wallets/balance/decrease_service_spec.rb
+++ b/spec/services/wallets/balance/decrease_service_spec.rb
@@ -86,5 +86,28 @@ RSpec.describe Wallets::Balance::DecreaseService do
           .and change { stale_wallet.consumed_credits }.from(0).to(4.5)
       end
     end
+
+    context "when the rate can produce rounding issues" do
+      let(:wallet) do
+        create(
+          :wallet,
+          balance_cents: 13750,
+          credits_balance: 100.0,
+          rate_amount: BigDecimal("1.375")
+        )
+      end
+
+      let(:wallet_transaction) do
+        create(:wallet_transaction, wallet:, amount: "1.00", credit_amount: BigDecimal("0.72727"))
+      end
+
+      it "correctly updates wallet balance and consumed status" do
+        expect { subject }
+          .to change(wallet.reload, :consumed_credits).from(0).to(0.72727)
+          .and change(wallet, :consumed_amount_cents).from(0).to(100)
+          .and change(wallet, :balance_cents).from(13750).to(13650)
+          .and change(wallet, :credits_balance).from(100.0).to(99.27273)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Today consumed amounts are derived from consumed credits, which accumulates cents-level rounding drift that never self-corrects.

## Description

Stop deriving consumed amounts from credits. Use the outbound transaction's actual `amount_cents` to compute the wallet's `consumed_amount_cents`.