### PR TITLE
feat(order-forms): add sign lifecycle REST

### DIFF
--- a/app/controllers/api/v1/order_forms_controller.rb
+++ b/app/controllers/api/v1/order_forms_controller.rb
@@ -37,7 +37,7 @@ module Api
           order_form:,
           signed_document: mark_as_signed_params[:signed_document],
           execution_mode: mark_as_signed_params[:execution_mode],
-          execution_date: mark_as_signed_params[:execution_date]
+          execute_at: mark_as_signed_params[:execute_at]
         )
 
         if result.success?
@@ -75,7 +75,7 @@ module Api
       end
 
       def mark_as_signed_params
-        params.fetch(:order_form, {}).permit(:signed_document, :execution_mode, :execution_date)
+        params.fetch(:order_form, {}).permit(:signed_document, :execution_mode, :execute_at)
       end
 
       def render_order_form(order_form)

--- a/app/controllers/api/v1/order_forms_controller.rb
+++ b/app/controllers/api/v1/order_forms_controller.rb
@@ -30,6 +30,18 @@ module Api
         end
       end
 
+      def mark_as_signed
+        order_form = current_organization.order_forms.find_by(id: params[:id])
+
+        result = OrderForms::MarkAsSignedService.call(order_form:)
+
+        if result.success?
+          render_order_form(result.order_form)
+        else
+          render_error_response(result)
+        end
+      end
+
       def show
         order_form = current_organization.order_forms.find_by(id: params[:id])
         return not_found_error(resource: "order_form") unless order_form

--- a/app/controllers/api/v1/order_forms_controller.rb
+++ b/app/controllers/api/v1/order_forms_controller.rb
@@ -35,7 +35,9 @@ module Api
 
         result = OrderForms::MarkAsSignedService.call(
           order_form:,
-          signed_document: mark_as_signed_params[:signed_document]
+          signed_document: mark_as_signed_params[:signed_document],
+          execution_mode: mark_as_signed_params[:execution_mode],
+          execution_date: mark_as_signed_params[:execution_date]
         )
 
         if result.success?
@@ -73,7 +75,7 @@ module Api
       end
 
       def mark_as_signed_params
-        params.fetch(:order_form, {}).permit(:signed_document)
+        params.fetch(:order_form, {}).permit(:signed_document, :execution_mode, :execution_date)
       end
 
       def render_order_form(order_form)

--- a/app/controllers/api/v1/order_forms_controller.rb
+++ b/app/controllers/api/v1/order_forms_controller.rb
@@ -33,7 +33,10 @@ module Api
       def mark_as_signed
         order_form = current_organization.order_forms.find_by(id: params[:id])
 
-        result = OrderForms::MarkAsSignedService.call(order_form:)
+        result = OrderForms::MarkAsSignedService.call(
+          order_form:,
+          signed_document: mark_as_signed_params[:signed_document]
+        )
 
         if result.success?
           render_order_form(result.order_form)
@@ -67,6 +70,10 @@ module Api
           expires_at_from: params[:expires_at_from],
           expires_at_to: params[:expires_at_to]
         }
+      end
+
+      def mark_as_signed_params
+        params.fetch(:order_form, {}).permit(:signed_document)
       end
 
       def render_order_form(order_form)

--- a/app/controllers/api/v1/order_forms_controller.rb
+++ b/app/controllers/api/v1/order_forms_controller.rb
@@ -75,7 +75,7 @@ module Api
       end
 
       def mark_as_signed_params
-        params.fetch(:order_form, {}).permit(:signed_document, :execution_mode, :execute_at)
+        params.permit(order_form: [:signed_document, :execution_mode, :execute_at]).fetch(:order_form, {})
       end
 
       def render_order_form(order_form)

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -23,6 +23,8 @@ class OrderForm < ApplicationRecord
   belongs_to :quote_version
   has_one :quote, through: :quote_version
 
+  has_one_attached :signed_document
+
   enum :status, STATUSES,
     default: :generated,
     validate: true
@@ -31,6 +33,9 @@ class OrderForm < ApplicationRecord
     validate: {allow_nil: true}
 
   validates :void_reason, presence: true, if: :voided?
+  validates :signed_document,
+    content_type: ["application/pdf"],
+    size: {less_than: 20.megabytes}
 
   sequenced(
     scope: ->(order_form) { order_form.organization.order_forms },
@@ -39,6 +44,13 @@ class OrderForm < ApplicationRecord
 
   def self.ransackable_attributes(_ = nil)
     %w[number]
+  end
+
+  def signed_document_url
+    return unless signed_document.attached?
+    return unless signed_document.blob&.persisted?
+
+    Rails.application.routes.url_helpers.rails_blob_url(signed_document, host: ENV["LAGO_API_URL"])
   end
 
   private

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -51,6 +51,7 @@ class OrderForm < ApplicationRecord
 
   def signed_document_url
     return if signed_document.blank?
+    return unless signed_document.blob.persisted?
 
     Rails.application.routes.url_helpers.rails_blob_url(signed_document, host: ENV["LAGO_API_URL"])
   end

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -16,6 +16,9 @@ class OrderForm < ApplicationRecord
     invalid: "invalid"
   }.freeze
 
+  SIGNED_DOCUMENT_CONTENT_TYPES = %w[application/pdf image/jpeg image/png].freeze
+  SIGNED_DOCUMENT_MAX_SIZE = 10.megabytes
+
   before_save :ensure_number
 
   belongs_to :organization
