### PR TITLE
fix(integrations): Xero line item parity with Lago invoice (INT-51, INT-52)

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -159,6 +159,12 @@ class Fee < ApplicationRecord
     charge_filter&.display_name(separator:)
   end
 
+  def grouped_by_display
+    return "" if !charge? || grouped_by.values.compact.blank?
+
+    " • #{grouped_by.values.compact.join(" • ")}"
+  end
+
   def invoice_sorting_clause
     base_clause = "#{invoice_name} #{filter_display_name}".downcase
 

--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -12,6 +12,7 @@ module Integrations
           def item(fee)
             base_item = super
             base_item["item_code"] = base_item.delete("external_id")
+            base_item["description"] = "#{base_item["description"]}#{FeeDisplayHelper.grouped_by_display(fee)}"
 
             if fee.precise_unit_amount.round(2) != fee.precise_unit_amount
               base_item["units"] = 1

--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -12,7 +12,7 @@ module Integrations
           def item(fee)
             base_item = super
             base_item["item_code"] = base_item.delete("external_id")
-            base_item["description"] = "#{base_item["description"]}#{FeeDisplayHelper.grouped_by_display(fee)}"
+            base_item["description"] = "#{base_item["description"]}#{fee.grouped_by_display}"
 
             if fee.precise_unit_amount.round(2) != fee.precise_unit_amount
               base_item["units"] = 1
@@ -33,7 +33,7 @@ module Integrations
           private
 
           # Xero accepts zero-amount line items, so we bypass the
-          # NetSuite-specific filter in BasePayload (see #2359).
+          # zero-amount fee filter defined in BasePayload (see #2656).
           def fees
             @fees ||= invoice.fees.order(created_at: :asc)
           end

--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -32,6 +32,8 @@ module Integrations
 
           private
 
+          # Xero accepts zero-amount line items, so we bypass the
+          # NetSuite-specific filter in BasePayload (see #2359).
           def fees
             @fees ||= invoice.fees.order(created_at: :asc)
           end

--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -29,6 +29,12 @@ module Integrations
               discount["item_code"] = discount.delete("external_id")
             end
           end
+
+          private
+
+          def fees
+            @fees ||= invoice.fees.order(created_at: :asc)
+          end
         end
       end
     end

--- a/app/views/helpers/fee_display_helper.rb
+++ b/app/views/helpers/fee_display_helper.rb
@@ -2,9 +2,7 @@
 
 class FeeDisplayHelper
   def self.grouped_by_display(fee)
-    return "" if !fee.charge? || fee.grouped_by.values.compact.blank?
-
-    " • #{fee.grouped_by.values.compact.join(" • ")}"
+    fee.grouped_by_display
   end
 
   def self.fee_title(fee)

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -598,6 +598,72 @@ RSpec.describe Fee do
     end
   end
 
+  describe "#grouped_by_display" do
+    let(:charge) { create(:standard_charge, properties:) }
+    let(:fee) { described_class.new(charge:, fee_type: "charge", grouped_by:) }
+    let(:grouped_by) do
+      {
+        "key_1" => "mercredi",
+        "key_2" => "week_01",
+        "key_3" => "2024"
+      }
+    end
+    let(:properties) do
+      {
+        "amount" => "5",
+        "grouped_by" => %w[key_1 key_2 key_3]
+      }
+    end
+
+    context "when a standard charge fee has grouped_by values" do
+      it "formats the grouped_by values with bullet points" do
+        expect(fee.grouped_by_display).to eq(" • mercredi • week_01 • 2024")
+      end
+    end
+
+    context "when the charge properties are missing the grouped_by property" do
+      let(:properties) do
+        {
+          "amount" => "5"
+        }
+      end
+
+      it "formats the grouped_by values with bullet points" do
+        expect(fee.grouped_by_display).to eq(" • mercredi • week_01 • 2024")
+      end
+    end
+
+    context "when some grouped_by values are nil" do
+      let(:grouped_by) do
+        {
+          "key_1" => nil,
+          "key_2" => "week_01",
+          "key_3" => "2024"
+        }
+      end
+
+      it "skips nil values and formats only the present values" do
+        expect(fee.grouped_by_display).to eq(" • week_01 • 2024")
+      end
+    end
+
+    context "when grouped_by values are all blank" do
+      let(:grouped_by) { {"key_1" => nil} }
+
+      it "returns an empty string" do
+        expect(fee.grouped_by_display).to eq("")
+      end
+    end
+
+    context "when the fee is not a charge" do
+      let(:fee) { described_class.new(fee_type: "subscription", grouped_by:) }
+
+      it "returns an empty string" do
+        expect(fee.grouped_by_display).to eq("")
+      end
+    end
+  end
+
   describe "#non_zero?" do
     subject { fee.non_zero? }
 

