### PR TITLE
fix: Fix ISO8601 date/datetime parsing validation

### DIFF
--- a/app/controllers/concerns/common.rb
+++ b/app/controllers/concerns/common.rb
@@ -6,11 +6,6 @@ module Common
   private
 
   def valid_date?(date)
-    return false unless date
-
-    Date.iso8601(date)
-    true
-  rescue Date::Error
-    false
+    Utils::Datetime.parse_iso8601_date(date).present?
   end
 end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -51,13 +51,9 @@ class BaseQuery < BaseService
 
   def parse_datetime_filter(field_name)
     value = filters[field_name]
-    return value if [Time, ActiveSupport::TimeWithZone, Date, DateTime].include?(value.class)
+    parsed_value = Utils::Datetime.parse_iso8601(value)
+    return parsed_value if parsed_value
 
-    DateTime.iso8601(value)
-  # Date::Error inherits from ArgumentError so it is caught here too.
-  # A bare ArgumentError is raised e.g. for strings longer than 128 chars
-  # ("string length exceeds the limit 128").
-  rescue ArgumentError
     result.single_validation_failure!(field: field_name.to_sym, error_code: "invalid_date")
       .raise_if_error!
   end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -51,6 +51,8 @@ class BaseQuery < BaseService
 
   def parse_datetime_filter(field_name)
     value = filters[field_name]
+    return value if Utils::Datetime.datetime_like?(value)
+
     parsed_value = Utils::Datetime.parse_iso8601(value)
     return parsed_value if parsed_value
 

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -97,27 +97,24 @@ module Fees
     def valid_boundaries?(fee)
       return true if fee[:from_datetime].nil? && fee[:to_datetime].nil?
 
-      fee[:from_datetime] &&
-        fee[:to_datetime] &&
-        Utils::Datetime.valid_format?(fee[:from_datetime]) &&
-        Utils::Datetime.valid_format?(fee[:to_datetime]) &&
-        from_datetime(fee) <= to_datetime(fee)
+      return false unless fee[:from_datetime] && fee[:to_datetime]
+
+      from = from_datetime(fee)
+      to = to_datetime(fee)
+
+      from && to && from <= to
     end
 
     def from_datetime(fee)
-      if fee[:from_datetime].is_a?(String)
-        DateTime.iso8601(fee[:from_datetime])
-      else
-        fee[:from_datetime] || Time.current
-      end
+      return Time.current if fee[:from_datetime].nil?
+
+      Utils::Datetime.parse_iso8601(fee[:from_datetime])
     end
 
     def to_datetime(fee)
-      if fee[:to_datetime].is_a?(String)
-        DateTime.iso8601(fee[:to_datetime])
-      else
-        fee[:to_datetime] || Time.current
-      end
+      return Time.current if fee[:to_datetime].nil?
+
+      Utils::Datetime.parse_iso8601(fee[:to_datetime])
     end
   end
 end

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -98,11 +98,10 @@ module Fees
       return true if fee[:from_datetime].nil? && fee[:to_datetime].nil?
 
       return false unless fee[:from_datetime] && fee[:to_datetime]
+      return false unless Utils::Datetime.valid_format?(fee[:from_datetime])
+      return false unless Utils::Datetime.valid_format?(fee[:to_datetime])
 
-      from = from_datetime(fee)
-      to = to_datetime(fee)
-
-      from && to && from <= to
+      from_datetime(fee) <= to_datetime(fee)
     end
 
     def from_datetime(fee)

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -40,7 +40,7 @@ module Subscriptions
     end
 
     def valid_subscription_at?
-      return true if Utils::Datetime.valid_format?(args[:subscription_at])
+      return true if subscription_at
 
       add_error(field: :subscription_at, error_code: "invalid_date")
 
@@ -50,8 +50,8 @@ module Subscriptions
     def valid_ending_at?
       return true if args[:ending_at].blank?
 
-      if Utils::Datetime.valid_format?(args[:ending_at]) &&
-          Utils::Datetime.valid_format?(args[:subscription_at]) &&
+      if ending_at &&
+          subscription_at &&
           ending_at.to_date > Time.current.to_date &&
           ending_at.to_date > subscription_at.to_date
         return true
