### PR TITLE
feat(payment-gated-subs): add Stripe refund and PSP dispatcher

### DIFF
--- a/app/jobs/payment_providers/refund_payment_job.rb
+++ b/app/jobs/payment_providers/refund_payment_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  class RefundPaymentJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_PAYMENTS"])
+        :payments
+      else
+        :providers
+      end
+    end
+
+    def perform(payment, reason: nil)
+      PaymentProviders::RefundPaymentService.call!(payment:, reason:)
+    end
+  end
+end

--- a/app/services/payment_providers/refund_payment_service.rb
+++ b/app/services/payment_providers/refund_payment_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  class RefundPaymentService < BaseService
+    Result = BaseResult[:payment, :refund]
+
+    def initialize(payment:, reason: nil)
+      @payment = payment
+      @reason = reason
+      super
+    end
+
+    def call
+      result.payment = payment
+
+      return result if payment.payment_provider.blank?
+      return result if payment.provider_payment_id.blank?
+      return existing_refund_result if existing_refund
+
+      case payment.payment_provider.type
+      when "PaymentProviders::StripeProvider"
+        delegate_to(PaymentProviders::Stripe::Payments::RefundService)
+      else
+        # TODO(M4-providers): Adyen and GoCardless refund services land in
+        # follow-up PRs; their case branches go here when the services exist.
+        # TODO(M4-webhooks): emit `payment.refund_requires_action` outbound
+        # webhook so ops can issue the refund manually for Cashfree,
+        # Flutterwave, and Moneyhash (no PSP refund API integration).
+        Rails.logger.info(
+          "PaymentProviders::RefundPaymentService: PSP refund not supported for " \
+          "#{payment.payment_provider.type} (payment #{payment.id}); skipping"
+        )
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :payment, :reason
+
+    # M4 issues full-payment refunds, so a single Refund row per payment
+    # is the contract — once a payment is refunded, we can't refund it
+    # again regardless of reason or status. The PSP idempotency key in
+    # the provider-specific service is the second layer of defense
+    # against duplicate side effects.
+    def existing_refund
+      @existing_refund ||= Refund.find_by(payment_id: payment.id)
+    end
+
+    def existing_refund_result
+      result.refund = existing_refund
+      result
+    end
+
+    def delegate_to(service)
+      provider_result = service.call!(payment:, reason:)
+      result.refund = provider_result.refund
+      result
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/payments/refund_service.rb
+++ b/app/services/payment_providers/stripe/payments/refund_service.rb
@@ -24,11 +24,20 @@ module PaymentProviders
           )
           refund.save!
 
+          # TODO(M4-webhooks): emit `payment.refunded` outbound webhook once the
+          # webhook services land.
           result.refund = refund
           result
         rescue ActiveRecord::RecordInvalid => e
           result.record_validation_failure!(record: e.record)
         rescue ::Stripe::InvalidRequestError => e
+          # Stripe rejected the refund (e.g. charge already refunded, charge not
+          # refundable). We persist a Refund row in `failed` state so the dispatcher's
+          # "skip if refund already exists" idempotency guard stops further attempts.
+          # The provider_refund_id column is NOT NULL, but there's no PSP refund id
+          # to record here — Stripe never created one. Use the Lago-side idempotency
+          # key as a sentinel: it's unique per payment and clearly not a Stripe id
+          # shape, so lookups by it can't collide with a real refund.
           refund = build_refund(
             amount_cents: payment.amount_cents,
             amount_currency: payment.amount_currency,
@@ -37,6 +46,9 @@ module PaymentProviders
           )
           refund.save!
 
+          # TODO(M4-webhooks): emit `payment.refund_failure` outbound webhook
+          # carrying the PSP message + code, and produce a `payment.refund_failure`
+          # activity log entry. Both land once the webhook services exist.
           result.refund = refund
           result.service_failure!(code: "stripe_error", message: e.message)
         end

