### PR TITLE
[ING-271] fix(wallet): release refresh lock when executing

### DIFF
--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -11,7 +11,7 @@ module Customers
       end
     end
 
-    unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+    unique :until_executing, on_conflict: :log, lock_ttl: 12.hours
 
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
     retry_on BaseService::TooManyProviderRequestsFailure, wait: :polynomially_longer, attempts: 25

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Customers::RefreshWalletJob do
     end
   end
 
+  describe "unique" do
+    it "has unique :until_executing constraint" do
+      expect(described_class.lock_strategy_class).to eq(ActiveJob::Uniqueness::Strategies::UntilExecuting)
+    end
+  end
+
   describe "#perform" do
     subject { described_class.perform_now(customer, wallet_ids:) }
 


### PR DESCRIPTION
## Context

`Customers::RefreshWalletJob` guarded itself with `unique :until_executed`. With that strategy the uniqueness lock is held from the moment the job is enqueued until it finishes executing. If a customer is re-flagged for a wallet refresh while a previous run is still executing, the new enqueue is dropped because the lock is still held. The running job then clears the `awaiting_wallet_refresh` flag on completion, so the later change is never recomputed until an unrelated event re-flags the customer. The clock-driven refresh path is affected by this window.

## Description

The lock strategy is switched to `until_executing`, which releases the lock when the job starts performing rather than when it finishes. A second enqueue that arrives after a run has begun is now accepted, so a follow-up run executes with the newer state. Enqueues that pile up while a job is still queued keep coalescing, so the extra work is bounded to at most one trailing run per in-flight change. `RefreshWalletJob#perform` already no-ops when the customer is no longer awaiting a refresh, so a redundant trailing run is cheap.

A spec asserts the job's lock strategy.
