### PR TITLE
[ING-235] feat(wallets): allow target rules to grant credits

### DIFF
--- a/app/controllers/concerns/wallet_actions.rb
+++ b/app/controllers/concerns/wallet_actions.rb
@@ -114,6 +114,7 @@ module WalletActions
       ],
       recurring_transaction_rules: [
         :granted_credits,
+        :grants_target_top_up,
         :interval,
         :method,
         :paid_credits,
@@ -174,6 +175,7 @@ module WalletActions
         :trigger,
         :paid_credits,
         :granted_credits,
+        :grants_target_top_up,
         :invoice_requires_successful_payment,
         :ignore_paid_top_up_limits,
         :transaction_name,

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -15,6 +15,8 @@ class RecurringTransactionRule < ApplicationRecord
     source: :invoice_custom_section
 
   validates :transaction_name, length: {minimum: 1, maximum: 255}, allow_nil: true
+  validates :grants_target_top_up, inclusion: {in: [true, false]}, if: :target?
+  validates :grants_target_top_up, exclusion: {in: [true, false]}, unless: :target?
 
   STATUSES = [
     :active,
@@ -70,7 +72,9 @@ class RecurringTransactionRule < ApplicationRecord
 
   def compute_paid_credits(ongoing_balance:)
     if target?
-      compute_target_paid_credits(ongoing_balance:)
+      return 0.0 if grants_target_top_up?
+
+      compute_target_top_up_amount(ongoing_balance:)
     else
       paid_credits
     end
@@ -78,6 +82,8 @@ class RecurringTransactionRule < ApplicationRecord
 
   def compute_granted_credits
     if target?
+      return compute_target_top_up_amount(ongoing_balance: wallet.credits_ongoing_balance) if grants_target_top_up?
+
       0.0
     else
       granted_credits
@@ -86,12 +92,15 @@ class RecurringTransactionRule < ApplicationRecord
 
   private
 
-  def compute_target_paid_credits(ongoing_balance:)
+  def compute_target_top_up_amount(ongoing_balance:)
     if ongoing_balance >= target_ongoing_balance
       return 0.0
     end
 
     gap = target_ongoing_balance - ongoing_balance
+
+    # NOTE: granted top-ups skip the paid_top_up_min limit since no payment occurs
+    return gap if grants_target_top_up?
 
     # NOTE: in case of target rule, we don't apply max because reaching target balance is the most important
     apply_min_top_up_limits(credit_amount: gap)
@@ -106,6 +115,7 @@ end
 #  id                                  :uuid             not null, primary key
 #  expiration_at                       :datetime
 #  granted_credits                     :decimal(30, 5)   default(0.0), not null
+#  grants_target_top_up                :boolean
 #  ignore_paid_top_up_limits           :boolean          default(FALSE), not null
 #  interval                            :integer          default("weekly")
 #  invoice_requires_successful_payment :boolean          default(FALSE), not null

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -8,6 +8,7 @@ module V1
           lago_id: model.id,
           paid_credits: model.paid_credits,
           granted_credits: model.granted_credits,
+          grants_target_top_up: model.grants_target_top_up,
           interval: model.interval,
           method: model.method,
           started_at: model.started_at&.iso8601,

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -6,7 +6,8 @@ module Wallets
 
     def call
       recurring_transaction_rules.each do |rule|
-        paid_credits = rule.compute_paid_credits(ongoing_balance: rule.wallet.credits_ongoing_balance)
+        ongoing_balance = rule.wallet.credits_ongoing_balance
+        paid_credits = rule.compute_paid_credits(ongoing_balance:)
         granted_credits = rule.compute_granted_credits
 
         next if rule.target? && paid_credits.zero? && granted_credits.zero?

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -40,6 +40,10 @@ module Wallets
           attributes[:ignore_paid_top_up_limits] = ActiveModel::Type::Boolean.new.cast(rule_params[:ignore_paid_top_up_limits])
         end
 
+        attributes[:grants_target_top_up] = if method == "target"
+          ActiveModel::Type::Boolean.new.cast(rule_params[:grants_target_top_up]) || false
+        end
+
         if rule_params.key?(:payment_method)
           attributes[:payment_method_type] = rule_params[:payment_method][:payment_method_type] if rule_params[:payment_method].key?(:payment_method_type)
           attributes[:payment_method_id] = rule_params[:payment_method][:payment_method_id] if rule_params[:payment_method].key?(:payment_method_id)

--- a/app/services/wallets/recurring_transaction_rules/update_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/update_service.rb
@@ -35,6 +35,8 @@ module Wallets
 
           recurring_rule = wallet.recurring_transaction_rules.active.find_by(id: lago_id)
 
+          normalize_grants_target_top_up!(rule_attributes, recurring_rule)
+
           if rule_attributes.key?(:invoice_custom_section)
             invoice_custom_section = {
               invoice_custom_section: rule_attributes.delete(:invoice_custom_section)
@@ -95,6 +97,20 @@ module Wallets
 
       def hash_recurring_rules
         @hash_recurring_rules ||= params.map { |m| m.to_h.deep_symbolize_keys }
+      end
+
+      def normalize_grants_target_top_up!(rule_attributes, recurring_rule)
+        effective_method = rule_attributes[:method]&.to_s || recurring_rule&.method
+
+        if effective_method == "target"
+          if rule_attributes.key?(:grants_target_top_up)
+            rule_attributes[:grants_target_top_up] = ActiveModel::Type::Boolean.new.cast(rule_attributes[:grants_target_top_up])
+          elsif recurring_rule&.grants_target_top_up.nil?
+            rule_attributes[:grants_target_top_up] = false
+          end
+        else
+          rule_attributes[:grants_target_top_up] = nil
+        end
       end
 
       def valid_payment_methods?

--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -14,6 +14,7 @@ module Wallets
         return false unless valid_credits?
         return false unless valid_metadata?
         return false unless valid_expiration_at?
+        return false unless valid_grants_target_top_up?
 
         true
       end
@@ -67,6 +68,12 @@ module Wallets
         return true if Validators::ExpirationDateValidator.valid?(params[:expiration_at])
 
         false
+      end
+
+      def valid_grants_target_top_up?
+        return true if params[:grants_target_top_up].nil?
+
+        method == "target"
       end
     end
   end

--- a/db/migrate/20260526182506_add_grants_target_top_up_to_recurring_transaction_rules.rb
+++ b/db/migrate/20260526182506_add_grants_target_top_up_to_recurring_transaction_rules.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGrantsTargetTopUpToRecurringTransactionRules < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recurring_transaction_rules, :grants_target_top_up, :boolean
+  end
+end

--- a/db/migrate/20260528175021_backfill_grants_target_top_up_on_target_rules.rb
+++ b/db/migrate/20260528175021_backfill_grants_target_top_up_on_target_rules.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class BackfillGrantsTargetTopUpOnTargetRules < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Local model so the migration stays self-contained. Using the real
+  # `RecurringTransactionRule` would couple this migration to the live model:
+  # if the enum mapping, validations, or callbacks change later, replaying
+  # this migration on a fresh database could behave differently than it did
+  # on production. The local class freezes the enum mapping at the values
+  # that were in place when the migration was written.
+  class RecurringTransactionRule < ApplicationRecord
+    self.table_name = "recurring_transaction_rules"
+    enum :method, {fixed: 0, target: 1}
+  end
+
+  def up
+    RecurringTransactionRule.where(method: :target, grants_target_top_up: nil)
+      .in_batches(of: 1000)
+      .update_all(grants_target_top_up: false) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def down
+    # irreversible
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4872,7 +4872,8 @@ CREATE TABLE public.recurring_transaction_rules (
     transaction_name character varying(255),
     payment_method_id uuid,
     payment_method_type public.payment_method_types DEFAULT 'provider'::public.payment_method_types NOT NULL,
-    skip_invoice_custom_sections boolean DEFAULT false NOT NULL
+    skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
+    grants_target_top_up boolean
 );
 
 
@@ -12218,6 +12219,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260528175021'),
+('20260526182506'),
 ('20260525102114'),
 ('20260520075420'),
 ('20260517101105'),

--- a/spec/factories/recurring_transaction_rules.rb
+++ b/spec/factories/recurring_transaction_rules.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     interval { "monthly" }
     trigger { "interval" }
     transaction_name { "Recurring Transaction Rule" }
+
+    after(:build) do |rule|
+      rule.grants_target_top_up = false if rule.method.to_s == "target" && rule.grants_target_top_up.nil?
+    end
   end
 end

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -23,6 +23,46 @@ RSpec.describe RecurringTransactionRule do
 
   describe "validations" do
     it { is_expected.to validate_length_of(:transaction_name).is_at_least(1).is_at_most(255).allow_nil }
+
+    describe "grants_target_top_up validation" do
+      context "when method is target" do
+        it "rejects nil" do
+          rule = build(:recurring_transaction_rule, method: :target)
+          rule.grants_target_top_up = nil
+          expect(rule).not_to be_valid
+          expect(rule.errors[:grants_target_top_up]).to be_present
+        end
+
+        it "accepts true" do
+          rule = build(:recurring_transaction_rule, method: :target, grants_target_top_up: true)
+          expect(rule).to be_valid
+        end
+
+        it "accepts false" do
+          rule = build(:recurring_transaction_rule, method: :target, grants_target_top_up: false)
+          expect(rule).to be_valid
+        end
+      end
+
+      context "when method is not target" do
+        it "rejects true" do
+          rule = build(:recurring_transaction_rule, method: :fixed, grants_target_top_up: true)
+          expect(rule).not_to be_valid
+          expect(rule.errors[:grants_target_top_up]).to be_present
+        end
+
+        it "rejects false" do
+          rule = build(:recurring_transaction_rule, method: :fixed, grants_target_top_up: false)
+          expect(rule).not_to be_valid
+          expect(rule.errors[:grants_target_top_up]).to be_present
+        end
+
+        it "accepts nil" do
+          rule = build(:recurring_transaction_rule, method: :fixed)
+          expect(rule).to be_valid
+        end
+      end
+    end
   end
 
   describe "scopes" do
@@ -138,6 +178,30 @@ RSpec.describe RecurringTransactionRule do
       it "returns zero" do
         expect(subject).to eq 0.0
       end
+
+      context "when grants_target_top_up is true" do
+        let(:rule) do
+          create(
+            :recurring_transaction_rule,
+            wallet:,
+            method: :target,
+            grants_target_top_up: true,
+            target_ongoing_balance: 101.0
+          )
+        end
+        let(:wallet) do
+          create(:wallet, rate_amount: 0.5, paid_top_up_min_amount_cents: 25_00, credits_ongoing_balance: 100.0)
+        end
+
+        it "returns the raw gap, bypassing the paid_top_up_min limit" do
+          expect(subject).to eq 1.0
+        end
+
+        it "makes the rule grant the gap-fill instead of paying for it" do
+          expect(rule.compute_paid_credits(ongoing_balance: 100.0)).to eq 0.0
+          expect(rule.compute_granted_credits).to eq 1.0
+        end
+      end
     end
   end
 
@@ -181,6 +245,23 @@ RSpec.describe RecurringTransactionRule do
 
         it "returns the gag with applied limits from wallet" do
           expect(subject).to eq 50.0 # min amount 25 x 2 because of wallet's rate 0.5
+        end
+      end
+
+      context "when grants_target_top_up is true" do
+        let(:rule) do
+          create(
+            :recurring_transaction_rule,
+            wallet:,
+            method: :target,
+            grants_target_top_up: true,
+            target_ongoing_balance:
+          )
+        end
+        let(:target_ongoing_balance) { 101.0 }
+
+        it "returns zero" do
+          expect(subject).to eq 0.0
         end
       end
     end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
       "target_ongoing_balance" => recurring_transaction_rule.target_ongoing_balance,
       "threshold_credits" => recurring_transaction_rule.threshold_credits.to_s,
       "granted_credits" => recurring_transaction_rule.granted_credits.to_s,
+      "grants_target_top_up" => recurring_transaction_rule.grants_target_top_up,
       "created_at" => recurring_transaction_rule.created_at.iso8601,
       "invoice_requires_successful_payment" => recurring_transaction_rule.invoice_requires_successful_payment,
       "transaction_metadata" => recurring_transaction_rule.transaction_metadata,

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -145,6 +145,31 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
             )
           end
         end
+
+        context "when grants_target_top_up is true" do
+          let(:recurring_transaction_rule) do
+            create(
+              :recurring_transaction_rule,
+              trigger: :interval,
+              wallet:,
+              interval:,
+              created_at: created_at + 1.second,
+              method: "target",
+              target_ongoing_balance: "200",
+              grants_target_top_up: true
+            )
+          end
+
+          it "enqueues the raw gap as granted credits, bypassing the paid_top_up_min limit" do
+            travel_to(current_date) do
+              create_interval_transactions_service.call
+              expect_to_have_scheduled_wallet_transaction(
+                paid_credits: "0.0",
+                granted_credits: "150.0"
+              )
+            end
+          end
+        end
       end
     end
 

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -139,17 +139,58 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
           }
         end
 
-        it "creates rule with expected attributes ignoring wallet limits" do
+        it "creates rule with expected attributes ignoring wallet limits and grants_target_top_up defaulting to false" do
           expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
 
           expect(wallet.recurring_transaction_rules.first).to have_attributes(
             granted_credits: 0.0,
+            grants_target_top_up: false,
             method: "target",
             paid_credits: 5.0,
             target_ongoing_balance: nil,
             threshold_credits: 1.0,
             trigger: "threshold"
           )
+        end
+
+        context "when grants_target_top_up is true" do
+          let(:rule_params) do
+            {
+              trigger: "threshold",
+              method: "target",
+              threshold_credits: "1.0",
+              grants_target_top_up: "true"
+            }
+          end
+
+          it "creates rule with grants_target_top_up true" do
+            expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
+
+            expect(wallet.recurring_transaction_rules.first).to have_attributes(
+              method: "target",
+              grants_target_top_up: true
+            )
+          end
+        end
+
+        context "when grants_target_top_up is false" do
+          let(:rule_params) do
+            {
+              trigger: "threshold",
+              method: "target",
+              threshold_credits: "1.0",
+              grants_target_top_up: "false"
+            }
+          end
+
+          it "creates rule with grants_target_top_up false" do
+            expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
+
+            expect(wallet.recurring_transaction_rules.first).to have_attributes(
+              method: "target",
+              grants_target_top_up: false
+            )
+          end
         end
       end
 

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -147,6 +147,62 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
       end
     end
 
+    context "when updating grants_target_top_up" do
+      let(:recurring_transaction_rule) do
+        create(:recurring_transaction_rule, wallet:, method: :target, target_ongoing_balance: 300, grants_target_top_up: false)
+      end
+      let(:params) do
+        [
+          {
+            lago_id: recurring_transaction_rule.id,
+            method: "target",
+            trigger: "interval",
+            interval: "weekly",
+            target_ongoing_balance: "300",
+            grants_target_top_up: true
+          }
+        ]
+      end
+
+      it "updates the rule to grant credits" do
+        rule = result.wallet.reload.recurring_transaction_rules.active.first
+
+        expect(rule).to have_attributes(
+          id: recurring_transaction_rule.id,
+          method: "target",
+          grants_target_top_up: true
+        )
+      end
+
+      context "when flipping grants_target_top_up from true to false" do
+        let(:recurring_transaction_rule) do
+          create(:recurring_transaction_rule, wallet:, method: :target, target_ongoing_balance: 300, grants_target_top_up: true)
+        end
+        let(:params) do
+          [
+            {
+              lago_id: recurring_transaction_rule.id,
+              method: "target",
+              trigger: "interval",
+              interval: "weekly",
+              target_ongoing_balance: "300",
+              grants_target_top_up: false
+            }
+          ]
+        end
+
+        it "updates the rule to stop granting credits" do
+          rule = result.wallet.reload.recurring_transaction_rules.active.first
+
+          expect(rule).to have_attributes(
+            id: recurring_transaction_rule.id,
+            method: "target",
+            grants_target_top_up: false
+          )
+        end
+      end
+    end
+
     context "when empty array is sent as argument" do
       let(:params) { [] }
 

--- a/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
@@ -100,6 +100,143 @@ RSpec.describe Wallets::RecurringTransactionRules::ValidateService do
       end
     end
 
+    describe "#valid_grants_target_top_up?" do
+      context "when grants_target_top_up is true and method is target" do
+        let(:params) do
+          {
+            method: "target",
+            trigger: "interval",
+            interval: "weekly",
+            target_ongoing_balance: "100",
+            grants_target_top_up: true
+          }
+        end
+
+        it "returns true" do
+          expect(validate_service.call).to eq true
+        end
+      end
+
+      context "when grants_target_top_up is true and method is not target" do
+        let(:params) do
+          {
+            method: "fixed",
+            trigger: "interval",
+            interval: "weekly",
+            grants_target_top_up: true
+          }
+        end
+
+        it "returns false" do
+          expect(validate_service.call).to be_falsey
+        end
+      end
+
+      context "when grants_target_top_up is false and method is not target" do
+        let(:params) do
+          {
+            method: "fixed",
+            trigger: "interval",
+            interval: "weekly",
+            grants_target_top_up: false
+          }
+        end
+
+        it "returns false" do
+          expect(validate_service.call).to be_falsey
+        end
+      end
+
+      context "when grants_target_top_up is omitted" do
+        let(:params) do
+          {
+            method: "fixed",
+            trigger: "interval",
+            interval: "weekly"
+          }
+        end
+
+        it "returns true" do
+          expect(validate_service.call).to eq true
+        end
+      end
+
+      context "when grants_target_top_up is nil" do
+        let(:params) do
+          {
+            method: "fixed",
+            trigger: "interval",
+            interval: "weekly",
+            grants_target_top_up: nil
+          }
+        end
+
+        it "returns true" do
+          expect(validate_service.call).to eq true
+        end
+      end
+
+      context "when grants_target_top_up is true but method is omitted from a partial update payload" do
+        let(:params) do
+          {
+            trigger: "interval",
+            interval: "weekly",
+            grants_target_top_up: true
+          }
+        end
+
+        it "returns false" do
+          expect(validate_service.call).to be_falsey
+        end
+      end
+
+      context "when grants_target_top_up is the string \"true\" and method is target" do
+        let(:params) do
+          {
+            method: "target",
+            trigger: "interval",
+            interval: "weekly",
+            target_ongoing_balance: "100",
+            grants_target_top_up: "true"
+          }
+        end
+
+        it "returns true" do
+          expect(validate_service.call).to eq true
+        end
+      end
+
+      context "when grants_target_top_up is the string \"true\" and method is not target" do
+        let(:params) do
+          {
+            method: "fixed",
+            trigger: "interval",
+            interval: "weekly",
+            grants_target_top_up: "true"
+          }
+        end
+
+        it "returns false" do
+          expect(validate_service.call).to be_falsey
+        end
+      end
+
+      context "when grants_target_top_up is the string \"false\" and method is not target" do
+        let(:params) do
+          {
+            method: "fixed",
+            trigger: "interval",
+            interval: "weekly",
+            grants_target_top_up: "false"
+          }
+        end
+
+        it "returns false" do
+          expect(validate_service.call).to be_falsey
+        end
+      end
+    end
+
     describe "#valid_expiration_at?" do
       context "when expiration_at is blank" do
         let(:params) do

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -187,6 +187,32 @@ RSpec.describe Wallets::ThresholdTopUpService do
             unique_transaction: true
           )
       end
