### PR TITLE
fix(tax-providers): Filter out zero amount fees from tax provider calls

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -300,6 +300,10 @@ class Fee < ApplicationRecord
     units.positive? || amount_cents.positive? || events_count.to_i.positive?
   end
 
+  def taxable?
+    amount_cents.positive?
+  end
+
   def date_boundaries
     if charge? && !pay_in_advance? && charge.pay_in_advance?
       timestamp = invoice.invoice_subscription(subscription.id).timestamp

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -211,6 +211,11 @@ module Invoices
     def compute_amounts_with_provider_taxes
       invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
 
+      # NOTE: Set the sub total so Invoices::ApplyProviderTaxesService prorates taxes_rate
+      #       by amount (like persisted invoices) instead of falling back to its zero-amount
+      #       count-based branch, which would dilute the rate with the excluded non-taxable fees.
+      invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
+
       # NOTE: Only fees with a positive amount can incur tax, so non-taxable fees are
       #       excluded from the provider request. This also keeps the payload under the
       #       provider line-item limit (Anrok/Avalara reject payloads above 1200 items).

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -211,13 +211,18 @@ module Invoices
     def compute_amounts_with_provider_taxes
       invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
 
-      taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: invoice.fees)
+      # NOTE: Zero fees are excluded from the tax provider request to stay under its
+      #       line-item limit (Anrok/Avalara reject payloads above 1200 items). They owe
+      #       no tax, so they keep their default zero taxes and stay in the usage response.
+      taxable_fees = invoice.fees.select(&:non_zero?)
+
+      taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: taxable_fees)
 
       return result.validation_failure!(errors: {tax_error: [taxes_result.error.message]}) unless taxes_result.success?
 
       result.fees_taxes = taxes_result.fees
 
-      invoice.fees.each do |fee|
+      taxable_fees.each do |fee|
         fee_taxes = result.fees_taxes.find do |item|
           item.item_key == fee.item_key
         end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -211,9 +211,10 @@ module Invoices
     def compute_amounts_with_provider_taxes
       invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
 
-      # NOTE: Zero fees are excluded from the tax provider request to stay under its
-      #       line-item limit (Anrok/Avalara reject payloads above 1200 items). They owe
-      #       no tax, so they keep their default zero taxes and stay in the usage response.
+      # NOTE: Only fees with a positive amount can incur tax, so non-taxable fees are
+      #       excluded from the provider request. This also keeps the payload under the
+      #       provider line-item limit (Anrok/Avalara reject payloads above 1200 items).
+      #       Excluded fees owe no tax and keep their default zero taxes in the usage response.
       taxable_fees = invoice.fees.select(&:taxable?)
 
       taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: taxable_fees)

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -214,7 +214,7 @@ module Invoices
       # NOTE: Zero fees are excluded from the tax provider request to stay under its
       #       line-item limit (Anrok/Avalara reject payloads above 1200 items). They owe
       #       no tax, so they keep their default zero taxes and stay in the usage response.
-      taxable_fees = invoice.fees.select(&:non_zero?)
+      taxable_fees = invoice.fees.select(&:taxable?)
 
       taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: taxable_fees)
 

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -635,6 +635,32 @@ RSpec.describe Fee do
     end
   end
 
