### PR TITLE
misc(daily_usage): Improve performances of the history backfill

### DIFF
--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -15,6 +15,7 @@ module DailyUsages
 
     def call
       previous_daily_usage = nil
+      produces_daily_usage = produces_daily_usage_without_events?
 
       (from..to).each do |date|
         if !sandbox && (existing_daily_usage = subscription.daily_usages.find_by(usage_date: date))
@@ -27,6 +28,15 @@ module DailyUsages
 
         Timecop.thread_safe = true
         time_to_freeze = datetime.in_time_zone(subscription.customer.applicable_timezone).end_of_day
+
+        # Check if events were received for this date
+        if event_dates.exclude?(date)
+          # NOTE: On first day of a period, recurring metrics should be considered to report usage from
+          #       the previous period. Otherwise we can skip them until new events are received
+          force_recurring = recurring_charges? && billing_period_first_days.include?(date)
+          next if !produces_daily_usage && !force_recurring
+        end
+
         Timecop.freeze(time_to_freeze) do
           usage = Invoices::CustomerUsageService.call(
             customer: subscription.customer,
@@ -107,6 +117,71 @@ module DailyUsages
 
     def timezone
       @timezone ||= subscription.customer.applicable_timezone
+    end
+
+    # NOTE: Returns the set of dates (in the customer timezone) that received at least one event
+    #       over the whole [from..to] range. Computed in a single query to avoid a per-day lookup.
+    def event_dates
+      @event_dates ||= begin
+        range = from.in_time_zone(timezone).beginning_of_day..to.in_time_zone(timezone).end_of_day
+
+        dates = if ENV["LAGO_CLICKHOUSE_ENABLED"].present? && subscription.organization.clickhouse_events_store?
+          quoted_timezone = Clickhouse::BaseRecord.connection.quote(timezone)
+
+          Clickhouse::EventsEnriched
+            .where(organization_id: subscription.organization_id)
+            .where(external_subscription_id: subscription.external_id)
+            .where(timestamp: range)
+            .distinct
+            .pluck(Arel.sql("toDate(timestamp, #{quoted_timezone})"))
+        else
+          quoted_timezone = Event.connection.quote(timezone)
+
+          Event
+            .where(organization_id: subscription.organization_id)
+            .where(external_subscription_id: subscription.external_id)
+            .where(timestamp: range)
+            .distinct
+            .pluck(Arel.sql("DATE((events.timestamp)::timestamptz AT TIME ZONE #{quoted_timezone})"))
+        end
+
+        dates.map { |date| date.is_a?(Date) ? date : Date.parse(date.to_s) }.to_set
+      end
+    end
+
+    # NOTE: Usage on prorated or weighted sum charges evolves daily even without events.
+    #       These require a forced daily usage snapshot on every day of the range.
+    def produces_daily_usage_without_events?
+      Charge.joins(:billable_metric)
+        .where(plan_id: subscription.plan_id)
+        .where(
+          "charges.prorated = ? OR billable_metrics.aggregation_type = ?",
+          true,
+          BillableMetric.aggregation_types[:weighted_sum_agg]
+        )
+        .exists?
+    end
+
+    def recurring_charges?
+      return @recurring_charges if defined?(@recurring_charges)
+
+      @recurring_charges = Charge.joins(:billable_metric)
+        .where(plan_id: subscription.plan_id)
+        .where(billable_metrics: {recurring: true})
+        .exists?
+    end
+
+    # NOTE: Returns the set of dates (in the customer timezone) that are the first day of a billing
+    #       period within the [from..to] range.
+    def billing_period_first_days
+      @billing_period_first_days ||= (from..to).each_with_object(Set.new) do |date, set|
+        date_service = Subscriptions::DatesService.new_instance(
+          subscription,
+          date.in_time_zone(timezone).end_of_day,
+          current_usage: true
+        )
+        set << date_service.from_datetime.in_time_zone(timezone).to_date
+      end
     end
   end
 end

--- a/spec/scenarios/daily_usages/fill_history_spec.rb
+++ b/spec/scenarios/daily_usages/fill_history_spec.rb
@@ -49,7 +49,9 @@ describe "Daily Usages: Fill History", :premium, :time_travel, transaction: fals
 
     DailyUsages::FillHistoryService.call!(subscription:, from_date: mar_18.to_date, to_date: apr_20.to_date)
 
-    expect(DailyUsage.count).to eq(34) # 34 days from mar_18 to apr_20
+    # NOTE: events are received from mar_18 to apr_18 (32 days). apr_19 and apr_20
+    #       receive no event, so the guard skips them and no daily usage is created.
+    expect(DailyUsage.count).to eq(32)
 
     first_daily_usage = DailyUsage.find_by(usage_date: mar_18.to_date)
     second_daily_usage = DailyUsage.find_by(usage_date: mar_19.to_date)
@@ -58,7 +60,6 @@ describe "Daily Usages: Fill History", :premium, :time_travel, transaction: fals
     last_daily_usage = DailyUsage.find_by(usage_date: apr_17.to_date)
 
     first_next_period_daily_usage = DailyUsage.find_by(usage_date: apr_18.to_date)
-    second_next_period_daily_usage = DailyUsage.find_by(usage_date: apr_19.to_date)
 
     expect(first_daily_usage).to have_attributes(
       usage_date: mar_18.to_date,
@@ -100,13 +101,9 @@ describe "Daily Usages: Fill History", :premium, :time_travel, transaction: fals
       usage_diff: match(including("amount_cents" => 100))
     )
 
-    expect(second_next_period_daily_usage).to have_attributes(
-      usage_date: apr_19.to_date,
-      from_datetime: apr_18.beginning_of_day,
-      to_datetime: may_18.beginning_of_day - 1.second,
-      usage: match(including("amount_cents" => 100)),
-      usage_diff: match(including("amount_cents" => 0))
-    )
+    # apr_19 and apr_20 received no event, so no daily usage is created for them
+    expect(DailyUsage.find_by(usage_date: apr_19.to_date)).to be_nil
+    expect(DailyUsage.find_by(usage_date: apr_20.to_date)).to be_nil
   end
 
   context "with recurring metric and prorated charge" do
@@ -146,6 +143,8 @@ describe "Daily Usages: Fill History", :premium, :time_travel, transaction: fals
 
       DailyUsages::FillHistoryService.call!(subscription:, from_date: from.to_date, to_date: to.to_date)
 
+      # The recurring metric reports usage even on days without events, so the
+      # guard does not skip and a daily usage is created for every day in the range.
       usages = DailyUsage.where(usage_date: from.to_date..to.to_date)
       expect(usages.count).to eq(31)
       expect(usages.pluck(Arel.sql("usage['amount_cents']")).uniq).to eq([100])
@@ -190,6 +189,8 @@ describe "Daily Usages: Fill History", :premium, :time_travel, transaction: fals
 
       DailyUsages::FillHistoryService.call!(subscription:, from_date: from.to_date, to_date: to.to_date)
 
+      # The recurring metric reports usage every day, so the guard never skips
+      # and a daily usage is created for each day in the range.
       expect(DailyUsage.count).to eq(32)
       expect(DailyUsage.order(usage_date: :asc).first.usage_date).to eq(Date.new(2025, 4, 30))
       expect(DailyUsage.order(usage_date: :asc).last.usage_date).to eq(Date.new(2025, 5, 31))

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -174,14 +174,14 @@ RSpec.describe DailyUsages::ComputeAllService do
         expect(DailyUsages::ComputeJob).not_to have_been_enqueued
       end
     end
-  end
 
-  context "when skip_daily_usage is true" do
-    let(:subscriptions) { create_list(:subscription, 5, customer:, last_received_event_on: timestamp.to_date, skip_daily_usage: true) }
+    context "when skip_daily_usage is true" do
+      let(:subscriptions) { create_list(:subscription, 5, customer:, last_received_event_on: timestamp.to_date, skip_daily_usage: true) }
 
-    it "does not enqueue any job" do
-      expect(compute_service.call).to be_success
-      expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+      it "does not enqueue any job" do
+        expect(compute_service.call).to be_success
+        expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+      end
     end
   end
 end

--- a/spec/services/daily_usages/fill_history_service_spec.rb
+++ b/spec/services/daily_usages/fill_history_service_spec.rb
@@ -67,6 +67,163 @@ RSpec.describe DailyUsages::FillHistoryService do
       end
     end
 
+    context "when only some dates in the range received events" do
+      let(:from_date) { Date.parse("2024-10-14") }
+      let(:to_date) { Date.parse("2024-10-16") }
+
+      before do
+        create(:standard_charge, plan:, billable_metric:, properties: {amount: "1"})
+        create(
+          :event,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp: Time.zone.parse("2024-10-14 10:00:00"),
+          created_at: Time.zone.parse("2024-10-14 10:00:00")
+        )
+        create(
+          :event,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp: Time.zone.parse("2024-10-16 10:00:00"),
+          created_at: Time.zone.parse("2024-10-16 10:00:00")
+        )
+      end
+
+      it "only creates daily usages for dates that received events" do
+        travel_to(Time.zone.parse("2024-10-17 12:00:00")) do
+          expect { call_service }.to change(DailyUsage, :count).by(2)
+        end
+
+        expect(DailyUsage.pluck(:usage_date))
+          .to match_array([Date.parse("2024-10-14"), Date.parse("2024-10-16")])
+      end
+    end
+
+    context "when no date in the range received events" do
+      before { create(:standard_charge, plan:, billable_metric:, properties: {amount: "1"}) }
+
+      it "does not create any daily usage" do
+        travel_to(Time.zone.parse("2024-10-16 12:00:00")) do
+          expect { call_service }.not_to change(DailyUsage, :count)
+        end
+      end
+    end
+
+    context "when the plan has a prorated charge" do
+      let(:from_date) { Date.parse("2024-10-14") }
+      let(:to_date) { Date.parse("2024-10-15") }
+      let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+
+      before do
+        create(:standard_charge, plan:, billable_metric:, prorated: true, properties: {amount: "1"})
+        create(
+          :event,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp: Time.zone.parse("2024-10-14 10:00:00"),
+          created_at: Time.zone.parse("2024-10-14 10:00:00"),
+          properties: {"item_id" => 1}
+        )
+      end
+
+      it "creates a daily usage even on dates without events" do
+        travel_to(Time.zone.parse("2024-10-16 12:00:00")) do
+          expect { call_service }.to change(DailyUsage, :count).by(2)
+        end
+
+        expect(DailyUsage.pluck(:usage_date))
+          .to match_array([Date.parse("2024-10-14"), Date.parse("2024-10-15")])
+      end
+    end
+
+    context "when the plan has a recurring billable metric" do
+      let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+
+      before { create(:standard_charge, plan:, billable_metric:, properties: {amount: "1"}) }
+
+      context "when the range stays within a single billing period" do
+        let(:from_date) { Date.parse("2024-10-14") }
+        let(:to_date) { Date.parse("2024-10-15") }
+
+        before do
+          create(
+            :event,
+            organization:,
+            external_subscription_id: subscription.external_id,
+            code: billable_metric.code,
+            timestamp: Time.zone.parse("2024-10-14 10:00:00"),
+            created_at: Time.zone.parse("2024-10-14 10:00:00"),
+            properties: {"item_id" => 1}
+          )
+        end
+
+        it "does not force a daily usage on event-less days" do
+          travel_to(Time.zone.parse("2024-10-16 12:00:00")) do
+            expect { call_service }.to change(DailyUsage, :count).by(1)
+          end
+
+          expect(DailyUsage.pluck(:usage_date)).to eq([Date.parse("2024-10-14")])
+        end
+      end
+
+      context "when the range crosses a billing period boundary" do
+        let(:from_date) { Date.parse("2024-10-30") }
+        let(:to_date) { Date.parse("2024-11-02") }
+
+        before do
+          create(
+            :event,
+            organization:,
+            external_subscription_id: subscription.external_id,
+            code: billable_metric.code,
+            timestamp: Time.zone.parse("2024-10-30 10:00:00"),
+            created_at: Time.zone.parse("2024-10-30 10:00:00"),
+            properties: {"item_id" => 1}
+          )
+        end
+
+        it "forces a daily usage on the first day of the new period only" do
+          travel_to(Time.zone.parse("2024-11-03 12:00:00")) do
+            expect { call_service }.to change(DailyUsage, :count).by(2)
+          end
+
+          expect(DailyUsage.pluck(:usage_date))
+            .to match_array([Date.parse("2024-10-30"), Date.parse("2024-11-01")])
+        end
+      end
+    end
+
+    context "when the plan has a weighted sum billable metric" do
+      let(:from_date) { Date.parse("2024-10-14") }
+      let(:to_date) { Date.parse("2024-10-15") }
+      let(:billable_metric) { create(:weighted_sum_billable_metric, organization:) }
+
+      before do
+        create(:standard_charge, plan:, billable_metric:, properties: {amount: "1"})
+        create(
+          :event,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp: Time.zone.parse("2024-10-14 10:00:00"),
+          created_at: Time.zone.parse("2024-10-14 10:00:00"),
+          properties: {"value" => 1}
+        )
+      end
+
+      it "creates a daily usage even on dates without events" do
+        travel_to(Time.zone.parse("2024-10-16 12:00:00")) do
+          expect { call_service }.to change(DailyUsage, :count).by(2)
+        end
+
+        expect(DailyUsage.pluck(:usage_date))
+          .to match_array([Date.parse("2024-10-14"), Date.parse("2024-10-15")])
+      end
+    end
+
     context "when an existing daily_usage covers a date in the middle of the range" do
       let(:from_date) { Date.parse("2024-10-14") }
       let(:to_date) { Date.parse("2024-10-16") }
@@ -93,6 +250,14 @@ RSpec.describe DailyUsages::FillHistoryService do
           code: billable_metric.code,
           timestamp: Time.zone.parse("2024-10-14 10:00:00"),
           created_at: Time.zone.parse("2024-10-14 10:00:00")
+        )
+        create(
+          :event,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp: Time.zone.parse("2024-10-16 10:00:00"),
+          created_at: Time.zone.parse("2024-10-16 10:00:00")
         )
         existing_daily_usage
       end


### PR DESCRIPTION
## Description

This PR is an attempt to improve the performances of the `DailyUsages::FillHistoryService` to allow us to fix historical daily usage on organizations with a lot of subscriptions.

The main change is that we are now skipping all days for witch no events where received (except plans with recurring or weighted sum billable metric, or for prorated charges)

This PR is related to https://github.com/getlago/lago-api/pull/5627 that will address the day to day case of daily_usage computation with the same rules