### PR TITLE
chore(order-forms): remove marked_as_signed_by_user

### DIFF
--- a/app/graphql/types/order_forms/object.rb
+++ b/app/graphql/types/order_forms/object.rb
@@ -12,7 +12,6 @@ module Types
 
       field :billing_snapshot, GraphQL::Types::JSON, null: false
       field :expires_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :marked_as_signed_by_user_id, ID, null: true
       field :signed_at, GraphQL::Types::ISO8601DateTime, null: true
       field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
 

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -21,7 +21,6 @@ class OrderForm < ApplicationRecord
   belongs_to :organization
   belongs_to :customer
   belongs_to :quote_version
-  belongs_to :marked_as_signed_by_user, class_name: "User", optional: true
   has_one :quote, through: :quote_version
 
   enum :status, STATUSES,
@@ -59,25 +58,23 @@ end
 # Table name: order_forms
 # Database name: primary
 #
-#  id                          :uuid             not null, primary key
-#  expires_at                  :datetime
-#  number                      :string           not null
-#  signed_at                   :datetime
-#  status                      :enum             default("generated"), not null
-#  void_reason                 :enum
-#  voided_at                   :datetime
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
-#  customer_id                 :uuid             not null
-#  marked_as_signed_by_user_id :uuid
-#  organization_id             :uuid             not null
-#  quote_version_id            :uuid             not null
-#  sequential_id               :integer          not null
+#  id               :uuid             not null, primary key
+#  expires_at       :datetime
+#  number           :string           not null
+#  signed_at        :datetime
+#  status           :enum             default("generated"), not null
+#  void_reason      :enum
+#  voided_at        :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  customer_id      :uuid             not null
+#  organization_id  :uuid             not null
+#  quote_version_id :uuid             not null
+#  sequential_id    :integer          not null
 #
 # Indexes
 #
 #  index_order_forms_on_customer_id                        (customer_id)
-#  index_order_forms_on_marked_as_signed_by_user_id        (marked_as_signed_by_user_id)
 #  index_order_forms_on_organization_id_and_created_at     (organization_id,created_at)
 #  index_order_forms_on_organization_id_and_expires_at     (organization_id,expires_at)
 #  index_order_forms_on_organization_id_and_status         (organization_id,status)
@@ -88,7 +85,6 @@ end
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
-#  fk_rails_...  (marked_as_signed_by_user_id => users.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (quote_version_id => quote_versions.id)
 #

--- a/app/serializers/v1/order_form_serializer.rb
+++ b/app/serializers/v1/order_form_serializer.rb
@@ -11,7 +11,6 @@ module V1
         expires_at: model.expires_at&.iso8601,
         signed_at: model.signed_at&.iso8601,
         voided_at: model.voided_at&.iso8601,
-        lago_marked_as_signed_by_user_id: model.marked_as_signed_by_user_id,
         lago_organization_id: model.organization_id,
         lago_customer_id: model.customer_id,
         lago_quote_id: model.quote_version.quote_id,

--- a/db/migrate/20260601174030_remove_marked_as_signed_by_user_from_order_forms.rb
+++ b/db/migrate/20260601174030_remove_marked_as_signed_by_user_from_order_forms.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveMarkedAsSignedByUserFromOrderForms < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_reference :order_forms, :marked_as_signed_by_user,
+        foreign_key: {to_table: :users},
+        type: :uuid
+    end
+  end
+end

--- a/db/seeds/70_order_forms.rb
+++ b/db/seeds/70_order_forms.rb
@@ -24,7 +24,7 @@ def create_quote_version(quote:, **params)
   quote_version
 end
 
