### PR TITLE
feat(stripe): Add basic support for Shared Payment Token

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -33,3 +33,7 @@ multi_entity_billing:
 order_forms:
   description: "Enable quotes, order forms and orders"
   owners: ["@murparreira", "@toommz", "@rinasergeeva"]
+
+stripe_shared_payment_token:
+  description: "Use Stripe Shared Payment Token for agent-initiated payments when no other payment method is attached"
+  owners: ["@ancorcruz"]

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -151,6 +151,7 @@ module PaymentProviders
 
         def shared_payment_token
           # NOTE: Only use the shared payment token if no other payment method exist (no default, nothing in the list)
+          return nil unless invoice.organization.feature_flag_enabled?(:stripe_shared_payment_token)
           return nil if stripe_customer.deleted?
           return nil if stripe_customer.invoice_settings.default_payment_method
           return nil if stripe_customer.default_source

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -98,12 +98,14 @@ module PaymentProviders
           payment_method&.id
         end
 
-        def update_payment_method_id
-          stripe_customer = ::Stripe::Customer.retrieve(
+        def stripe_customer
+          @stripe_customer ||= ::Stripe::Customer.retrieve(
             provider_customer.provider_customer_id,
             {api_key: payment_provider.secret_key}
           )
+        end
 
+        def update_payment_method_id
           # TODO: stripe customer should be updated/deleted
           # TODO: deliver error webhook
           # TODO(payment): update payment status
@@ -111,13 +113,6 @@ module PaymentProviders
 
           if (payment_method_id = stripe_customer.invoice_settings.default_payment_method || stripe_customer.default_source)
             provider_customer.update!(payment_method_id:)
-            return
-          end
-
-          # NOTE: Only use the shared payment token if no other payment method exist (no default, nothing in the list)
-          shared_payment_token = stripe_customer.invoice_settings.try(:default_shared_payment_token)
-          if shared_payment_token && customer_payment_methods.none?
-            @shared_payment_token = shared_payment_token
           end
         end
 
@@ -154,6 +149,16 @@ module PaymentProviders
           )
         end
 
