### PR TITLE
fix(integrations): include pricing group key values in Xero line item description

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -12,6 +12,7 @@ module Integrations
           def item(fee)
             base_item = super
             base_item["item_code"] = base_item.delete("external_id")
+            base_item["description"] = "#{base_item["description"]}#{FeeDisplayHelper.grouped_by_display(fee)}"
 
             if fee.precise_unit_amount.round(2) != fee.precise_unit_amount
               base_item["units"] = 1

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -163,5 +163,136 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
         expect(fee_item).not_to have_key("amount_cents")
       end
     end
+
+    context "when a charge fee has grouped_by pricing group key values" do
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:xero_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+      let(:subscription) { create(:subscription, organization:, plan:) }
+
+      let(:invoice) do
+        invoice = create(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity:,
+          coupons_amount_cents: 0,
+          prepaid_credit_amount_cents: 0,
+          progressive_billing_credit_amount_cents: 0,
+          credit_notes_amount_cents: 0,
+          taxes_amount_cents: 0,
+          issuing_date: DateTime.new(2024, 7, 8)
+        )
+        create(:invoice_subscription, invoice:, subscription:)
+        invoice
+      end
+
+      let(:grouped_fee) do
+        create(
+          :charge_fee,
+          invoice:,
+          charge:,
+          billable_metric:,
+          units: 10,
+          amount_cents: 1000,
+          precise_unit_amount: 100.0,
+          taxes_amount_cents: 0,
+          invoice_display_name: "Storage usage",
+          grouped_by: {"deployment_name" => "green"}
+        )
+      end
+
+      let(:billable_metric_mapping) do
+        create(
+          :xero_mapping,
+          integration:,
+          mappable_type: "BillableMetric",
+          mappable_id: billable_metric.id,
+          billing_entity:,
+          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
+        )
+      end
+
+      before do
+        billable_metric_mapping
+        grouped_fee
+      end
+
+      it "appends the grouped_by values to the line item description" do
+        fee_item = payload.first["fees"].first
+
+        expect(fee_item["description"]).to eq("Storage usage • green")
+      end
+    end
+
+    context "when a charge fee has no grouped_by values" do
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:xero_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+      let(:subscription) { create(:subscription, organization:, plan:) }
+
+      let(:invoice) do
+        invoice = create(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity:,
+          coupons_amount_cents: 0,
+          prepaid_credit_amount_cents: 0,
+          progressive_billing_credit_amount_cents: 0,
+          credit_notes_amount_cents: 0,
+          taxes_amount_cents: 0,
+          issuing_date: DateTime.new(2024, 7, 8)
+        )
+        create(:invoice_subscription, invoice:, subscription:)
+        invoice
+      end
+
+      let(:plain_fee) do
+        create(
+          :charge_fee,
+          invoice:,
+          charge:,
+          billable_metric:,
+          units: 10,
+          amount_cents: 1000,
+          precise_unit_amount: 100.0,
+          taxes_amount_cents: 0,
+          invoice_display_name: "Storage usage"
+        )
+      end
+
+      let(:billable_metric_mapping) do
+        create(
+          :xero_mapping,
+          integration:,
+          mappable_type: "BillableMetric",
+          mappable_id: billable_metric.id,
+          billing_entity:,
+          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
+        )
+      end
+
+      before do
+        billable_metric_mapping
+        plain_fee
+      end
+
+      it "leaves the line item description unchanged" do
+        fee_item = payload.first["fees"].first
+
+        expect(fee_item["description"]).to eq("Storage usage")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes [INT-51](https://linear.app/getlago/issue/INT-51/xero-invoice-line-items-missing-pricing-group-key-names-compared-to). Xero line items now include the grouped_by pricing group key values that already appear on the matching Lago invoice (e.g. `Storage usage • green`).

The Xero payload built the description from `fee.invoice_name` (or the charge filter display name) only. `fee.grouped_by` values were silently dropped, producing inconsistent line items between the Lago invoice and the synced Xero invoice. The Lago invoice template uses `FeeDisplayHelper.grouped_by_display(fee)` for the same suffix — this PR reuses the helper from the Xero payload override, so the two stay in sync without re-implementing the format.

Scope is Xero-only by design. The same dropped-grouped_by behavior likely affects Anrok / NetSuite / Hubspot payloads (they share the same `BasePayload#item`), but those integrations are out of scope for this ticket — they should be handled in their own tickets so their reviewers can confirm the integration accepts the format.

The PR does not touch the charge_filter branch of the existing description: when a fee has a `charge_filter`, the description still uses the filter's display name, matching pre-existing behavior. That is a separate hidden inconsistency with the Lago invoice and out of scope here.

## What changed
- `app/services/integrations/aggregator/invoices/payloads/xero.rb` — append `FeeDisplayHelper.grouped_by_display(fee)` to the description in the Xero `#item` override.

## Tests
- New context: `when a charge fee has grouped_by pricing group key values` — asserts description is `"Storage usage • green"`.
- New context: `when a charge fee has no grouped_by values` — asserts description stays `"Storage usage"` (regression guard).

## How to verify locally
1. Run `bundle exec rspec spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb` — both new contexts pass.
2. Manual: reproduce the ticket steps (Xero integration, charge with pricing group key on `deployment_name`, event with `deployment_name: green`, terminate subscription, finalize invoice). The Xero line item description should now read `<invoice_name> • green`.

## Out of scope / not done
- Anrok / NetSuite / Hubspot payloads — same `BasePayload#item` source, likely same bug, separate tickets if confirmed.
- Charge filter description (filter name replaces invoice name rather than appending) — pre-existing, separate fix.

## Validation mode
Mode B (CI-centric). The local runner has Ruby 3.2.2 but `.ruby-version` requires 4.0.2, so bundle exec / rspec / rubocop were not run locally. Validation delegated to CI — please do not review until CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)