### PR TITLE
fix(invoices): Apply custom sections when tax is deferred

### DIFF
--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -51,16 +51,18 @@ module Invoices
         invoice.payment_method = payment_method
         invoice.skip_automatic_payment = skip_psp
 
+        # NOTE: Custom sections are applied before computing taxes so they are persisted even when
+        #       tax computation is deferred to a tax provider (the `next` below skips the rest of the block).
+        unless skip_custom_sections?
+          Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, custom_section_ids: invoice_custom_section_ids)
+        end
+
         totals_result = Invoices::ComputeTaxesAndTotalsService.call(invoice:)
         if totals_result.failure? && totals_result.error.is_a?(BaseService::UnknownTaxFailure)
           tax_deferred = true
           next
         end
         totals_result.raise_if_error!
-
-        unless skip_custom_sections?
-          Invoices::ApplyInvoiceCustomSectionsService.call(invoice:, custom_section_ids: invoice_custom_section_ids)
-        end
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         Invoices::TransitionToFinalStatusService.call(invoice:)

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -27,6 +27,10 @@ module Invoices
         invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
         Credits::AppliedCouponsService.call(invoice:) if invoice.fees_amount_cents&.positive?
 
+        # NOTE: Custom sections are applied before computing taxes so they are persisted even when
+        #       tax computation is deferred to a tax provider (the `next` below skips the rest of the block).
+        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
+
         totals_result = Invoices::ComputeTaxesAndTotalsService.call(invoice:)
         if totals_result.failure? && totals_result.error.is_a?(BaseService::UnknownTaxFailure)
           tax_deferred = true
@@ -36,7 +40,6 @@ module Invoices
 
         create_credit_note_credit
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         Invoices::TransitionToFinalStatusService.call(invoice:)

--- a/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
+++ b/app/services/invoices/create_pay_in_advance_fixed_charges_service.rb
@@ -36,6 +36,10 @@ module Invoices
         invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
         Credits::AppliedCouponsService.call(invoice:) if invoice.fees_amount_cents&.positive?
 
+        # NOTE: Custom sections are applied before computing taxes so they are persisted even when
+        #       tax computation is deferred to a tax provider (the `next` below skips the rest of the block).
+        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
+
         totals_result = Invoices::ComputeTaxesAndTotalsService.call(invoice:)
         if totals_result.failure? && totals_result.error.is_a?(BaseService::UnknownTaxFailure)
           tax_deferred = true
@@ -45,7 +49,6 @@ module Invoices
 
         create_credit_note_credit
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
-        Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
         skip_payment_gating_for_zero_amount if subscription.payment_gated? && invoice.total_amount_cents.zero? && !invoice.tax_pending?
 

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -241,6 +241,22 @@ RSpec.describe Invoices::CreateOneOffService do
 
         expect(Utils::ActivityLog).not_to have_produced("invoice.one_off_created").with(result.invoice)
       end
+
+      context "with custom sections applied at the billing entity level" do
+        let(:custom_section) { create(:invoice_custom_section, organization:) }
+
+        before do
+          create(:billing_entity_applied_invoice_custom_section, organization:, billing_entity:, invoice_custom_section: custom_section)
+        end
+
+        it "applies the custom sections even though tax resolution is deferred" do
+          result = described_class.call(**args)
+
+          expect(result).to be_success
+          expect(result.invoice.status).to eq("pending")
+          expect(result.invoice.applied_invoice_custom_sections.pluck(:code)).to eq([custom_section.code])
+        end
+      end
     end
 
     context "when invoice amount in cents is zero" do

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -242,6 +242,22 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService do
         expect(SendWebhookJob).to have_been_enqueued.with("fee.created", anything)
         expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
       end
+
+      context "with custom sections applied at the billing entity level" do
+        let(:custom_section) { create(:invoice_custom_section, organization:) }
+
+        before do
+          create(:billing_entity_applied_invoice_custom_section, organization:, billing_entity:, invoice_custom_section: custom_section)
+        end
+
+        it "applies the custom sections even though tax resolution is deferred" do
+          result = invoice_service.call
+
+          expect(result).to be_success
+          expect(result.invoice.status).to eq("pending")
+          expect(result.invoice.applied_invoice_custom_sections.pluck(:code)).to eq([custom_section.code])
+        end
+      end
     end
 
     context "with grace period" do

--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -464,6 +464,22 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
         expect(SendWebhookJob).to have_been_enqueued.with("fee.created", anything)
         expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.created", anything)
       end
+
+      context "with custom sections applied at the billing entity level" do
+        let(:custom_section) { create(:invoice_custom_section, organization:) }
+
+        before do
+          create(:billing_entity_applied_invoice_custom_section, organization:, billing_entity:, invoice_custom_section: custom_section)
+        end
+
+        it "applies the custom sections even though tax resolution is deferred" do
+          result = invoice_service.call
+
+          expect(result).to be_success
+          expect(result.invoice.status).to eq("pending")
+          expect(result.invoice.applied_invoice_custom_sections.pluck(:code)).to eq([custom_section.code])
+        end
+      end
     end
 
     context "when an error occurs" do


### PR DESCRIPTION
## Context

[BIL-39](https://linear.app/getlago/issue/BIL-39/invoice-footer-not-applied-for-anrok-tax-provider-customers): invoice custom sections (footer) were missing on one-off invoices for customers connected to a tax provider (Anrok), while they appeared correctly for other customers.

## Description

Ensures configured invoice custom sections are applied to invoices whose tax computation is deferred to a tax provider, instead of being skipped on that path. Covers one-off and pay-in-advance charge invoices, with regression specs.