### PR TITLE
feat(payment-gated-subs): adapt refund model for expired subscriptions

### DIFF
--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -3,11 +3,27 @@
 class Refund < ApplicationRecord
   include PaperTrailTraceable
 
+  REASONS = {
+    credit_note: "credit_note",
+    subscription_activation_expired: "subscription_activation_expired"
+  }.freeze
+
   belongs_to :payment
-  belongs_to :credit_note
+  belongs_to :credit_note, optional: true
+  belongs_to :refundable, polymorphic: true, optional: true
   belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
   belongs_to :payment_provider_customer, class_name: "PaymentProviderCustomers::BaseCustomer"
   belongs_to :organization
+
+  enum :reason, REASONS, validate: {allow_nil: true}
+
+  validates :refundable, presence: true, unless: :credit_note_present?
+
+  private
+
+  def credit_note_present?
+    credit_note_id.present? || credit_note.present?
+  end
 end
 
 # == Schema Information

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -20,6 +20,8 @@ module CreditNotes
         refund = Refund.new(
           organization_id: credit_note.organization_id,
           credit_note:,
+          refundable: credit_note,
+          reason: :credit_note,
           payment:,
           payment_provider: payment.payment_provider,
           payment_provider_customer: payment_provider_customer(customer),

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -24,6 +24,8 @@ module CreditNotes
         refund = Refund.new(
           organization_id: credit_note.organization_id,
           credit_note:,
+          refundable: credit_note,
+          reason: :credit_note,
           payment:,
           payment_provider: payment.payment_provider,
           payment_provider_customer: payment_provider_customer(customer),

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -22,6 +22,8 @@ module CreditNotes
         refund = Refund.new(
           organization_id: credit_note.organization_id,
           credit_note:,
+          refundable: credit_note,
+          reason: :credit_note,
           payment:,
           payment_provider: payment.payment_provider,
           payment_provider_customer: payment_provider_customer(customer),

--- a/spec/factories/refunds.rb
+++ b/spec/factories/refunds.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :refund do
     credit_note
+    refundable { credit_note }
     payment
     organization { credit_note&.organization || payment&.organization || association(:organization) }
     association :payment_provider, factory: :stripe_provider
@@ -11,6 +12,31 @@ FactoryBot.define do
     amount_cents { 200 }
     amount_currency { "EUR" }
     provider_refund_id { SecureRandom.uuid }
+    reason { :credit_note }
     status { "pending" }
+
+    trait :subscription_activation_expired do
+      credit_note { nil }
+      association :refundable, factory: :invoice, status: :closed
+      reason { :subscription_activation_expired }
+      organization { refundable.organization }
+      payment do
+        association(
+          :payment,
+          payable: refundable,
+          organization: refundable.organization,
+          customer: refundable.customer,
+          payable_payment_status: "succeeded"
+        )
+      end
+      payment_provider { payment.payment_provider }
+      payment_provider_customer { payment.payment_provider_customer }
+      amount_cents { payment.amount_cents }
+      amount_currency { payment.amount_currency }
+    end
+
+    factory :subscription_activation_expired_refund do
+      subscription_activation_expired
+    end
   end
 end

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -5,7 +5,49 @@ require "rails_helper"
 RSpec.describe Refund do
   subject(:refund) { build(:refund) }
 
+  describe "enums" do
+    it do
+      expect(subject).to define_enum_for(:reason)
+        .backed_by_column_of_type(:string)
+        .with_values(described_class::REASONS)
+        .validating(allowing_nil: true)
+    end
+  end
+
   describe "associations" do
-    it { is_expected.to belong_to(:organization) }
+    it do
+      expect(subject).to belong_to(:payment)
+      expect(subject).to belong_to(:credit_note).optional
+      expect(subject).to belong_to(:payment_provider).class_name("PaymentProviders::BaseProvider").optional
+      expect(subject).to belong_to(:payment_provider_customer).class_name("PaymentProviderCustomers::BaseCustomer")
+      expect(subject).to belong_to(:organization)
+
+      association = described_class.reflect_on_association(:refundable)
+      expect(association.macro).to eq(:belongs_to)
+      expect(association.options).to include(polymorphic: true, optional: true)
+    end
+  end
+
+  describe "validations" do
+    it "requires a refundable when the refund is not linked to a credit note" do
+      refund.credit_note = nil
+      refund.refundable = nil
+      expect(refund).not_to be_valid
+      expect(refund.errors.added?(:refundable, :blank)).to be(true)
+    end
+
+    it "allows legacy credit-note refunds without a refundable association" do
+      refund.credit_note = create(:credit_note)
+      refund.refundable = nil
+      expect(refund).to be_valid
+    end
+
+    it "allows activation-expired refunds without a credit note" do
+      activation_refund = build(:subscription_activation_expired_refund)
+      expect(activation_refund).to be_valid
+      expect(activation_refund.credit_note).to be_nil
+      expect(activation_refund.refundable).to be_closed
+      expect(activation_refund.reason).to eq("subscription_activation_expired")
+    end
   end
 end

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -49,5 +49,9 @@ RSpec.describe Refund do
       expect(activation_refund.refundable).to be_closed
       expect(activation_refund.reason).to eq("subscription_activation_expired")
     end
+
+    it "is valid with an unpersisted credit note" do
+      expect(build(:refund, refundable: nil)).to be_valid
+    end
   end
 end

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe CreditNotes::Refunds::AdyenService do
       expect(result.refund.id).to be_present
 
       expect(result.refund.credit_note).to eq(credit_note)
+      expect(result.refund.refundable).to eq(credit_note)
+      expect(result.refund.reason).to eq("credit_note")
       expect(result.refund.payment).to eq(payment)
       expect(result.refund.payment_provider).to eq(adyen_payment_provider)
       expect(result.refund.payment_provider_customer).to eq(adyen_customer)

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe CreditNotes::Refunds::GocardlessService do
       expect(result.refund.id).to be_present
 
       expect(result.refund.credit_note).to eq(credit_note)
+      expect(result.refund.refundable).to eq(credit_note)
+      expect(result.refund.reason).to eq("credit_note")
       expect(result.refund.payment).to eq(payment)
       expect(result.refund.payment_provider).to eq(gocardless_payment_provider)
       expect(result.refund.payment_provider_customer).to eq(gocardless_customer)

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe CreditNotes::Refunds::StripeService do
       expect(result.refund.id).to be_present
 
       expect(result.refund.credit_note).to eq(credit_note)
+      expect(result.refund.refundable).to eq(credit_note)
+      expect(result.refund.reason).to eq("credit_note")
       expect(result.refund.payment).to eq(payment)
       expect(result.refund.payment_provider).to eq(stripe_payment_provider)
       expect(result.refund.payment_provider_customer).to eq(stripe_customer)


### PR DESCRIPTION
## Context

Payment-gated subscription activation rules needs refund late payments that settle after a subscription activation timeout. The DB changes are now on main, and this PR wires the model and existing credit-note refund writers to the new fields.

## Description

- Add Refund model support for polymorphic refundable records and explicit refund reasons.
- Add factory coverage for credit-note refunds and subscription-activation-expired refunds.
- Update Stripe, Adyen, and GoCardless credit-note refund creation to set refundable and reason fields.
