### PR TITLE
[ING-217] misc(clickhouse): Add task to enable clickhouse events store

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -154,6 +154,9 @@ module BillableMetrics
       end
 
       def deduplicate?
+        override = Events::Stores::StoreFactory.override
+        return override[:deduplicate] if override
+
         organization = subscription&.organization
         return false unless organization
 

--- a/app/services/events/stores/store_factory.rb
+++ b/app/services/events/stores/store_factory.rb
@@ -3,13 +3,36 @@
 module Events
   module Stores
     class StoreFactory
+      OVERRIDE_KEY = :lago_event_store_override
+
       class << self
         def supports_clickhouse?
           ENV["LAGO_CLICKHOUSE_ENABLED"].present?
         end
+
+        # Temporarily override the resolved store class and deduplication flag
+        # for the duration of the given block. Used by tooling that needs to
+        # exercise a different event store without persisting state on the
+        # organization (e.g. the ClickHouse migration recipe).
+        def with_override(store_class:, deduplicate:)
+          raise "Events::Stores::StoreFactory override already active" if Thread.current[OVERRIDE_KEY]
+
+          Thread.current[OVERRIDE_KEY] = {store_class:, deduplicate:}
+          begin
+            yield
+          ensure
+            Thread.current[OVERRIDE_KEY] = nil
+          end
+        end
+
+        def override
+          Thread.current[OVERRIDE_KEY]
+        end
       end
 
       def self.store_class(organization:)
+        return override[:store_class] if override
+
         event_store = Events::Stores::PostgresStore
 
         if supports_clickhouse? && organization.clickhouse_events_store?