--- a/spec/services/integrations/aggregator/invoices/payloads/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/base_payload_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::BasePayload do
       let(:fee1) { create(:fee, invoice:, amount_cents: 1000, created_at: 1.day.ago) }
       let(:fee2) { create(:fee, invoice:, amount_cents: 2000, created_at: 2.days.ago) }
 
+      before do
+        fee1
+        fee2
+      end
+
       it "returns fees with positive amount_cents ordered by created_at" do
         expect(fees_call).to eq([fee2, fee1])
       end
@@ -26,18 +31,28 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::BasePayload do
       let(:fee1) { create(:fee, invoice:, amount_cents: 0, created_at: 1.day.ago) }
       let(:fee2) { create(:fee, invoice:, amount_cents: -1000, created_at: 2.days.ago) }
 
+      before do
+        fee1
+        fee2
+      end
+
       it "returns all fees ordered by created_at" do
         expect(fees_call).to eq([fee2, fee1])
       end
     end
 
     context "when there are fees with positive and zero amount_cents" do
-      let(:fee1) { create(:fee, invoice:, amount_cents: 0, created_at: 1.day.ago) }
       let(:fee2) { create(:fee, invoice:, amount_cents: 100, created_at: 2.days.ago) }
       let(:fee3) { create(:fee, invoice:, amount_cents: 200, created_at: 3.days.ago) }
 
+      before do
+        create(:fee, invoice:, amount_cents: 0, created_at: 1.day.ago)
+        fee2
+        fee3
+      end
+
       it "returns only positive fees ordered by created_at" do
-        expect(fees_call).to eq([fee2, fee1])
+        expect(fees_call).to eq([fee3, fee2])
       end
     end
   end

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -248,10 +248,12 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
 
         before { grouped_fee }
 
-        it "joins the grouped_by values into the line item description" do
+        it "joins the grouped_by values into the line item description with a ' • ' separator" do
           fee_item = payload.first["fees"].first
 
-          expect(fee_item["description"]).to eq("Storage usage • eu • gold")
+          # JSONB does not preserve insertion order, so accept either ordering
+          # of the two grouped_by values — we only lock in the separator format.
+          expect(fee_item["description"]).to match(/\AStorage usage • (eu • gold|gold • eu)\z/)
         end
       end
 

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
       end
     end
 
-    context "when a charge fee has grouped_by pricing group key values" do
+    context "with a single billable metric charge" do
       let(:organization) { create(:organization) }
       let(:billing_entity) { create(:billing_entity, organization:) }
       let(:integration) { create(:xero_integration, organization:) }
@@ -192,21 +192,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
         invoice
       end
 
-      let(:grouped_fee) do
-        create(
-          :charge_fee,
-          invoice:,
-          charge:,
-          billable_metric:,
-          units: 10,
-          amount_cents: 1000,
-          precise_unit_amount: 100.0,
-          taxes_amount_cents: 0,
-          invoice_display_name: "Storage usage",
-          grouped_by: {"deployment_name" => "green"}
-        )
-      end
-
       let(:billable_metric_mapping) do
         create(
           :xero_mapping,
@@ -218,162 +203,172 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
         )
       end
 
