### PR TITLE
perf(subscriptions): Fix N+1 for Subscriptions in GraphQL

### DIFF
--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -31,7 +31,7 @@ module Resolvers
       )
 
       result.subscriptions.preload(
-        :next_subscriptions,
+        {next_subscriptions: :plan},
         {customer: :billing_entity}
       )
     end

--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -30,7 +30,10 @@ module Resolvers
         search_term:
       )
 
-      result.subscriptions
+      result.subscriptions.preload(
+        :next_subscriptions,
+        {customer: :billing_entity}
+      )
     end
   end
 end

--- a/spec/graphql/resolvers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions_resolver_spec.rb
@@ -144,4 +144,71 @@ RSpec.describe Resolvers::SubscriptionsResolver do
       expect(response["metadata"]["totalCount"]).to eq(1)
     end
   end
+
+  context "with N+1 query detection on associations", bullet: {unused_eager_loading: false} do
+    let(:query) do
+      <<~GQL
+        query {
+          subscriptions(limit: 5, planCode: "#{plan.code}", status: [active]) {
+            collection { 
+              id
+              status
+              startedAt
+              nextSubscriptionAt
+              nextSubscriptionType
+              name
+              nextName
+              externalId
+              subscriptionAt
+              endingAt
+              terminatedAt
+              customer {
+                id
+                name
+                displayName
+                applicableTimezone
+              }
+              plan {
+                id
+                isOverridden
+                payInAdvance
+                amountCurrency
+                name
+                interval
+              }
+              nextPlan {
+                id
+                name
+                code
+                interval
+              }
+              nextSubscription {
+                id
+                name
+                externalId
+                status
+              }
+            }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      create(:subscription, customer:, plan:)
+      create(:subscription, customer:, plan:)
+    end
+
+    it "does not trigger N+1 queries on associations" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      expect(result["data"]["subscriptions"]["collection"].count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Context
`SubscriptionsResolver` loads a few associations for subscriptions, which ends up causing N+1 queries.

## Description

This PR preloads all necessary associations in `SubscriptionsResolver` to avoid the N+1 queries.