### PR TITLE
feat(fc-units-override): resolve sub-aware units in preview aggregation

### DIFF
--- a/app/services/fixed_charge_events/aggregations/preview_aggregation_service.rb
+++ b/app/services/fixed_charge_events/aggregations/preview_aggregation_service.rb
@@ -7,15 +7,19 @@ module FixedChargeEvents
         units = if fixed_charge.prorated?
           calculate_prorated_units
         else
-          fixed_charge.units
+          effective_units
         end
 
         result.aggregation = units
-        result.full_units_number = fixed_charge.units
+        result.full_units_number = effective_units
         result
       end
 
       private
+
+      def effective_units
+        @effective_units ||= fixed_charge.effective_units_for(subscription)
+      end
 
       def calculate_prorated_units
         from_date = from_datetime.to_date
@@ -24,10 +28,10 @@ module FixedChargeEvents
         billing_period_days = (to_date - from_date).to_i + 1
         full_period_days = charges_duration || billing_period_days
 
-        return fixed_charge.units if billing_period_days >= full_period_days
+        return effective_units if billing_period_days >= full_period_days
 
         # Prorate units based on the ratio of billing period to full period
-        fixed_charge.units * (billing_period_days.to_f / full_period_days)
+        effective_units * (billing_period_days.to_f / full_period_days)
       end
     end
   end

--- a/spec/services/fixed_charge_events/aggregations/preview_aggregation_service_spec.rb
+++ b/spec/services/fixed_charge_events/aggregations/preview_aggregation_service_spec.rb
@@ -152,4 +152,63 @@ RSpec.describe FixedChargeEvents::Aggregations::PreviewAggregationService do
       end
     end
   end
+
+  context "when a subscription-level units override exists" do
+    let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+    before do
+      create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 42)
+    end
+
+    it "returns the override units" do
+      expect(result).to be_success
+      expect(result.aggregation).to eq(42)
+      expect(result.full_units_number).to eq(42)
+    end
+
+    context "when the fixed_charge is prorated" do
+      let(:fixed_charge) do
+        create(
+          :fixed_charge,
+          plan:,
+          add_on:,
+          charge_model: "standard",
+          prorated: true,
+          units: 100,
+          properties: {amount: "10"}
+        )
+      end
+      let(:fixed_charges_from_datetime) { Time.zone.parse("2024-03-15 00:00:00") }
+      let(:fixed_charges_to_datetime) { Time.zone.parse("2024-03-31 23:59:59") }
+      let(:boundaries) do
+        {
+          "fixed_charges_from_datetime" => fixed_charges_from_datetime,
+          "fixed_charges_to_datetime" => fixed_charges_to_datetime,
+          "fixed_charges_duration" => 31
+        }
+      end
+
+      it "prorates against the override units" do
+        expect(result).to be_success
+
+        # Billing period: March 15-31 = 17 days
+        # Full period: 31 days
+        # Prorated units: 42 * (17 / 31) ≈ 23.03
+        expect(result.aggregation).to be_within(0.01).of(23.03)
+        expect(result.full_units_number).to eq(42)
+      end
+    end
+
+    context "when the override has been discarded" do
+      before do
+        Subscription::FixedChargeUnitsOverride.unscoped.find_by(subscription:, fixed_charge:).discard!
+      end
+
+      it "falls back to the fixed_charge units" do
+        expect(result).to be_success
+        expect(result.aggregation).to eq(5)
+        expect(result.full_units_number).to eq(5)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Invoice preview is the one fee-pipeline read site that derives a fixed charge's units directly from the parent record. The other paths already route units through either a FixedChargeEvent (sub-aware once events are emitted with the resolver) or an AdjustedFee row (already customer-specific), so they pick up overrides automatically. The preview path runs against an in-memory or freshly persisted subscription where no event has been emitted yet, so it has to ask the resolver itself.

## Description

`FixedChargeEvents::Aggregations::PreviewAggregationService` now reads units through `fixed_charge.units_for(subscription)` at every site that previously hit `fixed_charge.units`. The lookup is wrapped in a single `effective_units` helper so both the prorated and non-prorated branches share one read path.

Specs cover three new shapes on top of the existing preview cases: override returns its own value, prorated path scales the override units, and a discarded override falls back to the plan-level units.