-      before do
-        billable_metric_mapping
-        grouped_fee
+      before { billable_metric_mapping }
+
+      context "when a charge fee has a single grouped_by pricing group key value" do
+        let(:grouped_fee) do
+          create(
+            :charge_fee,
+            invoice:,
+            charge:,
+            billable_metric:,
+            units: 10,
+            amount_cents: 1000,
+            precise_unit_amount: 100.0,
+            taxes_amount_cents: 0,
+            invoice_display_name: "Storage usage",
+            grouped_by: {"deployment_name" => "green"}
+          )
+        end
+
+        before { grouped_fee }
+
+        it "appends the grouped_by value to the line item description" do
+          fee_item = payload.first["fees"].first
+
+          expect(fee_item["description"]).to eq("Storage usage • green")
+        end
       end
 
-      it "appends the grouped_by values to the line item description" do
-        fee_item = payload.first["fees"].first
+      context "when a charge fee has multiple grouped_by pricing group key values" do
+        let(:grouped_fee) do
+          create(
+            :charge_fee,
+            invoice:,
+            charge:,
+            billable_metric:,
+            units: 10,
+            amount_cents: 1000,
+            precise_unit_amount: 100.0,
+            taxes_amount_cents: 0,
+            invoice_display_name: "Storage usage",
+            grouped_by: {"region" => "eu", "tier" => "gold"}
+          )
+        end
 
-        expect(fee_item["description"]).to eq("Storage usage • green")
-      end
-    end
+        before { grouped_fee }
 
-    context "when a charge fee has no grouped_by values" do
-      let(:organization) { create(:organization) }
-      let(:billing_entity) { create(:billing_entity, organization:) }
-      let(:integration) { create(:xero_integration, organization:) }
-      let(:customer) { create(:customer, organization:, billing_entity:) }
-      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
-      let(:billable_metric) { create(:billable_metric, organization:) }
-      let(:plan) { create(:plan, organization:) }
-      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
-      let(:subscription) { create(:subscription, organization:, plan:) }
+        it "joins the grouped_by values into the line item description" do
+          fee_item = payload.first["fees"].first
 
-      let(:invoice) do
-        invoice = create(
-          :invoice,
-          customer:,
-          organization:,
-          billing_entity:,
-          coupons_amount_cents: 0,
-          prepaid_credit_amount_cents: 0,
-          progressive_billing_credit_amount_cents: 0,
-          credit_notes_amount_cents: 0,
-          taxes_amount_cents: 0,
-          issuing_date: DateTime.new(2024, 7, 8)
-        )
-        create(:invoice_subscription, invoice:, subscription:)
-        invoice
+          expect(fee_item["description"]).to eq("Storage usage • eu • gold")
+        end
       end
 
-      let(:plain_fee) do
-        create(
-          :charge_fee,
-          invoice:,
-          charge:,
-          billable_metric:,
-          units: 10,
-          amount_cents: 1000,
-          precise_unit_amount: 100.0,
-          taxes_amount_cents: 0,
-          invoice_display_name: "Storage usage"
-        )
+      context "when a charge fee has no grouped_by values" do
+        let(:plain_fee) do
+          create(
+            :charge_fee,
+            invoice:,
+            charge:,
+            billable_metric:,
+            units: 10,
+            amount_cents: 1000,
+            precise_unit_amount: 100.0,
+            taxes_amount_cents: 0,
+            invoice_display_name: "Storage usage"
+          )
+        end
+
+        before { plain_fee }
+
+        it "leaves the line item description unchanged" do
+          fee_item = payload.first["fees"].first
+
+          expect(fee_item["description"]).to eq("Storage usage")
+        end
       end
 
