### PR TITLE
[codex] Skip invalid pay-in-advance SUM events

### DIFF
--- a/app/services/events/pay_in_advance_service.rb
+++ b/app/services/events/pay_in_advance_service.rb
@@ -60,7 +60,18 @@ module Events
       # NOTE: `custom_agg` and `count_agg` are the only 2 aggregations
       #       that don't require a field set in property.
       #       For other aggregation, if the field isn't set we shouldn't create a fee/invoice.
-      billable_metric.count_agg? || billable_metric.custom_agg? || properties[billable_metric.field_name].present?
+      return true if billable_metric.count_agg? || billable_metric.custom_agg?
+      value = (properties || {})[billable_metric.field_name]
+      return false if value.blank?
+      return true unless billable_metric.sum_agg?
+
+      valid_decimal?(value)
+    end
+
+    def valid_decimal?(value)
+      BigDecimal(value.to_s).finite?
+    rescue ArgumentError
+      false
     end
 
     def kafka_producer_enabled?

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -16,6 +16,8 @@ module Fees
     end
 
     def call
+      return skipped_result unless valid_pay_in_advance_event?
+
       fees = []
 
       ActiveRecord::Base.transaction(**isolation_mode) do
@@ -51,6 +53,22 @@ module Fees
 
     delegate :billable_metric, to: :charge
     delegate :subscription, to: :event
+
+    def skipped_result
+      result.fees = []
+      result
+    end
+
+    def valid_pay_in_advance_event?
+      return true unless billable_metric.sum_agg?
+
+      value = (event.properties || {})[billable_metric.field_name]
+      return false if value.blank?
+
+      BigDecimal(value.to_s).finite?
+    rescue ArgumentError
+      false
+    end
 
     def filter
       @filter ||= ChargeFilters::EventMatchingService.call(charge:, event:).charge_filter

--- a/spec/services/events/pay_in_advance_service_spec.rb
+++ b/spec/services/events/pay_in_advance_service_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe Events::PayInAdvanceService do
       expect { in_advance_service.call }.to have_enqueued_job(Fees::CreatePayInAdvanceJob)
     end
 
+    context "when value for sum_agg is not numeric" do
+      let(:event_properties) { {billable_metric.field_name => "test_001"} }
+
+      it "does not enqueue a job to perform the pay_in_advance aggregation" do
+        expect { in_advance_service.call }.not_to have_enqueued_job(Fees::CreatePayInAdvanceJob)
+      end
+    end
+
     context "when charge is invoiceable" do
       before { charge.update!(invoiceable: true) }
 
@@ -69,6 +77,15 @@ RSpec.describe Events::PayInAdvanceService do
 
       it "enqueues a job to create the pay_in_advance charge invoice" do
         expect { in_advance_service.call }.to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
+      end
+
+      context "when value for sum_agg is not numeric" do
+        let(:event_properties) { {billable_metric.field_name => "test_001"} }
+
+        it "does not enqueue a job to create the pay_in_advance charge invoice" do
+          expect { in_advance_service.call }
+            .not_to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
+        end
       end
 
       context "when charge is not invoiceable" do

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -107,6 +107,20 @@ RSpec.describe Fees::CreatePayInAdvanceService do
         .with("fee.created", Fee)
     end
 
+    context "when a sum aggregation event value is not numeric" do
+      let(:billable_metric) { create(:sum_billable_metric, organization:) }
+      let(:event_properties) { {billable_metric.field_name => "test_001"} }
+
+      it "skips fee creation without calling the aggregation service" do
+        result = fee_service.call
+
+        expect(result).to be_success
+        expect(result.fees).to eq([])
+        expect(Charges::PayInAdvanceAggregationService).not_to have_received(:call)
+        expect(SendWebhookJob).not_to have_been_enqueued.with("fee.created", Fee)
+      end
+    end
+
     context "when aggregation fails" do
       let(:aggregation_result) do
         BaseService::Result.new.service_failure!(code: "failure", message: "Failure")


### PR DESCRIPTION
## Summary

Fixes ING-20.

Pay-in-advance SUM aggregation events with non-decimal values, such as `test_001`, could reach the async fee creation path and raise while parsing the event value with `BigDecimal`. This prevents those invalid events from dead-jobbing.

Changes:
- skip pay-in-advance job enqueueing when a SUM aggregation property is present but not decimal-convertible
- make `Fees::CreatePayInAdvanceService` return a successful empty fee result for invalid SUM event values, covering already-enqueued jobs and direct callers
- add regression specs for non-invoiceable and invoiceable pay-in-advance paths

## Validation

- `git diff --check`
- Targeted local RSpec attempted but blocked by local Ruby/Bundler mismatch: repo requires Bundler 4.0.4 / Ruby 4.0.2, while this machine exposes system Ruby 2.6 tooling.

GitHub CI should run the project runtime.