### PR TITLE
fix(daily-usages):diff across event gaps

### DIFF
--- a/app/services/daily_usages/compute_diff_service.rb
+++ b/app/services/daily_usages/compute_diff_service.rb
@@ -53,10 +53,21 @@ module DailyUsages
 
     delegate :subscription, :usage_date, :from_datetime, :to_datetime, to: :daily_usage
 
+    # Returns the most recent daily_usage for the same subscription and billing period that is
+    # strictly older than the current usage_date.
+    #
+    # We intentionally do NOT restrict the lookup to `usage_date - 1.day`. On days without events,
+    # no daily_usage row is saved (see DailyUsages::ComputeAllService `last_received_event_on`
+    # guard and DailyUsages::ComputeService returning early when `current_usage.fees` is empty),
+    # so the immediately preceding row may live several days back. Falling back to "full usage"
+    # in those cases would double-count the gap days in downstream analytics that sum
+    # `usage_diff` (see lago-data `data_pipeline/models/usage/usage_daily_base.sql`).
     def previous_daily_usage
       @previous_daily_usage ||= subscription.daily_usages
         .where(from_datetime:, to_datetime:)
-        .find_by(usage_date: usage_date - 1.day)
+        .where("usage_date < ?", usage_date)
+        .order(usage_date: :desc)
+        .first
     end
 
     # Prorates previous taxes based on how much of the previous amount came from charges

--- a/spec/services/daily_usages/compute_diff_service_spec.rb
+++ b/spec/services/daily_usages/compute_diff_service_spec.rb
@@ -760,6 +760,65 @@ RSpec.describe DailyUsages::ComputeDiffService do
       expect(diff["charges_usage"].first["units"]).to eq("0.5")
       expect(diff["charges_usage"].first["events_count"]).to eq(3)
     end
+
+    context "when there is a gap of several days without events" do
+      # Simulates: events on day 4, none on days 5-8, events again on day 9 of the same billing
+      # period. The previous daily_usage lives 5 days back, not at usage_date - 1.day, so the
+      # diff must look further back than yesterday to avoid double-counting the day 4 events.
+      let(:daily_usage) do
+        create(:daily_usage, subscription:, from_datetime:, to_datetime:, usage_date: Date.new(2022, 7, 9), usage:)
+      end
+
+      before do
+        # Wipe the default previous_daily_usage at 2022-07-14 created above; here we only want
+        # the 2022-07-04 row to exist as the prior snapshot.
+        DailyUsage.where(subscription:).where.not(usage_date: Date.new(2022, 7, 4)).delete_all
+
+        create(
+          :daily_usage,
+          subscription:,
+          from_datetime:,
+          to_datetime:,
+          usage_date: Date.new(2022, 7, 4),
+          usage: previous_usage_data
+        )
+      end
+
+      it "diffs against the latest prior daily usage in the same billing period" do
+        diff = diff_service.call.usage_diff
+
+        expect(diff["amount_cents"]).to eq(50)
+        expect(diff["charges_usage"].first["amount_cents"]).to eq(50)
+        expect(diff["charges_usage"].first["units"]).to eq("0.5")
+        expect(diff["charges_usage"].first["events_count"]).to eq(3)
+      end
+    end
+
+    context "when a prior daily usage exists in a different billing period" do
+      # The prior daily_usage belongs to the previous billing period (different from_datetime /
+      # to_datetime); it must NOT be used as the diff baseline for the current period's first
+      # row — that row should fall back to "full usage".
+      let(:daily_usage) do
+        create(:daily_usage, subscription:, from_datetime:, to_datetime:, usage_date: Date.new(2022, 7, 1), usage:)
+      end
+
+      before do
+        DailyUsage.where(subscription:).where.not(id: daily_usage.id).delete_all
+
+        create(
+          :daily_usage,
+          subscription:,
+          from_datetime: from_datetime - 1.month,
+          to_datetime: to_datetime - 1.month,
+          usage_date: Date.new(2022, 6, 30),
+          usage: previous_usage_data
+        )
+      end
+
+      it "returns the full current usage instead of diffing across periods" do
+        expect(diff_service.call.usage_diff).to eq(usage)
+      end
+    end
   end
 
   context "when the previous daily usage is nil" do


### PR DESCRIPTION
## Context

Since the `last_received_event_on >= yesterday` guard was intruduced, subscriptions that go a day without events are skipped by `DailyUsages::ComputeAllService`, so no `daily_usage` row is saved on those days.

When events resume after a gap, `DailyUsages::ComputeDiffService#previous_daily_usage` was looking strictly at `usage_date - 1.day`. With gap days in between, that lookup returned nil and the service fell back to the "no previous → use full usage" branch. But `daily_usage.usage` is the cumulative usage from the start of the billing period, so the resulting `usage_diff` includes every prior day's events,
not just the day being computed.

This `usage_diff` is consumed by lago-data's and the Data API. Result: gap-day events were double-counted
every time a later snapshot rolled them in.

## Description

Look back across the entire current billing period for the most recent prior snapshot instead of only at `usage_date - 1.day`. The scope is still constrained to the same `(subscription, from_datetime, to_datetime)`, so the first row of a
new billing period correctly falls back to "full usage" (which equals the cumulative from the period start = legitimate diff vs. zero baseline).