@@ -34,8 +37,8 @@ class OrderForm < ApplicationRecord
 
   validates :void_reason, presence: true, if: :voided?
   validates :signed_document,
-    content_type: %w[application/pdf image/jpeg image/png],
-    size: {less_than: 10.megabytes}
+    content_type: SIGNED_DOCUMENT_CONTENT_TYPES,
+    size: {less_than: SIGNED_DOCUMENT_MAX_SIZE}
 
   sequenced(
     scope: ->(order_form) { order_form.organization.order_forms },

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -50,8 +50,7 @@ class OrderForm < ApplicationRecord
   end
 
   def signed_document_url
-    return unless signed_document.attached?
-    return unless signed_document.blob&.persisted?
+    return if signed_document.blank?
 
     Rails.application.routes.url_helpers.rails_blob_url(signed_document, host: ENV["LAGO_API_URL"])
   end

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -34,8 +34,8 @@ class OrderForm < ApplicationRecord
 
   validates :void_reason, presence: true, if: :voided?
   validates :signed_document,
-    content_type: ["application/pdf"],
-    size: {less_than: 20.megabytes}
+    content_type: %w[application/pdf image/jpeg image/png],
+    size: {less_than: 10.megabytes}
 
   sequenced(
     scope: ->(order_form) { order_form.organization.order_forms },

--- a/app/serializers/v1/order_form_serializer.rb
+++ b/app/serializers/v1/order_form_serializer.rb
@@ -11,6 +11,7 @@ module V1
         expires_at: model.expires_at&.iso8601,
         signed_at: model.signed_at&.iso8601,
         voided_at: model.voided_at&.iso8601,
+        signed_document_url: model.signed_document_url,
         lago_organization_id: model.organization_id,
         lago_customer_id: model.customer_id,
         lago_quote_id: model.quote_version.quote_id,

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module OrderForms
+  class MarkAsSignedService < BaseService
+    Result = BaseResult[:order_form, :order]
+
+    def initialize(order_form:)
+      @order_form = order_form
+
+      super
+    end
+
+    activity_loggable(
+      action: "order_form.signed",
+      record: -> { order_form }
+    )
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+      return result.not_found_failure!(resource: "order_form") unless order_form
+      return result.not_allowed_failure!(code: "not_signable") unless order_form.generated?
+
+      order_form.assign_attributes(
+        status: :signed,
+        signed_at: Time.current
+      )
+
+      ActiveRecord::Base.transaction do
+        order_form.save!
+
+        # TODO: Create the Order here
+
+        # TODO: Enqueue Orders::ExecuteOrderJob.perform_after_commit(result.order) when auto_execute is true
+      end
+
+      result.order_form = order_form
+      result
+    end
+
+    private
+
+    attr_reader :order_form
+
+    def quote
+      @quote ||= order_form.quote
+    end
+  end
+end

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -33,13 +33,16 @@ module OrderForms
         return result.single_validation_failure!(field: :execution_date, error_code: "invalid_date")
       end
 
+      blob = signed_document_blob
+      return result if result.failure?
+
       order_form.assign_attributes(
         status: :signed,
         signed_at: Time.current
       )
 
       ActiveRecord::Base.transaction do
-        attach_signed_document
+        order_form.signed_document.attach(blob) if blob
         order_form.save!
 
         # TODO: Create the Order here using execution_mode/execution_date
@@ -50,18 +53,34 @@ module OrderForms
       result.order_form = order_form
       result
     rescue ActiveRecord::RecordInvalid => e
+      blob&.purge_later
       result.record_validation_failure!(record: e.record)
+    rescue
+      blob&.purge_later
+      raise
     end
 
     private
 
     attr_reader :order_form, :signed_document, :execution_mode, :execution_date
 
-    def attach_signed_document
+    # Validates and uploads the document OUTSIDE the transaction; returns the persisted blob (or nil).
+    def signed_document_blob
       return if signed_document.blank?
 
       decoded = Utils::Base64File.decode(signed_document)
-      order_form.signed_document.attach(
+
+      unless OrderForm::SIGNED_DOCUMENT_CONTENT_TYPES.include?(decoded.content_type)
+        result.single_validation_failure!(field: :signed_document, error_code: "invalid_content_type")
+        return
+      end
+
+      unless decoded.io.size < OrderForm::SIGNED_DOCUMENT_MAX_SIZE
+        result.single_validation_failure!(field: :signed_document, error_code: "file_too_large")
+        return
+      end
+
+      ActiveStorage::Blob.create_and_upload!(
         io: decoded.io,
         filename: order_form.number,
         content_type: decoded.content_type

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -93,6 +93,11 @@ module OrderForms
 
       decoded = Utils::Base64File.decode(signed_document)
 
+      if decoded.nil?
+        result.single_validation_failure!(field: :signed_document, error_code: "invalid_format")
+        return
+      end
+
       unless OrderForm::SIGNED_DOCUMENT_CONTENT_TYPES.include?(decoded.content_type)
         result.single_validation_failure!(field: :signed_document, error_code: "invalid_content_type")
         return

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -2,6 +2,8 @@
 
 module OrderForms
   class MarkAsSignedService < BaseService
+    include OrderForms::Premium
+
     Result = BaseResult[:order_form, :order]
 
     EXECUTION_MODES = %w[execute_in_lago order_only].freeze
@@ -21,8 +23,8 @@ module OrderForms
     )
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "order_form") unless order_form
+      return result.forbidden_failure! unless order_forms_enabled?(order_form.organization)
       return result.not_allowed_failure!(code: "not_signable") unless order_form.generated?
 
       validate_execution_settings

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -4,8 +4,9 @@ module OrderForms
   class MarkAsSignedService < BaseService
     Result = BaseResult[:order_form, :order]
 
-    def initialize(order_form:)
+    def initialize(order_form:, signed_document: nil)
       @order_form = order_form
+      @signed_document = signed_document
 
       super
     end
@@ -26,6 +27,7 @@ module OrderForms
       )
 
       ActiveRecord::Base.transaction do
+        attach_signed_document
         order_form.save!
 
         # TODO: Create the Order here
@@ -35,11 +37,27 @@ module OrderForms
 
       result.order_form = order_form
       result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
     end
 
     private
 
-    attr_reader :order_form
+    attr_reader :order_form, :signed_document
+
+    def attach_signed_document
+      return if signed_document.blank?
+
+      base64_data = signed_document.split(",")
+      decoded = Base64.decode64(base64_data.second)
+      content_type = base64_data.first.split(";").first.split(":").second
+
+      order_form.signed_document.attach(
+        io: StringIO.new(decoded),
+        filename: "#{order_form.number}.pdf",
+        content_type:
+      )
+    end
 
     def quote
       @quote ||= order_form.quote

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -6,11 +6,11 @@ module OrderForms
 
     EXECUTION_MODES = %w[execute_in_lago order_only].freeze
 
-    def initialize(order_form:, signed_document: nil, execution_mode: nil, execution_date: nil)
+    def initialize(order_form:, signed_document: nil, execution_mode: nil, execute_at: nil)
       @order_form = order_form
       @signed_document = signed_document
       @execution_mode = execution_mode
-      @execution_date = execution_date
+      @execute_at = execute_at
 
       super
     end
@@ -25,13 +25,8 @@ module OrderForms
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.not_allowed_failure!(code: "not_signable") unless order_form.generated?
 
-      if execution_mode.present? && EXECUTION_MODES.exclude?(execution_mode)
-        return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
-      end
-
-      if execution_date.present? && !Utils::Datetime.valid_format?(execution_date, format: :any)
-        return result.single_validation_failure!(field: :execution_date, error_code: "invalid_date")
-      end
+      validate_execution_settings
+      return result if result.failure?
 
       blob = signed_document_blob
       return result if result.failure?
@@ -45,7 +40,7 @@ module OrderForms
         order_form.signed_document.attach(blob) if blob
         order_form.save!
 
-        # TODO: Create the Order here using execution_mode/execution_date
+        # TODO: Create the Order here using execution_mode/execute_at
 
         # TODO: Enqueue Orders::ExecuteOrderJob.perform_after_commit(result.order) when execution_mode == "execute_in_lago"
       end
@@ -62,7 +57,33 @@ module OrderForms
 
     private
 
-    attr_reader :order_form, :signed_document, :execution_mode, :execution_date
+    attr_reader :order_form, :signed_document, :execution_mode, :execute_at
+
+    def validate_execution_settings
+      validate_execution_mode
+      return if result.failure?
+
+      validate_execute_at
+    end
+
+    def validate_execution_mode
+      return if execution_mode.blank? && execute_at.blank?
+
+      if execution_mode.blank?
+        return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
+      end
+
+      return if EXECUTION_MODES.include?(execution_mode)
+
+      result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
+    end
+
+    def validate_execute_at
+      return if execute_at.blank?
+      return if Utils::Datetime.future_date?(execute_at)
+
+      result.single_validation_failure!(field: :execute_at, error_code: "invalid_date")
+    end
 
     # Validates and uploads the document OUTSIDE the transaction; returns the persisted blob (or nil).
     def signed_document_blob
@@ -85,10 +106,6 @@ module OrderForms
         filename: order_form.number,
         content_type: decoded.content_type
       )
