### PR TITLE
perf(billable_metrics): Improve ChargeFilter bulk update query performance

### DIFF
--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -125,16 +125,16 @@ module BillableMetricFilters
         .where(id: filter_value_ids)
         .unscope(:order)
         .distinct
-        .select(:charge_filter_id)
+        .pluck(:charge_filter_id)
 
       return if charge_filter_ids.empty?
 
       ChargeFilter
         .where(id: charge_filter_ids, deleted_at: nil)
-        .where.not(
-          id: ChargeFilterValue
-            .where(deleted_at: nil, charge_filter_id: charge_filter_ids)
-            .select(:charge_filter_id)
+        .where(
+          "NOT EXISTS (SELECT 1 FROM charge_filter_values" \
+          " WHERE charge_filter_values.charge_filter_id = charge_filters.id" \
+          " AND charge_filter_values.deleted_at IS NULL)"
         )
         .unscope(:order)
         .update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
## Context
Updating a billable metric's filters (`BillableMetricFilters::CreateOrUpdateBatchService`) took 6–29s per call. 
Profiling pinned it to `bulk_discard_emptied_charge_filters_for`, the query that discards `charge_filters` left empty after their filter values are removed. Its cost grew with the total size of the `charge_filters` / `charge_filter_values` tables rather than with the batch being processed, so it got worse over time as data accumulated.

## Description

The improvement is that the "has a kept value?" check now runs as an index-only anti-join against the `index_active_charge_filter_values` partial index — one index probe per candidate `charge_filter` — instead of full-scanning `charge_filter_values` inside a NOT IN sub-plan evaluated for every row.

### EXPLAIN ANALYZE
<details>
<summary>Original query</summary>

```
Gather  (cost=31652.55..39024.97 rows=495 width=16) (actual time=50.039..52.032 rows=0 loops=1)
  Workers Planned: 2
  Workers Launched: 2
  Buffers: shared hit=34841 read=3761 written=1414
  ->  Hash Join  (cost=30652.55..37975.47 rows=206 width=16) (actual time=44.518..44.522 rows=0 loops=3)
        Hash Cond: (charge_filters.id = charge_filter_values.charge_filter_id)
        Buffers: shared hit=34841 read=3761 written=1414
        ->  Parallel Seq Scan on charge_filters  (cost=23072.65..30177.18 rows=83199 width=16) (actual time=5.411..33.702 rows=133325 loops=3)
              Filter: ((deleted_at IS NULL) AND (deleted_at IS NULL) AND (NOT (hashed SubPlan 1)))
              Rows Removed by Filter: 981
              Buffers: shared hit=25571 read=3759 written=1414
              SubPlan 1
                ->  Sort  (cost=23057.40..23065.03 rows=3050 width=24) (actual time=5.125..5.173 rows=2000 loops=3)
                      Sort Key: charge_filter_values_1.updated_at
                      Sort Method: quicksort  Memory: 174kB
                      Buffers: shared hit=24324
                      Worker 0:  Sort Method: quicksort  Memory: 174kB
                      Worker 1:  Sort Method: quicksort  Memory: 174kB
                      ->  Nested Loop  (cost=7552.84..22880.89 rows=3050 width=24) (actual time=1.070..4.850 rows=2000 loops=3)
                            Buffers: shared hit=24308
                            ->  Unique  (cost=7552.41..7557.41 rows=999 width=16) (actual time=1.053..1.231 rows=1000 loops=3)
                                  Buffers: shared hit=9216
                                  ->  Sort  (cost=7552.41..7554.91 rows=1000 width=16) (actual time=1.052..1.134 rows=1000 loops=3)
                                        Sort Key: charge_filter_values_2.charge_filter_id
                                        Sort Method: quicksort  Memory: 79kB
                                        Buffers: shared hit=9216
                                        Worker 0:  Sort Method: quicksort  Memory: 79kB
                                        Worker 1:  Sort Method: quicksort  Memory: 79kB
                                        ->  Bitmap Heap Scan on charge_filter_values charge_filter_values_2  (cost=4213.75..7502.59 rows=1000 width=16) (actual time=0.841..0.946 rows=1000 loops=3)
                                              Recheck Cond: (id = ANY ('{<uuid>}'::uuid[]))
                                              Heap Blocks: exact=20
                                              Buffers: shared hit=9216
                                              ->  Bitmap Index Scan on charge_filter_values_pkey  (cost=0.00..4211.00 rows=1000 width=0) (actual time=0.835..0.835 rows=2000 loops=3)
                                                    Index Cond: (id = ANY ('{<uuid>}'::uuid[]))
                                                    Buffers: shared hit=9000
                            ->  Index Scan using index_charge_filter_values_on_charge_filter_id on charge_filter_values charge_filter_values_1  (cost=0.43..15.30 rows=3 width=24) (actual time=0.003..0.003 rows=2 loops=3000)
                                  Index Cond: (charge_filter_id = charge_filter_values_2.charge_filter_id)
                                  Filter: ((deleted_at IS NULL) AND (deleted_at IS NULL))
                                  Rows Removed by Filter: 1
                                  Buffers: shared hit=15092
        ->  Hash  (cost=7567.40..7567.40 rows=999 width=16) (actual time=2.961..2.962 rows=1000 loops=3)
              Buckets: 1024  Batches: 1  Memory Usage: 55kB
              Buffers: shared hit=9234
              ->  Unique  (cost=7552.41..7557.41 rows=999 width=16) (actual time=2.795..2.887 rows=1000 loops=3)
                    Buffers: shared hit=9234
                    ->  Sort  (cost=7552.41..7554.91 rows=1000 width=16) (actual time=2.795..2.827 rows=1000 loops=3)
                          Sort Key: charge_filter_values.charge_filter_id
                          Sort Method: quicksort  Memory: 79kB
                          Buffers: shared hit=9234
                          Worker 0:  Sort Method: quicksort  Memory: 79kB
                          Worker 1:  Sort Method: quicksort  Memory: 79kB
                          ->  Bitmap Heap Scan on charge_filter_values  (cost=4213.75..7502.59 rows=1000 width=16) (actual time=2.475..2.660 rows=1000 loops=3)
                                Recheck Cond: (id = ANY ('{<uuid>}'::uuid[]))
                                Heap Blocks: exact=20
                                Buffers: shared hit=9218
                                ->  Bitmap Index Scan on charge_filter_values_pkey  (cost=0.00..4211.00 rows=1000 width=0) (actual time=2.467..2.467 rows=2000 loops=3)
                                      Index Cond: (id = ANY ('{<uuid>}'::uuid[]))
                                      Buffers: shared hit=9002
Planning:
  Buffers: shared hit=19 read=2
Planning Time: 0.849 ms
Execution Time: 52.325 ms
```
</details>

<details>
<summary>Improved query</summary>

```
Nested Loop Anti Join  (cost=3785.18..10116.66 rows=24 width=16) (actual time=3.953..3.953 rows=0 loops=1)
  Buffers: shared hit=7025 read=8 written=6
  ->  Bitmap Heap Scan on charge_filters  (cost=3784.75..6275.79 rows=991 width=16) (actual time=1.139..1.251 rows=1000 loops=1)
        Recheck Cond: (id = ANY ('{<uuid>}'::uuid[]))
        Filter: ((deleted_at IS NULL) AND (deleted_at IS NULL))
        Heap Blocks: exact=14
        Buffers: shared hit=3014
        ->  Bitmap Index Scan on charge_filters_pkey  (cost=0.00..3782.00 rows=1000 width=0) (actual time=1.134..1.134 rows=1000 loops=1)
              Index Cond: (id = ANY ('{<uuid>}'::uuid[]))
              Buffers: shared hit=3000
  ->  Index Only Scan using index_active_charge_filter_values on charge_filter_values  (cost=0.43..7.46 rows=3 width=16) (actual time=0.003..0.003 rows=1 loops=1000)
        Index Cond: (charge_filter_id = charge_filters.id)
        Heap Fetches: 2000
        Buffers: shared hit=4011 read=8 written=6
Planning:
  Buffers: shared hit=17
Planning Time: 0.340 ms
Execution Time: 4.002 ms
```
</details>