### PR TITLE
fix(past-usage): Add customer_usage key to past_usage serializer response

### DIFF
--- a/app/serializers/v1/customers/past_usage_serializer.rb
+++ b/app/serializers/v1/customers/past_usage_serializer.rb
@@ -16,7 +16,7 @@ module V1
         }
 
         payload.merge!(charges_usage) if include?(:charges_usage)
-        payload
+        {customer_usage: payload}
       end
 
       private

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -954,7 +954,7 @@ RSpec.describe Api::V1::Customers::UsageController do
 
       expect(json[:usage_periods].count).to eq(1)
 
-      usage = json[:usage_periods].first
+      usage = json[:usage_periods].first[:customer_usage]
       expect(usage[:from_datetime]).to eq(invoice_subscription.charges_from_datetime.iso8601)
       expect(usage[:to_datetime]).to eq(invoice_subscription.charges_to_datetime.iso8601)
       expect(usage[:issuing_date]).to eq(invoice.issuing_date.iso8601)

--- a/spec/serializers/v1/customers/past_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/past_usage_serializer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ::V1::Customers::PastUsageSerializer do
   it "serializes the past usage" do
     result = JSON.parse(serializer.to_json)
 
-    expect(result["usage_period"]).to include(
+    expect(result["usage_period"]["customer_usage"]).to include(
       "from_datetime" => "2023-08-17T00:00:00Z",
       "to_datetime" => "2023-09-16T23:59:59Z",
       "issuing_date" => invoice.issuing_date.iso8601,
@@ -46,8 +46,8 @@ RSpec.describe ::V1::Customers::PastUsageSerializer do
       "lago_invoice_id" => invoice.id
     )
 
-    expect(result["usage_period"]["charges_usage"].count).to eq(2)
-    expect(result["usage_period"]["charges_usage"].first["presentation_breakdowns"]).to eq([{"presentation_by" => {"department" => "engineering"}, "units" => "60.0"}])
-    expect(result["usage_period"]["charges_usage"].second["presentation_breakdowns"]).to eq([])
+    expect(result["usage_period"]["customer_usage"]["charges_usage"].count).to eq(2)
+    expect(result["usage_period"]["customer_usage"]["charges_usage"].first["presentation_breakdowns"]).to eq([{"presentation_by" => {"department" => "engineering"}, "units" => "60.0"}])
+    expect(result["usage_period"]["customer_usage"]["charges_usage"].second["presentation_breakdowns"]).to eq([])
   end
 end


### PR DESCRIPTION
## Context

The response shape for the past_usage endpoint does not match our [current API spec](https://getlago.com/docs/api-reference/customer-usage/get-past).


## Description

Add customer_usage key to past_usage serializer response so it will match our API spec.
