### PR TITLE
feat(payment-gated-subs): Defer invoice creation on tax providers to success path

### DIFF
--- a/app/jobs/integrations/aggregator/taxes/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/taxes/invoices/create_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Taxes
+      module Invoices
+        class CreateJob < ApplicationJob
+          queue_as "providers"
+
+          unique :until_executed, on_conflict: :log
+
+          retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
+          retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
+
+          def perform(invoice:)
+            Integrations::Aggregator::Taxes::Invoices::CreateService.call!(invoice:, fees: invoice.fees)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -16,7 +16,7 @@ module Invoices
         return result unless invoice.tax_pending?
 
         invoice.error_details.tax_error.discard_all # rubocop:disable Lago/DiscardAll
-        taxes_result = if invoice.draft?
+        taxes_result = if invoice.draft? || invoice.subscription_gated?
           Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: invoice.fees)
         else
           Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)

--- a/app/services/subscriptions/activation_rules/payment/resolve_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/resolve_service.rb
@@ -43,6 +43,7 @@ module Subscriptions
             Invoices::GenerateDocumentsJob.perform_later(invoice:, notify: should_deliver_email?)
             Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
             Integrations::Aggregator::Invoices::Hubspot::CreateJob.perform_later(invoice:) if invoice.should_sync_hubspot_invoice?
+            Integrations::Aggregator::Taxes::Invoices::CreateJob.perform_later(invoice:) if invoice.customer.tax_customer
             Utils::SegmentTrack.invoice_created(invoice)
           end
         end

--- a/spec/jobs/integrations/aggregator/taxes/invoices/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/taxes/invoices/create_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateJob do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call!).and_return(result)
+  end
+
+  it "calls CreateService with the invoice and its fees" do
+    described_class.perform_now(invoice:)
+
+    expect(Integrations::Aggregator::Taxes::Invoices::CreateService)
+      .to have_received(:call!).with(invoice:, fees: invoice.fees)
+  end
+end

--- a/spec/jobs/integrations/aggregator/taxes/invoices/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/taxes/invoices/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateJob do
+describe Integrations::Aggregator::Taxes::Invoices::CreateJob do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -578,6 +578,16 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
         expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
       end
 
+      it "calls Integrations::Aggregator::Taxes::Invoices::CreateDraftService" do
+        allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:call).and_call_original
+        allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call).and_call_original
+
+        pull_taxes_service.call
+
+        expect(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to have_received(:call).with(invoice:, fees: invoice.fees)
+        expect(Integrations::Aggregator::Taxes::Invoices::CreateService).not_to have_received(:call)
+      end
+
       context "when invoice total is zero after tax computation" do
         let(:rule) { subscription.activation_rules.payment.sole }
         let(:fee_subscription) do

--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -171,6 +171,28 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
       end
     end
 
+    context "when customer has a tax provider integration" do
+      let(:integration) { create(:anrok_integration, organization:) }
+
+      before do
+        create(:anrok_customer, integration:, customer:)
+      end
+
+      it "enqueues Aggregator::Taxes::Invoices::CreateJob to commit the finalized tax record" do
+        result
+
+        expect(Integrations::Aggregator::Taxes::Invoices::CreateJob).to have_been_enqueued.with(invoice:)
+      end
+    end
+
+    context "when customer does not have a tax provider integration" do
+      it "does not enqueue Aggregator::Taxes::Invoices::CreateJob" do
+        result
+
+        expect(Integrations::Aggregator::Taxes::Invoices::CreateJob).not_to have_been_enqueued
+      end
+    end
+
     context "when subscription is already active (idempotency)" do
       let(:subscription) { create(:subscription, organization:, customer:, plan:) }
 


### PR DESCRIPTION
## Context

For payment-gated subscriptions, `PullTaxesAndApplyService` was hitting the tax provider's `finalized_invoices` endpoint while the invoice was still `:open` waiting for payment, because the draft/finalized branch only checked `invoice.draft?`. That committed a finalized Anrok/Avalara transaction (and, for Avalara, an `IntegrationResource`) before the customer ever paid; if payment then failed, the provider was left out of sync with Lago's now-closed invoice.

## Description

While the gated invoice is still `:open`, route tax computation to `CreateDraftService` so the provider only sees a calculation, not a committed transaction. Commit via `CreateService` once payment succeeds and `Payment::ResolveService#handle_success` finalizes the invoice — enqueued through a new `Integrations::Aggregator::Taxes::Invoices::CreateJob`, gated on the customer having a tax integration.

No cleanup is needed on payment failure: drafts on Anrok/Avalara aren't committed transactions, so closing the invoice is enough.