-    end
-
-    def quote
-      @quote ||= order_form.quote
     end
   end
 end

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -4,9 +4,13 @@ module OrderForms
   class MarkAsSignedService < BaseService
     Result = BaseResult[:order_form, :order]
 
-    def initialize(order_form:, signed_document: nil)
+    EXECUTION_MODES = %w[execute_in_lago order_only].freeze
+
+    def initialize(order_form:, signed_document: nil, execution_mode: nil, execution_date: nil)
       @order_form = order_form
       @signed_document = signed_document
+      @execution_mode = execution_mode
+      @execution_date = execution_date
 
       super
     end
@@ -21,6 +25,14 @@ module OrderForms
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.not_allowed_failure!(code: "not_signable") unless order_form.generated?
 
+      if execution_mode.present? && EXECUTION_MODES.exclude?(execution_mode)
+        return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
+      end
+
+      if execution_date.present? && !Utils::Datetime.valid_format?(execution_date, format: :any)
+        return result.single_validation_failure!(field: :execution_date, error_code: "invalid_date")
+      end
+
       order_form.assign_attributes(
         status: :signed,
         signed_at: Time.current
@@ -30,9 +42,9 @@ module OrderForms
         attach_signed_document
         order_form.save!
 
-        # TODO: Create the Order here
+        # TODO: Create the Order here using execution_mode/execution_date
 
-        # TODO: Enqueue Orders::ExecuteOrderJob.perform_after_commit(result.order) when auto_execute is true
+        # TODO: Enqueue Orders::ExecuteOrderJob.perform_after_commit(result.order) when execution_mode == "execute_in_lago"
       end
 
       result.order_form = order_form
@@ -43,7 +55,7 @@ module OrderForms
 
     private
 
-    attr_reader :order_form, :signed_document
+    attr_reader :order_form, :signed_document, :execution_mode, :execution_date
 
     def attach_signed_document
       return if signed_document.blank?

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -63,7 +63,7 @@ module OrderForms
       decoded = Utils::Base64File.decode(signed_document)
       order_form.signed_document.attach(
         io: decoded.io,
-        filename: "#{order_form.number}.pdf",
+        filename: order_form.number,
         content_type: decoded.content_type
       )
     end

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -48,14 +48,11 @@ module OrderForms
     def attach_signed_document
       return if signed_document.blank?
 
-      base64_data = signed_document.split(",")
-      decoded = Base64.decode64(base64_data.second)
-      content_type = base64_data.first.split(";").first.split(":").second
-
+      decoded = Utils::Base64File.decode(signed_document)
       order_form.signed_document.attach(
-        io: StringIO.new(decoded),
+        io: decoded.io,
         filename: "#{order_form.number}.pdf",
-        content_type:
+        content_type: decoded.content_type
       )
     end
 

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -30,7 +30,7 @@ module OrderForms
       validate_execution_settings
       return result if result.failure?
 
-      blob = signed_document_blob
+      attachment = signed_document_attachment
       return result if result.failure?
 
       order_form.assign_attributes(
@@ -39,7 +39,7 @@ module OrderForms
       )
 
       ActiveRecord::Base.transaction do
-        order_form.signed_document.attach(blob) if blob
+        order_form.signed_document.attach(attachment) if attachment
         order_form.save!
 
         # TODO: Create the Order here using execution_mode/execute_at
@@ -50,11 +50,7 @@ module OrderForms
       result.order_form = order_form
       result
     rescue ActiveRecord::RecordInvalid => e
-      blob&.purge_later
       result.record_validation_failure!(record: e.record)
-    rescue
-      blob&.purge_later
-      raise
     end
 
     private
@@ -87,8 +83,7 @@ module OrderForms
       result.single_validation_failure!(field: :execute_at, error_code: "invalid_date")
     end
 
-    # Validates and uploads the document OUTSIDE the transaction; returns the persisted blob (or nil).
-    def signed_document_blob
+    def signed_document_attachment
       return if signed_document.blank?
 
       decoded = Utils::Base64File.decode(signed_document)
@@ -98,21 +93,11 @@ module OrderForms
         return
       end
 
-      unless OrderForm::SIGNED_DOCUMENT_CONTENT_TYPES.include?(decoded.content_type)
-        result.single_validation_failure!(field: :signed_document, error_code: "invalid_content_type")
-        return
-      end
-
-      unless decoded.io.size < OrderForm::SIGNED_DOCUMENT_MAX_SIZE
-        result.single_validation_failure!(field: :signed_document, error_code: "file_too_large")
-        return
-      end
-
-      ActiveStorage::Blob.create_and_upload!(
+      {
         io: decoded.io,
         filename: order_form.number,
         content_type: decoded.content_type
-      )
+      }
     end
   end
 end

--- a/app/services/utils/base64_file.rb
+++ b/app/services/utils/base64_file.rb
@@ -5,8 +5,11 @@ module Utils
     Decoded = Data.define(:io, :content_type)
 
     def self.decode(data_uri)
-      metadata, data = data_uri.split(",", 2)
-      content_type = metadata.split(";").first.split(":").second
+      metadata, data = data_uri.to_s.split(",", 2)
+      return if data.nil?
+
+      content_type = metadata.split(";").first&.split(":")&.second
+      return if content_type.blank?
 
       Decoded.new(io: StringIO.new(Base64.decode64(data)), content_type:)
     end

--- a/app/services/utils/base64_file.rb
+++ b/app/services/utils/base64_file.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Utils
+  class Base64File
+    Decoded = Data.define(:io, :content_type)
+
+    def self.decode(data_uri)
+      metadata, data = data_uri.split(",", 2)
+      content_type = metadata.split(";").first.split(":").second
+
+      Decoded.new(io: StringIO.new(Base64.decode64(data)), content_type:)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,11 +5,13 @@ en:
       messages:
         blank: value_is_mandatory
         cannot_be_empty: cannot_be_empty
+        content_type_invalid: invalid_content_type
         country_code_invalid: not_a_valid_country_code
         country_must_be_present: country_must_be_present
         country_not_supported: country_not_supported
         exclusion: value_is_reserved
         feature_unavailable: feature_unavailable
+        file_size_not_less_than: file_too_large
         graduated_percentage_requires_premium_license: graduated_percentage_requires_premium_license
         greater_than: value_is_out_of_range
         greater_than_or_equal_to: value_is_out_of_range

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,9 @@ Rails.application.routes.draw do
         post :resend_email, on: :member
       end
       resources :payment_requests, only: %i[create index show]
-      resources :order_forms, only: %i[show index]
+      resources :order_forms, only: %i[show index] do
+        post :mark_as_signed, on: :member
+      end
       resources :payments, only: %i[create index show]
       resources :plans, param: :code, code: /.*/ do
         resources :charges, only: %i[index show create update destroy], param: :code, code: /.*/, controller: "plans/charges" do

--- a/spec/factories/order_forms.rb
+++ b/spec/factories/order_forms.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
       signed_at { Time.current }
     end
 
+    trait :with_signed_document do
+      signed_document { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/blank.pdf"), "application/pdf") }
+    end
+
     trait :expired do
       status { :expired }
       expires_at { 1.day.ago }

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe OrderForm do
         expect(order_form.errors.added?(:void_reason, :blank)).to be(false)
       end
     end
+
+    describe "signed_document validation" do
+      it { is_expected.to validate_content_type_of(:signed_document).allowing("application/pdf").rejecting("image/png") }
+      it { is_expected.to validate_size_of(:signed_document).less_than(20.megabytes) }
+    end
   end
 
   describe "sequencing" do
@@ -80,6 +85,17 @@ RSpec.describe OrderForm do
     it "preserves an explicitly assigned number" do
       order_form = create(:order_form, number: "OF-CUSTOM-0001")
       expect(order_form.number).to eq("OF-CUSTOM-0001")
+    end
+  end
+
+  describe "#signed_document_url" do
+    it "returns nil when no document is attached" do
+      expect(order_form.signed_document_url).to be_nil
+    end
+
+    it "returns a blob url when a document is attached" do
+      order_form = create(:order_form, :with_signed_document)
+      expect(order_form.signed_document_url).to include("/rails/active_storage/blobs")
     end
   end
 end

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -102,5 +102,10 @@ RSpec.describe OrderForm do
       order_form = create(:order_form, :with_signed_document)
       expect(order_form.signed_document_url).to include("/rails/active_storage/blobs")
     end
+
+    it "returns nil when the attached document is not persisted yet" do
+      order_form.signed_document.attach(io: StringIO.new("pdf"), filename: "doc", content_type: "application/pdf")
+      expect(order_form.signed_document_url).to be_nil
+    end
   end
 end

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -46,8 +46,13 @@ RSpec.describe OrderForm do
     end
 
     describe "signed_document validation" do
-      it { is_expected.to validate_content_type_of(:signed_document).allowing("application/pdf").rejecting("image/png") }
-      it { is_expected.to validate_size_of(:signed_document).less_than(20.megabytes) }
+      it do
+        expect(order_form).to validate_content_type_of(:signed_document)
+          .allowing("application/pdf", "image/jpeg", "image/png")
+          .rejecting("image/gif", "text/plain")
+      end
+
+      it { is_expected.to validate_size_of(:signed_document).less_than(10.megabytes) }
     end
   end
 

--- a/spec/requests/api/v1/order_forms_controller_spec.rb
+++ b/spec/requests/api/v1/order_forms_controller_spec.rb
@@ -172,5 +172,56 @@ RSpec.describe Api::V1::OrderFormsController do
         expect(json[:error_details]).to include(:signed_document)
       end
     end
+
+    context "when execution_mode and execution_date are provided" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+          {order_form: {execution_mode: "execute_in_lago", execution_date: "2026-06-15"}}
+        )
+      end
+
+      it "marks the order form as signed" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:order_form][:status]).to eq("signed")
+      end
+    end
+
+    context "when execution_mode is invalid" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+          {order_form: {execution_mode: "unknown"}}
+        )
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:execution_mode)
+      end
+    end
+
+    context "when execution_date is not a date" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+          {order_form: {execution_date: "not-a-date"}}
+        )
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:execution_date)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/order_forms_controller_spec.rb
+++ b/spec/requests/api/v1/order_forms_controller_spec.rb
@@ -173,12 +173,12 @@ RSpec.describe Api::V1::OrderFormsController do
       end
     end
 
