### PR TITLE
feat(payment-gated-subs): Recredit on invoice cancellation due to payment failure or expiration

### DIFF
--- a/app/jobs/applied_coupons/recredit_job.rb
+++ b/app/jobs/applied_coupons/recredit_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module AppliedCoupons
+  class RecreditJob < ApplicationJob
+    queue_as "default"
+
+    def perform(credit)
+      return if credit.applied_coupon.nil?
+
+      AppliedCoupons::RecreditService.call!(credit:)
+    end
+  end
+end

--- a/app/jobs/credit_notes/recredit_job.rb
+++ b/app/jobs/credit_notes/recredit_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class RecreditJob < ApplicationJob
+    queue_as "default"
+
+    def perform(credit)
+      credit_note = credit.credit_note
+      return if credit_note.nil? || credit_note.voided?
+
+      CreditNotes::RecreditService.call!(credit:)
+    end
+  end
+end

--- a/app/jobs/wallet_transactions/recredit_job.rb
+++ b/app/jobs/wallet_transactions/recredit_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WalletTransactions
+  class RecreditJob < ApplicationJob
+    queue_as "default"
+
+    def perform(wallet_transaction)
+      return unless wallet_transaction.wallet.active?
+
+      WalletTransactions::RecreditService.call!(wallet_transaction:)
+    end
+  end
+end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -18,7 +18,9 @@ class Credit < ApplicationRecord
   scope :coupon_kind, -> { where.not(applied_coupon_id: nil) }
   scope :credit_note_kind, -> { where.not(credit_note_id: nil) }
   scope :progressive_billing_invoice_kind, -> { where.not(progressive_billing_invoice_id: nil) }
-  scope :active, -> { joins(:invoice).where.not(invoices: {status: :voided}) }
+  # Closed invoices (gated subscriptions that failed payment or timed out) never produced
+  # value for the customer; their credits are released back to the source like voided ones.
+  scope :active, -> { joins(:invoice).where.not(invoices: {status: %i[voided closed]}) }
   scope :voided, -> { joins(:invoice).where(invoices: {status: :voided}) }
 
   def item_id

--- a/app/services/subscriptions/activation_rules/expire_service.rb
+++ b/app/services/subscriptions/activation_rules/expire_service.rb
@@ -27,6 +27,7 @@ module Subscriptions
           subscription.update!(cancelation_reason: :timeout)
 
           enqueue_psp_cancel(invoice)
+          enqueue_recredit_jobs(invoice)
         end
 
         result.subscription = subscription
@@ -36,6 +37,20 @@ module Subscriptions
       private
 
       attr_reader :subscription
+
+      def enqueue_recredit_jobs(invoice)
+        invoice.credits.coupon_kind.find_each do |credit|
+          AppliedCoupons::RecreditJob.perform_after_commit(credit)
+        end
+
+        invoice.credits.credit_note_kind.find_each do |credit|
+          CreditNotes::RecreditJob.perform_after_commit(credit)
+        end
+
+        invoice.wallet_transactions.outbound.find_each do |wallet_transaction|
+          WalletTransactions::RecreditJob.perform_after_commit(wallet_transaction)
+        end
+      end
 
       def enqueue_psp_cancel(invoice)
         # A partial unique index on payments guarantees at most one

--- a/app/services/subscriptions/activation_rules/payment/resolve_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/resolve_service.rb
@@ -54,6 +54,24 @@ module Subscriptions
           invoice.closed!
           ActivationRules::ResolveSubscriptionStatusService.call!(subscription:)
           subscription.update!(cancelation_reason: :payment_failed)
+
+          after_commit do
+            enqueue_recredit_jobs
+          end
+        end
+
+        def enqueue_recredit_jobs
+          invoice.credits.coupon_kind.find_each do |credit|
+            AppliedCoupons::RecreditJob.perform_later(credit)
+          end
+
+          invoice.credits.credit_note_kind.find_each do |credit|
+            CreditNotes::RecreditJob.perform_later(credit)
+          end
+
+          invoice.wallet_transactions.outbound.find_each do |wallet_transaction|
+            WalletTransactions::RecreditJob.perform_later(wallet_transaction)
+          end
         end
 
         def payment_rule

