### PR TITLE
fix(payment_requests): Do not flip succeeded invoices back to failed

### DIFF
--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -121,6 +121,8 @@ module PaymentRequests
 
       def update_invoices_payment_status(payment_status:, deliver_webhook: true)
         payable.invoices.each do |invoice|
+          next if invoice.payment_succeeded? && !payment_status_succeeded?(payment_status)
+
           Invoices::UpdateService.call(
             invoice:,
             params: {

--- a/app/services/payment_requests/payments/cashfree_service.rb
+++ b/app/services/payment_requests/payments/cashfree_service.rb
@@ -132,6 +132,8 @@ module PaymentRequests
 
       def update_invoices_payment_status(payment_status:, deliver_webhook: true)
         payable.invoices.each do |invoice|
+          next if invoice.payment_succeeded? && !payment_status_succeeded?(payment_status)
+
           Invoices::UpdateService.call(
             invoice:,
             params: {

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -136,6 +136,8 @@ module PaymentRequests
 
       def update_invoices_payment_status(payment_status:)
         payable.invoices.each do |invoice|
+          next if invoice.payment_succeeded? && payment_status.to_sym != :succeeded
+
           Invoices::UpdateService.call!(
             invoice:,
             params: {

--- a/app/services/payment_requests/payments/flutterwave_service.rb
+++ b/app/services/payment_requests/payments/flutterwave_service.rb
@@ -182,6 +182,8 @@ module PaymentRequests
 
       def update_invoices_payment_status(payment_status:, deliver_webhook: true)
         payable.invoices.each do |invoice|
+          next if invoice.payment_succeeded? && !payment_status_succeeded?(payment_status)
+
           Invoices::UpdateService.call(
             invoice:,
             params: {

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -83,6 +83,8 @@ module PaymentRequests
 
       def update_invoices_payment_status(payment_status:, deliver_webhook: true)
         result.payable.invoices.each do |invoice|
+          next if invoice.payment_succeeded? && !payment_status_succeeded?(payment_status)
+
           Invoices::UpdateService.call(
             invoice:,
             params: {

--- a/app/services/payment_requests/payments/moneyhash_service.rb
+++ b/app/services/payment_requests/payments/moneyhash_service.rb
@@ -204,6 +204,8 @@ module PaymentRequests
 
       def update_invoices_payment_status(payment_status:, deliver_webhook: true, processing: false)
         result.payable.invoices.each do |invoice|
+          next if invoice.payment_succeeded? && payment_status.to_sym != :succeeded
+
           Invoices::UpdateService.call(
             invoice: invoice,
             params: {

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -123,6 +123,8 @@ module PaymentRequests
 
       def update_invoices_payment_status(payment_status:, deliver_webhook: true, processing: false)
         result.payable.invoices.each do |invoice|
+          next if invoice.payment_succeeded? && !payment_status_succeeded?(payment_status)
+
           Invoices::UpdateService.call(
             invoice: invoice,
             params: {

--- a/spec/services/payment_requests/payments/adyen_service_spec.rb
+++ b/spec/services/payment_requests/payments/adyen_service_spec.rb
@@ -260,6 +260,26 @@ RSpec.describe PaymentRequests::Payments::AdyenService do
       end
     end
 
+    context "when a failed webhook arrives after the invoices were already paid through another path" do
+      let(:status) { "Refused" }
+
+      before do
+        payment_request.payment_failed!
+        invoice_1.payment_succeeded!
+        invoice_2.payment_succeeded!
+      end
+
+      it "leaves already-succeeded invoices untouched" do
+        expect { result }
+          .to not_change { invoice_1.reload.payment_status }
+          .and not_change { invoice_2.reload.payment_status }
+
+        expect(result).to be_success
+        expect(invoice_1.reload).to be_payment_succeeded
+        expect(invoice_2.reload).to be_payment_succeeded
+      end
+    end
+
     context "with invalid status" do
       let(:status) { "invalid-status" }
 

--- a/spec/services/payment_requests/payments/cashfree_service_spec.rb
+++ b/spec/services/payment_requests/payments/cashfree_service_spec.rb
@@ -218,6 +218,32 @@ RSpec.describe PaymentRequests::Payments::CashfreeService do
       end
     end
 
+    context "when a failed webhook arrives after the invoices were already paid through another path" do
+      let(:cashfree_payment) do
+        PaymentProviders::CashfreeProvider::CashfreePayment.new(
+          id: payment_request.id,
+          status: "EXPIRED",
+          metadata: {}
+        )
+      end
+
+      before do
+        payment_request.payment_failed!
+        invoice_1.payment_succeeded!
+        invoice_2.payment_succeeded!
+      end
+
+      it "leaves already-succeeded invoices untouched" do
+        expect { result }
+          .to not_change { invoice_1.reload.payment_status }
+          .and not_change { invoice_2.reload.payment_status }
+
+        expect(result).to be_success
+        expect(invoice_1.reload).to be_payment_succeeded
+        expect(invoice_2.reload).to be_payment_succeeded
+      end
+    end
+
     context "with invalid status" do
       let(:cashfree_payment) do
         PaymentProviders::CashfreeProvider::CashfreePayment.new(

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -259,6 +259,22 @@ RSpec.describe PaymentRequests::Payments::CreateService do
             .to have_enqueued_mail(PaymentRequestMailer, :requested)
             .with(params: {payment_request:}, args: [])
         end
+
+        context "when invoices were already paid through another path" do
+          before do
+            invoice_1.payment_succeeded!
+            invoice_2.payment_succeeded!
+          end
+
+          it "leaves already-succeeded invoices untouched" do
+            expect { create_service.call }
+              .to not_change { invoice_1.reload.payment_status }
+              .and not_change { invoice_2.reload.payment_status }
+
+            expect(invoice_1.reload).to be_payment_succeeded
+            expect(invoice_2.reload).to be_payment_succeeded
+          end
+        end
       end
 
       context "when manual payment method is passed in params" do

--- a/spec/services/payment_requests/payments/flutterwave_service_spec.rb
+++ b/spec/services/payment_requests/payments/flutterwave_service_spec.rb
@@ -249,6 +249,25 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
         expect(PaymentRequestMailer).to have_received(:with).with(payment_request: payment_request)
       end
     end
+
+    context "when a failed webhook arrives after the invoice was already paid through another path" do
+      before do
+        payment_request.payment_failed!
+        invoice.payment_succeeded!
+      end
+
+      it "leaves the already-succeeded invoice untouched" do
+        expect do
+          flutterwave_service.update_payment_status(
+            organization_id: organization.id,
+            status: :failed,
+            flutterwave_payment: flutterwave_payment
+          )
+        end.not_to change { invoice.reload.payment_status }
+
+        expect(invoice.reload).to be_payment_succeeded
+      end
+    end
   end
 
   describe "private methods" do

--- a/spec/services/payment_requests/payments/gocardless_service_spec.rb
+++ b/spec/services/payment_requests/payments/gocardless_service_spec.rb
@@ -198,6 +198,26 @@ RSpec.describe PaymentRequests::Payments::GocardlessService do
       end
     end
 
+    context "when a failed webhook arrives after the invoice was already paid through another path" do
+      let(:status) { "failed" }
+
+      before do
+        payment_request.payment_failed!
+        invoice_1.payment_succeeded!
+        invoice_2.payment_succeeded!
+      end
+
+      it "leaves already-succeeded invoices untouched" do
+        expect { result }
+          .to not_change { invoice_1.reload.payment_status }
+          .and not_change { invoice_2.reload.payment_status }
+
+        expect(result).to be_success
+        expect(invoice_1.reload).to be_payment_succeeded
+        expect(invoice_2.reload).to be_payment_succeeded
+      end
+    end
+
     context "with invalid status" do
       let(:status) { "invalid-status" }
 

--- a/spec/services/payment_requests/payments/moneyhash_service_spec.rb
+++ b/spec/services/payment_requests/payments/moneyhash_service_spec.rb
@@ -305,5 +305,26 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
         expect(payable.reload.payment_status).to eq("succeeded")
       end
     end
+
+    context "when a failed webhook arrives after the invoices were already paid through another path" do
+      before do
+        payable.payment_failed!
+        invoice_1.payment_succeeded!
+        invoice_2.payment_succeeded!
+      end
+
+      it "leaves already-succeeded invoices untouched" do
+        result = moneyhash_service.update_payment_status(
+          organization_id: organization.id,
+          provider_payment_id: payment_response_json.dig("data", "id"),
+          status: "FAILED",
+          metadata: payment_response_json.dig("data", "custom_fields")
+        )
+
+        expect(result).to be_success
+        expect(invoice_1.reload).to be_payment_succeeded
+        expect(invoice_2.reload).to be_payment_succeeded
+      end
+    end
   end
 end

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -443,6 +443,26 @@ RSpec.describe PaymentRequests::Payments::StripeService do
       end
     end
 
+    context "when a failed webhook arrives after the invoice was already paid through another path" do
+      let(:status) { "failed" }
+
+      before do
+        payment_request.payment_failed!
+        invoice_1.payment_succeeded!
+        invoice_2.payment_succeeded!
+      end
+
+      it "leaves already-succeeded invoices untouched" do
+        expect { result }
+          .to not_change { invoice_1.reload.payment_status }
+          .and not_change { invoice_2.reload.payment_status }
+
+        expect(result).to be_success
+        expect(invoice_1.reload).to be_payment_succeeded
+        expect(invoice_2.reload).to be_payment_succeeded
+      end
+    end
+
     context "with invalid status" do
       let(:status) { "invalid-status" }
 


### PR DESCRIPTION
## Context

When a Stripe PaymentRequest payable PaymentIntent auto-cancels after ~24h, the payment_intent.canceled webhook is routed through PaymentIntentPaymentFailedService. The PR-payable guard only checks payment_request.payment_succeeded?, so if the linked invoice was moved to succeeded by another path (e.g. manual API retry on the invoice), the cascade flipped it back to failed and the clock job re-marked it overdue.

## Description

Add a per-invoice guard in update_invoices_payment_status across all PR payment provider services (stripe, adyen, cashfree, flutterwave, gocardless, moneyhash, create_service): skip the update when the invoice is already payment_succeeded and the incoming status is not :succeeded.
