### PR TITLE
[ING-122] fix(billing): preserve recurring sum sign

### DIFF
--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -106,21 +106,6 @@ module BillableMetrics
       private
 
       attr_reader :base_aggregator
-
-      def previous_charge_fee(grouped_by_values: nil)
-        subscription_ids = customer.subscriptions
-          .where(external_id: subscription.external_id)
-          .pluck(:id)
-
-        Fee.joins(:charge)
-          .where(charge: {billable_metric_id: billable_metric.id})
-          .where(charge: {prorated: true})
-          .where(subscription_id: subscription_ids, fee_type: :charge, charge_filter_id: charge_filter&.id)
-          .where("CAST(fees.properties->>'charges_to_datetime' AS timestamp) < ?", boundaries[:to_datetime])
-          .where(grouped_by: grouped_by_values.presence || {})
-          .order(created_at: :desc)
-          .first
-      end
     end
   end
 end

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -158,13 +158,12 @@ module BillableMetrics
       end
 
       def recurring_value(grouped_by_values: nil)
-        previous_charge_fee_units = previous_charge_fee(grouped_by_values:)&.units
-        return previous_charge_fee_units if previous_charge_fee_units
-
         store = persisted_event_store_instance
-        recurring_value_before_first_fee = store.with_grouped_by_values(grouped_by_values) { store.sum }
+        raw_sum = store.with_grouped_by_values(grouped_by_values) { store.sum }
 
-        ((recurring_value_before_first_fee || 0) <= 0) ? nil : recurring_value_before_first_fee
+        return nil if raw_sum.nil? || raw_sum.zero?
+
+        raw_sum
       end
 
       def compute_grouped_event_aggregation

--- a/spec/scenarios/recurring_graduated_prorated_cross_period_spec.rb
+++ b/spec/scenarios/recurring_graduated_prorated_cross_period_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Recurring graduated prorated usage across billing periods", transaction: false do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) do
+    create(:plan, organization:, amount_cents: 0, pay_in_advance: false, interval: "monthly")
+  end
+  let(:billable_metric) do
+    create(
+      :billable_metric,
+      organization:,
+      aggregation_type: "sum_agg",
+      field_name: "amount",
+      recurring: true
+    )
+  end
+  let(:subscription) { customer.subscriptions.first }
+
+  let(:period_one_start) { DateTime.new(2026, 4, 8, 12, 0, 0) }
+  let(:period_two_start) { DateTime.new(2026, 5, 8, 0, 1, 0) }
+  let(:in_period_two) { DateTime.new(2026, 5, 9, 12, 0, 0) }
+
+  before do
+    create(
+      :graduated_charge,
+      plan:,
+      billable_metric:,
+      prorated: true,
+      pay_in_advance: false,
+      properties: {
+        graduated_ranges: [
+          {from_value: 0, to_value: 2, per_unit_amount: "0", flat_amount: "0"},
+          {from_value: 3, to_value: nil, per_unit_amount: "150", flat_amount: "0"}
+        ]
+      }
+    )
+
+    travel_to(period_one_start) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          subscription_at: period_one_start.iso8601,
+          billing_time: "anniversary"
+        }
+      )
+    end
+  end
+
+  it "prices the net 1 unit at 0 cents (free tier) after periods cross" do
+    travel_to(period_two_start - 1.hour) do
+      3.times do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: customer.external_id,
+            properties: {amount: -1}
+          }
+        )
+      end
+    end
+
+    travel_to(period_two_start) do
+      BillSubscriptionJob.perform_now([subscription], Time.current, invoicing_reason: :subscription_periodic)
+    end
+
+    period_one_invoice = subscription.invoices.order(:created_at).last
+    expect(period_one_invoice.total_amount_cents).to eq(0)
+
+    travel_to(in_period_two) do
+      4.times do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: customer.external_id,
+            properties: {amount: 1}
+          }
+        )
+      end
+
+      fetch_current_usage(customer:)
+    end
+
+    charge_usage = json[:customer_usage][:charges_usage].first
+
+    expect(charge_usage[:units]).to eq("1.0")
+    expect(charge_usage[:amount_cents]).to eq(0)
+  end
+
+  it "reflects backdated events from period 1 in the period 2 running sum" do
+    travel_to(period_one_start + 1.day) do
+      3.times do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: customer.external_id,
+            properties: {amount: -1}
+          }
+        )
+      end
+    end
+
+    travel_to(period_two_start) do
+      BillSubscriptionJob.perform_now([subscription], Time.current, invoicing_reason: :subscription_periodic)
+    end
+
+    travel_to(in_period_two) do
+      4.times do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: customer.external_id,
+            properties: {amount: 1}
+          }
+        )
+      end
+
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: customer.external_id,
+          properties: {amount: 1},
+          timestamp: (period_one_start + 5.days).to_i
+        }
+      )
+
+      fetch_current_usage(customer:)
+    end
+
+    charge_usage = json[:customer_usage][:charges_usage].first
+    expect(charge_usage[:units]).to eq("2.0")
+  end
+end


### PR DESCRIPTION
## Context

