### PR TITLE
feat(order-forms): add void lifecycle GraphQL mutation

### DIFF
--- a/app/graphql/mutations/order_forms/void.rb
+++ b/app/graphql/mutations/order_forms/void.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Mutations
+  module OrderForms
+    class Void < BaseMutation
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "order_forms:void"
+
+      graphql_name "VoidOrderForm"
+      description "Void an order form"
+
+      input_object_class Types::OrderForms::VoidInput
+
+      type Types::OrderForms::Object
+
+      def resolve(**args)
+        order_form = current_organization.order_forms.find_by(id: args[:id])
+        result = ::OrderForms::VoidService.call(order_form:)
+
+        result.success? ? result.order_form : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -149,6 +149,8 @@ module Types
     field :update_quote_version, mutation: Mutations::QuoteVersions::Update
     field :void_quote_version, mutation: Mutations::QuoteVersions::Void
 
+    field :void_order_form, mutation: Mutations::OrderForms::Void
+
     field :download_payment_receipt, mutation: Mutations::PaymentReceipts::Download
     field :download_xml_payment_receipt, mutation: Mutations::PaymentReceipts::DownloadXml
     field :resend_payment_receipt_email, mutation: Mutations::PaymentReceipts::ResendEmail

--- a/app/graphql/types/order_forms/void_input.rb
+++ b/app/graphql/types/order_forms/void_input.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module OrderForms
+    class VoidInput < Types::BaseInputObject
+      description "Void Order Form input arguments"
+
+      argument :id, ID, required: true
+    end
+  end
+end

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -148,6 +148,8 @@ order_forms:
     - manager
   sign:
     - manager
+  void:
+    - manager
 organization:
   view:
     - finance

--- a/schema.graphql
+++ b/schema.graphql
@@ -8985,6 +8985,16 @@ type Mutation {
   ): Invoice
 
   """
+  Void an order form
+  """
+  voidOrderForm(
+    """
+    Parameters for VoidOrderForm
+    """
+    input: VoidOrderFormInput!
+  ): OrderForm
+
+  """
   Void a quote version
   """
   voidQuoteVersion(
@@ -9431,6 +9441,7 @@ enum PermissionEnum {
   invoices_void
   order_forms_sign
   order_forms_view
+  order_forms_void
   organization_emails_update
   organization_emails_view
   organization_integrations_create
@@ -9546,6 +9557,7 @@ type Permissions {
   invoicesVoid: Boolean!
   orderFormsSign: Boolean!
   orderFormsView: Boolean!
+  orderFormsVoid: Boolean!
   organizationEmailsUpdate: Boolean!
   organizationEmailsView: Boolean!
   organizationIntegrationsCreate: Boolean!
@@ -13485,6 +13497,17 @@ input VoidInvoiceInput {
   generateCreditNote: Boolean
   id: ID!
   refundAmount: BigInt
+}
+
+"""
+Void Order Form input arguments
+"""
+input VoidOrderFormInput {
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  id: ID!
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -42864,6 +42864,35 @@
               "deprecationReason": null
             },
             {
+              "name": "voidOrderForm",
+              "description": "Void an order form",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for VoidOrderForm",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "VoidOrderFormInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "OrderForm",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "voidQuoteVersion",
               "description": "Void a quote version",
               "args": [
@@ -46012,6 +46041,12 @@
               "deprecationReason": null
             },
             {
+              "name": "order_forms_void",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -47223,6 +47258,22 @@
             },
             {
               "name": "orderFormsView",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderFormsVoid",
               "description": null,
               "args": [],
               "type": {
@@ -72198,6 +72249,45 @@
                 "kind": "SCALAR",
                 "name": "BigInt",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "VoidOrderFormInput",
+          "description": "Void Order Form input arguments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/order_forms/void_spec.rb
+++ b/spec/graphql/mutations/order_forms/void_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe Mutations::OrderForms::Void do
     expect(data["voidReason"]).to eq("manual")
   end
 
+  context "without a premium license" do
+    it "returns a forbidden error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: order_form.id}}
+      )
+
+      expect_graphql_error(result:, message: "feature_unavailable")
+    end
+  end
+
   context "when order form is not voidable", :premium do
     let(:order_form) { create(:order_form, :signed, organization:, customer:) }
 

--- a/spec/graphql/mutations/order_forms/void_spec.rb
+++ b/spec/graphql/mutations/order_forms/void_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::OrderForms::Void do
+  let(:required_permission) { "order_forms:void" }
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:membership) { create(:membership, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:order_form) { create(:order_form, organization:, customer:) }
+
+  let(:mutation) do
+    <<~GQL
+      mutation($input: VoidOrderFormInput!) {
+        voidOrderForm(input: $input) {
+          id
+          status
+          voidReason
+        }
+      }
+    GQL
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "order_forms:void"
+
+  it "voids the order form", :premium do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input: {id: order_form.id}}
+    )
+
+    data = result["data"]["voidOrderForm"]
+
+    expect(data["id"]).to eq(order_form.id)
+    expect(data["status"]).to eq("voided")
+    expect(data["voidReason"]).to eq("manual")
+  end
+
+  context "when order form is not voidable", :premium do
+    let(:order_form) { create(:order_form, :signed, organization:, customer:) }
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: order_form.id}}
+      )
+
+      expect_graphql_error(result:, message: "Method Not Allowed")
+    end
+  end
+
+  context "when order form is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: SecureRandom.uuid}}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/create-quotes-order-forms

## Context

Order forms sometimes need to be cancelled before they are signed: wrong terms, renegotiated deal, sent by mistake.

## Description

This PR adds the ability to void an order form, through a GraphQL mutation.

REST API part in #5621