-      let(:billable_metric_mapping) do
-        create(
-          :xero_mapping,
-          integration:,
-          mappable_type: "BillableMetric",
-          mappable_id: billable_metric.id,
-          billing_entity:,
-          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
-        )
+      context "when the invoice has a mix of $0 and positive amount fees" do
+        let(:positive_fee) do
+          create(
+            :charge_fee,
+            invoice:,
+            charge:,
+            billable_metric:,
+            units: 2,
+            amount_cents: 200,
+            precise_unit_amount: 100.0,
+            taxes_amount_cents: 0,
+            invoice_display_name: "Paid usage",
+            created_at: 2.minutes.ago
+          )
+        end
+
+        let(:zero_amount_fee) do
+          create(
+            :charge_fee,
+            invoice:,
+            charge:,
+            billable_metric:,
+            units: 5,
+            amount_cents: 0,
+            precise_unit_amount: 0.0,
+            taxes_amount_cents: 0,
+            invoice_display_name: "Free usage",
+            created_at: 1.minute.ago
+          )
+        end
+
+        before do
+          positive_fee
+          zero_amount_fee
+        end
+
+        it "includes the $0 fee line item alongside the positive fee, preserving creation order" do
+          fees = payload.first["fees"]
+
+          expect(fees.size).to eq(2)
+          expect(fees.map { |f| f["description"] }).to eq(["Paid usage", "Free usage"])
+
+          zero_item = fees.last
+          expect(zero_item["units"]).to eq(5)
+          expect(zero_item["precise_unit_amount"]).to eq(0.0)
+        end
       end
 
-      before do
-        billable_metric_mapping
-        plain_fee
-      end
+      context "when every fee on the invoice has a $0 amount" do
+        let(:zero_fee_a) do
+          create(
+            :charge_fee,
+            invoice:,
+            charge:,
+            billable_metric:,
+            units: 1,
+            amount_cents: 0,
+            precise_unit_amount: 0.0,
+            taxes_amount_cents: 0,
+            invoice_display_name: "Free usage A",
+            created_at: 2.minutes.ago
+          )
+        end
 
-      it "leaves the line item description unchanged" do
-        fee_item = payload.first["fees"].first
+        let(:zero_fee_b) do
+          create(
+            :charge_fee,
+            invoice:,
+            charge:,
+            billable_metric:,
+            units: 2,
+            amount_cents: 0,
+            precise_unit_amount: 0.0,
+            taxes_amount_cents: 0,
+            invoice_display_name: "Free usage B",
+            created_at: 1.minute.ago
+          )
+        end
 
-        expect(fee_item["description"]).to eq("Storage usage")
-      end
-    end
+        before do
+          zero_fee_a
+          zero_fee_b
+        end
 
-    context "when the invoice has a mix of $0 and positive amount fees" do
-      let(:organization) { create(:organization) }
-      let(:billing_entity) { create(:billing_entity, organization:) }
-      let(:integration) { create(:xero_integration, organization:) }
-      let(:customer) { create(:customer, organization:, billing_entity:) }
-      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
-      let(:billable_metric) { create(:billable_metric, organization:) }
-      let(:plan) { create(:plan, organization:) }
-      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
-      let(:subscription) { create(:subscription, organization:, plan:) }
+        it "still includes every $0 fee in the payload" do
+          fees = payload.first["fees"]
 
-      let(:invoice) do
-        invoice = create(
-          :invoice,
-          customer:,
-          organization:,
-          billing_entity:,
-          coupons_amount_cents: 0,
-          prepaid_credit_amount_cents: 0,
-          progressive_billing_credit_amount_cents: 0,
-          credit_notes_amount_cents: 0,
-          taxes_amount_cents: 0,
-          issuing_date: DateTime.new(2024, 7, 8)
-        )
-        create(:invoice_subscription, invoice:, subscription:)
-        invoice
-      end
-
-      let(:positive_fee) do
-        create(
-          :charge_fee,
-          invoice:,
-          charge:,
-          billable_metric:,
-          units: 2,
-          amount_cents: 200,
-          precise_unit_amount: 100.0,
-          taxes_amount_cents: 0,
-          invoice_display_name: "Paid usage",
-          created_at: 2.minutes.ago
-        )
-      end
-
-      let(:zero_amount_fee) do
-        create(
-          :charge_fee,
-          invoice:,
-          charge:,
-          billable_metric:,
-          units: 5,
-          amount_cents: 0,
-          precise_unit_amount: 0.0,
-          taxes_amount_cents: 0,
-          invoice_display_name: "Free usage",
-          created_at: 1.minute.ago
-        )
-      end
-
-      let(:billable_metric_mapping) do
-        create(
-          :xero_mapping,
-          integration:,
-          mappable_type: "BillableMetric",
-          mappable_id: billable_metric.id,
-          billing_entity:,
-          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
-        )
-      end
-
-      before do
-        billable_metric_mapping
-        positive_fee
-        zero_amount_fee
-      end
-
-      it "includes the $0 fee line item alongside the positive fee" do
-        descriptions = payload.first["fees"].map { |f| f["description"] }
-
-        expect(descriptions).to include("Paid usage", "Free usage")
+          expect(fees.size).to eq(2)
+          expect(fees.map { |f| f["description"] }).to eq(["Free usage A", "Free usage B"])
+        end
       end
     end
   end

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -96,74 +96,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
       end
     end
 
