### PR TITLE
feat(daily_usage): Add ability to skip daily usage creation per subscription

### DIFF
--- a/app/jobs/daily_usages/fill_history_job.rb
+++ b/app/jobs/daily_usages/fill_history_job.rb
@@ -4,7 +4,7 @@ module DailyUsages
   class FillHistoryJob < ApplicationJob
     queue_as do
       if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_ANALYTICS"])
-        :analytics
+        :analytics_low_priority
       else
         :long_running
       end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -331,6 +331,7 @@ end
 #  on_termination_invoice       :enum             default("generate"), not null
 #  payment_method_type          :enum             default("provider"), not null
 #  progressive_billing_disabled :boolean          default(FALSE), not null
+#  skip_daily_usage             :boolean          default(FALSE), not null
 #  skip_invoice_custom_sections :boolean          default(FALSE), not null
 #  started_at                   :datetime
 #  status                       :integer          not null

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -68,6 +68,7 @@ module DailyUsages
               .active
               .where.not(id: subscription_ids_with_daily_usage)
               .where("last_received_event_on >= ?", timestamp.to_date - 1.day)
+              .where(skip_daily_usage: false)
               .find_each do |subscription|
                 yield subscription
             end

--- a/config/sidekiq/sidekiq_analytics.yml
+++ b/config/sidekiq/sidekiq_analytics.yml
@@ -3,6 +3,7 @@ timeout: 25
 retry: 1
 queues:
   - analytics
+  - analytics_low_priority
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10) %>

--- a/db/migrate/20260602092156_add_skip_daily_usage_to_subscriptions.rb
+++ b/db/migrate/20260602092156_add_skip_daily_usage_to_subscriptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSkipDailyUsageToSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :subscriptions, :skip_daily_usage, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3277,7 +3277,8 @@ CREATE TABLE public.subscriptions (
     incompleted_at timestamp(6) without time zone,
     activated_at timestamp(6) without time zone,
     billing_entity_id uuid,
-    consolidate_invoice boolean DEFAULT true NOT NULL
+    consolidate_invoice boolean DEFAULT true NOT NULL,
+    skip_daily_usage boolean DEFAULT false NOT NULL
 );
 
 
@@ -12465,6 +12466,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260602092156'),
 ('20260601174030'),
 ('20260601120429'),
 ('20260601120428'),

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -175,4 +175,13 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
     end
   end
+
+  context "when skip_daily_usage is true" do
+    let(:subscriptions) { create_list(:subscription, 5, customer:, last_received_event_on: timestamp.to_date, skip_daily_usage: true) }
+
+    it "does not enqueue any job" do
+      expect(compute_service.call).to be_success
+      expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+    end
+  end
 end


### PR DESCRIPTION
## Context

Today, daily usage computation depends on the activation of the `revenue_analytics` premium integration.
Enabling this integration will ensure that every subscription attached to the organization will be taken into account, but the ability to disable it at subscription level (temporary) is lacking.

## Description

This PR adds a new `skip_daily_usage` attribute to the subscriptions table, allowing us to disable the daily usage creation for this subscription. The flag will default to false.

The PR also moves the `DailyUsages::FillHistoryJob` jobs from `analytics` to the `analytics_low_priority` queue