--- a/lib/tasks/recipes/clickhouse.rake
+++ b/lib/tasks/recipes/clickhouse.rake
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require_relative "../../task_prompt"
+
+namespace :recipes do
+  namespace :clickhouse do
+    desc "Check if an organization can be safely migrated to ClickHouse events store, and enable it if possible"
+    task enable_clickhouse_events_store: :environment do
+      Rails.logger.level = Logger::Severity::ERROR
+
+      usage_comparison_sample_window = 30.days
+
+      organization = TaskPrompt.ask_for_organization
+      abort "The organization is already using ClickHouse events store." if organization.clickhouse_events_store?
+
+      active_subscriptions_count = Subscription.active.where(organization_id: organization.id).count
+      puts "Organization has #{active_subscriptions_count} active subscription(s)."
+      sample_size_input = TaskPrompt.ask("Number of subscriptions to sample for usage comparison [default: 100]: ")
+      usage_comparison_sample_size = sample_size_input.empty? ? 100 : sample_size_input.to_i
+
+      puts "Step 1: Compare the number of events in Postgres and ClickHouse"
+      max_age = Time.current.beginning_of_hour
+
+      sub_ids = Event.where(organization_id: organization.id).select("DISTINCT(external_subscription_id)")
+      postgres_count = Event.with_discarded
+        .where(organization_id: organization.id)
+        .where(external_subscription_id: sub_ids)
+        .where(timestamp: ..max_age)
+        .count
+
+      deduped_events = Clickhouse::EventsEnriched
+        .where(organization_id: organization.id)
+        .where(timestamp: ..max_age)
+        .group(:transaction_id, :timestamp, :code, :external_subscription_id)
+        .select(:transaction_id, :timestamp, :code, :external_subscription_id)
+
+      clickhouse_count = Clickhouse::EventsEnriched
+        .with(deduped_events:)
+        .from("deduped_events")
+        .count
+
+      puts "Postgres count: #{postgres_count}, ClickHouse count: #{clickhouse_count}"
+      abort "The number of events in Postgres and ClickHouse does not match." unless postgres_count == clickhouse_count
+
+      puts "Step 2: Check for events with enrichment issues"
+      value_issues_count = Clickhouse::EventsEnriched.where(organization_id: organization.id)
+        .where(value: "<nil>")
+        .count
+      abort "There are #{value_issues_count} events with enrichment issues. Please fix them before proceeding." if value_issues_count > 0
+
+      puts "Step 3: Compare usage on Postgres vs ClickHouse for top #{usage_comparison_sample_size} subscriptions"
+      top_external_ids = Clickhouse::EventsEnriched
+        .where(organization_id: organization.id, timestamp: usage_comparison_sample_window.ago..)
+        .group(:external_subscription_id)
+        .order(Arel.sql("COUNT(*) DESC"))
+        .limit(usage_comparison_sample_size)
+        .count
+        .keys
+
+      sampled_subscriptions = top_external_ids.filter_map do |external_id|
+        Subscription.where(organization_id: organization.id, external_id:, status: :active).first
+      end
+
+      if sampled_subscriptions.empty?
+        puts "  No active subscriptions with recent events found, skipping usage comparison."
+      else
+        diffs = []
+
+        sampled_subscriptions.each do |subscription|
+          legacy_total, enriched_total, legacy_fees, enriched_fees =
+            compute_usage_totals(subscription)
+
+          if legacy_total != enriched_total && recent_events?(organization, subscription)
+            puts "  Subscription #{subscription.id}: detected events received in last minute, waiting before retry..."
+            Kernel.sleep 5
+            legacy_total, enriched_total, legacy_fees, enriched_fees =
+              compute_usage_totals(subscription)
+          end
+
+          status = (legacy_total == enriched_total) ? "OK" : "DIFF"
+          puts "  Subscription #{subscription.id}: PG=#{legacy_total} CH=#{enriched_total} [#{status}]"
+
+          if legacy_total != enriched_total
+            diffs << {subscription:, legacy_total:, enriched_total:, legacy_fees:, enriched_fees:}
+          end
+        end
+
+        if diffs.any?
+          puts ""
+          puts "Usage mismatch detected on #{diffs.size} subscription(s):"
+          diffs.each do |d|
+            puts "  - Subscription #{d[:subscription].id} (external_id=#{d[:subscription].external_id})"
+            puts "      PG total:  #{d[:legacy_total]} (#{d[:legacy_fees].size} fees)"
+            puts "      CH total:  #{d[:enriched_total]} (#{d[:enriched_fees].size} fees)"
+            puts "      Diff:      #{d[:legacy_total] - d[:enriched_total]}"
+          end
+          abort "Total amount mismatch detected. Investigate before enabling ClickHouse events store."
+        end
+      end
+
+      puts "Step 4: Enabling ClickHouse events store for the organization"
+      puts ""
+      puts "  /!\\ Before confirming, verify manually that the organization is NOT in the middle"
+      puts "      of an ingestion burst. Follow the 'Migrating' section of the runbook:"
+      puts "      https://www.notion.so/getlago/Migration-an-organization-from-Postgres-to-Clickhouse-2f8ef63110d28004bbdadda69c4b2630"
+      puts "      Confirming below acknowledges this check has been performed."
+      puts ""
+      TaskPrompt.confirm!("Do you want to proceed? (y/n): ")
+      organization.update!(clickhouse_events_store: true, clickhouse_deduplication_enabled: true)
+      ApiKeys::CacheService.expire_all_cache(organization)
+
+      puts "DONE."
+    end
+  end
+end
+
+def compute_usage_totals(subscription)
+  legacy_result = Invoices::CustomerUsageService.call(
+    customer: subscription.customer,
+    subscription:,
+    with_cache: true,
+    apply_taxes: false
+  )
+  legacy_fees = legacy_result.usage&.fees || []
+
+  enriched_result = Events::Stores::StoreFactory.with_override(
+    store_class: Events::Stores::ClickhouseStore,
+    deduplicate: true
+  ) do
+    Invoices::CustomerUsageService.call(
+      customer: subscription.customer,
+      subscription:,
+      with_cache: false,
+      apply_taxes: false
+    )
+  end
+  enriched_fees = enriched_result.usage&.fees || []
+
+  [legacy_fees.sum(&:amount_cents), enriched_fees.sum(&:amount_cents), legacy_fees, enriched_fees]
+end
+
+def recent_events?(organization, subscription)
+  Event
+    .where(organization_id: organization.id, external_subscription_id: subscription.external_id)
+    .where(timestamp: 1.minute.ago..)
+    .exists?
+end

