### PR TITLE
perf(subscriptions): Speed up SubscriptionsQuery with index on order fields

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -350,6 +350,7 @@ end
 #
 # Indexes
 #
+#  idx_on_organization_id_subscription_at_created_at_id        (organization_id,subscription_at DESC NULLS LAST,created_at DESC,id)
 #  index_subscriptions_on_billing_entity_id                    (billing_entity_id)
 #  index_subscriptions_on_customer_id                          (customer_id)
 #  index_subscriptions_on_ending_at_active                     (ending_at) WHERE ((status = 1) AND (ending_at IS NOT NULL))

--- a/db/migrate/20260603121349_add_index_on_subscription_at_and_created_at_and_id_to_subscriptions.rb
+++ b/db/migrate/20260603121349_add_index_on_subscription_at_and_created_at_and_id_to_subscriptions.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddIndexOnSubscriptionAtAndCreatedAtAndIdToSubscriptions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_index(
+        :subscriptions,
+        [:organization_id, :subscription_at, :created_at, :id],
+        order: {subscription_at: "DESC NULLS LAST", created_at: :desc},
+        name: :idx_on_organization_id_subscription_at_created_at_id,
+        algorithm: :concurrently
+      )
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -809,6 +809,7 @@ DROP INDEX IF EXISTS public.idx_on_subscription_id_295edd8bb3;
 DROP INDEX IF EXISTS public.idx_on_recurring_transaction_rule_id_fba3d39cca;
 DROP INDEX IF EXISTS public.idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb;
 DROP INDEX IF EXISTS public.idx_on_outbound_wallet_transaction_id_cf6ff733c6;
+DROP INDEX IF EXISTS public.idx_on_organization_id_subscription_at_created_at_id;
 DROP INDEX IF EXISTS public.idx_on_organization_id_organization_sequential_id_2387146f54;
 DROP INDEX IF EXISTS public.idx_on_organization_id_external_subscription_id_df3a30d96d;
 DROP INDEX IF EXISTS public.idx_on_organization_id_e742f77454;
@@ -6649,6 +6650,13 @@ CREATE INDEX idx_on_organization_id_organization_sequential_id_2387146f54 ON pub
 
 
 --
+-- Name: idx_on_organization_id_subscription_at_created_at_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_organization_id_subscription_at_created_at_id ON public.subscriptions USING btree (organization_id, subscription_at DESC NULLS LAST, created_at DESC, id);
+
+
+--
 -- Name: idx_on_outbound_wallet_transaction_id_cf6ff733c6; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12466,6 +12474,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260603121349'),
 ('20260602092156'),
 ('20260601174030'),
 ('20260601120429'),


### PR DESCRIPTION
## Context

`SubscriptionsQuery` sorts subscriptions by `subscription_at`, `created_at`, and `id` for all subscription searches. Right now, the sorting happens in memory – using quicksort for smaller result sets and a top-N heapsort for larger ones – which ends up being pretty expensive.

For example, lets compare the following query with and without sorting:

```sql
SELECT
	*
FROM
	"subscriptions"
	LEFT JOIN subscriptions AS prev_subscriptions ON subscriptions.previous_subscription_id = prev_subscriptions.id
WHERE
	"subscriptions"."organization_id" = '11111111-2222-3333-4444-555555555555'
	AND (
		subscriptions.previous_subscription_id IS NULL
		OR prev_subscriptions.status = 2
		OR subscriptions.status = 3
	)
ORDER BY
	subscriptions.subscription_at DESC NULLS LAST,
	subscriptions.created_at DESC,
	"subscriptions"."id" ASC
LIMIT
	20
OFFSET
	0
```

### Without Sorting

Without sorting, the query completes in just a few milliseconds, even on databases with 1M–10M subscriptions.

```sql
Limit  (cost=0.56..94.62 rows=20 width=522) (actual time=0.017..0.035 rows=20 loops=1)
  -> Nested Loop Left Join (cost=0.56..61283262.37 rows=13030895 width=522) (actual time=0.016..0.032 rows=20 loops=1)
    Filter: ((subscriptions.previous_subscription_id IS NULL) OR (prev_subscriptions.status = 2) OR (subscriptions.status = 3))
    -> Seq Scan on subscriptions  (cost=0.00..629381.66 rows=13259559 width=261) (actual time=0.011..0.019 rows=20 loops=1)
      Filter: (organization_id = '11111111-2222-3333-4444-555555555555'::uuid)
      Rows Removed by Filter: 1
      -> Index Scan using subscriptions_pkey on subscriptions prev_subscriptions (cost=0.56..4.56 rows=1 width=261) (actual time=0.000..0.000 rows=0 loops=20)
        Index Cond: (id = subscriptions.previous_subscription_id)
Planning Time: 0.381 ms
Execution Time: 0.129 ms
```