+  describe "#taxable?" do
+    subject { fee.taxable? }
+
+    let(:fee) { build(:fee, units:, amount_cents:, events_count:) }
+    let(:units) { 0 }
+    let(:amount_cents) { 0 }
+    let(:events_count) { 0 }
+
+    context "when amount_cents is positive" do
+      let(:amount_cents) { 100 }
+
+      it { is_expected.to be true }
+    end
+
+    context "when amount_cents is zero" do
+      it { is_expected.to be false }
+    end
+
+    context "when amount_cents is zero but units and events_count are positive" do
+      let(:units) { 5 }
+      let(:events_count) { 3 }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe "#has_charge_filter?" do
     subject(:fee) { create(:add_on_fee) }
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -201,9 +201,14 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         let(:timestamp) { current_date }
         let(:empty_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
         let(:empty_charge) { create(:standard_charge, plan:, billable_metric: empty_metric, properties: {amount: "5"}) }
+        # Free usage: has events and units but a zero amount, so it is non_zero? but not taxable?
+        let(:free_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+        let(:free_charge) { create(:standard_charge, plan:, billable_metric: free_metric, properties: {amount: "0"}) }
 
         before do
           empty_charge
+          free_charge
+          create_list(:event, 2, organization:, subscription:, customer:, code: free_metric.code, timestamp:)
           allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:call).and_call_original
 
           stub_request(:post, endpoint).to_return do |request|
@@ -220,26 +225,31 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
           end
         end
 
-        it "keeps the zero fee in the usage but excludes it from the tax provider payload" do
+        it "keeps the non-taxable fees in the usage but excludes them from the tax provider payload" do
           travel_to(current_date) do
             result = usage_service.call
 
             expect(result).to be_success
-            expect(result.usage.fees.map(&:amount_cents)).to match_array([0, 2532])
+            # both zero-amount fees (empty + free usage) stay in the usage response
+            expect(result.usage.fees.map(&:amount_cents)).to match_array([0, 0, 2532])
+            # only the taxable (positive-amount) fee is sent to the provider
             expect(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to have_received(:call) do |invoice:, fees:|
               expect(fees.map(&:amount_cents)).to match_array([2532])
             end
           end
         end
 
-        it "leaves the excluded zero fee with default zero taxes" do
+        it "leaves the excluded non-taxable fees with default zero taxes" do
           travel_to(current_date) do
             result = usage_service.call
 
-            zero_fee = result.usage.fees.find { |fee| fee.amount_cents.zero? }
-            expect(zero_fee.taxes_amount_cents).to eq(0)
-            expect(zero_fee.taxes_rate).to eq(0)
-            expect(zero_fee.applied_taxes).to be_empty
+            non_taxable_fees = result.usage.fees.reject(&:taxable?)
+            expect(non_taxable_fees.size).to eq(2)
+            non_taxable_fees.each do |fee|
+              expect(fee.taxes_amount_cents).to eq(0)
+              expect(fee.taxes_rate).to eq(0)
+              expect(fee.applied_taxes).to be_empty
+            end
           end
         end
       end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -252,6 +252,17 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             end
           end
         end
+
+        it "computes the invoice taxes_rate without diluting it by the excluded fees" do
+          travel_to(current_date) do
+            result = usage_service.call
+
+            # The rate is prorated by amount over the taxable fee only (10%), not by fee
+            # count over all three fees, which would dilute it to 1/3 * 10 = 3.33%.
+            expect(result.invoice.taxes_rate).to eq(10)
+            expect(result.usage.taxes_amount_cents).to eq(253)
+          end
+        end
       end
 
       context "when there is error received from the provider" do

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -196,6 +196,43 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         end
       end
 
+      context "when a charge produces a zero fee" do
+        let(:current_date) { DateTime.parse("2025-06-15") }
+        let(:timestamp) { current_date }
+        let(:empty_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+        let(:empty_charge) { create(:standard_charge, plan:, billable_metric: empty_metric, properties: {amount: "5"}) }
+
+        before do
+          empty_charge
+          allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:call).and_call_original
+
+          stub_request(:post, endpoint).to_return do |request|
+            response = JSON.parse(File.read(
+              Rails.root.join("spec/fixtures/integration_aggregator/taxes/invoices/success_response.json")
+            ))
+
+            key = JSON.parse(request.body).first["fees"].last["item_key"]
+            response["succeededInvoices"].first["fees"].last["item_key"] = key
+            response["succeededInvoices"].first["fees"].last["item_id"] = charge.billable_metric.id
+            response["succeededInvoices"].first["fees"].last["amount_cents"] = 2532
+
+            {body: response.to_json}
+          end
+        end
+
+        it "keeps the zero fee in the usage but excludes it from the tax provider payload" do
+          travel_to(current_date) do
+            result = usage_service.call
+
+            expect(result).to be_success
+            expect(result.usage.fees.map(&:charge_id)).to match_array([charge.id, empty_charge.id])
+            expect(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to have_received(:call) do |invoice:, fees:|
+              expect(fees.map(&:charge_id)).to match_array([charge.id])
+            end
+          end
+        end
+      end
+
       context "when there is error received from the provider" do
         before do
           stub_request(:post, endpoint).to_return do |request|

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -225,10 +225,21 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
             result = usage_service.call
 
             expect(result).to be_success
-            expect(result.usage.fees.map(&:charge_id)).to match_array([charge.id, empty_charge.id])
+            expect(result.usage.fees.map(&:amount_cents)).to match_array([0, 2532])
             expect(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to have_received(:call) do |invoice:, fees:|
-              expect(fees.map(&:charge_id)).to match_array([charge.id])
+              expect(fees.map(&:amount_cents)).to match_array([2532])
             end
+          end
+        end
+
+        it "leaves the excluded zero fee with default zero taxes" do
+          travel_to(current_date) do
+            result = usage_service.call
+
+            zero_fee = result.usage.fees.find { |fee| fee.amount_cents.zero? }
+            expect(zero_fee.taxes_amount_cents).to eq(0)
+            expect(zero_fee.taxes_rate).to eq(0)
+            expect(zero_fee.applied_taxes).to be_empty
           end
         end
       end


### PR DESCRIPTION
## Context

`Customers::RefreshWalletJob` ends up in the dead set for customers with a tax integration whose subscription generates more than 1200 fees in the current period: when computing current usage, every fee is sent to the tax provider (Anrok/Avalara), which rejects payloads above 1200 line items. Fees with a zero amount carry no tax, yet still count toward that limit.

## Description

When computing current usage with provider taxation, only taxable fees — those with a positive amount — are sent to the `CreateDraftService` request and the matching tax-application loop, keeping the payload under the provider's line-item limit. A `Fee#taxable?` predicate captures this: tax is a function of the amount, so a fee with zero amount owes no tax regardless of its units or events count, and keeps its default zero taxes.

The fees themselves are left untouched everywhere else — the current and projected usage responses, daily usage, lifetime usage, and alerts still include them exactly as before. Only the tax-provider request is trimmed.

Invoice-level tax totals are unchanged: an excluded fee has a zero taxable base, so it would have been taxed at zero anyway, and it contributes nothing to the invoice's tax amount or rate. The one observable difference is per-fee: an excluded zero-amount fee now comes back in the usage response with no applied taxes and a zero tax rate, instead of a non-zero tax rate.
