### PR TITLE
feat(exports): ING-297 add metadata to credit notes export view

### DIFF
--- a/app/graphql/mutations/credit_notes/update.rb
+++ b/app/graphql/mutations/credit_notes/update.rb
@@ -18,8 +18,7 @@ module Mutations
       def resolve(**args)
         result = ::CreditNotes::UpdateService.new(
           credit_note: current_organization.credit_notes.find_by(id: args[:id]),
-          refund_status: args[:refund_status],
-          metadata: args[:metadata]
+          **args.slice(:refund_status, :metadata)
         ).call
 
         result.success? ? result.credit_note : result_error(result)

--- a/app/services/credit_notes/update_service.rb
+++ b/app/services/credit_notes/update_service.rb
@@ -21,7 +21,11 @@ module CreditNotes
         end
 
         update_metadata!
-        credit_note.save! if credit_note.changed?
+        if credit_note.changed?
+          credit_note.save!
+        elsif metadata_changed
+          credit_note.touch # rubocop:disable Rails/SkipsModelValidations
+        end
       end
 
       handle_changes
@@ -46,16 +50,16 @@ module CreditNotes
 
     # @return [Boolean] if the metadata was changed in any way
     def update_metadata!
+      return unless params.key?(:metadata)
+
       value = params[:metadata]&.then { |m| m.respond_to?(:to_unsafe_h) ? m.to_unsafe_h : m.to_h }
-      Metadata::UpdateItemService.call!(owner: credit_note, value:, partial: partial_metadata.present?)
-      @metadata_changed = result.metadata_changed
+      metadata_result = Metadata::UpdateItemService.call!(owner: credit_note, value:, partial: partial_metadata.present?)
+      @metadata_changed = metadata_result.metadata_changed
     end
 
     def handle_changes
       if credit_note.previous_changes.key?(:refund_status)
         Utils::SegmentTrack.refund_status_changed(credit_note.refund_status, credit_note.id, credit_note.organization.id)
-      elsif metadata_changed
-        # Potential place for future tracking of credit note metadata changes
       end
     end
   end

--- a/db/migrate/20260604153307_update_exports_credit_notes_to_version_4.rb
+++ b/db/migrate/20260604153307_update_exports_credit_notes_to_version_4.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateExportsCreditNotesToVersion4 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :exports_credit_notes, version: 4, revert_to_version: 3
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1073,7 +1073,6 @@ DROP TABLE IF EXISTS public.payments;
 DROP TABLE IF EXISTS public.payment_requests;
 DROP TABLE IF EXISTS public.invoices_payment_requests;
 DROP VIEW IF EXISTS public.exports_item_metadata;
-DROP TABLE IF EXISTS public.item_metadata;
 DROP VIEW IF EXISTS public.exports_invoices_taxes;
 DROP TABLE IF EXISTS public.invoices_taxes;
 DROP VIEW IF EXISTS public.exports_invoices;
@@ -1100,6 +1099,7 @@ DROP TABLE IF EXISTS public.payment_provider_customers;
 DROP TABLE IF EXISTS public.organizations;
 DROP VIEW IF EXISTS public.exports_credit_notes_taxes;
 DROP VIEW IF EXISTS public.exports_credit_notes;
+DROP TABLE IF EXISTS public.item_metadata;
 DROP VIEW IF EXISTS public.exports_coupons;
 DROP VIEW IF EXISTS public.exports_charges;
 DROP VIEW IF EXISTS public.exports_billing_entities;
@@ -2922,6 +2922,22 @@ CREATE VIEW public.exports_coupons AS
 
 
 --
+-- Name: item_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.item_metadata (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    owner_type character varying NOT NULL,
+    owner_id uuid NOT NULL,
+    value jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT item_metadata_value_must_be_json_object CHECK ((jsonb_typeof(value) = 'object'::text))
+);
+
+
+--
 -- Name: exports_credit_notes; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -2971,9 +2987,13 @@ CREATE VIEW public.exports_credit_notes AS
     ( SELECT json_agg(json_build_object('lago_id', ci.id, 'amount_cents', ci.amount_cents, 'amount_currency', ci.amount_currency, 'lago_fee_id', ci.fee_id)) AS json_agg
            FROM public.credit_note_items ci
           WHERE (ci.credit_note_id = cn.id)) AS items,
