### PR TITLE
[ING-205] feat(clickhouse): Expose organization event store in REST API and GraphQL

### DIFF
--- a/app/graphql/types/organizations/current_organization_type.rb
+++ b/app/graphql/types/organizations/current_organization_type.rb
@@ -38,6 +38,8 @@ module Types
 
       field :eu_tax_management, Boolean, null: false
 
+      field :events_store, Types::Organizations::EventsStoreEnum, null: false
+
       # TODO: Also check if Nango ENV var is set in order to lock/unlock this feature
       #       This would enable us to use premium add_on logic on OSS version
       field :premium_integrations, [Types::Integrations::PremiumIntegrationTypeEnum], null: false

--- a/app/graphql/types/organizations/events_store_enum.rb
+++ b/app/graphql/types/organizations/events_store_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Organizations
+    class EventsStoreEnum < Types::BaseEnum
+      description "Organization events store values"
+
+      Organization::EVENTS_STORES.values.each do |store|
+        value store, description: "#{store.capitalize} events store"
+      end
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -109,6 +109,11 @@ class Organization < ApplicationRecord
 
   has_one_attached :logo
 
+  EVENTS_STORES = {
+    clickhouse: "clickhouse",
+    postgres: "postgres"
+  }.freeze
+
   DOCUMENT_NUMBERINGS = [
     :per_customer,
     :per_organization
@@ -261,6 +266,10 @@ class Organization < ApplicationRecord
 
   def postgres_events_store?
     !clickhouse_events_store?
+  end
+
+  def events_store
+    clickhouse_events_store? ? EVENTS_STORES[:clickhouse] : EVENTS_STORES[:postgres]
   end
 
   # This is added to have a common interface for all organization-related models to access the organization.

--- a/app/serializers/v1/organization_serializer.rb
+++ b/app/serializers/v1/organization_serializer.rb
@@ -27,7 +27,8 @@ module V1
         document_number_prefix: model.document_number_prefix,
         tax_identification_number: model.tax_identification_number,
         finalize_zero_amount_invoice: model.finalize_zero_amount_invoice,
-        billing_configuration:
+        billing_configuration:,
+        events_store: model.events_store
       }
 
       payload = payload.merge(taxes) if include?(:taxes)

--- a/schema.graphql
+++ b/schema.graphql
@@ -4292,6 +4292,7 @@ type CurrentOrganization {
   email: String
   emailSettings: [EmailSettingsEnum!]
   euTaxManagement: Boolean!
+  eventsStore: EventsStoreEnum!
   featureFlags: [FeatureFlagEnum!]!
   finalizeZeroAmountInvoice: Boolean!
   gocardlessPaymentProviders: [GocardlessProvider!]
@@ -5805,6 +5806,21 @@ enum EventTypeEnum {
   wallet_transaction_payment_failure
   wallet_transaction_updated
   wallet_updated
+}
+
+"""
+Organization events store values
+"""
+enum EventsStoreEnum {
+  """
+  Clickhouse events store
+  """
+  clickhouse
+
+  """
+  Postgres events store
+  """
+  postgres
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -18585,6 +18585,22 @@
               "deprecationReason": null
             },
             {
+              "name": "eventsStore",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EventsStoreEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "featureFlags",
               "description": null,
               "args": [],
@@ -28194,6 +28210,29 @@
             {
               "name": "all",
               "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EventsStoreEnum",
+          "description": "Organization events store values",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "clickhouse",
+              "description": "Clickhouse events store",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postgres",
+              "description": "Postgres events store",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/spec/graphql/types/organizations/current_organization_type_spec.rb
+++ b/spec/graphql/types/organizations/current_organization_type_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe Types::Organizations::CurrentOrganizationType do
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
 
+    expect(subject).to have_field(:events_store).of_type("EventsStoreEnum!")
+
     expect(subject).to have_field(:finalize_zero_amount_invoice).of_type("Boolean!")
     expect(subject).to have_field(:billing_configuration).of_type("OrganizationBillingConfiguration").with_permission("organization:invoices:view")
     expect(subject).to have_field(:email_settings).of_type("[EmailSettingsEnum!]").with_permission("organization:emails:view")

--- a/spec/graphql/types/organizations/events_store_enum_spec.rb
+++ b/spec/graphql/types/organizations/events_store_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Organizations::EventsStoreEnum do
+  it "has the correct values" do
+    expect(described_class.values.keys).to eq(Organization::EVENTS_STORES.values)
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -555,6 +555,20 @@ RSpec.describe Organization do
     end
   end
 
+  describe "#events_store" do
+    it "returns the events store" do
+      expect(organization.events_store).to eq("postgres")
+    end
+
+    context "when clickhouse_events_store is true" do
+      let(:organization) { create(:organization, clickhouse_events_store: true) }
+
+      it "returns clickhouse" do
+        expect(organization.events_store).to eq("clickhouse")
+      end
+    end
+  end
+
   describe "#organization" do
     it "returns the organization" do
       expect(organization.organization).to eq(organization)

--- a/spec/serializers/v1/organization_serializer_spec.rb
+++ b/spec/serializers/v1/organization_serializer_spec.rb
@@ -39,5 +39,6 @@ RSpec.describe ::V1::OrganizationSerializer do
     expect(result["organization"]["net_payment_term"]).to eq(org.net_payment_term)
     expect(result["organization"]["finalize_zero_amount_invoice"]).to eq(org.finalize_zero_amount_invoice)
     expect(result["organization"]["taxes"].count).to eq(1)
+    expect(result["organization"]["events_store"]).to eq(org.events_store)
   end
 end


### PR DESCRIPTION
## Description

This features goal is to bring more visibility on witch event store is attached to their organization. It exposes the `events_store` attribute on the organization type on both REST and GraphQL API.

