### PR TITLE
perf(customers): Fix N+1 for Customers in GraphQL

### DIFF
--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -52,7 +52,7 @@ module Resolvers
         :hubspot_customer,
         :netsuite_customer,
         :salesforce_customer,
-        :xero_customer,
+        :xero_customer
       )
     end
   end

--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -44,7 +44,16 @@ module Resolvers
         filters:
       )
 
-      result.customers
+      result.customers.preload(
+        :billing_entity,
+        :metadata,
+        :anrok_customer,
+        :avalara_customer,
+        :hubspot_customer,
+        :netsuite_customer,
+        :salesforce_customer,
+        :xero_customer,
+      )
     end
   end
 end

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -320,20 +320,17 @@ RSpec.describe Resolvers::CustomersResolver do
                 country
                 state
                 zipcode
-                __typename
               }
               metadata {
                 id
                 key
                 value
                 displayInInvoice
-                __typename
               }
               billingEntity {
                 id
                 code
                 name
-                __typename
               }
               netsuiteCustomer {
                 id
@@ -343,10 +340,8 @@ RSpec.describe Resolvers::CustomersResolver do
                 integrationType
                 subsidiaryId
                 syncWithProvider
-                __typename
               }
               anrokCustomer {
-                __typename
                 id
                 integrationId
                 externalCustomerId
@@ -355,7 +350,6 @@ RSpec.describe Resolvers::CustomersResolver do
                 syncWithProvider
               }
               avalaraCustomer {
-                __typename
                 id
                 integrationId
                 externalCustomerId
@@ -364,7 +358,6 @@ RSpec.describe Resolvers::CustomersResolver do
                 syncWithProvider
               }
               xeroCustomer {
-                __typename
                 id
                 integrationId
                 externalCustomerId
@@ -373,7 +366,6 @@ RSpec.describe Resolvers::CustomersResolver do
                 syncWithProvider
               }
               hubspotCustomer {
-                __typename
                 id
                 integrationId
                 externalCustomerId
@@ -383,7 +375,6 @@ RSpec.describe Resolvers::CustomersResolver do
                 targetedObject
               }
               salesforceCustomer {
-                __typename
                 id
                 integrationId
                 externalCustomerId
@@ -396,9 +387,7 @@ RSpec.describe Resolvers::CustomersResolver do
                 providerCustomerId
                 syncWithProvider
                 providerPaymentMethods
-                __typename
               }
-              __typename
             }
             metadata { currentPage, totalCount }
           }

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -270,4 +270,156 @@ RSpec.describe Resolvers::CustomersResolver do
       )
     end
   end
+
+  context "with N+1 query detection on associations", bullet: {unused_eager_loading: false} do
+    let(:query) do
+      <<~GQL
+        query(
+          $searchTerm: String,
+          $page: Int,
+          $limit: Int,
+          $accountType: [CustomerAccountTypeEnum!],
+          $billingEntityIds: [ID!],
+          $activeSubscriptionsCountFrom: Int,
+          $activeSubscriptionsCountTo: Int,
+          $customerType: CustomerTypeEnum,
+          $hasCustomerType: Boolean,
+          $hasTaxIdentificationNumber: Boolean,
+          $countries: [CountryCode!],
+          $states: [String!],
+          $zipcodes: [String!],
+          $currencies: [CurrencyEnum!],
+          $withDeleted: Boolean,
+          $metadata: [CustomerMetadataFilter!]
+        ) {
+          customers(
+            limit: $limit,
+            searchTerm: $searchTerm,
+            page: $page,
+            accountType: $accountType,
+            billingEntityIds: $billingEntityIds,
+            activeSubscriptionsCountFrom: $activeSubscriptionsCountFrom,
+            activeSubscriptionsCountTo: $activeSubscriptionsCountTo,
+            customerType: $customerType,
+            hasCustomerType: $hasCustomerType,
+            hasTaxIdentificationNumber: $hasTaxIdentificationNumber,
+            countries: $countries,
+            states: $states,
+            zipcodes: $zipcodes,
+            currencies: $currencies,
+            withDeleted: $withDeleted,
+            metadata: $metadata
+          ) {
+            collection {
+              id
+              activeSubscriptionsCount
+              shippingAddress {
+                addressLine1
+                addressLine2
+                city
+                country
+                state
+                zipcode
+                __typename
+              }
+              metadata {
+                id
+                key
+                value
+                displayInInvoice
+                __typename
+              }
+              billingEntity {
+                id
+                code
+                name
+                __typename
+              }
+              netsuiteCustomer {
+                id
+                integrationId
+                externalCustomerId
+                integrationCode
+                integrationType
+                subsidiaryId
+                syncWithProvider
+                __typename
+              }
+              anrokCustomer {
+                __typename
+                id
+                integrationId
+                externalCustomerId
+                integrationCode
+                integrationType
+                syncWithProvider
+              }
+              avalaraCustomer {
+                __typename
+                id
+                integrationId
+                externalCustomerId
+                integrationCode
+                integrationType
+                syncWithProvider
+              }
+              xeroCustomer {
+                __typename
+                id
+                integrationId
+                externalCustomerId
+                integrationCode
+                integrationType
+                syncWithProvider
+              }
+              hubspotCustomer {
+                __typename
+                id
+                integrationId
+                externalCustomerId
+                integrationCode
+                integrationType
+                syncWithProvider
+                targetedObject
+              }
+              salesforceCustomer {
+                __typename
+                id
+                integrationId
+                externalCustomerId
+                integrationCode
+                integrationType
+                syncWithProvider
+              }
+              providerCustomer {
+                id
+                providerCustomerId
+                syncWithProvider
+                providerPaymentMethods
+                __typename
+              }
+              __typename
+            }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      create(:customer, organization:, billing_entity: billing_entity1)
+      create(:customer, organization:, billing_entity: billing_entity2)
+    end
+
+    it "does not trigger N+1 queries on associations" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      expect(result["data"]["customers"]["collection"].count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Context
`CustomersResolver` loads a bunch of associations for customers, which ends up causing N+1 queries.

## Description

This PR preloads all necessary associations in `CustomersResolver` to avoid the N+1 queries.