-def create_order_form(quote_version:, status: :generated, marked_as_signed_by_user: nil, expires_at: nil)
+def create_order_form(quote_version:, status: :generated, expires_at: nil)
   attrs = {
     organization: quote_version.organization,
     customer: quote_version.quote.customer,
@@ -36,7 +36,6 @@ def create_order_form(quote_version:, status: :generated, marked_as_signed_by_us
   case status
   when :signed
     attrs[:signed_at] = 1.day.ago
-    attrs[:marked_as_signed_by_user] = marked_as_signed_by_user
   when :expired
     attrs[:expires_at] = 2.days.ago
     attrs[:voided_at] = 1.day.ago
@@ -96,7 +95,7 @@ end
 # on approved quote_versions, so we build a fresh quote/version dedicated to
 # them — without touching the draft quotes seeded above, which may be relied on
 # by other QA flows.
-def create_approved_quote_with_order_form(organization:, customer:, status: :generated, marked_as_signed_by_user: nil, expires_at: nil)
+def create_approved_quote_with_order_form(organization:, customer:, status: :generated, expires_at: nil)
   quote = create_quote(
     organization: organization,
     customer: customer,
@@ -111,7 +110,6 @@ def create_approved_quote_with_order_form(organization:, customer:, status: :gen
   create_order_form(
     quote_version: quote_version,
     status: status,
-    marked_as_signed_by_user: marked_as_signed_by_user,
     expires_at: expires_at
   )
 end
@@ -119,11 +117,10 @@ end
 create_quote_chain(organization: @organization, customer: @customer)
 create_draft_quote_for_each_customer(organization: @organization)
 
-gavin = User.find_by(email: "gavin@hooli.com")
 [
   {customer_external_id: "cust_john-doe", status: :generated},
   {customer_external_id: "cust_1", status: :generated},
-  {customer_external_id: "cust_2", status: :signed, marked_as_signed_by_user: gavin},
+  {customer_external_id: "cust_2", status: :signed},
   {customer_external_id: "cust_3", status: :expired},
   {customer_external_id: "cust_4", status: :voided},
   {customer_external_id: "cust_5", status: :generated, expires_at: 7.days.from_now}

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -44,7 +44,6 @@ ALTER TABLE IF EXISTS ONLY public.user_devices DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_e4a58fbcac;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_e3cf54daac;
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
-ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS fk_rails_dff929ff7d;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_de7694c307;
@@ -503,7 +502,6 @@ DROP INDEX IF EXISTS public.index_order_forms_on_quote_version_id;
 DROP INDEX IF EXISTS public.index_order_forms_on_organization_id_and_status;
 DROP INDEX IF EXISTS public.index_order_forms_on_organization_id_and_expires_at;
 DROP INDEX IF EXISTS public.index_order_forms_on_organization_id_and_created_at;
-DROP INDEX IF EXISTS public.index_order_forms_on_marked_as_signed_by_user_id;
 DROP INDEX IF EXISTS public.index_order_forms_on_customer_id;
 DROP INDEX IF EXISTS public.index_memberships_on_user_id_and_organization_id;
 DROP INDEX IF EXISTS public.index_memberships_on_user_id;
@@ -4651,7 +4649,6 @@ CREATE TABLE public.order_forms (
     organization_id uuid NOT NULL,
     customer_id uuid NOT NULL,
     quote_version_id uuid NOT NULL,
-    marked_as_signed_by_user_id uuid,
     number character varying NOT NULL,
     sequential_id integer NOT NULL,
     status public.order_form_status DEFAULT 'generated'::public.order_form_status NOT NULL,
@@ -8803,13 +8800,6 @@ CREATE INDEX index_order_forms_on_customer_id ON public.order_forms USING btree 
 
 
 --
--- Name: index_order_forms_on_marked_as_signed_by_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_order_forms_on_marked_as_signed_by_user_id ON public.order_forms USING btree (marked_as_signed_by_user_id);
-
-
---
 -- Name: index_order_forms_on_organization_id_and_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12188,14 +12178,6 @@ ALTER TABLE ONLY public.customer_metadata
 
 
 --
--- Name: order_forms fk_rails_dff929ff7d; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.order_forms
-    ADD CONSTRAINT fk_rails_dff929ff7d FOREIGN KEY (marked_as_signed_by_user_id) REFERENCES public.users(id);
-
-
---
 -- Name: integration_collection_mappings fk_rails_e148d17c1f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12482,6 +12464,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260601174030'),
 ('20260601120429'),
 ('20260601120428'),
 ('20260526142247'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -9076,7 +9076,6 @@ type OrderForm {
   customer: Customer!
   expiresAt: ISO8601DateTime
   id: ID!
-  markedAsSignedByUserId: ID
   number: String!
   quote: Quote!
   signedAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -43592,18 +43592,6 @@
               "deprecationReason": null
             },
             {
-              "name": "markedAsSignedByUserId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "number",
               "description": null,
               "args": [],

--- a/spec/factories/order_forms.rb
+++ b/spec/factories/order_forms.rb
@@ -14,7 +14,6 @@ FactoryBot.define do
     trait :signed do
       status { :signed }
       signed_at { Time.current }
-      marked_as_signed_by_user { association(:user) }
     end
 
     trait :expired do

--- a/spec/graphql/types/order_forms/object_spec.rb
+++ b/spec/graphql/types/order_forms/object_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Types::OrderForms::Object do
     expect(subject).to have_field(:billing_snapshot).of_type("JSON!")
     expect(subject).to have_field(:expires_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:signed_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:marked_as_signed_by_user_id).of_type("ID")
     expect(subject).to have_field(:voided_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:customer).of_type("Customer!")
     expect(subject).to have_field(:quote).of_type("Quote!")

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe OrderForm do
       expect(order_form).to belong_to(:organization)
       expect(order_form).to belong_to(:customer)
       expect(order_form).to belong_to(:quote_version)
-      expect(order_form).to belong_to(:marked_as_signed_by_user).class_name("User").optional
       expect(order_form).to have_one(:quote).through(:quote_version)
     end
   end

--- a/spec/serializers/v1/order_form_serializer_spec.rb
+++ b/spec/serializers/v1/order_form_serializer_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe ::V1::OrderFormSerializer do
       "expires_at" => nil,
       "signed_at" => nil,
       "voided_at" => nil,
-      "lago_marked_as_signed_by_user_id" => nil,
       "lago_organization_id" => order_form.organization_id,
       "lago_customer_id" => order_form.customer_id,
       "lago_quote_id" => order_form.quote_version.quote_id,


### PR DESCRIPTION
We don't need the `order_forms.marked_as_signed_by_user_id` column actually. This PR removes it and references to it.