### PR TITLE
fix(invoices): Assign voided applied_usage_thresholds to regenerated invoice

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -245,6 +245,12 @@ class Invoice < ApplicationRecord
     sorted_invoice_subscriptions.map(&:subscription)
   end
 
+  def progressive_billing_last_applied_usage_threshold
+    return unless progressive_billing?
+
+    applied_usage_thresholds.order(created_at: :asc).last
+  end
+
   def subscription_fees(subscription_id)
     invoice_subscription(subscription_id).fees
   end

--- a/app/services/invoices/regenerate_from_voided_service.rb
+++ b/app/services/invoices/regenerate_from_voided_service.rb
@@ -24,6 +24,7 @@ module Invoices
         create_invoice_subscriptions
         process_fees
         adjust_fees
+        assign_applied_usage_thresholds
         Invoices::ApplyInvoiceCustomSectionsService.call!(invoice: regenerated_invoice)
         regenerated_invoice.fees_amount_cents = regenerated_invoice.fees.sum(:amount_cents)
         regenerated_invoice.sub_total_excluding_taxes_amount_cents = regenerated_invoice.fees.sum(:amount_cents)
@@ -177,10 +178,25 @@ module Invoices
       end
     end
 
+    def assign_applied_usage_thresholds
+      return unless voided_invoice.progressive_billing?
+
+      voided_invoice.applied_usage_thresholds.find_each do |applied_usage_threshold|
+        applied_usage_threshold.dup.tap do |duplicate|
+          duplicate.invoice = regenerated_invoice
+          duplicate.save!
+        end
+      end
+    end
+
+    def voided_invoice_fees
+      @voided_invoice_fees ||= voided_invoice.fees.where(id: fees_params.map { |fee| fee[:id] }.compact).index_by(&:id)
+    end
+
     def process_fees
       fees_params.each do |fee_params|
         if fee_params[:id].present?
-          voided_fee = voided_invoice.fees.find_by(id: fee_params[:id])
+          voided_fee = voided_invoice_fees[fee_params[:id]]
           dup_fee = duplicate_fee(voided_fee, fee_params) if voided_fee
         end
 

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -496,9 +496,9 @@ html
 
       == SlimHelper.render('templates/invoices/v4/_eu_tax_management', self)
 
-      - if progressive_billing?
+      - applied_usage_threshold = progressive_billing_last_applied_usage_threshold
+      - if applied_usage_threshold
         p.body-3.mb-24
-          - applied_usage_threshold = applied_usage_thresholds.order(created_at: :asc).last
           = I18n.t('invoice.reached_usage_threshold', usage_amount: MoneyHelper.format(applied_usage_threshold.lifetime_usage_amount), threshold_amount: MoneyHelper.format(applied_usage_threshold.passed_threshold_amount))
 
       - if applied_invoice_custom_sections.present?

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -480,9 +480,9 @@ html
 
       == SlimHelper.render('templates/invoices/v4/_eu_tax_management', self)
 
-      - if progressive_billing?
+      - applied_usage_threshold = progressive_billing_last_applied_usage_threshold
+      - if applied_usage_threshold
         p.body-3.mb-24
-          - applied_usage_threshold = applied_usage_thresholds.order(created_at: :asc).last
           = I18n.t('invoice.reached_usage_threshold', usage_amount: MoneyHelper.format(applied_usage_threshold.lifetime_usage_amount), threshold_amount: MoneyHelper.format(applied_usage_threshold.passed_threshold_amount))
 
       - if applied_invoice_custom_sections.present?

--- a/app/views/templates/payment_receipts/v1.slim
+++ b/app/views/templates/payment_receipts/v1.slim
@@ -117,9 +117,9 @@ html
 
         == SlimHelper.render('templates/invoices/v4/_eu_tax_management', payment.payable)
 
-        - if payment.payable.progressive_billing?
+        - applied_usage_threshold = payment.payable.progressive_billing_last_applied_usage_threshold
+        - if applied_usage_threshold
           p.body-3.mb-24