--- a/app/services/payment_providers/stripe/payments/refund_service.rb
+++ b/app/services/payment_providers/stripe/payments/refund_service.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    module Payments
+      class RefundService < BaseService
+        Result = BaseResult[:payment, :refund]
+
+        def initialize(payment:, reason: nil)
+          @payment = payment
+          @reason = reason
+          super
+        end
+
+        def call
+          result.payment = payment
+
+          stripe_result = create_stripe_refund
+          refund = build_refund(
+            amount_cents: stripe_result.amount,
+            amount_currency: stripe_result.currency&.upcase,
+            status: stripe_result.status,
+            provider_refund_id: stripe_result.id
+          )
+          refund.save!
+
+          result.refund = refund
+          result
+        rescue ActiveRecord::RecordInvalid => e
+          result.record_validation_failure!(record: e.record)
+        rescue ::Stripe::InvalidRequestError => e
+          refund = build_refund(
+            amount_cents: payment.amount_cents,
+            amount_currency: payment.amount_currency,
+            status: "failed",
+            provider_refund_id: idempotency_key
+          )
+          refund.save!
+
+          result.refund = refund
+          result.service_failure!(code: "stripe_error", message: e.message)
+        end
+
+        private
+
+        attr_reader :payment, :reason
+
+        def create_stripe_refund
+          ::Stripe::Refund.create(
+            stripe_refund_payload,
+            {
+              api_key: payment.payment_provider.secret_key,
+              idempotency_key:
+            }
+          )
+        end
+
+        def stripe_refund_payload
+          {
+            payment_intent: payment.provider_payment_id,
+            amount: payment.amount_cents,
+            reason: :requested_by_customer,
+            metadata: {
+              lago_customer_id: payment.customer_id,
+              lago_refundable_id: refundable.id,
+              lago_refundable_type: refundable.class.name,
+              lago_payment_id: payment.id,
+              lago_refund_reason: reason&.to_s
+            }.compact
+          }
+        end
+
+        def build_refund(amount_cents:, amount_currency:, status:, provider_refund_id:)
+          Refund.new(
+            organization_id: payment.organization_id,
+            credit_note: nil,
+            refundable:,
+            reason:,
+            payment:,
+            payment_provider: payment.payment_provider,
+            payment_provider_customer: payment.payment_provider_customer,
+            amount_cents:,
+            amount_currency:,
+            status:,
+            provider_refund_id:
+          )
+        end
+
+        def refundable
+          @refundable ||= payment.payable
+        end
+
+        def idempotency_key
+          @idempotency_key ||= "payment-refund-#{payment.id}"
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/payment_providers/refund_payment_job_spec.rb
+++ b/spec/jobs/payment_providers/refund_payment_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::RefundPaymentJob do
+  subject(:perform_job) { described_class.perform_now(payment, reason:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:payment) { create(:payment, payable: invoice, organization:, customer:) }
+  let(:reason) { :subscription_activation_expired }
+
+  before do
+    allow(PaymentProviders::RefundPaymentService).to receive(:call!)
+  end
+
+  it "delegates to RefundPaymentService with payment and reason" do
+    perform_job
+
+    expect(PaymentProviders::RefundPaymentService).to have_received(:call!).with(payment:, reason:)
+  end
+
+  context "without a reason" do
+    subject(:perform_job) { described_class.perform_now(payment) }
+
+    it "delegates with reason: nil" do
+      perform_job
+
+      expect(PaymentProviders::RefundPaymentService).to have_received(:call!).with(payment:, reason: nil)
+    end
+  end
+end

--- a/spec/services/payment_providers/refund_payment_service_spec.rb
+++ b/spec/services/payment_providers/refund_payment_service_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::RefundPaymentService do
+  subject(:service_result) { described_class.call(payment:, reason:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:, status: :closed) }
+  let(:reason) { :subscription_activation_expired }
+  let(:payment_provider) { create(:stripe_provider, organization:) }
+  let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider:) }
+  let(:payment) do
+    create(
+      :payment,
+      payable: invoice,
+      payment_provider:,
+      payment_provider_customer: stripe_customer,
+      organization:,
+      customer:,
+      provider_payment_id: "pi_123",
+      payable_payment_status: :succeeded,
+      amount_cents: 25_00,
+      amount_currency: "EUR"
+    )
+  end
+
+  let(:stripe_refund_row) do
+    build_stubbed(:refund, payment:, refundable: invoice, organization:, reason: :subscription_activation_expired)
+  end
+  let(:stripe_service_result) do
+    PaymentProviders::Stripe::Payments::RefundService::Result.new.tap do |r|
+      r.payment = payment
+      r.refund = stripe_refund_row
+    end
+  end
+
+  before do
+    allow(PaymentProviders::Stripe::Payments::RefundService).to receive(:call!).and_return(stripe_service_result)
+  end
+
+  context "when the payment provider is Stripe" do
+    it "delegates to the Stripe refund service with payment and reason" do
+      service_result
+
+      expect(PaymentProviders::Stripe::Payments::RefundService).to have_received(:call!).with(payment:, reason:)
+    end
+
+    it "returns the payment and the underlying refund" do
+      expect(service_result).to be_success
+      expect(service_result.payment).to eq(payment)
+      expect(service_result.refund).to eq(stripe_refund_row)
+    end
+  end
+
+  context "when the payment has no payment_provider" do
+    let(:payment) do
+      create(:payment, payable: invoice, payment_provider: nil, organization:, customer:,
+        provider_payment_id: "pi_123", payable_payment_status: :succeeded)
+    end
+
+    it "returns a successful result without dispatching" do
+      expect(service_result).to be_success
+      expect(service_result.refund).to be_nil
+      expect(PaymentProviders::Stripe::Payments::RefundService).not_to have_received(:call!)
+    end
+  end
+
+  context "when the payment has no provider_payment_id" do
+    before { payment.update!(provider_payment_id: nil) }
+
+    it "returns a successful result without dispatching" do
+      expect(service_result).to be_success
+      expect(service_result.refund).to be_nil
+      expect(PaymentProviders::Stripe::Payments::RefundService).not_to have_received(:call!)
+    end
+  end
+
+  context "when a Refund row already exists for the payment" do
+    let(:existing_refund) do
+      create(:refund, :subscription_activation_expired, payment:, refundable: invoice, organization:)
+    end
+
+    before { existing_refund }
+
+    it "returns the existing refund without dispatching" do
+      expect(service_result).to be_success
+      expect(service_result.refund).to eq(existing_refund)
+      expect(PaymentProviders::Stripe::Payments::RefundService).not_to have_received(:call!)
+    end
+
+    context "when the existing refund has a different reason" do
+      let(:existing_refund) do
+        create(:refund, payment:, refundable: invoice, organization:, reason: :credit_note,
+          credit_note: create(:credit_note, customer:, organization:))
+      end
+
+      it "still short-circuits — a payment can only be refunded once" do
+        expect(service_result).to be_success
+        expect(service_result.refund).to eq(existing_refund)
+        expect(PaymentProviders::Stripe::Payments::RefundService).not_to have_received(:call!)
+      end
+    end
+
+    context "when the existing refund is failed" do
+      let(:existing_refund) do
+        create(:refund, :subscription_activation_expired, payment:, refundable: invoice, organization:, status: "failed")
+      end
+
+      it "still short-circuits — failed refunds need manual ops, not retry" do
+        expect(service_result).to be_success
+        expect(service_result.refund).to eq(existing_refund)
+        expect(PaymentProviders::Stripe::Payments::RefundService).not_to have_received(:call!)
+      end
+    end
+  end
+
+  context "when the payment provider has no refund integration" do
+    let(:payment_provider) { create(:cashfree_provider, organization:) }
+    let(:payment) do
+      create(:payment, payable: invoice, payment_provider:, organization:, customer:,
+        provider_payment_id: "cf_123", payable_payment_status: :succeeded)
+    end
+
+    it "returns a successful result without dispatching" do
+      expect(service_result).to be_success
+      expect(service_result.refund).to be_nil
+      expect(PaymentProviders::Stripe::Payments::RefundService).not_to have_received(:call!)
+    end
+
+    it "logs that the provider is unsupported" do
+      allow(Rails.logger).to receive(:info)
+
+      service_result
+
+      expect(Rails.logger).to have_received(:info)
+        .with(a_string_matching(/PSP refund not supported.*CashfreeProvider/))
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe/payments/refund_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/refund_service_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Stripe::Payments::RefundService do
+  subject(:service_result) { described_class.call(payment:, reason:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:, status: :closed) }
+  let(:reason) { :subscription_activation_expired }
+  let(:payment_provider) { create(:stripe_provider, organization:, secret_key: "sk_test_123") }
+  let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider:) }
+  let(:payment) do
+    create(
+      :payment,
+      payable: invoice,
+      payment_provider:,
+      payment_provider_customer: stripe_customer,
+      organization:,
+      customer:,
+      provider_payment_id: "pi_test_123",
+      payable_payment_status: :succeeded,
+      amount_cents: 25_00,
+      amount_currency: "EUR"
+    )
+  end
+
+  before do
+    allow(::Stripe::Refund).to receive(:create)
+      .and_return(
+        ::Stripe::Refund.construct_from(
+          id: "re_123456",
+          status: "succeeded",
+          amount: 25_00,
+          currency: "eur"
+        )
+      )
+  end
+
+  it "calls Stripe with the full payment amount and Lago payment metadata" do
+    service_result
+
+    expect(::Stripe::Refund).to have_received(:create).with(
+      {
+        payment_intent: "pi_test_123",
+        amount: 25_00,
+        reason: :requested_by_customer,
+        metadata: {
+          lago_customer_id: customer.id,
+          lago_refundable_id: invoice.id,
+          lago_refundable_type: "Invoice",
+          lago_payment_id: payment.id,
+          lago_refund_reason: "subscription_activation_expired"
+        }
+      },
+      {
+        api_key: "sk_test_123",
+        idempotency_key: "payment-refund-#{payment.id}"
+      }
+    )
+  end
+
+  it "creates a payment refund row" do
+    expect { service_result }.to change(Refund, :count).by(1)
+
+    refund = service_result.refund
+    expect(refund.credit_note).to be_nil
+    expect(refund.refundable).to eq(invoice)
+    expect(refund.reason).to eq("subscription_activation_expired")
+    expect(refund.payment).to eq(payment)
+    expect(refund.payment_provider).to eq(payment_provider)
+    expect(refund.payment_provider_customer).to eq(stripe_customer)
+    expect(refund.amount_cents).to eq(25_00)
+    expect(refund.amount_currency).to eq("EUR")
+    expect(refund.status).to eq("succeeded")
+    expect(refund.provider_refund_id).to eq("re_123456")
+  end
+
+  it "returns the payment and refund" do
+    expect(service_result).to be_success
+    expect(service_result.payment).to eq(payment)
+    expect(service_result.refund).to be_a(Refund)
+  end
+
+  context "when no Lago refund reason is provided" do
+    let(:reason) { nil }
+
+    it "creates a refund without a reason" do
+      service_result
+
+      expect(service_result.refund.reason).to be_nil
+    end
+
+    it "does not send an empty refund reason in Stripe metadata" do
+      service_result
+
+      expect(::Stripe::Refund).to have_received(:create).with(
+        hash_including(metadata: hash_excluding(:lago_refund_reason)),
+        anything
+      )
+    end
+  end
+
+  context "when Stripe rejects the refund request" do
+    before do
+      allow(::Stripe::Refund).to receive(:create)
+        .and_raise(
+          ::Stripe::InvalidRequestError.new(
+            "Charge has already been refunded",
+            "payment_intent",
+            code: "charge_already_refunded"
+          )
+        )
+    end
+
+    it "creates a failed payment refund row" do
+      expect { service_result }.to change(Refund, :count).by(1)
+
+      refund = service_result.refund
+      expect(refund.credit_note).to be_nil
+      expect(refund.refundable).to eq(invoice)
+      expect(refund.reason).to eq("subscription_activation_expired")
+      expect(refund.payment).to eq(payment)
+      expect(refund.amount_cents).to eq(25_00)
+      expect(refund.amount_currency).to eq("EUR")
+      expect(refund.status).to eq("failed")
+      expect(refund.provider_refund_id).to eq("payment-refund-#{payment.id}")
+    end
+
+    it "returns a service failure with the Stripe error" do
+      expect(service_result).to be_failure
+      expect(service_result.error).to be_a(BaseService::ServiceFailure)
+      expect(service_result.error.code).to eq("stripe_error")
+      expect(service_result.error.error_message).to eq("Charge has already been refunded")
+    end
+  end
+
+  context "when Stripe returns a transient error" do
+    before do
+      allow(::Stripe::Refund).to receive(:create)
+        .and_raise(::Stripe::APIConnectionError.new("network error"))
+    end
+
+    it "propagates the error so Sidekiq can retry" do
+      expect { service_result }.to raise_error(::Stripe::APIConnectionError)
+      expect(Refund.where(payment:, reason: :subscription_activation_expired)).not_to exist
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe/payments/refund_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/refund_service_spec.rb
@@ -147,4 +147,36 @@ RSpec.describe PaymentProviders::Stripe::Payments::RefundService do
       expect(Refund.where(payment:, reason: :subscription_activation_expired)).not_to exist
     end
   end