@@ -80,19 +80,15 @@ module Subscriptions
     end
 
     def ending_at
-      @ending_at ||= if args[:ending_at].is_a?(String)
-        DateTime.iso8601(args[:ending_at])
-      else
-        args[:ending_at]
-      end
+      return @ending_at if defined?(@ending_at)
+
+      @ending_at = Utils::Datetime.parse_iso8601(args[:ending_at])
     end
 
     def subscription_at
-      @subscription_at ||= if args[:subscription_at].is_a?(String)
-        DateTime.iso8601(args[:subscription_at])
-      else
-        args[:subscription_at]
-      end
+      return @subscription_at if defined?(@subscription_at)
+
+      @subscription_at = Utils::Datetime.parse_iso8601(args[:subscription_at])
     end
 
     def valid_payment_method?

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -40,7 +40,7 @@ module Subscriptions
     end
 
     def valid_subscription_at?
-      return true if subscription_at
+      return true if Utils::Datetime.valid_format?(args[:subscription_at])
 
       add_error(field: :subscription_at, error_code: "invalid_date")
 
@@ -50,8 +50,8 @@ module Subscriptions
     def valid_ending_at?
       return true if args[:ending_at].blank?
 
-      if ending_at &&
-          subscription_at &&
+      if Utils::Datetime.valid_format?(args[:ending_at]) &&
+          Utils::Datetime.valid_format?(args[:subscription_at]) &&
           ending_at.to_date > Time.current.to_date &&
           ending_at.to_date > subscription_at.to_date
         return true

--- a/app/services/utils/datetime.rb
+++ b/app/services/utils/datetime.rb
@@ -2,6 +2,24 @@
 
 module Utils
   class Datetime
+    def self.parse_iso8601(datetime)
+      return datetime if datetime.respond_to?(:strftime)
+      return unless datetime.is_a?(String)
+
+      DateTime.iso8601(datetime)
+    rescue ArgumentError
+      nil
+    end
+
+    def self.parse_iso8601_date(date)
+      return date if date.respond_to?(:strftime)
+      return unless date.is_a?(String)
+
+      Date.iso8601(date)
+    rescue ArgumentError
+      nil
+    end
+
     def self.valid_format?(datetime, format: :iso8601)
       return true if datetime.respond_to?(:strftime)
       return false unless datetime.is_a?(String)
@@ -10,7 +28,7 @@ module Utils
       when :any
         Time.zone.parse(datetime).present?
       else
-        Time.zone.iso8601(datetime).present?
+        parse_iso8601(datetime).present?
       end
     rescue ArgumentError
       false

--- a/app/services/utils/datetime.rb
+++ b/app/services/utils/datetime.rb
@@ -28,7 +28,7 @@ module Utils
       when :any
         Time.zone.parse(datetime).present?
       else
-        parse_iso8601(datetime).present?
+        Time.zone.iso8601(datetime).present?
       end
     rescue ArgumentError
       false

--- a/app/services/utils/datetime.rb
+++ b/app/services/utils/datetime.rb
@@ -12,7 +12,7 @@ module Utils
     end
 
     def self.parse_iso8601_date(date)
-      return date if date.respond_to?(:strftime)
+      return date.to_date if date.respond_to?(:strftime)
       return unless date.is_a?(String)
 
       Date.iso8601(date)

--- a/app/services/utils/datetime.rb
+++ b/app/services/utils/datetime.rb
@@ -2,26 +2,36 @@
 
 module Utils
   class Datetime
+    def self.datetime_like?(value)
+      value.respond_to?(:strftime)
+    end
+
     def self.parse_iso8601(datetime)
-      return datetime if datetime.respond_to?(:strftime)
+      return datetime if datetime_like?(datetime)
       return unless datetime.is_a?(String)
 
       DateTime.iso8601(datetime)
+    # Date::Error inherits from ArgumentError so it is caught here too.
+    # A bare ArgumentError is raised e.g. for strings longer than 128 chars
+    # ("string length exceeds the limit 128").
     rescue ArgumentError
       nil
     end
 
     def self.parse_iso8601_date(date)