--- a/spec/jobs/applied_coupons/recredit_job_spec.rb
+++ b/spec/jobs/applied_coupons/recredit_job_spec.rb
@@ -2,50 +2,18 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedCoupons::RecreditJob do
+describe AppliedCoupons::RecreditJob do
   subject(:perform_job) { described_class.perform_now(credit) }
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, organization:, customer:) }
-  let(:coupon) { create(:coupon, organization:) }
-  let(:applied_coupon) { create(:applied_coupon, organization:, customer:, coupon:, frequency:, status:) }
+  let(:applied_coupon) { create(:applied_coupon, organization:, customer:) }
   let(:credit) { create(:credit, organization:, invoice:, applied_coupon:) }
-  let(:frequency) { "once" }
-  let(:status) { "active" }
 
   before { allow(AppliedCoupons::RecreditService).to receive(:call!) }
 
-  context "when the applied coupon is once and terminated" do
-    let(:frequency) { "once" }
-    let(:status) { "terminated" }
-
-    it "delegates to AppliedCoupons::RecreditService" do
-      perform_job
-
-      expect(AppliedCoupons::RecreditService).to have_received(:call!).with(credit:)
-    end
-  end
-
-  context "when the applied coupon is recurring and active" do
-    let(:frequency) { "recurring" }
-    let(:status) { "active" }
-    let(:applied_coupon) do
-      create(:applied_coupon, organization:, customer:, coupon:,
-        frequency:, status:, frequency_duration: 3, frequency_duration_remaining: 2)
-    end
-
-    it "delegates to AppliedCoupons::RecreditService" do
-      perform_job
-
-      expect(AppliedCoupons::RecreditService).to have_received(:call!).with(credit:)
-    end
-  end
-
-  context "when the applied coupon is forever" do
-    let(:frequency) { "forever" }
-    let(:status) { "active" }
-
+  context "when the applied coupon is present" do
     it "delegates to AppliedCoupons::RecreditService" do
       perform_job
 
@@ -54,7 +22,7 @@ RSpec.describe AppliedCoupons::RecreditJob do
   end
 
   context "when the applied coupon is nil" do
-    before { credit.update!(applied_coupon: nil) }
+    let(:credit) { create(:credit, organization:, invoice:, applied_coupon: nil) }
 
     it "does not call AppliedCoupons::RecreditService" do
       perform_job

--- a/spec/jobs/applied_coupons/recredit_job_spec.rb
+++ b/spec/jobs/applied_coupons/recredit_job_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AppliedCoupons::RecreditJob do
+  subject(:perform_job) { described_class.perform_now(credit) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:applied_coupon) { create(:applied_coupon, organization:, customer:, coupon:, frequency:, status:) }
+  let(:credit) { create(:credit, organization:, invoice:, applied_coupon:) }
+  let(:frequency) { "once" }
+  let(:status) { "active" }
+
+  before { allow(AppliedCoupons::RecreditService).to receive(:call!) }
+
+  context "when the applied coupon is once and terminated" do
+    let(:frequency) { "once" }
+    let(:status) { "terminated" }
+
+    it "delegates to AppliedCoupons::RecreditService" do
+      perform_job
+
+      expect(AppliedCoupons::RecreditService).to have_received(:call!).with(credit:)
+    end
+  end
+
+  context "when the applied coupon is recurring and active" do
+    let(:frequency) { "recurring" }
+    let(:status) { "active" }
+    let(:applied_coupon) do
+      create(:applied_coupon, organization:, customer:, coupon:,
+        frequency:, status:, frequency_duration: 3, frequency_duration_remaining: 2)
+    end
+
+    it "delegates to AppliedCoupons::RecreditService" do
+      perform_job
+
+      expect(AppliedCoupons::RecreditService).to have_received(:call!).with(credit:)
+    end
+  end
+
+  context "when the applied coupon is forever" do
+    let(:frequency) { "forever" }
+    let(:status) { "active" }
+
+    it "delegates to AppliedCoupons::RecreditService" do
+      perform_job
+
+      expect(AppliedCoupons::RecreditService).to have_received(:call!).with(credit:)
+    end
+  end
+
+  context "when the applied coupon is nil" do
+    before { credit.update!(applied_coupon: nil) }
+
+    it "does not call AppliedCoupons::RecreditService" do
+      perform_job
+
+      expect(AppliedCoupons::RecreditService).not_to have_received(:call!)
+    end
+  end
+end

