### PR TITLE
[ING-21] fix(events): clickhouse removal on metric deletion

### DIFF
--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -5,45 +5,7 @@ module BillableMetrics
     queue_as :default
 
     def perform(metric)
-      return unless metric.discarded?
-
-      deleted_at = Time.current
-
-      # Delete events having an old-style `subscription_id`
-      Event.where(
-        code: metric.code,
-        subscription_id: Charge.with_discarded
-          .where(billable_metric_id: metric.id)
-          .joins(plan: :subscriptions).pluck("subscriptions.id")
-      ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
-
-      # Delete events using the new `external_subscription_id`
-      Event.where(
-        organization_id: metric.organization.id,
-        code: metric.code,
-        external_subscription_id: Charge.with_discarded
-          .where(billable_metric_id: metric.id)
-          .joins(plan: :subscriptions).pluck("subscriptions.external_id")
-      ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
-
-      # Delete events_raw & events_enriched on clickhouse using `external_subscription_id`
-      if ENV["LAGO_CLICKHOUSE_ENABLED"].present?
-        Clickhouse::EventsRaw.where(
-          organization_id: metric.organization.id,
-          code: metric.code,
-          external_subscription_id: Charge.with_discarded
-            .where(billable_metric_id: metric.id)
-            .joins(plan: :subscriptions).pluck("subscriptions.external_id")
-        ).delete_all
-
-        Clickhouse::EventsEnriched.where(
-          organization_id: metric.organization.id,
-          code: metric.code,
-          external_subscription_id: Charge.with_discarded
-            .where(billable_metric_id: metric.id)
-            .joins(plan: :subscriptions).pluck("subscriptions.external_id")
-        ).delete_all
-      end
+      Events::DeleteForMetricService.call!(billable_metric: metric)
     end
   end
 end

--- a/app/services/events/delete_for_metric_service.rb
+++ b/app/services/events/delete_for_metric_service.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Events
+  class DeleteForMetricService < BaseService
+    Result = BaseResult
+
+    def initialize(billable_metric:)
+      @billable_metric = billable_metric
+      @deleted_at = billable_metric.deleted_at
+      super
+    end
+
+    def call
+      return result unless billable_metric.discarded?
+
+      clickhouse_enabled = ENV["LAGO_CLICKHOUSE_ENABLED"].present?
+
+      # The subscription is queried in batches to avoid memory pressure
+      # and cross-database subqueries: events is built to live on a dedicated
+      # database (so is clickhouse) while subscriptions/charges live on the primary database.
+      subscriptions_relation.in_batches(of: BATCH_SIZE) do |batch|
+        rows = batch.pluck(:id, :external_id)
+        next if rows.empty?
+
+        subscription_ids, external_subscription_ids = rows.transpose
+
+        delete_postgres_events(subscription_ids, external_subscription_ids)
+        delete_clickhouse_events(external_subscription_ids) if clickhouse_enabled
+      end
+
+      result
+    end
+
+    private
+
+    BATCH_SIZE = 10_000
+    CLICKHOUSE_TABLES = %w[events_raw events_enriched events_enriched_expanded].freeze
+    CLICKHOUSE_MUTATIONS_SYNC = "0" # Async
+
+    attr_reader :billable_metric, :deleted_at
+
+    delegate :code, :organization_id, to: :billable_metric
+
+    def subscriptions_relation
+      # Explicit SQL join bypasses Charge's `default_scope -> { kept }` so
+      # discarded charges are still considered when collecting subscriptions.
+      Subscription
+        .joins(:plan)
+        .joins("INNER JOIN charges ON charges.plan_id = plans.id")
+        .where("charges.billable_metric_id = ?", billable_metric.id)
+        .distinct
+    end
+
+    def delete_postgres_events(subscription_ids, external_subscription_ids)
+      # Delete events having an old-style `subscription_id`
+      Event.where(
+        organization_id: organization_id,
+        code: code,
+        subscription_id: subscription_ids
+      ).where("events.timestamp <= ?", deleted_at)
+        .in_batches.update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+
+      # Delete events using the new `external_subscription_id`
+      Event.where(
+        organization_id: organization_id,
+        code: code,
+        external_subscription_id: external_subscription_ids
+      ).where("events.timestamp <= ?", deleted_at)
+        .in_batches.update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    # Delete clickhouse events using async mutations to avoid blocking or
+    # timeouts when the metric is attached to a large number of events.
+    def delete_clickhouse_events(external_subscription_ids)
+      CLICKHOUSE_TABLES.each do |table|
+        async_delete_clickhouse(table, external_subscription_ids)
+      end
+    end
+
+    def async_delete_clickhouse(table, external_subscription_ids)
+      sql = ::Clickhouse::BaseRecord.sanitize_sql_array([
+        "ALTER TABLE #{table} DELETE " \
+          "WHERE organization_id = ? AND code = ? " \
+          "AND external_subscription_id IN (?) AND timestamp <= ? " \
+          "SETTINGS mutations_sync = #{CLICKHOUSE_MUTATIONS_SYNC}",
+        organization_id,
+        code,
+        external_subscription_ids,
+        deleted_at
+      ])
+
+      ::Clickhouse::BaseRecord.connection.execute(sql)
+    end
+  end
+end

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -2,57 +2,17 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::DeleteEventsJob, clickhouse: true, transaction: false do
+RSpec.describe BillableMetrics::DeleteEventsJob, type: :job do
   let(:billable_metric) { create(:billable_metric, :deleted) }
-  let(:subscription) { create(:subscription) }
 
-  it "deletes related events" do
-    create(:standard_charge, plan: subscription.plan, billable_metric:)
-    not_impacted_event = create(:event, subscription_id: subscription.id)
-    event = create(:event, code: billable_metric.code, subscription_id: subscription.id)
-
-    freeze_time do
-      expect { described_class.perform_now(billable_metric) }
-        .to change { event.reload.deleted_at }.from(nil).to(Time.current)
-
-      expect(not_impacted_event.reload.deleted_at).to be_nil
-    end
+  before do
+    allow(Events::DeleteForMetricService).to receive(:call!).and_call_original
   end
 
-  it "deletes new-style external_subscription based events" do
-    create(:standard_charge, plan: subscription.plan, billable_metric:)
-    not_impacted_event = create(:event, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id)
-    event = create(:event, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id)
+  it "delegates to Events::DeleteForMetricService" do
+    described_class.perform_now(billable_metric)
 
-    freeze_time do
-      expect { described_class.perform_now(billable_metric) }
-        .to change { event.reload.deleted_at }.from(nil).to(Time.current)
-
-      expect(not_impacted_event.reload.deleted_at).to be_nil
-    end
-  end
-
-  it "deletes new-style external_subscription based events stored in clickhouse" do
-    create(:standard_charge, plan: subscription.plan, billable_metric:)
-    not_impacted_event = create(:clickhouse_events_raw, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id)
-    event = create(:clickhouse_events_raw, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id)
-
-    freeze_time do
-      described_class.perform_now(billable_metric)
-      expect(Clickhouse::EventsRaw.find_by(transaction_id: event.transaction_id)).to eq(nil)
-      expect(Clickhouse::EventsRaw.find_by(transaction_id: not_impacted_event.transaction_id)).not_to eq(nil)
-    end
-  end
-
-  it "deletes new-style external_subscription based events_enriched stored in clickhouse" do
-    create(:standard_charge, plan: subscription.plan, billable_metric:)
-    not_impacted_event = create(:clickhouse_events_enriched, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id)
-    event = create(:clickhouse_events_enriched, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id)
-
-    freeze_time do
-      described_class.perform_now(billable_metric)
-      expect(Clickhouse::EventsEnriched.find_by(transaction_id: event.transaction_id)).to eq(nil)
-      expect(Clickhouse::EventsEnriched.find_by(transaction_id: not_impacted_event.transaction_id)).not_to eq(nil)
-    end
+    expect(Events::DeleteForMetricService).to have_received(:call!)
+      .with(billable_metric: billable_metric)
   end
 end

--- a/spec/services/events/delete_for_metric_service_spec.rb
+++ b/spec/services/events/delete_for_metric_service_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: false do
+  subject(:service) { described_class.new(billable_metric:) }
+
+  let(:billable_metric) { create(:billable_metric, :deleted) }
+  let(:subscription) { create(:subscription) }
+
+  let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
+
+  let(:event_timestamp) { (billable_metric.deleted_at || Time.current) - 1.minute }
+  let(:event) { create(:event, code: billable_metric.code, subscription_id: subscription.id, organization_id: billable_metric.organization_id, timestamp: event_timestamp) }
+  let(:not_impacted_event) { create(:event, subscription_id: subscription.id, organization_id: billable_metric.organization_id, timestamp: event_timestamp) }
+
+  before do
+    charge
+    event
+    not_impacted_event
+  end
+
+  describe "call" do
+    it "deletes related events" do
+      expect { service.call }
+        .to change { event.reload.deleted_at }.from(nil).to(billable_metric.deleted_at)
+
+      expect(not_impacted_event.reload.deleted_at).to be_nil
+    end
+
+    context "with new-style external_subscription based events" do
+      let(:event) { create(:event, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id, timestamp: event_timestamp) }
+      let(:not_impacted_event) { create(:event, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id, timestamp: event_timestamp) }
+
+      it "deletes related events" do
+        expect { service.call }.to change { event.reload.deleted_at }.from(nil).to(billable_metric.deleted_at)
+
+        expect(not_impacted_event.reload.deleted_at).to be_nil
+      end
+    end
+
+    context "when the charge is discarded" do
+      before { charge.discard }
+
+      it "still deletes related events" do
+        expect { service.call }
+          .to change { event.reload.deleted_at }.from(nil).to(billable_metric.deleted_at)
+      end
+    end
+
+    context "when event timestamp is after billable_metric deletion" do
+      let(:event) do
+        create(
+          :event,
+          code: billable_metric.code,
+          subscription_id: subscription.id,
+          timestamp: billable_metric.deleted_at + 1.hour
+        )
+      end
+
+      it "does not delete events received after the metric deletion" do
+        expect { service.call }.not_to change { event.reload.deleted_at }
+      end
+    end
+
+    context "when billable_metric is not deleted" do
+      let(:billable_metric) { create(:billable_metric) }
+
+      it "does not delete events" do
+        expect(service.call!).to be_success
+        expect(event.reload.deleted_at).to be_nil
+        expect(not_impacted_event.reload.deleted_at).to be_nil
+      end
+    end
+
+    context "with clickhouse events" do
+      include_context "with clickhouse availability"
+
+      let(:ch_event) do
+        create(
+          :clickhouse_events_raw,
+          organization_id: billable_metric.organization_id,
+          code: billable_metric.code,
+          external_subscription_id: subscription.external_id,
+          timestamp: event_timestamp
+        )
+      end
+
+      let(:not_impacted_ch_event) do
+        create(
+          :clickhouse_events_raw,
+          organization_id: billable_metric.organization_id,
+          external_subscription_id: SecureRandom.uuid,
+          timestamp: event_timestamp
+        )
+      end
+
+      let(:ch_enriched_event) do
+        create(
+          :clickhouse_events_enriched,
+          organization_id: billable_metric.organization_id,
+          code: billable_metric.code,
+          external_subscription_id: subscription.external_id,
+          timestamp: event_timestamp
+        )
+      end
+
+      let(:not_impacted_ch_enriched_event) do
+        create(
+          :clickhouse_events_enriched,
+          organization_id: billable_metric.organization_id,
+          external_subscription_id: SecureRandom.uuid,
+          timestamp: event_timestamp
+        )
+      end
+
+      let(:ch_enriched_expanded_event) do
+        create(
+          :clickhouse_events_enriched_expanded,
+          organization_id: billable_metric.organization_id,
+          code: billable_metric.code,
+          external_subscription_id: subscription.external_id,
+          timestamp: event_timestamp
+        )
+      end
+
+      let(:not_impacted_ch_enriched_expanded_event) do
+        create(
+          :clickhouse_events_enriched_expanded,
+          organization_id: billable_metric.organization_id,
+          external_subscription_id: SecureRandom.uuid,
+          timestamp: event_timestamp
+        )
+      end
+
+      before do
+        # Force ALTER TABLE DELETE mutations to run synchronously so the test can
+        # observe the deletion immediately. In production this stays at "0" (async).
+        stub_const("#{described_class}::CLICKHOUSE_MUTATIONS_SYNC", "2")
+
+        ch_event
+        not_impacted_ch_event
+        ch_enriched_event
+        not_impacted_ch_enriched_event
+        ch_enriched_expanded_event
+        not_impacted_ch_enriched_expanded_event
+      end
+
+      it "deletes matching clickhouse events_raw" do
+        service.call
+
+        expect(Clickhouse::EventsRaw.where(transaction_id: ch_event.transaction_id).count)
+          .to eq(0)
+        expect(Clickhouse::EventsRaw.where(transaction_id: not_impacted_ch_event.transaction_id).count)
+          .to eq(1)
+      end
+
+      it "deletes matching clickhouse events_enriched" do
+        service.call
+
+        expect(Clickhouse::EventsEnriched.where(transaction_id: ch_enriched_event.transaction_id).count)
+          .to eq(0)
+        expect(Clickhouse::EventsEnriched.where(transaction_id: not_impacted_ch_enriched_event.transaction_id).count)
+          .to eq(1)
+      end
+
+      it "deletes matching clickhouse events_enriched_expanded" do
+        service.call
+
+        expect(Clickhouse::EventsEnrichedExpanded.where(transaction_id: ch_enriched_expanded_event.transaction_id).count)
+          .to eq(0)
+        expect(Clickhouse::EventsEnrichedExpanded.where(transaction_id: not_impacted_ch_enriched_expanded_event.transaction_id).count)
+          .to eq(1)
+      end
+
+      context "with clickhouse events received after the metric deletion" do
+        let(:late_ch_event) do
+          create(
+            :clickhouse_events_raw,
+            organization_id: billable_metric.organization_id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: billable_metric.deleted_at + 1.hour
+          )
+        end
+
+        before { late_ch_event }
+
+        it "does not delete events with timestamp after the metric deletion" do
+          service.call
+
+          expect(Clickhouse::EventsRaw.where(transaction_id: late_ch_event.transaction_id).count)
+            .to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

When a billable metric is deleted, `BillableMetrics::DeleteEventsJob` deletes associated events from ClickHouse tables (`events_raw` and `events_enriched`) using synchronous `.delete_all` calls.
For billable metrics with a large number of associated events, the ClickHouse `DELETE FROM` mutation takes longer than the 60-second `Net::HTTP` read timeout, causing a `Net::ReadTimeout` error.

## Description

This PR:
- Extracts the removal logic from the `BillableMetrics::DeleteEventsJobs` to a new `Events::DeleteForMetricService`
- Uses the ClickHouse async delete mutation approach when removing Clickhouse events so that the removals happens in background
- Batches the subscription selection to avoid memory issue for metrics attached to more thant 10_000 subscriptions
