### PR TITLE
fix(presentation_group_keys): Display presentation breakdowns in a single PDF page

### DIFF
--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -368,6 +368,11 @@ html
       .breakdown-details-table tr:first-child td {
         border-top: 1px solid var(--border-color);
       }
+
+      .presentation-breakdowns-page {
+        page-break-before: always;
+      }
+
       .presentation-breakdowns .breakdown-details-table tr td {
         border-bottom: none;
         border-top: none;

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -368,11 +368,13 @@ html
       .breakdown-details-table tr:first-child td {
         border-top: 1px solid var(--border-color);
       }
-
+      .breakdown-details.presentation-breakdowns {
+        overflow: visible;
+      }
       .presentation-breakdowns-page {
         page-break-before: always;
+        padding-top: 24px;
       }
-
       .presentation-breakdowns .breakdown-details-table tr td {
         border-bottom: none;
         border-top: none;

--- a/app/views/templates/invoices/v4/_presentation_breakdowns.slim
+++ b/app/views/templates/invoices/v4/_presentation_breakdowns.slim
@@ -1,5 +1,8 @@
 - fees_with_presentation_breakdowns = fees.select { |fee| fee.charge? && fee.presentation_breakdowns_displayed_in_invoice.any? }
 
+- if fees_with_presentation_breakdowns.any?
+  .presentation-breakdowns-page
+
 - fees_with_presentation_breakdowns.group_by(&:charge_id).each do |_charge_id, charge_group_fees|
   - displayable_keys = charge_group_fees.first.presentation_group_keys_values_displayed_in_invoice
 

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -365,6 +365,10 @@ html
         border-bottom: 1px solid #d9dee7;
         padding-bottom: 24px;
       }
+      .presentation-breakdowns-page {
+        page-break-before: always;
+      }
+
       .presentation-breakdowns .breakdown-details-table tr td {
         border-bottom: none;
         border-top: none;

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -365,10 +365,13 @@ html
         border-bottom: 1px solid #d9dee7;
         padding-bottom: 24px;
       }
+      .breakdown-details.presentation-breakdowns {
+        overflow: visible;
+      }
       .presentation-breakdowns-page {
         page-break-before: always;
+        padding-top: 24px;
       }
-
       .presentation-breakdowns .breakdown-details-table tr td {
         border-bottom: none;
         border-top: none;

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -328,6 +328,10 @@ html
       .breakdown-details-table tr:first-child td {
         border-top: 1px solid var(--border-color);
       }
+      .presentation-breakdowns-page {
+        page-break-before: always;
+      }
+
       .presentation-breakdowns .breakdown-details-table tr td {
         border-bottom: none;
         border-top: none;

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -328,10 +328,14 @@ html
       .breakdown-details-table tr:first-child td {
         border-top: 1px solid var(--border-color);
       }
+
+      .breakdown-details.presentation-breakdowns {
+        overflow: visible;
+      }
       .presentation-breakdowns-page {
         page-break-before: always;
+        padding-top: 24px;
       }
-
       .presentation-breakdowns .breakdown-details-table tr td {
         border-bottom: none;
         border-top: none;

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_charge_fees_have_presentation_breakdowns/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_charge_fees_have_presentation_breakdowns/renders_correctly.html.snap
@@ -152,6 +152,7 @@
           </table>
         </div>
         <div class="invoice-resume mb-24 overflow-auto"></div>
+        <div class="presentation-breakdowns-page"></div>
         <div class="breakdown-details overflow-auto mb-24 presentation-breakdowns">
           <table class="breakdown-details-table" width="100%">
             <tr class="first_child section-end">

--- a/spec/views/app/views/templates/invoices/v4/__snapshots__/templates_invoices_v4_charge.slim/with_presentation_breakdowns/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/v4/__snapshots__/templates_invoices_v4_charge.slim/with_presentation_breakdowns/renders_correctly.html.snap
@@ -146,6 +146,7 @@
           </tr>
         </table>
       </div>
+      <div class="presentation-breakdowns-page"></div>
       <div class="breakdown-details overflow-auto mb-24 presentation-breakdowns">
         <table class="breakdown-details-table" width="100%">
           <tr class="first_child section-end">


### PR DESCRIPTION
This commit contains some changes to update invoices slim layouts

We're changing how the presentation breakdowns are displayed. Before
they were displayed right after the fee units and its breakdown. With this
commit, we're moving to a separate page.