+        def shared_payment_token
+          # NOTE: Only use the shared payment token if no other payment method exist (no default, nothing in the list)
+          return nil if stripe_customer.deleted?
+          return nil if stripe_customer.invoice_settings.default_payment_method
+          return nil if stripe_customer.default_source
+          return nil if customer_payment_methods.any?
+
+          stripe_customer.invoice_settings[:default_shared_payment_token]
+        end
+
         def payment_intent_payload
           payload = {
             amount: payment.amount_cents,
@@ -170,8 +175,8 @@ module PaymentProviders
 
           if provider_customer.provider_payment_methods == ["customer_balance"]
             payload.merge!(customer_balance_fields)
-          elsif @shared_payment_token
-            payload[:payment_method_data] = {shared_payment_granted_token: @shared_payment_token}
+          elsif shared_payment_token
+            payload[:payment_method_data] = {shared_payment_granted_token: shared_payment_token}
             payload.delete(:return_url)
             payload.delete(:off_session)
           else

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -86,11 +86,7 @@ module PaymentProviders
           end
 
           # NOTE: Retrieve list of existing payment_methods
-          payment_method = ::Stripe::Customer.list_payment_methods(
-            provider_customer.provider_customer_id,
-            {},
-            {api_key: payment_provider.secret_key}
-          ).first
+          payment_method = customer_payment_methods.first
 
           if invoice.organization.feature_flag_enabled?(:multiple_payment_methods)
             # TODO: Double check
@@ -115,7 +111,22 @@ module PaymentProviders
 
           if (payment_method_id = stripe_customer.invoice_settings.default_payment_method || stripe_customer.default_source)
             provider_customer.update!(payment_method_id:)
+            return
           end
+
+          # NOTE: Only use the shared payment token if no other payment method exist (no default, nothing in the list)
+          shared_payment_token = stripe_customer.invoice_settings.try(:default_shared_payment_token)
+          if shared_payment_token && customer_payment_methods.none?
+            @shared_payment_token = shared_payment_token
+          end
+        end
+
+        def customer_payment_methods
+          @customer_payment_methods ||= ::Stripe::Customer.list_payment_methods(
+            provider_customer.provider_customer_id,
+            {},
+            {api_key: payment_provider.secret_key}
+          )
         end
 
         def create_payment_intent
@@ -159,6 +170,10 @@ module PaymentProviders
 
           if provider_customer.provider_payment_methods == ["customer_balance"]
             payload.merge!(customer_balance_fields)
+          elsif @shared_payment_token
+            payload[:payment_method_data] = {shared_payment_granted_token: @shared_payment_token}
+            payload.delete(:return_url)
+            payload.delete(:off_session)
           else
             payload[:payment_method] = stripe_payment_method
           end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5841,6 +5841,7 @@ enum FeatureFlagEnum {
   order_forms
   payment_gated_subscriptions
   postgres_enriched_events
+  stripe_shared_payment_token
   wallet_traceability
 }
 

--- a/schema.json
+++ b/schema.json
@@ -28380,6 +28380,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "stripe_shared_payment_token",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/spec/integration/stripe/simple_payment_integration_spec.rb
+++ b/spec/integration/stripe/simple_payment_integration_spec.rb
@@ -22,7 +22,7 @@ describe "Stripe Payment Integration Test", :premium, :with_pdf_generation_stub,
   include_context "with webhook tracking"
 
   before do
-    raise "You need to set the SPEC_STRIPE_SECRET_KEY environment variable" unless api_key
+    raise "You need to set the STRIPE_API_KEY environment variable" unless api_key
 
     # Uncomment to print Stripe logs
     # ::Stripe.log_level = Logger::INFO
@@ -279,6 +279,75 @@ describe "Stripe Payment Integration Test", :premium, :with_pdf_generation_stub,
     end
   end
 
+  context "with Shared Payment Token" do
+    it "pays the subscription invoice using the shared payment token" do
+      # Provision the Stripe customer first, attach the shared payment token,
+      # then pass the existing provider id to Lago — same flow as production
+      # where the token is granted before Lago knows about the customer.
+
+      spt_id = create_shared_payment_token(
+        currency: "eur",
+        max_amount: 50_00,
+        expires_at: 30.days.from_now
+      )
+
+      stripe_customer_id = ::Stripe::Customer.create({
+        name: "SPT Integration Test [#{external_id}]",
+        invoice_settings: {default_shared_payment_token: spt_id}
+      }).id
+
+      customer = create_customer(
+        billing_configuration: {
+          payment_provider: "stripe",
+          payment_provider_code: provider.code,
+          provider_customer_id: stripe_customer_id,
+          sync: true,
+          sync_with_provider: true,
+          provider_payment_methods:
+        }
+      )
+      stripe_customer = customer.payment_provider_customers.sole
+      expect(stripe_customer.provider_customer_id).to eq(stripe_customer_id)
+      webhooks_sent.clear
+
+      plan = create(:plan, organization:, code: "spt_plan_#{SecureRandom.hex(3)}",
+        pay_in_advance: true, amount_cents: 1_000, amount_currency: "EUR")
+
+      create_subscription({
+        plan_code: plan.code,
+        external_id: "sub_spt_#{external_id}",
+        external_customer_id: customer.external_id
+      })
+
+      perform_all_enqueued_jobs
+
+      invoice = customer.invoices.subscription.sole
+      expect(invoice.payment_status).to eq("succeeded")
+
+      payment = invoice.payments.sole
+      expect(payment.provider_payment_id).to start_with("pi_")
+
+      pi = ::Stripe::PaymentIntent.retrieve(payment.provider_payment_id)
+      expect(pi.status).to eq("succeeded")
+      expect(pi.shared_payment_granted_token).to eq(spt_id)
+      expect(pi.payment_method).to start_with("pm_")
+
+      # Replay the real `payment_intent.succeeded` event Stripe delivered to the
+      # webhook endpoint — this is what populates the underlying payment method
+      # id / last4 on the Lago payment.
+      event = fetch_payment_intent_succeeded_event(pi.id)
+      PaymentProviders::Stripe::HandleEventService.call(
+        organization:,
+        event_json: event.to_json
+      ).raise_if_error!
+
+      perform_all_enqueued_jobs
+
+      expect(payment.reload.provider_payment_method_id).to eq(pi.payment_method)
+      expect(payment.payment_receipt).to be_present
+    end
+  end
+
   context "with US Bank Account (ACH)" do
     let(:provider_payment_methods) { ["us_bank_account"] }
     let(:currency) { "USD" }
@@ -400,5 +469,32 @@ describe "Stripe Payment Integration Test", :premium, :with_pdf_generation_stub,
       pm.id,
       {customer: stripe_customer.provider_customer_id}
     ).id
