### PR TITLE
feat(fc-units-override): emit fixed-charge events with sub-aware units

### DIFF
--- a/app/services/fixed_charge_events/create_service.rb
+++ b/app/services/fixed_charge_events/create_service.rb
@@ -17,7 +17,7 @@ module FixedChargeEvents
         organization:,
         subscription:,
         fixed_charge:,
-        units: fixed_charge.units,
+        units: fixed_charge.effective_units_for(subscription),
         timestamp:
       )
 

--- a/spec/services/fixed_charge_events/create_service_spec.rb
+++ b/spec/services/fixed_charge_events/create_service_spec.rb
@@ -49,5 +49,18 @@ RSpec.describe FixedChargeEvents::CreateService do
         expect(result.error).to be_a(BaseService::ValidationFailure)
       end
     end
+
+    context "when a units override exists for the (subscription, fixed_charge) pair" do
+      let(:fixed_charge) { create(:fixed_charge, organization:, plan:, add_on:, units: 3) }
+
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 25)
+      end
+
+      it "stores the override units on the event" do
+        expect(result).to be_success
+        expect(result.fixed_charge_event.units).to eq(25)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

FixedChargeEvent rows drive downstream billing. When a subscription carries a per-subscription units override, the parent fixed charge is still reused for emission and its plain `units` value no longer reflects what the subscription should be billed for. The event row itself has to capture the effective units for the subscription so the Simple and Prorated aggregators (which read straight from FixedChargeEvent#units) pick up the override automatically.

## Description

`FixedChargeEvents::CreateService` now builds the event with `fixed_charge.units_for(subscription)` instead of `fixed_charge.units`. The resolver's existing behaviour with a nil subscription (returning the plan-level value) keeps the pre-existing nil-subscription validation path intact.

Spec adds one context covering the override-present path; existing cases (default units, missing-association validation failure) continue to pass unchanged.