### PR TITLE
perf(invoices): Use customer payments as association for invoices in GraphQL

### DIFF
--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -90,6 +90,7 @@ module Resolvers
           :regenerated_invoice,
           :error_details,
           :billing_entity,
+          :sorted_customer_payments,
           {customer: :billing_entity}
         )
       )

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -90,7 +90,7 @@ module Resolvers
           :regenerated_invoice,
           :error_details,
           :billing_entity,
-          :sorted_customer_payments,
+          :customer_payments,
           {customer: :billing_entity}
         )
       )

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -81,7 +81,7 @@ module Types
       field :integration_salesforce_syncable, GraphQL::Types::Boolean, null: false
       field :integration_syncable, GraphQL::Types::Boolean, null: false
       field :payable_type, GraphQL::Types::String, null: false
-      field :payments, [Types::Payments::Object], null: true
+      field :payments, [Types::Payments::Object], null: true, method: :sorted_customer_payments
       field :regenerated_invoice_id, String, null: true
       field :tax_provider_id, String, null: true
       field :tax_provider_voidable, GraphQL::Types::Boolean, null: false
@@ -102,10 +102,6 @@ module Types
         else
           object.applied_taxes.order(tax_rate: :desc)
         end
-      end
-
-      def payments
-        object.payments.where.not(customer_id: nil).order(updated_at: :desc)
       end
 
       def integration_syncable

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -81,7 +81,7 @@ module Types
       field :integration_salesforce_syncable, GraphQL::Types::Boolean, null: false
       field :integration_syncable, GraphQL::Types::Boolean, null: false
       field :payable_type, GraphQL::Types::String, null: false
-      field :payments, [Types::Payments::Object], null: true, method: :sorted_customer_payments
+      field :payments, [Types::Payments::Object], null: true, method: :customer_payments
       field :regenerated_invoice_id, String, null: true
       field :tax_provider_id, String, null: true
       field :tax_provider_voidable, GraphQL::Types::Boolean, null: false

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -42,6 +42,7 @@ class Invoice < ApplicationRecord
   has_many :payment_requests, through: :applied_payment_requests
   has_many :payments, as: :payable
   has_many :payment_receipts, through: :payments
+  has_many :sorted_customer_payments, -> { where.not(customer_id: nil).order(updated_at: :desc) }, class_name: "Payment", as: :payable
 
   has_many :applied_usage_thresholds
   has_many :usage_thresholds, through: :applied_usage_thresholds

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -42,7 +42,7 @@ class Invoice < ApplicationRecord
   has_many :payment_requests, through: :applied_payment_requests
   has_many :payments, as: :payable
   has_many :payment_receipts, through: :payments
-  has_many :sorted_customer_payments, -> { where.not(customer_id: nil).order(updated_at: :desc) }, class_name: "Payment", as: :payable
+  has_many :customer_payments, -> { where.not(customer_id: nil).order(updated_at: :desc) }, class_name: "Payment", as: :payable
 
   has_many :applied_usage_thresholds
   has_many :usage_thresholds, through: :applied_usage_thresholds

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -729,6 +729,47 @@ RSpec.describe Resolvers::InvoicesResolver do
     end
   end
 
+  context "with payments" do
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(limit: 5, customerExternalId: "#{invoice_first.customer.external_id}") {
+            collection {
+              id
+              payments {
+                id
+                __typename
+              }
+            }
+          }
+        }
+      GQL
+    end
+
+    let(:payment_first) { create(:payment, payable: invoice_first, payable_payment_status: :succeeded) }
+    let(:payment_second) { create(:payment, payable: invoice_first, payable_payment_status: :succeeded) }
+
+    before do
+      payment_first
+      payment_second
+    end
+
+    it "returns payments with customer sorted by updated_at desc" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      invoice = result["data"]["invoices"]["collection"].first
+
+      expect(invoice["payments"].count).to eq(2)
+      expect(invoice["payments"][0]["id"]).to eq(payment_second.id)
+      expect(invoice["payments"][1]["id"]).to eq(payment_first.id)
+    end
+  end
+
   context "with N+1 query detection on associations", bullet: {unused_eager_loading: false} do
     let(:query) do
       <<~GQL

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -729,47 +729,6 @@ RSpec.describe Resolvers::InvoicesResolver do
     end
   end
 
