### PR TITLE
[ING-225] refactor(subscriptions): share billing entity resolver

### DIFF
--- a/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
+++ b/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
@@ -7,17 +7,14 @@ module Subscriptions
 
       private
 
-      def resolve_billing_entity(customer:, params:)
-        return unless customer.organization.feature_flag_enabled?(:multi_entity_billing)
+      def resolve_billing_entity(organization:, params:)
+        return unless organization.feature_flag_enabled?(:multi_entity_billing)
 
-        attrs = if params[:billing_entity_id].present?
-          {id: params[:billing_entity_id]}
+        if params[:billing_entity_id].present?
+          organization.billing_entities.find(params[:billing_entity_id])
         elsif params[:billing_entity_code].present?
-          {code: params[:billing_entity_code]}
+          organization.billing_entities.find_by!(code: params[:billing_entity_code])
         end
-        return unless attrs
-
-        customer.organization.billing_entities.find_by!(attrs)
       rescue ActiveRecord::RecordNotFound
         result.not_found_failure!(resource: "billing_entity").raise_if_error!
       end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -133,7 +133,7 @@ module Subscriptions
         ending_at: params[:ending_at],
         progressive_billing_disabled: params[:progressive_billing_disabled] || false,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : true,
-        billing_entity: resolve_billing_entity(customer:, params:)
+        billing_entity: resolve_billing_entity(organization: customer.organization, params:)
       )
 
       if params.key?(:payment_method)

--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -45,7 +45,7 @@ module Subscriptions
         )
 
         if params[:billing_entity_id].present? || params[:billing_entity_code].present?
-          override_entity = resolve_billing_entity(customer:, params:)
+          override_entity = resolve_billing_entity(organization: current_subscription.organization, params:)
           new_sub.update!(billing_entity: override_entity) if override_entity
         end
 
@@ -77,7 +77,7 @@ module Subscriptions
       current_subscription.plan = plan
       current_subscription.name = name if name.present?
       if params[:billing_entity_id].present? || params[:billing_entity_code].present?
-        override_entity = resolve_billing_entity(customer:, params:)
+        override_entity = resolve_billing_entity(organization: current_subscription.organization, params:)
         current_subscription.billing_entity = override_entity if override_entity
       end
       current_subscription.save!

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -65,7 +65,7 @@ module Subscriptions
     attr_reader :current_subscription, :plan, :params, :name
 
     def new_subscription_with_overrides
-      resolved_entity = resolve_billing_entity(customer: current_subscription.customer, params:)
+      resolved_entity = resolve_billing_entity(organization: current_subscription.organization, params:)
       new_subscription = Subscription.new(
         organization_id: current_subscription.customer.organization_id,
         customer: current_subscription.customer,

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -2,6 +2,8 @@
 
 module Subscriptions
   class UpdateService < BaseService
+    include Subscriptions::Concerns::BillingEntityResolutionConcern
+
     Result = BaseResult[:subscription, :payment_method]
 
     def initialize(subscription:, params:)
@@ -66,7 +68,7 @@ module Subscriptions
         end
 
         if params.key?(:billing_entity_id) || params.key?(:billing_entity_code)
-          new_billing_entity = resolve_billing_entity
+          new_billing_entity = resolve_billing_entity(organization: subscription.organization, params:)
           subscription.billing_entity = new_billing_entity if new_billing_entity
         end
 
@@ -154,18 +156,6 @@ module Subscriptions
           Invoices::CreatePayInAdvanceFixedChargesJob.perform_after_commit(subscription, subscription.started_at + 1.second)
         end
       end
-    end
-
-    def resolve_billing_entity
-      return nil unless subscription.organization.feature_flag_enabled?(:multi_entity_billing)
-
-      if params[:billing_entity_id].present?
-        subscription.organization.billing_entities.find(params[:billing_entity_id])
-      elsif params[:billing_entity_code].present?
-        subscription.organization.billing_entities.find_by!(code: params[:billing_entity_code])
-      end
-    rescue ActiveRecord::RecordNotFound
-      result.not_found_failure!(resource: "billing_entity").raise_if_error!
     end
 
     def handle_plan_override


### PR DESCRIPTION
## Context

Four subscription services were resolving `billing_entity` from params. Three of them (`CreateService`, `PlanUpgradeService`, `PlanDowngradeService`) shared a concern; `UpdateService` had its own private copy with a cleaner shape that came out of [ING-41's review feedback](https://github.com/getlago/lago-api/pull/5498).

This PR consolidates the four onto one definition and ports it to the cleaner shape, picking up a thread from a [heads-up comment on ING-119](https://linear.app/getlago/issue/ING-119#comment-3a26277c) that didn't make it into #5503's scope.

## Description

- The shared concern now takes `organization:` instead of `customer:`: that's all it ever actually used.
- The body uses direct `find(id)` / `find_by!(code:)` per branch instead of building an `attrs` hash, matching what ING-41's review preferred.
- `UpdateService` includes the concern; its private `resolve_billing_entity` is gone.
- All four callers now go through the same definition.

Behaviour-preserving refactor: same `multi_entity_billing` feature flag, same precedence (`billing_entity_id` over `billing_entity_code`), same `not_found_failure!` on unknown values.

Out of scope: `Invoices::CreateOneOffService#resolve_billing_entity` (different module, different signature, not a subscription caller).

## Resolver contract

| flag | `params[:billing_entity_id]` | `params[:billing_entity_code]` | Result |
| --- | --- | --- | --- |
| off | any | any | `nil` |
| on | present | any | entity from `find(id)`, or `not_found_failure!` if unknown |
| on | blank | present | entity from `find_by!(code:)`, or `not_found_failure!` if unknown |
| on | blank | blank | `nil` |

Identical to the pre-PR behaviour. Every caller guards against `nil` before assigning, so the "no params → keep current binding" path stays a no-op.

## How to try locally

```sh
git checkout ing-225

lago exec api bundle exec rspec \
  spec/services/subscriptions/{create,plan_upgrade,plan_downgrade,update}_service_spec.rb \
  spec/graphql/mutations/subscriptions/update_spec.rb \
  -e billing_entity
```

All 45 billing-entity examples should pass.

Closes ING-225. Follow-up to ING-119 / ING-41.