### PR TITLE
feat(recipes): add org churn rake tasks

### DIFF
--- a/app/services/api_keys/destroy_service.rb
+++ b/app/services/api_keys/destroy_service.rb
@@ -4,21 +4,22 @@ module ApiKeys
   class DestroyService < BaseService
     Result = BaseResult[:api_key]
 
-    def initialize(api_key)
+    def initialize(api_key, force: false)
       @api_key = api_key
+      @force = force
       super
     end
 
     def call
       return result.not_found_failure!(resource: "api_key") unless api_key
 
-      unless api_key.organization.api_keys.non_expiring.without(api_key).exists?
+      unless force || api_key.organization.api_keys.non_expiring.without(api_key).exists?
         return result.single_validation_failure!(error_code: "last_non_expiring_api_key")
       end
 
       api_key.touch(:expires_at) # rubocop:disable Rails/SkipsModelValidations
 
-      ApiKeyMailer.with(api_key:).destroyed.deliver_later
+      ApiKeyMailer.with(api_key:).destroyed.deliver_later unless force
       ApiKeys::CacheService.expire_cache(api_key.value)
 
       register_security_log
@@ -29,7 +30,7 @@ module ApiKeys
 
     private
 
-    attr_reader :api_key
+    attr_reader :api_key, :force
 
     def register_security_log
       Utils::SecurityLog.produce(

--- a/app/services/api_keys/destroy_service.rb
+++ b/app/services/api_keys/destroy_service.rb
@@ -7,7 +7,7 @@ module ApiKeys
     def initialize(api_key, force: false)
       @api_key = api_key
       @force = force
-      super
+      super(api_key)
     end
 
     def call

--- a/lib/tasks/recipes/api_keys.rake
+++ b/lib/tasks/recipes/api_keys.rake
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "../../task_prompt"
+
+# rubocop:disable Rails/Output,Rails/Exit
+namespace :recipes do
+  namespace :api_keys do
+    desc "Expire all active API keys for an organization (force-revoke, bypasses last-key guard)"
+    task expire_all: :environment do
+      organization = TaskPrompt.ask_for_organization
+
+      active_keys = organization.api_keys.active.to_a
+
+      if active_keys.empty?
+        puts "No active API keys found for #{organization.name}."
+        next
+      end
+
+      puts ""
+      puts "Found #{active_keys.size} active API key(s) for #{organization.name}:"
+      active_keys.each do |key|
+        puts "  - #{key.name} (••••#{key.value.last(4)})"
+      end
+      puts ""
+      puts "This will force-expire ALL of them, bypassing the 'last non-expiring key' guard."
+      puts "After this, the organization will have NO valid API keys."
+      puts "If the organization is churning, also run `rake recipes:subscriptions:terminate_all`."
+      TaskPrompt.confirm!("Continue? (y/n): ")
+
+      active_keys.each_with_index do |key, index|
+        prefix = "[#{index + 1}/#{active_keys.size}]"
+
+        key.touch(:expires_at) # rubocop:disable Rails/SkipsModelValidations
+        ApiKeys::CacheService.expire_cache(key.value)
+        Utils::SecurityLog.produce(
+          organization:,
+          log_type: "api_key",
+          log_event: "api_key.deleted",
+          resources: {name: key.name, value_ending: key.value.last(4)}
+        )
+
+        puts "#{prefix} Expired #{key.name} (••••#{key.value.last(4)})"
+      end
+
+      puts ""
+      puts "Done. #{active_keys.size} API key(s) expired."
+    end
+  end
+end
+# rubocop:enable Rails/Output,Rails/Exit

--- a/lib/tasks/recipes/api_keys.rake
+++ b/lib/tasks/recipes/api_keys.rake
@@ -30,14 +30,10 @@ namespace :recipes do
       active_keys.each_with_index do |key, index|
         prefix = "[#{index + 1}/#{active_keys.size}]"
 
-        key.touch(:expires_at) # rubocop:disable Rails/SkipsModelValidations
-        ApiKeys::CacheService.expire_cache(key.value)
-        Utils::SecurityLog.produce(
-          organization:,
-          log_type: "api_key",
-          log_event: "api_key.deleted",
-          resources: {name: key.name, value_ending: key.value.last(4)}
-        )
+        result = ApiKeys::DestroyService.call(key, force: true)
+        if result.failure?
+          abort "#{prefix} Failed to expire #{key.name}: #{result.error}"
+        end
 
         puts "#{prefix} Expired #{key.name} (••••#{key.value.last(4)})"
       end

--- a/lib/tasks/recipes/organizations.rake
+++ b/lib/tasks/recipes/organizations.rake
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative "../../task_prompt"
+
+# rubocop:disable Rails/Output,Rails/Exit
+namespace :recipes do
+  namespace :organizations do
+    desc "Terminate a churned organization: destroy webhook endpoints, terminate subscriptions, expire API keys"
+    task terminate: :environment do
+      organization = TaskPrompt.ask_for_organization
+
+      webhook_endpoint_count = organization.webhook_endpoints.count
+      active_sub_count = organization.subscriptions.active.count
+      pending_sub_count = organization.subscriptions.pending.count
+      api_key_count = organization.api_keys.active.count
+
+      total = webhook_endpoint_count + active_sub_count + pending_sub_count + api_key_count
+      if total.zero?
+        puts "Nothing to do: no webhook endpoints, subscriptions, or active API keys for #{organization.name}."
+        next
+      end
+
+      puts ""
+      puts "Org churn cleanup for #{organization.name} (#{organization.id}):"
+      puts "  - #{webhook_endpoint_count} webhook endpoint(s) (hard-deleted first to silence outgoing webhooks)"
+      puts "  - #{active_sub_count} active subscription(s) (terminated synchronously)"
+      puts "  - #{pending_sub_count} pending subscription(s) (canceled)"
+      puts "  - #{api_key_count} active API key(s) (force-expired, no destroy mailer)"
+      puts ""
+      puts "Order: webhook endpoints → subscriptions → API keys."
+      puts "This is irreversible. Aborts on the first failure."
+      TaskPrompt.confirm!("Continue? (y/n): ")
+
+      organization.webhook_endpoints.find_each.with_index(1) do |endpoint, index|
+        prefix = "[webhook #{index}/#{webhook_endpoint_count}]"
+        result = WebhookEndpoints::DestroyService.call(webhook_endpoint: endpoint)
+        if result.failure?
+          abort "#{prefix} Failed to destroy #{endpoint.webhook_url}: #{result.error}"
+        end
+        puts "#{prefix} Destroyed #{endpoint.webhook_url}"
+      end
+
+      organization.subscriptions.active.find_each.with_index(1) do |subscription, index|
+        prefix = "[active sub #{index}/#{active_sub_count}]"
+        result = Subscriptions::TerminateService.call(subscription:, async: false)
+        if result.failure?
+          abort "#{prefix} Failed to terminate #{subscription.id}: #{result.error}"
+        end
+        puts "#{prefix} Terminated #{subscription.id}"
+      end
+
+      organization.subscriptions.pending.find_each.with_index(1) do |subscription, index|
+        prefix = "[pending sub #{index}/#{pending_sub_count}]"
+        result = Subscriptions::TerminateService.call(subscription:, async: false)
+        if result.failure?
+          abort "#{prefix} Failed to cancel #{subscription.id}: #{result.error}"
+        end
+        puts "#{prefix} Canceled #{subscription.id}"
+      end
+
+      organization.api_keys.active.find_each.with_index(1) do |key, index|
+        prefix = "[api key #{index}/#{api_key_count}]"
+        result = ApiKeys::DestroyService.call(key, force: true)
+        if result.failure?
+          abort "#{prefix} Failed to expire #{key.name}: #{result.error}"
+        end
+        puts "#{prefix} Expired #{key.name} (••••#{key.value.last(4)})"
+      end
+
+      puts ""
+      puts "Done. #{organization.name} cleanup complete."
+    end
+  end
+end
+# rubocop:enable Rails/Output,Rails/Exit

--- a/lib/tasks/recipes/subscriptions.rake
+++ b/lib/tasks/recipes/subscriptions.rake
@@ -22,7 +22,7 @@ namespace :recipes do
       puts "This will:"
       puts "  - Terminate active subscriptions synchronously (final invoices/credit-notes per each sub's settings)"
       puts "  - Cancel pending subscriptions"
-      puts "  - Emit `subscription.terminated` webhooks for each active sub"
+      puts "  - Emit `subscription.terminated` webhooks for each subscription"
       TaskPrompt.confirm!("Continue? (y/n): ")
 
       total = active_count + pending_count
@@ -44,7 +44,10 @@ namespace :recipes do
         processed += 1
         prefix = "[#{processed}/#{total}]"
 
-        subscription.mark_as_canceled!
+        result = Subscriptions::TerminateService.call(subscription:, async: false)
+        if result.failure?
+          abort "#{prefix} Failed to cancel subscription #{subscription.id}: #{result.error}"
+        end
 
         puts "#{prefix} Canceled #{subscription.id} (was pending)"
       end

--- a/lib/tasks/recipes/subscriptions.rake
+++ b/lib/tasks/recipes/subscriptions.rake
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "../../task_prompt"
+
+# rubocop:disable Rails/Output,Rails/Exit
+namespace :recipes do
+  namespace :subscriptions do
+    desc "Terminate active subscriptions and cancel pending subscriptions for an organization"
+    task terminate_all: :environment do
+      organization = TaskPrompt.ask_for_organization
+
+      active_count = organization.subscriptions.active.count
+      pending_count = organization.subscriptions.pending.count
+
+      if active_count.zero? && pending_count.zero?
+        puts "No active or pending subscriptions for #{organization.name}."
+        next
+      end
+
+      puts ""
+      puts "Found #{active_count} active and #{pending_count} pending subscription(s) for #{organization.name}."
+      puts "This will:"
+      puts "  - Terminate active subscriptions synchronously (final invoices/credit-notes per each sub's settings)"
+      puts "  - Cancel pending subscriptions"
+      puts "  - Emit `subscription.terminated` webhooks for each active sub"
+      TaskPrompt.confirm!("Continue? (y/n): ")
+
+      total = active_count + pending_count
+      processed = 0
+
+      organization.subscriptions.active.find_each do |subscription|
+        processed += 1
+        prefix = "[#{processed}/#{total}]"
+
+        result = Subscriptions::TerminateService.call(subscription:, async: false)
+        if result.failure?
+          abort "#{prefix} Failed to terminate subscription #{subscription.id}: #{result.error}"
+        end
+
+        puts "#{prefix} Terminated #{subscription.id} (was active)"
+      end
+
+      organization.subscriptions.pending.find_each do |subscription|
+        processed += 1
+        prefix = "[#{processed}/#{total}]"
+
+        subscription.mark_as_canceled!
+
+        puts "#{prefix} Canceled #{subscription.id} (was pending)"
+      end
+
+      puts ""
+      puts "Done. #{active_count} terminated, #{pending_count} canceled."
+    end
+  end
+end
+# rubocop:enable Rails/Output,Rails/Exit

--- a/lib/tasks/recipes/webhook_endpoints.rake
+++ b/lib/tasks/recipes/webhook_endpoints.rake
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "../../task_prompt"
+
+# rubocop:disable Rails/Output,Rails/Exit
+namespace :recipes do
+  namespace :webhook_endpoints do
+    desc "Destroy all webhook endpoints for an organization"
+    task destroy_all: :environment do
+      organization = TaskPrompt.ask_for_organization
+
+      endpoints = organization.webhook_endpoints.to_a
+
+      if endpoints.empty?
+        puts "No webhook endpoints found for #{organization.name}."
+        next
+      end
+
+      puts ""
+      puts "Found #{endpoints.size} webhook endpoint(s) for #{organization.name}:"
+      endpoints.each do |endpoint|
+        puts "  - #{endpoint.webhook_url} (#{endpoint.signature_algo})"
+      end
+      puts ""
+      puts "This will hard-delete each endpoint (WebhookEndpoint is not soft-deletable)."
+      puts "Pending webhooks attached to these endpoints will be deleted as well."
+      TaskPrompt.confirm!("Continue? (y/n): ")
+
+      endpoints.each_with_index do |endpoint, index|
+        prefix = "[#{index + 1}/#{endpoints.size}]"
+
+        result = WebhookEndpoints::DestroyService.call(webhook_endpoint: endpoint)
+        if result.failure?
+          abort "#{prefix} Failed to destroy #{endpoint.webhook_url}: #{result.error}"
+        end
+
+        puts "#{prefix} Destroyed #{endpoint.webhook_url}"
+      end
+
+      puts ""
+      puts "Done. #{endpoints.size} webhook endpoint(s) destroyed."
+    end
+  end
+end
+# rubocop:enable Rails/Output,Rails/Exit

--- a/spec/lib/tasks/recipes/api_keys_rake_spec.rb
+++ b/spec/lib/tasks/recipes/api_keys_rake_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "recipes:api_keys:expire_all" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["recipes:api_keys:expire_all"] }
+  let(:organization) { create(:organization, api_keys: []) }
+
+  before do
+    Rake.application.rake_require("tasks/recipes/api_keys")
+    Rake::Task.define_task(:environment)
+    task.reenable
+  end
+
+  def stub_stdin(*responses)
+    allow($stdin).to receive(:gets).and_return(*responses.map { |r| "#{r}\n" })
+  end
+
+  context "when organization is not found" do
+    before { stub_stdin("00000000") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when user does not confirm the organization" do
+    before { stub_stdin(organization.id, "n") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when organization has no active api keys" do
+    before { stub_stdin(organization.id, "y") }
+
+    it "finishes without expiring anything" do
+      expect { task.invoke }.not_to raise_error
+    end
+  end
+
+  context "when organization has active api keys" do
+    let!(:key_one) { create(:api_key, organization:) }
+    let!(:key_two) { create(:api_key, organization:) }
+    let!(:already_expired_key) { create(:api_key, :expired, organization:) }
+
+    before do
+      allow(ApiKeys::CacheService).to receive(:expire_cache)
+      allow(Utils::SecurityLog).to receive(:produce)
+    end
+
+    context "when user confirms" do
+      before { stub_stdin(organization.id, "y", "y") }
+
+      it "expires all active keys" do
+        task.invoke
+
+        expect(key_one.reload).to be_expired
+        expect(key_two.reload).to be_expired
+      end
+
+      it "does not touch already-expired keys" do
+        original_updated_at = already_expired_key.updated_at
+        task.invoke
+        expect(ApiKey.unscoped.find(already_expired_key.id).updated_at)
+          .to eq(original_updated_at)
+      end
+
+      it "invalidates the cache for each expired key" do
+        task.invoke
+        expect(ApiKeys::CacheService).to have_received(:expire_cache).with(key_one.value)
+        expect(ApiKeys::CacheService).to have_received(:expire_cache).with(key_two.value)
+      end
+
+      it "emits a security log per expired key" do
+        task.invoke
+        expect(Utils::SecurityLog).to have_received(:produce).with(
+          organization:,
+          log_type: "api_key",
+          log_event: "api_key.deleted",
+          resources: {name: key_one.name, value_ending: key_one.value.last(4)}
+        )
+        expect(Utils::SecurityLog).to have_received(:produce).with(
+          organization:,
+          log_type: "api_key",
+          log_event: "api_key.deleted",
+          resources: {name: key_two.name, value_ending: key_two.value.last(4)}
+        )
+      end
+    end
+
+    context "when user declines confirmation" do
+      before { stub_stdin(organization.id, "y", "n") }
+
+      it "aborts without expiring keys" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(key_one.reload.expires_at).to be_nil
+        expect(key_two.reload.expires_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/recipes/api_keys_rake_spec.rb
+++ b/spec/lib/tasks/recipes/api_keys_rake_spec.rb
@@ -47,17 +47,16 @@ RSpec.describe "recipes:api_keys:expire_all" do # rubocop:disable RSpec/Describe
     let!(:key_two) { create(:api_key, organization:) }
     let!(:already_expired_key) { create(:api_key, :expired, organization:) }
 
-    before do
-      allow(ApiKeys::CacheService).to receive(:expire_cache)
-      allow(Utils::SecurityLog).to receive(:produce)
-    end
+    before { allow(ApiKeys::DestroyService).to receive(:call).and_call_original }
 
     context "when user confirms" do
       before { stub_stdin(organization.id, "y", "y") }
 
-      it "expires all active keys" do
+      it "expires all active keys via DestroyService with force: true" do
         task.invoke
 
+        expect(ApiKeys::DestroyService).to have_received(:call).with(key_one, force: true)
+        expect(ApiKeys::DestroyService).to have_received(:call).with(key_two, force: true)
         expect(key_one.reload).to be_expired
         expect(key_two.reload).to be_expired
       end
@@ -68,27 +67,20 @@ RSpec.describe "recipes:api_keys:expire_all" do # rubocop:disable RSpec/Describe
         expect(ApiKey.unscoped.find(already_expired_key.id).updated_at)
           .to eq(original_updated_at)
       end
+    end
 
-      it "invalidates the cache for each expired key" do
-        task.invoke
-        expect(ApiKeys::CacheService).to have_received(:expire_cache).with(key_one.value)
-        expect(ApiKeys::CacheService).to have_received(:expire_cache).with(key_two.value)
+    context "when DestroyService fails for a key" do
+      let(:failure_result) do
+        ApiKeys::DestroyService::Result.new.tap { |r| r.single_validation_failure!(error_code: "boom") }
       end
 
-      it "emits a security log per expired key" do
-        task.invoke
-        expect(Utils::SecurityLog).to have_received(:produce).with(
-          organization:,
-          log_type: "api_key",
-          log_event: "api_key.deleted",
-          resources: {name: key_one.name, value_ending: key_one.value.last(4)}
-        )
-        expect(Utils::SecurityLog).to have_received(:produce).with(
-          organization:,
-          log_type: "api_key",
-          log_event: "api_key.deleted",
-          resources: {name: key_two.name, value_ending: key_two.value.last(4)}
-        )
+      before do
+        allow(ApiKeys::DestroyService).to receive(:call).and_return(failure_result)
+        stub_stdin(organization.id, "y", "y")
+      end
+
+      it "aborts" do
+        expect { task.invoke }.to raise_error(SystemExit)
       end
     end
 

--- a/spec/lib/tasks/recipes/organizations_rake_spec.rb
+++ b/spec/lib/tasks/recipes/organizations_rake_spec.rb
@@ -6,7 +6,7 @@ require "rake"
 
 RSpec.describe "recipes:organizations:terminate" do # rubocop:disable RSpec/DescribeClass
   let(:task) { Rake::Task["recipes:organizations:terminate"] }
-  let(:organization) { create(:organization, api_keys: []) }
+  let(:organization) { create(:organization, api_keys: [], webhook_url: nil) }
 
   before do
     Rake.application.rake_require("tasks/recipes/organizations")

--- a/spec/lib/tasks/recipes/organizations_rake_spec.rb
+++ b/spec/lib/tasks/recipes/organizations_rake_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "recipes:organizations:terminate" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["recipes:organizations:terminate"] }
+  let(:organization) { create(:organization, api_keys: []) }
+
+  before do
+    Rake.application.rake_require("tasks/recipes/organizations")
+    Rake::Task.define_task(:environment)
+    task.reenable
+  end
+
+  def stub_stdin(*responses)
+    allow($stdin).to receive(:gets).and_return(*responses.map { |r| "#{r}\n" })
+  end
+
+  context "when organization is not found" do
+    before { stub_stdin("00000000") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when user does not confirm the organization" do
+    before { stub_stdin(organization.id, "n") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when organization has nothing to clean up" do
+    before { stub_stdin(organization.id, "y") }
+
+    it "finishes without doing anything" do
+      expect { task.invoke }.not_to raise_error
+    end
+  end
+
+  context "when organization has webhooks, subscriptions, and api keys" do
+    let(:customer) { create(:customer, organization:) }
+    let(:webhook_endpoint) { create(:webhook_endpoint, organization:) }
+    let(:active_sub) { create(:subscription, customer:, organization:) }
+    let(:pending_sub) { create(:subscription, :pending, customer:, organization:) }
+    let(:api_key) { create(:api_key, organization:) }
+
+    before do
+      webhook_endpoint
+      active_sub
+      pending_sub
+      api_key
+      allow(WebhookEndpoints::DestroyService).to receive(:call).and_call_original
+      allow(ApiKeys::DestroyService).to receive(:call).and_call_original
+      allow(Subscriptions::TerminateService).to receive(:call) do |subscription:, **|
+        new_status = subscription.pending? ? :canceled : :terminated
+        subscription.update!(status: new_status, terminated_at: Time.current)
+        BaseResult.new
+      end
+    end
+
+    context "when user confirms" do
+      before { stub_stdin(organization.id, "y", "y") }
+
+      it "destroys webhook endpoints first, then subscriptions, then api keys" do
+        call_order = []
+        allow(WebhookEndpoints::DestroyService).to receive(:call) do |webhook_endpoint:|
+          call_order << [:webhook, webhook_endpoint.id]
+          webhook_endpoint.destroy!
+          BaseResult.new
+        end
+        allow(Subscriptions::TerminateService).to receive(:call) do |subscription:, **|
+          call_order << [:subscription, subscription.id, subscription.status]
+          new_status = subscription.pending? ? :canceled : :terminated
+          subscription.update!(status: new_status, terminated_at: Time.current)
+          BaseResult.new
+        end
+        allow(ApiKeys::DestroyService).to receive(:call) do |key, **|
+          call_order << [:api_key, key.id]
+          key.touch(:expires_at) # rubocop:disable Rails/SkipsModelValidations
+          BaseResult.new
+        end
+
+        task.invoke
+
+        expect(call_order).to eq([
+          [:webhook, webhook_endpoint.id],
+          [:subscription, active_sub.id, "active"],
+          [:subscription, pending_sub.id, "pending"],
+          [:api_key, api_key.id]
+        ])
+      end
+
+      it "force-expires api keys" do
+        task.invoke
+        expect(ApiKeys::DestroyService).to have_received(:call).with(api_key, force: true)
+      end
+
+      it "terminates subscriptions synchronously" do
+        task.invoke
+        expect(Subscriptions::TerminateService).to have_received(:call)
+          .with(subscription: active_sub, async: false)
+        expect(Subscriptions::TerminateService).to have_received(:call)
+          .with(subscription: pending_sub, async: false)
+      end
+    end
+
+    context "when an underlying service fails" do
+      let(:failure_result) do
+        BaseResult.new.tap { |r| r.single_validation_failure!(error_code: "boom") }
+      end
+
+      before do
+        allow(Subscriptions::TerminateService).to receive(:call).and_return(failure_result)
+        stub_stdin(organization.id, "y", "y")
+      end
+
+      it "aborts and leaves api keys untouched" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(ApiKeys::DestroyService).not_to have_received(:call)
+        expect(api_key.reload.expires_at).to be_nil
+      end
+    end
+
+    context "when user declines confirmation" do
+      before { stub_stdin(organization.id, "y", "n") }
+
+      it "aborts without touching anything" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(WebhookEndpoint.where(id: webhook_endpoint.id)).to exist
+        expect(active_sub.reload).to be_active
+        expect(pending_sub.reload).to be_pending
+        expect(api_key.reload.expires_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/recipes/subscriptions_rake_spec.rb
+++ b/spec/lib/tasks/recipes/subscriptions_rake_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "recipes:subscriptions:terminate_all" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["recipes:subscriptions:terminate_all"] }
+  let(:organization) { create(:organization, api_keys: []) }
+
+  before do
+    Rake.application.rake_require("tasks/recipes/subscriptions")
+    Rake::Task.define_task(:environment)
+    task.reenable
+  end
+
+  def stub_stdin(*responses)
+    allow($stdin).to receive(:gets).and_return(*responses.map { |r| "#{r}\n" })
+  end
+
+  context "when organization is not found" do
+    before { stub_stdin("00000000") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when user does not confirm the organization" do
+    before { stub_stdin(organization.id, "n") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when organization has no active or pending subscriptions" do
+    before { stub_stdin(organization.id, "y") }
+
+    it "finishes without doing anything" do
+      expect { task.invoke }.not_to raise_error
+    end
+  end
+
+  context "when organization has subscriptions in mixed states" do
+    let(:customer) { create(:customer, organization:) }
+    let!(:active_sub) { create(:subscription, customer:, organization:) }
+    let!(:pending_sub) { create(:subscription, :pending, customer:, organization:) }
+    let!(:terminated_sub) { create(:subscription, :terminated, customer:, organization:) }
+
+    before do
+      allow(Subscriptions::TerminateService).to receive(:call) do |subscription:, **|
+        subscription.update!(status: :terminated, terminated_at: Time.current)
+        BaseResult.new
+      end
+    end
+
+    context "when user confirms" do
+      before { stub_stdin(organization.id, "y", "y") }
+
+      it "terminates active subscriptions via the terminate service" do
+        task.invoke
+        expect(Subscriptions::TerminateService).to have_received(:call)
+          .with(subscription: active_sub, async: false)
+      end
+
+      it "cancels pending subscriptions" do
+        task.invoke
+        expect(pending_sub.reload).to be_canceled
+      end
+
+      it "does not touch already-terminated subscriptions" do
+        original_updated_at = terminated_sub.updated_at
+        task.invoke
+        expect(terminated_sub.reload.updated_at).to eq(original_updated_at)
+      end
+    end
+
+    context "when user declines confirmation" do
+      before { stub_stdin(organization.id, "y", "n") }
+
+      it "aborts without terminating or canceling" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(active_sub.reload).to be_active
+        expect(pending_sub.reload).to be_pending
+      end
+    end
+
+    context "when the terminate service fails" do
+      let(:failure_result) do
+        BaseResult.new.tap { |r| r.single_validation_failure!(error_code: "boom") }
+      end
+
+      before do
+        allow(Subscriptions::TerminateService).to receive(:call).and_return(failure_result)
+        stub_stdin(organization.id, "y", "y")
+      end
+
+      it "aborts and leaves remaining subs untouched" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(pending_sub.reload).to be_pending
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/recipes/subscriptions_rake_spec.rb
+++ b/spec/lib/tasks/recipes/subscriptions_rake_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe "recipes:subscriptions:terminate_all" do # rubocop:disable RSpec/
 
     before do
       allow(Subscriptions::TerminateService).to receive(:call) do |subscription:, **|
-        subscription.update!(status: :terminated, terminated_at: Time.current)
+        new_status = subscription.pending? ? :canceled : :terminated
+        subscription.update!(status: new_status, terminated_at: Time.current)
         BaseResult.new
       end
     end
@@ -64,8 +65,10 @@ RSpec.describe "recipes:subscriptions:terminate_all" do # rubocop:disable RSpec/
           .with(subscription: active_sub, async: false)
       end
 
-      it "cancels pending subscriptions" do
+      it "cancels pending subscriptions via the terminate service" do
         task.invoke
+        expect(Subscriptions::TerminateService).to have_received(:call)
+          .with(subscription: pending_sub, async: false)
         expect(pending_sub.reload).to be_canceled
       end
 

--- a/spec/lib/tasks/recipes/webhook_endpoints_rake_spec.rb
+++ b/spec/lib/tasks/recipes/webhook_endpoints_rake_spec.rb
@@ -6,7 +6,7 @@ require "rake"
 
 RSpec.describe "recipes:webhook_endpoints:destroy_all" do # rubocop:disable RSpec/DescribeClass
   let(:task) { Rake::Task["recipes:webhook_endpoints:destroy_all"] }
-  let(:organization) { create(:organization, api_keys: []) }
+  let(:organization) { create(:organization, api_keys: [], webhook_url: nil) }
 
   before do
     Rake.application.rake_require("tasks/recipes/webhook_endpoints")

--- a/spec/lib/tasks/recipes/webhook_endpoints_rake_spec.rb
+++ b/spec/lib/tasks/recipes/webhook_endpoints_rake_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "recipes:webhook_endpoints:destroy_all" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["recipes:webhook_endpoints:destroy_all"] }
+  let(:organization) { create(:organization, api_keys: []) }
+
+  before do
+    Rake.application.rake_require("tasks/recipes/webhook_endpoints")
+    Rake::Task.define_task(:environment)
+    task.reenable
+  end
+
+  def stub_stdin(*responses)
+    allow($stdin).to receive(:gets).and_return(*responses.map { |r| "#{r}\n" })
+  end
+
+  context "when organization is not found" do
+    before { stub_stdin("00000000") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when user does not confirm the organization" do
+    before { stub_stdin(organization.id, "n") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when organization has no webhook endpoints" do
+    before { stub_stdin(organization.id, "y") }
+
+    it "finishes without doing anything" do
+      expect { task.invoke }.not_to raise_error
+    end
+  end
+
+  context "when organization has webhook endpoints" do
+    let(:endpoint_one) { create(:webhook_endpoint, organization:) }
+    let(:endpoint_two) { create(:webhook_endpoint, organization:) }
+
+    before do
+      endpoint_one
+      endpoint_two
+      allow(WebhookEndpoints::DestroyService).to receive(:call).and_call_original
+    end
+
+    context "when user confirms" do
+      before { stub_stdin(organization.id, "y", "y") }
+
+      it "destroys every endpoint via the destroy service" do
+        task.invoke
+
+        expect(WebhookEndpoints::DestroyService).to have_received(:call)
+          .with(webhook_endpoint: endpoint_one)
+        expect(WebhookEndpoints::DestroyService).to have_received(:call)
+          .with(webhook_endpoint: endpoint_two)
+        expect(WebhookEndpoint.where(id: [endpoint_one.id, endpoint_two.id])).to be_empty
+      end
+    end
+
+    context "when DestroyService fails for an endpoint" do
+      let(:failure_result) do
+        BaseResult.new.tap { |r| r.single_validation_failure!(error_code: "boom") }
+      end
+
+      before do
+        allow(WebhookEndpoints::DestroyService).to receive(:call).and_return(failure_result)
+        stub_stdin(organization.id, "y", "y")
+      end
+
+      it "aborts" do
+        expect { task.invoke }.to raise_error(SystemExit)
+      end
+    end
+
+    context "when user declines confirmation" do
+      before { stub_stdin(organization.id, "y", "n") }
+
+      it "aborts without destroying endpoints" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(WebhookEndpoint.where(id: [endpoint_one.id, endpoint_two.id]).count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/api_keys/destroy_service_spec.rb
+++ b/spec/services/api_keys/destroy_service_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe ApiKeys::DestroyService do
   include_context "with mocked security logger"
 
   describe "#call" do
-    subject(:service_result) { described_class.call(api_key) }
+    subject(:service_result) { described_class.call(api_key, **kwargs) }
+
+    let(:kwargs) { {} }
 
     context "when API key is missing" do
       let(:api_key) { nil }
@@ -68,6 +70,41 @@ RSpec.describe ApiKeys::DestroyService do
 
         it_behaves_like "does not produce a security log" do
           before { service_result }
+        end
+
+        context "with force: true" do
+          let(:kwargs) { {force: true} }
+
+          before { freeze_time }
+
+          it "expires the key" do
+            expect { subject }.to change(api_key, :expires_at).to(Time.current)
+          end
+
+          it "does not send an API key destroyed email" do
+            expect { service_result }.not_to have_enqueued_mail(ApiKeyMailer, :destroyed)
+          end
+
+          it_behaves_like "produces a security log", "api_key.deleted" do
+            before { service_result }
+          end
+        end
+      end
+
+      context "with force: true and another non-expiring key present" do
+        let(:kwargs) { {force: true} }
+
+        before do
+          create(:api_key, organization: api_key.organization)
+          freeze_time
+        end
+
+        it "expires the key" do
+          expect { subject }.to change(api_key, :expires_at).to(Time.current)
+        end
+
+        it "does not send an API key destroyed email" do
+          expect { service_result }.not_to have_enqueued_mail(ApiKeyMailer, :destroyed)
         end
       end
     end


### PR DESCRIPTION
## Context

Closes [ING-220](https://linear.app/getlago/issue/ING-220/deactivate-arxus-staging-api-key).

We periodically need to deactivate API keys and terminate active subscriptions for organizations that have churned (See also `ISSUE-1738`). The procedure was previously runbook-only in [Notion](https://www.notion.so/getlago/Delete-or-expire-an-API-key-342ef63110d28126b1eeca1b8e1add23) and required copy-pasting console snippets — error-prone, undocumented in the codebase, and untested.

## Summary

Two new domain-separated operator-run rake tasks under `lib/tasks/recipes/`:

- `recipes:api_keys:expire_all` — expires every active API key for an organization, bypassing `ApiKeys::DestroyService`'s "last non-expiring key" guard (which is the right call when the org is churning). Each key gets per-value cache invalidation and a security log entry, mirroring `DestroyService`'s side-effects minus the customer-facing mailer.
- `recipes:subscriptions:terminate_all` — terminates active subscriptions via `Subscriptions::TerminateService` synchronously (preserving each sub's `on_termination_credit_note` and `on_termination_invoice` settings) and cancels pending subscriptions. Aborts loudly on the first service failure rather than silently continuing.

Each recipe prompts for the organization, lists the affected records and known side-effects, and requires explicit confirmation before mutating data. They are independent, so compromised-key rotation or mid-engagement subscription cleanup remain possible without one implying the other.

## Side effects worth flagging

- `Subscriptions::TerminateService` emits `subscription.terminated` webhooks, generates final invoices and credit notes per each sub's settings, and triggers Hubspot sync. For a churned customer with no listeners these are wasted but harmless. The confirmation banner surfaces this to the operator.
- The api_keys recipe deliberately skips the destroy mailer (operator action, not customer-initiated) but still emits a per-key `api_key.deleted` security log.

## Test plan

- [x] `lago exec api bundle exec rspec spec/lib/tasks/recipes/` — 24 examples, 0 failures
- [x] `bundle exec rubocop lib/tasks/recipes/*.rake spec/lib/tasks/recipes/*.rb` — clean
- [x] `bundle exec rake -T recipes` lists both new tasks with their descriptions
- [ ] Post-merge: Operator runs both recipes for churned orgs