+
+      context "when grants_target_top_up is true" do
+        let(:recurring_transaction_rule) do
+          create(
+            :recurring_transaction_rule,
+            wallet:,
+            trigger: "threshold",
+            threshold_credits: "6.0",
+            method: "target",
+            target_ongoing_balance: "200",
+            grants_target_top_up: true
+          )
+        end
+
+        it "enqueues the raw gap as granted credits, bypassing the paid_top_up_min limit" do
+          expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+            .with(
+              organization_id: wallet.organization.id,
+              params: hash_including(
+                paid_credits: "0.0",
+                granted_credits: "194.5"
+              ),
+              unique_transaction: true
+            )
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_examples/wallet_actions.rb
+++ b/spec/support/shared_examples/wallet_actions.rb
@@ -252,6 +252,69 @@ RSpec.shared_examples "a wallet create endpoint" do
       expect(recurring_rules.first[:payment_method][:payment_method_id]).to eq(payment_method.id)
     end
 
+    context "when grants_target_top_up is true on a target rule" do
+      let(:create_params) do
+        {
+          external_customer_id: customer.external_id,
+          rate_amount: "1",
+          name: "Wallet1",
+          currency: "EUR",
+          paid_credits: "10",
+          granted_credits: "10",
+          expiration_at:,
+          recurring_transaction_rules: [
+            {
+              trigger: "interval",
+              interval: "monthly",
+              method: "target",
+              target_ongoing_balance: "200",
+              grants_target_top_up: true
+            }
+          ]
+        }
+      end
+
+      it "creates the rule with grants_target_top_up true" do
+        subject
+
+        recurring_rules = json[:wallet][:recurring_transaction_rules]
+
+        expect(response).to have_http_status(:success)
+        expect(recurring_rules).to be_present
+        expect(recurring_rules.first[:method]).to eq("target")
+        expect(recurring_rules.first[:grants_target_top_up]).to eq(true)
+      end
+    end
+
+    context "when grants_target_top_up is true on a fixed rule" do
+      let(:create_params) do
+        {
+          external_customer_id: customer.external_id,
+          rate_amount: "1",
+          name: "Wallet1",
+          currency: "EUR",
+          paid_credits: "10",
+          granted_credits: "10",
+          expiration_at:,
+          recurring_transaction_rules: [
+            {
+              trigger: "interval",
+              interval: "monthly",
+              method: "fixed",
+              grants_target_top_up: true
+            }
+          ]
+        }
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details][:recurring_transaction_rules]).to include("invalid_recurring_rule")
+      end
+    end
+
     context "when invoice_requires_successful_payment is set at the wallet level but the rule level" do
       let(:create_params) do
         {
@@ -885,6 +948,35 @@ RSpec.shared_examples "a wallet update endpoint" do
       expect(recurring_rules.first[:payment_method][:payment_method_id]).to eq(payment_method.id)
 
       expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
+    end
+
+    context "when grants_target_top_up is updated to true on a target rule" do
+      let(:update_params) do
+        {
+          name: "wallet1",
+          recurring_transaction_rules: [
+            {
+              lago_id: recurring_transaction_rule.id,
+              method: "target",
+              trigger: "interval",
+              interval: "weekly",
+              target_ongoing_balance: "300",
+              grants_target_top_up: true
+            }
+          ]
+        }
+      end
+
+      it "updates the rule with grants_target_top_up true" do
+        subject
+
+        recurring_rules = json[:wallet][:recurring_transaction_rules]
+
+        expect(response).to have_http_status(:success)
+        expect(recurring_rules).to be_present
+        expect(recurring_rules.first[:lago_id]).to eq(recurring_transaction_rule.id)
+        expect(recurring_rules.first[:grants_target_top_up]).to eq(true)
+      end
     end
 
     context "when transaction expiration_at is set" do


### PR DESCRIPTION
## Context

Wallet recurring transaction rules of type `target` currently always create a paid top-up. Free credits are only available via fixed top-ups (the existing `granted_credits` decimal column). The limitation lives in the API itself, so it blocks both UI consumers and direct API consumers.

## Description

A new boolean column `grants_target_top_up` is added to `recurring_transaction_rules`. The column is nullable: target rules carry `true` or `false`, non-target rules carry `nil` (the flag does not apply). Model validations enforce this (`inclusion: [true, false]` when target, `exclusion: [true, false]` otherwise). A backfill migration sets `false` on existing target rules.

When `true` on a target rule, the gap-fill at top-up time grants credits (creates a `granted` wallet transaction) instead of paying for them. Fixed rules are unchanged: paid vs granted stays implicit via the existing `paid_credits` and `granted_credits` decimal amounts.

`Wallets::RecurringTransactionRules::CreateService` defaults new target rules to `grants_target_top_up: false` when not provided. `UpdateService` normalizes the payload on method transitions (switching to target without specifying defaults to false; switching to fixed forces nil). `ValidateService` rejects any non-nil value when the method isn't target and surfaces the existing `invalid_recurring_rule` error code.

`RecurringTransactionRule#compute_paid_credits` was updated to honor the flag. `#compute_granted_credits` was updated to compute the dynamic grant amount and now reads `wallet.credits_ongoing_balance` directly instead of taking it as a parameter (the two callers were passing exactly that value). The private helper was renamed from `compute_target_paid_credits` to `compute_target_top_up_amount` since both compute methods share it.

Granted gap-fills bypass `paid_top_up_min`. The limit exists to avoid processing tiny payments, and a granted top-up has no payment, so the floor has nothing to constrain. A wallet with a $50 paid minimum that grants a $1 gap will grant $1, not over-shoot the target.