+    ( SELECT json_agg(json_build_object('lago_id', im.id, 'key', je.key, 'value', je.value, 'created_at', im.created_at)) AS json_agg
+           FROM public.item_metadata im,
+            LATERAL jsonb_each_text(im.value) je(key, value)
+          WHERE (((im.owner_type)::text = 'CreditNote'::text) AND (im.owner_id = cn.id))) AS metadata,
     ( SELECT json_agg(json_build_object('lago_id', ed.id, 'error_code', ed.error_code, 'details', ed.details)) AS json_agg
            FROM public.error_details ed
-          WHERE (ed.owner_id = cn.id)) AS error_details
+          WHERE (((ed.owner_type)::text = 'CreditNote'::text) AND (ed.owner_id = cn.id))) AS error_details
    FROM public.credit_notes cn;
 
 
@@ -3757,22 +3777,6 @@ CREATE VIEW public.exports_invoices_taxes AS
     it.created_at,
     it.updated_at
    FROM public.invoices_taxes it;
-
-
---
--- Name: item_metadata; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.item_metadata (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    organization_id uuid NOT NULL,
-    owner_type character varying NOT NULL,
-    owner_id uuid NOT NULL,
-    value jsonb DEFAULT '{}'::jsonb NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    CONSTRAINT item_metadata_value_must_be_json_object CHECK ((jsonb_typeof(value) = 'object'::text))
-);
 
 
 --
@@ -12591,6 +12595,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260609161044'),
 ('20260608111837'),
 ('20260608074112'),
+('20260604153307'),
 ('20260603121349'),
 ('20260602092156'),
 ('20260601174030'),
@@ -13607,3 +13612,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2987,7 +2987,7 @@ CREATE VIEW public.exports_credit_notes AS
     ( SELECT json_agg(json_build_object('lago_id', ci.id, 'amount_cents', ci.amount_cents, 'amount_currency', ci.amount_currency, 'lago_fee_id', ci.fee_id)) AS json_agg
            FROM public.credit_note_items ci
           WHERE (ci.credit_note_id = cn.id)) AS items,
-    ( SELECT json_agg(json_build_object('lago_id', im.id, 'key', je.key, 'value', je.value, 'created_at', im.created_at)) AS json_agg
+    ( SELECT json_agg(json_build_object('key', je.key, 'value', je.value)) AS json_agg
            FROM public.item_metadata im,
             LATERAL jsonb_each_text(im.value) je(key, value)
           WHERE (((im.owner_type)::text = 'CreditNote'::text) AND (im.owner_id = cn.id))) AS metadata,

--- a/db/views/exports_credit_notes_v04.sql
+++ b/db/views/exports_credit_notes_v04.sql
@@ -1,0 +1,107 @@
+SELECT
+  cn.organization_id,
+  cn.id AS lago_id,
+  cn.sequential_id,
+  cn.number,
+  cn.invoice_id AS lago_invoice_id,
+  cn.issuing_date,
+  CASE cn.credit_status
+    WHEN 0 THEN 'available'
+    WHEN 1 THEN 'consumed'
+    WHEN 2 THEN 'voided'
+  END AS credit_status,
+  CASE cn.refund_status
+    WHEN 0 THEN 'pending'
+    WHEN 1 THEN 'succeeded'
+    WHEN 2 THEN 'failed'
+  END AS refund_status,
+  CASE cn.reason
+    WHEN 0 THEN 'duplicated_charge'
+    WHEN 1 THEN 'product_unsatisfactory'
+    WHEN 2 THEN 'order_change'
+    WHEN 3 THEN 'order_cancellation'
+    WHEN 4 THEN 'fraudulent_charge'
+    WHEN 5 THEN 'other'
+  END as reason,
+  cn.description,
+  cn.total_amount_currency AS currency,
+  cn.total_amount_cents,
+  cn.taxes_amount_cents,
+  ROUND(
+    (
+      SELECT
+        SUM(ci.precise_amount_cents)::bigint
+      FROM
+        credit_note_items AS ci
+      WHERE
+        ci.credit_note_id = cn.id
+    ) - cn.precise_coupons_adjustment_amount_cents
+  )::bigint AS sub_total_excluding_taxes_amount_cents,
+  cn.balance_amount_cents,
+  cn.credit_amount_cents,
+  cn.refund_amount_cents,
+  cn.coupons_adjustment_amount_cents,
+  cn.taxes_rate,
+  cn.created_at,
+  cn.updated_at,
+  cn.refunded_at,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'lago_id',
+          ci.id,
+          'amount_cents',
+          ci.amount_cents,
+          'amount_currency',
+          ci.amount_currency,
+          'lago_fee_id',
+          ci.fee_id
+        )
+      )
+    FROM
+      credit_note_items AS ci
+    WHERE
+      ci.credit_note_id = cn.id
+  ) AS items,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'lago_id',
+          im.id,
+          'key',
+          je.key,
+          'value',
+          je.value,
+          'created_at',
+          im.created_at
+        )
+      )
+    FROM
+      item_metadata AS im,
+      jsonb_each_text (im.value) AS je
+    WHERE
+      im.owner_type = 'CreditNote'
+      AND im.owner_id = cn.id
+  ) AS metadata,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'lago_id',
+          ed.id,
+          'error_code',
+          ed.error_code,
+          'details',
+          ed.details
+        )
+      )
+    FROM
+      error_details AS ed
+    WHERE
+      ed.owner_type = 'CreditNote'
+      AND ed.owner_id = cn.id
+  ) AS error_details
+FROM
+  credit_notes AS cn;