-  context "with payments" do
-    let(:query) do
-      <<~GQL
-        query {
-          invoices(limit: 5, customerExternalId: "#{invoice_first.customer.external_id}") {
-            collection {
-              id
-              payments {
-                id
-                __typename
-              }
-            }
-          }
-        }
-      GQL
-    end
-
-    let(:payment_first) { create(:payment, payable: invoice_first, payable_payment_status: :succeeded) }
-    let(:payment_second) { create(:payment, payable: invoice_first, payable_payment_status: :succeeded) }
-
-    before do
-      payment_first
-      payment_second
-    end
-
-    it "returns payments with customer sorted by updated_at desc" do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query:
-      )
-
-      invoice = result["data"]["invoices"]["collection"].first
-
-      expect(invoice["payments"].count).to eq(2)
-      expect(invoice["payments"][0]["id"]).to eq(payment_second.id)
-      expect(invoice["payments"][1]["id"]).to eq(payment_first.id)
-    end
-  end
-
   context "with N+1 query detection on associations", bullet: {unused_eager_loading: false} do
     let(:query) do
       <<~GQL

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -140,4 +140,19 @@ RSpec.describe Types::Invoices::Object do
       ])
     end
   end
+
+  describe "#payments" do
+    subject(:payments) { run_graphql_field("Invoice.payments", invoice) }
+
+    let(:invoice) { create(:invoice) }
+
+    before do
+      create(:payment, payable: invoice, payable_payment_status: :succeeded, amount_cents: 100, updated_at: 1.hour.ago)
+      create(:payment, payable: invoice, payable_payment_status: :succeeded, amount_cents: 200, updated_at: 2.hours.ago)
+    end
+
+    it "returns payments ordered by updated_at" do
+      expect(payments.map(&:amount_cents)).to eq([100, 200])
+    end
+  end
 end


### PR DESCRIPTION
## Context

The `Invoice` GraphQL object loads payments using a specific query, which causes N+1 queries in `InvoicesResolver`.

```ruby
def payments
  object.payments.where.not(customer_id: nil).order(updated_at: :desc)
end
```

```
DEBUG -- :   Payment Load (0.5ms)  SELECT "payments"."id", "payments"."invoice_id", "payments"."payment_provider_id", "payments"."payment_provider_customer_id", "payments"."amount_cents", "payments"."amount_currency", "payments"."provider_payment_id", "payments"."status", "payments"."created_at", "payments"."updated_at", "payments"."payable_type", "payments"."payable_id", "payments"."provider_payment_data", "payments"."payable_payment_status", "payments"."payment_type", "payments"."reference", "payments"."provider_payment_method_data", "payments"."provider_payment_method_id", "payments"."organization_id", "payments"."customer_id", "payments"."error_code", "payments"."payment_method_id" FROM "payments" WHERE "payments"."payable_id" = $1 AND "payments"."payable_type" = $2 AND "payments"."customer_id" IS NOT NULL ORDER BY "payments"."updated_at" DESC  [["payable_id", "60d500c2-cabf-44cd-8f50-58243d8278f4"], ["payable_type", "Invoice"]]
DEBUG -- :   Payment Load (0.4ms)  SELECT "payments"."id", "payments"."invoice_id", "payments"."payment_provider_id", "payments"."payment_provider_customer_id", "payments"."amount_cents", "payments"."amount_currency", "payments"."provider_payment_id", "payments"."status", "payments"."created_at", "payments"."updated_at", "payments"."payable_type", "payments"."payable_id", "payments"."provider_payment_data", "payments"."payable_payment_status", "payments"."payment_type", "payments"."reference", "payments"."provider_payment_method_data", "payments"."provider_payment_method_id", "payments"."organization_id", "payments"."customer_id", "payments"."error_code", "payments"."payment_method_id" FROM "payments" WHERE "payments"."payable_id" = $1 AND "payments"."payable_type" = $2 AND "payments"."customer_id" IS NOT NULL ORDER BY "payments"."updated_at" DESC  [["payable_id", "84bd9482-e59c-4776-b08a-8a917113bd73"], ["payable_type", "Invoice"]]
DEBUG -- :   Payment Load (0.5ms)  SELECT "payments"."id", "payments"."invoice_id", "payments"."payment_provider_id", "payments"."payment_provider_customer_id", "payments"."amount_cents", "payments"."amount_currency", "payments"."provider_payment_id", "payments"."status", "payments"."created_at", "payments"."updated_at", "payments"."payable_type", "payments"."payable_id", "payments"."provider_payment_data", "payments"."payable_payment_status", "payments"."payment_type", "payments"."reference", "payments"."provider_payment_method_data", "payments"."provider_payment_method_id", "payments"."organization_id", "payments"."customer_id", "payments"."error_code", "payments"."payment_method_id" FROM "payments" WHERE "payments"."payable_id" = $1 AND "payments"."payable_type" = $2 AND "payments"."customer_id" IS NOT NULL ORDER BY "payments"."updated_at" DESC  [["payable_id", "e7d95c72-7d7f-4b9f-b5b1-6017cf625337"], ["payable_type", "Invoice"]]
```

## Description

This PR moves that query into an association and preloads it in `InvoicesResolver` to avoid the N+1 queries.