### PR TITLE
feat(invoices): apply custom sections of resources

### DIFF
--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -68,6 +68,13 @@ class RecurringTransactionRule < ApplicationRecord
     end
   end
 
+  def invoice_custom_section_params
+    section_ids = applied_invoice_custom_sections.pluck(:invoice_custom_section_id)
+    return if section_ids.none? && !skip_invoice_custom_sections
+
+    {skip_invoice_custom_sections:, invoice_custom_section_ids: section_ids}
+  end
+
   def compute_paid_credits(ongoing_balance:)
     if target?
       compute_target_paid_credits(ongoing_balance:)

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -106,6 +106,15 @@ class WalletTransaction < ApplicationRecord
     remaining_amount_cents.fdiv(currency.subunit_to_unit).fdiv(wallet.rate_amount).to_s
   end
 
+  # Returns the resource that should drive invoice custom sections for this transaction.
+  # Priority chain: transaction first, then wallet.
+  def invoice_custom_section_resource
+    return self if skip_invoice_custom_sections || selected_invoice_custom_sections.any?
+    return wallet if wallet.skip_invoice_custom_sections || wallet.selected_invoice_custom_sections.any?
+
+    self
+  end
+
   def mark_as_failed!(timestamp = Time.zone.now)
     return if failed?
 

--- a/app/services/invoices/apply_invoice_custom_sections_service.rb
+++ b/app/services/invoices/apply_invoice_custom_sections_service.rb
@@ -2,10 +2,10 @@
 
 module Invoices
   class ApplyInvoiceCustomSectionsService < BaseService
-    def initialize(invoice:, resource: nil, custom_section_ids: [])
+    def initialize(invoice:, resources: [], custom_section_ids: [])
       @invoice = invoice
       @customer = invoice.customer
-      @resource = resource
+      @resources = resources
       @custom_section_ids = custom_section_ids
 
       super()
@@ -32,11 +32,11 @@ module Invoices
 
     private
 
-    attr_reader :invoice, :customer, :resource, :custom_section_ids
+    attr_reader :invoice, :customer, :resources, :custom_section_ids
 
     def skip_custom_sections?
-      return false if resource_has_custom_sections?
-      return true if resource&.skip_invoice_custom_sections
+      return false if participating_resources.any? { |r| resource_has_invoice_custom_sections?(r) }
+      return true if resources.any? && participating_resources.none?
       return false if custom_section_ids.present?
 
       customer.skip_invoice_custom_sections
@@ -45,8 +45,8 @@ module Invoices
     def applicable_sections
       manual_sections = if custom_section_ids.present?
         organization.invoice_custom_sections.where(id: custom_section_ids)
-      elsif resource_has_custom_sections?
-        resource.selected_invoice_custom_sections
+      elsif resources.any?
+        sections_from_resources
       else
         customer.configurable_invoice_custom_sections
       end
@@ -54,10 +54,23 @@ module Invoices
       manual_sections | customer.system_generated_invoice_custom_sections
     end
 
-    def resource_has_custom_sections?
-      return false unless resource
-      return false unless resource.respond_to?(:selected_invoice_custom_sections)
-      return false if resource.skip_invoice_custom_sections
+    def sections_from_resources
+      with_ics, without_ics = participating_resources.partition { |r| resource_has_invoice_custom_sections?(r) }
+
+      return customer.configurable_invoice_custom_sections if with_ics.empty?
+
+      sections = with_ics.flat_map(&:selected_invoice_custom_sections).uniq
+      sections |= customer.configurable_invoice_custom_sections if without_ics.any?
+
+      sections
+    end
+
+    def participating_resources
+      @participating_resources ||= resources.reject(&:skip_invoice_custom_sections)
+    end
+
+    def resource_has_invoice_custom_sections?(resource)
+      return false unless resource&.respond_to?(:selected_invoice_custom_sections)
 
       resource.selected_invoice_custom_sections.any?
     end

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -29,7 +29,7 @@ module Invoices
 
         # NOTE: Custom sections are applied before computing taxes so they are persisted even when
         #       tax computation is deferred to a tax provider (the `next` below skips the rest of the block).
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
+        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, resources: [subscription])
 
         totals_result = Invoices::ComputeTaxesAndTotalsService.call(invoice:)
         if totals_result.failure? && totals_result.error.is_a?(BaseService::UnknownTaxFailure)
