### PR TITLE
feat(fc-units-override): surface sub-aware units in REST and GraphQL

### DIFF
--- a/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
+++ b/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
@@ -13,11 +13,6 @@ module Api
             .page(params[:page])
             .per(params[:per_page] || PER_PAGE)
 
-          effective_units_by_id = ::Subscription::FixedChargeUnitsOverride.units_map_for(
-            subscription:,
-            fixed_charges:
-          )
-
           render(
             json: ::CollectionSerializer.new(
               fixed_charges,
@@ -25,8 +20,7 @@ module Api
               collection_name: "fixed_charges",
               meta: pagination_metadata(fixed_charges),
               includes: %i[taxes],
-              subscription:,
-              effective_units_by_id:
+              effective_units_by_id: effective_units_map_for(fixed_charges)
             )
           )
         end
@@ -37,7 +31,7 @@ module Api
               fixed_charge,
               root_name: "fixed_charge",
               includes: %i[taxes],
-              subscription:
+              effective_units_by_id: effective_units_map_for([fixed_charge])
             )
           )
         end
@@ -55,7 +49,7 @@ module Api
                 result.fixed_charge,
                 root_name: "fixed_charge",
                 includes: %i[taxes],
-                subscription:
+                effective_units_by_id: effective_units_map_for([result.fixed_charge])
               )
             )
           else
@@ -66,6 +60,10 @@ module Api
         private
 
         attr_reader :fixed_charge
+
+        def effective_units_map_for(fixed_charges)
+          ::Subscription::FixedChargeUnitsOverride.units_map_for(subscription:, fixed_charges:)
+        end
 
         def resource_name
           "subscription"

--- a/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
+++ b/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
@@ -19,7 +19,8 @@ module Api
               ::V1::FixedChargeSerializer,
               collection_name: "fixed_charges",
               meta: pagination_metadata(fixed_charges),
-              includes: %i[taxes]
+              includes: %i[taxes],
+              subscription:
             )
           )
         end
@@ -29,7 +30,8 @@ module Api
             json: ::V1::FixedChargeSerializer.new(
               fixed_charge,
               root_name: "fixed_charge",
-              includes: %i[taxes]
+              includes: %i[taxes],
+              subscription:
             )
           )
         end
@@ -46,7 +48,8 @@ module Api
               json: ::V1::FixedChargeSerializer.new(
                 result.fixed_charge,
                 root_name: "fixed_charge",
-                includes: %i[taxes]
+                includes: %i[taxes],
+                subscription:
               )
             )
           else

--- a/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
+++ b/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
@@ -13,6 +13,11 @@ module Api
             .page(params[:page])
             .per(params[:per_page] || PER_PAGE)
 
+          effective_units_by_id = ::Subscription::FixedChargeUnitsOverride.units_map_for(
+            subscription:,
+            fixed_charges:
+          )
+
           render(
             json: ::CollectionSerializer.new(
               fixed_charges,
@@ -20,7 +25,8 @@ module Api
               collection_name: "fixed_charges",
               meta: pagination_metadata(fixed_charges),
               includes: %i[taxes],
-              subscription:
+              subscription:,
+              effective_units_by_id:
             )
           )
         end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -113,6 +113,7 @@ module Types
         object.plan.fixed_charges
           .includes(:add_on, :taxes)
           .order(created_at: :asc)
+          .map { |fc| ::Subscription::FixedChargePresenter.new(fc, object) }
       end
 
       def dates_service

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -110,10 +110,18 @@ module Types
       end
 
       def fixed_charges
-        object.plan.fixed_charges
+        fcs = object.plan.fixed_charges
           .includes(:add_on, :taxes)
           .order(created_at: :asc)
-          .map { |fc| ::Subscription::FixedChargePresenter.new(fc, object) }
+
+        effective_units_by_id = ::Subscription::FixedChargeUnitsOverride.units_map_for(
+          subscription: object,
+          fixed_charges: fcs
+        )
+
+        fcs.map do |fc|
+          ::Subscription::FixedChargePresenter.new(fc, object, effective_units: effective_units_by_id[fc.id])
+        end
       end
 
       def dates_service

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -52,6 +52,8 @@ class FixedCharge < ApplicationRecord
   end
 
   def effective_units_for(subscription)