--- a/spec/jobs/credit_notes/recredit_job_spec.rb
+++ b/spec/jobs/credit_notes/recredit_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::RecreditJob do
+describe CreditNotes::RecreditJob do
   subject(:perform_job) { described_class.perform_now(credit) }
 
   let(:organization) { create(:organization) }
@@ -25,7 +25,9 @@ RSpec.describe CreditNotes::RecreditJob do
   end
 
   context "when the credit note is voided" do
-    before { credit_note.update!(credit_status: :voided) }
+    let(:credit_note) do
+      create(:credit_note, organization:, customer:, invoice: source_invoice, credit_status: :voided)
+    end
 
     it "does not call CreditNotes::RecreditService" do
       perform_job
@@ -35,7 +37,7 @@ RSpec.describe CreditNotes::RecreditJob do
   end
 
   context "when the credit note is nil" do
-    before { credit.update_columns(credit_note_id: nil) }
+    let(:credit) { create(:credit_note_credit, organization:, invoice:, credit_note: nil) }
 
     it "does not call CreditNotes::RecreditService" do
       perform_job

--- a/spec/jobs/credit_notes/recredit_job_spec.rb
+++ b/spec/jobs/credit_notes/recredit_job_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CreditNotes::RecreditJob do
+  subject(:perform_job) { described_class.perform_now(credit) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+  let(:source_invoice) { create(:invoice, organization:, customer:) }
+  let(:credit_note) do
+    create(:credit_note, organization:, customer:, invoice: source_invoice, credit_status: :available)
+  end
+  let(:credit) { create(:credit_note_credit, organization:, invoice:, credit_note:) }
+
+  before { allow(CreditNotes::RecreditService).to receive(:call!) }
+
+  context "when the credit note is available" do
+    it "delegates to CreditNotes::RecreditService" do
+      perform_job
+
+      expect(CreditNotes::RecreditService).to have_received(:call!).with(credit:)
+    end
+  end
+
+  context "when the credit note is voided" do
+    before { credit_note.update!(credit_status: :voided) }
+
+    it "does not call CreditNotes::RecreditService" do
+      perform_job
+
+      expect(CreditNotes::RecreditService).not_to have_received(:call!)
+    end
+  end
+
+  context "when the credit note is nil" do
+    before { credit.update_columns(credit_note_id: nil) }
+
+    it "does not call CreditNotes::RecreditService" do
+      perform_job
+
+      expect(CreditNotes::RecreditService).not_to have_received(:call!)
+    end
+  end
+end

--- a/spec/jobs/wallet_transactions/recredit_job_spec.rb
+++ b/spec/jobs/wallet_transactions/recredit_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::RecreditJob do
+describe WalletTransactions::RecreditJob do
   subject(:perform_job) { described_class.perform_now(wallet_transaction) }
 
   let(:organization) { create(:organization) }
@@ -24,7 +24,7 @@ RSpec.describe WalletTransactions::RecreditJob do
   end
 
   context "when the wallet is terminated" do
-    before { wallet.update!(status: :terminated) }
+    let(:wallet) { create(:wallet, :terminated, customer:, organization:) }
 
     it "does not call WalletTransactions::RecreditService" do
       perform_job

--- a/spec/jobs/wallet_transactions/recredit_job_spec.rb
+++ b/spec/jobs/wallet_transactions/recredit_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WalletTransactions::RecreditJob do
+  subject(:perform_job) { described_class.perform_now(wallet_transaction) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+  let(:wallet_transaction) do
+    create(:wallet_transaction, wallet:, organization:, transaction_type: :outbound, invoice:)
+  end
+
+  before { allow(WalletTransactions::RecreditService).to receive(:call!) }
+
+  context "when the wallet is active" do
+    it "delegates to WalletTransactions::RecreditService" do
+      perform_job
+
+      expect(WalletTransactions::RecreditService).to have_received(:call!).with(wallet_transaction:)
+    end
+  end
+
+  context "when the wallet is terminated" do
+    before { wallet.update!(status: :terminated) }
+
+    it "does not call WalletTransactions::RecreditService" do
+      perform_job
+
+      expect(WalletTransactions::RecreditService).not_to have_received(:call!)
+    end
+  end
+end

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe AppliedCoupon do
         expect(applied_coupon.remaining_amount).to eq(50)
       end
     end
+
+    context "when invoice is closed" do
+      let(:invoice) { create(:invoice, status: :closed) }
+
+      it "ignores the credit amount" do
+        expect(applied_coupon.remaining_amount).to eq(50)
+      end
+    end
   end
 
   describe "#mark_as_terminated!" do

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -16,11 +16,16 @@ RSpec.describe Credit do
   describe "scopes" do
     let!(:active_invoice) { create(:invoice, status: :finalized) }
     let!(:voided_invoice) { create(:invoice, status: :voided) }
+    let(:closed_invoice) { create(:invoice, status: :closed) }
     let!(:active_credit) { create(:credit, invoice: active_invoice) }
     let!(:voided_credit) { create(:credit, invoice: voided_invoice) }
 
+    before do
+      create(:credit, invoice: closed_invoice)
+    end
+
     describe ".active" do
-      it "returns only credits with non-voided invoices" do
+      it "returns only credits with non-voided and non-closed invoices" do
         expect(described_class.active).to match_array([active_credit])
       end
     end

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -419,10 +419,11 @@ describe "Payment Gated Subscription Activation Scenarios" do
         expect(credit_note).to be_consumed
         expect(wallet.reload.balance_cents).to eq(0)
 
-        # Push the rule's expires_at into the past and run the clock
-        customer.subscriptions.sole.activation_rules.sole.update!(expires_at: 1.hour.ago)
-        Clock::ExpireIncompleteSubscriptionsJob.perform_now
-        perform_all_enqueued_jobs
+        # Travel past the 48h timeout so the rule expires, then run the clock
+        travel_to(49.hours.from_now) do
+          Clock::ExpireIncompleteSubscriptionsJob.perform_now
+          perform_all_enqueued_jobs
+        end
 
         expect(invoice.reload).to be_closed
 
@@ -451,9 +452,10 @@ describe "Payment Gated Subscription Activation Scenarios" do
           invoice = customer.subscriptions.sole.invoices.sole
           expect(invoice.credits.credit_note_kind).to be_empty
 
-          customer.subscriptions.sole.activation_rules.sole.update!(expires_at: 1.hour.ago)
-          Clock::ExpireIncompleteSubscriptionsJob.perform_now
-          perform_all_enqueued_jobs
+          travel_to(49.hours.from_now) do
+            Clock::ExpireIncompleteSubscriptionsJob.perform_now
+            perform_all_enqueued_jobs
+          end
 
           expect(invoice.reload).to be_closed
           expect(credit_note.reload).to be_voided
@@ -474,9 +476,10 @@ describe "Payment Gated Subscription Activation Scenarios" do
           invoice = customer.subscriptions.sole.invoices.sole
           expect(invoice.wallet_transactions.outbound).to be_empty
 
-          customer.subscriptions.sole.activation_rules.sole.update!(expires_at: 1.hour.ago)
-          Clock::ExpireIncompleteSubscriptionsJob.perform_now
-          perform_all_enqueued_jobs
+          travel_to(49.hours.from_now) do
+            Clock::ExpireIncompleteSubscriptionsJob.perform_now
+            perform_all_enqueued_jobs
+          end
 
           expect(invoice.reload).to be_closed
           expect(wallet.reload).to be_terminated

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -128,6 +128,103 @@ describe "Payment Gated Subscription Activation Scenarios" do
 
       expect(invoice.reload).to be_closed
     end
+
+    context "with consumed coupon, credit note, and wallet credits" do
+      let(:coupon) do
+        create(:coupon, organization:, coupon_type: :fixed_amount,
+          amount_cents: 10, amount_currency: "EUR", frequency: :once)
+      end
+      let(:applied_coupon) do
+        create(:applied_coupon, customer:, coupon:, organization:,
+          amount_cents: 10, amount_currency: "EUR", frequency: :once, status: :active)
+      end
+      let(:source_invoice) do
+        create(:invoice, customer:, organization:, status: :finalized, currency: "EUR")
+      end
+      let(:credit_note) do
+        create(:credit_note, customer:, organization:, invoice: source_invoice,
+          credit_status: :available,
+          total_amount_cents: 10, total_amount_currency: "EUR",
+          credit_amount_cents: 10, credit_amount_currency: "EUR",
+          balance_amount_cents: 10, balance_amount_currency: "EUR")
+      end
+      let(:wallet) do
+        create(:wallet, :with_inbound_transaction, customer:, organization:, currency: "EUR",
+          balance_cents: 10, credits_balance: 0.1, rate_amount: 1)
+      end
+
+      before do
+        applied_coupon
+        credit_note
+        wallet
+      end
+
+      it "restores the coupon, credit note balance, and wallet credits when payment fails" do
+        create_subscription(subscription_params)
+        perform_all_enqueued_jobs
+
+        invoice = customer.subscriptions.sole.invoices.sole
+        expect(invoice).to be_open
+
+        # Resources consumed by the gated invoice
+        expect(applied_coupon.reload).to be_terminated
+        expect(credit_note.reload.balance_amount_cents).to eq(0)
+        expect(credit_note).to be_consumed
+        expect(wallet.reload.balance_cents).to eq(0)
+
+        simulate_stripe_webhook(status: "failed")
+
+        expect(invoice.reload).to be_closed
+
+        # Resources restored after the gated invoice was closed
+        expect(applied_coupon.reload).to be_active
+        expect(applied_coupon.remaining_amount).to eq(10)
+        expect(credit_note.reload.balance_amount_cents).to eq(10)
+        expect(credit_note).to be_available
+        expect(wallet.reload.balance_cents).to eq(10)
+        expect(wallet.wallet_transactions.inbound.where(voided_invoice_id: invoice.id)).to exist
+      end
+
+      context "when the credit note is voided" do
+        let(:credit_note) do
+          create(:credit_note, customer:, organization:, invoice: source_invoice,
+            credit_status: :voided,
+            total_amount_cents: 10, total_amount_currency: "EUR",
+            credit_amount_cents: 10, credit_amount_currency: "EUR",
+            balance_amount_cents: 10, balance_amount_currency: "EUR")
+        end
+
+        it "leaves the voided credit note untouched when payment fails" do
+          create_subscription(subscription_params)
+          perform_all_enqueued_jobs
+
+          simulate_stripe_webhook(status: "failed")
+
+          expect(invoice.reload).to be_closed
+          expect(credit_note.reload).to be_voided
+          expect(credit_note.balance_amount_cents).to eq(10)
+        end
+      end
+
+      context "when the wallet is terminated" do
+        let(:wallet) do
+          create(:wallet, :terminated, customer:, organization:, currency: "EUR",
+            balance_cents: 10, credits_balance: 0.1, rate_amount: 1)
+        end
+
+        it "leaves the terminated wallet untouched when payment fails" do
+          create_subscription(subscription_params)
+          perform_all_enqueued_jobs
+
+          simulate_stripe_webhook(status: "failed")
+
+          expect(invoice.reload).to be_closed
+          expect(wallet.reload).to be_terminated
+          expect(wallet.balance_cents).to eq(10)
+          expect(wallet.wallet_transactions.inbound.where(voided_invoice_id: invoice.id)).not_to exist
+        end
+      end
+    end
   end
 
   describe "backdated subscription: rules ignored" do
@@ -273,6 +370,116 @@ describe "Payment Gated Subscription Activation Scenarios" do
 
       expect(subscription.reload).to be_incomplete
       expect(subscription.activation_rules.sole).to be_pending
+    end
+
+    context "with consumed coupon, credit note, and wallet credits" do
+      let(:coupon) do
+        create(:coupon, organization:, coupon_type: :fixed_amount,
+          amount_cents: 10, amount_currency: "EUR", frequency: :once)
+      end
+      let(:applied_coupon) do
+        create(:applied_coupon, customer:, coupon:, organization:,
+          amount_cents: 10, amount_currency: "EUR", frequency: :once, status: :active)
+      end
+      let(:source_invoice) do
+        create(:invoice, customer:, organization:, status: :finalized, currency: "EUR")
+      end
+      let(:credit_note) do
+        create(:credit_note, customer:, organization:, invoice: source_invoice,
+          credit_status: :available,
+          total_amount_cents: 10, total_amount_currency: "EUR",
+          credit_amount_cents: 10, credit_amount_currency: "EUR",
+          balance_amount_cents: 10, balance_amount_currency: "EUR")
+      end
+      let(:wallet) do
+        create(:wallet, :with_inbound_transaction, customer:, organization:, currency: "EUR",
+          balance_cents: 10, credits_balance: 0.1, rate_amount: 1)
+      end
+
+      before do
+        applied_coupon
+        credit_note
+        wallet
+      end
+
+      it "restores the coupon, credit note balance, and wallet credits when the rule expires" do
+        create_subscription(subscription_params)
+        perform_all_enqueued_jobs
+
+        invoice = customer.subscriptions.sole.invoices.sole
+        expect(invoice).to be_open
+
+        # Resources consumed by the gated invoice
+        expect(applied_coupon.reload).to be_terminated
+        expect(credit_note.reload.balance_amount_cents).to eq(0)
+        expect(credit_note).to be_consumed
+        expect(wallet.reload.balance_cents).to eq(0)
+
+        # Push the rule's expires_at into the past and run the clock
+        customer.subscriptions.sole.activation_rules.sole.update!(expires_at: 1.hour.ago)
+        Clock::ExpireIncompleteSubscriptionsJob.perform_now
+        perform_all_enqueued_jobs
+
+        expect(invoice.reload).to be_closed
+
+        # Resources restored after the gated invoice was closed
+        expect(applied_coupon.reload).to be_active
+        expect(applied_coupon.remaining_amount).to eq(10)
+        expect(credit_note.reload.balance_amount_cents).to eq(10)
+        expect(credit_note).to be_available
+        expect(wallet.reload.balance_cents).to eq(10)
+        expect(wallet.wallet_transactions.inbound.where(voided_invoice_id: invoice.id)).to exist
+      end
+
+      context "when the credit note is voided" do
+        let(:credit_note) do
+          create(:credit_note, customer:, organization:, invoice: source_invoice,
+            credit_status: :voided,
+            total_amount_cents: 10, total_amount_currency: "EUR",
+            credit_amount_cents: 10, credit_amount_currency: "EUR",
+            balance_amount_cents: 10, balance_amount_currency: "EUR")
+        end
+
+        it "leaves the voided credit note untouched when the rule expires" do
+          create_subscription(subscription_params)
+          perform_all_enqueued_jobs
+
+          invoice = customer.subscriptions.sole.invoices.sole
+          expect(invoice.credits.credit_note_kind).to be_empty
+
+          customer.subscriptions.sole.activation_rules.sole.update!(expires_at: 1.hour.ago)
+          Clock::ExpireIncompleteSubscriptionsJob.perform_now
+          perform_all_enqueued_jobs
+
+          expect(invoice.reload).to be_closed
+          expect(credit_note.reload).to be_voided
+          expect(credit_note.balance_amount_cents).to eq(10)
+        end
+      end
+
+      context "when the wallet is terminated" do
+        let(:wallet) do
+          create(:wallet, :terminated, customer:, organization:, currency: "EUR",
+            balance_cents: 10, credits_balance: 0.1, rate_amount: 1)
+        end
+
+        it "leaves the terminated wallet untouched when the rule expires" do
+          create_subscription(subscription_params)
+          perform_all_enqueued_jobs
+
+          invoice = customer.subscriptions.sole.invoices.sole
+          expect(invoice.wallet_transactions.outbound).to be_empty
+
+          customer.subscriptions.sole.activation_rules.sole.update!(expires_at: 1.hour.ago)
+          Clock::ExpireIncompleteSubscriptionsJob.perform_now
+          perform_all_enqueued_jobs
+
+          expect(invoice.reload).to be_closed
+          expect(wallet.reload).to be_terminated
+          expect(wallet.balance_cents).to eq(10)
+          expect(wallet.wallet_transactions.inbound.where(voided_invoice_id: invoice.id)).not_to exist
+        end
+      end
     end
   end
 

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -200,6 +200,8 @@ describe "Payment Gated Subscription Activation Scenarios" do
 
           simulate_stripe_webhook(status: "failed")
 
+          invoice = customer.subscriptions.sole.invoices.sole
+
           expect(invoice.reload).to be_closed
           expect(credit_note.reload).to be_voided
           expect(credit_note.balance_amount_cents).to eq(10)
@@ -217,6 +219,8 @@ describe "Payment Gated Subscription Activation Scenarios" do
           perform_all_enqueued_jobs
 
           simulate_stripe_webhook(status: "failed")
+
+          invoice = customer.subscriptions.sole.invoices.sole
 
           expect(invoice.reload).to be_closed
           expect(wallet.reload).to be_terminated

--- a/spec/services/subscriptions/activation_rules/expire_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/expire_service_spec.rb
@@ -62,6 +62,45 @@ RSpec.describe Subscriptions::ActivationRules::ExpireService do
       expect(result).to be_success
       expect(result.subscription).to eq(subscription)
     end
+
+    context "when an applied-coupon credit was consumed" do
+      let(:applied_coupon) { create(:applied_coupon, customer:, organization:, status: :terminated) }
+      let(:credit) { create(:credit, invoice:, organization:, applied_coupon:) }
+
+      before { credit }
+
+      it "enqueues an AppliedCoupons::RecreditJob" do
+        result
+
+        expect(AppliedCoupons::RecreditJob).to have_been_enqueued.with(credit)
+      end
+    end
+
+    context "when a credit-note credit was consumed" do
+      let(:credit_note) { create(:credit_note, customer:, organization:, invoice:, credit_status: :available) }
+      let(:credit) { create(:credit_note_credit, invoice:, organization:, credit_note:) }
+
+      before { credit }
+
+      it "enqueues a CreditNotes::RecreditJob" do
+        result
+
+        expect(CreditNotes::RecreditJob).to have_been_enqueued.with(credit)
+      end
+    end
+
+    context "when an outbound wallet transaction was consumed" do
+      let(:wallet) { create(:wallet, customer:, organization:) }
+      let(:wallet_transaction) { create(:wallet_transaction, wallet:, organization:, invoice:, transaction_type: :outbound) }
+
+      before { wallet_transaction }
+
+      it "enqueues a WalletTransactions::RecreditJob" do
+        result
+
+        expect(WalletTransactions::RecreditJob).to have_been_enqueued.with(wallet_transaction)
+      end
+    end
   end
 
   context "when the subscription is no longer incomplete (resolved concurrently)" do

--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -210,5 +210,44 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
 
       expect(SendWebhookJob).to have_been_enqueued.with("subscription.canceled", subscription)
     end
+
+    context "when an applied-coupon credit was consumed" do
+      let(:applied_coupon) { create(:applied_coupon, customer:, organization:, status: :terminated) }
+      let(:credit) { create(:credit, invoice:, organization:, applied_coupon:) }
+
+      before { credit }
+
+      it "enqueues an AppliedCoupons::RecreditJob" do
+        result
+
+        expect(AppliedCoupons::RecreditJob).to have_been_enqueued.with(credit)
+      end
+    end
+
+    context "when a credit-note credit was consumed" do
+      let(:credit_note) { create(:credit_note, customer:, organization:, invoice:, credit_status: :available) }
+      let(:credit) { create(:credit_note_credit, invoice:, organization:, credit_note:) }
+
+      before { credit }
+
+      it "enqueues a CreditNotes::RecreditJob" do
+        result
+
+        expect(CreditNotes::RecreditJob).to have_been_enqueued.with(credit)
+      end
+    end
+
+    context "when an outbound wallet transaction was consumed" do
+      let(:wallet) { create(:wallet, customer:, organization:) }
+      let(:wallet_transaction) { create(:wallet_transaction, wallet:, organization:, invoice:, transaction_type: :outbound) }
+
+      before { wallet_transaction }
+
+      it "enqueues a WalletTransactions::RecreditJob" do
+        result
+
+        expect(WalletTransactions::RecreditJob).to have_been_enqueued.with(wallet_transaction)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Payment-gated subscription invoices live in `:open` while waiting for payment. During their creation they consume customer balances — applied coupons, credit-note balance, and prepaid wallet credits — via `Invoices::CalculateFeesService` and `Invoices::CreatePayInAdvanceFixedChargesService`. When the gated invoice later transitions to `:closed` because payment failed (`Subscriptions::ActivationRules::Payment::ResolveService`) or the activation rule timed out (`Subscriptions::ActivationRules::ExpireService`), those consumptions were not reversed: customers permanently lost balances on invoices that were never billed.

## Description

Both close paths now enqueue per-resource recredit jobs after the close transaction commits:
- `AppliedCoupons::RecreditJob`, `CreditNotes::RecreditJob`, and `WalletTransactions::RecreditJob` are thin wrappers around the existing recredit services, one job per `Credit` row or outbound `WalletTransaction`. Per-resource isolation keeps a failure in one re-credit from interfering with the others.
- Each job pre-checks the resource is still eligible (applied_coupon non-nil, credit_note non-voided, wallet active) so transient state changes between enqueue and execute don't trigger needless retries.
- `Credit#active` scope extended to exclude `:closed` invoices in addition to `:voided`, so `applied_coupon.remaining_amount` correctly reflects coupons released by a closed gated invoice (the existing recredit service is a no-op for `:once` coupons unless `Credit#active` lets the balance recompute).