### PR TITLE
fix(events): preserve event timestamp precision

### DIFF
--- a/app/models/events/common.rb
+++ b/app/models/events/common.rb
@@ -46,7 +46,22 @@ module Events
     end
 
     def as_json
-      super.tap { |j| j["timestamp"] = timestamp.to_f }
+      super.tap do |j|
+        j["timestamp"] = timestamp.to_f
+        j["timestamp_with_precision"] = timestamp.iso8601(9)
+      end
+    end
+
+    def self.timestamp_from_source(source)
+      timestamp = Time.zone.parse(source["timestamp_with_precision"])
+
+      if timestamp.present?
+        return timestamp
+      end
+
+      Time.zone.at(source["timestamp"].to_f)
+    rescue TypeError, ArgumentError
+      Time.zone.at(source["timestamp"].to_f)
     end
   end
 end

--- a/app/services/events/common_factory.rb
+++ b/app/services/events/common_factory.rb
@@ -12,8 +12,7 @@ module Events
           organization_id: source["organization_id"],
           transaction_id: source["transaction_id"],
           external_subscription_id: source["external_subscription_id"],
-          # Keep in mind that we need the milliseconds precision!
-          timestamp: Time.zone.at(source["timestamp"].to_f),
+          timestamp: Events::Common.timestamp_from_source(source),
           code: source["code"],
           properties: source["properties"]
         )

--- a/spec/models/events/common_spec.rb
+++ b/spec/models/events/common_spec.rb
@@ -150,8 +150,34 @@ RSpec.describe Events::Common do
         "external_subscription_id" => subscription.external_id,
         "code" => billable_metric.code,
         "properties" => {},
-        "timestamp" => timestamp.to_f
+        "timestamp" => timestamp.to_f,
+        "timestamp_with_precision" => timestamp.iso8601(9)
       )
+    end
+  end
+
+  describe ".timestamp_from_source" do
+    let(:timestamp) { Time.zone.parse("2026-05-22 10:04:50.227587000 +0000") }
+    let(:source) { event.as_json }
+
+    it "preserves timestamp precision from the serialized event" do
+      expect(described_class.timestamp_from_source(source)).to eq(timestamp)
+    end
+
+    context "when the precise timestamp is not present" do
+      before { source.delete("timestamp_with_precision") }
+
+      it "falls back to the float timestamp" do
+        expect(described_class.timestamp_from_source(source)).to eq(Time.zone.at(source["timestamp"].to_f))
+      end
+    end
+
+    context "when the precise timestamp cannot be parsed" do
+      before { source["timestamp_with_precision"] = "invalid" }
+
+      it "falls back to the float timestamp" do
+        expect(described_class.timestamp_from_source(source)).to eq(Time.zone.at(source["timestamp"].to_f))
+      end
     end
   end
 end

--- a/spec/services/events/common_factory_spec.rb
+++ b/spec/services/events/common_factory_spec.rb
@@ -22,10 +22,22 @@ RSpec.describe Events::CommonFactory do
         expect(new_instance.organization_id).to eq(source["organization_id"])
         expect(new_instance.transaction_id).to eq(source["transaction_id"])
         expect(new_instance.external_subscription_id).to eq(source["external_subscription_id"])
-        # Keep in mind that we need the milliseconds precision!
-        expect(new_instance.timestamp).to eq(Time.zone.at(source["timestamp"].to_f))
+        expect(new_instance.timestamp).to eq(Events::Common.timestamp_from_source(source))
         expect(new_instance.code).to eq(source["code"])
         expect(new_instance.properties).to eq(source["properties"])
+      end
+
+      context "when the serialized timestamp loses precision as a float" do
+        let(:timestamp) { Time.zone.parse("2026-05-22 10:04:50.227587000 +0000") }
+        let(:source) { build(:common_event, timestamp:).as_json }
+
+        it "preserves the precise timestamp" do
+          new_instance = described_class.new_instance(source:)
+
+          expect(Time.zone.at(source["timestamp"].to_f).usec).to eq(227586)
+          expect(new_instance.timestamp).to eq(timestamp)
+          expect(new_instance.timestamp.usec).to eq(227587)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

Pay-in-advance aggregation filters uses persisted events with a max timestamp from the serialized common event in order to perform the aggregations. Serializing only with .to_f can round microseconds down example: `2026-05-22 10:04:50.227587000 +0000` becomes `227586` usec after `Time.zone.at(timestamp.to_f)`, which can exclude the current event from grouped_sum query or other aggregation that depends on `max_timestamp`.

<img width="1121" height="517" alt="Screenshot 2026-05-27 at 11 34 05" src="https://github.com/user-attachments/assets/60dd2fb2-38d9-47bc-9684-1d0801bf23fc" />


## Description

Serialize an additional `iso8601(9)` timestamp so hash-based common events can be rebuilt with nanosecond precision while keeping the existing float timestamp for compatibility. Fall back to the `.to_f` path when the precise timestamp is missing or cannot be parsed.