@@ -40,10 +40,6 @@ module Invoices
 
         create_credit_note_credit
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
-<<<<<<< feat/apply-invoice-custom-sections
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, resources: [subscription])
-=======
->>>>>>> main
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         Invoices::TransitionToFinalStatusService.call(invoice:)

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -36,7 +36,7 @@ module Invoices
 
         create_credit_note_credit
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
+        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, resources: [subscription])
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         Invoices::TransitionToFinalStatusService.call(invoice:)

--- a/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
+++ b/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
@@ -45,7 +45,7 @@ module Invoices
 
         create_credit_note_credit
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
+        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, resources: [subscription])
 
         skip_payment_gating_for_zero_amount if subscription.payment_gated? && invoice.total_amount_cents.zero? && !invoice.tax_pending?
 

--- a/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
+++ b/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
@@ -38,7 +38,7 @@ module Invoices
 
         # NOTE: Custom sections are applied before computing taxes so they are persisted even when
         #       tax computation is deferred to a tax provider (the `next` below skips the rest of the block).
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
+        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, resources: [subscription])
 
         totals_result = Invoices::ComputeTaxesAndTotalsService.call(invoice:)
         if totals_result.failure? && totals_result.error.is_a?(BaseService::UnknownTaxFailure)
@@ -49,10 +49,6 @@ module Invoices
 
         create_credit_note_credit
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
-<<<<<<< feat/apply-invoice-custom-sections
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, resources: [subscription])
-=======
->>>>>>> main
 
         skip_payment_gating_for_zero_amount if subscription.payment_gated? && invoice.total_amount_cents.zero? && !invoice.tax_pending?
 

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -24,7 +24,7 @@ module Invoices
       ActiveRecord::Base.transaction do
         create_credit_fee(invoice)
         compute_amounts(invoice)
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
+        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, resources: [wallet_transaction.invoice_custom_section_resource])
 
         if License.premium? && wallet_transaction.invoice_requires_successful_payment?
           invoice.open!

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -38,7 +38,7 @@ module Invoices
           recurring:,
           context:
         )
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
+        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, resources: subscriptions)
 
         skip_payment_gating_for_zero_amount if subscription_payment_gated? && invoice.total_amount_cents.zero? && !invoice.tax_pending?
 

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -11,17 +11,21 @@ module Wallets
 
         next if rule.target? && paid_credits.zero? && granted_credits.zero?
 
+        params = {
+          wallet_id: rule.wallet.id,
+          paid_credits: paid_credits.to_s,
+          granted_credits: granted_credits.to_s,
+          source: :interval,
+          invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
+          metadata: rule.transaction_metadata,
+          name: rule.transaction_name
+        }
+
+        params[:invoice_custom_section] = rule.invoice_custom_section_params if rule.invoice_custom_section_params
+
         WalletTransactions::CreateJob.perform_later(
           organization_id: rule.wallet.organization.id,
-          params: {
-            wallet_id: rule.wallet.id,
-            paid_credits: paid_credits.to_s,
-            granted_credits: granted_credits.to_s,
-            source: :interval,
-            invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
-            metadata: rule.transaction_metadata,
-            name: rule.transaction_name
-          }
+          params:
         )
       end
 

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -14,18 +14,22 @@ module Wallets
       return result if wallet.credits_ongoing_balance > rule.threshold_credits
       return result if (pending_transactions_amount + wallet.credits_ongoing_balance) > rule.threshold_credits
 
+      params = {
+        wallet_id: wallet.id,
+        paid_credits: rule.compute_paid_credits(ongoing_balance: wallet.credits_ongoing_balance).to_s,
+        granted_credits: rule.compute_granted_credits.to_s,
+        source: :threshold,
+        invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
+        metadata: rule.transaction_metadata,
+        name: rule.transaction_name,
+        ignore_paid_top_up_limits: rule.ignore_paid_top_up_limits?
+      }
+
+      params[:invoice_custom_section] = rule.invoice_custom_section_params if rule.invoice_custom_section_params
+
       WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(
         organization_id: wallet.organization.id,
-        params: {
-          wallet_id: wallet.id,
-          paid_credits: rule.compute_paid_credits(ongoing_balance: wallet.credits_ongoing_balance).to_s,
-          granted_credits: rule.compute_granted_credits.to_s,
-          source: :threshold,
-          invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
-          metadata: rule.transaction_metadata,
-          name: rule.transaction_name,
-          ignore_paid_top_up_limits: rule.ignore_paid_top_up_limits?
-        },
+        params:,
         unique_transaction: true
       )
 

