### PR TITLE
[ING-250] fix(billing-entity): clear on sub/wallet update

### DIFF
--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -69,7 +69,7 @@ module Subscriptions
 
         if params.key?(:billing_entity_id) || params.key?(:billing_entity_code)
           new_billing_entity = resolve_billing_entity(organization: subscription.organization, params:)
-          subscription.billing_entity = new_billing_entity if new_billing_entity
+          subscription.billing_entity = new_billing_entity
         end
 
         subscription.plan = handle_plan_override.plan if params.key?(:plan_overrides)

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -67,7 +67,8 @@ module Subscriptions
           subscription.payment_method_id = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
         end
 
-        if params.key?(:billing_entity_id) || params.key?(:billing_entity_code)
+        if subscription.organization.feature_flag_enabled?(:multi_entity_billing) &&
+            (params.key?(:billing_entity_id) || params.key?(:billing_entity_code))
           new_billing_entity = resolve_billing_entity(organization: subscription.organization, params:)
           subscription.billing_entity = new_billing_entity
         end

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -24,10 +24,15 @@ module Wallets
       return result unless valid_limitations?
       return result unless valid_payment_method?
 
-      if organization_flag_enabled?(:multi_entity_billing) && (params[:billing_entity_id].present? || params[:billing_entity_code].present?)
-        return result.not_found_failure!(resource: "billing_entity") unless billing_entity
+      if organization_flag_enabled?(:multi_entity_billing) &&
+          (params.key?(:billing_entity_id) || params.key?(:billing_entity_code))
+        if params[:billing_entity_id].present? || params[:billing_entity_code].present?
+          return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 
-        wallet.billing_entity_id = billing_entity.id
+          wallet.billing_entity_id = billing_entity.id
+        else
+          wallet.billing_entity_id = nil
+        end
       end
 
       ActiveRecord::Base.transaction do

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -25,9 +25,11 @@ module Wallets
       return result unless valid_payment_method?
 
       if organization_flag_enabled?(:multi_entity_billing) && billing_entity_param_sent?
-        return result.not_found_failure!(resource: "billing_entity") if billing_entity_value_provided? && billing_entity.nil?
+        if billing_entity_value_provided? && billing_entity.nil?
+          return result.not_found_failure!(resource: "billing_entity")
+        end
 
-        wallet.billing_entity_id = billing_entity&.id
+        wallet.billing_entity = billing_entity
       end
 
       ActiveRecord::Base.transaction do

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -24,15 +24,10 @@ module Wallets
       return result unless valid_limitations?
       return result unless valid_payment_method?
 
-      if organization_flag_enabled?(:multi_entity_billing) &&
-          (params.key?(:billing_entity_id) || params.key?(:billing_entity_code))
-        if params[:billing_entity_id].present? || params[:billing_entity_code].present?
-          return result.not_found_failure!(resource: "billing_entity") unless billing_entity
+      if organization_flag_enabled?(:multi_entity_billing) && billing_entity_param_sent?
+        return result.not_found_failure!(resource: "billing_entity") if billing_entity_value_provided? && billing_entity.nil?
 
-          wallet.billing_entity_id = billing_entity.id
-        else
-          wallet.billing_entity_id = nil
-        end
+        wallet.billing_entity_id = billing_entity&.id
       end
 
       ActiveRecord::Base.transaction do
@@ -191,6 +186,14 @@ module Wallets
 
     def organization_flag_enabled?(flag)
       wallet.customer.organization.feature_flag_enabled?(flag)
+    end
+
+    def billing_entity_param_sent?
+      params.key?(:billing_entity_id) || params.key?(:billing_entity_code)
+    end
+
+    def billing_entity_value_provided?
+      params[:billing_entity_id].present? || params[:billing_entity_code].present?
     end
 
     def billing_entity

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1225,6 +1225,88 @@ RSpec.describe Subscriptions::UpdateService do
             expect(result.error.resource).to eq("billing_entity")
           end
         end