-    context "when execution_mode and execution_date are provided" do
+    context "when execution_mode and execute_at are provided" do
       subject do
         post_with_token(
           organization,
           "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
-          {order_form: {execution_mode: "execute_in_lago", execution_date: "2026-06-15"}}
+          {order_form: {execution_mode: "execute_in_lago", execute_at: 1.month.from_now.iso8601}}
         )
       end
 
@@ -207,12 +207,12 @@ RSpec.describe Api::V1::OrderFormsController do
       end
     end
 
-    context "when execution_date is not a date" do
+    context "when execute_at is set without execution_mode" do
       subject do
         post_with_token(
           organization,
           "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
-          {order_form: {execution_date: "not-a-date"}}
+          {order_form: {execute_at: 1.month.from_now.iso8601}}
         )
       end
 
@@ -220,7 +220,41 @@ RSpec.describe Api::V1::OrderFormsController do
         subject
 
         expect(response).to have_http_status(:unprocessable_content)
-        expect(json[:error_details]).to include(:execution_date)
+        expect(json[:error_details]).to include(:execution_mode)
+      end
+    end
+
+    context "when execute_at is not a date" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+          {order_form: {execution_mode: "execute_in_lago", execute_at: "not-a-date"}}
+        )
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:execute_at)
+      end
+    end
+
+    context "when execute_at is in the past" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+          {order_form: {execution_mode: "execute_in_lago", execute_at: 1.day.ago.iso8601}}
+        )
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:execute_at)
       end
     end
   end