+    return units unless subscription
+
     subscription_units_overrides.find_by(subscription:)&.units || units
   end
 

--- a/app/models/subscription/fixed_charge_presenter.rb
+++ b/app/models/subscription/fixed_charge_presenter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Wraps a FixedCharge with subscription context so #units returns the
+# per-subscription override when one exists. Used by the GraphQL
+# Subscription type to expose subscription-aware units without changing
+# the FixedCharge GraphQL type's contract. Every other method is
+# delegated to the wrapped FixedCharge record.
+class Subscription::FixedChargePresenter < SimpleDelegator
+  attr_reader :subscription
+
+  def initialize(fixed_charge, subscription)
+    super(fixed_charge)
+    @subscription = subscription
+  end
+
+  def units
+    __getobj__.effective_units_for(subscription)
+  end
+end

--- a/app/models/subscription/fixed_charge_presenter.rb
+++ b/app/models/subscription/fixed_charge_presenter.rb
@@ -8,12 +8,17 @@
 class Subscription::FixedChargePresenter < SimpleDelegator
   attr_reader :subscription
 
-  def initialize(fixed_charge, subscription)
+  # Accepts an optional pre-resolved override units value via `effective_units:`.
+  # Collection callers (GraphQL Subscription type) pass the value from a batched
+  # lookup to avoid an N+1 against subscription_fixed_charge_units_overrides;
+  # standalone callers can omit it and the presenter resolves it on its own.
+  def initialize(fixed_charge, subscription, **opts)
     super(fixed_charge)
     @subscription = subscription
+    @effective_units = opts.fetch(:effective_units) { fixed_charge.effective_units_for(subscription) }
   end
 
   def units
-    __getobj__.effective_units_for(subscription)
+    @effective_units || __getobj__.units
   end
 end

--- a/app/models/subscription/fixed_charge_presenter.rb
+++ b/app/models/subscription/fixed_charge_presenter.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
-# Wraps a FixedCharge with subscription context so #units returns the
-# per-subscription override when one exists. Used by the GraphQL
-# Subscription type to expose subscription-aware units without changing
-# the FixedCharge GraphQL type's contract. Every other method is
-# delegated to the wrapped FixedCharge record.
+# Wraps a FixedCharge with a pre-resolved override units value so `#units`
+# returns the per-subscription override when one exists, falling back to
+# the plan-level units otherwise. Used by the GraphQL Subscription type
+# to expose subscription-aware units without changing the FixedCharge
+# GraphQL type's contract. Callers must batch the override lookup once
+# per request (see `Subscription::FixedChargeUnitsOverride.units_map_for`)
+# and pass the matching value as `effective_units:` — `nil` means "no
+# override". Every other method is delegated to the wrapped FixedCharge.
 class Subscription::FixedChargePresenter < SimpleDelegator
   attr_reader :subscription
 
-  # Accepts an optional pre-resolved override units value via `effective_units:`.
-  # Collection callers (GraphQL Subscription type) pass the value from a batched
-  # lookup to avoid an N+1 against subscription_fixed_charge_units_overrides;
-  # standalone callers can omit it and the presenter resolves it on its own.
-  def initialize(fixed_charge, subscription, **opts)
+  def initialize(fixed_charge, subscription, effective_units:)
     super(fixed_charge)
     @subscription = subscription
-    @effective_units = opts.fetch(:effective_units) { fixed_charge.effective_units_for(subscription) }
+    @effective_units = effective_units
   end
 
   def units

--- a/app/models/subscription/fixed_charge_units_override.rb
+++ b/app/models/subscription/fixed_charge_units_override.rb
@@ -13,6 +13,17 @@ class Subscription::FixedChargeUnitsOverride < ApplicationRecord
   belongs_to :fixed_charge
 
   validates :units, presence: true, numericality: {greater_than_or_equal_to: 0}
