### PR TITLE
fix(multi-currency): Wallet ongoing balance not filtered by subscription currency

### DIFF
--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -97,7 +97,7 @@ module Customers
     end
 
     def applicable_fees(fees, fee_map, wallet)
-      fees.select { |fee| fee_map[fee.item_key] == wallet.id }
+      fees.select { |fee| fee_map[fee.item_key] == wallet.id && fee.amount_currency == wallet.balance_currency }
     end
   end
 end

--- a/app/services/wallets/build_allocation_rules_service.rb
+++ b/app/services/wallets/build_allocation_rules_service.rb
@@ -37,8 +37,11 @@ module Wallets
       bm_map = Hash.new { |h, k| h[k] = [] }
       type_map = Hash.new { |h, k| h[k] = [] }
       unrestricted = []
+      wallet_currencies = {}
 
       wallets.each do |wallet|
+        wallet_currencies[wallet.id] = wallet.balance_currency
+
         if wallet.wallet_targets.any?
           handle_billable_metric_wallet(wallet, bm_map, type_map, unrestricted)
         elsif wallet.allowed_fee_types.present?
@@ -48,7 +51,7 @@ module Wallets
         end
       end
 
-      result.allocation_rules = {bm_map:, type_map:, unrestricted:}
+      result.allocation_rules = {bm_map:, type_map:, unrestricted:, wallet_currencies:}
       result
     end
 

--- a/app/services/wallets/find_applicable_on_fees_service.rb
+++ b/app/services/wallets/find_applicable_on_fees_service.rb
@@ -23,14 +23,15 @@ module Wallets
       end
 
       bm_id = fee.charge&.billable_metric_id
+      fee_currency = fee.amount_currency
 
-      bm_wallets = allocation_rules[:bm_map][bm_id]
+      bm_wallets = filter_by_currency(allocation_rules[:bm_map][bm_id], fee_currency)
       return result_with(bm_wallets) if bm_wallets&.any?
 
-      type_wallets = allocation_rules[:type_map][fee.fee_type]
+      type_wallets = filter_by_currency(allocation_rules[:type_map][fee.fee_type], fee_currency)
       return result_with(type_wallets) if type_wallets&.any?
 
-      unrestricted_wallets = allocation_rules[:unrestricted]
+      unrestricted_wallets = filter_by_currency(allocation_rules[:unrestricted], fee_currency)
       return result_with(unrestricted_wallets) if unrestricted_wallets&.any?
 
       result_with([])
@@ -39,6 +40,16 @@ module Wallets
     private
 
     attr_reader :allocation_rules, :fee, :customer_id, :fee_targeting_wallets_enabled
+
+    def filter_by_currency(wallet_ids, fee_currency)
+      return nil if wallet_ids.nil?
+
+      wallet_currencies = allocation_rules[:wallet_currencies]
+      return wallet_ids if wallet_currencies.blank?
+
+      wallet_ids.select { |id| wallet_currencies[id] == fee_currency }
+    end
+
     def find_wallet_by_code(code)
       return nil unless customer_id
 

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -341,5 +341,108 @@ RSpec.describe Customers::RefreshWalletsService do
         expect(unrestricted_wallet.credits_ongoing_balance).to eq(15.0)
       end
     end
