### PR TITLE
feat(fc-units-override): preserve sub-level units on plan updates

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -80,7 +80,10 @@ class Subscription < ApplicationRecord
   scope :starting_in_the_future, -> { pending.where(previous_subscription: nil) }
   scope :expirable, -> { incomplete.joins(:activation_rules).merge(Subscription::ActivationRule.expirable) }
   scope :without_fixed_charge_units_override_for, ->(fixed_charge) {
-    where.not(id: Subscription::FixedChargeUnitsOverride.where(fixed_charge:).select(:subscription_id))
+    overrides = Subscription::FixedChargeUnitsOverride
+      .where(fixed_charge:)
+      .where("subscription_fixed_charge_units_overrides.subscription_id = subscriptions.id")
+    where.not(overrides.arel.exists)
   }
 
   # NOTE: SQL query to get subscription_at into customer timezone

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -79,6 +79,9 @@ class Subscription < ApplicationRecord
 
   scope :starting_in_the_future, -> { pending.where(previous_subscription: nil) }
   scope :expirable, -> { incomplete.joins(:activation_rules).merge(Subscription::ActivationRule.expirable) }
+  scope :without_fixed_charge_units_override_for, ->(fixed_charge) {
+    where.not(id: Subscription::FixedChargeUnitsOverride.where(fixed_charge:).select(:subscription_id))
+  }
 
   # NOTE: SQL query to get subscription_at into customer timezone
   def self.subscription_at_in_timezone_sql

--- a/app/services/fixed_charges/emit_events_service.rb
+++ b/app/services/fixed_charges/emit_events_service.rb
@@ -31,13 +31,17 @@ module FixedCharges
     def subscriptions
       # When a specific subscription is provided, emit event for that subscription only
       # This handles cases like plan overrides where the subscription hasn't been updated yet
-      # otherwise, emit events for all active subscriptions on the plan
+      # otherwise, emit events for all active subscriptions on the plan, except subscriptions
+      # that carry a per-subscription units override for this fixed charge (their units are
+      # decoupled from the plan-level value and a plan-level update must not touch them).
       if subscription
         # Emit events for active and incomplete subscriptions
         # Pending subscriptions will have events created when they activate
         (subscription.active? || subscription.incomplete?) ? [subscription] : []
       else
-        fixed_charge.plan.subscriptions.where(status: %i[active incomplete])
+        fixed_charge.plan.subscriptions
+          .where(status: %i[active incomplete])
+          .without_fixed_charge_units_override_for(fixed_charge)
       end
     end
 

--- a/app/services/fixed_charges/update_service.rb
+++ b/app/services/fixed_charges/update_service.rb
@@ -49,11 +49,13 @@ module FixedCharges
           )
 
           if trigger_billing && params[:apply_units_immediately] && fixed_charge.pay_in_advance?
-            plan.subscriptions.active.find_each do |subscription|
-              after_commit do
-                Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+            plan.subscriptions.active
+              .without_fixed_charge_units_override_for(fixed_charge)
+              .find_each do |subscription|
+                after_commit do
+                  Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+                end
               end
-            end
           end
         end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -160,6 +160,38 @@ RSpec.describe Subscription do
         expect(described_class.expirable).to match_array([expirable_subscription])
       end
     end
+
+    describe ".without_fixed_charge_units_override_for" do
+      let(:organization) { create(:organization) }
+      let(:plan) { create(:plan, organization:) }
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:) }
+      let(:other_fixed_charge) { create(:fixed_charge, plan:, organization:) }
+      let(:overridden_sub) { create(:subscription, plan:) }
+      let(:bare_sub) { create(:subscription, plan:) }
+      let(:other_fc_overridden_sub) { create(:subscription, plan:) }
+
+      before do
+        create(:subscription_fixed_charge_units_override, subscription: overridden_sub, fixed_charge:, organization:)
+        create(:subscription_fixed_charge_units_override, subscription: other_fc_overridden_sub, fixed_charge: other_fixed_charge, organization:)
+      end
+
+      it "excludes subscriptions with a kept override for the given fixed charge" do
+        result = described_class.without_fixed_charge_units_override_for(fixed_charge)
+
+        expect(result).to include(bare_sub, other_fc_overridden_sub)
+        expect(result).not_to include(overridden_sub)
+      end
+
+      context "when the override row was discarded" do
+        before do
+          Subscription::FixedChargeUnitsOverride.unscoped.find_by(subscription: overridden_sub, fixed_charge:).discard!
+        end
+
+        it "stops excluding the subscription" do
+          expect(described_class.without_fixed_charge_units_override_for(fixed_charge)).to include(overridden_sub)
+        end
+      end
+    end
   end
 
   describe "validations" do