-      return date.to_date if date.respond_to?(:strftime)
+      return date.to_date if datetime_like?(date)
       return unless date.is_a?(String)
 
       Date.iso8601(date)
+    # Date::Error inherits from ArgumentError so it is caught here too.
+    # A bare ArgumentError is raised e.g. for strings longer than 128 chars
+    # ("string length exceeds the limit 128").
     rescue ArgumentError
       nil
     end
 
     def self.valid_format?(datetime, format: :iso8601)
-      return true if datetime.respond_to?(:strftime)
+      return true if datetime_like?(datetime)
       return false unless datetime.is_a?(String)
 
       case format

--- a/spec/controllers/concerns/common_spec.rb
+++ b/spec/controllers/concerns/common_spec.rb
@@ -53,5 +53,13 @@ RSpec.describe Common do
         expect(subject).to be false
       end
     end
+
+    context "when a malformed date raises a bare ArgumentError" do
+      let(:date) { "1" * 129 }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
   end
 end

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -224,6 +224,30 @@ RSpec.describe Fees::OneOffService do
       end
     end
 
+    context "when one boundary raises a bare ArgumentError while parsing" do
+      let(:fees) do
+        [
+          {
+            add_on_code: add_on_first.code,
+            unit_amount_cents: 1200,
+            units: 2,
+            description: "desc-123",
+            from_datetime: "1" * 129,
+            to_datetime: "2022-01-31T23:59:59Z",
+            tax_codes: [tax2.code]
+          }
+        ]
+      end
+
+      it "returns validation failure" do
+        result = one_off_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:boundaries]).to include("values_are_invalid")
+      end
+    end
+
     context "when one boundary is missing" do
       let(:fees) do
         [

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -248,6 +248,30 @@ RSpec.describe Fees::OneOffService do
       end
     end
 
+    context "when one boundary is in ISO8601 week-date format" do
+      let(:fees) do
+        [
+          {
+            add_on_code: add_on_first.code,
+            unit_amount_cents: 1200,
+            units: 2,
+            description: "desc-123",
+            from_datetime: "2022-W04-1",
+            to_datetime: "2022-01-31T23:59:59Z",
+            tax_codes: [tax2.code]
+          }
+        ]
+      end
+
+      it "returns validation failure" do
+        result = one_off_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:boundaries]).to include("values_are_invalid")
+      end
+    end
+
     context "when one boundary is missing" do
       let(:fees) do
         [

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -116,6 +116,15 @@ RSpec.describe Subscriptions::ValidateService do
           expect(result.error.messages[:subscription_at]).to eq(["invalid_date"])
         end
       end
+
+      context "when subscription_at raises a bare ArgumentError while parsing" do
+        let(:subscription_at) { "1" * 129 }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:subscription_at]).to eq(["invalid_date"])
+        end
+      end
     end
 
     context "with invalid ending_at" do
@@ -130,6 +139,15 @@ RSpec.describe Subscriptions::ValidateService do
 
       context "when ending_at is integer" do
         let(:ending_at) { 123 }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:ending_at]).to eq(["invalid_date"])
+        end
+      end
+
+      context "when ending_at raises a bare ArgumentError while parsing" do
+        let(:ending_at) { "1" * 129 }
 
         it "returns false and result has errors" do
           expect(validate_service).not_to be_valid

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -125,6 +125,15 @@ RSpec.describe Subscriptions::ValidateService do
           expect(result.error.messages[:subscription_at]).to eq(["invalid_date"])
         end
       end
+
+      context "when subscription_at is in ISO8601 week-date format" do
+        let(:subscription_at) { "2022-W50-2" }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:subscription_at]).to eq(["invalid_date"])
+        end
+      end
     end
 
     context "with invalid ending_at" do
@@ -155,6 +164,15 @@ RSpec.describe Subscriptions::ValidateService do
         end
       end
 
+      context "when ending_at is in ISO8601 week-date format" do
+        let(:ending_at) { "2099-W50-2" }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:ending_at]).to eq(["invalid_date"])
+        end
+      end
+
       context "when ending_at uses an invalid date format" do
         let(:ending_at) { "2025-08-20T16:11:39.061+02:00" }
 
