### PR TITLE
[ING-264] fix(payment-requests): 422 cross-entity

### DIFF
--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -79,7 +79,7 @@ module PaymentRequests
       end
 
       if invoices.pluck(:billing_entity_id).uniq.size > 1
-        return result.not_allowed_failure!(code: "invoices_have_different_billing_entities")
+        return result.single_validation_failure!(error_code: "invoices_have_different_billing_entities")
       end
 
       if invoices.exists?(ready_for_payment_processing: false)

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe Api::V1::PaymentRequestsController do
       expect(json[:payment_request][:invoices].map { |i| i[:lago_id] }).to contain_exactly(invoice.id)
       expect(json[:payment_request][:customer][:lago_id]).to eq(customer.id)
     end
+
+    context "when invoices belong to different billing entities" do
+      before do
+        allow(PaymentRequests::CreateService).to receive(:call).and_return(
+          BaseService::Result.new.tap do |r|
+            r.single_validation_failure!(error_code: "invoices_have_different_billing_entities")
+          end
+        )
+      end
+
+      it "responds with 422 and the validation_errors body shape" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:code]).to eq("validation_errors")
+        expect(json[:error_details][:base]).to eq(["invoices_have_different_billing_entities"])
+      end
+    end
   end
 
   describe "GET /api/v1/payment_requests" do

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -97,12 +97,12 @@ RSpec.describe PaymentRequests::CreateService, :premium do
 
       before { second_invoice.update!(billing_entity: other_billing_entity) }
 
-      it "returns not allowed failure" do
+      it "returns a validation failure" do
         result = create_service.call
 
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("invoices_have_different_billing_entities")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq(base: ["invoices_have_different_billing_entities"])
       end
     end
 


### PR DESCRIPTION
## Context

Posting `POST /api/v1/payment_requests` with invoices that belonged to different billing entities returned `405 Method Not Allowed` with body `code: invoices_have_different_billing_entities`. The status was misleading — clients interpret 405 as "wrong HTTP verb on this URI" rather than a payload-level rejection. Per the dive-in QA plan (S52/S53), the right shape is `422 Unprocessable Entity`, matching how subscriptions, wallets, and one-off invoices report the same class of payload-validation failure.

## Description

`PaymentRequests::CreateService#check_preconditions` now uses `single_validation_failure!(error_code:
"invoices_have_different_billing_entities")` for that one precondition, which routes through `BaseService::ValidationFailure` and lands as `422` with the canonical `validation_errors` body in the controller. The other three preconditions
(`invoices_not_overdue`, `invoices_have_different_currencies`, `invoices_not_ready_for_payment_processing`) are intentionally left on `not_allowed_failure!` — only the billing-entity case is in scope here.