+
+        context "when the subscription already has a billing_entity attached" do
+          let(:current_entity) { create(:billing_entity, organization:) }
+          let(:other_entity) { create(:billing_entity, organization:) }
+          let(:subscription) { create(:subscription, customer:, plan:, organization:, billing_entity: current_entity) }
+
+          context "with billing_entity_id: nil" do
+            let(:params) { {billing_entity_id: nil} }
+
+            it "clears the billing_entity_id" do
+              update_service.call
+
+              expect(subscription.reload.billing_entity_id).to be_nil
+            end
+          end
+
+          context "with billing_entity_id pointing at a different entity" do
+            let(:params) { {billing_entity_id: other_entity.id} }
+
+            it "switches to the new entity" do
+              update_service.call
+
+              expect(subscription.reload.billing_entity_id).to eq(other_entity.id)
+            end
+          end
+
+          context "with an unknown billing_entity_id" do
+            let(:params) { {billing_entity_id: SecureRandom.uuid} }
+
+            it "returns not_found_failure and leaves billing_entity_id unchanged" do
+              result = update_service.call
+
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.resource).to eq("billing_entity")
+              expect(subscription.reload.billing_entity_id).to eq(current_entity.id)
+            end
+          end
+
+          context "with billing_entity_code: nil" do
+            let(:params) { {billing_entity_code: nil} }
+
+            it "clears the billing_entity_id" do
+              update_service.call
+
+              expect(subscription.reload.billing_entity_id).to be_nil
+            end
+          end
+
+          context "with billing_entity_code pointing at a different entity" do
+            let(:params) { {billing_entity_code: other_entity.code} }
+
+            it "switches to the new entity" do
+              update_service.call
+
+              expect(subscription.reload.billing_entity_id).to eq(other_entity.id)
+            end
+          end
+
+          context "without any billing_entity key in the payload" do
+            let(:params) { {name: "renamed"} }
+
+            it "leaves billing_entity_id unchanged" do
+              update_service.call
+
+              expect(subscription.reload.billing_entity_id).to eq(current_entity.id)
+            end
+          end
+
+          context "with an unknown billing_entity_code" do
+            let(:params) { {billing_entity_code: "nonexistent"} }
+
+            it "returns not_found_failure and leaves billing_entity_id unchanged" do
+              result = update_service.call
+
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.resource).to eq("billing_entity")
+              expect(subscription.reload.billing_entity_id).to eq(current_entity.id)
+            end
+          end
+        end
       end
 
       context "with multi_entity_billing feature flag disabled" do

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1231,7 +1231,7 @@ RSpec.describe Subscriptions::UpdateService do
           let(:other_entity) { create(:billing_entity, organization:) }
           let(:subscription) { create(:subscription, customer:, plan:, organization:, billing_entity: current_entity) }
 
-          context "with billing_entity_id: nil" do
+          context "when billing_entity_id is nil" do
             let(:params) { {billing_entity_id: nil} }
 
             it "clears the billing_entity_id" do
@@ -1241,7 +1241,7 @@ RSpec.describe Subscriptions::UpdateService do
             end
           end
 
-          context "with billing_entity_id pointing at a different entity" do
+          context "when billing_entity_id points at a different entity" do
             let(:params) { {billing_entity_id: other_entity.id} }
 
             it "switches to the new entity" do
@@ -1251,7 +1251,7 @@ RSpec.describe Subscriptions::UpdateService do
             end
           end
 
-          context "with an unknown billing_entity_id" do
+          context "when billing_entity_id is unknown" do
             let(:params) { {billing_entity_id: SecureRandom.uuid} }
 
             it "returns not_found_failure and leaves billing_entity_id unchanged" do
@@ -1264,7 +1264,7 @@ RSpec.describe Subscriptions::UpdateService do
             end
           end
 
-          context "with billing_entity_code: nil" do
+          context "when billing_entity_code is nil" do
             let(:params) { {billing_entity_code: nil} }
 
             it "clears the billing_entity_id" do
@@ -1274,7 +1274,7 @@ RSpec.describe Subscriptions::UpdateService do
             end
           end
 
-          context "with billing_entity_code pointing at a different entity" do
+          context "when billing_entity_code points at a different entity" do
             let(:params) { {billing_entity_code: other_entity.code} }
 
             it "switches to the new entity" do
@@ -1284,7 +1284,7 @@ RSpec.describe Subscriptions::UpdateService do
             end
           end
 
-          context "without any billing_entity key in the payload" do
+          context "when no billing_entity key is sent" do
             let(:params) { {name: "renamed"} }
 
             it "leaves billing_entity_id unchanged" do
@@ -1294,7 +1294,7 @@ RSpec.describe Subscriptions::UpdateService do
             end
           end
 
-          context "with an unknown billing_entity_code" do
+          context "when billing_entity_code is unknown" do
             let(:params) { {billing_entity_code: "nonexistent"} }
 
             it "returns not_found_failure and leaves billing_entity_id unchanged" do
@@ -1320,6 +1320,23 @@ RSpec.describe Subscriptions::UpdateService do
 
         it "returns success" do
           expect(update_service.call).to be_success