### With Sorting

With sorting, the query takes around 700ms on average for 1M subscriptions and can take up to ~60 seconds for 10M subscriptions.

```sql
Limit (cost=2096668.71..2096671.04 rows=20 width=522) (actual time=59127.534..59882.681 rows=20 loops=1)
  -> Gather Merge (cost=2096668.71..3363649.83 rows=10859080 width=522) (actual time=59127.532..59882.676 rows=20 loops=1)
      Workers Planned: 2
      Workers Launched: 2
      -> Sort (cost=2095668.68..2109242.53 rows=5429540 width=522) (actual time=59113.629..59113.795 rows=14 loops=3)
        Sort Key: subscriptions.subscription_at DESC NULLS LAST, subscriptions.created_at DESC, subscriptions.id
        Sort Method: top-N heapsort  Memory: 35kB
        Worker 0: Sort Method: top-N heapsort  Memory: 35kB
        Worker 1: Sort Method: top-N heapsort  Memory: 34kB
        -> Parallel Hash Left Join (cost=806052.24..1951190.58 rows=5429540 width=522) (actual time=50273.263..55215.907 rows=4419608 loops=3)
          Hash Cond: (subscriptions.previous_subscription_id = prev_subscriptions.id)
          Filter: ((subscriptions.previous_subscription_id IS NULL) OR (prev_subscriptions.status = 2) OR (subscriptions.status = 3))
            -> Parallel Seq Scan on subscriptions  (cost=0.00..517590.69 rows=5524816 width=261) (actual time=0.030..10214.101 rows=4419608 loops=3)
              Filter: (organization_id = '11111111-2222-3333-4444-555555555555'::uuid)
              Rows Removed by Filter: 695582
            -> Parallel Hash  (cost=501620.55..501620.55 rows=6388055 width=261) (actual time=25836.194..25836.195 rows=5115190 loops=3)
              Buckets: 16384  Batches: 2048  Memory Usage: 1920kB
              -> Parallel Seq Scan on subscriptions prev_subscriptions  (cost=0.00..501620.55 rows=6388055 width=261) (actual time=0.023..11863.287 rows=5115190 loops=3)
Planning Time: 0.603 ms
Execution Time: 59882.766 ms
```

## Description

To address the slow sorting, this PR adds an index that matches the sort order used by `SubscriptionsQuery`:

```sql
(organization_id, subscription_at DESC NULLS LAST, created_at DESC, id)
```

Combined with a `LIMIT`, this lets Postgres scan the index and return records in the correct order directly, instead of loading and sorting them in memory. As a result, queries with sorting are also completed in just a few milliseconds.

```sql
Limit  (cost=0.85..16.58 rows=20 width=528) (actual time=0.033..0.045 rows=20 loops=1)
  ->  Nested Loop Left Join  (cost=0.85..770957.48 rows=980343 width=528) (actual time=0.032..0.044 rows=20 loops=1)
        Filter: ((subscriptions.previous_subscription_id IS NULL) OR (prev_subscriptions.status = 2) OR (subscriptions.status = 3))
        ->  Index Scan using idx_on_organization_id_subscription_at_created_at_id on subscriptions  (cost=0.43..158643.70 rows=980343 width=264) (actual time=0.025..0.031 rows=20 loops=1)
"              Index Cond: (organization_id = '11111111-2222-3333-4444-555555555555'::uuid)"
        ->  Index Scan using subscriptions_pkey on subscriptions prev_subscriptions  (cost=0.43..0.61 rows=1 width=264) (actual time=0.000..0.000 rows=0 loops=20)
              Index Cond: (id = subscriptions.previous_subscription_id)
Planning Time: 0.201 ms
Execution Time: 0.107 ms
```

## Benchmarks

Here are some benchmarks without index (before) and with index (after).

Benchmarking was done with `pgbench` on a database containing **~1.2m** subscriptions. The benchmark used 10 clients and 5 threads, ran for 30 seconds against a warmed-up database. 

```
pgbench --protocol=prepared -c 10 -j 5 -T 30 -h localhost -U lago -d lago -n -f subscriptions.sql
```

Solution | TPS | Latency (ms)
-- | -- | --
without index (before) | 5.82 | 1718.333
with index (after) | 13041.6 | 0.767