--- a/spec/services/invoices/apply_invoice_custom_sections_service_spec.rb
+++ b/spec/services/invoices/apply_invoice_custom_sections_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Invoices::ApplyInvoiceCustomSectionsService do
-  subject(:invoice_service) { described_class.new(invoice:, resource:, custom_section_ids:) }
+  subject(:invoice_service) { described_class.new(invoice:, resources:, custom_section_ids:) }
 
   let(:organization) { create(:organization) }
   let(:billing_entity) { create(:billing_entity, organization:) }
@@ -12,7 +12,7 @@ RSpec.describe Invoices::ApplyInvoiceCustomSectionsService do
   let(:custom_section_1) { create(:invoice_custom_section, organization:) }
   let(:custom_section_2) { create(:invoice_custom_section, organization:) }
   let(:custom_section_3) { create(:invoice_custom_section, organization:) }
-  let(:resource) { nil }
+  let(:resources) { [] }
   let(:custom_section_ids) { [] }
 
   before do
@@ -71,11 +71,12 @@ RSpec.describe Invoices::ApplyInvoiceCustomSectionsService do
       end
     end
 
-    context "with subscription source" do
-      let(:resource) { create(:subscription, customer:, organization:) }
+    context "with a single resource" do
+      let(:subscription) { create(:subscription, customer:, organization:) }
+      let(:resources) { [subscription] }
 
       context "when skip_invoice_custom_sections is true" do
-        let(:resource) { create(:subscription, customer:, organization:, skip_invoice_custom_sections: true) }
+        let(:subscription) { create(:subscription, customer:, organization:, skip_invoice_custom_sections: true) }
 
         it "does not attach custom sections on the invoice" do
           result = invoice_service.call
@@ -117,7 +118,7 @@ RSpec.describe Invoices::ApplyInvoiceCustomSectionsService do
 
       context "when skip_invoice_custom_sections is false and there are attached custom sections" do
         before do
-          create(:subscription_applied_invoice_custom_section, organization:, subscription: resource, invoice_custom_section: custom_section_2)
+          create(:subscription_applied_invoice_custom_section, organization:, subscription:, invoice_custom_section: custom_section_2)
         end
 
         it "applies custom sections from the subscription" do
@@ -128,6 +129,76 @@ RSpec.describe Invoices::ApplyInvoiceCustomSectionsService do
           expect(sections.map(&:details)).to contain_exactly(custom_section_2.details)
           expect(sections.map(&:display_name)).to contain_exactly(custom_section_2.display_name)
           expect(sections.map(&:name)).to contain_exactly(custom_section_2.name)