-    context "when a fee has precise_unit_amount with more than 2 decimal places" do
-      let(:organization) { create(:organization) }
-      let(:billing_entity) { create(:billing_entity, organization:) }
-      let(:integration) { create(:xero_integration, organization:) }
-      let(:customer) { create(:customer, organization:, billing_entity:) }
-      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
-      let(:billable_metric) { create(:billable_metric, organization:) }
-      let(:plan) { create(:plan, organization:) }
-      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
-      let(:subscription) { create(:subscription, organization:, plan:) }
-
-      let(:invoice) do
-        invoice = create(
-          :invoice,
-          customer:,
-          organization:,
-          billing_entity:,
-          coupons_amount_cents: 0,
-          prepaid_credit_amount_cents: 0,
-          progressive_billing_credit_amount_cents: 0,
-          credit_notes_amount_cents: 0,
-          taxes_amount_cents: 0,
-          issuing_date: DateTime.new(2024, 7, 8)
-        )
-        create(:invoice_subscription, invoice:, subscription:)
-        invoice
-      end
-
-      let(:high_precision_fee) do
-        create(
-          :charge_fee,
-          invoice:,
-          charge:,
-          billable_metric:,
-          units: 74_759_000,
-          amount_cents: 89_566,
-          precise_unit_amount: 0.000018,
-          taxes_amount_cents: 0
-        )
-      end
-
-      let(:billable_metric_mapping) do
-        create(
-          :xero_mapping,
-          integration:,
-          mappable_type: "BillableMetric",
-          mappable_id: billable_metric.id,
-          billing_entity:,
-          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
-        )
-      end
-
-      before do
-        billable_metric_mapping
-        high_precision_fee
-      end
-
-      it "sends precise_unit_amount as the total amount in currency units instead of amount_cents" do
-        fee_item = payload.first["fees"].first
-
-        expect(fee_item).to include(
-          "units" => 1,
-          "precise_unit_amount" => 895.66
-        )
-        expect(fee_item).not_to have_key("amount_cents")
-      end
-    end
-
     context "with a single billable metric charge" do
       let(:organization) { create(:organization) }
       let(:billing_entity) { create(:billing_entity, organization:) }
@@ -204,6 +136,33 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
       end
 
       before { billable_metric_mapping }
+
+      context "when a fee has precise_unit_amount with more than 2 decimal places" do
+        let(:high_precision_fee) do
+          create(
+            :charge_fee,
+            invoice:,
+            charge:,
+            billable_metric:,
+            units: 74_759_000,
+            amount_cents: 89_566,
+            precise_unit_amount: 0.000018,
+            taxes_amount_cents: 0
+          )
+        end
+
+        before { high_precision_fee }
+
+        it "sends precise_unit_amount as the total amount in currency units instead of amount_cents" do
+          fee_item = payload.first["fees"].first
+
+          expect(fee_item).to include(
+            "units" => 1,
+            "precise_unit_amount" => 895.66
+          )
+          expect(fee_item).not_to have_key("amount_cents")
+        end
+      end
 
       context "when a charge fee has a single grouped_by pricing group key value" do
         let(:grouped_fee) do
@@ -317,6 +276,9 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
           zero_amount_fee
         end
 
+        # The base payload drops $0 fees when a positive fee exists; Xero keeps
+        # them. This mix is the scenario where Xero's behavior diverges from the
+        # base, so it is the meaningful guard for the override.
         it "includes the $0 fee line item alongside the positive fee, preserving creation order" do
           fees = payload.first["fees"]
 