--- a/spec/requests/api/v1/order_forms_controller_spec.rb
+++ b/spec/requests/api/v1/order_forms_controller_spec.rb
@@ -173,6 +173,23 @@ RSpec.describe Api::V1::OrderFormsController do
       end
     end
 
+    context "when the signed_document is malformed" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+          {order_form: {signed_document: "not-a-data-uri"}}
+        )
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:signed_document)
+      end
+    end
+
     context "when execution_mode and execute_at are provided" do
       subject do
         post_with_token(

--- a/spec/requests/api/v1/order_forms_controller_spec.rb
+++ b/spec/requests/api/v1/order_forms_controller_spec.rb
@@ -86,4 +86,52 @@ RSpec.describe Api::V1::OrderFormsController do
       end
     end
   end
+
+  describe "POST /api/v1/order_forms/:id/mark_as_signed", :premium do
+    subject do
+      post_with_token(
+        organization,
+        "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+        {}
+      )
+    end
+
+    before { order_form }
+
+    include_examples "requires API permission", "order_form", "write"
+
+    it "marks the order form as signed" do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:order_form][:lago_id]).to eq(order_form.id)
+      expect(json[:order_form][:status]).to eq("signed")
+    end
+
+    context "when order form is not signable" do
+      let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
+
+      it "returns an error" do
+        subject
+
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+
+    context "when order form does not exist" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{SecureRandom.uuid}/mark_as_signed",
+          {}
+        )
+      end
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("order_form")
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/order_forms_controller_spec.rb
+++ b/spec/requests/api/v1/order_forms_controller_spec.rb
@@ -133,5 +133,44 @@ RSpec.describe Api::V1::OrderFormsController do
         expect(response).to be_not_found_error("order_form")
       end
     end