-            - applied_usage_threshold = payment.payable.applied_usage_thresholds.order(created_at: :asc).last
             = I18n.t('invoice.reached_usage_threshold', usage_amount: MoneyHelper.format(applied_usage_threshold.lifetime_usage_amount), threshold_amount: MoneyHelper.format(applied_usage_threshold.passed_threshold_amount))
 
         - if payment.payable.applied_invoice_custom_sections.present?

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -101,6 +101,31 @@ RSpec.describe Invoice do
     end
   end
 
+  describe "#progressive_billing_last_applied_usage_threshold" do
+    context "when invoice is progressive billing" do
+      let(:invoice) { create(:invoice, invoice_type: :progressive_billing) }
+
+      it "returns the last applied usage threshold" do
+        create(:applied_usage_threshold, invoice:, organization:, created_at: 2.days.ago)
+        applied_usage_threshold = create(:applied_usage_threshold, invoice:, organization:, created_at: 1.day.ago)
+
+        expect(invoice.progressive_billing_last_applied_usage_threshold).to eq(applied_usage_threshold)
+      end
+
+      it "returns nil when no applied usage threshold exists" do
+        expect(invoice.progressive_billing_last_applied_usage_threshold).to be_nil
+      end
+    end
+
+    context "when invoice is not progressive billing" do
+      it "returns nil" do
+        create(:applied_usage_threshold, invoice:, organization:)
+
+        expect(invoice.progressive_billing_last_applied_usage_threshold).to be_nil
+      end
+    end
+  end
+
   describe "sequential_id" do
     let(:customer) { create(:customer, organization:) }
     let(:billing_entity) { customer.billing_entity }

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -99,12 +99,37 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
         let(:original_fee) do
           create(:charge_fee, invoice: voided_invoice, subscription:, amount_cents: 1000, unit_amount_cents: 1000)
         end
+        let(:second_usage_threshold) { create(:usage_threshold, plan:, amount_cents: 2000) }
+        let(:second_applied_usage_threshold) do
+          create(
+            :applied_usage_threshold,
+            invoice: voided_invoice,
+            usage_threshold: second_usage_threshold,
+            organization:,
+            lifetime_usage_amount_cents: 2000
+          )
+        end
+
+        before do
+          second_applied_usage_threshold
+        end
 
         it "duplicates invoice_subscriptions to the regenerated invoice" do
           regenerated_invoice = regenerate_result.invoice
 
           expect(regenerated_invoice.invoice_subscriptions).not_to be_empty
           expect(regenerated_invoice.invoice_subscriptions.count).to eq(voided_invoice.invoice_subscriptions.count)
+        end
+
+        it "duplicates applied_usage_thresholds to the regenerated invoice" do
+          regenerated_invoice = regenerate_result.invoice
+
+          expect(voided_invoice.applied_usage_thresholds.count).to eq(2)
+          expect(regenerated_invoice.applied_usage_thresholds.count).to eq(2)
+          expect(regenerated_invoice.applied_usage_thresholds.pluck(:usage_threshold_id, :lifetime_usage_amount_cents))
+            .to match_array(voided_invoice.applied_usage_thresholds.pluck(:usage_threshold_id, :lifetime_usage_amount_cents))
+          expect(regenerated_invoice.applied_usage_thresholds.pluck(:id))
+            .not_to match_array(voided_invoice.applied_usage_thresholds.pluck(:id))
         end
       end
 

--- a/spec/views/app/views/templates/invoices/v4.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4.slim_spec.rb
@@ -1290,6 +1290,14 @@ RSpec.describe "templates/invoices/v4.slim" do
     it "renders correctly" do
       expect(rendered_template).to match_html_snapshot
     end
+
+    context "when invoice does not have any applied usage threshold" do
+      let(:applied_usage_threshold) { nil }
+
+      it "renders without the reached usage threshold line" do
+        expect(rendered_template).not_to include("This progressive billing is generated because your cumulative usage has reached")
+      end
+    end
   end
 
   context "when charge has filters and minimum commitment (true_up fee)" do