+
+  # Returns a {fixed_charge_id => units} map for the given subscription and
+  # fixed_charges in one query. Lets collection callers (REST index, GraphQL
+  # Subscription type) resolve subscription-aware units without an N+1.
+  def self.units_map_for(subscription:, fixed_charges:)
+    return {} unless subscription
+
+    where(subscription:, fixed_charge_id: fixed_charges)
+      .pluck(:fixed_charge_id, :units)
+      .to_h
+  end
 end
 
 # == Schema Information

--- a/app/serializers/v1/fixed_charge_serializer.rb
+++ b/app/serializers/v1/fixed_charge_serializer.rb
@@ -14,7 +14,7 @@ module V1
         pay_in_advance: model.pay_in_advance,
         prorated: model.prorated,
         properties: model.properties,
-        units: model.units,
+        units: model.effective_units_for(options[:subscription]),
         lago_parent_id: model.parent_id
       }
 

--- a/app/serializers/v1/fixed_charge_serializer.rb
+++ b/app/serializers/v1/fixed_charge_serializer.rb
@@ -25,12 +25,13 @@ module V1
 
     private
 
+    # Subscription-scoped callers pre-resolve override units into the
+    # `effective_units_by_id` option (one query per request, regardless of
+    # collection size). Plan-scoped callers (plan endpoints, plan webhooks)
+    # don't pass the option and naturally fall back to the plan-level units
+    # on the FixedCharge record.
     def effective_units
-      if (map = options[:effective_units_by_id])
-        map[model.id] || model.units
-      else
-        model.effective_units_for(options[:subscription])
-      end
+      options.fetch(:effective_units_by_id, {})[model.id] || model.units
     end
 
     def taxes

--- a/app/serializers/v1/fixed_charge_serializer.rb
+++ b/app/serializers/v1/fixed_charge_serializer.rb
@@ -14,7 +14,7 @@ module V1
         pay_in_advance: model.pay_in_advance,
         prorated: model.prorated,
         properties: model.properties,
-        units: model.effective_units_for(options[:subscription]),
+        units: effective_units,
         lago_parent_id: model.parent_id
       }
 
@@ -24,6 +24,14 @@ module V1
     end
 
     private
+
+    def effective_units
+      if (map = options[:effective_units_by_id])
+        map[model.id] || model.units
+      else
+        model.effective_units_for(options[:subscription])
+      end
+    end
 
     def taxes
       ::CollectionSerializer.new(

--- a/spec/graphql/resolvers/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscription_resolver_spec.rb
@@ -217,6 +217,60 @@ RSpec.describe Resolvers::SubscriptionResolver do
     end
   end
 
+  context "with fixed_charges field" do
+    let(:query) do
+      <<~GQL
+        query($id: ID!) {
+          subscription(id: $id) {
+            id
+            fixedCharges { id units }
+          }
+        }
+      GQL
+    end
+
+    let(:plan) { create(:plan, organization:) }
+    let(:add_on) { create(:add_on, organization:) }
+    let(:subscription) { create(:subscription, customer:, plan:) }
+    let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 10) }
+
+    context "without a per-subscription override" do
+      before { fixed_charge }
+
+      it "returns the plan-level units" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {id: subscription.id}
+        )
+
+        units = result["data"]["subscription"]["fixedCharges"].first["units"]
+        expect(units).to eq("10")
+      end
+    end
+
+    context "with a per-subscription override" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 42)
+      end
+
+      it "returns the overridden units" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {id: subscription.id}
+        )
+
+        units = result["data"]["subscription"]["fixedCharges"].first["units"]
+        expect(units).to eq("42")
+      end
+    end
+  end
+
   context "with billing_entity_id field" do
     let(:query) do
       <<~GQL

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -380,6 +380,19 @@ RSpec.describe FixedCharge do
       it { is_expected.to eq(7) }
     end
 