+
+    context "when a signed_document is provided" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+          {order_form: {signed_document:}}
+        )
+      end
+
+      let(:signed_document) do
+        "data:application/pdf;base64,#{Base64.encode64(File.read(Rails.root.join("spec/fixtures/blank.pdf")))}"
+      end
+
+      it "marks the order form as signed and returns the document url" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:order_form][:status]).to eq("signed")
+        expect(json[:order_form][:signed_document_url]).to be_present
+      end
+    end
+
+    context "when the signed_document is not a PDF" do
+      subject do
+        post_with_token(
+          organization,
+          "/api/v1/order_forms/#{order_form.id}/mark_as_signed",
+          {order_form: {signed_document: "data:text/plain;base64,#{Base64.encode64("not a pdf")}"}}
+        )
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:signed_document)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/order_forms_controller_spec.rb
+++ b/spec/requests/api/v1/order_forms_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Api::V1::OrderFormsController do
       end
     end
 
-    context "when the signed_document is not a PDF" do
+    context "when the signed_document type is unsupported" do
       subject do
         post_with_token(
           organization,

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -111,6 +111,44 @@ RSpec.describe OrderForms::MarkAsSignedService do
         end
       end
 
+      context "when the signed_document exceeds the max size" do
+        let(:signed_document) { "data:application/pdf;base64,#{Base64.strict_encode64("pdf")}" }
+
+        before do
+          decoded = Utils::Base64File::Decoded.new(io: instance_double(StringIO, size: 11.megabytes), content_type: "application/pdf")
+          allow(Utils::Base64File).to receive(:decode).and_return(decoded)
+        end
+
+        it "returns a validation failure without uploading" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to have_key(:signed_document)
+          expect(order_form.reload).to be_generated
+        end
+      end
+
+      context "when saving fails after the document is uploaded" do
+        let(:signed_document) { "data:application/pdf;base64,#{Base64.strict_encode64("pdf")}" }
+        let(:uploaded_blob) do
+          ActiveStorage::Blob.create_and_upload!(io: StringIO.new("pdf"), filename: "doc", content_type: "application/pdf")
+        end
+
+        before do
+          allow(ActiveStorage::Blob).to receive(:create_and_upload!).and_return(uploaded_blob)
+          allow(uploaded_blob).to receive(:purge_later)
+          allow(order_form).to receive(:save!).and_raise(ActiveRecord::RecordInvalid.new(order_form))
+        end
+
+        it "purges the orphaned blob and returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(uploaded_blob).to have_received(:purge_later)
+        end
+      end
+
       context "when execution_mode and execution_date are provided" do
         let(:execution_mode) { "execute_in_lago" }
         let(:execution_date) { "2026-06-15" }

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrderForms::MarkAsSignedService do
+  subject(:service) { described_class.new(order_form:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, customer:, organization:, order_type: :subscription_creation) }
+  let(:order_form) { create(:order_form, customer:, organization:, quote:) }
+
+  describe "#call" do
+    context "without premium license" do
+      it "returns a forbidden failure" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "with premium license", :premium do
+      context "when order_form is nil" do
+        let(:order_form) { nil }
+
+        it "returns a not found failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("order_form")
+        end
+      end
+
+      context "when order_form is not generated" do
+        let(:order_form) { create(:order_form, :signed, customer:, organization:, quote:) }
+
+        it "returns a not allowed failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq("not_signable")
+        end
+      end
+
+      context "when order_form is voided" do
+        let(:order_form) { create(:order_form, :voided, customer:, organization:, quote:) }
+
+        it "returns a not allowed failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq("not_signable")
+        end
+      end
+
+      context "when order_form is expired" do
+        let(:order_form) { create(:order_form, :expired, customer:, organization:, quote:) }
+
+        it "returns a not allowed failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq("not_signable")
+        end
+      end
+
+      context "when order_form is generated" do
+        it "transitions the order form to signed" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order_form).to be_signed
+          expect(result.order_form.signed_at).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe OrderForms::MarkAsSignedService do
 
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages).to have_key(:signed_document)
+          expect(result.error.messages[:signed_document]).to eq(["invalid_content_type"])
           expect(order_form.reload).to be_generated
         end
       end