--- a/spec/lib/tasks/recipes/clickhouse_rake_spec.rb
+++ b/spec/lib/tasks/recipes/clickhouse_rake_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "recipes:clickhouse:enable_clickhouse_events_store", clickhouse: true do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["recipes:clickhouse:enable_clickhouse_events_store"] }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, organization:) }
+  let(:timestamp) { Time.current.beginning_of_hour - 1.hour }
+
+  before do
+    Rake.application.rake_require("tasks/recipes/clickhouse")
+    Rake::Task.define_task(:environment)
+    task.reenable
+
+    ::Clickhouse::EventsEnriched.connection.execute("TRUNCATE TABLE events_enriched")
+  end
+
+  def stub_stdin(*responses)
+    allow($stdin).to receive(:gets).and_return(*responses.map { |r| "#{r}\n" })
+  end
+
+  def stub_usage(*amount_cents_per_call)
+    stub = allow(Invoices::CustomerUsageService).to receive(:call)
+    return if amount_cents_per_call.empty?
+
+    results = amount_cents_per_call.map do |cents|
+      fees = cents.nil? ? [] : [Fee.new(amount_cents: cents)]
+      BaseService::LegacyResult.new.tap { |r| r.usage = SubscriptionUsage.new(fees:) }
+    end
+    stub.and_return(*results)
+  end
+
+  context "when organization is not found" do
+    before { stub_stdin("00000000") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when organization already uses ClickHouse events store" do
+    let(:organization) { create(:organization, clickhouse_events_store: true) }
+
+    before { stub_stdin(organization.id, "y") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when Postgres and ClickHouse counts do not match" do
+    before do
+      create(:event,
+        organization_id: organization.id,
+        subscription:,
+        external_subscription_id: subscription.external_id,
+        timestamp:)
+
+      stub_stdin(organization.id, "y", "")
+    end
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+      expect(organization.reload.clickhouse_events_store).to be(false)
+    end
+  end
+
+  context "when ClickHouse has events with enrichment issues" do
+    before do
+      create(:event,
+        organization_id: organization.id,
+        subscription:,
+        external_subscription_id: subscription.external_id,
+        timestamp:)
+
+      create(:clickhouse_events_enriched,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        timestamp:,
+        value: "<nil>")
+
+      stub_stdin(organization.id, "y", "")
+    end
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+      expect(organization.reload.clickhouse_events_store).to be(false)
+    end
+  end
+
+  context "when counts match and no enrichment issues" do
+    before do
+      allow(ApiKeys::CacheService).to receive(:expire_all_cache)
+      stub_usage(1000, 1000)
+
+      create(:event,
+        organization_id: organization.id,
+        subscription:,
+        external_subscription_id: subscription.external_id,
+        timestamp:)
+
+      create(:clickhouse_events_enriched,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        timestamp:)
+    end
+
+    context "when user confirms" do
+      before { stub_stdin(organization.id, "y", "", "y") }
+
+      it "enables ClickHouse events store and expires the API key cache" do
+        task.invoke
+
+        organization.reload
+        expect(organization.clickhouse_events_store).to be(true)
+        expect(organization.clickhouse_deduplication_enabled).to be(true)
+        expect(ApiKeys::CacheService).to have_received(:expire_all_cache).with(organization)
+      end
+    end
+
+    context "when user declines the final confirmation" do
+      before { stub_stdin(organization.id, "y", "", "n") }
+
+      it "aborts without updating the organization" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(organization.reload.clickhouse_events_store).to be(false)
+      end
+    end
+  end
+
+  context "when ClickHouse has duplicate rows for the same logical event" do
+    let(:transaction_id) { "tr_#{SecureRandom.hex}" }
+    let(:code) { "event_code" }
+
+    before do
+      allow(ApiKeys::CacheService).to receive(:expire_all_cache)
+      stub_usage(1000, 1000)
+
+      create(:event,
+        organization_id: organization.id,
+        subscription:,
+        external_subscription_id: subscription.external_id,
+        transaction_id:,
+        code:,
+        timestamp:)
+
+      2.times do
+        create(:clickhouse_events_enriched,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          transaction_id:,
+          code:,
+          timestamp:)
+      end
+
+      stub_stdin(organization.id, "y", "", "y")
+    end
+
+    it "deduplicates ClickHouse rows and enables the store" do
+      task.invoke
+
+      expect(organization.reload.clickhouse_events_store).to be(true)
+    end
+  end
+
+  context "with usage comparison step" do
+    before do
+      allow(ApiKeys::CacheService).to receive(:expire_all_cache)
+
+      create(:event,
+        organization_id: organization.id,
+        subscription:,
+        external_subscription_id: subscription.external_id,
+        timestamp:)
+
+      create(:clickhouse_events_enriched,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        timestamp:)
+    end
+
+    context "when PG and CH usage totals diverge and no recent events were received" do
+      before do
+        stub_usage(1000, 1200)
+        stub_stdin(organization.id, "y", "")
+      end
+
+      it "aborts" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(organization.reload.clickhouse_events_store).to be(false)
+      end
+    end
+
+    context "when PG and CH usage totals diverge but events were received in the last minute" do
+      before do
+        create(:event,
+          organization_id: organization.id,
+          subscription:,
+          external_subscription_id: subscription.external_id,
+          timestamp: 10.seconds.ago)
+
+        allow(Kernel).to receive(:sleep) # rubocop:disable  RSpec/AnyInstance
+      end
+
+      context "when the retry resolves the difference" do
+        before do
+          stub_usage(1000, 1200, 1000, 1000)
+          stub_stdin(organization.id, "y", "", "y")
+        end
+
+        it "retries and proceeds to enable the store" do
+          task.invoke
+
+          expect(organization.reload.clickhouse_events_store).to be(true)
+          expect(Invoices::CustomerUsageService).to have_received(:call).exactly(4).times
+        end
+      end
+
+      context "when the retry still shows a difference" do
+        before do
+          stub_usage(1000, 1200, 1000, 1300)
+          stub_stdin(organization.id, "y", "")
+        end
+
+        it "aborts" do
+          expect { task.invoke }.to raise_error(SystemExit)
+          expect(organization.reload.clickhouse_events_store).to be(false)
+        end
+      end
+    end
+
+    context "when no active subscription matches the top external_ids" do
+      let(:subscription) { create(:subscription, :canceled, customer:, organization:) }
+
+      before do
+        stub_usage  # never called
+        stub_stdin(organization.id, "y", "", "y")
+      end
+
+      it "skips the comparison and proceeds" do
+        task.invoke
+
+        expect(organization.reload.clickhouse_events_store).to be(true)
+        expect(Invoices::CustomerUsageService).not_to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/store_factory_spec.rb
+++ b/spec/services/events/stores/store_factory_spec.rb
@@ -58,4 +58,34 @@ RSpec.describe Events::Stores::StoreFactory do
       end
     end
   end
+
+  describe ".with_override" do
+    it "forces the store class for the duration of the block" do
+      described_class.with_override(store_class: Events::Stores::ClickhouseStore, deduplicate: true) do
+        expect(described_class.store_class(organization:)).to eq(Events::Stores::ClickhouseStore)
+        expect(described_class.override).to eq(store_class: Events::Stores::ClickhouseStore, deduplicate: true)
+      end
+    end
+
+    it "clears the override after the block returns" do
+      described_class.with_override(store_class: Events::Stores::ClickhouseStore, deduplicate: true) {}
+      expect(described_class.override).to be_nil
+    end
+
+    it "clears the override when the block raises" do
+      expect {
+        described_class.with_override(store_class: Events::Stores::ClickhouseStore, deduplicate: true) { raise "boom" }
+      }.to raise_error("boom")
+      expect(described_class.override).to be_nil
+    end
+
+    it "raises when nested" do
+      described_class.with_override(store_class: Events::Stores::ClickhouseStore, deduplicate: true) do
+        expect {
+          described_class.with_override(store_class: Events::Stores::PostgresStore, deduplicate: false) {}
+        }.to raise_error("Events::Stores::StoreFactory override already active")
+        expect(described_class.override).to eq(store_class: Events::Stores::ClickhouseStore, deduplicate: true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Today, migrating an organization from the Postgres event store to the Clickhouse one is a manual process that requires few steps to check if an organization can be safely migrated.

The check includes:
- The event count comparison
- The correct enrichment of all events
- The correct current usage for the top 5 subscriptions (by number of received events on the last 30 days)

## Description

This PR automates the checks and enables the clickhouse events store wtith the deduplication turned on.