+        end
+      end
+    end
+
+    context "with multiple resources" do
+      let(:subscription_a) { create(:subscription, customer:, organization:) }
+      let(:subscription_b) { create(:subscription, customer:, organization:) }
+      let(:resources) { [subscription_a, subscription_b] }
+
+      context "when no resource has ICS" do
+        it "falls back to customer sections" do
+          result = invoice_service.call
+          expect(result).to be_success
+          sections = invoice.applied_invoice_custom_sections.reload
+          expect(sections.map(&:code)).to contain_exactly(custom_section_1.code, custom_section_2.code)
+        end
+      end
+
+      context "when all resources have ICS" do
+        before do
+          create(:subscription_applied_invoice_custom_section, organization:, subscription: subscription_a, invoice_custom_section: custom_section_1)
+          create(:subscription_applied_invoice_custom_section, organization:, subscription: subscription_b, invoice_custom_section: custom_section_2)
+        end
+
+        it "merges ICS from all resources" do
+          result = invoice_service.call
+          expect(result).to be_success
+          sections = invoice.applied_invoice_custom_sections.reload
+          expect(sections.map(&:code)).to contain_exactly(custom_section_1.code, custom_section_2.code)
+        end
+      end
+
+      context "when some resources have ICS and some do not" do
+        before do
+          create(:subscription_applied_invoice_custom_section, organization:, subscription: subscription_a, invoice_custom_section: custom_section_1)
+          create(:customer_applied_invoice_custom_section, organization:, billing_entity:, customer:, invoice_custom_section: custom_section_3)
+        end
+
+        it "merges resource ICS with customer sections" do
+          result = invoice_service.call
+          expect(result).to be_success
+          sections = invoice.applied_invoice_custom_sections.reload
+          expect(sections.map(&:code)).to contain_exactly(custom_section_1.code, custom_section_3.code)
+        end
+      end
+
+      context "when all resources have skip_invoice_custom_sections" do
+        let(:subscription_a) { create(:subscription, customer:, organization:, skip_invoice_custom_sections: true) }
+        let(:subscription_b) { create(:subscription, customer:, organization:, skip_invoice_custom_sections: true) }
+
+        it "does not apply any custom sections" do
+          result = invoice_service.call
+          expect(result).to be_success
+          expect(result.applied_sections).to be_empty
+          expect(invoice.reload.applied_invoice_custom_sections).to be_empty
+        end
+      end
+
+      context "when one resource skips and another has ICS" do
+        let(:subscription_a) { create(:subscription, customer:, organization:, skip_invoice_custom_sections: true) }
+
+        before do
+          create(:subscription_applied_invoice_custom_section, organization:, subscription: subscription_b, invoice_custom_section: custom_section_2)
+        end
+
+        it "applies only the non-skipping resource's ICS" do
+          result = invoice_service.call
+          expect(result).to be_success
+          sections = invoice.applied_invoice_custom_sections.reload
+          expect(sections.map(&:code)).to contain_exactly(custom_section_2.code)
         end
       end
     end

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -293,6 +293,13 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService do
       let(:service_call) { invoice_service.call }
     end
 
+    it_behaves_like "applies invoice_custom_sections from resource" do
+      let(:service_call) { invoice_service.call }
+      let(:resource_with_custom_section) { subscription }
+      let(:applied_section_factory) { :subscription_applied_invoice_custom_section }
+      let(:resource_association_key) { :subscription }
+    end
+
     context "when an error occurs" do
       context "with a stale object error" do
         before do

--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -331,6 +331,13 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
       let(:service_call) { invoice_service.call }
     end
 
+    it_behaves_like "applies invoice_custom_sections from resource" do
+      let(:service_call) { invoice_service.call }
+      let(:resource_with_custom_section) { subscription }
+      let(:applied_section_factory) { :subscription_applied_invoice_custom_section }
+      let(:resource_association_key) { :subscription }
+    end
+
     context "when fee build service fails" do
       before do
         allow(Fees::BuildPayInAdvanceFixedChargeService)

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -76,6 +76,39 @@ RSpec.describe Invoices::PaidCreditService do
       let(:service_call) { invoice_service.call }
     end
 
+    it_behaves_like "applies invoice_custom_sections from resource" do
+      let(:service_call) { invoice_service.call }
+      let(:resource_with_custom_section) { wallet_transaction }
+      let(:applied_section_factory) { :wallet_transaction_applied_invoice_custom_section }
+      let(:resource_association_key) { :wallet_transaction }
+    end
+
+    it_behaves_like "applies invoice_custom_sections from resource" do
+      let(:service_call) { invoice_service.call }
+      let(:resource_with_custom_section) { wallet }
+      let(:applied_section_factory) { :wallet_applied_invoice_custom_section }
+      let(:resource_association_key) { :wallet }
+    end
+
+    context "when wallet_transaction has skip_invoice_custom_sections" do
+      let(:wallet_transaction) do
+        create(:wallet_transaction, wallet:, amount: "15.00", credit_amount: "15.00",
+          invoice_requires_successful_payment:, skip_invoice_custom_sections: true)
+      end
+
+      before do
+        create(:billing_entity_applied_invoice_custom_section, organization:,
+          billing_entity:, invoice_custom_section: create(:invoice_custom_section, organization:))
+        create(:wallet_applied_invoice_custom_section, organization:, wallet:,
+          invoice_custom_section: create(:invoice_custom_section, organization:))
+      end
+
+      it "skips all sections without falling back to wallet or customer sections" do
+        result = invoice_service.call
+        expect(result.invoice.applied_invoice_custom_sections).to be_empty
+      end
+    end
+
     it "does not enqueue an SendEmailJob" do
       expect do
         invoice_service.call

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -109,6 +109,20 @@ RSpec.describe Invoices::PaidCreditService do
       end
     end
 
