### PR TITLE
fix(ING-118): Allow 15 wallet transaction metadata keys

### DIFF
--- a/app/services/wallet_transactions/validate_service.rb
+++ b/app/services/wallet_transactions/validate_service.rb
@@ -71,7 +71,7 @@ module WalletTransactions
     end
 
     def valid_metadata?
-      validator = ::Validators::MetadataValidator.new(args[:metadata], max_keys: MAX_METADATA_KEYS)
+      validator = ::Validators::MetadataValidator.new(args[:metadata], {max_keys: MAX_METADATA_KEYS})
       unless validator.valid?
         validator.errors.each do |field, error_code|
           add_error(field: field, error_code: error_code)

--- a/app/services/wallet_transactions/validate_service.rb
+++ b/app/services/wallet_transactions/validate_service.rb
@@ -22,7 +22,8 @@ module WalletTransactions
     private
 
     MAX_AMOUNT = 10**25 - 1
-    private_constant :MAX_AMOUNT
+    MAX_METADATA_KEYS = 15
+    private_constant :MAX_AMOUNT, :MAX_METADATA_KEYS
 
     def valid_amount?(amount)
       ::Validators::DecimalAmountService.new(amount).valid_amount? &&
@@ -70,7 +71,7 @@ module WalletTransactions
     end
 
     def valid_metadata?
-      validator = ::Validators::MetadataValidator.new(args[:metadata])
+      validator = ::Validators::MetadataValidator.new(args[:metadata], max_keys: MAX_METADATA_KEYS)
       unless validator.valid?
         validator.errors.each do |field, error_code|
           add_error(field: field, error_code: error_code)

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -170,6 +170,44 @@ RSpec.describe WalletTransactions::ValidateService do
       end
     end
 
+    context "with the maximum number of metadata key-value pairs" do
+      let(:args) do
+        {
+          wallet_id:,
+          customer_id: customer.external_id,
+          organization_id: organization.id,
+          paid_credits:,
+          granted_credits:,
+          voided_credits:,
+          metadata: (1..15).map { |i| {"key" => "key#{i}", "value" => "value#{i}"} }
+        }
+      end
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+        expect(result.error).to be_nil
+      end
+    end
+
+    context "with too many metadata key-value pairs" do
+      let(:args) do
+        {
+          wallet_id:,
+          customer_id: customer.external_id,
+          organization_id: organization.id,
+          paid_credits:,
+          granted_credits:,
+          voided_credits:,
+          metadata: (1..16).map { |i| {"key" => "key#{i}", "value" => "value#{i}"} }
+        }
+      end
+
+      it "returns false and result has errors for metadata" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:metadata]).to eq(["too_many_keys"])
+      end
+    end
+
     context "with valid name" do
       let(:name) { "Valid Transaction Name" }
 


### PR DESCRIPTION
## Context

Wallet transaction metadata was validated through the shared `Validators::MetadataValidator`, which caps the number of key-value pairs at its default of 5. This limit is too low for wallet transactions, where integrations need to attach more contextual data to a single transaction.

## Description

The `WalletTransactions::ValidateService` now passes an explicit `max_keys: 15` to `Validators::MetadataValidator` when validating wallet transaction metadata. The limit lives in a private `MAX_METADATA_KEYS` constant on the service, so the change is scoped to wallet transactions only. The shared validator keeps its default of 5 keys for every other metadata surface.

Specs cover the new boundary: 15 keys are accepted and 16 keys fail with the `too_many_keys` error on the `metadata` field.