### PR TITLE
chore(console): add check_stripe_payment helper

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -130,6 +130,35 @@ Rails.application.console do
     inv.file&.destroy
   end
 
+  def check_stripe_payment(invoice_id)
+    invoice = Invoice.with_discarded.find(invoice_id)
+    payments = invoice.payments.includes(:payment_provider).order(:created_at)
+
+    puts "Invoice #{invoice.id}  total=#{invoice.total_amount_cents} due=#{invoice.total_due_amount_cents} #{invoice.currency}"
+    puts ""
+
+    payments.each do |payment|
+      puts "Lago Payment #{payment.id}: #{payment.amount_cents} #{payment.amount_currency} status=#{payment.status} payable_status=#{payment.payable_payment_status || '-'} pi=#{payment.provider_payment_id || '-'}"
+
+      next unless payment.payment_provider.is_a?(PaymentProviders::StripeProvider) && payment.provider_payment_id.present?
+
+      pi = ::Stripe::PaymentIntent.retrieve(
+        payment.provider_payment_id,
+        {api_key: payment.payment_provider.secret_key}
+      )
+      puts "Stripe PI #{pi.id}: #{pi.amount} #{pi.currency} status=#{pi.status}"
+      if pi.last_payment_error
+        puts "  last_payment_error: #{pi.last_payment_error.code} #{pi.last_payment_error.message}"
+      end
+      puts ""
+    rescue ::Stripe::StripeError => e
+      puts "  ! Stripe fetch failed: #{e.class} #{e.message}"
+      puts ""
+    end
+
+    invoice
+  end
+
   def find_dead_jobs_by_job_name_and_error(job_name, error_class)
     ds = Sidekiq::DeadSet.new
 

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -138,7 +138,7 @@ Rails.application.console do
     puts ""
 
     payments.each do |payment|
-      puts "Lago Payment #{payment.id}: #{payment.amount_cents} #{payment.amount_currency} status=#{payment.status} payable_status=#{payment.payable_payment_status || '-'} pi=#{payment.provider_payment_id || '-'}"
+      puts "Lago Payment #{payment.id}: #{payment.amount_cents} #{payment.amount_currency} status=#{payment.status} payable_status=#{payment.payable_payment_status || "-"} pi=#{payment.provider_payment_id || "-"}"
 
       next unless payment.payment_provider.is_a?(PaymentProviders::StripeProvider) && payment.provider_payment_id.present?
 


### PR DESCRIPTION
## Context

When a Lago customer reports an issue with a Stripe-backed invoice, we can't look at their Stripe dashboard — the connected account belongs to them, not to us. The only way to compare what Lago recorded against what Stripe actually sees is to retrieve the PaymentIntent through the API using the organization's stored secret key. Doing that by hand for every payment on an invoice is slow, especially when there are multiple attempts.

## Description

Adds a `check_stripe_payment(invoice_id)` console helper that prints, for a given invoice, every Lago payment alongside the current state of its Stripe PaymentIntent — amount, currency, status, and `last_payment_error` when set.

- Loads the invoice with `with_discarded` so soft-deleted invoices can still be inspected.
- Shows both `status` and `payable_payment_status` on each Lago payment, since they can diverge.
- Skips non-Stripe payments and payments without a `provider_payment_id`.
- Rescues `Stripe::StripeError` per payment so one failed lookup doesn't abort the whole report.

Console-only helper; no runtime behavior change.