+  end
+
+  def create_shared_payment_token(currency:, max_amount:, expires_at:)
+    uri = URI("https://api.stripe.com/v1/test_helpers/shared_payment/granted_tokens")
+    req = Net::HTTP::Post.new(uri)
+    req.basic_auth(api_key, "")
+    req["Stripe-Version"] = ::Stripe.api_version if ::Stripe.api_version
+    req.set_form_data(
+      "payment_method" => "pm_card_visa",
+      "usage_limits[currency]" => currency.downcase,
+      "usage_limits[max_amount]" => max_amount.to_s,
+      "usage_limits[expires_at]" => expires_at.to_i.to_s
+    )
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+    raise "Failed to create shared payment token: #{response.code} #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+    JSON.parse(response.body).fetch("id")
+  end
+
+  def fetch_payment_intent_succeeded_event(payment_intent_id, timeout: 15)
+    deadline = Time.current + timeout
+    loop do
+      events = ::Stripe::Event.list(type: "payment_intent.succeeded", limit: 30)
+      event = events.data.find { it.data.object.id == payment_intent_id }
+      return event if event
+      raise "Timed out waiting for payment_intent.succeeded event for #{payment_intent_id}" if Time.current > deadline
+      sleep 1
+    end
   end
 end

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -174,6 +174,8 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
       let(:shared_payment_token) { "spt_test_123" }
 
       before do