+
+    context "when customer has multi-currency subscriptions" do
+      subject(:result) { described_class.call(customer: mc_customer, include_generating_invoices: false) }
+
+      let(:mc_org) { create(:organization) }
+      let(:mc_customer) { create(:customer, organization: mc_org, awaiting_wallet_refresh: true) }
+      let(:mc_billable_metric) { create(:billable_metric, organization: mc_org, aggregation_type: "count_agg") }
+      let(:mc_pia_billable_metric) { create(:billable_metric, organization: mc_org, aggregation_type: "count_agg") }
+
+      let(:usd_plan) { create(:plan, organization: mc_org, amount_cents: 10_000, amount_currency: "USD") }
+      let(:eur_plan) { create(:plan, organization: mc_org, amount_cents: 10_000, amount_currency: "EUR") }
+
+      let(:usd_subscription) { create(:subscription, organization: mc_org, customer: mc_customer, plan: usd_plan, started_at: Time.zone.now - 1.year) }
+      let(:eur_subscription) { create(:subscription, organization: mc_org, customer: mc_customer, plan: eur_plan, started_at: Time.zone.now - 1.year) }
+
+      let!(:usd_wallet) do
+        create(
+          :wallet,
+          customer: mc_customer,
+          organization: mc_org,
+          currency: "USD",
+          balance_cents: 10_000,
+          ongoing_balance_cents: 10_000,
+          ongoing_usage_balance_cents: 0,
+          credits_balance: 100.0,
+          credits_ongoing_balance: 100.0,
+          credits_ongoing_usage_balance: 0
+        )
+      end
+
+      let!(:eur_wallet) do
+        create(
+          :wallet,
+          customer: mc_customer,
+          organization: mc_org,
+          currency: "EUR",
+          balance_cents: 10_000,
+          ongoing_balance_cents: 10_000,
+          ongoing_usage_balance_cents: 0,
+          credits_balance: 100.0,
+          credits_ongoing_balance: 100.0,
+          credits_ongoing_usage_balance: 0
+        )
+      end
+
+      before do
+        # In-arrears charges
+        create(:standard_charge, plan: usd_plan, billable_metric: mc_billable_metric, properties: {amount: "3"})
+        create(:standard_charge, plan: eur_plan, billable_metric: mc_billable_metric, properties: {amount: "5"})
+
+        # Pay-in-advance charges
+        create(:standard_charge, plan: usd_plan, billable_metric: mc_pia_billable_metric, properties: {amount: "2"}, pay_in_advance: true, invoiceable: true)
+        create(:standard_charge, plan: eur_plan, billable_metric: mc_pia_billable_metric, properties: {amount: "4"}, pay_in_advance: true, invoiceable: true)
+
+        # 2 events for USD in-arrears -> 2 * $3 = 600 cents
+        create_list(
+          :event, 2,
+          organization: mc_org,
+          subscription: usd_subscription,
+          customer: mc_customer,
+          code: mc_billable_metric.code
+        )
+
+        # 3 events for EUR in-arrears -> 3 * €5 = 1500 cents
+        create_list(
+          :event, 3,
+          organization: mc_org,
+          subscription: eur_subscription,
+          customer: mc_customer,
+          code: mc_billable_metric.code
+        )
+
+        # 1 event for USD PIA -> 1 * $2 = 200 cents (included in total usage, subtracted as billed)
+        create(
+          :event,
+          organization: mc_org,
+          subscription: usd_subscription,
+          customer: mc_customer,
+          code: mc_pia_billable_metric.code
+        )
+
+        # 1 event for EUR PIA -> 1 * €4 = 400 cents (included in total usage, subtracted as billed)
+        create(
+          :event,
+          organization: mc_org,
+          subscription: eur_subscription,
+          customer: mc_customer,
+          code: mc_pia_billable_metric.code
+        )
+      end
+
+      it "calculates ongoing balance separately per currency" do
+        expect(result).to be_success
+
+        # USD: in-arrears 600 + PIA 200 = 800 total usage, minus 200 PIA billed = 600 ongoing usage
+        expect(usd_wallet.reload.ongoing_usage_balance_cents).to eq(600)
+        expect(usd_wallet.ongoing_balance_cents).to eq(9400)
+
+        # EUR: in-arrears 1500 + PIA 400 = 1900 total usage, minus 400 PIA billed = 1500 ongoing usage
+        expect(eur_wallet.reload.ongoing_usage_balance_cents).to eq(1500)
+        expect(eur_wallet.ongoing_balance_cents).to eq(8500)
+      end
+    end
   end
 end

--- a/spec/services/wallets/build_allocation_rules_service_spec.rb
+++ b/spec/services/wallets/build_allocation_rules_service_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Wallets::BuildAllocationRulesService do
     let(:type_map) { allocation_rules[:type_map] }
     let(:unrestricted) { allocation_rules[:unrestricted] }
 
+    let(:wallet_currencies) { allocation_rules[:wallet_currencies] }
+
     let(:organization) { create(:organization) }
     let(:customer) { create(:customer, organization:) }
 
@@ -21,6 +23,7 @@ RSpec.describe Wallets::BuildAllocationRulesService do
         expect(bm_map).to eq({})
         expect(type_map).to eq({})
         expect(unrestricted).to eq([])
+        expect(wallet_currencies).to eq({})
       end
     end
 
@@ -28,12 +31,12 @@ RSpec.describe Wallets::BuildAllocationRulesService do
       let(:bm1) { create(:billable_metric, organization:) }
       let(:bm2) { create(:billable_metric, organization:) }
 
