### PR TITLE
fix(daily-usage): add correct daily usage when amount is zero for terminated invoice

### DIFF
--- a/app/services/daily_usages/fill_from_invoice_service.rb
+++ b/app/services/daily_usages/fill_from_invoice_service.rb
@@ -21,7 +21,7 @@ module DailyUsages
         next if existing_daily_usage(invoice_subscription).present?
 
         usage = invoice_usage(subscription, invoice_subscription)
-        if usage.total_amount_cents.positive?
+        if usage.fees.any?
           daily_usage = DailyUsage.new(
             organization: invoice.organization,
             customer: invoice.customer,
@@ -54,7 +54,7 @@ module DailyUsages
       in_adv_fees = in_advance_fees(subscription, invoice_subscription)
 
       fees = in_adv_fees +
-        invoice.fees.charge.select { |f| f.subscription_id == subscription.id && f.units.positive? }
+        invoice.fees.charge.select { |f| f.subscription_id == subscription.id && f.non_zero? }
 
       amount_cents = in_adv_fees.sum(:amount_cents) + invoice.fees.charge.sum(:amount_cents)
       taxes_amount_cents = in_adv_fees.sum(:taxes_amount_cents) + invoice.fees.charge.sum(:taxes_amount_cents)

--- a/spec/services/daily_usages/fill_from_invoice_service_spec.rb
+++ b/spec/services/daily_usages/fill_from_invoice_service_spec.rb
@@ -142,6 +142,24 @@ RSpec.describe DailyUsages::FillFromInvoiceService do
         end
       end
 
+      context "when the only consumed charge is free (zero amount)" do
+        before do
+          invoice.fees.charge.destroy_all
+          charge = create(:standard_charge, plan: subscription.plan, properties: {"amount" => "0"})
+          create(:charge_fee, invoice:, charge:, units: 5, amount_cents: 0, taxes_amount_cents: 0, subscription:)
+        end
+
+        it "creates a daily usage based on consumed units" do
+          travel_to(timestamp) do
+            expect { fill_service.call }.to change(DailyUsage, :count).by(1)
+
+            daily_usage = subscription.daily_usages.order(:created_at).last
+            expect(daily_usage.usage["amount_cents"]).to eq(0)
+            expect(daily_usage.usage["charges_usage"].count).to eq(1)
+          end
+        end
+      end
+
       context "when the daily usage already exists" do
         before do
           create(
@@ -179,7 +197,11 @@ RSpec.describe DailyUsages::FillFromInvoiceService do
           )
         end
 
-        before { invoice_subscription2 }
+        before do
+          invoice_subscription2
+          charge = create(:standard_charge, plan: subscription2.plan)
+          create(:charge_fee, invoice:, charge:, units: 12, amount_cents: 1200, subscription: subscription2)
+        end
 
         it "creates daily usages for all the subscriptions" do
           expect { fill_service.call }.to change(DailyUsage, :count).by(2)


### PR DESCRIPTION
## Context

Currently, the daily usage record is skipped if the current usage amount is zero. However, we should always generate a daily usage record if any usage has been ingested. The only use case where we don't want a daily usage record is when no usage has been ingested at all.

## Description

This PR handles the case from above for `FillFromInvoiceService`. This logic also matches what we currently have on all other places where we create daily usages - https://github.com/getlago/lago-api/pull/5458