@@ -326,50 +288,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
           zero_item = fees.last
           expect(zero_item["units"]).to eq(5)
           expect(zero_item["precise_unit_amount"]).to eq(0.0)
-        end
-      end
-
-      context "when every fee on the invoice has a $0 amount" do
-        let(:zero_fee_a) do
-          create(
-            :charge_fee,
-            invoice:,
-            charge:,
-            billable_metric:,
-            units: 1,
-            amount_cents: 0,
-            precise_unit_amount: 0.0,
-            taxes_amount_cents: 0,
-            invoice_display_name: "Free usage A",
-            created_at: 2.minutes.ago
-          )
-        end
-
-        let(:zero_fee_b) do
-          create(
-            :charge_fee,
-            invoice:,
-            charge:,
-            billable_metric:,
-            units: 2,
-            amount_cents: 0,
-            precise_unit_amount: 0.0,
-            taxes_amount_cents: 0,
-            invoice_display_name: "Free usage B",
-            created_at: 1.minute.ago
-          )
-        end
-
-        before do
-          zero_fee_a
-          zero_fee_b
-        end
-
-        it "still includes every $0 fee in the payload" do
-          fees = payload.first["fees"]
-
-          expect(fees.size).to eq(2)
-          expect(fees.map { |f| f["description"] }).to eq(["Free usage A", "Free usage B"])
         end
       end
     end

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -294,5 +294,87 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
         expect(fee_item["description"]).to eq("Storage usage")
       end
     end
+
+    context "when the invoice has a mix of $0 and positive amount fees" do
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:xero_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+      let(:subscription) { create(:subscription, organization:, plan:) }
+
+      let(:invoice) do
+        invoice = create(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity:,
+          coupons_amount_cents: 0,
+          prepaid_credit_amount_cents: 0,
+          progressive_billing_credit_amount_cents: 0,
+          credit_notes_amount_cents: 0,
+          taxes_amount_cents: 0,
+          issuing_date: DateTime.new(2024, 7, 8)
+        )
+        create(:invoice_subscription, invoice:, subscription:)
+        invoice
+      end
+
+      let(:positive_fee) do
+        create(
+          :charge_fee,
+          invoice:,
+          charge:,
+          billable_metric:,
+          units: 2,
+          amount_cents: 200,
+          precise_unit_amount: 100.0,
+          taxes_amount_cents: 0,
+          invoice_display_name: "Paid usage",
+          created_at: 2.minutes.ago
+        )
+      end
+
+      let(:zero_amount_fee) do
+        create(
+          :charge_fee,
+          invoice:,
+          charge:,
+          billable_metric:,
+          units: 5,
+          amount_cents: 0,
+          precise_unit_amount: 0.0,
+          taxes_amount_cents: 0,
+          invoice_display_name: "Free usage",
+          created_at: 1.minute.ago
+        )
+      end
+
+      let(:billable_metric_mapping) do
+        create(
+          :xero_mapping,
+          integration:,
+          mappable_type: "BillableMetric",
+          mappable_id: billable_metric.id,
+          billing_entity:,
+          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
+        )
+      end
+
+      before do
+        billable_metric_mapping
+        positive_fee
+        zero_amount_fee
+      end
+
+      it "includes the $0 fee line item alongside the positive fee" do
+        descriptions = payload.first["fees"].map { |f| f["description"] }
+
+        expect(descriptions).to include("Paid usage", "Free usage")
+      end
+    end
   end
 end

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -163,5 +163,136 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
         expect(fee_item).not_to have_key("amount_cents")
       end
     end