+        end
+
+        context "when the subscription already has a billing_entity attached" do
+          let(:current_entity) { create(:billing_entity, organization:) }
+          let(:subscription) { create(:subscription, customer:, plan:, organization:, billing_entity: current_entity) }
+
+          it "leaves billing_entity_id unchanged when an id is sent" do
+            update_service.call
+
+            expect(subscription.reload.billing_entity_id).to eq(current_entity.id)
+          end
+
+          it "leaves billing_entity_id unchanged when nil is sent" do
+            described_class.new(subscription:, params: {billing_entity_id: nil}).call
+
+            expect(subscription.reload.billing_entity_id).to eq(current_entity.id)
+          end
         end
       end
     end

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -1032,7 +1032,7 @@ RSpec.describe Wallets::UpdateService do
         let(:other_entity) { create(:billing_entity, organization:, code: "other_be") }
         let(:wallet) { create(:wallet, customer:, billing_entity: current_entity, allowed_fee_types: []) }
 
-        context "with billing_entity_id: nil" do
+        context "when billing_entity_id is nil" do
           let(:params) { {id: wallet&.id, billing_entity_id: nil} }
 
           it "clears the billing_entity_id" do
@@ -1041,7 +1041,7 @@ RSpec.describe Wallets::UpdateService do
           end
         end
 
-        context "with billing_entity_id pointing at a different entity" do
+        context "when billing_entity_id points at a different entity" do
           let(:params) { {id: wallet&.id, billing_entity_id: other_entity.id} }
 
           it "switches to the new entity" do
@@ -1050,7 +1050,7 @@ RSpec.describe Wallets::UpdateService do
           end
         end
 
-        context "with an unknown billing_entity_id" do
+        context "when billing_entity_id is unknown" do
           let(:params) { {id: wallet&.id, billing_entity_id: SecureRandom.uuid} }
 
           it "returns not_found_failure and leaves billing_entity_id unchanged" do
@@ -1061,7 +1061,7 @@ RSpec.describe Wallets::UpdateService do
           end
         end
 
-        context "with billing_entity_code: nil" do
+        context "when billing_entity_code is nil" do
           let(:params) { {id: wallet&.id, billing_entity_code: nil} }
 
           it "clears the billing_entity_id" do
@@ -1070,7 +1070,7 @@ RSpec.describe Wallets::UpdateService do
           end
         end
 
-        context "with billing_entity_code pointing at a different entity" do
+        context "when billing_entity_code points at a different entity" do
           let(:params) { {id: wallet&.id, billing_entity_code: other_entity.code} }
 
           it "switches to the new entity" do
@@ -1079,7 +1079,7 @@ RSpec.describe Wallets::UpdateService do
           end
         end
 
-        context "without any billing_entity key in the payload" do
+        context "when no billing_entity key is sent" do
           let(:params) { {id: wallet&.id, name: "renamed"} }
 
           it "leaves billing_entity_id unchanged" do
@@ -1088,7 +1088,7 @@ RSpec.describe Wallets::UpdateService do
           end
         end
 
-        context "with an unknown billing_entity_code" do
+        context "when billing_entity_code is unknown" do
           let(:params) { {id: wallet&.id, billing_entity_code: "nonexistent"} }
 
           it "returns not_found_failure and leaves billing_entity_id unchanged" do

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -1026,6 +1026,79 @@ RSpec.describe Wallets::UpdateService do
           expect(result.wallet.billing_entity_id).to eq(billing_entity.id)
         end
       end
