### PR TITLE
ING 255/254 filter by single BE

### DIFF
--- a/app/controllers/api/v1/customers/wallets_controller.rb
+++ b/app/controllers/api/v1/customers/wallets_controller.rb
@@ -29,11 +29,15 @@ module Api
         end
 
         def index
-          permitted_params = params.permit(:currency, billing_entity_codes: [])
+          permitted_params = params.permit(:currency, :billing_entity_code, billing_entity_codes: [])
+          billing_entity_codes = (
+            Array.wrap(permitted_params[:billing_entity_codes]) +
+            Array.wrap(permitted_params[:billing_entity_code])
+          ).compact_blank.uniq.presence
           wallet_index(
             external_customer_id: customer.external_id,
             currency: permitted_params[:currency],
-            billing_entity_codes: permitted_params[:billing_entity_codes]
+            billing_entity_codes: billing_entity_codes
           )
         end
 

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -28,10 +28,18 @@ module Api
       end
 
       def index
-        permitted_params = params.permit(:external_customer_id, :currency, billing_entity_codes: [])
+        permitted_params = params.permit(
+          :external_customer_id,
+          :currency,
+          :billing_entity_code,
+          billing_entity_codes: []
+        )
         external_customer_id = permitted_params[:external_customer_id]
         currency = permitted_params[:currency]
-        billing_entity_codes = permitted_params[:billing_entity_codes]
+        billing_entity_codes = (
+          Array.wrap(permitted_params[:billing_entity_codes]) +
+          Array.wrap(permitted_params[:billing_entity_code])
+        ).compact_blank.uniq.presence
 
         wallet_index(external_customer_id:, currency:, billing_entity_codes:)
       end

--- a/app/controllers/concerns/payment_request_index.rb
+++ b/app/controllers/concerns/payment_request_index.rb
@@ -5,12 +5,15 @@ module PaymentRequestIndex
   extend ActiveSupport::Concern
 
   def payment_request_index(external_customer_id:)
-    filters = params.permit(:payment_status, :currency, billing_entity_codes: []).to_h
-    billing_entity_codes = filters.delete(:billing_entity_codes)
+    filters = params.permit(:payment_status, :currency, :billing_entity_code, billing_entity_codes: []).to_h
+    billing_entity_codes = (
+      Array.wrap(filters.delete(:billing_entity_codes)) +
+      Array.wrap(filters.delete(:billing_entity_code))
+    ).compact_blank.uniq
 
     if billing_entity_codes.present?
       billing_entities = current_organization.all_billing_entities.where(code: billing_entity_codes)
-      return not_found_error(resource: "billing_entity") if billing_entities.count != billing_entity_codes.uniq.count
+      return not_found_error(resource: "billing_entity") if billing_entities.count != billing_entity_codes.count
 
       filters[:billing_entity_ids] = billing_entities.ids
     end

--- a/app/controllers/concerns/subscription_index.rb
+++ b/app/controllers/concerns/subscription_index.rb
@@ -5,8 +5,15 @@ module SubscriptionIndex
   extend ActiveSupport::Concern
 
   def subscription_index(external_customer_id: nil)
-    billing_entities = current_organization.all_billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
-    return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count
+    billing_entity_codes = (
+      Array.wrap(params[:billing_entity_codes]) +
+      Array.wrap(params[:billing_entity_code])
+    ).compact_blank.uniq
+
+    if billing_entity_codes.present?
+      billing_entities = current_organization.all_billing_entities.where(code: billing_entity_codes)
+      return not_found_error(resource: "billing_entity") if billing_entities.count != billing_entity_codes.count
+    end
 
     filters = params.permit(:plan_code, :overriden, :overridden, :currency, status: [])
     filters[:status] = ["active"] if filters[:status].blank?

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -136,6 +136,38 @@ RSpec.describe Api::V1::PaymentRequestsController do
           expect(response).to be_not_found_error("billing_entity")
         end
       end
+
+      context "with the scalar billing_entity_code form" do
+        it "returns only payment requests under the requested billing entity" do
+          get_with_token(organization, "/api/v1/payment_requests?billing_entity_code=EU")
+
+          expect(response).to have_http_status(:success)
+          expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(payment_request_eu.id)
+        end
+
+        context "when the scalar billing_entity_code is unknown" do
+          it "returns a not found error" do
+            get_with_token(organization, "/api/v1/payment_requests?billing_entity_code=BOGUS")
+
+            expect(response).to be_not_found_error("billing_entity")
+          end
+        end
+
+        context "when combined with the bracketed form" do
+          it "unions both inputs into the filter" do
+            get_with_token(
+              organization,
+              "/api/v1/payment_requests?billing_entity_code=EU&billing_entity_codes[]=US"
+            )
+
+            expect(response).to have_http_status(:success)
+            expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(
+              payment_request_eu.id,
+              payment_request_us.id
+            )
+          end
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -117,6 +117,35 @@ RSpec.describe Api::V1::WalletsController do
           expect(response).to be_not_found_error("billing_entity")
         end
       end