-      let!(:w_bm2) { create(:wallet, customer:, organization:, priority: 6) }
-      let!(:w_charge) { create(:wallet, customer:, organization:, priority: 2, allowed_fee_types: ["charge"]) }
-      let!(:w_bm1) { create(:wallet, customer:, organization:, priority: 4) }
-      let!(:w_subscription) { create(:wallet, customer:, organization:, priority: 3, allowed_fee_types: ["subscription"]) }
-      let!(:w_unres_low) { create(:wallet, customer:, organization:, priority: 5) }
-      let!(:w_unres_high) { create(:wallet, customer:, organization:, priority: 1) }
+      let!(:w_bm2) { create(:wallet, customer:, organization:, currency: "USD", priority: 6) }
+      let!(:w_charge) { create(:wallet, customer:, organization:, currency: "EUR", priority: 2, allowed_fee_types: ["charge"]) }
+      let!(:w_bm1) { create(:wallet, customer:, organization:, currency: "USD", priority: 4) }
+      let!(:w_subscription) { create(:wallet, customer:, organization:, currency: "EUR", priority: 3, allowed_fee_types: ["subscription"]) }
+      let!(:w_unres_low) { create(:wallet, customer:, organization:, currency: "EUR", priority: 5) }
+      let!(:w_unres_high) { create(:wallet, customer:, organization:, currency: "USD", priority: 1) }
 
       before do
         create(:wallet_target, wallet: w_bm1, billable_metric: bm1, organization:)
@@ -57,6 +60,16 @@ RSpec.describe Wallets::BuildAllocationRulesService do
 
         expect(bm_map[bm1.id]).to eq([w_unres_high.id, w_charge.id, w_bm1.id, w_unres_low.id])
         expect(bm_map[bm2.id]).to eq([w_unres_high.id, w_charge.id, w_unres_low.id, w_bm2.id])
+
+        # Wallet currencies map all active wallets to their currency
+        expect(wallet_currencies).to eq(
+          w_unres_high.id => w_unres_high.balance_currency,
+          w_charge.id => w_charge.balance_currency,
+          w_subscription.id => w_subscription.balance_currency,
+          w_bm1.id => w_bm1.balance_currency,
+          w_unres_low.id => w_unres_low.balance_currency,
+          w_bm2.id => w_bm2.balance_currency
+        )
       end
     end
 
@@ -78,6 +91,13 @@ RSpec.describe Wallets::BuildAllocationRulesService do
             wallet_priority_5_newer.id,
             wallet_priority_50.id
           ]
+        )
+
+        expect(wallet_currencies).to eq(
+          wallet_priority_1.id => wallet_priority_1.balance_currency,
+          wallet_priority_5_older.id => wallet_priority_5_older.balance_currency,
+          wallet_priority_5_newer.id => wallet_priority_5_newer.balance_currency,
+          wallet_priority_50.id => wallet_priority_50.balance_currency
         )
       end
     end

--- a/spec/services/wallets/find_applicable_on_fees_service_spec.rb
+++ b/spec/services/wallets/find_applicable_on_fees_service_spec.rb
@@ -236,5 +236,92 @@ RSpec.describe Wallets::FindApplicableOnFeesService do
         end
       end
     end