+    context "when wallet has skip_invoice_custom_sections and wallet_transaction has no opinion" do
+      let(:wallet) { create(:wallet, customer:, skip_invoice_custom_sections: true) }
+
+      before do
+        create(:billing_entity_applied_invoice_custom_section, organization:,
+          billing_entity:, invoice_custom_section: create(:invoice_custom_section, organization:))
+      end
+
+      it "skips all sections without falling back to customer sections" do
+        result = invoice_service.call
+        expect(result.invoice.applied_invoice_custom_sections).to be_empty
+      end
+    end
+
     it "does not enqueue an SendEmailJob" do
       expect do
         invoice_service.call

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -194,6 +194,13 @@ RSpec.describe Invoices::SubscriptionService do
       let(:service_call) { invoice_service.call }
     end
 
+    it_behaves_like "applies invoice_custom_sections from resource" do
+      let(:service_call) { invoice_service.call }
+      let(:resource_with_custom_section) { subscription }
+      let(:applied_section_factory) { :subscription_applied_invoice_custom_section }
+      let(:resource_association_key) { :subscription }
+    end
+
     it "enqueues a SendWebhookJob" do
       expect do
         invoice_service.call

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -201,6 +201,53 @@ RSpec.describe Invoices::SubscriptionService do
       let(:resource_association_key) { :subscription }
     end
 
+    context "with multiple subscriptions" do
+      let(:subscription_2) { create(:subscription, plan:, customer:, subscription_at: started_at.to_date, started_at:, created_at: started_at) }
+      let(:subscriptions) { [subscription, subscription_2] }
+      let(:section_1) { create(:invoice_custom_section, organization:) }
+      let(:section_2) { create(:invoice_custom_section, organization:) }
+
+      before do
+        create(:billing_entity_applied_invoice_custom_section, organization:, billing_entity:, invoice_custom_section: create(:invoice_custom_section, organization:))
+      end
+
+      context "when all subscriptions have ICS configured" do
+        before do
+          create(:subscription_applied_invoice_custom_section, organization:, subscription:, invoice_custom_section: section_1)
+          create(:subscription_applied_invoice_custom_section, organization:, subscription: subscription_2, invoice_custom_section: section_2)
+        end
+
+        it "applies the union of all subscriptions' sections, ignoring billing entity sections" do
+          result = invoice_service.call
+          expect(result.invoice.applied_invoice_custom_sections.pluck(:code)).to match_array([section_1.code, section_2.code])
+        end
+      end
+
+      context "when only some subscriptions have ICS configured" do
+        let(:customer_section) { create(:invoice_custom_section, organization:) }
+
+        before do
+          create(:subscription_applied_invoice_custom_section, organization:, subscription:, invoice_custom_section: section_1)
+          create(:customer_applied_invoice_custom_section, organization:, billing_entity:, customer:, invoice_custom_section: customer_section)
+        end
+
+        it "merges sections from configured subscriptions with customer sections" do
+          result = invoice_service.call
+          expect(result.invoice.applied_invoice_custom_sections.pluck(:code)).to match_array([section_1.code, customer_section.code])
+        end
+      end
+
+      context "when all subscriptions have skip_invoice_custom_sections" do
+        let(:subscription) { create(:subscription, plan:, customer:, subscription_at: started_at.to_date, started_at:, created_at: started_at, skip_invoice_custom_sections: true) }
+        let(:subscription_2) { create(:subscription, plan:, customer:, subscription_at: started_at.to_date, started_at:, created_at: started_at, skip_invoice_custom_sections: true) }
+
+        it "does not apply any sections" do
+          result = invoice_service.call
+          expect(result.invoice.applied_invoice_custom_sections).to be_empty
+        end
+      end
+    end
+
     it "enqueues a SendWebhookJob" do
       expect do
         invoice_service.call

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -417,10 +417,45 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
         create(:invoice_custom_section, organization:, code: "section_code_1")
       end
 
+      after { CurrentContext.source = nil }
+
       it "creates wallet transaction with invoice_custom_section" do
         applied_sections = result.wallet_transactions.first.applied_invoice_custom_sections
         expect(applied_sections.count).to eq(1)
         expect(applied_sections.first.invoice_custom_section.code).to eq("section_code_1")