+        organization.enable_feature_flag!("stripe_shared_payment_token")
+
         allow(Stripe::Customer).to receive(:retrieve)
           .and_return(Stripe::StripeObject.construct_from(
             {
@@ -213,6 +215,23 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
 
           expect(result).to be_success
           expect(Stripe::Customer).to have_received(:list_payment_methods).once
+        end
+
+        context "when the stripe_shared_payment_token feature flag is disabled" do
+          before { organization.disable_feature_flag!("stripe_shared_payment_token") }
+
+          it "ignores the shared payment token even when no other payment method is attached" do
+            WebMock.stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+              .with(body: ->(request) {
+                params = Rack::Utils.parse_nested_query(request)
+                expect(params).not_to have_key("payment_method_data")
+              })
+              .to_return(body: stripe_payment_intent_data.to_json)
+
+            result = create_service.call
+
+            expect(result).to be_success
+          end
         end
       end
 

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
               expect(params).not_to have_key("payment_method")
               expect(params).not_to have_key("return_url")
               expect(params).not_to have_key("off_session")
+              expect(params["error_on_requires_action"]).to eq("true")
             })
             .to_return(body: stripe_payment_intent_data.to_json)
 

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -169,6 +169,77 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
       end
     end
 
+    context "when customer has a default shared payment token" do
+      let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider: stripe_payment_provider) }
+      let(:shared_payment_token) { "spt_test_123" }
+
+      before do
+        allow(Stripe::Customer).to receive(:retrieve)
+          .and_return(Stripe::StripeObject.construct_from(
+            {
+              invoice_settings: {
+                default_payment_method: nil,
+                default_shared_payment_token: shared_payment_token
+              },
+              default_source: nil
+            }
+          ))
+
+        allow(Stripe::Customer).to receive(:list_payment_methods).and_call_original
+        stub_request(:get, %r{/v1/customers/#{stripe_customer.provider_customer_id}/payment_methods}).and_return(
+          status: 200, body: payment_methods_response
+        )
+      end
+
+      context "when no other payment method is attached" do
+        let(:payment_methods_response) do
+          get_stripe_fixtures("customer_list_payment_methods_response.json") do |h|
+            h[:data] = []
+          end
+        end
+
+        it "uses the shared payment token in the payment intent payload" do
+          WebMock.stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+            .with(body: ->(request) {
+              params = Rack::Utils.parse_nested_query(request)
+              expect(params.dig("payment_method_data", "shared_payment_granted_token")).to eq(shared_payment_token)
+              expect(params).not_to have_key("payment_method")
+              expect(params).not_to have_key("return_url")
+              expect(params).not_to have_key("off_session")
+            })
+            .to_return(body: stripe_payment_intent_data.to_json)
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(Stripe::Customer).to have_received(:list_payment_methods).once
+        end
+      end
+
+      context "when another payment method is attached" do
+        let(:payment_methods_response) do
+          get_stripe_fixtures("customer_list_payment_methods_response.json") do |h|
+            h[:data][0][:id] = "pm_existing"
+          end
+        end
+
+        it "ignores the shared payment token and uses the existing payment method" do
+          WebMock.stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+            .with(body: ->(request) {
+              params = Rack::Utils.parse_nested_query(request)
+              expect(params).not_to have_key("payment_method_data")
+              expect(params["payment_method"]).to eq("pm_existing")
+            })
+            .to_return(body: stripe_payment_intent_data.to_json)
+
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(Stripe::Customer).to have_received(:list_payment_methods).once
+        end
+      end
+    end
+
     context "with card error on stripe" do
       let(:payment_response) do
         get_stripe_fixtures("payment_intent_card_declined_response.json") do |h|


### PR DESCRIPTION
## Context

Shared Payment Token is a new payment way added by Stripe specifically for agent-initiated purchases. It's very new. It's still in public preview.  

https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens

> [!WARNING]
> To be able to test this, make sure your Stripe account has `default_shared_payment_token` feature flag enabled (ask your account rep).

## Description

This PR adds basic support to Stripe Shared Payment Token. 

The flow is that **the user has to attach the token directly to the Stripe customer** with

```
POST https://api.stripe.com/v1/customers/cus_123
{
  invoice_settings: {
    default_shared_payment_token: "spt_123"
  }
}
```

When Lago tries to collect the payment with Stripe, it already pulls the customer from stripe API to check the default payment method.

This PR also check for this new attribute to see if there is a default token. So notice there is no extra call made.

The token is **only used if no other payment method is found**. If the user already has a card or customer balance or whatever this token is ignored entirely. 

This is basically the difference between a card payment today and a token payment

```diff
{
  amount: 2000,
  currency: 'usd',
  ...
- payment_method: 'pm_123',
- off_session: true,
- return_url: "...",
+ payment_method_data: {
+  shared_payment_granted_token: 'spt_123',
+ }
}
```


### Just regular payment method behind the scenes

The good news is that behind the scenes Stripe will still use a regular payment method `pm_123`.

The means jobs reacting to the `payment_intent.succeeded` which update the payment method of the payment in db, and retrieve the `last4` number for the Payment Receipt will still work the same way.

<img width="3266" height="2604" alt="CleanShot 2026-05-21 at 12 17 34@2x" src="https://github.com/user-attachments/assets/fc2162e0-6cff-4fcf-b565-aae1e531bf39" />


## Next steps

If successful and if needed, Lago could support it later as a regular payment method. For now, this is mostly used for [Stripe Projects](https://projects.dev/) and since this is still Public Preview on stripe, there is no rush to handle this differently I think.