--- a/db/views/exports_credit_notes_v04.sql
+++ b/db/views/exports_credit_notes_v04.sql
@@ -68,14 +68,10 @@ SELECT
     SELECT
       json_agg (
         json_build_object (
-          'lago_id',
-          im.id,
           'key',
           je.key,
           'value',
-          je.value,
-          'created_at',
-          im.created_at
+          je.value
         )
       )
     FROM

--- a/spec/db/views/exports_credit_notes_spec.rb
+++ b/spec/db/views/exports_credit_notes_spec.rb
@@ -91,10 +91,8 @@ RSpec.describe "exports_credit_notes view" do # rubocop:disable RSpec/DescribeCl
           ],
           "metadata" => [
             {
-              "lago_id" => metadata.id,
               "key" => "key",
-              "value" => "value",
-              "created_at" => metadata.reload.created_at.strftime("%FT%H:%M:%S.%6N")
+              "value" => "value"
             }
           ],
           # The view exports the raw integer error_code column, not the enum string.
@@ -292,7 +290,6 @@ RSpec.describe "exports_credit_notes view" do # rubocop:disable RSpec/DescribeCl
         parsed = JSON.parse(metadata_for(credit_note.id))
 
         expect(parsed.map { |m| [m["key"], m["value"]] }).to match_array([["key", "value"], ["another", "thing"]])
-        expect(parsed.map { |m| m["lago_id"] }.uniq).to eq([credit_note.metadata.id])
       end
     end
 

--- a/spec/db/views/exports_credit_notes_spec.rb
+++ b/spec/db/views/exports_credit_notes_spec.rb
@@ -47,9 +47,6 @@ RSpec.describe "exports_credit_notes view" do # rubocop:disable RSpec/DescribeCl
       let!(:item) do
         create(:credit_note_item, credit_note:, precise_amount_cents: 100.4, amount_cents: 100, amount_currency: "EUR")
       end
-      let!(:metadata) do
-        create(:item_metadata, owner: credit_note, organization: credit_note.organization, value: {"key" => "value"})
-      end
       let!(:error_detail) do
         create(:error_detail, owner: credit_note, organization: credit_note.organization, error_code: "tax_error", details: {"foo" => "bar"})
       end
@@ -104,6 +101,10 @@ RSpec.describe "exports_credit_notes view" do # rubocop:disable RSpec/DescribeCl
             }
           ]
         }
+      end
+
+      before do
+        create(:item_metadata, owner: credit_note, organization: credit_note.organization, value: {"key" => "value"})
       end
 
       it "exposes every column of the view" do