+
+      context "with the scalar billing_entity_code form" do
+        it "returns only wallets under the requested billing entity" do
+          get_with_token(organization, "/api/v1/wallets?billing_entity_code=EU")
+
+          expect(response).to have_http_status(:success)
+          expect(json[:wallets].map { |w| w[:lago_id] }).to contain_exactly(wallet_eu.id)
+        end
+
+        context "when the scalar billing_entity_code is unknown" do
+          it "returns a not found error" do
+            get_with_token(organization, "/api/v1/wallets?billing_entity_code=BOGUS")
+
+            expect(response).to be_not_found_error("billing_entity")
+          end
+        end
+
+        context "when combined with the bracketed form" do
+          it "unions both inputs into the filter" do
+            get_with_token(
+              organization,
+              "/api/v1/wallets?billing_entity_code=EU&billing_entity_codes[]=US"
+            )
+
+            expect(response).to have_http_status(:success)
+            expect(json[:wallets].map { |w| w[:lago_id] }).to contain_exactly(wallet_eu.id, wallet_us.id)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_examples/subscription_index.rb
+++ b/spec/support/shared_examples/subscription_index.rb
@@ -192,6 +192,38 @@ RSpec.shared_examples "a subscription index endpoint" do
         expect(response).to be_not_found_error("billing_entity")
       end
     end
+
+    context "with the scalar billing_entity_code form" do
+      let(:params) { {billing_entity_code: eu_entity.code} }
+
+      it "returns only subscriptions stamped under that entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscriptions].pluck(:lago_id)).to eq([eu_subscription.id])
+      end
+
+      context "when the scalar code does not exist" do
+        let(:params) { {billing_entity_code: "unknown"} }
+
+        it "returns a not found error" do
+          subject
+
+          expect(response).to be_not_found_error("billing_entity")
+        end
+      end
+
+      context "when combined with the bracketed form" do
+        let(:params) { {billing_entity_code: eu_entity.code, billing_entity_codes: [us_entity.code]} }
+
+        it "unions both inputs into the filter" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:subscriptions].pluck(:lago_id)).to match_array([eu_subscription.id, us_subscription.id])
+        end
+      end
+    end
   end
 
   context "with N+1 query detection", bullet: {n_plus_one_query: true, unused_eager_loading: false} do


### PR DESCRIPTION
## Context

`billing_entity_code` (scalar) was silently dropped on `GET /wallets`, `GET /subscriptions`, and `GET /payment_requests`. The endpoints returned `200 OK` with the full unfiltered list and no error. Only the bracketed `billing_entity_codes[]=…` form was honoured, even though the scalar form is the shape in the dive-in QA plan (S69) and the OpenAPI spec — so any workflow scoping by entity through that parameter was getting wrong data.

**Closes ING-255 and ING-254** (sister ticket flagging the same gap on `/payment_requests`).

## Fix

The bug lived only in the param-parsing layer — controllers/concerns inspected `:billing_entity_codes` but not `:billing_entity_code`. The query layer (`WalletsQuery` / `SubscriptionsQuery` / `PaymentRequestsQuery`) already accepts a list of IDs correctly. So the fix is the same one-line pattern in three places: permit both params, `Array.wrap` each, union, dedupe.

After this PR, all of these work the same way and produce the same result:

```
?billing_entity_code=acme_eu
?billing_entity_codes[]=acme_eu
?billing_entity_code=acme_eu&billing_entity_codes[]=acme_us   (union)
```

Unknown codes still return `404 billing_entity_not_found` in either form.

## Commits

| Commit | Subject | Where |
|---|---|---|
| `8b332cef4` | `feat(wallets): accept scalar entity code` | both wallets controllers |
| `b4179cff7` | `feat(subscriptions): accept scalar code` | `SubscriptionIndex` concern |
| `eb0b2ce30` | `feat(payment-requests): scalar code` | `PaymentRequestIndex` concern |

Each commit includes the matching spec additions (single code, unknown-code 404, scalar + bracketed union). The two concerns are shared between the top-level and customer-scoped controllers, so all six endpoints get the fix.

## How to test

```
lago exec api bundle exec rspec \
  spec/requests/api/v1/wallets_controller_spec.rb \
  spec/requests/api/v1/customers/wallets_controller_spec.rb \
  spec/requests/api/v1/subscriptions_controller_spec.rb \
  spec/requests/api/v1/customers/subscriptions_controller_spec.rb \
  spec/requests/api/v1/payment_requests_controller_spec.rb \
  spec/requests/api/v1/customers/payment_requests_controller_spec.rb
```