### PR TITLE
[ING-228] fix(subs): match inherited entity

### DIFF
--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -100,7 +100,12 @@ class SubscriptionsQuery < BaseQuery
   end
 
   def with_billing_entity_ids(scope)
-    scope.where(billing_entity_id: filters.billing_entity_ids)
+    scope.joins(:customer).where(
+      "subscriptions.billing_entity_id IN (?) OR " \
+      "(subscriptions.billing_entity_id IS NULL AND customers.billing_entity_id IN (?))",
+      filters.billing_entity_ids,
+      filters.billing_entity_ids
+    )
   end
 
   def with_excluded_next_subscriptions(scope)

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -355,6 +355,39 @@ RSpec.describe SubscriptionsQuery do
         expect(result.subscriptions).to match_array([eu_subscription, us_subscription])
       end
     end
+
+    context "when a subscription has NULL billing_entity_id inherits from customer" do
+      let(:us_customer) { create(:customer, organization:, billing_entity: us_entity) }
+      let(:eu_customer) { create(:customer, organization:, billing_entity: eu_entity) }
+
+      let!(:inherits_eu) { create(:subscription, customer: eu_customer, plan:, billing_entity: nil) }
+      let!(:inherits_us) { create(:subscription, customer: us_customer, plan:, billing_entity: nil) }
+      let!(:explicit_us_inherit_eu) do
+        create(:subscription, customer: eu_customer, plan:, billing_entity: us_entity)
+      end
+      let!(:explicit_eu_inherit_eu) do
+        create(:subscription, customer: eu_customer, plan:, billing_entity: eu_entity)
+      end
+
+      context "when filtering for the EU entity" do
+        let(:filters) { {billing_entity_ids: [eu_entity.id]} }
+
+        it "returns explicit and inherited matches, excludes mismatched explicit and inherited" do
+          expect(result).to be_success
+          expect(result.subscriptions).to match_array([
+            eu_subscription,
+            inherits_eu,
+            explicit_eu_inherit_eu
+          ])
+          expect(returned_ids).not_to include(inherits_us.id)
+          expect(returned_ids).not_to include(explicit_us_inherit_eu.id)
+        end
+
+        it "does not duplicate subscriptions whose explicit and inherited values both match" do
+          expect(returned_ids.count(explicit_eu_inherit_eu.id)).to eq(1)
+        end
+      end
+    end
   end
 
   context "with currency filter" do


### PR DESCRIPTION
## Context

ING-90 added a `billing_entity_ids` filter to the GraphQL `subscriptions` resolver and to `SubscriptionsQuery`, but the query predicate only matched subscriptions with an explicit `billing_entity_id` value:

```ruby
def with_billing_entity_ids(scope)
  scope.where(billing_entity_id: filters.billing_entity_ids)
end
```

Per the multi-entity dive-in (§Decision 5.6), a `NULL` `subscriptions.billing_entity_id` is the canonical way to say "this subscription inherits its customer's default entity at billing time." Those subscriptions were operationally affiliated with their customer's entity but were silently excluded by the filter.

**Symptom (frontend):** Filtering the subscriptions list by "Acme US" hid every subscription that inherited "Acme US" from its customer. Operators reported the filter as broken.

## The fix

`with_billing_entity_ids` now joins `customers` and matches either the explicit FK or, when it's `NULL`, the customer's default:

```ruby
def with_billing_entity_ids(scope)
  scope.joins(:customer).where(
    "subscriptions.billing_entity_id IN (?) OR " \
    "(subscriptions.billing_entity_id IS NULL AND customers.billing_entity_id IN (?))",
    filters.billing_entity_ids,
    filters.billing_entity_ids
  )
end
```

### Why not `COALESCE`?

`COALESCE(subscriptions.billing_entity_id, customers.billing_entity_id) IN (?)` is cleaner to read but not sargable — Postgres can't use the existing index on `subscriptions(billing_entity_id)` when the column is wrapped in a function, so it falls back to a sequential scan. The hand-written `OR` form lets the planner use the index for the explicit branch and a bitmap + join for the inherit branch.

A partial index on the inherit branch (`ON subscriptions(customer_id) WHERE billing_entity_id IS NULL`) is suggested in the ticket as a future migration if production telemetry shows the OR branch is slow at ≥1M subscriptions. Not included here.

## Acceptance criteria (all covered by tests)

For a filter value `[X]`:

- Sub with `billing_entity_id = X` explicit → returned ✅
- Sub with `billing_entity_id = NULL`, customer's default = X → returned (inherits to X) ✅
- Sub with `billing_entity_id = NULL`, customer's default = Y ≠ X → NOT returned ✅
- Sub with `billing_entity_id = Y` explicit, customer's default = X → NOT returned (explicit wins) ✅
- Sub with `billing_entity_id = X` explicit, customer's default = X → returned once (no OR-duplicate) ✅

## Frontend impact

ING-91 already wires `billingEntityIds` to the GraphQL resolver, so once this ships the FE filter starts behaving correctly with no further work.

## How to test

```
lago exec api bundle exec rspec \
  spec/queries/subscriptions_query_spec.rb \
  spec/graphql/resolvers/subscriptions_resolver_spec.rb \
  spec/requests/api/v1/subscriptions_controller_spec.rb \
  spec/requests/api/v1/customers/subscriptions_controller_spec.rb
```

All 186 examples pass.

## Related

- ING-90 — original GraphQL resolver wiring that introduced the limitation
- ING-91 — frontend filter (already shipped)