@@ -139,7 +139,9 @@ RSpec.describe OrderForms::MarkAsSignedService do
         let(:signed_document) { "data:application/pdf;base64,#{Base64.strict_encode64("pdf")}" }
 
         before do
-          decoded = Utils::Base64File::Decoded.new(io: instance_double(StringIO, size: 11.megabytes), content_type: "application/pdf")
+          io = StringIO.new("pdf")
+          allow(io).to receive(:size).and_return(11.megabytes)
+          decoded = Utils::Base64File::Decoded.new(io:, content_type: "application/pdf")
           allow(Utils::Base64File).to receive(:decode).and_return(decoded)
         end
 
@@ -148,28 +150,28 @@ RSpec.describe OrderForms::MarkAsSignedService do
 
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages).to have_key(:signed_document)
+          expect(result.error.messages[:signed_document]).to eq(["file_too_large"])
           expect(order_form.reload).to be_generated
         end
       end
 
-      context "when saving fails after the document is uploaded" do
+      context "when saving fails" do
         let(:signed_document) { "data:application/pdf;base64,#{Base64.strict_encode64("pdf")}" }
-        let(:uploaded_blob) do
-          ActiveStorage::Blob.create_and_upload!(io: StringIO.new("pdf"), filename: "doc", content_type: "application/pdf")
-        end
 
         before do
-          allow(ActiveStorage::Blob).to receive(:create_and_upload!).and_return(uploaded_blob)
-          allow(uploaded_blob).to receive(:purge_later)
           allow(order_form).to receive(:save!).and_raise(ActiveRecord::RecordInvalid.new(order_form))
         end
 
-        it "purges the orphaned blob and returns a validation failure" do
+        it "rolls back without persisting a blob" do
+          expect { service.call }.not_to change(ActiveStorage::Blob, :count)
+        end
+
+        it "returns a validation failure without signing" do
           result = service.call
 
           expect(result).not_to be_success
-          expect(uploaded_blob).to have_received(:purge_later)
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(order_form.reload).to be_generated
         end
       end
 

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -122,6 +122,19 @@ RSpec.describe OrderForms::MarkAsSignedService do
         end
       end
 
+      context "when the signed_document is malformed" do
+        let(:signed_document) { "not-a-data-uri" }
+
+        it "returns a validation failure without signing" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:signed_document]).to eq(["invalid_format"])
+          expect(order_form.reload).to be_generated
+        end
+      end
+
       context "when the signed_document exceeds the max size" do
         let(:signed_document) { "data:application/pdf;base64,#{Base64.strict_encode64("pdf")}" }
 

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe OrderForms::MarkAsSignedService do
-  subject(:service) { described_class.new(order_form:, signed_document:, execution_mode:, execution_date:) }
+  subject(:service) { described_class.new(order_form:, signed_document:, execution_mode:, execute_at:) }
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
@@ -11,7 +11,7 @@ RSpec.describe OrderForms::MarkAsSignedService do
   let(:order_form) { create(:order_form, customer:, organization:, quote:) }
   let(:signed_document) { nil }
   let(:execution_mode) { nil }
-  let(:execution_date) { nil }
+  let(:execute_at) { nil }
 
   describe "#call" do
     context "without premium license" do
@@ -149,9 +149,9 @@ RSpec.describe OrderForms::MarkAsSignedService do
         end
       end
 
-      context "when execution_mode and execution_date are provided" do
+      context "when execution_mode and execute_at are provided" do
         let(:execution_mode) { "execute_in_lago" }
-        let(:execution_date) { "2026-06-15" }
+        let(:execute_at) { 1.month.from_now.iso8601 }
 
         it "signs the order form without acting on them" do
           result = service.call
@@ -173,15 +173,54 @@ RSpec.describe OrderForms::MarkAsSignedService do
         end
       end
 
-      context "when execution_date is not a date" do
-        let(:execution_date) { "not-a-date" }
+      context "when execute_at is set without execution_mode" do
+        let(:execute_at) { 1.month.from_now.iso8601 }
 
-        it "returns a validation failure on execution_date" do
+        it "returns a validation failure on execution_mode" do
           result = service.call
 
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages).to have_key(:execution_date)
+          expect(result.error.messages[:execution_mode]).to eq(["value_is_mandatory"])
+        end
+      end
+
+      context "when execute_at is not a date" do
+        let(:execution_mode) { "execute_in_lago" }
+        let(:execute_at) { "not-a-date" }
+
+        it "returns a validation failure on execute_at" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to have_key(:execute_at)
+        end
+      end
+
+      context "when execute_at is in the past" do
+        let(:execution_mode) { "execute_in_lago" }
+        let(:execute_at) { 1.day.ago.iso8601 }
+
+        it "returns a validation failure on execute_at" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:execute_at]).to eq(["invalid_date"])
+        end
+      end
+
+      context "when execute_at is the current date" do
+        let(:execution_mode) { "execute_in_lago" }
+        let(:execute_at) { Date.current.iso8601 }
+
+        it "returns a validation failure on execute_at" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:execute_at]).to eq(["invalid_date"])
         end
       end
     end

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -3,12 +3,13 @@
 require "rails_helper"
 
 RSpec.describe OrderForms::MarkAsSignedService do
-  subject(:service) { described_class.new(order_form:) }
+  subject(:service) { described_class.new(order_form:, signed_document:) }
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, customer:, organization:, order_type: :subscription_creation) }
   let(:order_form) { create(:order_form, customer:, organization:, quote:) }
