### PR TITLE
fix(wallets): Fix wallet increase refresh to be async

### DIFF
--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -18,7 +18,9 @@ module Customers
     retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
 
     def perform(customer, wallet_ids: nil)
-      return unless customer.awaiting_wallet_refresh?
+      # When targeting specific wallets, the refresh is explicitly requested (e.g. balance increase)
+      # so we don't rely on the customer-wide awaiting_wallet_refresh flag.
+      return if wallet_ids.nil? && !customer.awaiting_wallet_refresh?
       return if customer.error_details.tax_error.exists?
 
       Customers::RefreshWalletsService.call!(customer:, target_wallet_ids: wallet_ids)

--- a/app/services/wallets/balance/increase_service.rb
+++ b/app/services/wallets/balance/increase_service.rb
@@ -33,9 +33,8 @@ module Wallets
 
         # we only need to update all wallets when there is usage applied. In case we're increasing balance of only one wallet,
         # only this wallet will be affected and needs recalculation
-        Customers::RefreshWalletsService.call(customer: wallet.customer, target_wallet_ids: [wallet.id])
-
         after_commit do
+          Customers::RefreshWalletJob.perform_later(wallet.customer, wallet_ids: [wallet.id])
           SendWebhookJob.perform_later("wallet.updated", wallet)
           UsageMonitoring::ProcessWalletAlertsJob.perform_later(wallet)
         end

--- a/app/services/wallets/balance/increase_service.rb
+++ b/app/services/wallets/balance/increase_service.rb
@@ -33,11 +33,9 @@ module Wallets
 
         # we only need to update all wallets when there is usage applied. In case we're increasing balance of only one wallet,
         # only this wallet will be affected and needs recalculation
-        after_commit do
-          Customers::RefreshWalletJob.perform_later(wallet.customer, wallet_ids: [wallet.id])
-          SendWebhookJob.perform_later("wallet.updated", wallet)
-          UsageMonitoring::ProcessWalletAlertsJob.perform_later(wallet)
-        end
+        Customers::RefreshWalletJob.perform_after_commit(wallet.customer, wallet_ids: [wallet.id])
+        SendWebhookJob.perform_after_commit("wallet.updated", wallet)
+        UsageMonitoring::ProcessWalletAlertsJob.perform_after_commit(wallet)
 
         result.wallet = wallet
         result

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe Customers::RefreshWalletJob do
         subject
         expect(Customers::RefreshWalletsService).not_to have_received(:call)
       end
+
+      context "when wallet_ids are provided" do
+        let(:wallet_ids) { create_list(:wallet, 2, customer:).map(&:id) }
+
+        it "calls the Customers::RefreshWalletsService service scoped to the given wallets" do
+          subject
+          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:, target_wallet_ids: wallet_ids)
+        end
+      end
     end
 
     context "when customer is awaiting wallet refresh" do

--- a/spec/services/wallets/balance/increase_service_spec.rb
+++ b/spec/services/wallets/balance/increase_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Wallets::Balance::IncreaseService do
 
     it "enqueues a RefreshWalletJob targeting the wallet" do
       expect { create_service.call }
-        .to have_enqueued_job(Customers::RefreshWalletJob).with(wallet.customer, wallet_ids: [wallet.id])
+        .to have_enqueued_job_after_commit(Customers::RefreshWalletJob).with(wallet.customer, wallet_ids: [wallet.id])
     end
 
     it "sends a `wallet.updated` webhook" do

--- a/spec/services/wallets/balance/increase_service_spec.rb
+++ b/spec/services/wallets/balance/increase_service_spec.rb
@@ -38,11 +38,9 @@ RSpec.describe Wallets::Balance::IncreaseService do
       expect(wallet.credits_balance).to eq(14.5)
     end
 
-    it "refreshes wallet ongoing balance" do
-      call_and_reload_wallet
-
-      expect(wallet.ongoing_balance_cents).to eq(1450)
-      expect(wallet.credits_ongoing_balance).to eq(14.5)
+    it "enqueues a RefreshWalletJob targeting the wallet" do
+      expect { create_service.call }
+        .to have_enqueued_job(Customers::RefreshWalletJob).with(wallet.customer, wallet_ids: [wallet.id])
     end
 
     it "sends a `wallet.updated` webhook" do


### PR DESCRIPTION
## Context

We were refreshing the wallet when doing an increase, to ensure returned `balance` and `ongoing_balance` were up to date if there was any usage coming. The wallet refresh sync slow down the wallet transaction creation process and response AND the returned wallet was not reloaded, so the wallet refresh was not reflected in the service response.

## Changes

- Refresh the wallet asynchronously after wallet increase, keeping the wallet targeting (added in https://github.com/getlago/lago-api/pull/5618)
- Update the refresh wallet job to run if a list of wallet is provided, even if the customer is not flagged as to be refreshed. We did not want to update the customer at this level to avoid any lock contention.