### PR TITLE
feat(payment-gated-subs): add polymorphic refundable to refunds

### DIFF
--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -18,15 +18,18 @@ end
 #  id                           :uuid             not null, primary key
 #  amount_cents                 :bigint           default(0), not null
 #  amount_currency              :string           not null
+#  reason                       :string
+#  refundable_type              :string
 #  status                       :string           not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
-#  credit_note_id               :uuid             not null
+#  credit_note_id               :uuid
 #  organization_id              :uuid             not null
 #  payment_id                   :uuid             not null
 #  payment_provider_customer_id :uuid             not null
 #  payment_provider_id          :uuid
 #  provider_refund_id           :string           not null
+#  refundable_id                :uuid
 #
 # Indexes
 #
@@ -35,6 +38,7 @@ end
 #  index_refunds_on_payment_id                    (payment_id)
 #  index_refunds_on_payment_provider_customer_id  (payment_provider_customer_id)
 #  index_refunds_on_payment_provider_id           (payment_provider_id)
+#  index_refunds_on_refundable                    (refundable_type,refundable_id)
 #
 # Foreign Keys
 #

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -317,34 +317,34 @@ end
 # Table name: subscriptions
 # Database name: primary
 #
-#  id                            :uuid             not null, primary key
-#  activated_at                  :datetime
-#  billing_time                  :integer          default("calendar"), not null
-#  cancelation_reason            :enum
-#  canceled_at                   :datetime
-#  consolidate_invoice           :boolean          default(TRUE), not null
-#  ending_at                     :datetime
-#  last_received_event_on        :date
-#  name                          :string
-#  on_termination_credit_note    :enum
-#  on_termination_invoice        :enum             default("generate"), not null
-#  payment_method_type           :enum             default("provider"), not null
-#  progressive_billing_disabled  :boolean          default(FALSE), not null
-#  skip_invoice_custom_sections  :boolean          default(FALSE), not null
-#  started_at                    :datetime
-#  status                        :integer          not null
-#  subscription_at               :datetime
-#  terminated_at                 :datetime
-#  trial_ended_at                :datetime
-#  created_at                    :datetime         not null
-#  updated_at                    :datetime         not null
-#  billing_entity_id             :uuid
-#  customer_id                   :uuid             not null
-#  external_id                   :string           not null
-#  organization_id               :uuid             not null
-#  payment_method_id             :uuid
-#  plan_id                       :uuid             not null
-#  previous_subscription_id      :uuid
+#  id                           :uuid             not null, primary key
+#  activated_at                 :datetime
+#  billing_time                 :integer          default("calendar"), not null
+#  cancelation_reason           :enum
+#  canceled_at                  :datetime
+#  consolidate_invoice          :boolean          default(TRUE), not null
+#  ending_at                    :datetime
+#  last_received_event_on       :date
+#  name                         :string
+#  on_termination_credit_note   :enum
+#  on_termination_invoice       :enum             default("generate"), not null
+#  payment_method_type          :enum             default("provider"), not null
+#  progressive_billing_disabled :boolean          default(FALSE), not null
+#  skip_invoice_custom_sections :boolean          default(FALSE), not null
+#  started_at                   :datetime
+#  status                       :integer          not null
+#  subscription_at              :datetime
+#  terminated_at                :datetime
+#  trial_ended_at               :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  billing_entity_id            :uuid
+#  customer_id                  :uuid             not null
+#  external_id                  :string           not null
+#  organization_id              :uuid             not null
+#  payment_method_id            :uuid
+#  plan_id                      :uuid             not null
+#  previous_subscription_id     :uuid
 #
 # Indexes
 #

--- a/db/migrate/20260526131452_add_polymorphic_refundable_to_refunds.rb
+++ b/db/migrate/20260526131452_add_polymorphic_refundable_to_refunds.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddPolymorphicRefundableToRefunds < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :refunds, :refundable, type: :uuid, polymorphic: true, index: {algorithm: :concurrently}
+
+    safety_assured do
+      change_column_null :refunds, :credit_note_id, true
+    end
+
+    add_column :refunds, :reason, :string
+  end
+end

--- a/db/migrate/20260526131452_add_polymorphic_refundable_to_refunds.rb
+++ b/db/migrate/20260526131452_add_polymorphic_refundable_to_refunds.rb
@@ -6,10 +6,13 @@ class AddPolymorphicRefundableToRefunds < ActiveRecord::Migration[8.0]
   def change
     add_reference :refunds, :refundable, type: :uuid, polymorphic: true, index: {algorithm: :concurrently}
 
