### PR TITLE
feat(order-forms): create at quote version approval

### DIFF
--- a/app/services/order_forms/create_service.rb
+++ b/app/services/order_forms/create_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module OrderForms
+  class CreateService < BaseService
+    include OrderForms::Premium
+
+    Result = BaseResult[:order_form]
+
+    def initialize(quote_version:)
+      @quote_version = quote_version
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "quote_version") unless quote_version
+      return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
+      return result.not_allowed_failure!(code: "quote_version_not_approved") unless quote_version.approved?
+
+      order_form = OrderForm.create!(
+        organization: quote_version.organization,
+        customer: quote_version.quote.customer,
+        quote_version:,
+        status: :generated
+      )
+
+      result.order_form = order_form
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :quote_version
+  end
+end

--- a/app/services/order_forms/create_service.rb
+++ b/app/services/order_forms/create_service.rb
@@ -27,6 +27,8 @@ module OrderForms
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::RecordNotUnique
+      result.single_validation_failure!(field: :quote_version_id, error_code: "value_already_exist")
     end
 
     private

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -6,7 +6,7 @@ module QuoteVersions
 
     attr_reader :quote_version
 
-    Result = BaseResult[:quote_version]
+    Result = BaseResult[:quote_version, :order_form]
 
     def initialize(quote_version:)
       @quote_version = quote_version
@@ -18,12 +18,15 @@ module QuoteVersions
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.not_allowed_failure!(code: "inappropriate_state") unless approvable?
 
-      quote_version.update!(
-        status: :approved,
-        approved_at: Time.current
-      )
+      QuoteVersion.transaction do
+        quote_version.update!(
+          status: :approved,
+          approved_at: Time.current
+        )
 
-      # TODO: OrderForms::CreateService.call
+        result.order_form = OrderForms::CreateService.call!(quote_version:).order_form
+      end
+
       # TODO: SendWebhookJob.perform_after_commit("quote_version.approved", quote_version)
 
       result.quote_version = quote_version

--- a/spec/services/order_forms/create_service_spec.rb
+++ b/spec/services/order_forms/create_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrderForms::CreateService do
+  subject(:create_service) { described_class.new(quote_version:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:quote) { create(:quote, organization:) }
+  let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+  describe ".call" do
+    let(:result) { create_service.call }
+
+    context "when the quote version is approved", :premium do
+      it "creates an order form" do
+        expect { result }.to change(OrderForm, :count).by(1)
+      end
+
+      it "returns the order form with the expected attributes" do
+        expect(result).to be_success
+        expect(result.order_form).to have_attributes(
+          organization_id: organization.id,
+          customer_id: quote.customer_id,
+          quote_version_id: quote_version.id,
+          status: "generated"
+        )
+      end
+    end
+
+    context "when the quote version is not approved", :premium do
+      let(:quote_version) { create(:quote_version, quote:, organization:) }
+
+      it "does not create an order form" do
+        expect { result }.not_to change(OrderForm, :count)
+      end
+
+      it "returns a method not allowed failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("quote_version_not_approved")
+      end
+    end
+
+    context "when license is not premium" do
+      it "does not create an order form" do
+        expect { result }.not_to change(OrderForm, :count)
+      end
+
+      it "returns a forbidden failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "when the quote version does not exist", :premium do
+      let(:quote_version) { nil }
+
+      it "returns a not found failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("quote_version_not_found")
+      end
+    end
+  end
+end

--- a/spec/services/order_forms/create_service_spec.rb
+++ b/spec/services/order_forms/create_service_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe OrderForms::CreateService do
       end
     end
 
+    context "when an order form already exists for the quote version", :premium do
+      before { create(:order_form, quote_version:, organization:, customer: quote.customer) }
+
+      it "does not create another order form" do
+        expect { result }.not_to change(OrderForm, :count)
+      end
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq(quote_version_id: ["value_already_exist"])
+      end
+    end
+
     context "when the quote version does not exist", :premium do
       let(:quote_version) { nil }
 

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe QuoteVersions::ApproveService do
           expect(result.quote_version.approved_at).to eq(Time.current)
         end
       end
+
+      it "creates an order form for the approved quote version" do
+        expect { result }.to change(OrderForm, :count).by(1)
+
+        expect(result.order_form).to have_attributes(
+          quote_version_id: quote_version.id,
+          customer_id: quote.customer_id,
+          status: "generated"
+        )
+      end
     end
 
     context "when the quote version is voided", :premium do
@@ -33,6 +43,10 @@ RSpec.describe QuoteVersions::ApproveService do
         quote_version.reload
         expect(quote_version.approved?).to eq(false)
         expect(quote_version.approved_at).to eq(nil)
+      end
+
+      it "does not create an order form" do
+        expect { result }.not_to change(OrderForm, :count)
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  [Quotes & Order forms](https://getlago.canny.io/feature-requests/p/create-quotes-order-forms)

## Context

An order form only ever exists on an approved quote version (one-to-one). `QuoteVersions::ApproveService` already flipped a version to `approved` but left a `# TODO: OrderForms::CreateService.call` placeholder, so approving a quote version never produced the order form the business expects.

## Description

Generate the order form as part of quote version approval.