--- a/spec/views/app/views/templates/invoices/v4/self_billed.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4/self_billed.slim_spec.rb
@@ -210,6 +210,81 @@ RSpec.describe "templates/invoices/v4/self_billed.slim" do
     end
   end
 
+  context "when invoice_type is progressive_billing with prepaid credits" do
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: false, invoice_display_name: "Progressive Billing Plan") }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, invoice_display_name: "Usage Charge") }
+    let(:subscription) { create(:subscription, customer:, plan:, status: "active") }
+    let(:wallet) { create(:wallet, customer:, organization:, rate_amount: BigDecimal("1.0"), balance_currency: "USD") }
+    let(:wallet_transaction) { create(:wallet_transaction, wallet:, invoice:, credit_amount: BigDecimal("5.0"), amount: BigDecimal("5.0")) }
+    let(:applied_usage_threshold) { nil }
+
+    let(:invoice) do
+      create(
+        :invoice,
+        :self_billed,
+        customer:,
+        organization:,
+        number: "LAGO-202509-SB-005",
+        payment_due_date: Date.parse("2025-09-15"),
+        issuing_date: Date.parse("2025-09-15"),
+        invoice_type: :progressive_billing,
+        total_amount_cents: 9500,
+        currency: "USD",
+        fees_amount_cents: 10000,
+        sub_total_excluding_taxes_amount_cents: 10000,
+        sub_total_including_taxes_amount_cents: 10000,
+        prepaid_credit_amount_cents: 500,
+        prepaid_granted_credit_amount_cents: 200,
+        prepaid_purchased_credit_amount_cents: 300
+      )
+    end
+
+    let(:invoice_subscription) do
+      create(
+        :invoice_subscription,
+        invoice:,
+        subscription:,
+        from_datetime: Time.zone.parse("2025-09-01 00:00:00"),
+        to_datetime: Time.zone.parse("2025-09-30 23:59:59"),
+        charges_from_datetime: Time.zone.parse("2025-09-01 00:00:00"),
+        charges_to_datetime: Time.zone.parse("2025-09-15 23:59:59"),
+        timestamp: Time.zone.parse("2025-09-15 12:00:00")
+      )
+    end
+
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 10000,
+        amount_currency: "USD",
+        units: 100,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        invoice_display_name: "Usage Charge Fee",
+        properties: {
+          "timestamp" => "2025-09-15 12:00:00",
+          "charges_from_datetime" => "2025-09-01 00:00:00",
+          "charges_to_datetime" => "2025-09-15 23:59:59"
+        }
+      )
+    end
+
+    before do
+      invoice_subscription
+      charge_fee
+      wallet_transaction
+      applied_usage_threshold
+    end
+
+    it "renders without the reached usage threshold line" do
+      expect(rendered_template).not_to include("This progressive billing is generated because your cumulative usage has reached")
+    end
+  end
+
   context "with taxes applied" do
     let(:add_on) { create(:add_on, organization:, name: "Commission") }
     let(:tax) { create(:tax, organization:, name: "VAT", rate: 20.0) }

