### PR TITLE
fix(integrations): keep zero-amount fees in Xero invoice payload

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -28,6 +28,12 @@ module Integrations
               discount["item_code"] = discount.delete("external_id")
             end
           end
+
+          private
+
+          def fees
+            @fees ||= invoice.fees.order(created_at: :asc)
+          end
         end
       end
     end

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -163,5 +163,87 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
         expect(fee_item).not_to have_key("amount_cents")
       end
     end
+
+    context "when the invoice has a mix of $0 and positive amount fees" do
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:xero_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+      let(:subscription) { create(:subscription, organization:, plan:) }
+
+      let(:invoice) do
+        invoice = create(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity:,
+          coupons_amount_cents: 0,
+          prepaid_credit_amount_cents: 0,
+          progressive_billing_credit_amount_cents: 0,
+          credit_notes_amount_cents: 0,
+          taxes_amount_cents: 0,
+          issuing_date: DateTime.new(2024, 7, 8)
+        )
+        create(:invoice_subscription, invoice:, subscription:)
+        invoice
+      end
+
+      let(:positive_fee) do
+        create(
+          :charge_fee,
+          invoice:,
+          charge:,
+          billable_metric:,
+          units: 2,
+          amount_cents: 200,
+          precise_unit_amount: 100.0,
+          taxes_amount_cents: 0,
+          invoice_display_name: "Paid usage",
+          created_at: 2.minutes.ago
+        )
+      end
+
+      let(:zero_amount_fee) do
+        create(
+          :charge_fee,
+          invoice:,
+          charge:,
+          billable_metric:,
+          units: 5,
+          amount_cents: 0,
+          precise_unit_amount: 0.0,
+          taxes_amount_cents: 0,
+          invoice_display_name: "Free usage",
+          created_at: 1.minute.ago
+        )
+      end
+
+      let(:billable_metric_mapping) do
+        create(
+          :xero_mapping,
+          integration:,
+          mappable_type: "BillableMetric",
+          mappable_id: billable_metric.id,
+          billing_entity:,
+          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
+        )
+      end
+
+      before do
+        billable_metric_mapping
+        positive_fee
+        zero_amount_fee
+      end
+
+      it "includes the $0 fee line item alongside the positive fee" do
+        descriptions = payload.first["fees"].map { |f| f["description"] }
+
+        expect(descriptions).to include("Paid usage", "Free usage")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes [INT-52](https://linear.app/getlago/issue/INT-52/fees-with-dollar0-amount-appear-on-lago-invoices-but-not-on-xero). Xero invoices now include `$0` line items that already appear on the matching Lago invoice.

`BasePayload#fees` filters out fees with `amount_cents == 0` whenever any other fee on the invoice has a positive amount. That filter was introduced for NetSuite ([#2359](https://github.com/getlago/lago-api/pull/2359) — "Do not send line items with 0 amount cents"), which rejects zero-amount line items, but it also applies to Xero. Xero accepts zero-amount line items, so the filter creates a mismatch between Lago and the synced Xero invoice for any invoice with mixed `$0` / positive fees.

This PR overrides `#fees` in the Xero payload to return every fee on the invoice. NetSuite, Anrok, and Hubspot continue to inherit the original filter. Existing tax adjustment and discounts logic is unaffected: `$0` fees contribute `0` to `taxes_amount_cents` and don't disturb `tax_adjusted_fee_items`.

## What changed
- `app/services/integrations/aggregator/invoices/payloads/xero.rb` — override `#fees` to return all invoice fees, skipping the inherited `amount_cents > 0` filter.

## Tests
- New context: `when the invoice has a mix of \$0 and positive amount fees` — asserts both fees appear in the Xero payload (regression guard against the inherited filter).

## How to verify locally
1. Run `bundle exec rspec spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb` — new context passes; existing tests still pass (the shared example uses only positive fees, so it's unaffected).
2. Manual: follow the ticket repro (Xero integration, plan with `$0` subscription + `$0` charge per event, send events, terminate subscription, finalize invoice). All Lago line items — including `$0` ones — should now appear in the Xero invoice.

## Out of scope / not done
- NetSuite, Anrok, Hubspot — they share `BasePayload#fees` but have different vendor constraints. Out of scope.
- The original `BasePayload#fees` filter is kept untouched to preserve NetSuite behavior. A future refactor could move the filter to NetSuite's own payload class, but that's beyond INT-52.

## Validation mode
Mode B (CI-centric). The local runner has Ruby 3.2.2 but `.ruby-version` requires 4.0.2, so bundle exec / rspec / rubocop were not run locally. Validation delegated to CI — please do not review until CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)