### PR TITLE
feat(premium_integrations): add revenue_recognition

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -153,6 +153,7 @@ class Organization < ApplicationRecord
     security_logs
     granular_lifetime_usage
     order_forms
+    revenue_recognition
   ].freeze
 
   SECURITY_LOGS_RETENTION_DAYS = 90

--- a/schema.graphql
+++ b/schema.graphql
@@ -6515,6 +6515,7 @@ enum IntegrationTypeEnum {
   projected_usage
   remove_branding_watermark
   revenue_analytics
+  revenue_recognition
   revenue_share
   salesforce
   security_logs
@@ -9696,6 +9697,7 @@ enum PremiumIntegrationTypeEnum {
   projected_usage
   remove_branding_watermark
   revenue_analytics
+  revenue_recognition
   revenue_share
   salesforce
   security_logs

--- a/schema.json
+++ b/schema.json
@@ -33544,6 +33544,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "revenue_recognition",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -49094,6 +49100,12 @@
             },
             {
               "name": "order_forms",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revenue_recognition",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
       security_logs
       granular_lifetime_usage
       order_forms
+      revenue_recognition
     ]
   end
 


### PR DESCRIPTION
 ## Context

The revenue recognition feature needs to be gated as a premium integration so it can be enabled per organization ahead of the staging release.

 ## Description

Add `revenue_recognition` to `Organization::PREMIUM_INTEGRATIONS`, which automatically wires up the `with_revenue_recognition_support` scope and `revenue_recognition_enabled?` predicate, and exposes the value through the GraphQL premium integration type enum.