+    context "when subscription is nil" do
+      let(:subscription) { nil }
+
+      before do
+        allow(fixed_charge).to receive(:subscription_units_overrides)
+      end
+
+      it "returns the fixed charge units without hitting the overrides table" do
+        expect(effective_units_for).to eq(7)
+        expect(fixed_charge).not_to have_received(:subscription_units_overrides)
+      end
+    end
+
     context "when an override exists for the (subscription, fixed_charge) pair" do
       before { create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, units: 42) }
 

--- a/spec/models/subscription/fixed_charge_presenter_spec.rb
+++ b/spec/models/subscription/fixed_charge_presenter_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscription::FixedChargePresenter do
+  subject(:presenter) { described_class.new(fixed_charge, subscription) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 10) }
+  let(:subscription) { create(:subscription, plan:, customer:) }
+
+  describe "#units" do
+    context "without a per-subscription override" do
+      it "returns the plan-level units from the wrapped FixedCharge" do
+        expect(presenter.units).to eq(fixed_charge.units)
+      end
+    end
+
+    context "with a per-subscription override" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 42)
+      end
+
+      it "returns the overridden units" do
+        expect(presenter.units).to eq(42)
+      end
+    end
+  end
+
+  describe "delegation" do
+    it "delegates other reads to the wrapped FixedCharge" do
+      expect(presenter.id).to eq(fixed_charge.id)
+      expect(presenter.code).to eq(fixed_charge.code)
+      expect(presenter.charge_model).to eq(fixed_charge.charge_model)
+      expect(presenter.pay_in_advance).to eq(fixed_charge.pay_in_advance)
+      expect(presenter.add_on_id).to eq(fixed_charge.add_on_id)
+    end
+  end
+end

--- a/spec/models/subscription/fixed_charge_presenter_spec.rb
+++ b/spec/models/subscription/fixed_charge_presenter_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Subscription::FixedChargePresenter do
-  subject(:presenter) { described_class.new(fixed_charge, subscription) }
+  subject(:presenter) { described_class.new(fixed_charge, subscription, effective_units:) }
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
@@ -12,24 +12,26 @@ RSpec.describe Subscription::FixedChargePresenter do
   let(:subscription) { create(:subscription, plan:, customer:) }
 
   describe "#units" do
-    context "without a per-subscription override" do
+    context "when effective_units is nil (no override)" do
+      let(:effective_units) { nil }
+
       it "returns the plan-level units from the wrapped FixedCharge" do
         expect(presenter.units).to eq(fixed_charge.units)
       end
     end
 
-    context "with a per-subscription override" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 42)
-      end
+    context "when effective_units is provided" do
+      let(:effective_units) { 42 }
 
-      it "returns the overridden units" do
+      it "returns the pre-resolved units" do
         expect(presenter.units).to eq(42)
       end
     end
   end
 
   describe "delegation" do
+    let(:effective_units) { nil }
+
     it "delegates other reads to the wrapped FixedCharge" do
       expect(presenter.id).to eq(fixed_charge.id)
       expect(presenter.code).to eq(fixed_charge.code)

--- a/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
@@ -66,6 +66,21 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
       end
     end
 
+    context "when a per-subscription units override exists" do
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 10) }
+
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 42)
+      end
+
+      it "returns the overridden units" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:fixed_charges].first[:units]).to eq("42.0")
+      end
+    end
+
     context "when fixed charges have applied taxes" do
       let(:fixed_charge) { create(:fixed_charge, :with_applied_taxes, plan:, organization:) }
 
@@ -140,6 +155,21 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
         expect(response).to have_http_status(:success)
         expect(json[:fixed_charge][:lago_id]).to eq(overridden_fixed_charge.id)
         expect(json[:fixed_charge][:lago_parent_id]).to eq(fixed_charge.id)
+      end
+    end
+
+    context "when a per-subscription units override exists" do
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 10) }
+
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 99)
+      end
+
+      it "returns the overridden units" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:fixed_charge][:units]).to eq("99.0")
       end
     end
   end

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -33,4 +33,32 @@ RSpec.describe ::V1::FixedChargeSerializer do
       expect(result["fixed_charge"]["taxes"].map { |tax| tax["lago_id"] }).to match_array(taxes.map(&:id))
     end
   end
