### PR TITLE
fix(tax-providers): Add guard to skip compute_amounts_with_provider_taxes if taxable_fees is empty

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -209,18 +209,23 @@ module Invoices
     end
 
     def compute_amounts_with_provider_taxes
+      # NOTE: Only fees with a positive amount can incur tax, so non-taxable fees are
+      #       excluded from the provider request. This also keeps the payload under the
+      #       provider line-item limit (Anrok/Avalara reject payloads above 1200 items).
+      #       Excluded fees owe no tax and keep their default zero taxes in the usage response.
+      taxable_fees = invoice.fees.select(&:taxable?)
+
+      # NOTE: With no taxable fees the provider request would carry an empty line-item
+      #       array, which Anrok/Avalara reject. There is no tax to compute, so fall back
+      #       to the zero-tax path and skip the provider entirely.
+      return compute_amounts_without_tax if taxable_fees.empty?
+
       invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
 
       # NOTE: Set the sub total so Invoices::ApplyProviderTaxesService prorates taxes_rate
       #       by amount (like persisted invoices) instead of falling back to its zero-amount
       #       count-based branch, which would dilute the rate with the excluded non-taxable fees.
       invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
-
-      # NOTE: Only fees with a positive amount can incur tax, so non-taxable fees are
-      #       excluded from the provider request. This also keeps the payload under the
-      #       provider line-item limit (Anrok/Avalara reject payloads above 1200 items).
-      #       Excluded fees owe no tax and keep their default zero taxes in the usage response.
-      taxable_fees = invoice.fees.select(&:taxable?)
 
       taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: taxable_fees)
 

--- a/spec/requests/api/v1/customers/projected_usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/projected_usage_controller_spec.rb
@@ -155,9 +155,11 @@ RSpec.describe Api::V1::Customers::ProjectedUsageController, :premium do
         }
 
         it "rescue from provider throttles" do
-          subject
-          expect(response).to have_http_status(:too_many_requests)
-          expect(response.body).to match(/anrok.*Try again later/)
+          travel_to(Time.parse("2025-07-03T10:00:00Z")) do
+            subject
+            expect(response).to have_http_status(:too_many_requests)
+            expect(response.body).to match(/anrok.*Try again later/)
+          end
         end
       end
     end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -265,6 +265,36 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         end
       end
 
+      context "when there are no taxable fees" do
+        # The single charge produces a zero-amount fee, so taxable_fees is empty.
+        let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "0"}) }
+
+        before do
+          allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:call)
+        end
+
+        it "skips the provider request and returns a zero-tax usage" do
+          result = usage_service.call
+
+          expect(result).to be_success
+          expect(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).not_to have_received(:call)
+          expect(result.usage).to have_attributes(
+            amount_cents: 0,
+            taxes_amount_cents: 0,
+            total_amount_cents: 0
+          )
+        end
+
+        it "leaves the zero fee with default zero taxes" do
+          result = usage_service.call
+
+          fee = result.usage.fees.sole
+          expect(fee.taxes_amount_cents).to eq(0)
+          expect(fee.taxes_rate).to eq(0)
+          expect(fee.applied_taxes).to be_empty
+        end
+      end
+
       context "when there is error received from the provider" do
         before do
           stub_request(:post, endpoint).to_return do |request|


### PR DESCRIPTION
## Context

`Invoices::CustomerUsageService` filters fees down to taxable (positive-amount) ones before requesting taxes from the provider. When every fee on the usage invoice is zero-amount, that subset is empty and the request carries an empty line-item array, which Anrok/Avalara reject (`validationError: "lineItems": Array must contain at least 1 element(s)`), surfacing as a `ValidationFailure`.

## Description

Guard `compute_amounts_with_provider_taxes` so that when there are no taxable fees it skips the provider call and falls back to the existing zero-tax path, returning a valid usage with zero taxes.
