### PR TITLE
[ING-90] feat(graphql): filter subs by entity ids

### DIFF
--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -9,6 +9,7 @@ module Resolvers
 
     description "Query subscriptions of an organization"
 
+    argument :billing_entity_ids, [ID], required: false
     argument :currency, String, required: false
     argument :external_customer_id, String, required: false
     argument :limit, Integer, required: false
@@ -20,12 +21,12 @@ module Resolvers
 
     type Types::Subscriptions::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil, plan_code: nil, status: nil, external_customer_id: nil, overriden: nil, search_term: nil, currency: nil)
+    def resolve(page: nil, limit: nil, plan_code: nil, status: nil, external_customer_id: nil, overriden: nil, search_term: nil, currency: nil, billing_entity_ids: nil)
       # In FE we include next subscription in the list, so we need to exclude subscriptions with previous subscription from the list
       result = SubscriptionsQuery.call(
         organization: current_organization,
         pagination: {page:, limit:},
-        filters: {plan_code:, status:, external_customer_id:, overriden:, currency:, exclude_next_subscriptions: true},
+        filters: {plan_code:, status:, external_customer_id:, overriden:, currency:, billing_entity_ids:, exclude_next_subscriptions: true},
         search_term:
       )
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -10614,7 +10614,7 @@ type Query {
   """
   Query subscriptions of an organization
   """
-  subscriptions(currency: String, externalCustomerId: String, limit: Int, overriden: Boolean, page: Int, planCode: String, searchTerm: String, status: [StatusTypeEnum!]): SubscriptionCollection!
+  subscriptions(billingEntityIds: [ID!], currency: String, externalCustomerId: String, limit: Int, overriden: Boolean, page: Int, planCode: String, searchTerm: String, status: [StatusTypeEnum!]): SubscriptionCollection!
 
   """
   Query all Superset dashboards with embedded configuration and guest tokens

--- a/schema.json
+++ b/schema.json
@@ -57083,6 +57083,26 @@
               "description": "Query subscriptions of an organization",
               "args": [
                 {
+                  "name": "billingEntityIds",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "currency",
                   "description": null,
                   "type": {

--- a/spec/graphql/resolvers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions_resolver_spec.rb
@@ -55,6 +55,66 @@ RSpec.describe Resolvers::SubscriptionsResolver do
     expect(response["metadata"]["totalCount"]).to eq(2)
   end
 
+  context "with billing_entity_ids filter" do
+    let(:billing_entity_eu) { create(:billing_entity, organization:, code: "EU") }
+    let(:billing_entity_us) { create(:billing_entity, organization:, code: "US") }
+    let!(:eu_subscription) { create(:subscription, customer:, plan:, billing_entity: billing_entity_eu) }
+    let!(:us_subscription) { create(:subscription, customer:, plan:, billing_entity: billing_entity_us) }
+
+    let(:query) do
+      <<~GQL
+        query {
+          subscriptions(limit: 5, billingEntityIds: ["#{billing_entity_eu.id}"]) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only subscriptions for the specified billing entity" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+      response = result["data"]["subscriptions"]
+
+      expect(response["collection"].map { |s| s["id"] }).to contain_exactly(eu_subscription.id)
+      expect(response["metadata"]["totalCount"]).to eq(1)
+    end
+
+    context "with multiple billing_entity_ids" do
+      let(:query) do
+        <<~GQL
+          query {
+            subscriptions(limit: 5, billingEntityIds: ["#{billing_entity_eu.id}", "#{billing_entity_us.id}"]) {
+              collection { id }
+              metadata { totalCount }
+            }
+          }
+        GQL
+      end
+
+      it "returns subscriptions matching any of the provided ids" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:
+        )
+        response = result["data"]["subscriptions"]
+
+        expect(response["collection"].map { |s| s["id"] }).to contain_exactly(
+          eu_subscription.id,
+          us_subscription.id
+        )
+        expect(response["metadata"]["totalCount"]).to eq(2)
+      end
+    end
+  end
+
   context "with currency filter" do
     let(:brl_plan) { create(:plan, organization:, amount_currency: "BRL") }
     let!(:brl_subscription) { create(:subscription, customer:, plan: brl_plan) }


### PR DESCRIPTION
## Context

ING-47 added a `billing_entity_codes` filter to the REST list endpoints for subscriptions, wiring `:billing_entity_ids` through `SubscriptionsQuery#with_billing_entity_ids` (a direct `where(billing_entity_id: …)`). This PR brings the same filter to the GraphQL `subscriptions` resolver so the FE can scope the list to one or more billing entities.

## Description

Adds `argument :billing_entity_ids, [ID], required: false` to `Resolvers::SubscriptionsResolver` and forwards it as `billing_entity_ids:` into `SubscriptionsQuery`. No query-side change is needed — `SubscriptionsQuery` already accepts the filter and applies it as a direct column predicate on `subscriptions.billing_entity_id`.

Backwards compatible: the argument is optional and existing callers see no change.

## How to test

GraphQL:

```graphql
query {
  subscriptions(billingEntityIds: ["<billing_entity_id>"]) {
    collection { id externalId billingEntity { code } }
    metadata { totalCount }
  }
}
```

Or with multiple ids:

```graphql
query {
  subscriptions(billingEntityIds: ["<id_eu>", "<id_us>"]) {
    collection { id }
    metadata { totalCount }
  }
}
```

Automated:

```
lago exec api bundle exec rspec spec/graphql/resolvers/subscriptions_resolver_spec.rb
```

Covers the single-id and multi-id cases alongside the existing resolver scenarios.