@@ -166,6 +184,26 @@ RSpec.describe Subscriptions::ValidateService do
 
       context "when ending_at is less than subscription_at and current time" do
         let(:ending_at) { (Time.current - 1.year).iso8601 }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:ending_at]).to eq(["invalid_date"])
+        end
+      end
+
+      context "when ending_at is in the future but not after subscription_at" do
+        let(:subscription_at) { (Time.current + 2.years).iso8601 }
+        let(:ending_at) { (Time.current + 1.year).iso8601 }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:ending_at]).to eq(["invalid_date"])
+        end
+      end
+
+      context "when ending_at is valid but subscription_at uses an invalid format" do
+        let(:subscription_at) { "2022-W50-2" }
+        let(:ending_at) { (Time.current + 1.year).iso8601 }
 
         it "returns false and result has errors" do
           expect(validate_service).not_to be_valid

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -5,6 +5,56 @@ require "rails_helper"
 RSpec.describe Utils::Datetime do
   subject(:datetime) { described_class }
 
+  describe ".parse_iso8601" do
+    context "when the value is an ISO8601 string" do
+      let(:value) { "2022-12-13T12:00:00Z" }
+
+      it "returns the parsed datetime" do
+        expect(datetime.parse_iso8601(value)).to eq(DateTime.iso8601(value))
+      end
+    end
+
+    context "when the value is already date-like" do
+      let(:value) { Time.current }
+
+      it "returns the value" do
+        expect(datetime.parse_iso8601(value)).to eq(value)
+      end
+    end
+
+    context "when the value raises a bare ArgumentError" do
+      let(:value) { "1" * 129 }
+
+      it "returns nil" do
+        expect(datetime.parse_iso8601(value)).to be_nil
+      end
+    end
+
+    context "when the value is not a string or date-like object" do
+      it "returns nil" do
+        expect(datetime.parse_iso8601(123)).to be_nil
+      end
+    end
+  end
+
+  describe ".parse_iso8601_date" do
+    context "when the value is an ISO8601 date string" do
+      let(:value) { "2022-12-13" }
+
+      it "returns the parsed date" do
+        expect(datetime.parse_iso8601_date(value)).to eq(Date.iso8601(value))
+      end
+    end
+
+    context "when the value raises a bare ArgumentError" do
+      let(:value) { "1" * 129 }
+
+      it "returns nil" do
+        expect(datetime.parse_iso8601_date(value)).to be_nil
+      end
+    end
+  end
+
   describe ".valid_format?" do
     context "when the parameter is a string" do
       context "when the date is not in ISO8601 format" do
@@ -22,6 +72,12 @@ RSpec.describe Utils::Datetime do
       context "when the date includes microseconds" do
         it "returns true" do
           expect(datetime).to be_valid_format("2024-05-30T09:45:44.394316274Z")
+        end
+      end
+
+      context "when the date raises a bare ArgumentError" do
+        it "returns false" do
+          expect(datetime).not_to be_valid_format("1" * 129)
         end
       end
     end

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Utils::Datetime do
     end
 
     context "when the value is already date-like" do
-      it "returns the value unchanged for every datetime-like class" do
+      it "returns it as a date for every datetime-like class" do
         [Time.current.to_time, Time.current, Date.current, DateTime.now].each do |value|
-          expect(datetime.parse_iso8601_date(value)).to eq(value)
+          expect(datetime.parse_iso8601_date(value)).to eq(value.to_date)
         end
       end
     end

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe Utils::Datetime do
           expect(datetime).not_to be_valid_format("1" * 129)
         end
       end
+
+      context "when the date is in ISO8601 week-date format" do
+        it "returns false" do
+          expect(datetime).not_to be_valid_format("2022-W50-2")
+        end
+      end
+    end
+
+    context "when the parameter is neither a string nor a datetime object" do
+      it "returns false" do
+        expect(datetime).not_to be_valid_format(123)
+      end
     end
 
     context "when the parameter is a datetime object" do

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -5,6 +5,24 @@ require "rails_helper"
 RSpec.describe Utils::Datetime do
   subject(:datetime) { described_class }
 
