### PR TITLE
fix(daily-usages): compute subs with time-dependent charges

### DIFF
--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -69,7 +69,7 @@ module DailyUsages
               .where.not(id: subscription_ids_with_daily_usage)
               .where(skip_daily_usage: false)
               .where(
-                "last_received_event_on >= :yesterday ",
+                "last_received_event_on >= :yesterday OR #{TIME_DEPENDENT_USAGE_SQL}",
                 yesterday: timestamp.to_date - 1.day
               )
               .find_each do |subscription|

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -67,8 +67,11 @@ module DailyUsages
             Subscription.where(customer_id: customer_ids)
               .active
               .where.not(id: subscription_ids_with_daily_usage)
-              .where("last_received_event_on >= ?", timestamp.to_date - 1.day)
               .where(skip_daily_usage: false)
+              .where(
+                "last_received_event_on >= :yesterday ",
+                yesterday: timestamp.to_date - 1.day
+              )
               .find_each do |subscription|
                 yield subscription
             end
@@ -76,5 +79,25 @@ module DailyUsages
         end
       end
     end
+
+    # Subscriptions whose usage can change between billing boundaries even without receiving new
+    # events: prorated charges, recurring billable metrics, and weighted_sum aggregations (which
+    # are time-weighted). These must be recomputed every day regardless of `last_received_event_on`,
+    # otherwise their daily usage would go stale until the next event arrives.
+    TIME_DEPENDENT_USAGE_SQL = <<~SQL.squish.freeze
+      EXISTS (
+        SELECT 1
+        FROM charges
+        JOIN billable_metrics ON billable_metrics.id = charges.billable_metric_id
+        WHERE charges.plan_id = subscriptions.plan_id
+          AND charges.deleted_at IS NULL
+          AND billable_metrics.deleted_at IS NULL
+          AND (
+            charges.prorated = TRUE
+            OR billable_metrics.recurring = TRUE
+            OR billable_metrics.aggregation_type = #{BillableMetric.aggregation_types[:weighted_sum_agg]}
+          )
+      )
+    SQL
   end
 end

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -69,7 +69,7 @@ module DailyUsages
               .where.not(id: subscription_ids_with_daily_usage)
               .where(skip_daily_usage: false)
               .where(
-                "last_received_event_on >= :yesterday OR #{TIME_DEPENDENT_USAGE_SQL}",
+                "last_received_event_on >= :yesterday OR #{PLAN_HAS_TIME_DEPENDENT_CHARGE_SQL}",
                 yesterday: timestamp.to_date - 1.day
               )
               .find_each do |subscription|
@@ -84,7 +84,7 @@ module DailyUsages
     # events: prorated charges, recurring billable metrics, and weighted_sum aggregations (which
     # are time-weighted). These must be recomputed every day regardless of `last_received_event_on`,
     # otherwise their daily usage would go stale until the next event arrives.
