### PR TITLE
fix(current-usage): Filter out non-zero fees from current usage flow

### DIFF
--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -19,8 +19,6 @@ module DailyUsages
         return result
       end
 
-      current_usage.fees = current_usage.fees.select(&:non_zero?)
-
       if current_usage.fees.any?
         daily_usage = DailyUsage.new(
           organization: subscription.organization,

--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -43,8 +43,6 @@ module DailyUsages
             previous_daily_usage = nil
           end
 
-          usage.fees = usage.fees.select(&:non_zero?)
-
           if usage.fees.any?
             daily_usage = DailyUsage.new(
               organization:,

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -119,6 +119,7 @@ module Invoices
       fees = []
       filters = event_filters(subscription, boundaries).charges
       charges.find_each { |c| fees += charge_usage(c, filters[c.id] || []) }
+      fees.select!(&:non_zero?)
       return fees if usage_filters.has_charge_filter?
 
       fees.sort_by { |f| f.billable_metric.name.downcase }

--- a/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
@@ -338,16 +338,11 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
         expect(standard_charge_usage["projectedPresentationBreakdowns"]).to be_empty
 
         grouped_usage = standard_charge_usage["groupedUsage"]
+        expect(grouped_usage.size).to eq(1)
         expect(grouped_usage.first["presentationBreakdowns"]).to be_empty
         expect(grouped_usage.first["projectedPresentationBreakdowns"]).to be_empty
-        expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
-        expect(grouped_usage.second["projectedPresentationBreakdowns"]).to be_empty
-        expect(standard_charge_usage["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
-        expect(standard_charge_usage["filters"].second["projectedPresentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "8.27"}])
-        expect(standard_charge_usage["filters"].map { |filter| filter["projectedPresentationBreakdowns"] }).to match_array([
-          [],
-          [{"presentationBy" => {"cloud" => "aws"}, "units" => "8.27"}]
-        ])
+        expect(standard_charge_usage["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+        expect(standard_charge_usage["filters"].first["projectedPresentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "8.27"}])
       end
     end
 
@@ -441,10 +436,9 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
           expect(sum_charge_usage["groupedUsage"]).to be_empty
           expect(sum_charge_usage["presentationBreakdowns"]).to be_empty
           expect(sum_charge_usage["projectedPresentationBreakdowns"]).to be_empty
-          expect(sum_charge_usage["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
-          expect(sum_charge_usage["filters"].second["projectedPresentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "8.27"}])
+          expect(sum_charge_usage["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+          expect(sum_charge_usage["filters"].first["projectedPresentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "8.27"}])
           expect(sum_charge_usage["filters"].map { |filter| filter["projectedPresentationBreakdowns"] }).to match_array([
-            [],
             [{"presentationBy" => {"cloud" => "aws"}, "units" => "8.27"}]
           ])
         end

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -307,8 +307,8 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
         charges_usage = result["data"]["customerPortalCustomerUsage"]["chargesUsage"]
         sum_charge_usage = charges_usage.find { |usage| usage["billableMetric"]["code"] == sum_metric.code }
         expect(sum_charge_usage["presentationBreakdowns"]).to be_empty
-        expect(sum_charge_usage["filters"].first["presentationBreakdowns"]).to be_empty
-        expect(sum_charge_usage["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+        expect(sum_charge_usage["filters"].size).to eq(1)
+        expect(sum_charge_usage["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
         metric_charge_usage = charges_usage.find { |usage| usage["billableMetric"]["code"] == metric.code }
         expect(metric_charge_usage["presentationBreakdowns"]).to be_empty
       end
@@ -366,9 +366,9 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
           expect(sum_charge["presentationBreakdowns"]).to be_empty
 
           grouped_usage = sum_charge["groupedUsage"]
+          expect(grouped_usage.size).to eq(1)
           expect(grouped_usage.first["presentationBreakdowns"]).to be_empty
-          expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
-          expect(sum_charge["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+          expect(sum_charge["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
 
           metric_charge = charges_usage.find { |usage| usage["billableMetric"]["code"] == metric.code }
           expect(metric_charge["presentationBreakdowns"]).to be_empty
@@ -451,7 +451,7 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
 
           expect(sum_charge_usage["groupedUsage"]).to be_empty
           expect(sum_charge_usage["presentationBreakdowns"]).to be_empty
-          expect(sum_charge_usage["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+          expect(sum_charge_usage["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
         end
       end
 

--- a/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
@@ -350,9 +350,9 @@ RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
         expect(standard_charge_usage["presentationBreakdowns"]).to be_empty
 
         grouped_usage = standard_charge_usage["groupedUsage"]
+        expect(grouped_usage.size).to eq(1)
         expect(grouped_usage.first["presentationBreakdowns"]).to be_empty
-        expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
-        expect(standard_charge_usage["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+        expect(standard_charge_usage["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
       end
     end
 
@@ -447,7 +447,7 @@ RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
 
           expect(sum_charge_usage["groupedUsage"]).to be_empty
           expect(sum_charge_usage["presentationBreakdowns"]).to be_empty
-          expect(sum_charge_usage["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+          expect(sum_charge_usage["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
         end
       end
 

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -216,8 +216,8 @@ RSpec.describe Resolvers::Customers::UsageResolver do
 
       charges_usage = result["data"]["customerUsage"]["chargesUsage"]
       expect(charges_usage.first["presentationBreakdowns"]).to be_empty
-      expect(charges_usage.second["filters"].first["presentationBreakdowns"]).to be_empty
-      expect(charges_usage.second["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+      expect(charges_usage.second["filters"].size).to eq(1)
+      expect(charges_usage.second["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
     end
 
     context "without charge filters" do
@@ -269,9 +269,9 @@ RSpec.describe Resolvers::Customers::UsageResolver do
         expect(charges_usage.second["presentationBreakdowns"]).to be_empty
 
         grouped_usage = charges_usage.second["groupedUsage"]
+        expect(grouped_usage.size).to eq(1)
         expect(grouped_usage.first["presentationBreakdowns"]).to be_empty
-        expect(grouped_usage.second["presentationBreakdowns"]).to be_empty
-        expect(charges_usage.second["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+        expect(charges_usage.second["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
       end
 
       context "without charge filters" do
@@ -349,7 +349,7 @@ RSpec.describe Resolvers::Customers::UsageResolver do
 
         expect(sum_charge_usage["groupedUsage"]).to be_empty
         expect(sum_charge_usage["presentationBreakdowns"]).to be_empty
-        expect(sum_charge_usage["filters"].second["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
+        expect(sum_charge_usage["filters"].first["presentationBreakdowns"]).to eq([{"presentationBy" => {"cloud" => "aws"}, "units" => "4.0"}])
       end
 
       context "without charge filters" do

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -136,6 +136,31 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
       end
     end
 
+    context "when some charges produce only zero fees" do
+      let(:apply_taxes) { false }
+      let(:empty_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+      let(:empty_charge) { create(:standard_charge, plan:, billable_metric: empty_metric, properties: {amount: "5"}) }
+      let(:zero_value_metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "value") }
+      let(:zero_value_charge) { create(:standard_charge, plan:, billable_metric: zero_value_metric, properties: {amount: "10"}) }
+
+      before do
+        empty_charge
+        zero_value_charge
+        create(:event, organization:, subscription:, customer:, code: zero_value_metric.code, timestamp:, properties: {value: 0})
+      end
+
+      it "drops fully-empty fees but keeps fees that recorded events" do
+        result = usage_service.call
+
+        expect(result).to be_success
+        expect(result.usage.fees.map(&:charge_id)).to match_array([charge.id, zero_value_charge.id])
+
+        zero_value_fee = result.usage.fees.find { |f| f.charge_id == zero_value_charge.id }
+        expect(zero_value_fee).to have_attributes(units: 0, amount_cents: 0)
+        expect(zero_value_fee.events_count).to be_positive
+      end
+    end
+
     context "when there is tax provider integration" do
       let(:integration) { create(:anrok_integration, organization:) }
       let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
@@ -192,6 +217,43 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             )
             expect(result.usage.fees.size).to eq(1)
             expect(result.usage.fees.first.charge.invoice_display_name).to eq(charge.invoice_display_name)
+          end
+        end
+      end
+
+      context "when a charge produces a zero fee" do
+        let(:current_date) { DateTime.parse("2025-06-15") }
+        let(:timestamp) { current_date }
+        let(:empty_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+        let(:empty_charge) { create(:standard_charge, plan:, billable_metric: empty_metric, properties: {amount: "5"}) }
+
+        before do
+          empty_charge
+          allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:call).and_call_original
+
+          stub_request(:post, endpoint).to_return do |request|
+            response = JSON.parse(File.read(
+              Rails.root.join("spec/fixtures/integration_aggregator/taxes/invoices/success_response.json")
+            ))
+
+            key = JSON.parse(request.body).first["fees"].last["item_key"]
+            response["succeededInvoices"].first["fees"].last["item_key"] = key
+            response["succeededInvoices"].first["fees"].last["item_id"] = charge.billable_metric.id
+            response["succeededInvoices"].first["fees"].last["amount_cents"] = 2532
+
+            {body: response.to_json}
+          end
+        end
+
+        it "excludes the zero fee from the tax provider payload" do
+          travel_to(current_date) do
+            result = usage_service.call
+
+            expect(result).to be_success
+            expect(result.usage.fees.map(&:charge_id)).to match_array([charge.id])
+            expect(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to have_received(:call) do |invoice:, fees:|
+              expect(fees.map(&:charge_id)).to match_array([charge.id])
+            end
           end
         end
       end


### PR DESCRIPTION
## Context

`Customers::RefreshWalletJob` ends up in the dead set for customers with a tax integration whose subscription generates more than 1200 fees in the current period: the current-usage flow sends every fee to the tax provider (Anrok/Avalara), which rejects payloads above 1200 line items. Unlike end-of-month invoices, current usage never skipped fees with no units, amount, or events, so empty fees inflated the count.

Fixes INT-15.

## Description

Current usage now drops fees whose units, amount, and events count are all zero — the same rule already applied when persisting end-of-month invoice fees — using `Fee#non_zero?` in `CustomerUsageService`. This keeps the tax-provider payload under the limit and aligns current usage with the eventual invoice.

Since the filtering now happens at the source, the redundant `non_zero?` calls in `DailyUsages::ComputeService` and `FillHistoryService` are removed.

### ⚠️ Behavior change ⚠️

The filter removes a fee only when units **and** amount **and** events count are all zero. This changes the current **and projected** usage responses across the dashboard GraphQL, customer-portal GraphQL, and the REST `GET /customers/:id/usage`:

- **Zero-activity charge filters disappear.** Both the implicit catch-all filter and any defined filter that got no events in the period (e.g. a `cloud=gcp` filter with no `gcp` events) are no longer returned under `filters` / `groupedUsage`. Until now the default `with_zero_units_filters: true` kept these for transparency.
- **A charge with no usage at all is omitted entirely** from `chargesUsage` — there is no longer a `$0` placeholder line for a charge that hasn't been used yet this period.
- **Anything that recorded events is kept**, even when it resolves to 0 units and 0 amount (`events_count > 0`), so genuine "used but free" usage still shows. Note this is stricter than `with_zero_units_filters`, which only looked at units: a zero-unit fee that still carries amount or events is unaffected; only fully-empty fees are dropped.

This matches end-of-month invoices (which never contain these empty lines), but it is a visible change for any consumer that assumed an exhaustive, stable list of charges/filters in the usage payload — dashboards, the customer portal, and public API integrations.
