### PR TITLE
feat(fc-units-override): add FixedCharge#units_for resolver

### DIFF
--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -51,6 +51,10 @@ class FixedCharge < ApplicationRecord
       units == fixed_charge.units
   end
 
+  def effective_units_for(subscription)
+    subscription_units_overrides.find_by(subscription:)&.units || units
+  end
+
   # When upgrading a subscription with fixed_charges paid_in_advance,
   # this exact charge might have already been paid at the beginning of billing period.
   # in case of prorating, we need to deduct the prorated amount (remaining of the billing_period)

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -369,4 +369,41 @@ RSpec.describe FixedCharge do
       end
     end
   end
+
+  describe "#effective_units_for" do
+    subject(:effective_units_for) { fixed_charge.effective_units_for(subscription) }
+
+    let(:fixed_charge) { create(:fixed_charge, units: 7) }
+    let(:subscription) { create(:subscription, plan: fixed_charge.plan) }
+
+    context "when no override exists" do
+      it { is_expected.to eq(7) }
+    end
+
+    context "when an override exists for the (subscription, fixed_charge) pair" do
+      before { create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 42) }
+
+      it { is_expected.to eq(42) }
+    end
+
+    context "when the override has been discarded" do
+      before do
+        override = create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 42)
+        override.discard!
+      end
+
+      it "falls back to the fixed charge units" do
+        expect(effective_units_for).to eq(7)
+      end
+    end
+
+    context "when an override exists for a different subscription" do
+      before do
+        other_subscription = create(:subscription, plan: fixed_charge.plan)
+        create(:subscription_fixed_charge_units_override, subscription: other_subscription, fixed_charge:, units: 42)
+      end
+
+      it { is_expected.to eq(7) }
+    end
+  end
 end


### PR DESCRIPTION
## Context

Read paths that consume a fixed charge's units in a subscription context (events, aggregation, fee creation, invoice preview, serializers, GraphQL types) need to honour the per-subscription override when one exists. A single accessor on FixedCharge lets callers drop in a subscription-aware lookup without rewriting every read site.

The accessor lands ahead of the read-path swaps so subsequent changes are mechanical one-liners. No callers yet; the resolver is a no-op while the override table is empty.

## Description

- New `FixedCharge#units_for(subscription)` returns the matching `Subscription::FixedChargeUnitsOverride#units` when a kept override row exists for the (subscription, fixed_charge) pair, and falls back to the fixed charge's own `units` otherwise.
- Lookup goes through the existing `subscription_units_overrides` association, so soft-discarded rows are excluded by the default scope on the override model.
- Spec covers the four shapes: no override, override present, discarded override falls back, and override for a different subscription falls back.