### PR TITLE
feat (quotes): Add new `currency`, `start_date` and `end_date` fields

### DIFF
--- a/app/graphql/types/quote_versions/object.rb
+++ b/app/graphql/types/quote_versions/object.rb
@@ -9,10 +9,13 @@ module Types
       field :billing_items, GraphQL::Types::JSON, null: true
       field :content, String, null: true
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :currency, String, null: true
+      field :end_date, GraphQL::Types::ISO8601Date, null: true
       field :id, ID, null: false
       field :organization, Types::Organizations::OrganizationType, null: false
       field :quote, Types::Quotes::Object, null: false
       field :share_token, String, null: true
+      field :start_date, GraphQL::Types::ISO8601Date, null: true
       field :status, Types::QuoteVersions::StatusEnum, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       field :version, Integer, null: false

--- a/app/graphql/types/quote_versions/update_input.rb
+++ b/app/graphql/types/quote_versions/update_input.rb
@@ -7,7 +7,10 @@ module Types
 
       argument :billing_items, GraphQL::Types::JSON, required: false
       argument :content, String, required: false
+      argument :currency, String, required: false
+      argument :end_date, GraphQL::Types::ISO8601Date, required: false
       argument :id, ID, required: true
+      argument :start_date, GraphQL::Types::ISO8601Date, required: false
     end
   end
 end

--- a/app/graphql/types/quotes/create_input.rb
+++ b/app/graphql/types/quotes/create_input.rb
@@ -7,9 +7,12 @@ module Types
 
       argument :billing_items, GraphQL::Types::JSON, required: false
       argument :content, String, required: false
+      argument :currency, String, required: false
       argument :customer_id, ID, required: true
+      argument :end_date, GraphQL::Types::ISO8601Date, required: false
       argument :order_type, Types::Quotes::OrderTypeEnum, required: true
       argument :owners, [ID], required: false
+      argument :start_date, GraphQL::Types::ISO8601Date, required: false
       argument :subscription_id, ID, required: false
     end
   end

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -66,7 +66,10 @@ end
 #  approved_at     :datetime
 #  billing_items   :jsonb
 #  content         :text
+#  currency        :string
+#  end_date        :date
 #  share_token     :string
+#  start_date      :date
 #  status          :enum             default("draft"), not null
 #  void_reason     :enum
 #  voided_at       :datetime

--- a/app/services/quote_versions/create_service.rb
+++ b/app/services/quote_versions/create_service.rb
@@ -21,7 +21,13 @@ module QuoteVersions
 
       quote_version = quote.versions.create!(
         organization: quote.organization,
-        **params.slice(:billing_items, :content)
+        **params.slice(
+          :billing_items,
+          :content,
+          :currency,
+          :start_date,
+          :end_date
+        )
       )
 
       result.quote_version = quote_version

--- a/app/services/quote_versions/update_service.rb
+++ b/app/services/quote_versions/update_service.rb
@@ -19,7 +19,15 @@ module QuoteVersions
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.not_allowed_failure!(code: "inappropriate_state") unless editable?
 
-      quote_version.update!(params.slice(:billing_items, :content))
+      quote_version.update!(
+        params.slice(
+          :billing_items,
+          :content,
+          :currency,
+          :start_date,
+          :end_date
+        )
+      )
       result.quote_version = quote_version
 
       # TODO: SendWebhookJob.perform_after_commit("quote_version.updated", quote_version)

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -64,7 +64,13 @@ module Quotes
     def initialize_version!(quote:)
       QuoteVersions::CreateService.call!(
         quote: quote,
-        params: params.slice(:billing_items, :content)
+        params: params.slice(
+          :billing_items,
+          :content,
+          :currency,
+          :start_date,
+          :end_date
+        )
       )
     end
 