+
+    context "when wallet_currencies is present in allocation rules" do
+      let(:usd_wallet_id) { SecureRandom.uuid }
+      let(:eur_wallet_id) { SecureRandom.uuid }
+
+      let(:allocation_rules) do
+        {
+          bm_map: {},
+          type_map: {},
+          unrestricted: [eur_wallet_id, usd_wallet_id],
+          wallet_currencies: {
+            eur_wallet_id => "EUR",
+            usd_wallet_id => "USD"
+          }
+        }
+      end
+
+      context "when fee currency matches a wallet" do
+        let(:fee) { create(:add_on_fee, amount_currency: "USD") }
+
+        it "returns the wallet matching the fee currency" do
+          expect(result).to be_success
+          expect(result.top_priority_wallet).to eq(usd_wallet_id)
+        end
+      end
+
+      context "when fee currency matches the higher-priority wallet" do
+        let(:fee) { create(:add_on_fee, amount_currency: "EUR") }
+
+        it "returns the higher-priority wallet" do
+          expect(result).to be_success
+          expect(result.top_priority_wallet).to eq(eur_wallet_id)
+        end
+      end
+
+      context "when fee currency does not match any wallet" do
+        let(:fee) { create(:add_on_fee, amount_currency: "GBP") }
+
+        it "returns nil" do
+          expect(result).to be_success
+          expect(result.top_priority_wallet).to be_nil
+        end
+      end
+
+      context "when filtering applies to billable metric wallets" do
+        let(:fee) { create(:charge_fee, amount_currency: "USD") }
+        let(:bm_id) { fee.charge.billable_metric_id }
+
+        let(:allocation_rules) do
+          {
+            bm_map: {bm_id => [eur_wallet_id, usd_wallet_id]},
+            type_map: {},
+            unrestricted: [],
+            wallet_currencies: {
+              eur_wallet_id => "EUR",
+              usd_wallet_id => "USD"
+            }
+          }
+        end
+
+        it "returns the wallet matching the fee currency" do
+          expect(result).to be_success
+          expect(result.top_priority_wallet).to eq(usd_wallet_id)
+        end
+      end
+
+      context "when filtering applies to fee type wallets" do
+        let(:fee) { create(:charge_fee, amount_currency: "USD") }
+
+        let(:allocation_rules) do
+          {
+            bm_map: {},
+            type_map: {"charge" => [eur_wallet_id, usd_wallet_id]},
+            unrestricted: [],
+            wallet_currencies: {
+              eur_wallet_id => "EUR",
+              usd_wallet_id => "USD"
+            }
+          }
+        end
+
+        it "returns the wallet matching the fee currency" do
+          expect(result).to be_success
+          expect(result.top_priority_wallet).to eq(usd_wallet_id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Wallet ongoing balance calculation ignores subscription currency when assigning fees to wallets, causing incorrect balances for multi-currency customers. A customer with USD and EUR subscriptions sees all fees attributed to whichever wallet has the highest priority, leaving the other wallet with zero ongoing usage.

This fix was originally merged as #5310 on 2026-04-10, but against the `multi-currency-qa` branch -- which never rolled forward to main. The other PRs in the multi-currency stream landed directly on main; this one stayed stranded. Since `multi_currency` is a live feature flag on main today, any org with the flag enabled has the bug this fix addresses. Re-targeting here to land it on main directly.

## Description

The wallet allocation pipeline (`BuildAllocationRulesService` -> `FindApplicableOnFeesService` -> `applicable_fees`) matches fees to wallets based on billable metric targets, fee types, and priority order, but never checks whether the fee's currency matches the wallet's currency. This only manifests under `multi_currency`, which lets a customer hold subscriptions in different currencies. With a USD wallet (priority 1) and a EUR wallet (priority 2), all fees from both subscriptions get assigned to the USD wallet; the EUR wallet shows zero ongoing usage and the USD wallet's ongoing balance is deflated by cross-currency charges it shouldn't be tracking. The fix is not gated behind the flag: for single-currency customers, all fees and wallets share the same currency, so the filter is a no-op.

Setup for the table below: customer with `multi_currency` enabled, USD + EUR subscriptions, both with in-arrears and pay-in-advance charges, USD wallet ($100) and EUR wallet (€100).

| | **USD Wallet** | | | **EUR Wallet** | | |
|---|---|---|---|---|---|---|
| **Field** | **Before** | **After** | **Status** | **Before** | **After** | **Status** |
| `balance_cents` | 10000 | 10000 | unchanged | 10000 | 10000 | unchanged |
| `ongoing_usage_balance_cents` | 2100 | 600 | fixed | 0 | 1500 | fixed |
| `ongoing_balance_cents` | 7900 | 9400 | fixed | 10000 | 8500 | fixed |

Before: all fees (USD + EUR) get assigned to the first wallet by priority. USD wallet ends up with total usage 2700 (own 800 + cross-currency 1900) minus all PIA 600 = 2100; EUR wallet gets nothing. After: each wallet only sees fees matching its currency. USD wallet: 800 total - 200 PIA = 600. EUR wallet: 1900 total - 400 PIA = 1500.

`BuildAllocationRulesService` now exposes a `wallet_currencies` map (`{ wallet_id => balance_currency }`) alongside the existing allocation rules; wallets are already loaded so no extra queries. `FindApplicableOnFeesService` filters wallet candidates by the fee's `amount_currency` at every priority level (billable metric, fee type, unrestricted); explicit `target_wallet_code` targeting is unchanged since that represents intentional user routing. `RefreshWalletsService` adds a currency guard in `applicable_fees` as defense-in-depth, ensuring no cross-currency fee leaks through regardless of how the fee-to-wallet map was built.

## How to try locally

```bash
lago exec api bundle exec rspec \
  spec/services/wallets/build_allocation_rules_service_spec.rb \
  spec/services/wallets/find_applicable_on_fees_service_spec.rb \
  spec/services/customers/refresh_wallets_service_spec.rb
```

The multi-currency test in `refresh_wallets_service_spec.rb` reproduces the scenario: two subscriptions (USD + EUR), two wallets, in-arrears and pay-in-advance charges, verifying each wallet's ongoing balance only reflects same-currency usage. Verified locally against current `main`: 30 examples, 0 failures.