### PR TITLE
feat(plans): Make charges optional on update input for GraphQL

### DIFF
--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -15,7 +15,7 @@ module Mutations
       type Types::Plans::Object
 
       def resolve(entitlements: nil, **args)
-        args[:charges].map!(&:to_h)
+        args[:charges]&.map!(&:to_h)
         args[:fixed_charges]&.map!(&:to_h)
         plan = current_organization.plans.find_by(id: args[:id])
 

--- a/app/graphql/types/plans/update_input.rb
+++ b/app/graphql/types/plans/update_input.rb
@@ -22,7 +22,7 @@ module Types
       argument :tax_codes, [String], required: false
       argument :trial_period, Float, required: false
 
-      argument :charges, [Types::Charges::Input]
+      argument :charges, [Types::Charges::Input], required: false
       argument :fixed_charges, [Types::FixedCharges::Input], required: false
       argument :minimum_commitment, Types::Commitments::Input, required: false
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -13069,7 +13069,7 @@ input UpdatePlanInput {
   billChargesMonthly: Boolean
   billFixedChargesMonthly: Boolean
   cascadeUpdates: Boolean
-  charges: [ChargeInput!]!
+  charges: [ChargeInput!]
 
   """
   A unique identifier for the client performing the mutation.

--- a/schema.json
+++ b/schema.json
@@ -69178,19 +69178,15 @@
               "name": "charges",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "ChargeInput",
-                      "ofType": null
-                    }
+                    "kind": "INPUT_OBJECT",
+                    "name": "ChargeInput",
+                    "ofType": null
                   }
                 }
               },

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -487,6 +487,43 @@ RSpec.describe Mutations::Plans::Update do
     end
   end
 
+  context "when charges are not provided" do
+    let(:existing_charge) do
+      create(:standard_charge, plan:, billable_metric: billable_metrics[0], properties: {amount: "42.00"})
+    end
+
+    before do
+      existing_charge
+    end
+
+    it "updates the plan without changing charges" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: plan.id,
+            name: "Updated plan",
+            code: "updated_plan",
+            interval: "monthly",
+            payInAdvance: true,
+            amountCents: 200,
+            amountCurrency: "EUR"
+          }
+        }
+      )
+
+      result_data = result["data"]["updatePlan"]
+
+      expect(result_data["name"]).to eq("Updated plan")
+      expect(result_data["charges"].count).to eq(1)
+      expect(result_data["charges"].first["id"]).to eq(existing_charge.id)
+      expect(result_data["charges"].first["properties"]["amount"]).to eq("42.00")
+    end
+  end
+
   context "when fixed charges are not provided" do
     let(:fixed_charge) { create(:fixed_charge, plan:, charge_model: "standard", properties: {amount: "100.00"}) }
 

--- a/spec/graphql/types/plans/update_input_spec.rb
+++ b/spec/graphql/types/plans/update_input_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Types::Plans::UpdateInput do
   it { is_expected.to accept_argument(:tax_codes).of_type("[String!]") }
   it { is_expected.to accept_argument(:trial_period).of_type("Float") }
 
-  it { is_expected.to accept_argument(:charges).of_type("[ChargeInput!]!") }
+  it { is_expected.to accept_argument(:charges).of_type("[ChargeInput!]") }
   it { is_expected.to accept_argument(:fixed_charges).of_type("[FixedChargeInput!]") }
   it { is_expected.to accept_argument(:minimum_commitment).of_type("CommitmentInput") }
   it { is_expected.to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]") }


### PR DESCRIPTION
The UpdatePlanInput GraphQL mutation required the full charges array on every update. Clients had to resend the entire collection even when only changing unrelated fields such as the plan name, while fixed_charges was already optional.

Mark the charges argument as optional on UpdatePlanInput, mirroring fixed_charges. When the field is omitted, charges are left untouched.

The API already accepts plan updates without sending charges.