--- a/spec/db/views/exports_credit_notes_spec.rb
+++ b/spec/db/views/exports_credit_notes_spec.rb
@@ -1,0 +1,325 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "exports_credit_notes view" do # rubocop:disable RSpec/DescribeClass
+  let(:credit_note) { create(:credit_note) }
+
+  def row_for(id)
+    ActiveRecord::Base.connection.select_one(
+      "SELECT * FROM exports_credit_notes WHERE lago_id = #{ActiveRecord::Base.connection.quote(id)}"
+    )
+  end
+
+  # Parsing the JSON aggregate columns in place keeps the final comparison a
+  # single hash covering every column of the view.
+  def parsed_row_for(id)
+    row = row_for(id)
+    %w[items metadata error_details].each do |column|
+      row[column] = row[column] && JSON.parse(row[column])
+    end
+    row
+  end
+
+  describe "full row" do
+    context "with a fully populated credit note" do
+      let(:credit_note) do
+        create(
+          :credit_note,
+          sequential_id: 42,
+          description: "a refund",
+          total_amount_cents: 1500,
+          total_amount_currency: "USD",
+          taxes_amount_cents: 200,
+          balance_amount_cents: 1300,
+          credit_amount_cents: 1000,
+          refund_amount_cents: 300,
+          coupons_adjustment_amount_cents: 50,
+          precise_coupons_adjustment_amount_cents: 0.5,
+          taxes_rate: 20.0,
+          refunded_at: Time.current,
+          credit_status: :available,
+          refund_status: :pending,
+          reason: :duplicated_charge
+        )
+      end
+
+      let!(:item) do
+        create(:credit_note_item, credit_note:, precise_amount_cents: 100.4, amount_cents: 100, amount_currency: "EUR")
+      end
+      let!(:metadata) do
+        create(:item_metadata, owner: credit_note, organization: credit_note.organization, value: {"key" => "value"})
+      end
+      let!(:error_detail) do
+        create(:error_detail, owner: credit_note, organization: credit_note.organization, error_code: "tax_error", details: {"foo" => "bar"})
+      end
+
+      let(:expected_row) do
+        credit_note.reload
+        {
+          "organization_id" => credit_note.organization_id,
+          "lago_id" => credit_note.id,
+          "sequential_id" => 42,
+          "number" => credit_note.number,
+          "lago_invoice_id" => credit_note.invoice_id,
+          "issuing_date" => credit_note.issuing_date,
+          "credit_status" => "available",
+          "refund_status" => "pending",
+          "reason" => "duplicated_charge",
+          "description" => "a refund",
+          "currency" => "USD",
+          "total_amount_cents" => 1500,
+          "taxes_amount_cents" => 200,
+          # SUM(precise_amount_cents)::bigint casts 100.4 to 100 BEFORE subtracting
+          # the coupons adjustment, then ROUND(100 - 0.5) = ROUND(99.5) = 100.
+          "sub_total_excluding_taxes_amount_cents" => 100,
+          "balance_amount_cents" => 1300,
+          "credit_amount_cents" => 1000,
+          "refund_amount_cents" => 300,
+          "coupons_adjustment_amount_cents" => 50,
+          "taxes_rate" => 20.0,
+          "created_at" => credit_note.created_at,
+          "updated_at" => credit_note.updated_at,
+          "refunded_at" => credit_note.refunded_at,
+          "items" => [
+            {
+              "lago_id" => item.id,
+              "amount_cents" => 100,
+              "amount_currency" => "EUR",
+              "lago_fee_id" => item.fee_id
+            }
+          ],
+          "metadata" => [
+            {
+              "lago_id" => metadata.id,
+              "key" => "key",
+              "value" => "value",
+              "created_at" => metadata.reload.created_at.strftime("%FT%H:%M:%S.%6N")
+            }
+          ],
+          # The view exports the raw integer error_code column, not the enum string.
+          "error_details" => [
+            {
+              "lago_id" => error_detail.id,
+              "error_code" => ErrorDetail.error_codes["tax_error"],
+              "details" => {"foo" => "bar"}
+            }
+          ]
+        }
+      end
+
+      it "exposes every column of the view" do
+        expect(parsed_row_for(credit_note.id)).to eq(expected_row)
+      end
+    end
+
+    context "with a bare credit note" do
+      let(:credit_note) do
+        create(
+          :credit_note,
+          sequential_id: 7,
+          description: nil,
+          total_amount_cents: 800,
+          total_amount_currency: "EUR",
+          taxes_amount_cents: 0,
+          balance_amount_cents: 800,
+          credit_amount_cents: 800,
+          refund_amount_cents: 0,
+          coupons_adjustment_amount_cents: 0,
+          precise_coupons_adjustment_amount_cents: 0,
+          taxes_rate: 0.0,
+          refunded_at: nil,
+          credit_status: :available,
+          refund_status: :pending,
+          reason: :other
+        )
+      end
+
+      let(:expected_row) do
+        credit_note.reload
+        {
+          "organization_id" => credit_note.organization_id,
+          "lago_id" => credit_note.id,
+          "sequential_id" => 7,
+          "number" => credit_note.number,
+          "lago_invoice_id" => credit_note.invoice_id,
+          "issuing_date" => credit_note.issuing_date,
+          "credit_status" => "available",
+          "refund_status" => "pending",
+          "reason" => "other",
+          "description" => nil,
+          "currency" => "EUR",
+          "total_amount_cents" => 800,
+          "taxes_amount_cents" => 0,
+          # SUM over zero items is NULL, and NULL minus the adjustment stays NULL.
+          "sub_total_excluding_taxes_amount_cents" => nil,
+          "balance_amount_cents" => 800,
+          "credit_amount_cents" => 800,
+          "refund_amount_cents" => 0,
+          "coupons_adjustment_amount_cents" => 0,
+          "taxes_rate" => 0.0,
+          "created_at" => credit_note.created_at,
+          "updated_at" => credit_note.updated_at,
+          "refunded_at" => nil,
+          "items" => nil,
+          "metadata" => nil,
+          "error_details" => nil
+        }
+      end
+
+      it "exposes every column with NULL aggregates" do
+        expect(parsed_row_for(credit_note.id)).to eq(expected_row)
+      end
+    end
+  end
+
+  describe "enum CASE mappings" do
+    def value_for(id, column)
+      row_for(id)[column]
+    end
+
+    context "with credit_status" do
+      {available: "available", consumed: "consumed", voided: "voided"}.each do |enum_name, expected|
+        it "maps #{enum_name} to '#{expected}'" do
+          cn = create(:credit_note, credit_status: enum_name)
+
+          expect(value_for(cn.id, "credit_status")).to eq(expected)
+        end
+      end
+    end
+
+    context "with refund_status" do
+      {pending: "pending", succeeded: "succeeded", failed: "failed"}.each do |enum_name, expected|
+        it "maps #{enum_name} to '#{expected}'" do
+          cn = create(:credit_note, refund_status: enum_name)
+
+          expect(value_for(cn.id, "refund_status")).to eq(expected)
+        end
+      end
+    end
+
+    context "with reason" do
+      {
+        duplicated_charge: "duplicated_charge",
+        product_unsatisfactory: "product_unsatisfactory",
+        order_change: "order_change",
+        order_cancellation: "order_cancellation",
+        fraudulent_charge: "fraudulent_charge",
+        other: "other"
+      }.each do |enum_name, expected|
+        it "maps #{enum_name} to '#{expected}'" do
+          cn = create(:credit_note, reason: enum_name)
+
+          expect(value_for(cn.id, "reason")).to eq(expected)
+        end
+      end
+    end
+  end
+
+  describe "sub_total_excluding_taxes_amount_cents" do
+    def sub_total_for(id)
+      row_for(id)["sub_total_excluding_taxes_amount_cents"]
+    end
+
+    context "when the credit note has items" do
+      let(:credit_note) { create(:credit_note, precise_coupons_adjustment_amount_cents: 0.5) }
+
+      before do
+        create(:credit_note_item, credit_note:, precise_amount_cents: 100.4)
+        create(:credit_note_item, credit_note:, precise_amount_cents: 200.3)
+      end
+
+      # SUM(precise_amount_cents)::bigint rounds 300.7 to 301 before subtracting,
+      # then ROUND(301 - 0.5) = ROUND(300.5) = 301.
+      it "rounds the bigint sum minus the coupons adjustment" do
+        expect(sub_total_for(credit_note.id)).to eq(301)
+      end
+    end
+  end
+
+  describe "items aggregation" do
+    def items_for(id)
+      raw = row_for(id)["items"]
+      raw && JSON.parse(raw)
+    end
+
+    context "when the credit note has multiple items" do
+      let!(:item_one) { create(:credit_note_item, credit_note:, amount_cents: 100, amount_currency: "EUR") }
+      let!(:item_two) { create(:credit_note_item, credit_note:, amount_cents: 250, amount_currency: "USD") }
+
+      it "aggregates each item as a JSON object regardless of order" do
+        items = items_for(credit_note.id)
+
+        tuples = items.map { |i| [i["lago_id"], i["amount_cents"], i["amount_currency"], i["lago_fee_id"]] }
+        expect(tuples).to match_array(
+          [
+            [item_one.id, 100, "EUR", item_one.fee_id],
+            [item_two.id, 250, "USD", item_two.fee_id]
+          ]
+        )
+      end
+    end
+  end
+
+  describe "row presence" do
+    let!(:available_note) { create(:credit_note, credit_status: :available) }
+    let!(:voided_note) { create(:credit_note, credit_status: :voided) }
+    let!(:draft_note) { create(:credit_note, :draft) }
+
+    # The view has no WHERE clause, so draft and voided notes still appear.
+    it "exposes every credit note regardless of status" do
+      ids = [available_note.id, voided_note.id, draft_note.id]
+      quoted_ids = ids.map { |id| ActiveRecord::Base.connection.quote(id) }.join(",")
+      count = ActiveRecord::Base.connection.select_value(
+        "SELECT COUNT(*) FROM exports_credit_notes WHERE lago_id IN (#{quoted_ids})"
+      )
+
+      expect(count).to eq(3)
+    end
+  end
+
+  describe "metadata aggregation" do
+    def metadata_for(id)
+      row_for(id)["metadata"]
+    end
+
+    context "when the credit note has multiple metadata keys" do
+      let(:value) { {"key" => "value", "another" => "thing"} }
+
+      before { create(:item_metadata, owner: credit_note, organization: credit_note.organization, value:) }
+
+      it "returns one row per metadata key as a JSON array" do
+        parsed = JSON.parse(metadata_for(credit_note.id))
+
+        expect(parsed.map { |m| [m["key"], m["value"]] }).to match_array([["key", "value"], ["another", "thing"]])
+        expect(parsed.map { |m| m["lago_id"] }.uniq).to eq([credit_note.metadata.id])
+      end
+    end
+
+    context "when metadata with the same owner_id belongs to a different owner_type" do
+      let(:wallet) { create(:wallet, id: credit_note.id) }
+
+      before { create(:item_metadata, owner: wallet, organization: credit_note.organization, value: {"leak" => "no"}) }
+
+      it "does not leak the other owner's metadata into the credit note row" do
+        expect(metadata_for(credit_note.id)).to be_nil
+      end
+    end
+  end
+
+  describe "error_details aggregation" do
+    def error_details_for(id)
+      row_for(id)["error_details"]
+    end
+
+    context "when an error detail with the same owner_id belongs to a different owner_type" do
+      let(:wallet) { create(:wallet, id: credit_note.id) }
+
+      before { create(:error_detail, owner: wallet, organization: credit_note.organization, error_code: "tax_error") }
+
+      it "does not leak the other owner's error detail into the credit note row" do
+        expect(error_details_for(credit_note.id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/graphql/mutations/credit_notes/update_spec.rb
+++ b/spec/graphql/mutations/credit_notes/update_spec.rb
@@ -80,5 +80,17 @@ RSpec.describe Mutations::CreditNotes::Update do
       result_data = result["data"]["updateCreditNote"]
       expect(result_data["metadata"]).to eq([{"key" => "new", "value" => "data"}])
     end
+
+    it "keeps the existing metadata when only the refund status is updated" do
+      execute_query(
+        query: mutation,
+        input: {
+          id: credit_note.id,
+          refundStatus: "succeeded"
+        }
+      )
+
+      expect(credit_note.reload.metadata.value).to eq({"existing" => "value"})
+    end
   end
 end

--- a/spec/services/credit_notes/update_service_spec.rb
+++ b/spec/services/credit_notes/update_service_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe CreditNotes::UpdateService do
         expect(result).to be_success
         expect(credit_note.reload.metadata).to be_nil
       end
+
+      it "touches the credit note" do
+        travel_to(1.minute.from_now) do
+          expect { credit_note_service.call }.to change { credit_note.reload.updated_at }
+        end
+      end
     end
 
     context "when creating metadata" do
@@ -99,6 +105,12 @@ RSpec.describe CreditNotes::UpdateService do
         expect(result).to be_success
         expect(credit_note.reload.metadata.value).to eq({"baz" => "qux"})
       end
+
+      it "touches the credit note" do
+        travel_to(1.minute.from_now) do
+          expect { credit_note_service.call }.to change { credit_note.reload.updated_at }
+        end
+      end
     end
 
     context "when merging metadata" do
@@ -112,6 +124,35 @@ RSpec.describe CreditNotes::UpdateService do
 
         expect(result).to be_success
         expect(credit_note.reload.metadata.value).to eq({"foo" => "bar", "baz" => "qux"})
+      end
+    end
+
+    context "when there is no metadata change" do
+      let(:params) { {} }
+
+      before { create(:item_metadata, owner: credit_note, organization:, value: {"foo" => "bar"}) }
+
+      it "does not touch the credit note" do
+        expect { credit_note_service.call }.not_to change { credit_note.reload.updated_at }
+      end
+
+      it "keeps the existing metadata" do
+        credit_note_service.call
+
+        expect(credit_note.reload.metadata.value).to eq({"foo" => "bar"})
+      end
+    end
+
+    context "when metadata param is omitted" do
+      let(:params) { {refund_status: "succeeded"} }
+
+      before { create(:item_metadata, owner: credit_note, organization:, value: {"foo" => "bar"}) }
+
+      it "keeps the existing metadata" do
+        result = credit_note_service.call
+
+        expect(result).to be_success
+        expect(credit_note.reload.metadata.value).to eq({"foo" => "bar"})
       end
     end
   end


### PR DESCRIPTION
## Context

Lago customers consuming Lago data through the warehouse-sharing pipeline do not currently have access to credit note metadata in their `credit_notes` table. Credit notes store metadata as a single `item_metadata` row holding a JSONB hash, unlike invoices and customers whose metadata models are key/value rows.

## Description

The `exports_credit_notes` view was bumped to version 4 with a `metadata` column. The JSONB hash is exploded via `jsonb_each_text` into a JSON array of `key`/`value` objects. Unlike invoices and customers, credit note metadata is stored as a single `item_metadata` row, so a per-entry `lago_id` and `created_at` would be the same value repeated across every key/value pair; both were left out. The column is `NULL` when no metadata exists, like `items` and `error_details`.

Several issues surfaced while wiring this up:

- The replication pipeline syncs incrementally on `credit_notes.updated_at`, but a metadata-only update never touched the credit note row (`InvoiceMetadata` declares `touch: true`, the polymorphic `ItemMetadata` does not). `CreditNotes::UpdateService` now touches the credit note inside the transaction when only the metadata changed. The shared `ItemMetadata` model was left untouched to avoid changing behavior for other models.
- `update_metadata!` read `metadata_changed` from the service's own `LegacyResult` (an `OpenStruct`), which always returned `nil`, so the `metadata_changed` flag was dead. It now reads the inner `Metadata::UpdateItemService` result.
- A refund-status-only update deleted existing metadata: the absent `metadata` param was treated like an explicit null, and the GraphQL mutation always forwarded the key. The service now skips the metadata update unless the key is present, and the mutation forwards only provided arguments. An explicit `metadata: null` still deletes.
- The `error_details` subselect filtered on `owner_id` only, although the table is polymorphic. The new view version scopes it to `owner_type = 'CreditNote'`, matching the metadata subselect.

A spec for the view was added under `spec/db/views/`, the first one covering an `exports_*` view: it compares full rows against the complete column contract, covers every enum CASE branch and aggregate, and asserts that metadata or error details from another owner type do not leak in. The service spec gained assertions that metadata changes bump `updated_at`, that a no-op call does not, and that omitted metadata is preserved.