+
+    context "when a charge fee has grouped_by pricing group key values" do
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:xero_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+      let(:subscription) { create(:subscription, organization:, plan:) }
+
+      let(:invoice) do
+        invoice = create(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity:,
+          coupons_amount_cents: 0,
+          prepaid_credit_amount_cents: 0,
+          progressive_billing_credit_amount_cents: 0,
+          credit_notes_amount_cents: 0,
+          taxes_amount_cents: 0,
+          issuing_date: DateTime.new(2024, 7, 8)
+        )
+        create(:invoice_subscription, invoice:, subscription:)
+        invoice
+      end
+
+      let(:grouped_fee) do
+        create(
+          :charge_fee,
+          invoice:,
+          charge:,
+          billable_metric:,
+          units: 10,
+          amount_cents: 1000,
+          precise_unit_amount: 100.0,
+          taxes_amount_cents: 0,
+          invoice_display_name: "Storage usage",
+          grouped_by: {"deployment_name" => "green"}
+        )
+      end
+
+      let(:billable_metric_mapping) do
+        create(
+          :xero_mapping,
+          integration:,
+          mappable_type: "BillableMetric",
+          mappable_id: billable_metric.id,
+          billing_entity:,
+          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
+        )
+      end
+
+      before do
+        billable_metric_mapping
+        grouped_fee
+      end
+
+      it "appends the grouped_by values to the line item description" do
+        fee_item = payload.first["fees"].first
+
+        expect(fee_item["description"]).to eq("Storage usage • green")
+      end
+    end
+
+    context "when a charge fee has no grouped_by values" do
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:integration) { create(:xero_integration, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:integration_customer) { create(:xero_customer, customer:, integration:) }
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:charge) { create(:standard_charge, plan:, organization:, billable_metric:) }
+      let(:subscription) { create(:subscription, organization:, plan:) }
+
+      let(:invoice) do
+        invoice = create(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity:,
+          coupons_amount_cents: 0,
+          prepaid_credit_amount_cents: 0,
+          progressive_billing_credit_amount_cents: 0,
+          credit_notes_amount_cents: 0,
+          taxes_amount_cents: 0,
+          issuing_date: DateTime.new(2024, 7, 8)
+        )
+        create(:invoice_subscription, invoice:, subscription:)
+        invoice
+      end
+
+      let(:plain_fee) do
+        create(
+          :charge_fee,
+          invoice:,
+          charge:,
+          billable_metric:,
+          units: 10,
+          amount_cents: 1000,
+          precise_unit_amount: 100.0,
+          taxes_amount_cents: 0,
+          invoice_display_name: "Storage usage"
+        )
+      end
+
+      let(:billable_metric_mapping) do
+        create(
+          :xero_mapping,
+          integration:,
+          mappable_type: "BillableMetric",
+          mappable_id: billable_metric.id,
+          billing_entity:,
+          settings: {external_id: "metric_ext_id", external_account_code: "100", external_name: "metric"}
+        )
+      end
+
+      before do
+        billable_metric_mapping
+        plain_fee
+      end
+
+      it "leaves the line item description unchanged" do
+        fee_item = payload.first["fees"].first
+
+        expect(fee_item["description"]).to eq("Storage usage")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Two Xero invoice line-item bugs live in the same `Xero` payload class. Closes [INT-51](https://linear.app/getlago/issue/INT-51/xero-invoice-line-items-missing-pricing-group-key-names-compared-to) and [INT-52](https://linear.app/getlago/issue/INT-52/fees-with-dollar0-amount-appear-on-lago-invoices-but-not-on-xero).

- **INT-51** — Xero line item descriptions were built from the invoice/charge-filter name only, dropping `fee.grouped_by` values. The synced Xero invoice diverged from the Lago invoice (e.g. `Storage usage • green` on Lago, `Storage usage` on Xero).
- **INT-52** — `$0` fees were missing from Xero invoices. `BasePayload#fees` (shared by all invoice integrations, last changed in #2656) drops zero-amount fees whenever a positive fee exists, since some vendors reject `$0` line items. Xero accepts them, so the filter created a mismatch. Xero already existed when #2656 landed and has inherited this filter — and the resulting `$0` mismatch — ever since.

## Description

- Add `Fee#grouped_by_display`, returning the ` • `-joined `grouped_by` values for charge fees. `FeeDisplayHelper.grouped_by_display` now delegates to it, so the Lago invoice template and the Xero payload share a single implementation rather than the service reaching into a view helper.
- The Xero payload appends `fee.grouped_by_display` to the line item description.
- The Xero payload overrides `#fees` to keep zero-amount fees, bypassing the `BasePayload` filter. Other integrations keep the inherited behavior.
