### PR TITLE
perf(invoices): Preload values for `Invoice#voidable?` in InvoicesPreloader

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -398,11 +398,19 @@ class Invoice < ApplicationRecord
   end
 
   def voidable?
-    if payment_dispute_lost_at? || total_paid_amount_cents > 0 || credit_notes.where.not(credit_status: :voided).any?
+    if payment_dispute_lost_at? || total_paid_amount_cents > 0 || has_non_voided_credit_notes?
       return false
     end
 
     finalized? && (payment_pending? || payment_failed?)
+  end
+
+  def has_non_voided_credit_notes?
+    if preloader_cache.has_key?(:has_non_voided_credit_notes)
+      preloader_cache[:has_non_voided_credit_notes]
+    else
+      credit_notes.where.not(credit_status: :voided).any?
+    end
   end
 
   # Checks if all charges from subscription plans have corresponding fees

--- a/app/preloaders/invoices_preloader.rb
+++ b/app/preloaders/invoices_preloader.rb
@@ -5,6 +5,7 @@ class InvoicesPreloader < BasePreloader
     offset_amount_cents
     refunded_amount_cents
     credited_amount_cents
+    has_non_voided_credit_notes
   ]
 
   private
@@ -37,5 +38,17 @@ class InvoicesPreloader < BasePreloader
       .sum(:amount_cents)
 
     cache(fees, :credited_amount_cents, credited_amounts)
+  end
+
+  def preload_has_non_voided_credit_notes
+    non_voided = CreditNote
+      .where(invoice_id: record_ids)
+      .where.not(credit_status: :voided)
+      .group(:invoice_id)
+      .count
+
+    records.each do |record|
+      record.preloader_cache[:has_non_voided_credit_notes] = non_voided.has_key?(record.id)
+    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1662,6 +1662,60 @@ RSpec.describe Invoice do
     end
   end
 
+  describe "#has_non_voided_credit_notes?" do
+    let(:invoice) { create(:invoice) }
+
+    context "when there are no credit notes" do
+      it "returns false" do
+        expect(invoice.has_non_voided_credit_notes?).to be(false)
+      end
+    end
+
+    context "when there are only voided credit notes" do
+      before do
+        create(:credit_note, invoice:, credit_status: :voided)
+      end
+
+      it "returns false" do
+        expect(invoice.has_non_voided_credit_notes?).to be(false)
+      end
+    end
+
+    context "when there are non-voided credit notes" do
+      before do
+        create(:credit_note, invoice:, credit_status: :available)
+        create(:credit_note, invoice:, credit_status: :voided)
+      end
+
+      it "returns true" do
+        expect(invoice.has_non_voided_credit_notes?).to be(true)
+      end
+    end
+
+    context "when the value is cached by a preloader" do
+      context "with true" do
+        before do
+          invoice.preloader_cache[:has_non_voided_credit_notes] = true
+        end
+
+        it "returns the cached value" do
+          expect(invoice.has_non_voided_credit_notes?).to be(true)
+        end
+      end
+
+      context "with false" do
+        before do
+          create(:credit_note, invoice:, credit_status: :available)
+          invoice.preloader_cache[:has_non_voided_credit_notes] = false
+        end
+
+        it "returns the cached value" do
+          expect(invoice.has_non_voided_credit_notes?).to be(false)
+        end
+      end
+    end
+  end
+
   describe "#mark_as_voided!" do
     subject(:force_void_call) { invoice.void! }
 

--- a/spec/preloaders/invoices_preloader_spec.rb
+++ b/spec/preloaders/invoices_preloader_spec.rb
@@ -9,7 +9,7 @@ describe InvoicesPreloader do
 
   before do
     create(:credit_note, invoice:, offset_amount_cents: 5_00, refund_amount_cents: 5_00)
-    create(:credit_note, invoice:, offset_amount_cents: 10_00, refund_amount_cents: 10_00)
+    create(:credit_note, invoice:, offset_amount_cents: 10_00, refund_amount_cents: 10_00, credit_status: :voided)
     create(:credit_note, invoice:, offset_amount_cents: 20_00, refund_amount_cents: 20_00, status: :draft)
 
     credit_note = create(:credit_note, invoice:)
@@ -30,7 +30,8 @@ describe InvoicesPreloader do
 
         expect(invoice.preloader_cache).to eq(
           offset_amount_cents: 15_00,
-          refunded_amount_cents: 35_00
+          refunded_amount_cents: 35_00,
+          has_non_voided_credit_notes: true
         )
 
         expect(invoice.fees.first.preloader_cache).to eq(


### PR DESCRIPTION
## Context

`Invoice#voidable?` makes an `exists` query to the db to check if there are any non-voided credit notes, which causes N+1 queries in `InvoicesResolver`.

```
DEBUG -- :   CreditNote Exists? (0.1ms)  SELECT 1 AS one FROM "credit_notes" WHERE "credit_notes"."invoice_id" = $1 AND "credit_notes"."credit_status" != $2 LIMIT $3  [["invoice_id", "b72e2b87-bb1f-4947-b5c5-b4f1545ddc59"], ["credit_status", 2], ["LIMIT", 1]]
DEBUG -- :   ↳ app/models/invoice.rb:401:in 'Invoice#voidable?'
DEBUG -- :   CreditNote Exists? (0.1ms)  SELECT 1 AS one FROM "credit_notes" WHERE "credit_notes"."invoice_id" = $1 AND "credit_notes"."credit_status" != $2 LIMIT $3  [["invoice_id", "87bfa2d7-ada7-4f44-af64-91beafb39c53"], ["credit_status", 2], ["LIMIT", 1]]
DEBUG -- :   ↳ app/models/invoice.rb:401:in 'Invoice#voidable?'
DEBUG -- :   CreditNote Exists? (0.1ms)  SELECT 1 AS one FROM "credit_notes" WHERE "credit_notes"."invoice_id" = $1 AND "credit_notes"."credit_status" != $2 LIMIT $3  [["invoice_id", "4a311db6-8374-46d0-a3eb-6dcc157bd34e"], ["credit_status", 2], ["LIMIT", 1]]
DEBUG -- :   ↳ app/models/invoice.rb:401:in 'Invoice#voidable?'
```

## Description

This PR builds on the preloaders introduced #5588 and adds preloading logic for non-voided credit notes.