--- a/spec/views/app/views/templates/payment_receipts/v1.slim_spec.rb
+++ b/spec/views/app/views/templates/payment_receipts/v1.slim_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "templates/payment_receipts/v1.slim" do
+  subject(:rendered_template) do
+    Slim::Template.new(template, 1, pretty: true).render(payment_receipt)
+  end
+
+  let(:template) { Rails.root.join("app/views/templates/payment_receipts/v1.slim") }
+  let(:organization) { create(:organization, :with_static_values) }
+  let(:billing_entity) { organization.default_billing_entity }
+  let(:customer) { create(:customer, :with_static_values, organization:) }
+
+  before do
+    I18n.locale = :en
+  end
+
+  context "when payable invoice is progressive_billing with prepaid credits" do
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: false, invoice_display_name: "Progressive Billing Plan") }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, invoice_display_name: "Usage Charge") }
+    let(:subscription) { create(:subscription, customer:, plan:, status: "active") }
+    let(:wallet) { create(:wallet, customer:, organization:, rate_amount: BigDecimal("1.0"), balance_currency: "USD") }
+    let(:wallet_transaction) { create(:wallet_transaction, wallet:, invoice:, credit_amount: BigDecimal("5.0"), amount: BigDecimal("5.0")) }
+    let(:applied_usage_threshold) { nil }
+
+    let(:invoice) do
+      create(
+        :invoice,
+        customer:,
+        organization:,
+        billing_entity:,
+        number: "LAGO-202509-PR-001",
+        payment_due_date: Date.parse("2025-09-15"),
+        issuing_date: Date.parse("2025-09-15"),
+        invoice_type: :progressive_billing,
+        total_amount_cents: 9500,
+        total_paid_amount_cents: 9500,
+        currency: "USD",
+        fees_amount_cents: 10000,
+        sub_total_excluding_taxes_amount_cents: 10000,
+        sub_total_including_taxes_amount_cents: 10000,
+        prepaid_credit_amount_cents: 500,
+        prepaid_granted_credit_amount_cents: 200,
+        prepaid_purchased_credit_amount_cents: 300
+      )
+    end
+
+    let(:invoice_subscription) do
+      create(
+        :invoice_subscription,
+        invoice:,
+        subscription:,
+        from_datetime: Time.zone.parse("2025-09-01 00:00:00"),
+        to_datetime: Time.zone.parse("2025-09-30 23:59:59"),
+        charges_from_datetime: Time.zone.parse("2025-09-01 00:00:00"),
+        charges_to_datetime: Time.zone.parse("2025-09-15 23:59:59"),
+        timestamp: Time.zone.parse("2025-09-15 12:00:00")
+      )
+    end
+
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 10000,
+        amount_currency: "USD",
+        units: 100,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        invoice_display_name: "Usage Charge Fee",
+        properties: {
+          "timestamp" => "2025-09-15 12:00:00",
+          "charges_from_datetime" => "2025-09-01 00:00:00",
+          "charges_to_datetime" => "2025-09-15 23:59:59"
+        }
+      )
+    end
+
+    let(:payment) do
+      create(
+        :payment,
+        payable: invoice,
+        organization:,
+        customer:,
+        amount_cents: 9500,
+        amount_currency: "USD",
+        status: "succeeded",
+        payable_payment_status: "succeeded"
+      )
+    end
+
+    let(:payment_receipt) do
+      create(:payment_receipt, payment:, organization:, billing_entity:, number: "RCT-202509-001")
+    end
+
+    before do
+      invoice_subscription
+      charge_fee
+      wallet_transaction
+      applied_usage_threshold
+    end
+
+    it "renders without the reached usage threshold line" do
+      expect(rendered_template).not_to include("This progressive billing is generated because your cumulative usage has reached")
+    end
+  end
+end


### PR DESCRIPTION
This commit changes the RegenerateFromVoidedService to assign the applied_usage_thresholds

We have a behavior, progressive billing invoices can be voided and
during the regeneration process, we lost the applied_usage_thresholds.
And, a side effect, the PDF can't be generated because the logic to get
the newest applied_usage_threshold was retuning nil.

We're fixing this, first, we avoid break the PDF if the relation doesn't
exist and, in this commit, we're keep the data from voided invoice to the
regenerated invoice.

There is some edge cases, for example, the Fee's of regenerated invoice
can be changed and this affects directly the applied_usage_thresholds.
And, the subsequent finalized invoices (if they exist).
After talking with Customer Support, we're not tackling this for now
because it's not a common case to change such numbers and the edge case
can be solved in another way.

Additional changes: We're changing the O(N+1) query to load the fee from
voided invoice to happen in a single query instead. Having a
considerable amount of Fee's (> 10) slows the service.