--- a/spec/services/fixed_charges/emit_events_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_service_spec.rb
@@ -238,5 +238,21 @@ RSpec.describe FixedCharges::EmitEventsService do
         end
       end
     end
+
+    context "when one of the plan subscriptions has a per-subscription units override" do
+      before do
+        create(:subscription_fixed_charge_units_override,
+          subscription: active_subscription_1,
+          fixed_charge:,
+          organization:)
+      end
+
+      it "skips the overridden subscription when iterating plan subscriptions" do
+        expect { result }.to change(FixedChargeEvent, :count).by(1)
+
+        expect(result.fixed_charge_events.map(&:subscription_id)).to contain_exactly(active_subscription_2.id)
+        expect(FixedChargeEvent.where(subscription: active_subscription_1, fixed_charge:)).not_to exist
+      end
+    end
   end
 end

--- a/spec/services/fixed_charges/emit_events_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_service_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe FixedCharges::EmitEventsService do
       end
     end
 
-    context "when one of the plan subscriptions has a per-subscription units override" do
+    context "when an active plan subscription has a per-subscription units override" do
       before do
         create(:subscription_fixed_charge_units_override,
           subscription: active_subscription_1,
@@ -252,6 +252,35 @@ RSpec.describe FixedCharges::EmitEventsService do
 
         expect(result.fixed_charge_events.map(&:subscription_id)).to contain_exactly(active_subscription_2.id)
         expect(FixedChargeEvent.where(subscription: active_subscription_1, fixed_charge:)).not_to exist
+      end
+    end
+
+    context "when an incomplete plan subscription has a per-subscription units override" do
+      let(:incomplete_subscription) do
+        create(
+          :subscription,
+          :incomplete,
+          :anniversary,
+          plan:,
+          customer: customer_1,
+          started_at: 1.day.ago,
+          subscription_at: 1.day.ago
+        )
+      end
+
+      before do
+        create(:subscription_fixed_charge_units_override,
+          subscription: incomplete_subscription,
+          fixed_charge:,
+          organization:)
+      end
+
+      it "skips the overridden incomplete subscription while still emitting for the other active subscriptions" do
+        expect { result }.to change(FixedChargeEvent, :count).by(2)
+
+        expect(result.fixed_charge_events.map(&:subscription_id))
+          .to contain_exactly(active_subscription_1.id, active_subscription_2.id)
+        expect(FixedChargeEvent.where(subscription: incomplete_subscription, fixed_charge:)).not_to exist
       end
     end
   end

--- a/spec/services/fixed_charges/update_service_spec.rb
+++ b/spec/services/fixed_charges/update_service_spec.rb
@@ -294,6 +294,34 @@ RSpec.describe FixedCharges::UpdateService do
               .to have_been_enqueued
               .with(subscription, timestamp)
           end
+
+          context "when the subscription has a per-subscription units override" do
+            let(:other_subscription) { create(:subscription, plan:) }
+
+            before do
+              other_subscription
+              create(:subscription_fixed_charge_units_override,
+                subscription:,
+                fixed_charge:,
+                organization:)
+            end
+
+            it "does not enqueue the billing job for the overridden subscription" do
+              result
+
+              expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+                .not_to have_been_enqueued
+                .with(subscription, timestamp)
+            end
+
+            it "still enqueues the billing job for other plan subscriptions" do
+              result
+
+              expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+                .to have_been_enqueued
+                .with(other_subscription, timestamp)
+            end
+          end
         end
 
         context "when apply_units_immediately is false" do


### PR DESCRIPTION
## Context

When the plan-level units of a fixed charge change, every active subscription on the plan currently receives a FixedChargeEvent (and a pay-in-advance billing job when requested). Subscriptions that have already decoupled their units via a per-subscription override row are not on the plan default anymore — overwriting them from the plan-level update would silently revert per-customer commitments.

Amount and properties changes don't need filtering: they live on the plan-level fixed_charge record and don't trigger event emission, so they continue to broadcast to every subscription on the next billing cycle (multiplied by each subscription's effective units).

## Description

- New `Subscription.without_fixed_charge_units_override_for(fixed_charge)` scope filters out subscriptions that hold a kept override row for the given fixed charge. Soft-discarded rows stop excluding so a removed override behaves like no override at all.
- `FixedCharges::EmitEventsService` applies the scope in its iterate- all-plan-subscriptions branch. The single-subscription branch is untouched — callers passing a specific subscription stay in control.
- `FixedCharges::UpdateService` applies the same scope when dispatching `Invoices::CreatePayInAdvanceFixedChargesJob` so the mid-period delta invoice skips overridden subscriptions as well.

Specs cover the scope, the EmitEventsService skip on iteration, and the UpdateService dispatch skip.