+    add_column :refunds, :reason, :string
+
+    # Last in forward = first in reverse. If any row has credit_note_id
+    # NULL (M4 activation refunds), rollback aborts here before any other
+    # column is dropped, leaving the schema intact.
     safety_assured do
       change_column_null :refunds, :credit_note_id, true
     end
-
-    add_column :refunds, :reason, :string
   end
 end

--- a/db/migrate/20260601120428_add_credit_note_or_refundable_check_constraint_to_refunds.rb
+++ b/db/migrate/20260601120428_add_credit_note_or_refundable_check_constraint_to_refunds.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddCreditNoteOrRefundableCheckConstraintToRefunds < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :refunds,
+      "credit_note_id IS NOT NULL OR (refundable_type IS NOT NULL AND refundable_id IS NOT NULL)",
+      name: "refunds_credit_note_or_refundable_present",
+      validate: false
+  end
+end

--- a/db/migrate/20260601120429_validate_credit_note_or_refundable_check_constraint_on_refunds.rb
+++ b/db/migrate/20260601120429_validate_credit_note_or_refundable_check_constraint_on_refunds.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCreditNoteOrRefundableCheckConstraintOnRefunds < ActiveRecord::Migration[8.0]
+  def change
+    validate_check_constraint :refunds, name: "refunds_credit_note_or_refundable_present"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4972,7 +4972,8 @@ CREATE TABLE public.refunds (
     organization_id uuid NOT NULL,
     refundable_type character varying,
     refundable_id uuid,
-    reason character varying
+    reason character varying,
+    CONSTRAINT refunds_credit_note_or_refundable_present CHECK (((credit_note_id IS NOT NULL) OR ((refundable_type IS NOT NULL) AND (refundable_id IS NOT NULL))))
 );
 
 
@@ -12387,6 +12388,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260601120429'),
+('20260601120428'),
 ('20260526131452'),
 ('20260525102114'),
 ('20260520075420'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -414,6 +414,7 @@ DROP INDEX IF EXISTS public.index_rtr_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_roles_on_organization_id;
 DROP INDEX IF EXISTS public.index_roles_by_unique_admin;
 DROP INDEX IF EXISTS public.index_roles_by_code_per_organization;
+DROP INDEX IF EXISTS public.index_refunds_on_refundable;
 DROP INDEX IF EXISTS public.index_refunds_on_payment_provider_id;
 DROP INDEX IF EXISTS public.index_refunds_on_payment_provider_customer_id;
 DROP INDEX IF EXISTS public.index_refunds_on_payment_id;
@@ -4959,7 +4960,7 @@ CREATE TABLE public.recurring_transaction_rules_invoice_custom_sections (
 CREATE TABLE public.refunds (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     payment_id uuid NOT NULL,
-    credit_note_id uuid NOT NULL,
+    credit_note_id uuid,
     payment_provider_id uuid,
     payment_provider_customer_id uuid NOT NULL,
     amount_cents bigint DEFAULT 0 NOT NULL,
@@ -4968,7 +4969,10 @@ CREATE TABLE public.refunds (
     provider_refund_id character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    refundable_type character varying,
+    refundable_id uuid,
+    reason character varying
 );
 
 
@@ -9330,6 +9334,13 @@ CREATE INDEX index_refunds_on_payment_provider_id ON public.refunds USING btree 
 
 
 --
+-- Name: index_refunds_on_refundable; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_refunds_on_refundable ON public.refunds USING btree (refundable_type, refundable_id);
+
+
+--
 -- Name: index_roles_by_code_per_organization; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12376,6 +12387,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260526131452'),
 ('20260525102114'),
 ('20260520075420'),
 ('20260518152858'),


### PR DESCRIPTION
 ## Context

Milestone 4 of payment-gated subscription activation introduces automatic refunds for the late-payment-after-timeout race condition. The refund flow needs to create Refund records for payments tied to closed invoices (not to credit notes), so the existing Refund schema needs to accept refundables other than CreditNote.

 ## Description

Extends the refunds table to support payment-only refunds:

- Adds a polymorphic refundable association (refundable_type + refundable_id) with a composite index, so a Refund can target a CreditNote (existing use) or another model such as Invoice (M4 use case).
- Drops the NOT NULL on credit_note_id so activation-expired refunds can be persisted without a credit note.
- Adds a reason string column to distinguish credit-note refunds from subscription-activation-expired refunds at the data layer.

Model and service changes that consume the new columns ship in follow-up PRs.
