### PR TITLE
[ING-133] fix(events-query): Add transaction_id pagination tiebreaker

### DIFF
--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -19,11 +19,11 @@ class EventsQuery < BaseQuery
     events = paginate(events)
 
     events = if pg_event?
-      events.order(timestamp: :desc)
+      events.order(timestamp: :desc, transaction_id: :asc)
     elsif ch_event_raw?
-      events.order(ingested_at: :desc)
+      events.order(ingested_at: :desc, transaction_id: :asc)
     elsif ch_event_enriched?
-      events.order(enriched_at: :desc)
+      events.order(enriched_at: :desc, transaction_id: :asc)
     end
 
     events = with_code(events) if filters.code

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -34,6 +34,30 @@ RSpec.describe EventsQuery do
       end
     end
 
+    context "when several events share the same timestamp" do
+      let(:external_subscription_id) { "sub_tie_break" }
+      let(:shared_timestamp) { 1.hour.ago.change(usec: 0) }
+      let(:transaction_ids) { Array.new(5) { |i| format("txn_%02d", i) } }
+
+      before do
+        transaction_ids.shuffle.each do |transaction_id|
+          create(:event, organization:, external_subscription_id:, timestamp: shared_timestamp, transaction_id:)
+        end
+      end
+
+      it "paginates deterministically without duplicated or missing events" do
+        collected = (1..3).flat_map do |page|
+          described_class.new(
+            organization:,
+            pagination: {page:, limit: 2},
+            filters: {external_subscription_id:}
+          ).call.events.map(&:transaction_id)
+        end
+
+        expect(collected).to eq(transaction_ids)
+      end
+    end
+
     context "with code filter" do
       let(:event2) { create(:event, organization:) }
       let(:filters) { {code: event.code} }
@@ -170,6 +194,43 @@ RSpec.describe EventsQuery do
           expect(result).to be_failure
           expect(result.error.messages).to eq({external_subscription_id: ["required with timestamp_from_started_at"]})
         end
+      end
+    end
+  end
+
+  describe "call with clickhouse store", clickhouse: true, transaction: false do
+    let(:organization) { create(:organization, clickhouse_events_store: true) }
+    let(:subscription) { create(:subscription, organization:) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
+
+    context "when several events share the same ingested_at" do
+      let(:ingested_at) { 2.days.ago.change(usec: 0) }
+      let(:transaction_ids) { Array.new(25) { |i| format("txn_%02d", i) } }
+
+      before do
+        transaction_ids.shuffle.each do |transaction_id|
+          Clickhouse::EventsRaw.create!(
+            transaction_id:,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            code: billable_metric.code,
+            timestamp: ingested_at,
+            properties: {},
+            ingested_at:
+          )
+        end
+      end
+
+      it "paginates deterministically without duplicated or missing events" do
+        collected = (1..3).flat_map do |page|
+          described_class.new(
+            organization:,
+            pagination: {page:, limit: 10},
+            filters: {}
+          ).call.events.map(&:transaction_id)
+        end
+
+        expect(collected).to eq(transaction_ids)
       end
     end
   end


### PR DESCRIPTION
## Context

The Events API (`GET /api/v1/events`) returned inconsistent results across paginated calls when a batch of events shared the same `ingested_at` timestamp. `EventsQuery` ordered raw ClickHouse events by `ingested_at: :desc` with no secondary key (the Postgres and enriched paths had the same gap). A single sort key over non-unique values is only a partial order, so the database is free to break ties differently between the separate queries that fetch each page. Tied rows drifted between pages: some appeared more than once, others never appeared. In the reported incident, a customer auditing bulk-ingested usage saw 18 of 156 same-timestamp events never show up across 4 pages.

(Note: the ticket framed this as "pagination applied before ordering", but `paginate` returns a lazy relation and `.order` is chained onto it, so the emitted SQL always carries both `ORDER BY` and `LIMIT/OFFSET`. The real cause is the missing tiebreaker, not the chaining order.)

## Description

`transaction_id` is added as a deterministic secondary sort key on all three ordering paths. Combined with the primary key it produces a total order, so offset windows can no longer overlap or skip rows. `transaction_id` is present on every events model and already sits in the `events_raw` / `events_enriched` ClickHouse sort keys, so it is the natural tiebreaker.

| Store | Before | After |
|---|---|---|
| Postgres | `ORDER BY timestamp DESC` | `ORDER BY timestamp DESC, transaction_id ASC` |
| ClickHouse raw | `ORDER BY ingested_at DESC` | `ORDER BY ingested_at DESC, transaction_id ASC` |
| ClickHouse enriched | `ORDER BY enriched_at DESC` | `ORDER BY enriched_at DESC, transaction_id ASC` |

Covered by two regression specs (Postgres same-`timestamp`, ClickHouse same-`ingested_at`) that insert events in shuffled order and assert pagination returns every event exactly once in a stable sequence. Both fail without the fix.

## How to try locally

```
lago exec api bundle exec rspec spec/queries/events_query_spec.rb
lago exec api bundle exec rspec spec/queries/events_query_spec.rb --tag clickhouse
```

ClickHouse specs need the test schema loaded first:

```
lago exec api bash -c 'LAGO_CLICKHOUSE_MIGRATIONS_ENABLED=true RAILS_ENV=test bin/rails db:migrate:clickhouse'
```