+  let(:signed_document) { nil }
 
   describe "#call" do
     context "without premium license" do
@@ -77,6 +78,34 @@ RSpec.describe OrderForms::MarkAsSignedService do
           expect(result).to be_success
           expect(result.order_form).to be_signed
           expect(result.order_form.signed_at).to be_present
+        end
+      end
+
+      context "when a signed_document is provided" do
+        let(:signed_document) do
+          "data:application/pdf;base64,#{Base64.encode64(File.read(Rails.root.join("spec/fixtures/blank.pdf")))}"
+        end
+
+        it "signs the order form and attaches the document" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order_form).to be_signed
+          expect(result.order_form.signed_document).to be_attached
+          expect(result.order_form.signed_document.blob.content_type).to eq("application/pdf")
+        end
+      end
+
+      context "when the signed_document is not a PDF" do
+        let(:signed_document) { "data:text/plain;base64,#{Base64.encode64("not a pdf")}" }
+
+        it "returns a validation failure and does not sign the order form" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to have_key(:signed_document)
+          expect(order_form.reload).to be_generated
         end
       end
     end

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe OrderForms::MarkAsSignedService do
         end
       end
 
-      context "when the signed_document is not a PDF" do
+      context "when the signed_document type is unsupported" do
         let(:signed_document) { "data:text/plain;base64,#{Base64.encode64("not a pdf")}" }
 
         it "returns a validation failure and does not sign the order form" do

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -3,13 +3,15 @@
 require "rails_helper"
 
 RSpec.describe OrderForms::MarkAsSignedService do
-  subject(:service) { described_class.new(order_form:, signed_document:) }
+  subject(:service) { described_class.new(order_form:, signed_document:, execution_mode:, execution_date:) }
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, customer:, organization:, order_type: :subscription_creation) }
   let(:order_form) { create(:order_form, customer:, organization:, quote:) }
   let(:signed_document) { nil }
+  let(:execution_mode) { nil }
+  let(:execution_date) { nil }
 
   describe "#call" do
     context "without premium license" do
@@ -106,6 +108,42 @@ RSpec.describe OrderForms::MarkAsSignedService do
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages).to have_key(:signed_document)
           expect(order_form.reload).to be_generated
+        end
+      end
+
+      context "when execution_mode and execution_date are provided" do
+        let(:execution_mode) { "execute_in_lago" }
+        let(:execution_date) { "2026-06-15" }
+
+        it "signs the order form without acting on them" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order_form).to be_signed
+        end
+      end
+
+      context "when execution_mode is invalid" do
+        let(:execution_mode) { "unknown" }
+
+        it "returns a validation failure on execution_mode" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to have_key(:execution_mode)
+        end
+      end
+
+      context "when execution_date is not a date" do
+        let(:execution_date) { "not-a-date" }
+
+        it "returns a validation failure on execution_date" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to have_key(:execution_date)
         end
       end
     end

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe OrderForms::MarkAsSignedService do
   subject(:service) { described_class.new(order_form:, signed_document:, execution_mode:, execute_at:) }
 
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
   let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, customer:, organization:, order_type: :subscription_creation) }
   let(:order_form) { create(:order_form, customer:, organization:, quote:) }
@@ -34,6 +34,17 @@ RSpec.describe OrderForms::MarkAsSignedService do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::NotFoundFailure)
           expect(result.error.resource).to eq("order_form")
+        end
+      end
+
+      context "when the order_forms feature flag is disabled" do
+        let(:organization) { create(:organization) }
+
+        it "returns a forbidden failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ForbiddenFailure)
         end
       end
 

--- a/spec/services/utils/base64_file_spec.rb
+++ b/spec/services/utils/base64_file_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Utils::Base64File do
+  describe ".decode" do
+    subject(:decoded) { described_class.decode(data_uri) }
+
+    let(:content) { "hello world" }
+    let(:data_uri) { "data:application/pdf;base64,#{Base64.strict_encode64(content)}" }
+
+    it "extracts the declared content type from the data URI" do
+      expect(decoded.content_type).to eq("application/pdf")
+    end
+
+    it "decodes the payload into a readable io" do
+      expect(decoded.io.read).to eq(content)
+    end
+
+    context "with a different declared mime type" do
+      let(:data_uri) { "data:image/png;base64,#{Base64.strict_encode64(content)}" }
+
+      it "returns that content type" do
+        expect(decoded.content_type).to eq("image/png")
+      end
+    end
+  end
+end

--- a/spec/services/utils/base64_file_spec.rb
+++ b/spec/services/utils/base64_file_spec.rb
@@ -24,5 +24,21 @@ RSpec.describe Utils::Base64File do
         expect(decoded.content_type).to eq("image/png")
       end
     end
+
+    context "when the data URI has no comma" do
+      let(:data_uri) { "not-a-data-uri" }
+
+      it "returns nil" do
+        expect(decoded).to be_nil
+      end
+    end
+
+    context "when the metadata carries no content type" do
+      let(:data_uri) { "base64,#{Base64.strict_encode64(content)}" }
+
+      it "returns nil" do
+        expect(decoded).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  [Quotes & Order forms](https://getlago.canny.io/feature-requests/p/create-quotes-order-forms)

## Context

Once an order form has been generated for an approved quote version, the next step in its lifecycle is signature. There was no way to mark an order form as signed through the REST API, so the `generated → signed` transition could not be driven by clients.

## Description

Add a `mark_as_signed` lifecycle action to order forms.

