### PR TITLE
perf(plans): Fix N+1 on charge filters in OverrideService

### DIFF
--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -35,7 +35,7 @@ module Plans
         charges_params_by_id = (params[:charges] || []).index_by { |p| p[:id] }
         fixed_charges_params_by_id = (params[:fixed_charges] || []).index_by { |p| p[:id] }
 
-        plan.charges.find_each do |charge|
+        plan.charges.includes(filters: :values).find_each do |charge|
           charge_params = (charges_params_by_id[charge.id] || {}).merge(plan_id: new_plan.id)
           Charges::OverrideService.call(charge:, params: charge_params)
         end


### PR DESCRIPTION
## Context

When creating a subscription with `plan_overrides`, `Plans::OverrideService` iterates over each charge to duplicate it. Each iteration triggered separate SQL queries for `charge_filters` and `charge_filter_values` per charge, causing an N+1 detected in production (Sentry API-EU-HH).

## Description

Eager-load `filters` and their `values` when loading the plan's charges so the association data is fetched in bulk queries instead of one per charge.

Fixes API-EU-HH