+
+      context "when the wallet already has a billing_entity attached" do
+        let(:current_entity) { create(:billing_entity, organization:, code: "current_be") }
+        let(:other_entity) { create(:billing_entity, organization:, code: "other_be") }
+        let(:wallet) { create(:wallet, customer:, billing_entity: current_entity, allowed_fee_types: []) }
+
+        context "with billing_entity_id: nil" do
+          let(:params) { {id: wallet&.id, billing_entity_id: nil} }
+
+          it "clears the billing_entity_id" do
+            expect(result).to be_success
+            expect(result.wallet.billing_entity_id).to be_nil
+          end
+        end
+
+        context "with billing_entity_id pointing at a different entity" do
+          let(:params) { {id: wallet&.id, billing_entity_id: other_entity.id} }
+
+          it "switches to the new entity" do
+            expect(result).to be_success
+            expect(result.wallet.billing_entity_id).to eq(other_entity.id)
+          end
+        end
+
+        context "with an unknown billing_entity_id" do
+          let(:params) { {id: wallet&.id, billing_entity_id: SecureRandom.uuid} }
+
+          it "returns not_found_failure and leaves billing_entity_id unchanged" do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.resource).to eq("billing_entity")
+            expect(wallet.reload.billing_entity_id).to eq(current_entity.id)
+          end
+        end
+
+        context "with billing_entity_code: nil" do
+          let(:params) { {id: wallet&.id, billing_entity_code: nil} }
+
+          it "clears the billing_entity_id" do
+            expect(result).to be_success
+            expect(result.wallet.billing_entity_id).to be_nil
+          end
+        end
+
+        context "with billing_entity_code pointing at a different entity" do
+          let(:params) { {id: wallet&.id, billing_entity_code: other_entity.code} }
+
+          it "switches to the new entity" do
+            expect(result).to be_success
+            expect(result.wallet.billing_entity_id).to eq(other_entity.id)
+          end
+        end
+
+        context "without any billing_entity key in the payload" do
+          let(:params) { {id: wallet&.id, name: "renamed"} }
+
+          it "leaves billing_entity_id unchanged" do
+            expect(result).to be_success
+            expect(result.wallet.billing_entity_id).to eq(current_entity.id)
+          end
+        end
+
+        context "with an unknown billing_entity_code" do
+          let(:params) { {id: wallet&.id, billing_entity_code: "nonexistent"} }
+
+          it "returns not_found_failure and leaves billing_entity_id unchanged" do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.resource).to eq("billing_entity")
+            expect(wallet.reload.billing_entity_id).to eq(current_entity.id)
+          end
+        end
+      end
     end
 
     context "when multi_entity_billing is not enabled" do


### PR DESCRIPTION
## Context

A subscription's / wallet's `billing_entity_id` is mutable, and `NULL` is the canonical way to say "inherit from the customer's default at billing time". The FE picker now sends `billingEntityId: null` when the operator clears the dropdown, but the BE was silently ignoring that signal: an entity once attached could not be removed via the UI.

Two distinct bugs caused the regression:

- `Subscriptions::UpdateService` had a trailing `if new_billing_entity` guard that blocked the assignment when the resolver returned `nil`.
- `Wallets::UpdateService` gated the entire branch on `.present?`, which collapses `nil` / `""` / absent into the same bucket, so an explicit `null` payload skipped the assignment entirely.

Linear: [ING-250](https://linear.app/getlago/issue/ING-250/be-allow-clearing-billing-entity-id-on-subscription-wallet-update)

## Description

Subscription patch drops the trailing guard. The outer `params.key?` check already prevents unintended writes when the field is omitted.

Wallet patch splits the gate in two: the outer condition tests "was the key sent" (`params.key?`) and stays inside the `multi_entity_billing` flag check; the inner condition tests "is the value meaningful" (`.present?`). A real value flows through the existing lookup (still 404 on unknown id/code); an explicit nil resets `billing_entity_id` to inherit from the customer.

| Scenario | Before | After |
| --- | --- | --- |
| Existing `X`, payload `{ billing_entity_id: nil }` | stays `X` | becomes `NULL` |
| Existing `X`, payload `{ billing_entity_id: "Y" }` | becomes `Y` | becomes `Y` |
| Existing `X`, payload `{}` (key absent) | stays `X` | stays `X` |
| Existing `X`, payload `{ billing_entity_id: "<unknown>" }` | 404 | 404 |

Behaviour for `billing_entity_code` matches `billing_entity_id` on all four scenarios. Both services have new specs covering the four canonical cases against both keys (the omit-key case is shared).

### Worth noting for review

The subscription patch keeps the outer guard as `params.key?(...)` only, matching the ticket spec. The `multi_entity_billing` flag check lives only inside `resolve_billing_entity`, which now returns `nil` and triggers a clear assignment regardless of flag state. The existing "flag disabled" spec still passes because its starting state is `NULL`. For an org that previously had the flag on with `billing_entity_id` populated and then flipped it off, an unrelated update could now clear the column. This is a narrow asymmetry versus the wallet path (whose outer guard does check the flag); happy to harmonize if we want symmetric behaviour.

## How to try locally

In the FE subscription or wallet edit form, attach a billing entity to a subscription/wallet whose org has `multi_entity_billing` enabled, save, reopen the form, clear the picker, and submit. The column should now go to `NULL`.

For automated coverage:

```
lago exec api bundle exec rspec \
  spec/services/subscriptions/update_service_spec.rb \
  spec/services/wallets/update_service_spec.rb
```