A user reported that the current usage shown for a recurring `sum_agg` billable metric on a graduated prorated charge was inflated after a billing period boundary. With a configuration where the first two units are free and the third+ unit costs $150, the customer expected `$0` on a net usage of `1` unit (well inside the free tier) and observed roughly `$300` instead.

Reproduction (matches the original report):

1. Recurring `sum_agg` metric on field `amount`.
2. Plan with a graduated prorated charge: tier `0–2` at `$0`, tier `3+` at `$150`. Pay-in-arrears.
3. Customer on **anniversary** billing, subscription starting one month before the close of period 1.
4. Three `-1` events near the end of period 1, then bill period 1 (invoice total: `$0`, as expected).
5. Four `+1` events early in period 2. Net running sum: `-3 + 4 = 1`.
6. Check current usage in period 2.

Expected: `1` unit, `$0`. Observed: `1` unit, `~$290–300`.

## Why it was broken

`BillableMetrics::ProratedAggregations::SumService#recurring_value` fed the graduated charge model the *starting state* for tier walking across a period boundary. It read that starting state from the previous billing period's fee row (`previous_charge_fee.units`) instead of from the event store itself.

That source is lossy. `Fees::ChargeService#init_fee` deliberately clips negative `units` (and `full_units_number`) to `0` so we never invoice for a negative quantity:

```ruby
# app/services/fees/charge_service.rb
if amount_result.units.negative? || amount_result.amount.negative?
  amount_result.amount = amount_result.unit_amount = BigDecimal(0)
  amount_result.full_units_number = amount_result.units = BigDecimal(0)
end
```

That clipping is fine for the invoice itself. The issue is that the *next* period then read this clipped `0` back as if it were the raw running sum. Concretely, in the reproducer:

- Raw running sum at the end of period 1: `-3`.
- Period 1's fee stored `units = 0` (clipped).
- Period 2 read `recurring_value = 0` instead of `-3`.
- The graduated walker started at `full_sum = 0`, the four `+1` events pushed it to `4`, and units `3` and `4` landed in the `$150` tier, prorated to roughly `$290`.

The reason this only reproduces under **anniversary** billing is that the late-period subtractive events have to prorate down to nearly zero (so the period-1 fee ends up clipped to `0`) while the period-2 events prorate normally. Under calendar billing the boundary alignment differs and the issue does not surface.

## The fix

`recurring_value` now queries the event store directly for the raw running sum at the boundary instead of reading the fee row:

```ruby
def recurring_value(grouped_by_values: nil)
  store = persisted_event_store_instance
  raw_sum = store.with_grouped_by_values(grouped_by_values) { store.sum }

  return nil if raw_sum.nil? || raw_sum.zero?

  raw_sum
end
```

Properties:

- **Sign- and magnitude-preserving.** A `-3` carry-over is fed in as `-3`. The graduated walker already accumulates overflow correctly when the running sum starts negative — it walks `-3 → -2 → -1 → 0 → 1`, stays in the free tier, and yields `$0`.
- **`init_fee`'s clipping is left untouched.** That clipping is the correct behavior at the invoice boundary; only the *downstream consumer* (this method) needed to stop using the clipped value as a proxy for raw state.
- **No new column or migration.** The event store is already the source of truth for a recurring metric's balance.

The now-unused `previous_charge_fee` helper in `ProratedAggregations::BaseService` is removed.

`UniqueCountService` uses a different design — its `per_event_aggregation` emits individual prior-period events with zero prorated values and the graduated walker has explicit skip logic for them. It does not use `recurring_value` and is not affected by this bug.

## Tests

- **New regression test:** `spec/scenarios/recurring_graduated_prorated_cross_period_spec.rb` reproduces the original report end-to-end on anniversary billing. Case 1 (priced amount): fails on `main` with `expected 0, got 29032` cents; passes after the fix. Case 2 (backdated event into the prior period reflected in the next period's running sum): passes on `main` already — included to lock in the behavior.
- **No existing tests required changes.** Where the previous fee's `units` and the raw `store.sum` agreed (the positive, non-clipped case), the new code produces identical values, so no test that depended on the old code path needed to change.

Verified suites (all green):

```
spec/services/charge_models/                                    # 129
spec/scenarios/current_usage/by_charge_model/                   # 80
spec/services/billable_metrics/prorated_aggregations/           # 111
spec/scenarios/fees/recurring_fees_spec.rb
spec/scenarios/invoices/recurring_fees_spec.rb
spec/scenarios/recurring_graduated_prorated_cross_period_spec.rb
```

## How to test manually

1. Create a recurring `sum_agg` billable metric on field `amount`.
2. Plan: `$0` monthly subscription fee, one graduated prorated charge with tiers `0–2 @ $0` and `3+ @ $150`, pay-in-arrears.
3. Subscribe a customer on **anniversary** billing, start date one month before tomorrow.
4. Send three events with `amount: -1`. Current usage should show `0`.
5. Bill the period. Invoice total: `$0`.
6. Send four events with `amount: 1`. Net usage: `1` unit.
7. Check current usage: should show `1.0` units and `$0`.

On `main`, step 7 reports `~$300`. With this PR, it reports `$0`.
