### PR TITLE
[ING-236] feat(graphql): expose grants_target_top_up on recurring rule

### DIFF
--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -8,6 +8,7 @@ module Types
 
         argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
         argument :granted_credits, String, required: false
+        argument :grants_target_top_up, Boolean, required: false
         argument :ignore_paid_top_up_limits, Boolean, required: false
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
         argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false

--- a/app/graphql/types/wallets/recurring_transaction_rules/object.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/object.rb
@@ -11,6 +11,7 @@ module Types
         field :created_at, GraphQL::Types::ISO8601DateTime, null: false
         field :expiration_at, GraphQL::Types::ISO8601DateTime, null: true
         field :granted_credits, String, null: false
+        field :grants_target_top_up, Boolean, null: true
         field :ignore_paid_top_up_limits, Boolean, null: false
         field :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, null: true
         field :invoice_requires_successful_payment, Boolean, null: false

--- a/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
@@ -8,6 +8,7 @@ module Types
 
         argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
         argument :granted_credits, String, required: false
+        argument :grants_target_top_up, Boolean, required: false
         argument :ignore_paid_top_up_limits, Boolean, required: false
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
         argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -3309,6 +3309,7 @@ input CreateQuoteInput {
 input CreateRecurringTransactionRuleInput {
   expirationAt: ISO8601DateTime
   grantedCredits: String
+  grantsTargetTopUp: Boolean
   ignorePaidTopUpLimits: Boolean
   interval: RecurringTransactionIntervalEnum
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
@@ -11075,6 +11076,7 @@ type RecurringTransactionRule {
   createdAt: ISO8601DateTime!
   expirationAt: ISO8601DateTime
   grantedCredits: String!
+  grantsTargetTopUp: Boolean
   ignorePaidTopUpLimits: Boolean!
   interval: RecurringTransactionIntervalEnum
   invoiceRequiresSuccessfulPayment: Boolean!
@@ -13377,6 +13379,7 @@ input UpdateQuoteVersionInput {
 input UpdateRecurringTransactionRuleInput {
   expirationAt: ISO8601DateTime
   grantedCredits: String
+  grantsTargetTopUp: Boolean
   ignorePaidTopUpLimits: Boolean
   interval: RecurringTransactionIntervalEnum
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput

--- a/schema.json
+++ b/schema.json
@@ -15187,6 +15187,18 @@
               "deprecationReason": null
             },
             {
+              "name": "grantsTargetTopUp",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "ignorePaidTopUpLimits",
               "description": null,
               "type": {
@@ -60650,6 +60662,18 @@
               "deprecationReason": null
             },
             {
+              "name": "grantsTargetTopUp",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "ignorePaidTopUpLimits",
               "description": null,
               "args": [],
@@ -71544,6 +71568,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "grantsTargetTopUp",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Mutations::Wallets::Create, :premium do
             thresholdCredits
             paidCredits
             grantedCredits
+            grantsTargetTopUp
             targetOngoingBalance
             invoiceRequiresSuccessfulPayment
             expirationAt
@@ -90,6 +91,7 @@ RSpec.describe Mutations::Wallets::Create, :premium do
               invoiceRequiresSuccessfulPayment: true,
               expirationAt: expiration_at.iso8601,
               ignorePaidTopUpLimits: true,
+              grantsTargetTopUp: true,
               transactionMetadata: [
                 {key: "example_key", value: "example_value"},
                 {key: "another_key", value: "another_value"}
@@ -124,6 +126,7 @@ RSpec.describe Mutations::Wallets::Create, :premium do
     expect(result_data["recurringTransactionRules"][0]["grantedCredits"]).to eq("0.0")
     expect(result_data["recurringTransactionRules"][0]["invoiceRequiresSuccessfulPayment"]).to eq(true)
     expect(result_data["recurringTransactionRules"][0]["ignorePaidTopUpLimits"]).to eq(true)
+    expect(result_data["recurringTransactionRules"][0]["grantsTargetTopUp"]).to eq(true)
     expect(result_data["recurringTransactionRules"][0]["transactionMetadata"]).to contain_exactly(
       {"key" => "example_key", "value" => "example_value"},
       {"key" => "another_key", "value" => "another_value"}
@@ -146,6 +149,42 @@ RSpec.describe Mutations::Wallets::Create, :premium do
       }
     )
     expect(SendWebhookJob).to have_been_enqueued.with("wallet.created", Wallet)
+  end
+
+  context "when grants_target_top_up is omitted on a target rule" do
+    it "defaults grants_target_top_up to false" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            name: "Default Wallet",
+            priority: 9,
+            rateAmount: "1",
+            paidCredits: "0.00",
+            grantedCredits: "0.00",
+            expirationAt: expiration_at.iso8601,
+            currency: "EUR",
+            recurringTransactionRules: [
+              {
+                method: "target",
+                trigger: "interval",
+                interval: "monthly",
+                targetOngoingBalance: "0.0"
+              }
+            ]
+          }
+        }
+      )
+
+      result_data = result["data"]["createCustomerWallet"]
+
+      expect(result_data["recurringTransactionRules"].count).to eq(1)
+      expect(result_data["recurringTransactionRules"][0]).to include("grantsTargetTopUp" => false)
+    end
   end
 
   context "when name is not present" do

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Mutations::Wallets::Update, :premium do
             thresholdCredits
             paidCredits
             grantedCredits
+            grantsTargetTopUp
             targetOngoingBalance
             invoiceRequiresSuccessfulPayment
             ignorePaidTopUpLimits
@@ -94,6 +95,7 @@ RSpec.describe Mutations::Wallets::Update, :premium do
               targetOngoingBalance: "300",
               invoiceRequiresSuccessfulPayment: true,
               ignorePaidTopUpLimits: true,
+              grantsTargetTopUp: false,
               expirationAt: expiration_at.iso8601,
               transactionMetadata: [
                 {key: "example_key", value: "example_value"},
@@ -139,7 +141,8 @@ RSpec.describe Mutations::Wallets::Update, :premium do
       "grantedCredits" => "22.2",
       "targetOngoingBalance" => "300.0",
       "invoiceRequiresSuccessfulPayment" => true,
-      "ignorePaidTopUpLimits" => true
+      "ignorePaidTopUpLimits" => true,
+      "grantsTargetTopUp" => false
     )
     expect(result_data["appliesTo"]["feeTypes"]).to eq(["subscription"])
     expect(result_data["appliesTo"]["billableMetrics"].first["id"]).to eq(billable_metric.id)

--- a/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::CreateInput do
   it do
     expect(subject).to accept_argument(:expiration_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:granted_credits).of_type("String")
+    expect(subject).to accept_argument(:grants_target_top_up).of_type("Boolean")
     expect(subject).to accept_argument(:interval).of_type("RecurringTransactionIntervalEnum")
     expect(subject).to accept_argument(:invoice_requires_successful_payment).of_type("Boolean")
     expect(subject).to accept_argument(:ignore_paid_top_up_limits).of_type("Boolean")

--- a/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::Object do
     expect(subject).to have_field(:threshold_credits).of_type("String")
     expect(subject).to have_field(:paid_credits).of_type("String!")
     expect(subject).to have_field(:granted_credits).of_type("String!")
+    expect(subject).to have_field(:grants_target_top_up).of_type("Boolean")
     expect(subject).to have_field(:ignore_paid_top_up_limits).of_type("Boolean!")
     expect(subject).to have_field(:invoice_requires_successful_payment).of_type("Boolean!")
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")

--- a/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::UpdateInput do
   it do
     expect(subject).to accept_argument(:expiration_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:granted_credits).of_type("String")
+    expect(subject).to accept_argument(:grants_target_top_up).of_type("Boolean")
     expect(subject).to accept_argument(:interval).of_type("RecurringTransactionIntervalEnum")
     expect(subject).to accept_argument(:ignore_paid_top_up_limits).of_type("Boolean")
     expect(subject).to accept_argument(:invoice_requires_successful_payment).of_type("Boolean")


### PR DESCRIPTION
## Context

#5755 added the `grants_target_top_up` boolean column on `recurring_transaction_rules` and exposed it on the REST API. The dashboard frontend reaches the same model through GraphQL, so the field needs to be on the GraphQL schema too.

The column is nullable: target rules carry `true`/`false`/`nil`, non-target rules carry `nil`. Service-level validation and defaulting was delivered alongside the REST exposure.

## Description

The `RecurringTransactionRule` GraphQL type gains a nullable `Boolean` field, and the create/update mutation inputs gain a matching optional argument. The wallet mutations already forward all arguments to `Wallets::CreateService` / `Wallets::UpdateService`, which delegate to the rule services, so no Ruby service code changes here.

`schema.graphql` and `schema.json` are regenerated. The GraphQL type specs gain one assertion each. The wallet mutation specs are extended to send `grantsTargetTopUp` in the input and assert on it in the response, mirroring how `ignorePaidTopUpLimits` is already exercised. A separate context covers the default-to-false behaviour for target rules created without the flag.

This PR is stacked on #5755 and should be rebased onto main once that one lands.