+      end
+    end
+
+    context "when invoice_custom_section_ids param exists (job context)" do
+      let(:section) { create(:invoice_custom_section, organization:) }
+      let(:params) do
+        {
+          wallet_id: wallet.id,
+          paid_credits:,
+          invoice_custom_section: {skip_invoice_custom_sections: false, invoice_custom_section_ids: [section.id]}
+        }
+      end
+
+      it "attaches the ICS to the wallet transaction by ID" do
+        applied_sections = result.wallet_transactions.first.applied_invoice_custom_sections
+        expect(applied_sections.count).to eq(1)
+        expect(applied_sections.first.invoice_custom_section).to eq(section)
+      end
+    end
+
+    context "when invoice_custom_section param has skip_invoice_custom_sections: true (job context)" do
+      let(:params) do
+        {
+          wallet_id: wallet.id,
+          paid_credits:,
+          invoice_custom_section: {skip_invoice_custom_sections: true, invoice_custom_section_ids: []}
+        }
+      end
+
+      it "marks the wallet transaction as skipping custom sections" do
+        transaction = result.wallet_transactions.first
+        expect(transaction.skip_invoice_custom_sections).to be(true)
+        expect(transaction.applied_invoice_custom_sections).to be_empty
       end
     end
 

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -423,6 +423,74 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
       end
     end
 
+    context "when rule has invoice custom sections" do
+      let(:invoice_custom_section) { create(:invoice_custom_section, organization: customer.organization) }
+      let(:interval) { :weekly }
+      let(:current_date) do
+        DateTime.parse("20 Jun 2022").prev_occurring(created_at.strftime("%A").downcase.to_sym)
+      end
+
+      before do
+        create(
+          :recurring_rule_applied_invoice_custom_section,
+          recurring_transaction_rule:,
+          invoice_custom_section:
+        )
+      end
+
+      it "forwards invoice_custom_section params to the job" do
+        travel_to(current_date) do
+          create_interval_transactions_service.call
+
+          expect(WalletTransactions::CreateJob).to have_been_enqueued
+            .with(
+              organization_id: customer.organization_id,
+              params: hash_including(
+                invoice_custom_section: {
+                  skip_invoice_custom_sections: false,
+                  invoice_custom_section_ids: [invoice_custom_section.id]
+                }
+              )
+            )
+        end
+      end
+    end
+
+    context "when rule has skip_invoice_custom_sections" do
+      let(:interval) { :weekly }
+      let(:current_date) do
+        DateTime.parse("20 Jun 2022").prev_occurring(created_at.strftime("%A").downcase.to_sym)
+      end
+      let(:recurring_transaction_rule) do
+        create(
+          :recurring_transaction_rule,
+          trigger: :interval,
+          wallet:,
+          interval:,
+          created_at: created_at + 1.second,
+          started_at:,
+          skip_invoice_custom_sections: true
+        )
+      end
+
+      it "forwards the skip flag to the job without fallback to other sections" do
+        travel_to(current_date) do
+          create_interval_transactions_service.call
+
+          expect(WalletTransactions::CreateJob).to have_been_enqueued
+            .with(
+              organization_id: customer.organization_id,
+              params: hash_including(
+                invoice_custom_section: {
+                  skip_invoice_custom_sections: true,
+                  invoice_custom_section_ids: []
+                }
+              )
+            )
+        end
+      end
+    end
+
     context "when recurring transaction rule has expired" do
       let(:created_at) { DateTime.parse("20 Feb 2021") }
       let(:recurring_transaction_rule) do

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -99,6 +99,58 @@ RSpec.describe Wallets::ThresholdTopUpService do
       end
     end
 
