### PR TITLE
fix(order-forms): align signer field with marked_as_signed_by_user

### DIFF
--- a/app/graphql/types/order_forms/object.rb
+++ b/app/graphql/types/order_forms/object.rb
@@ -12,8 +12,8 @@ module Types
 
       field :billing_snapshot, GraphQL::Types::JSON, null: false
       field :expires_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :marked_as_signed_by_user_id, ID, null: true
       field :signed_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :signed_by_user_id, ID, null: true
       field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :customer, Types::Customers::Object, null: false

--- a/db/seeds/70_order_forms.rb
+++ b/db/seeds/70_order_forms.rb
@@ -24,7 +24,7 @@ def create_quote_version(quote:, **params)
   quote_version
 end
 
-def create_order_form(quote_version:, status: :generated, signed_by: nil, expires_at: nil)
+def create_order_form(quote_version:, status: :generated, marked_as_signed_by_user: nil, expires_at: nil)
   attrs = {
     organization: quote_version.organization,
     customer: quote_version.quote.customer,
@@ -36,7 +36,7 @@ def create_order_form(quote_version:, status: :generated, signed_by: nil, expire
   case status
   when :signed
     attrs[:signed_at] = 1.day.ago
-    attrs[:marked_as_signed_by_user] = signed_by
+    attrs[:marked_as_signed_by_user] = marked_as_signed_by_user
   when :expired
     attrs[:expires_at] = 2.days.ago
     attrs[:voided_at] = 1.day.ago
@@ -96,7 +96,7 @@ end
 # on approved quote_versions, so we build a fresh quote/version dedicated to
 # them — without touching the draft quotes seeded above, which may be relied on
 # by other QA flows.
-def create_approved_quote_with_order_form(organization:, customer:, status: :generated, signed_by: nil, expires_at: nil)
+def create_approved_quote_with_order_form(organization:, customer:, status: :generated, marked_as_signed_by_user: nil, expires_at: nil)
   quote = create_quote(
     organization: organization,
     customer: customer,
@@ -111,7 +111,7 @@ def create_approved_quote_with_order_form(organization:, customer:, status: :gen
   create_order_form(
     quote_version: quote_version,
     status: status,
-    signed_by: signed_by,
+    marked_as_signed_by_user: marked_as_signed_by_user,
     expires_at: expires_at
   )
 end
@@ -123,7 +123,7 @@ gavin = User.find_by(email: "gavin@hooli.com")
 [
   {customer_external_id: "cust_john-doe", status: :generated},
   {customer_external_id: "cust_1", status: :generated},
-  {customer_external_id: "cust_2", status: :signed, signed_by: gavin},
+  {customer_external_id: "cust_2", status: :signed, marked_as_signed_by_user: gavin},
   {customer_external_id: "cust_3", status: :expired},
   {customer_external_id: "cust_4", status: :voided},
   {customer_external_id: "cust_5", status: :generated, expires_at: 7.days.from_now}

--- a/schema.graphql
+++ b/schema.graphql
@@ -9076,10 +9076,10 @@ type OrderForm {
   customer: Customer!
   expiresAt: ISO8601DateTime
   id: ID!
+  markedAsSignedByUserId: ID
   number: String!
   quote: Quote!
   signedAt: ISO8601DateTime
-  signedByUserId: ID
   status: OrderFormStatusEnum!
   updatedAt: ISO8601DateTime!
   voidReason: OrderFormVoidReasonEnum

--- a/schema.json
+++ b/schema.json
@@ -43592,6 +43592,18 @@
               "deprecationReason": null
             },
             {
+              "name": "markedAsSignedByUserId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "number",
               "description": null,
               "args": [],
@@ -43630,18 +43642,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "signedByUserId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/graphql/types/order_forms/object_spec.rb
+++ b/spec/graphql/types/order_forms/object_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Types::OrderForms::Object do
     expect(subject).to have_field(:billing_snapshot).of_type("JSON!")
     expect(subject).to have_field(:expires_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:signed_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:signed_by_user_id).of_type("ID")
+    expect(subject).to have_field(:marked_as_signed_by_user_id).of_type("ID")
     expect(subject).to have_field(:voided_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:customer).of_type("Customer!")
     expect(subject).to have_field(:quote).of_type("Quote!")


### PR DESCRIPTION
## Context

The `OrderForm` signer association was renamed to `marked_as_signed_by_user` (column `marked_as_signed_by_user_id`), but the GraphQL `OrderForm` type still exposed the field as `signedByUserId` with no matching resolver method, so it never resolved. The seed helper also still used a `signed_by` local parameter.

## Description

- Rename the GraphQL `OrderForm` field `signed_by_user_id` → `marked_as_signed_by_user_id` so it resolves to the real column, and re-sort it alphabetically.
- Regenerate the committed `schema.graphql` / `schema.json` dumps.
- Rename the `signed_by` seed parameter to `marked_as_signed_by_user` for consistency.