+
+  context "when the Refund row cannot be persisted" do
+    before do
+      allow_any_instance_of(Refund).to receive(:save!) # rubocop:disable RSpec/AnyInstance
+        .and_raise(ActiveRecord::RecordInvalid.new(Refund.new))
+    end
+
+    it "returns a record validation failure" do
+      expect(service_result).to be_failure
+      expect(service_result.error).to be_a(BaseService::ValidationFailure)
+    end
+
+    it "does not persist a Refund row" do
+      service_result
+
+      expect(Refund.where(payment:)).not_to exist
+    end
+  end
+
+  context "when called with a different refund reason" do
+    let(:reason) { :credit_note }
+
+    it "propagates the reason to the Refund row and Stripe metadata" do
+      service_result
+
+      expect(service_result.refund.reason).to eq("credit_note")
+      expect(::Stripe::Refund).to have_received(:create).with(
+        hash_including(metadata: hash_including(lago_refund_reason: "credit_note")),
+        anything
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Context

When a payment-gated subscription activation times out, the pending PSP payment is canceled on a best-effort basis. That cancel can fail (or be unsupported by the provider), in which case the payment may still settle successfully after the subscription has already been canceled. Without an automated refund path, the customer ends up charged for a subscription that never activated, requiring manual intervention.

## Description

- Add `PaymentProviders::RefundPaymentService`, a thin dispatcher that routes to the provider-specific refund service based on the payment's provider type. Mirrors the shape of the existing `PaymentProviders::CancelPaymentService`.
- Add `PaymentProviders::Stripe::Payments::RefundService` issuing full-amount refunds against the original payment intent, with Stripe-side idempotency keyed by payment id and Lago metadata attached for support traceability.
- Add `PaymentProviders::RefundPaymentJob` async wrapper.
- Idempotency is layered: the dispatcher short-circuits when a `Refund` row already exists for the payment (one refund per payment is the contract for full refunds), and the PSP idempotency key is the second line of defense.
- Stripe rejections (`InvalidRequestError`) persist a sentinel `Refund` row in `failed` state so the dispatcher does not silently reattempt. Recovery from a hard-failed refund is intentionally a manual operation.
- Adyen, GoCardless, Cashfree, Flutterwave, and Moneyhash fall through to a log line; their refund integrations land in follow-up PRs.