--- a/db/migrate/20260525102114_add_currency_and_subscription_dates_to_quote_versions.rb
+++ b/db/migrate/20260525102114_add_currency_and_subscription_dates_to_quote_versions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCurrencyAndSubscriptionDatesToQuoteVersions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :quote_versions, :currency, :string
+    add_column :quote_versions, :start_date, :date
+    add_column :quote_versions, :end_date, :date
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4818,6 +4818,9 @@ CREATE TABLE public.quote_versions (
     share_token character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    currency character varying,
+    start_date date,
+    end_date date,
     CONSTRAINT quote_versions_constraint_approved_at_matches_status CHECK (((status = 'approved'::public.quote_status) = (approved_at IS NOT NULL))),
     CONSTRAINT quote_versions_constraint_sequential_id_positive CHECK ((sequential_id > 0)),
     CONSTRAINT quote_versions_constraint_void_fields_match_status CHECK (((status = 'voided'::public.quote_status) = ((void_reason IS NOT NULL) AND (voided_at IS NOT NULL))))
@@ -12215,6 +12218,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260525102114'),
 ('20260520075420'),
 ('20260517101105'),
 ('20260513181544'),
@@ -13219,3 +13223,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/schema.graphql
+++ b/schema.graphql
@@ -3269,9 +3269,12 @@ input CreateQuoteInput {
   """
   clientMutationId: String
   content: String
+  currency: String
   customerId: ID!
+  endDate: ISO8601Date
   orderType: OrderTypeEnum!
   owners: [ID!]
+  startDate: ISO8601Date
   subscriptionId: ID
 }
 
@@ -10818,10 +10821,13 @@ type QuoteVersion {
   billingItems: JSON
   content: String
   createdAt: ISO8601DateTime!
+  currency: String
+  endDate: ISO8601Date
   id: ID!
   organization: Organization!
   quote: Quote!
   shareToken: String
+  startDate: ISO8601Date
   status: StatusEnum!
   updatedAt: ISO8601DateTime!
   version: Int!
@@ -13138,7 +13144,10 @@ input UpdateQuoteVersionInput {
   """
   clientMutationId: String
   content: String
+  currency: String
+  endDate: ISO8601Date
   id: ID!
+  startDate: ISO8601Date
 }
 
 input UpdateRecurringTransactionRuleInput {

--- a/schema.json
+++ b/schema.json
@@ -14874,6 +14874,18 @@
               "deprecationReason": null
             },
             {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "customerId",
               "description": null,
               "type": {
@@ -14884,6 +14896,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -14920,6 +14944,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -58470,6 +58506,30 @@
               "deprecationReason": null
             },
             {
+              "name": "currency",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [],
@@ -58524,6 +58584,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -69511,6 +69583,30 @@
               "deprecationReason": null
             },
             {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -69521,6 +69617,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/resolvers/quote_resolver_spec.rb
+++ b/spec/graphql/resolvers/quote_resolver_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Resolvers::QuoteResolver do
           subscription { id }
           number
           orderType
-          currentVersion { id version status billingItems content }
+          currentVersion { id version status billingItems content currency startDate endDate }
           versions { id version status }
           createdAt
           updatedAt
@@ -71,6 +71,9 @@ RSpec.describe Resolvers::QuoteResolver do
       expect(response.dig("currentVersion", "content")).to eq(quote.current_version.content)
       expect(response.dig("currentVersion", "status")).to eq(quote.current_version.status)
       expect(response.dig("currentVersion", "version")).to eq(quote.current_version.version)
+      expect(response.dig("currentVersion", "currency")).to eq(quote.current_version.currency)
+      expect(response.dig("currentVersion", "startDate")).to eq(quote.current_version.start_date&.iso8601)
+      expect(response.dig("currentVersion", "endDate")).to eq(quote.current_version.end_date&.iso8601)
       expect(response.dig("versions")).to match_array(
         [
           {

--- a/spec/graphql/types/quote_versions/object_spec.rb
+++ b/spec/graphql/types/quote_versions/object_spec.rb
@@ -19,5 +19,8 @@ RSpec.describe Types::QuoteVersions::Object do
     expect(subject).to have_field(:voided_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:currency).of_type("String")
+    expect(subject).to have_field(:start_date).of_type("ISO8601Date")
+    expect(subject).to have_field(:end_date).of_type("ISO8601Date")
   end
 end

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -11,8 +11,16 @@ RSpec.describe QuoteVersions::CreateService do
   let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:create_params) do
-    {billing_items: {}, content: "Test content"}
+    {
+      billing_items: {},
+      content: "Test content",
+      currency: "USD",
+      start_date:,
+      end_date:
+    }
   end
+  let(:start_date) { Date.new(2025, 2, 11) }
+  let(:end_date) { Date.new(2025, 3, 12) }
 
   describe ".call" do
     let(:result) { create_service.call }
@@ -27,6 +35,9 @@ RSpec.describe QuoteVersions::CreateService do
         expect(result.quote_version.content).to eq("Test content")
         expect(result.quote_version.share_token).not_to be_nil
         expect(result.quote_version.billing_items).to eq({})
+        expect(result.quote_version.currency).to eq("USD")
+        expect(result.quote_version.start_date).to eq(start_date)
+        expect(result.quote_version.end_date).to eq(end_date)
       end
     end
 

--- a/spec/services/quote_versions/update_service_spec.rb
+++ b/spec/services/quote_versions/update_service_spec.rb
@@ -11,9 +11,14 @@ RSpec.describe QuoteVersions::UpdateService do
   let(:update_params) {
     {
       billing_items: {},
-      content: "Test content"
+      content: "Test content",
+      currency: "USD",
+      start_date:,
+      end_date:
     }
   }
+  let(:start_date) { Date.new(2025, 2, 11) }
+  let(:end_date) { Date.new(2025, 3, 12) }
 
   describe ".call" do
     let(:result) { update_service.call }
@@ -28,6 +33,9 @@ RSpec.describe QuoteVersions::UpdateService do
         expect(result.quote_version.draft?).to eq(true)
         expect(result.quote_version.billing_items).to eq({})
         expect(result.quote_version.content).to eq("Test content")
+        expect(result.quote_version.currency).to eq("USD")
+        expect(result.quote_version.start_date).to eq(start_date)
+        expect(result.quote_version.end_date).to eq(end_date)
       end
     end
 

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -22,9 +22,14 @@ RSpec.describe Quotes::CreateService do
       billing_items: {},
       content: "Test content",
       order_type: :subscription_creation,
-      owners: [owner.id]
+      owners: [owner.id],
+      currency: "USD",
+      start_date:,
+      end_date:
     }
   end
+  let(:start_date) { Date.new(2025, 2, 11) }
+  let(:end_date) { Date.new(2025, 3, 12) }
 
   describe ".call" do
     let(:result) { create_service.call }
@@ -44,6 +49,10 @@ RSpec.describe Quotes::CreateService do
           expect(result.quote.current_version.version).to eq(1)
           expect(result.quote.current_version.draft?).to eq(true)
           expect(result.quote.current_version.content).to eq("Test content")
+          expect(result.quote.current_version.billing_items).to eq({})
+          expect(result.quote.current_version.currency).to eq("USD")
+          expect(result.quote.current_version.start_date).to eq(start_date)
+          expect(result.quote.current_version.end_date).to eq(end_date)
         end
       end
     end


### PR DESCRIPTION
Following the recent spec changes, this PR adds the following three fields to the Quote:

* `currency`
* `start_date`
* `end_date`

and exposes them via GraphQL.