### PR TITLE
perf(inovoices): Introduce Preloaders to preload calculations for a bunch of records

### DIFF
--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -59,7 +59,6 @@ module InvoiceIndex
     )
 
     if result.success?
-      #InvoicesPreloader.new(result.invoices, only: :offset_amount_cents).call
       invoices = InvoicesPreloader.new(
         result.invoices.includes(
           :metadata,
@@ -76,7 +75,8 @@ module InvoiceIndex
             :moneyhash_customer,
             {integration_customers: :integration}
           ]
-        )
+        ),
+        :offset_amount_cents
       ).call
 
       render(

--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -59,7 +59,8 @@ module InvoiceIndex
     )
 
     if result.success?
-      invoices = Invoice.preload_offset_amounts(
+      #InvoicesPreloader.new(result.invoices, only: :offset_amount_cents).call
+      invoices = InvoicesPreloader.new(
         result.invoices.includes(
           :metadata,
           :applied_taxes,
@@ -76,7 +77,7 @@ module InvoiceIndex
             {integration_customers: :integration}
           ]
         )
-      )
+      ).call
 
       render(
         json: ::CollectionSerializer.new(

--- a/app/graphql/resolvers/customer_portal/invoices_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/invoices_resolver.rb
@@ -27,8 +27,7 @@ module Resolvers
 
         return result_error(result) unless result.success?
 
-        #InvoicesPreloader.new(result.invoices, only: :offset_amount_cents).call
-        InvoicesPreloader.new(result.invoices).call
+        InvoicesPreloader.new(result.invoices, :offset_amount_cents).call
       rescue ActiveRecord::RecordNotFound
         not_found_error(resource: "customer")
       end

--- a/app/graphql/resolvers/customer_portal/invoices_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/invoices_resolver.rb
@@ -27,7 +27,8 @@ module Resolvers
 
         return result_error(result) unless result.success?
 
-        Invoice.preload_offset_amounts(result.invoices)
+        #InvoicesPreloader.new(result.invoices, only: :offset_amount_cents).call
+        InvoicesPreloader.new(result.invoices).call
       rescue ActiveRecord::RecordNotFound
         not_found_error(resource: "customer")
       end

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -35,7 +35,8 @@ module Resolvers
 
         return result_error(result) unless result.success?
 
-        Invoice.preload_offset_amounts(result.invoices)
+        #InvoicesPreloader.new(result.invoices, only: :offset_amount_cents).call
+        InvoicesPreloader.new(result.invoices).call
       rescue ActiveRecord::RecordNotFound
         not_found_error(resource: "customer")
       end

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -35,8 +35,7 @@ module Resolvers
 
         return result_error(result) unless result.success?
 
-        #InvoicesPreloader.new(result.invoices, only: :offset_amount_cents).call
-        InvoicesPreloader.new(result.invoices).call
+        InvoicesPreloader.new(result.invoices, :offset_amount_cents).call
       rescue ActiveRecord::RecordNotFound
         not_found_error(resource: "customer")
       end

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -84,15 +84,15 @@ module Resolvers
 
       return result_error(result) unless result.success?
 
-      invoices = result.invoices.preload(
-        :fees,
-        :regenerated_invoice,
-        :error_details,
-        :billing_entity,
-        {customer: :billing_entity}
-      )
-
-      ::InvoicesPreloader.new(invoices).call
+      ::InvoicesPreloader.new(
+        result.invoices.preload(
+          :fees,
+          :regenerated_invoice,
+          :error_details,
+          :billing_entity,
+          {customer: :billing_entity}
+        )
+      ).call
     end
   end
 end

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -84,15 +84,15 @@ module Resolvers
 
       return result_error(result) unless result.success?
 
-      Invoice.preload_offset_amounts(
-        result.invoices.preload(
-          :fees,
-          :regenerated_invoice,
-          :error_details,
-          :billing_entity,
-          {customer: :billing_entity}
-        )
+      invoices = result.invoices.preload(
+        :fees,
+        :regenerated_invoice,
+        :error_details,
+        :billing_entity,
+        {customer: :billing_entity}
       )
+
+      ::InvoicesPreloader.new(invoices).call
     end
   end
 end

--- a/app/models/concerns/preloader_cache.rb
+++ b/app/models/concerns/preloader_cache.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PreloaderCache
+  extend ActiveSupport::Concern
+
+  def preloader_cache
+    @preloader_cache ||= {}
+  end
+end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -3,6 +3,7 @@
 class Fee < ApplicationRecord
   include Currencies
   include Discard::Model
+  include PreloaderCache
 
   self.discard_column = :deleted_at
   self.ignored_columns += %w[duplicated_in_advance]
@@ -216,13 +217,18 @@ class Fee < ApplicationRecord
   end
 
   def creditable_amount_cents
-    remaining_amount = amount_cents - credit_note_items.sum(:amount_cents)
+    remaining_amount = amount_cents - credited_amount_cents
 
     if credit?
       return [remaining_amount, creditable_from_wallet_amount_cents].min
     end
 
     remaining_amount
+  end
+
+  def credited_amount_cents
+    preloader_cache[:credited_amount_cents] ||
+      credit_note_items.sum(:amount_cents)
   end
 
   def creditable_from_wallet_amount_cents

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -227,8 +227,7 @@ class Fee < ApplicationRecord
   end
 
   def credited_amount_cents
-    preloader_cache[:credited_amount_cents] ||
-      credit_note_items.sum(:amount_cents)
+    preloader_cache[:credited_amount_cents] || credit_note_items.sum(:amount_cents)
   end
 
   def creditable_from_wallet_amount_cents

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Invoice < ApplicationRecord
+  include PreloaderCache
+
   self.ignored_columns += [:negative_amount_cents] # TODO: remove when negative_amount_cents is removed from the database
 
   include AASM
@@ -154,34 +156,12 @@ class Invoice < ApplicationRecord
   validates :total_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :payment_dispute_lost_at, absence: true, unless: :payment_dispute_losable?
 
-  attr_writer :precalculated_offset_amount_cents
-
   def self.ransackable_attributes(_ = nil)
     %w[id number]
   end
 
   def self.ransackable_associations(_ = nil)
     %w[customer]
-  end
-
-  # Batch-loads offset_amount_cents for a collection of invoices in a single query,
-  # caching the result on each instance to avoid N+1 queries during serialization.
-  def self.preload_offset_amounts(invoices)
-    return unless invoices
-
-    invoice_ids = invoices.map(&:id).compact
-
-    offset_amounts = CreditNote
-      .where(invoice_id: invoice_ids)
-      .finalized
-      .group(:invoice_id)
-      .sum(:offset_amount_cents)
-
-    invoices.each do |invoice|
-      invoice.precalculated_offset_amount_cents = (offset_amounts[invoice.id] || 0)
-    end
-
-    invoices
   end
 
   def payment_invoices
@@ -317,9 +297,8 @@ class Invoice < ApplicationRecord
   end
 
   def offset_amount_cents
-    return @precalculated_offset_amount_cents if instance_variable_defined?(:@precalculated_offset_amount_cents)
-
-    credit_notes.finalized.sum(:offset_amount_cents)
+    preloader_cache[:offset_amount_cents] ||
+      credit_notes.finalized.sum(:offset_amount_cents)
   end
 
   def total_due_amount_cents
@@ -379,8 +358,7 @@ class Invoice < ApplicationRecord
     return 0 if version_number < CREDIT_NOTES_MIN_VERSION || draft?
     return 0 if !payment_succeeded? && total_paid_amount_cents == total_amount_cents
 
-    already_refunded_cents = credit_notes.sum("refund_amount_cents")
-    remaining_paid_cents = total_paid_amount_cents - already_refunded_cents
+    remaining_paid_cents = total_paid_amount_cents - refunded_amount_cents
 
     # when invoice is for pre paid credits we can issue a credit note only as refund
     # so creditable_amount_cents is always 0 but on that case we should allow to issue a credit note
@@ -391,6 +369,11 @@ class Invoice < ApplicationRecord
 
     refundable_cents = [remaining_paid_cents, creditable_amount_cents].min
     refundable_cents.negative? ? 0 : refundable_cents
+  end
+
+  def refunded_amount_cents
+    preloader_cache[:refunded_amount_cents] ||
+      credit_notes.sum("refund_amount_cents")
   end
 
   # Credit invoices have a single credit-type fee linked to the wallet transaction

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -372,8 +372,7 @@ class Invoice < ApplicationRecord
   end
 
   def refunded_amount_cents
-    preloader_cache[:refunded_amount_cents] ||
-      credit_notes.sum("refund_amount_cents")
+    preloader_cache[:refunded_amount_cents] || credit_notes.sum(:refund_amount_cents)
   end
 
   # Credit invoices have a single credit-type fee linked to the wallet transaction

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -297,8 +297,7 @@ class Invoice < ApplicationRecord
   end
 
   def offset_amount_cents
-    preloader_cache[:offset_amount_cents] ||
-      credit_notes.finalized.sum(:offset_amount_cents)
+    preloader_cache[:offset_amount_cents] || credit_notes.finalized.sum(:offset_amount_cents)
   end
 
   def total_due_amount_cents

--- a/app/preloaders/base_preloader.rb
+++ b/app/preloaders/base_preloader.rb
@@ -22,9 +22,9 @@ class BasePreloader
     @record_ids ||= records.map(&:id).compact
   end
 
-  def cache(records, value, preloaded, default: 0)
+  def cache(records, scope, values, default: 0)
     records.each do |record|
-      record.preloader_cache[value] = preloaded[record.id] || default
+      record.preloader_cache[scope] = values[record.id] || default
     end
   end
 end

--- a/app/preloaders/base_preloader.rb
+++ b/app/preloaders/base_preloader.rb
@@ -3,7 +3,7 @@
 class BasePreloader
   def initialize(scope, *preloads)
     @scope = scope
-    @preloads = preloads.any? ? preloads : self.class::PRELOAD
+    @preloads = preloads.any? ? preloads : self.class::PRELOADS
   end
 
   def call

--- a/app/preloaders/base_preloader.rb
+++ b/app/preloaders/base_preloader.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class BasePreloader
+  def initialize(scope, *values)
+    @scope = scope
+    @values = values.empty? ? self.class::PRELOAD : values
+  end
+
+  def call
+    values.each do |value|
+      send("preload_#{value}")
+    end
+
+    scope
+  end
+
+  private
+
+  attr_reader :scope, :values
+
+  def scope_ids
+    @scope_ids ||= scope.map(&:id).compact
+  end
+
+  def cache(records, value, preloaded)
+    records.each do |record|
+      record.preloader_cache[value] = preloaded[record.id] || 0
+    end
+  end
+end

--- a/app/preloaders/base_preloader.rb
+++ b/app/preloaders/base_preloader.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
 class BasePreloader
-  def initialize(scope, *preloads)
-    @scope = scope
-    @preloads = preloads.any? ? preloads : self.class::PRELOADS
+  def initialize(records, *scopes)
+    @records = records
+    @scopes = scopes.any? ? scopes : self.class::SCOPES
   end
 
   def call
-    preloads.each do |value|
-      send("preload_#{value}")
+    scopes.each do |scope|
+      send("preload_#{scope}")
     end
 
-    scope
+    records
   end
 
   private
 
-  attr_reader :scope, :preloads
+  attr_reader :records, :scopes
 
-  def scope_ids
-    @scope_ids ||= scope.map(&:id).compact
+  def record_ids
+    @record_ids ||= records.map(&:id).compact
   end
 
   def cache(records, value, preloaded, default: 0)

--- a/app/preloaders/base_preloader.rb
+++ b/app/preloaders/base_preloader.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class BasePreloader
-  def initialize(scope, *values)
+  def initialize(scope, *preloads)
     @scope = scope
-    @values = values.empty? ? self.class::PRELOAD : values
+    @preloads = preloads.any? ? preloads : self.class::PRELOAD
   end
 
   def call
-    values.each do |value|
+    preloads.each do |value|
       send("preload_#{value}")
     end
 
@@ -16,15 +16,15 @@ class BasePreloader
 
   private
 
-  attr_reader :scope, :values
+  attr_reader :scope, :preloads
 
   def scope_ids
     @scope_ids ||= scope.map(&:id).compact
   end
 
-  def cache(records, value, preloaded)
+  def cache(records, value, preloaded, default: 0)
     records.each do |record|
-      record.preloader_cache[value] = preloaded[record.id] || 0
+      record.preloader_cache[value] = preloaded[record.id] || default
     end
   end
 end

--- a/app/preloaders/invoices_preloader.rb
+++ b/app/preloaders/invoices_preloader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvoicesPreloader < BasePreloader
-  PRELOADS = %i[
+  SCOPES = %i[
     offset_amount_cents
     refunded_amount_cents
     credited_amount_cents
@@ -11,25 +11,25 @@ class InvoicesPreloader < BasePreloader
 
   def preload_offset_amount_cents
     offset_amounts = CreditNote
-      .where(invoice_id: scope_ids)
+      .where(invoice_id: record_ids)
       .finalized
       .group(:invoice_id)
       .sum(:offset_amount_cents)
 
-    cache(scope, :offset_amount_cents, offset_amounts)
+    cache(records, :offset_amount_cents, offset_amounts)
   end
 
   def preload_refunded_amount_cents
     refund_amounts = CreditNote
-      .where(invoice_id: scope_ids)
+      .where(invoice_id: record_ids)
       .group(:invoice_id)
       .sum(:refund_amount_cents)
 
-    cache(scope, :refunded_amount_cents, refund_amounts)
+    cache(records, :refunded_amount_cents, refund_amounts)
   end
 
   def preload_credited_amount_cents
-    fees = scope.map(&:fees).flatten
+    fees = records.flat_map(&:fees)
 
     credited_amounts = CreditNoteItem
       .where(fee_id: fees)

--- a/app/preloaders/invoices_preloader.rb
+++ b/app/preloaders/invoices_preloader.rb
@@ -3,8 +3,8 @@
 class InvoicesPreloader < BasePreloader
   PRELOAD = %i[
     offset_amount_cents
-    credited_amount_cents
     refunded_amount_cents
+    credited_amount_cents
   ]
 
   private
@@ -19,7 +19,16 @@ class InvoicesPreloader < BasePreloader
     cache(scope, :offset_amount_cents, offset_amounts)
   end
 
-  def preload_credited_amount_cents 
+  def preload_refunded_amount_cents
+    refund_amounts = CreditNote
+      .where(invoice_id: scope_ids)
+      .group(:invoice_id)
+      .sum(:refund_amount_cents)
+
+    cache(scope, :refunded_amount_cents, refund_amounts)
+  end
+
+  def preload_credited_amount_cents
     fees = scope.map(&:fees).flatten
 
     credited_amounts = CreditNoteItem
@@ -28,14 +37,5 @@ class InvoicesPreloader < BasePreloader
       .sum(:amount_cents)
 
     cache(fees, :credited_amount_cents, credited_amounts)
-  end
-
-  def preload_refunded_amount_cents
-    refund_amounts = CreditNote
-      .where(invoice_id: scope_ids)
-      .group(:invoice_id)
-      .sum(:refund_amount_cents)
-
-    cache(scope, :refunded_amount_cents, refund_amounts)
   end
 end

--- a/app/preloaders/invoices_preloader.rb
+++ b/app/preloaders/invoices_preloader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvoicesPreloader < BasePreloader
-  PRELOAD = %i[
+  PRELOADS = %i[
     offset_amount_cents
     refunded_amount_cents
     credited_amount_cents

--- a/app/preloaders/invoices_preloader.rb
+++ b/app/preloaders/invoices_preloader.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class InvoicesPreloader < BasePreloader
+  PRELOAD = %i[
+    offset_amount_cents
+    credited_amount_cents
+    refunded_amount_cents
+  ]
+
+  private
+
+  def preload_offset_amount_cents
+    offset_amounts = CreditNote
+      .where(invoice_id: scope_ids)
+      .finalized
+      .group(:invoice_id)
+      .sum(:offset_amount_cents)
+
+    cache(scope, :offset_amount_cents, offset_amounts)
+  end
+
+  def preload_credited_amount_cents 
+    fees = scope.map(&:fees).flatten
+
+    credited_amounts = CreditNoteItem
+      .where(fee_id: fees)
+      .group(:fee_id)
+      .sum(:amount_cents)
+
+    cache(fees, :credited_amount_cents, credited_amounts)
+  end
+
+  def preload_refunded_amount_cents
+    refund_amounts = CreditNote
+      .where(invoice_id: scope_ids)
+      .group(:invoice_id)
+      .sum(:refund_amount_cents)
+
+    cache(scope, :refunded_amount_cents, refund_amounts)
+  end
+end

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -101,8 +101,7 @@ module DataExports
       end
 
       def collection
-        #InvoicesPreloader.new(result.invoices, only: :offset_amount_cents).call
-        InvoicesPreloader.new(Invoice.find(data_export_part.object_ids)).call
+        InvoicesPreloader.new(Invoice.find(data_export_part.object_ids), :offset_amount_cents).call
       end
 
       def organization

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -101,7 +101,8 @@ module DataExports
       end
 
       def collection
-        Invoice.preload_offset_amounts(Invoice.find(data_export_part.object_ids))
+        #InvoicesPreloader.new(result.invoices, only: :offset_amount_cents).call
+        InvoicesPreloader.new(Invoice.find(data_export_part.object_ids)).call
       end
 
       def organization

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -723,6 +723,39 @@ RSpec.describe Fee do
     end
   end
 
+  describe "#credited_amount_cents" do
+    subject(:fee) { create(:fee) }
+
+    context "when there are no credit note items" do
+      it "returns 0" do
+        expect(fee.credited_amount_cents).to eq(0)
+      end
+    end
+
+    context "when there are credit note items" do
+      let(:credit_note) { create(:credit_note) }
+
+      before do
+        create(:credit_note_item, credit_note:, fee:, amount_cents: 100)
+        create(:credit_note_item, credit_note:, fee:, amount_cents: 200)
+      end
+
+      it "sums all the credit note items amount_cents" do
+        expect(fee.credited_amount_cents).to eq(300)
+      end
+    end
+
+    context "when the value is cached by a preloader" do
+      before do
+        fee.preloader_cache[:credited_amount_cents] = 100
+      end
+
+      it "returns the cached value" do
+        expect(fee.credited_amount_cents).to eq(100)
+      end
+    end
+  end
+
   describe "#creditable_from_wallet_amount_cents" do
     subject { fee.creditable_from_wallet_amount_cents }
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -2088,7 +2088,7 @@ RSpec.describe Invoice do
 
     context "when there are no credit notes" do
       it "returns 0" do
-        expect(invoice.offset_amount_cents).to eq(0)
+        expect(invoice.refunded_amount_cents).to eq(0)
       end
     end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -2083,6 +2083,37 @@ RSpec.describe Invoice do
     end
   end
 
+  describe "#refunded_amount_cents" do
+    let(:invoice) { create(:invoice) }
+
+    context "when there are no credit notes" do
+      it "returns 0" do
+        expect(invoice.offset_amount_cents).to eq(0)
+      end
+    end
+
+    context "when there are credit notes" do
+      before do
+        create(:credit_note, invoice:, refund_amount_cents: 100)
+        create(:credit_note, invoice:, refund_amount_cents: 200)
+      end
+
+      it "sums all the credit notes refund_amount_cents" do
+        expect(invoice.refunded_amount_cents).to eq(300)
+      end
+    end
+
+    context "when the value is cached by a preloader" do
+      before do
+        invoice.preloader_cache[:refunded_amount_cents] = 100
+      end
+
+      it "returns the cached value" do
+        expect(invoice.refunded_amount_cents).to eq(100)
+      end
+    end
+  end
+
   describe "#offset_amount_cents" do
     let(:invoice) { create(:invoice) }
 
@@ -2100,6 +2131,16 @@ RSpec.describe Invoice do
       create(:credit_note, invoice:, status: :draft, offset_amount_cents: 200)
       create(:credit_note, invoice:, status: :finalized, offset_amount_cents: 400)
       expect(invoice.offset_amount_cents).to eq(400)
+    end
+
+    context "when the value is cached by a preloader" do
+      before do
+        invoice.preloader_cache[:offset_amount_cents] = 100
+      end
+
+      it "returns the cached value" do
+        expect(invoice.offset_amount_cents).to eq(100)
+      end
     end
   end
 

--- a/spec/preloaders/invoices_preloader_spec.rb
+++ b/spec/preloaders/invoices_preloader_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe InvoicesPreloader do
+  subject(:preloader) { described_class.new([invoice]) }
+
+  let(:invoice) { create(:invoice) }
+
+  before do
+    create(:credit_note, invoice:, offset_amount_cents: 5_00, refund_amount_cents: 5_00)
+    create(:credit_note, invoice:, offset_amount_cents: 10_00, refund_amount_cents: 10_00)
+    create(:credit_note, invoice:, offset_amount_cents: 20_00, refund_amount_cents: 20_00, status: :draft)
+
+    credit_note = create(:credit_note, invoice:)
+    fee1 = create(:fee, invoice:)
+    fee2 = create(:fee, invoice:)
+
+    create(:credit_note_item, credit_note:, fee: fee1, amount_cents: 5_00)
+    create(:credit_note_item, credit_note:, fee: fee2, amount_cents: 10_00)
+    create(:credit_note_item, credit_note:, fee: fee2, amount_cents: 15_00)
+  end
+
+  describe "#call" do
+    it "preloads and caches amounts" do
+      preloader.call
+
+      expect(invoice.preloader_cache).to eq(
+        offset_amount_cents: 15_00,
+        refunded_amount_cents: 35_00
+      )
+
+      expect(invoice.fees.first.preloader_cache).to eq(
+        credited_amount_cents: 5_00
+      )
+
+      expect(invoice.fees.first.preloader_cache).to eq(
+        credited_amount_cents: 5_00
+      )
+    end
+  end
+end

--- a/spec/preloaders/invoices_preloader_spec.rb
+++ b/spec/preloaders/invoices_preloader_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe InvoicesPreloader do
-  subject(:preloader) { described_class.new([invoice]) }
+  subject(:preloader) { described_class.new([invoice], *preloads) }
 
   let(:invoice) { create(:invoice) }
 
@@ -22,21 +22,40 @@ describe InvoicesPreloader do
   end
 
   describe "#call" do
-    it "preloads and caches amounts" do
-      preloader.call
+    context "when no :preloads are passed" do
+      let(:preloads) { [] }
 
-      expect(invoice.preloader_cache).to eq(
-        offset_amount_cents: 15_00,
-        refunded_amount_cents: 35_00
-      )
+      it "preloads and caches all amounts" do
+        preloader.call
 
-      expect(invoice.fees.first.preloader_cache).to eq(
-        credited_amount_cents: 5_00
-      )
+        expect(invoice.preloader_cache).to eq(
+          offset_amount_cents: 15_00,
+          refunded_amount_cents: 35_00
+        )
 
-      expect(invoice.fees.first.preloader_cache).to eq(
-        credited_amount_cents: 5_00
-      )
+        expect(invoice.fees.first.preloader_cache).to eq(
+          credited_amount_cents: 5_00
+        )
+
+        expect(invoice.fees.last.preloader_cache).to eq(
+          credited_amount_cents: 25_00
+        )
+      end
+    end
+
+    context "when specific :preloads are passed" do
+      let(:preloads) { [:offset_amount_cents] }
+
+      it "preloads and caches only the passed :preloads" do
+        preloader.call
+
+        expect(invoice.preloader_cache).to eq(
+          offset_amount_cents: 15_00
+        )
+
+        expect(invoice.fees.first.preloader_cache).to eq({})
+        expect(invoice.fees.last.preloader_cache).to eq({})
+      end
     end
   end
 end

--- a/spec/preloaders/invoices_preloader_spec.rb
+++ b/spec/preloaders/invoices_preloader_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe InvoicesPreloader do
-  subject(:preloader) { described_class.new([invoice], *preloads) }
+  subject(:preloader) { described_class.new([invoice], *scopes) }
 
   let(:invoice) { create(:invoice) }
 
@@ -22,10 +22,10 @@ describe InvoicesPreloader do
   end
 
   describe "#call" do
-    context "when no :preloads are passed" do
-      let(:preloads) { [] }
+    context "when no :scopes are passed" do
+      let(:scopes) { [] }
 
-      it "preloads and caches all amounts" do
+      it "scopes and caches all amounts" do
         preloader.call
 
         expect(invoice.preloader_cache).to eq(
@@ -43,10 +43,10 @@ describe InvoicesPreloader do
       end
     end
 
-    context "when specific :preloads are passed" do
-      let(:preloads) { [:offset_amount_cents] }
+    context "when specific :scopes are passed" do
+      let(:scopes) { [:offset_amount_cents] }
 
-      it "preloads and caches only the passed :preloads" do
+      it "scopes and caches only the passed :scopes" do
         preloader.call
 
         expect(invoice.preloader_cache).to eq(


### PR DESCRIPTION
## Context

We have a bunch of calculation methods across the models that make requests to the database to calculate specific metrics, such as sum of values or checking whether specific records exist. For example, in `Fee#creditable_amount_cents` we sum all its credit note items' `amount_cents`:

```ruby
def creditable_amount_cents
  remaining_amount = amount_cents - credit_note_items.sum(:amount_cents)
  ...
end
```

This results in N+1 queries when we want to fetch multiple records for invoices, fees, etc.

For most of these cases we can't replace `sum(:field)` with its ruby equivalent `sum(&:field)` (which iterates over already-loaded records instead of querying the db), due to the high probability of having stale records when doing Usage & Fees calculations.

## Current Solutions

This issue was solved for `offset_amount_cents` by introducing a method `Invoice.preload_offset_amounts`. This method preloads `offset_amount_cents` for all records passed to it with a single query to the database and caches the preloaded values for each record in a separate instance variable.

## Preloaders

This PR introduces an extension of the `Invoice.preload_offset_amounts` in the form of Preloaders. A preloader is a class responsible for loading calculation values and caching them at the record level. 

Preloaders caching logic doesn't have any invalidation mechanism – its only purpose is to preload a bunch of calculations for API and GraphQL index responses. 

Preloaders live under the `preloaders/` directory and follow the naming convention `{Model}sPreloader`. For now we only have `InvoicesPreloader` for preloading values on invoices.

### Preloading Logic

To define the preloading logic, a preloader defines a method per calculation value you want to preload. The base preloader provides a `cache` method that sets the preloaded values onto the model.

```ruby
def preload_offset_amount_cents
  offset_amounts = CreditNote
    .where(invoice_id: record_ids)
    .finalized
    .group(:invoice_id)
    .sum(:offset_amount_cents)

  cache(records, :offset_amount_cents, offset_amounts)
end
```

### Preloader Cache

All preloaded values are stored in a `preloader_cache` hash, which can be added to a model by including the `PreloaderCache` concern. You can then use `preloader_cache` to read the preloaded value if it exists, or fall back to loading from the db:

```ruby
def offset_amount_cents
  preloader_cache[:offset_amount_cents] || credit_notes.finalized.sum(:offset_amount_cents)
end
```

### Usage

Usage of a preloader is straightforward – you just pass the records for which you want to preload data:

```ruby
InvoicesPreloader.new(invoices).call
```

This will load all the predefined preloaded values. If you only need to load specific values, you can pass them as a second argument to the preloader:

```ruby
InvoicesPreloader.new(invoices, :offset_amount_cents).call
```