-    TIME_DEPENDENT_USAGE_SQL = <<~SQL.squish.freeze
+    PLAN_HAS_TIME_DEPENDENT_CHARGE_SQL = <<~SQL.squish.freeze
       EXISTS (
         SELECT 1
         FROM charges

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -2,6 +2,8 @@
 
 module DailyUsages
   class ComputeAllService < BaseService
+    ENQUEUE_BATCH_SIZE = 1_000
+
     def initialize(timestamp: Time.current)
       @timestamp = timestamp
 
@@ -9,8 +11,20 @@ module DailyUsages
     end
 
     def call
-      each_subscription do |subscription|
-        schedule_daily_usage(subscription)
+      Organization.with_revenue_analytics_support.find_each do |organization|
+        ids = Set.new
+
+        # Each leg runs its (cheap, indexed) selection query ONCE via pluck. We never iterate the
+        # heavy relation with find_each, which would re-execute the whole query per 1000-row batch.
+        ids.merge(event_subscriptions(organization).pluck("subscriptions.id"))
+        ids.merge(time_dependent_subscriptions(organization).pluck("subscriptions.id"))
+        ids.merge(recurring_rollover_subscriptions(organization).pluck("subscriptions.id"))
+
+        # Drop subscriptions already computed for yesterday. Subtracting here runs the dedup query
+        # once per organization, instead of three times (once per leg) if it lived in base_scope.
+        ids.subtract(already_computed_subscription_ids(organization))
+
+        enqueue(ids)
       end
 
       result
@@ -20,15 +34,117 @@ module DailyUsages
 
     attr_reader :timestamp
 
+    # Recompute every day for subscriptions that received an event recently: their usage may have
+    # changed. Restricted to customers entering a new day in their timezone.
+    def event_subscriptions(organization)
+      base_scope(organization)
+        .joins(customer: :billing_entity)
+        .where(timezone_window_sql, timestamp:)
+        .where("last_received_event_on >= :yesterday", yesterday: yesterday)
+    end
+
+    # Recompute every day for subscriptions whose usage changes between billing boundaries WITHOUT
+    # new events (prorated charges, weighted_sum aggregations), even when no event was received.
+    #
+    # We resolve the time-dependent plan ids as a subquery and let Postgres hash semi-join, instead
+    # of a correlated EXISTS (which is evaluated per row and is catastrophic on plan-per-subscription
+    # organizations).
+    def time_dependent_subscriptions(organization)
+      base_scope(organization)
+        .where(plan_id: time_dependent_plan_ids(organization))
+        .joins(customer: :billing_entity)
+        .where(timezone_window_sql, timestamp:)
+        .where("last_received_event_on IS NULL OR last_received_event_on < :yesterday", yesterday: yesterday)
+    end
+
+    # Recurring metrics are constant between events, so they only need to be recomputed once per
+    # period, to capture the carried-over value of the new period.
+    #
+    # `ComputeService` skips the billing day itself (its usage comes from the periodic invoice), so
+    # the carry-over row (usage_date = period start) is created on the run of the *next* day. We
+    # therefore select subscriptions whose period rolled over yesterday (`timestamp - 1.day`).
+    def recurring_rollover_subscriptions(organization)
+      scope = base_scope(organization)
+        .where(plan_id: recurring_plan_ids(organization))
+        .where("last_received_event_on IS NULL OR last_received_event_on < :yesterday", yesterday: yesterday)
+
+      Subscriptions::BillingDateQuery.call(subscriptions: scope, timestamp: timestamp - 1.day)
+        .subscriptions
+        .where(timezone_window_sql, timestamp:)
+    end
+
+    def base_scope(organization)
+      Subscription.where(organization_id: organization.id)
+        .active
+        .where(skip_daily_usage: false)
+    end
+
+    # Plans with a charge whose usage changes daily without events: prorated charges or weighted_sum
+    # aggregations. Returned as a relation so it composes as a subquery (semi-join).
+    #
+    # NOTE: fixed charges are intentionally excluded — `CustomerUsageService` only computes usage
+    # charges, so a prorated fixed charge does not change the daily usage value.
+    def time_dependent_plan_ids(organization)
+      Charge.joins(:plan, :billable_metric)
+        .where(plans: {organization_id: organization.id})
+        .where(charges: {deleted_at: nil}, billable_metrics: {deleted_at: nil})
+        .where(
+          "charges.prorated = TRUE OR billable_metrics.aggregation_type = ?",
+          BillableMetric.aggregation_types[:weighted_sum_agg]
+        )
+        .select("charges.plan_id")
+    end
+
+    # Plans with a recurring billable metric. Returned as a relation so it composes as a subquery.
+    def recurring_plan_ids(organization)
+      Charge.joins(:plan, :billable_metric)
+        .where(plans: {organization_id: organization.id})
+        .where(charges: {deleted_at: nil}, billable_metrics: {deleted_at: nil, recurring: true})
+        .select("charges.plan_id")
+    end
+
+    # Load the matched subscriptions by primary key (cheap, indexed) and enqueue, in bounded slices
+    # so we never hold more than ENQUEUE_BATCH_SIZE records in memory at once.
+    def enqueue(ids)
+      ids.each_slice(ENQUEUE_BATCH_SIZE) do |batch|
+        # rubocop:disable Rails/FindEach -- each_slice already bounds the batch to ENQUEUE_BATCH_SIZE;
+        # find_each would add redundant keyset batching on top of an already-small `id IN (...)` query.
+        Subscription.where(id: batch).each do |subscription|
+          schedule_daily_usage(subscription)
+        end
+        # rubocop:enable Rails/FindEach
+      end
+    end
+
+    # Subscriptions that already have a daily usage for yesterday (in the customer's timezone).
+    # Pre-filters on the indexed raw usage_date before the timezone-aware match, to avoid scanning
+    # the org's whole history.
+    def already_computed_subscription_ids(organization)
+      DailyUsage
+        .usage_date_in_timezone(timestamp.to_date - 1.day)
+        .where(organization_id: organization.id)
+        .where(usage_date: (timestamp.to_date - 2.days)..timestamp.to_date)
+        .pluck(:subscription_id)
+    end
+
     def schedule_daily_usage(subscription)
       DailyUsages::ComputeJob.set(wait: job_wait_time).perform_later(subscription, timestamp:)
     end
 
+    def yesterday
+      @yesterday ||= timestamp.to_date - 1.day
+    end
+
+    # Only schedule customers entering a new day in their timezone; the hourly clock catches each
+    # timezone as it crosses midnight.
+    def timezone_window_sql
+      "DATE_PART('hour', (:timestamp#{at_time_zone})) IN (0, 1, 2)"
+    end
+
     def job_wait_time
-      # Randomize job wait time to distribute load across the system.
-      # This prevents thundering herd effect when processing large batches,
-      # and helps interleave jobs from different organizations since subscriptions
-      # within the same organization usually have very similar load profiles.
+      # Randomize job wait time to distribute load across the system. This prevents a thundering
+      # herd, and interleaves jobs from different organizations (subscriptions within an org usually
+      # share a load profile).
       rand(scheduling_interval)
     end
 
@@ -40,68 +156,5 @@ module DailyUsages
         (parsed || 30.minutes).to_i
       end
     end
-
-    def each_organization(&block)
-      Organization.with_revenue_analytics_support.find_each(&block)
-    end
-
-    def each_billing_entity(organization, &block)
-      organization.billing_entities.unscope(:order).find_each(&block)
-    end
-
-    def each_customer_batch(billing_entity, &block)
-      Customer.joins(:billing_entity)
-        .where(billing_entity_id: billing_entity.id)
-        .where("DATE_PART('hour', (:timestamp#{at_time_zone})) IN (0, 1, 2)", timestamp:)
-        .in_batches(&block)
-    end
-
-    def each_subscription(&block)
-      each_organization do |organization|
-        each_billing_entity(organization) do |billing_entity|
-          each_customer_batch(billing_entity) do |customers|
-            customer_ids = customers.select(:id)
-            subscription_ids_with_daily_usage = DailyUsage.usage_date_in_timezone(timestamp.to_date - 1.day)
-              .where(customer_id: customer_ids)
-              .select(:subscription_id)
-            Subscription.where(customer_id: customer_ids)
-              .active
-              .where.not(id: subscription_ids_with_daily_usage)
-              .where(skip_daily_usage: false)
-              .where(
-                "last_received_event_on >= :yesterday OR #{PLAN_HAS_TIME_DEPENDENT_CHARGE_SQL}",
-                yesterday: timestamp.to_date - 1.day
-              )
-              .find_each do |subscription|
-                yield subscription
-            end
-          end
-        end
-      end
-    end
-
-    # Subscriptions whose usage can change between billing boundaries even without receiving new
-    # events: prorated charges, recurring billable metrics, and weighted_sum aggregations (which
-    # are time-weighted). These must be recomputed every day regardless of `last_received_event_on`,
-    # otherwise their daily usage would go stale until the next event arrives.
-    #
-    # NOTE: fixed charges are intentionally excluded — they are not part of the metered daily usage
-    # (`CustomerUsageService` only computes usage charges), so a prorated fixed charge does not
-    # change the daily usage value.
-    PLAN_HAS_TIME_DEPENDENT_CHARGE_SQL = <<~SQL.squish.freeze
-      EXISTS (
-        SELECT 1
-        FROM charges
-        JOIN billable_metrics ON billable_metrics.id = charges.billable_metric_id
-        WHERE charges.plan_id = subscriptions.plan_id
-          AND charges.deleted_at IS NULL
-          AND billable_metrics.deleted_at IS NULL
-          AND (
-            charges.prorated = TRUE
-            OR billable_metrics.recurring = TRUE
-            OR billable_metrics.aggregation_type = #{BillableMetric.aggregation_types[:weighted_sum_agg]}
-          )
-      )
-    SQL
   end
 end

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -84,6 +84,10 @@ module DailyUsages
     # events: prorated charges, recurring billable metrics, and weighted_sum aggregations (which
     # are time-weighted). These must be recomputed every day regardless of `last_received_event_on`,
     # otherwise their daily usage would go stale until the next event arrives.
+    #
+    # NOTE: fixed charges are intentionally excluded — they are not part of the metered daily usage
+    # (`CustomerUsageService` only computes usage charges), so a prorated fixed charge does not
+    # change the daily usage value.
     PLAN_HAS_TIME_DEPENDENT_CHARGE_SQL = <<~SQL.squish.freeze
       EXISTS (
         SELECT 1

--- a/app/services/subscriptions/billing_date_query.rb
+++ b/app/services/subscriptions/billing_date_query.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  # Filters a subscriptions scope down to the ones whose billing period rolls over (i.e. is billed)
+  # on `timestamp`'s date, in the customer's applicable timezone.
+  #
+  # The calendar logic (calendar vs anniversary, every interval, end-of-month and leap-year edge
+  # cases, timezone) is intentionally identical to the periodic billing selection in
+  # `Subscriptions::OrganizationBillingService#billable_subscriptions`. It is expressed here as a
+  # single OR-ed WHERE so it can be composed onto any subscriptions scope.
+  #
+  # NOTE: the given scope must allow joining `:plan` and `customer: :billing_entity` (needed for the
+  #       timezone-aware date comparisons).
+  class BillingDateQuery < BaseService
+    Result = BaseResult[:subscriptions]
+
+    def initialize(subscriptions:, timestamp:)
+      @subscriptions = subscriptions
+      @timestamp = timestamp
+
+      super
+    end
+
+    def call
+      result.subscriptions = subscriptions
+        .joins(:plan, customer: :billing_entity)
+        .where(billing_day_conditions, today: timestamp)
+
+      result
+    end
+
+    private
+
+    attr_reader :subscriptions, :timestamp
+
+    def billing_day_conditions
+      [
+        scoped(:calendar, :weekly, weekly_calendar),
+        scoped(:calendar, :monthly, monthly_calendar),
+        scoped(:calendar, :quarterly, quarterly_calendar),
+        scoped(:calendar, :semiannual, semiannual_with_monthly_charges),
+        scoped(:calendar, :semiannual, semiannual_with_monthly_fixed_charges),
+        scoped(:calendar, :semiannual, semiannual_calendar),
+        scoped(:calendar, :yearly, yearly_with_monthly_charges),
+        scoped(:calendar, :yearly, yearly_with_monthly_fixed_charges),
+        scoped(:calendar, :yearly, yearly_calendar),
+        scoped(:anniversary, :weekly, weekly_anniversary),
+        scoped(:anniversary, :monthly, anniversary_day),
+        scoped(:anniversary, :quarterly, "#{quarterly_anniversary_month} AND #{anniversary_day}"),
+        scoped(:anniversary, :semiannual, "#{plan_bill_charges_monthly} AND #{anniversary_day}"),
+        scoped(:anniversary, :semiannual, "#{plan_bill_fixed_charges_monthly_only} AND #{anniversary_day}"),
+        scoped(:anniversary, :semiannual, "#{semiannual_anniversary_month} AND #{anniversary_day}"),
+        scoped(:anniversary, :yearly, "#{plan_bill_charges_monthly} AND #{anniversary_day}"),
+        scoped(:anniversary, :yearly, "#{plan_bill_fixed_charges_monthly_only} AND #{anniversary_day}"),
+        scoped(:anniversary, :yearly, "#{yearly_anniversary_month} AND #{yearly_anniversary_day}")
+      ].map { |condition| "(#{condition})" }.join(" OR ")
+    end
+
+    def scoped(billing_time, interval, condition)
+      "subscriptions.billing_time = #{Subscription.billing_times[billing_time]} " \
+        "AND plans.interval = #{Plan.intervals[interval]} " \
+        "AND (#{condition})"
+    end
+
+    def tz
+      @tz ||= at_time_zone
+    end
+
+    def weekly_calendar
+      "EXTRACT(ISODOW FROM (:today#{tz})) = 1"
+    end
+
+    def monthly_calendar
+      "DATE_PART('day', (:today#{tz})) = 1"
+    end
+
+    def quarterly_calendar
+      "DATE_PART('month', (:today#{tz})) IN (1, 4, 7, 10) AND DATE_PART('day', (:today#{tz})) = 1"
+    end
+
+    def semiannual_calendar
+      "DATE_PART('month', (:today#{tz})) IN (1, 7) AND DATE_PART('day', (:today#{tz})) = 1"
+    end
+
+    def yearly_calendar
+      "DATE_PART('month', (:today#{tz})) = 1 AND DATE_PART('day', (:today#{tz})) = 1"
+    end
+
+    def semiannual_with_monthly_charges
+      "DATE_PART('day', (:today#{tz})) = 1 AND #{plan_bill_charges_monthly}"
+    end
+
+    def semiannual_with_monthly_fixed_charges
+      "DATE_PART('day', (:today#{tz})) = 1 AND #{plan_bill_fixed_charges_monthly_only}"
+    end
+
+    def yearly_with_monthly_charges
+      "DATE_PART('day', (:today#{tz})) = 1 AND #{plan_bill_charges_monthly}"
+    end
+
+    def yearly_with_monthly_fixed_charges
+      "DATE_PART('day', (:today#{tz})) = 1 AND #{plan_bill_fixed_charges_monthly_only}"
+    end
+
+    def weekly_anniversary
+      "EXTRACT(ISODOW FROM (subscriptions.subscription_at#{tz})) = EXTRACT(ISODOW FROM (:today#{tz}))"
+    end
+
+    # The subscription_at day-of-month matches today, accounting for short months (e.g. a sub
+    # anchored on the 31st bills on the 30th/28th when the month is shorter).
+    def anniversary_day
+      <<~SQL.squish
+        DATE_PART('day', (subscriptions.subscription_at#{tz})) = ANY (
+          CASE WHEN DATE_PART('day', (#{end_of_month})) = DATE_PART('day', :today#{tz})
+          THEN
+            (SELECT ARRAY(SELECT generate_series(DATE_PART('day', :today#{tz})::integer, 31)))
+          ELSE
+            (SELECT ARRAY[DATE_PART('day', :today#{tz})])
+          END
+        )
+      SQL
+    end
+
+    def quarterly_anniversary_month
+      <<~SQL.squish
+        (
+          CASE WHEN MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{tz})) AS INTEGER), 3) = 0
+          THEN
+            (DATE_PART('month', :today#{tz}) IN (3, 6, 9, 12))
+          ELSE (
+            DATE_PART('month', (subscriptions.subscription_at#{tz})) = DATE_PART('month', :today#{tz})
+              OR MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{tz})) + 3 AS INTEGER), 12) = DATE_PART('month', :today#{tz})
+              OR MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{tz})) + 6 AS INTEGER), 12) = DATE_PART('month', :today#{tz})
+              OR MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{tz})) + 9 AS INTEGER), 12) = DATE_PART('month', :today#{tz})
+          )
+          END
+        )
+      SQL
+    end
+
+    def semiannual_anniversary_month
+      <<~SQL.squish
+        (
+          CASE WHEN MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{tz})) AS INTEGER), 6) = 0
+          THEN
+            (DATE_PART('month', :today#{tz}) IN (6, 12))
+          ELSE (
+            DATE_PART('month', (subscriptions.subscription_at#{tz})) = DATE_PART('month', :today#{tz})
+              OR MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{tz})) + 6 AS INTEGER), 12) = DATE_PART('month', :today#{tz})
+          )
+          END
+        )
+      SQL
+    end
+
+    def yearly_anniversary_month
+      "DATE_PART('month', (subscriptions.subscription_at#{tz})) = DATE_PART('month', :today#{tz})"
+    end
+
+    def yearly_anniversary_day
+      <<~SQL.squish
+        DATE_PART('day', (subscriptions.subscription_at#{tz})) = ANY (
+          CASE WHEN (
+            DATE_PART('month', :today#{tz}) = 2
+            AND DATE_PART('day', :today#{tz}) = 28
+            AND DATE_PART('day', (#{end_of_month})) = 28
+          )
+          THEN
+            ARRAY[28, 29]
+          ELSE
+            ARRAY[DATE_PART('day', :today#{tz})]
+          END
+        )
+      SQL
+    end
+
+    def plan_bill_charges_monthly
+      "plans.bill_charges_monthly = 't'"
+    end
+
+    def plan_bill_fixed_charges_monthly_only
+      "plans.bill_fixed_charges_monthly = 't' AND (plans.bill_charges_monthly = 'f' OR plans.bill_charges_monthly IS NULL)"
+    end
+
+    def end_of_month
+      "(DATE_TRUNC('month', :today#{tz}) + INTERVAL '1 month - 1 day')::date"
+    end
+  end
+end

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -166,6 +166,58 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
     end
 
+    context "when the subscription has time-dependent usage but no recent events" do
+      let(:plan) { create(:plan, organization:) }
+      let(:billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
+      let(:subscriptions) do
+        create_list(:subscription, 5, customer:, plan:, last_received_event_on: timestamp.to_date - 5.days)
+      end
+
+      context "with a prorated charge" do
+        before { create(:standard_charge, plan:, billable_metric:, prorated: true) }
+
+        it "enqueues jobs even though no event was received" do
+          expect(compute_service.call).to be_success
+          subscriptions.each do |subscription|
+            expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+          end
+        end
+      end
+
+      context "with a recurring billable metric" do
+        before { create(:standard_charge, plan:, billable_metric:) }
+
+        it "enqueues jobs even though no event was received" do
+          expect(compute_service.call).to be_success
+          subscriptions.each do |subscription|
+            expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+          end
+        end
+      end
+
+      context "with a weighted_sum aggregation" do
+        let(:billable_metric) { create(:weighted_sum_billable_metric, organization:) }
+
+        before { create(:standard_charge, plan:, billable_metric:) }
+
+        it "enqueues jobs even though no event was received" do
+          expect(compute_service.call).to be_success
+          subscriptions.each do |subscription|
+            expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+          end
+        end
+      end
+
+      context "with a deleted recurring charge" do
+        before { create(:standard_charge, plan:, billable_metric:, prorated: true, deleted_at: timestamp) }
+
+        it "does not enqueue any job" do
+          expect(compute_service.call).to be_success
+          expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+        end
+      end
+    end
+
     context "when revenue_analytics premium integration flag is not present" do
       let(:premium_integrations) { [] }
 

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -208,8 +208,19 @@ RSpec.describe DailyUsages::ComputeAllService do
         end
       end
 
+      context "with a charge that is not time-dependent" do
+        let(:billable_metric) { create(:billable_metric, organization:, recurring: false) }
+
+        before { create(:standard_charge, plan:, billable_metric:) }
+
+        it "does not enqueue any job" do
+          expect(compute_service.call).to be_success
+          expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+        end
+      end
+
       context "with a deleted recurring charge" do
-        before { create(:standard_charge, plan:, billable_metric:, prorated: true, deleted_at: timestamp) }
+        before { create(:standard_charge, plan:, billable_metric:, deleted_at: timestamp) }
 
         it "does not enqueue any job" do
           expect(compute_service.call).to be_success

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -246,6 +246,44 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
     end
 
+    context "when leg conditions overlap" do
+      let(:plan) { create(:plan, organization:) }
+
+      context "when a recurring subscription received a recent event off its rollover day" do
+        # 2024-10-22 is not a rollover for a calendar monthly plan, but the recent event keeps the
+        # subscription in the daily (event) leg — active recurring subs are not starved off-rollover.
+        let(:billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
+        let(:subscriptions) do
+          create_list(:subscription, 1, :calendar, customer:, plan:, last_received_event_on: timestamp.to_date)
+        end
+
+        before { create(:standard_charge, plan:, billable_metric:) }
+
+        it "still enqueues a job via the event leg" do
+          expect(compute_service.call).to be_success
+          expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscriptions.first, timestamp:)
+        end
+      end
+
+      context "when a subscription matches both the time-dependent and recurring legs" do
+        # A prorated charge on a recurring metric puts the plan in both the time-dependent leg
+        # (prorated) and the recurring leg (recurring metric). With no recent event, on its rollover
+        # day, the subscription matches both — the Set union must enqueue it only once.
+        let(:timestamp) { Time.zone.parse("2024-10-02 00:05:00") }
+        let(:billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
+        let(:subscriptions) do
+          create_list(:subscription, 1, :calendar, customer:, plan:, last_received_event_on: timestamp.to_date - 5.days)
+        end
+
+        before { create(:standard_charge, plan:, billable_metric:, prorated: true) }
+
+        it "enqueues the job only once" do
+          expect(compute_service.call).to be_success
+          expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscriptions.first, timestamp:).once
+        end
+      end
+    end
+
     context "when revenue_analytics premium integration flag is not present" do
       let(:premium_integrations) { [] }
 

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -185,12 +185,29 @@ RSpec.describe DailyUsages::ComputeAllService do
       end
 
       context "with a recurring billable metric" do
+        # Recurring metrics are constant between events, so they are recomputed once per period,
+        # on the run following the period rollover (timestamp - 1.day). With a calendar monthly
+        # plan, that rollover is the 1st of the month.
+        let(:timestamp) { Time.zone.parse("2024-10-02 00:05:00") }
+        let(:subscriptions) do
+          create_list(:subscription, 5, :calendar, customer:, plan:, last_received_event_on: timestamp.to_date - 5.days)
+        end
+
         before { create(:standard_charge, plan:, billable_metric:) }
 
-        it "enqueues jobs even though no event was received" do
+        it "enqueues jobs on the run following the period rollover" do
           expect(compute_service.call).to be_success
           subscriptions.each do |subscription|
             expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+          end
+        end
+
+        context "when no period rolled over the previous day" do
+          let(:timestamp) { Time.zone.parse("2024-10-22 00:05:00") }
+
+          it "does not enqueue any job" do
+            expect(compute_service.call).to be_success
+            expect(DailyUsages::ComputeJob).not_to have_been_enqueued
           end
         end
       end

--- a/spec/services/subscriptions/billing_date_query_spec.rb
+++ b/spec/services/subscriptions/billing_date_query_spec.rb
@@ -200,6 +200,22 @@ RSpec.describe Subscriptions::BillingDateQuery do
         bill_fixed_charges_monthly: true,
         billed_on: ["20 Jul 2022", "20 Aug 2022"],
         not_billed_on: ["21 Jul 2022"]
+      },
+      {
+        interval: :yearly,
+        billing_time: :calendar,
+        bill_fixed_charges_monthly: true,
+        billed_on: ["01 Aug 2022", "01 Sep 2022", "01 Oct 2022"],
+        not_billed_on: ["02 Aug 2022", "31 Aug 2022"]
+      },
+      # Semiannual anniversary anchored on a month divisible by 6 (exercises the MOD(month, 6) = 0
+      # branch: bills in June and December).
+      {
+        interval: :semiannual,
+        billing_time: :anniversary,
+        subscription_at: "20 Jun 2021",
+        billed_on: ["20 Jun 2022", "20 Dec 2022"],
+        not_billed_on: ["20 Aug 2022", "20 Sep 2022"]
       }
     ].each do |test_case|
       case_subscription_at = test_case[:subscription_at] || "20 Feb 2021"

--- a/spec/services/subscriptions/billing_date_query_spec.rb
+++ b/spec/services/subscriptions/billing_date_query_spec.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::BillingDateQuery do
+  subject(:result) { described_class.call(subscriptions:, timestamp:) }
+
+  let(:subscriptions) { Subscription.where(id: subscription.id) }
+
+  let(:billing_entity_timezone) { "UTC" }
+  let(:billing_entity) { create(:billing_entity, timezone: billing_entity_timezone) }
+  let(:organization) { billing_entity.organization }
+
+  let(:interval) { :monthly }
+  let(:bill_charges_monthly) { false }
+  let(:bill_fixed_charges_monthly) { false }
+  let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
+
+  let(:customer_timezone) { nil }
+  let(:customer) { create(:customer, organization:, billing_entity:, timezone: customer_timezone) }
+
+  let(:subscription_at) { DateTime.parse("20 Feb 2021") }
+  let(:billing_time) { :calendar }
+  let(:timestamp) { DateTime.parse("20 Jun 2022 12:00") }
+  let(:subscription) do
+    create(:subscription, customer:, plan:, subscription_at:, billing_time:, started_at: DateTime.parse("10 Jun 2022"))
+  end
+
+  before { subscription }
+
+  def selected?
+    result.subscriptions.exists?(subscription.id)
+  end
+
+  describe "#call" do
+    # The same billing-day matrix that validates Subscriptions::OrganizationBillingService#billable_subscriptions.
+    # BillingDateQuery extracts that calendar/anniversary/timezone logic, so it must select on the exact same days.
+    [
+      {interval: :weekly, billing_time: :calendar, billed_on: ["20 Jun 2022", "27 Jun 2022", "04 Jul 2022"], not_billed_on: ["21 Jun 2022"]},
+      {interval: :weekly, billing_time: :anniversary, billed_on: ["25 Jun 2022", "02 Jul 2022", "09 Jul 2022"], not_billed_on: ["26 Jun 2022"]},
+      {interval: :monthly, billing_time: :calendar, billed_on: ["01 Jul 2022", "01 Aug 2022", "01 Sep 2022"], not_billed_on: ["02 Jul 2022"]},
+      {interval: :monthly, billing_time: :anniversary, billed_on: ["20 Jun 2022", "20 Jul 2022", "20 Aug 2022"], not_billed_on: ["21 Jul 2022"]},
+      # 31st day monthly subscription (month normalization)
+      {
+        interval: :monthly,
+        billing_time: :anniversary,
+        subscription_at: "31 March 2021",
+        billed_on: ["28 Feb 2023", "29 Feb 2024", "30 Apr 2023", "31 Jan 2023"],
+        not_billed_on: ["27 Feb 2023"]
+      },
+      {
+        interval: :quarterly,
+        billing_time: :calendar,
+        billed_on: ["01 Jul 2022", "01 Oct 2022", "01 Jan 2023", "01 Apr 2030"],
+        not_billed_on: ["01 Feb 2022", "01 Mar 2022", "01 Dec 2023"]
+      },
+      # Quarterly cycle: Aug/Nov/Feb/May
+      {
+        interval: :quarterly,
+        billing_time: :anniversary,
+        billed_on: ["20 Aug 2022", "20 Nov 2022", "20 Feb 2023", "20 May 2030"],
+        not_billed_on: ["20 Sep 2022"]
+      },
+      # Quarterly cycle: Jan/Apr/Jul/Oct
+      {
+        interval: :quarterly,
+        billing_time: :anniversary,
+        subscription_at: "15 January 2021",
+        billed_on: ["15 Jul 2022", "15 Oct 2022", "15 Jan 2023", "15 Apr 2024"]
+      },
+      # Quarterly cycle: Mar/Jun/Sep/Dec
+      {
+        interval: :quarterly,
+        billing_time: :anniversary,
+        subscription_at: "15 March 2021",
+        billed_on: ["15 Jun 2022", "15 Sep 2022", "15 Dec 2022", "15 Mar 2023"]
+      },
+      # 31st day quarterly subscription (month normalization)
+      {
+        interval: :quarterly,
+        billing_time: :anniversary,
+        subscription_at: "31 May 2021",
+        billed_on: ["28 Feb 2023", "29 Feb 2024", "30 Nov 2023", "31 Aug 2023"]
+      },
+      # 30th day quarterly subscription (month normalization)
+      {
+        interval: :quarterly,
+        billing_time: :anniversary,
+        subscription_at: "30 May 2021",
+        billed_on: ["28 Feb 2023", "29 Feb 2024", "30 Nov 2023", "30 Aug 2023"],
+        not_billed_on: ["31 Aug 2023"]
+      },
+      {
+        interval: :semiannual,
+        billing_time: :calendar,
+        billed_on: ["01 Jul 2022", "01 Jan 2023", "01 Jul 2030"],
+        not_billed_on: ["01 Oct 2022"]
+      },
+      {
+        interval: :semiannual,
+        billing_time: :anniversary,
+        billed_on: ["20 Aug 2022", "20 Feb 2023", "20 Aug 2030"],
+        not_billed_on: ["20 Nov 2022"]
+      },
+      # 31st day semiannual subscription (month normalization)
+      {
+        interval: :semiannual,
+        billing_time: :anniversary,
+        subscription_at: "31 Aug 2021",
+        billed_on: ["28 Feb 2023", "29 Feb 2024", "31 Aug 2023"]
+      },
+      # 30th day semiannual subscription (month normalization)
+      {
+        interval: :semiannual,
+        billing_time: :anniversary,
+        subscription_at: "30 Aug 2021",
+        billed_on: ["28 Feb 2023", "29 Feb 2024", "30 Aug 2023"],
+        not_billed_on: ["31 Aug 2023"]
+      },
+      {
+        interval: :semiannual,
+        billing_time: :calendar,
+        bill_charges_monthly: true,
+        billed_on: ["01 Aug 2022"],
+        not_billed_on: ["02 Aug 2022"]
+      },
+      {
+        interval: :semiannual,
+        billing_time: :anniversary,
+        bill_charges_monthly: true,
+        billed_on: ["20 Jul 2022"],
+        not_billed_on: ["21 Jul 2022"]
+      },
+      # 31st day semiannual subscription with monthly charges (month normalization)
+      {
+        interval: :semiannual,
+        billing_time: :anniversary,
+        bill_charges_monthly: true,
+        subscription_at: "31 Aug 2021",
+        billed_on: ["28 Feb 2023", "29 Feb 2024", "30 Jun 2022", "31 Jul 2022"]
+      },
+      # Semiannual / yearly with monthly FIXED charges (bills monthly on the anchor day)
+      {
+        interval: :semiannual,
+        billing_time: :calendar,
+        bill_fixed_charges_monthly: true,
+        billed_on: ["01 Aug 2022", "01 Sep 2022"],
+        not_billed_on: ["02 Aug 2022"]
+      },
+      {
+        interval: :semiannual,
+        billing_time: :anniversary,
+        bill_fixed_charges_monthly: true,
+        billed_on: ["20 Jul 2022", "20 Aug 2022"],
+        not_billed_on: ["21 Jul 2022"]
+      },
+      {
+        interval: :yearly,
+        billing_time: :calendar,
+        billed_on: ["01 Jan 2023", "01 Jan 2024", "01 Jan 2030"],
+        not_billed_on: ["01 Feb 2023", "01 Dec 2022"]
+      },
+      {
+        interval: :yearly,
+        billing_time: :anniversary,
+        billed_on: ["20 Feb 2023", "20 Feb 2024", "20 Feb 2030"],
+        not_billed_on: ["20 Jan 2023", "20 Mar 2023"]
+      },
+      # Non-leap year Feb 28 subscription
+      {
+        interval: :yearly,
+        billing_time: :anniversary,
+        subscription_at: "28 Feb 2021",
+        billed_on: ["28 Feb 2023", "28 Feb 2024", "28 Feb 2030"]
+      },
+      # Leap year Feb 29 subscription
+      {
+        interval: :yearly,
+        billing_time: :anniversary,
+        subscription_at: "29 Feb 2020",
+        billed_on: ["28 Feb 2023", "29 Feb 2024", "28 Feb 2030"]
+      },
+      {
+        interval: :yearly,
+        billing_time: :calendar,
+        bill_charges_monthly: true,
+        billed_on: ["01 Aug 2022", "01 Sep 2022", "01 Oct 2022"],
+        not_billed_on: ["02 Aug 2022", "31 Aug 2022"]
+      },
+      {
+        interval: :yearly,
+        billing_time: :anniversary,
+        bill_charges_monthly: true,
+        billed_on: ["20 Jul 2022", "20 Aug 2022", "20 Sep 2022"],
+        not_billed_on: ["21 Jul 2022", "19 Jul 2022"]
+      },
+      {
+        interval: :yearly,
+        billing_time: :anniversary,
+        bill_fixed_charges_monthly: true,
+        billed_on: ["20 Jul 2022", "20 Aug 2022"],
+        not_billed_on: ["21 Jul 2022"]
+      }
+    ].each do |test_case|
+      case_subscription_at = test_case[:subscription_at] || "20 Feb 2021"
+      case_interval = test_case[:interval]
+      case_billing_time = test_case[:billing_time] || :calendar
+      case_bcm = test_case.fetch(:bill_charges_monthly, false)
+      case_bfcm = test_case.fetch(:bill_fixed_charges_monthly, false)
+      case_billed_on = test_case[:billed_on].map { DateTime.parse(it) }
+      case_not_billed_on = test_case.fetch(:not_billed_on, []).map { DateTime.parse(it) }
+
+      charges_label = " with monthly charges" if case_bcm
+      charges_label = " with monthly fixed charges" if case_bfcm
+      describe "#{case_interval} #{case_billing_time}#{charges_label}, subscribed on #{case_subscription_at}" do
+        let(:interval) { case_interval }
+        let(:billing_time) { case_billing_time }
+        let(:bill_charges_monthly) { case_bcm }
+        let(:bill_fixed_charges_monthly) { case_bfcm }
+        let(:subscription_at) { DateTime.parse(case_subscription_at) }
+
+        case_billed_on.each do |billed_on|
+          context "when on the billing day (#{billed_on.to_date})" do
+            let(:timestamp) { billed_on }
+
+            it "selects the subscription" do
+              expect(selected?).to be(true)
+            end
+          end
+        end
+
+        case_not_billed_on.each do |not_billed_on|
+          context "when on a non-billing day (#{not_billed_on.to_date})" do
+            let(:timestamp) { not_billed_on }
+
+            it "does not select the subscription" do
+              expect(selected?).to be(false)
+            end
+          end
+        end
+      end
+    end
+
+    describe "timezone handling" do
+      # Monthly calendar plan bills on the 1st.
+      let(:interval) { :monthly }
+      let(:billing_time) { :calendar }
+
+      context "when it is not yet the billing day in the customer timezone" do
+        let(:customer_timezone) { "America/Chicago" }
+        let(:timestamp) { DateTime.parse("01 Jul 2022 00:30") } # still 30 Jun in Chicago
+
+        it "does not select the subscription" do
+          expect(selected?).to be(false)
+        end
+      end
+
+      context "when it is the billing day in the customer timezone" do
+        let(:customer_timezone) { "America/Chicago" }
+        let(:timestamp) { DateTime.parse("01 Jul 2022 12:00") } # 1 Jul in Chicago
+
+        it "selects the subscription" do
+          expect(selected?).to be(true)
+        end
+      end
+
+      context "when it is already past the billing day in the customer timezone" do
+        let(:customer_timezone) { "Pacific/Auckland" }
+        let(:timestamp) { DateTime.parse("01 Jul 2022 18:00") } # 2 Jul in Auckland
+
+        it "does not select the subscription" do
+          expect(selected?).to be(false)
+        end
+      end
+
+      context "when the customer has no timezone" do
+        let(:customer_timezone) { nil }
+        let(:billing_entity_timezone) { "America/Chicago" }
+        let(:timestamp) { DateTime.parse("01 Jul 2022 00:30") } # still 30 Jun in the billing entity tz
+
+        it "falls back to the billing entity timezone" do
+          expect(selected?).to be(false)
+        end
+      end
+    end
+
+    context "when the subscription does not bill on the given day" do
+      let(:interval) { :monthly }
+      let(:billing_time) { :calendar }
+      let(:timestamp) { DateTime.parse("15 Jul 2022 12:00") }
+
+      it "returns an empty scope" do
+        expect(result.subscriptions).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

`DailyUsages::ComputeAllService` only scheduled a `ComputeJob` for subscriptions whose `last_received_event_on` was recent. But some subscriptions accrue usage between billing boundaries *without* receiving new events:

- **prorated charges** and **weighted_sum aggregations** — their value changes daily (time-weighted), even with no events;
- **recurring billable metrics** — their value is carried over and stays constant within a period, changing only at the period rollover.

These were silently skipped, so their daily usage went stale until the next event arrived — and then the whole gap was rolled into a single day.

## Description

Schedule a `ComputeJob` for three disjoint sets of subscriptions, per organization, restricted to customers entering a new day in their timezone:

1. **Recent events** — `last_received_event_on >= yesterday` (unchanged).
2. **Daily time-dependent** — plans with a prorated charge or a weighted_sum aggregation; recomputed every day.
3. **Recurring rollover** — plans with a recurring billable metric; recomputed **once per period** (on the run following the period rollover, since the value is constant in between). The rollover calendar is computed by the new `Subscriptions::BillingDateQuery`, which shares its calendar/anniversary/timezone logic with `Subscriptions::OrganizationBillingService`.

The plan-based sets are selected via a `plan_id` **subquery (semi-join)** instead of a correlated `EXISTS`, which was catastrophic on plan-per-subscription organizations.

Each selection query runs **once per organization** (the ids are `pluck`ed and unioned into a `Set`), already-computed subscriptions are removed in a single dedup query, and the survivors are enqueued by primary key in bounded batches. This avoids re-executing the heavy selection query per `find_each` batch.

### Performance

All numbers measured in production on the worst-case day (start of month, when every calendar-monthly period rolls over), across **all organizations**.

| Approach | Time |
|---|---|
| **Final** — 3 semi-join legs + `pluck`/`Set` + dedup subtract | **~52s** |


> [!NOTE]
> This increases the daily `ComputeJob` volume, since time-dependent and recurring subscriptions are now scheduled even without events. Watch the `analytics` queue latency after deploy; the existing 30-min scheduling jitter spreads the load. Subscriptions opted out via `skip_daily_usage` are still excluded, and the `ComputeJob` unique lock / `ComputeService#existing_daily_usage` keep computation idempotent.
