### PR TITLE
feat(wallets): Permit targeted wallet refresh on the RefreshWalletJob

### DIFF
--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -17,11 +17,11 @@ module Customers
     retry_on BaseService::TooManyProviderRequestsFailure, wait: :polynomially_longer, attempts: 25
     retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
 
-    def perform(customer)
+    def perform(customer, wallet_ids = nil)
       return unless customer.awaiting_wallet_refresh?
       return if customer.error_details.tax_error.exists?
 
-      Customers::RefreshWalletsService.call!(customer:)
+      Customers::RefreshWalletsService.call!(customer:, target_wallet_ids: wallet_ids)
     rescue BaseService::ValidationFailure => e
       tax_error = Array(e.messages[:tax_error])
 

--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -17,7 +17,7 @@ module Customers
     retry_on BaseService::TooManyProviderRequestsFailure, wait: :polynomially_longer, attempts: 25
     retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
 
-    def perform(customer, wallet_ids = nil)
+    def perform(customer, wallet_ids: nil)
       return unless customer.awaiting_wallet_refresh?
       return if customer.error_details.tax_error.exists?
 

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Customers::RefreshWalletJob do
   end
 
   describe "#perform" do
-    subject { described_class.perform_now(customer, wallet_ids) }
+    subject { described_class.perform_now(customer, wallet_ids:) }
 
     let(:customer) { create(:customer, awaiting_wallet_refresh:) }
     let(:organization) { customer.organization }

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -32,14 +32,15 @@ RSpec.describe Customers::RefreshWalletJob do
   end
 
   describe "#perform" do
-    subject { described_class.perform_now(customer) }
+    subject { described_class.perform_now(customer, wallet_ids) }
 
     let(:customer) { create(:customer, awaiting_wallet_refresh:) }
     let(:organization) { customer.organization }
     let(:result) { BaseService::Result.new }
+    let(:wallet_ids) { nil }
 
     before do
-      allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_return(result)
+      allow(Customers::RefreshWalletsService).to receive(:call).with(customer:, target_wallet_ids: wallet_ids).and_return(result)
     end
 
     context "when customer is not awaiting wallet refresh" do
@@ -57,7 +58,16 @@ RSpec.describe Customers::RefreshWalletJob do
       context "when refresh customer's wallets succeeds" do
         it "calls the Customers::RefreshWalletsService service" do
           subject
-          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:)
+          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:, target_wallet_ids: nil)
+        end
+      end
+
+      context "when wallet_ids are provided" do
+        let(:wallet_ids) { create_list(:wallet, 2, customer:).map(&:id) }
+
+        it "calls the Customers::RefreshWalletsService service scoped to the given wallets" do
+          subject
+          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:, target_wallet_ids: wallet_ids)
         end
       end
 
@@ -95,7 +105,7 @@ RSpec.describe Customers::RefreshWalletJob do
         ].each do |error_class|
           context "when the error is #{error_class.name.demodulize.underscore.humanize.downcase}" do
             before do
-              allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(error_class)
+              allow(Customers::RefreshWalletsService).to receive(:call).with(customer:, target_wallet_ids: nil).and_raise(error_class)
             end
 
             it "raises the error and retries the job" do


### PR DESCRIPTION
# Context

`Customers::RefreshWalletJob` always triggered a full wallet refresh for a customer, fanning out usage recomputation across all of the customer's active wallets. In cases where only specific wallets need refreshing (e.g. after a targeted credit grant), recomputing every wallet is unnecessary and costly.

`Customers::RefreshWalletsService` already supports a `target_wallet_ids` argument to scope the refresh. This change exposes that capability through the job.

# Description

  - Add an optional `wallet_ids` argument to `RefreshWalletJob#perform`
  - Keep the argument optional with a `nil` default so existing callers continue to trigger a full refresh unchanged
  - When `wallet_ids` is `nil`, the service refreshes all active wallets as before
  - Update the job spec
  - Add a spec context covering the targeted-refresh path (wallet ids provided)

# Notes

  - Backward compatible: no behavior change for existing single-argument callers
  - Service-level coverage for `target_wallet_ids` (both `nil` and set) already exists in `spec/services/customers/refresh_wallets_service_spec.rb`