+  describe ".datetime_like?" do
+    context "when the value is a datetime-like object" do
+      it "returns true for every datetime-like class" do
+        [Time.current.to_time, Time.current, Date.current, DateTime.now].each do |value|
+          expect(datetime.datetime_like?(value)).to be true
+        end
+      end
+    end
+
+    context "when the value is not datetime-like" do
+      it "returns false" do
+        expect(datetime.datetime_like?("2022-12-13")).to be false
+        expect(datetime.datetime_like?(123)).to be false
+        expect(datetime.datetime_like?(nil)).to be false
+      end
+    end
+  end
+
   describe ".parse_iso8601" do
     context "when the value is an ISO8601 string" do
       let(:value) { "2022-12-13T12:00:00Z" }

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Utils::Datetime do
       end
     end
 
+    context "when the value is a malformed string" do
+      let(:value) { "not-a-date" }
+
+      it "returns nil" do
+        expect(datetime.parse_iso8601(value)).to be_nil
+      end
+    end
+
     context "when the value raises a bare ArgumentError" do
       let(:value) { "1" * 129 }
 
@@ -69,6 +77,14 @@ RSpec.describe Utils::Datetime do
         [Time.current.to_time, Time.current, Date.current, DateTime.now].each do |value|
           expect(datetime.parse_iso8601_date(value)).to eq(value.to_date)
         end
+      end
+    end
+
+    context "when the value is a malformed string" do
+      let(:value) { "not-a-date" }
+
+      it "returns nil" do
+        expect(datetime.parse_iso8601_date(value)).to be_nil
       end
     end
 

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Utils::Datetime do
     end
 
     context "when the value is already date-like" do
-      let(:value) { Time.current }
-
-      it "returns the value" do
-        expect(datetime.parse_iso8601(value)).to eq(value)
+      it "returns the value unchanged for every datetime-like class" do
+        [Time.current.to_time, Time.current, Date.current, DateTime.now].each do |value|
+          expect(datetime.parse_iso8601(value)).to eq(value)
+        end
       end
     end
 
@@ -43,6 +43,14 @@ RSpec.describe Utils::Datetime do
 
       it "returns the parsed date" do
         expect(datetime.parse_iso8601_date(value)).to eq(Date.iso8601(value))
+      end
+    end
+
+    context "when the value is already date-like" do
+      it "returns the value unchanged for every datetime-like class" do
+        [Time.current.to_time, Time.current, Date.current, DateTime.now].each do |value|
+          expect(datetime.parse_iso8601_date(value)).to eq(value)
+        end
       end
     end
 
@@ -95,8 +103,10 @@ RSpec.describe Utils::Datetime do
     end
 
     context "when the parameter is a datetime object" do
-      it "returns true" do
-        expect(datetime).to be_valid_format(Time.current)
+      it "returns true for every datetime-like class" do
+        [Time.current.to_time, Time.current, Date.current, DateTime.now].each do |value|
+          expect(datetime).to be_valid_format(value)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

Malformed ISO8601 date and datetime values from API filters and payloads could raise a bare `ArgumentError` that was never rescued, so the request failed with a 500 instead of a validation error. The clearest case is a string longer than 128 characters: `Date.iso8601` / `DateTime.iso8601` raise `ArgumentError` ("string length exceeds the limit 128 bytes"), which is not a `Date::Error`, so the `rescue Date::Error` guards at the call sites let it through. Parsing was also spread across several call sites that each called `Date.iso8601` / `DateTime.iso8601` directly, with their own (and sometimes missing) rescue.

## Description

Date and datetime parsing now goes through two helpers on `Utils::Datetime`. `parse_iso8601` and `parse_iso8601_date` return `nil` instead of raising on malformed input, and return values that are already date-like as-is.

The helpers are reused in `BaseQuery`, subscription validation, and one-off fee boundary parsing (datetime), and in `Common#valid_date?` for invoice and credit note date filters (date). Malformed values now produce the existing validation errors (`invalid_date`, `values_are_invalid`) rather than a 500.

Validation stays strict. `Utils::Datetime.valid_format?` keeps using `Time.zone.iso8601` for the `:iso8601` format, so values the API rejected before (such as the ISO8601 week-date format `"2022-W50-2"`) keep returning `invalid_date` / `values_are_invalid`.

Fixes ING-245.