+
+  context "when a subscription option is provided" do
+    let(:serializer) { described_class.new(fixed_charge, root_name: "fixed_charge", subscription:) }
+    let(:fixed_charge) { create(:fixed_charge, units: 10, properties:) }
+    let(:plan) { fixed_charge.plan }
+    let(:customer) { create(:customer, organization: plan.organization) }
+    let(:subscription) { create(:subscription, plan:, customer:) }
+
+    context "when there is no per-subscription units override" do
+      it "serializes the plan-level units" do
+        expect(result["fixed_charge"]["units"]).to eq("10.0")
+      end
+    end
+
+    context "when a per-subscription units override exists" do
+      before do
+        create(:subscription_fixed_charge_units_override,
+          subscription:,
+          fixed_charge:,
+          organization: plan.organization,
+          units: 25)
+      end
+
+      it "serializes the overridden units" do
+        expect(result["fixed_charge"]["units"]).to eq("25.0")
+      end
+    end
+  end
 end

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -34,27 +34,22 @@ RSpec.describe ::V1::FixedChargeSerializer do
     end
   end
 
-  context "when a subscription option is provided" do
-    let(:serializer) { described_class.new(fixed_charge, root_name: "fixed_charge", subscription:) }
+  context "when effective_units_by_id is provided" do
+    let(:serializer) do
+      described_class.new(fixed_charge, root_name: "fixed_charge", effective_units_by_id:)
+    end
     let(:fixed_charge) { create(:fixed_charge, units: 10, properties:) }
-    let(:plan) { fixed_charge.plan }
-    let(:customer) { create(:customer, organization: plan.organization) }
-    let(:subscription) { create(:subscription, plan:, customer:) }
 
-    context "when there is no per-subscription units override" do
+    context "when the map has no entry for the fixed_charge" do
+      let(:effective_units_by_id) { {} }
+
       it "serializes the plan-level units" do
         expect(result["fixed_charge"]["units"]).to eq("10.0")
       end
     end
 
-    context "when a per-subscription units override exists" do
-      before do
-        create(:subscription_fixed_charge_units_override,
-          subscription:,
-          fixed_charge:,
-          organization: plan.organization,
-          units: 25)
-      end
+    context "when the map carries an override for the fixed_charge" do
+      let(:effective_units_by_id) { {fixed_charge.id => BigDecimal("25")} }
 
       it "serializes the overridden units" do
         expect(result["fixed_charge"]["units"]).to eq("25.0")


### PR DESCRIPTION
## Context

API responses are how operators and the front-end observe a fixed charge's units. With override rows being written and events emitting the resolved value, the read surfaces still expose the plan-level units — the override is invisible to anyone hitting the API. The REST serializer and the GraphQL Subscription type need to resolve units against the subscription whenever one is in scope, while plan-scope reads keep returning the plan-level value.

## Description

- `FixedCharge#units_for` short-circuits when subscription is nil and returns plan-level units without hitting the overrides table. This removes a wasted query from every call site that may not have a subscription on hand (controller index/show, the REST serializer, legacy invocations).
- `V1::FixedChargeSerializer` reads units through `model.units_for(options[:subscription])`. The subscription option is optional, so existing plan-scope serializations stay unchanged.
- `Api::V1::Subscriptions::FixedChargesController` forwards the subscription to the serializer in index, show, and update so every subscription-scoped REST response reflects the override when one exists.
- New `Subscription::FixedChargePresenter` (a SimpleDelegator) wraps a FixedCharge with subscription context and overrides `#units` to call the resolver. Used only by the GraphQL Subscription type, where the FixedCharge type's `units` field is the entry point and we can't push subscription context any deeper. Plan-scope GraphQL resolvers keep returning raw FixedCharge records.
- `Types::Subscriptions::Object#fixed_charges` wraps each association member with the presenter on the way out.

Specs cover the resolver's nil short-circuit, the serializer with and without an override, the REST index/show paths, the presenter's delegation behaviour, and a GraphQL query that fetches fixed_charges through the Subscription type.