+    context "when rule has invoice custom sections" do
+      let(:invoice_custom_section) { create(:invoice_custom_section, organization: wallet.organization) }
+
+      before do
+        create(:recurring_rule_applied_invoice_custom_section,
+          recurring_transaction_rule:,
+          invoice_custom_section:)
+      end
+
+      it "forwards invoice_custom_section params to the job" do
+        expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+          .with(
+            organization_id: wallet.organization.id,
+            params: hash_including(
+              invoice_custom_section: {
+                skip_invoice_custom_sections: false,
+                invoice_custom_section_ids: [invoice_custom_section.id]
+              }
+            ),
+            unique_transaction: true
+          )
+      end
+    end
+
+    context "when rule has skip_invoice_custom_sections" do
+      let(:recurring_transaction_rule) do
+        create(
+          :recurring_transaction_rule,
+          wallet:,
+          trigger: "threshold",
+          threshold_credits: "6.0",
+          paid_credits: "10.0",
+          granted_credits: "3.0",
+          skip_invoice_custom_sections: true
+        )
+      end
+
+      it "forwards the skip flag to the job without fallback to other sections" do
+        expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+          .with(
+            organization_id: wallet.organization.id,
+            params: hash_including(
+              invoice_custom_section: {
+                skip_invoice_custom_sections: true,
+                invoice_custom_section_ids: []
+              }
+            ),
+            unique_transaction: true
+          )
+      end
+    end
+
     context "when rule does not contain transaction_name" do
       let(:recurring_transaction_rule) do
         create(

--- a/spec/support/shared_examples/applied_invoice_custom_sections.rb
+++ b/spec/support/shared_examples/applied_invoice_custom_sections.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+RSpec.shared_examples "applies invoice_custom_sections from resource" do
+  let(:resource_invoice_custom_section) { create(:invoice_custom_section, organization:) }
+
+  before do
+    create(applied_section_factory, resource_association_key => resource_with_custom_section, :invoice_custom_section => resource_invoice_custom_section)
+    create(:billing_entity_applied_invoice_custom_section, organization:, billing_entity:, invoice_custom_section: create(:invoice_custom_section, organization:))
+  end
+
+  it "applies sections from the resource, overriding higher-level sections" do
+    result = service_call
+    expect(result.invoice.applied_invoice_custom_sections.pluck(:code)).to eq([resource_invoice_custom_section.code])
+  end
+
+  context "when the customer has :skip_invoice_custom_sections flag" do
+    before { customer.update!(skip_invoice_custom_sections: true) }
+
+    it "still applies sections from the resource" do
+      result = service_call
+      expect(result.invoice.applied_invoice_custom_sections.pluck(:code)).to eq([resource_invoice_custom_section.code])
+    end
+  end
+end
+
 RSpec.shared_examples "applies invoice_custom_sections" do
   let(:invoice_custom_sections) { create_list(:invoice_custom_section, 4, organization:) }
 


### PR DESCRIPTION
Closes BIL-21

## Context

Invoice custom sections could be assigned to subscriptions, wallets, wallet transactions, and recurring top-up rules, but resource-level assignments were never applied when generating invoices.

This PR fixes that.

## Description

- `ApplyInvoiceCustomSectionsService` now accepts `resources:` array instead of a single `resource:`. Multi-subscription invoices merge ICS across subscriptions. If some of them don't have a custom section, customer sections will be used.
- All invoice creation services pass their resource(s):
  - subscription services pass `[subscription]` / `subscriptions`,
  - `PaidCreditService` resolves via `WalletTransaction#invoice_custom_section_resource` (wallet transaction => wallet priority chain)
- Recurring top-up rules: `ThresholdTopUpService` and `CreateIntervalWalletTransactionsService` forward the rule's ICS config into `WalletTransactions::CreateJob` params
- Explicit `skip_invoice_custom_sections` on any resource skips all sections with no fallback
- Customer-level skip is the last fallback, only reached when no resource has ICS configured

## Use-cases

Scenario | Result
-- | --
No resource has ICS | Customer/billing entity sections used
Resource has ICS | Resource sections used, billing entity sections ignored
Resource has skip_invoice_custom_sections | No sections applied, no fallback
Customer has skip_invoice_custom_sections, resource has ICS | Resource sections still applied
Customer has skip_invoice_custom_sections, no resource has ICS | No sections applied
Multiple subscriptions, all have ICS | Union of all subscription sections
Multiple subscriptions, some have ICS | Sections from ICS-configured subscriptions + customer sections as fallback for the rest
Multiple subscriptions, all skip | No sections applied
Wallet transaction has ICS | Transaction sections used
Wallet transaction has no ICS, wallet has ICS | Wallet sections used
Wallet transaction skips | No sections applied, wallet sections ignored
Wallet skips, transaction has no opinion | No sections applied
Tax deferred to provider (Anrok) | ICS still applied
Recurring rule has ICS | ICS forwarded through job params to wallet transaction
Recurring rule has skip_invoice_custom_sections | Skip flag forwarded through job params

## Preview app

https://denis-apply-custom-sections-app.staging.getlago.com/

