### PR TITLE
invoice-preview: fix collapsed billing period on downgrade

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -85,7 +85,7 @@ module Types
       end
 
       def period_end_date
-        ::Subscriptions::DatesService.new_instance(object, Time.current)
+        ::Subscriptions::DatesService.new_instance(object, billing_reference_time)
           .next_end_of_period
       end
 
@@ -116,7 +116,18 @@ module Types
       end
 
       def dates_service
-        @dates_service ||= ::Subscriptions::DatesService.new_instance(object, Time.current, current_usage: true)
+        @dates_service ||= ::Subscriptions::DatesService.new_instance(object, billing_reference_time, current_usage: true)
+      end
+
+      # NOTE: For a subscription that has not started yet (e.g. a scheduled downgrade), `Time.current`
+      #       precedes `started_at`, so DatesService computes boundaries for the period containing "now"
+      #       — before the subscription exists — and collapses current_billing_period_* (and skews
+      #       period_end_date) onto `started_at`. Anchoring on the later of the two reports the real
+      #       first period. No-op for already-started subscriptions (started_at is in the past).
+      #       `compact` guards against a nil started_at (pending subscription with no start yet); it is
+      #       load-bearing — `max` raises on a nil element, so do not drop it.
+      def billing_reference_time
+        [Time.current, object.started_at].compact.max
       end
     end
   end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -116,8 +116,6 @@ module Types
       end
 
       def dates_service
-        # NOTE: anchored on `billing_reference_time` (not `Time.current`) so a not-yet-started
-        #       subscription reports its real first billing period instead of collapsing the bounds.
         @dates_service ||= ::Subscriptions::DatesService.new_instance(object, object.billing_reference_time, current_usage: true)
       end
     end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -85,7 +85,7 @@ module Types
       end
 
       def period_end_date
-        ::Subscriptions::DatesService.new_instance(object, billing_reference_time)
+        ::Subscriptions::DatesService.new_instance(object, object.billing_reference_time)
           .next_end_of_period
       end
 
@@ -116,18 +116,9 @@ module Types
       end
 
       def dates_service
-        @dates_service ||= ::Subscriptions::DatesService.new_instance(object, billing_reference_time, current_usage: true)
-      end
-
-      # NOTE: For a subscription that has not started yet (e.g. a scheduled downgrade), `Time.current`
-      #       precedes `started_at`, so DatesService computes boundaries for the period containing "now"
-      #       — before the subscription exists — and collapses current_billing_period_* (and skews
-      #       period_end_date) onto `started_at`. Anchoring on the later of the two reports the real
-      #       first period. No-op for already-started subscriptions (started_at is in the past).
-      #       `compact` guards against a nil started_at (pending subscription with no start yet); it is
-      #       load-bearing — `max` raises on a nil element, so do not drop it.
-      def billing_reference_time
-        [Time.current, object.started_at].compact.max
+        # NOTE: anchored on `billing_reference_time` (not `Time.current`) so a not-yet-started
+        #       subscription reports its real first billing period instead of collapsing the bounds.
+        @dates_service ||= ::Subscriptions::DatesService.new_instance(object, object.billing_reference_time, current_usage: true)
       end
     end
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -182,10 +182,8 @@ class Subscription < ApplicationRecord
     started_at.to_date < created_at.to_date
   end
 
-  # Anchor for the current billing period. When a subscription has not started yet (e.g. a scheduled
-  # downgrade in an invoice preview), Time.current precedes started_at and DatesService would collapse
-  # the period onto started_at; using the later of the two yields its real first period instead.
-  # compact handles a nil started_at (pending subscription).
+  # Falls back to started_at when the subscription has not started yet, so the billing period is
+  # computed from its first period rather than the period around Time.current.
   def billing_reference_time
     [Time.current, started_at].compact.max
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -182,6 +182,16 @@ class Subscription < ApplicationRecord
     started_at.to_date < created_at.to_date
   end
 
+  # NOTE: Anchor for computing the *current* billing period. For a subscription that has not started
+  #       yet (e.g. a scheduled downgrade surfaced in an invoice preview), Time.current precedes
+  #       started_at, so Subscriptions::DatesService would compute boundaries for the period containing
+  #       "now" — before the subscription exists — and collapse them onto started_at. Using the later of
+  #       the two yields the real first billing period. No-op once the subscription has started.
+  #       `compact` guards a nil started_at (pending subscription) — `max` raises on a nil element.
+  def billing_reference_time
+    [Time.current, started_at].compact.max
+  end
+
   def initial_started_at
     customer.subscriptions
       .where(external_id:)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -182,12 +182,10 @@ class Subscription < ApplicationRecord
     started_at.to_date < created_at.to_date
   end
 
-  # NOTE: Anchor for computing the *current* billing period. For a subscription that has not started
-  #       yet (e.g. a scheduled downgrade surfaced in an invoice preview), Time.current precedes
-  #       started_at, so Subscriptions::DatesService would compute boundaries for the period containing
-  #       "now" — before the subscription exists — and collapse them onto started_at. Using the later of
-  #       the two yields the real first billing period. No-op once the subscription has started.
-  #       `compact` guards a nil started_at (pending subscription) — `max` raises on a nil element.
+  # Anchor for the current billing period. When a subscription has not started yet (e.g. a scheduled
+  # downgrade in an invoice preview), Time.current precedes started_at and DatesService would collapse
+  # the period onto started_at; using the later of the two yields its real first period instead.
+  # compact handles a nil started_at (pending subscription).
   def billing_reference_time
     [Time.current, started_at].compact.max
   end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -86,7 +86,17 @@ module V1
     end
 
     def dates_service
-      @dates_service ||= ::Subscriptions::DatesService.new_instance(model, Time.current, current_usage: true)
+      @dates_service ||= ::Subscriptions::DatesService.new_instance(model, billing_reference_time, current_usage: true)
+    end
+
+    # NOTE: For a subscription that has not started yet (e.g. a scheduled downgrade returned in an
+    #       invoice preview), `Time.current` falls before `started_at`. The dates service would then
+    #       compute boundaries for the period containing "now" and clamp both ends down to `started_at`,
+    #       collapsing `current_billing_period_started_at` and `current_billing_period_ending_at` onto the
+    #       same value. Anchoring on the later of the two makes it report the real first billing period.
+    #       For already-started subscriptions this is a no-op (started_at is in the past).
+    def billing_reference_time
+      [Time.current, model.started_at].compact.max
     end
 
     def applicable_usage_thresholds

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -86,19 +86,9 @@ module V1
     end
 
     def dates_service
-      @dates_service ||= ::Subscriptions::DatesService.new_instance(model, billing_reference_time, current_usage: true)
-    end
-
-    # NOTE: For a subscription that has not started yet (e.g. a scheduled downgrade returned in an
-    #       invoice preview), `Time.current` falls before `started_at`. The dates service would then
-    #       compute boundaries for the period containing "now" and clamp both ends down to `started_at`,
-    #       collapsing `current_billing_period_started_at` and `current_billing_period_ending_at` onto the
-    #       same value. Anchoring on the later of the two makes it report the real first billing period.
-    #       For already-started subscriptions this is a no-op (started_at is in the past).
-    #       `compact` guards against a nil started_at (pending subscription with no start yet); it is
-    #       load-bearing — `max` raises on a nil element, so do not drop it.
-    def billing_reference_time
-      [Time.current, model.started_at].compact.max
+      # NOTE: anchored on `billing_reference_time` (not `Time.current`) so a not-yet-started
+      #       subscription reports its real first billing period instead of collapsing the bounds.
+      @dates_service ||= ::Subscriptions::DatesService.new_instance(model, model.billing_reference_time, current_usage: true)
     end
 
     def applicable_usage_thresholds

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -95,6 +95,8 @@ module V1
     #       collapsing `current_billing_period_started_at` and `current_billing_period_ending_at` onto the
     #       same value. Anchoring on the later of the two makes it report the real first billing period.
     #       For already-started subscriptions this is a no-op (started_at is in the past).
+    #       `compact` guards against a nil started_at (pending subscription with no start yet); it is
+    #       load-bearing — `max` raises on a nil element, so do not drop it.
     def billing_reference_time
       [Time.current, model.started_at].compact.max
     end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -86,8 +86,6 @@ module V1
     end
 
     def dates_service
-      # NOTE: anchored on `billing_reference_time` (not `Time.current`) so a not-yet-started
-      #       subscription reports its real first billing period instead of collapsing the bounds.
       @dates_service ||= ::Subscriptions::DatesService.new_instance(model, model.billing_reference_time, current_usage: true)
     end
 

--- a/app/services/invoices/preview/find_subscriptions_service.rb
+++ b/app/services/invoices/preview/find_subscriptions_service.rb
@@ -65,11 +65,8 @@ module Invoices
           .end_of_period + 1.day
       end
 
-      # NOTE: `rotation_date` is the old subscription's end-of-period timestamp shifted by a day,
-      #       so it lands on the end of the day (`T23:59:59`). The downgraded subscription actually
-      #       starts at the *beginning* of that day, so we normalize to the start of the day in the
-      #       customer timezone. Without this, `started_at` (and the serialized current billing period)
-      #       would be reported one day's worth of seconds late.
+      # rotation_date lands at the end of the day, but the new subscription starts at the beginning
+      # of that day in the customer timezone.
       def next_subscription_started_at(subscription)
         rotation_date(subscription)
           .in_time_zone(subscription.customer.applicable_timezone)

--- a/app/services/invoices/preview/find_subscriptions_service.rb
+++ b/app/services/invoices/preview/find_subscriptions_service.rb
@@ -53,7 +53,7 @@ module Invoices
 
         subscription.next_subscription.assign_attributes(
           status: :active,
-          started_at: rotation_date(subscription)
+          started_at: next_subscription_started_at(subscription)
         )
 
         subscription
@@ -63,6 +63,17 @@ module Invoices
         @rotation_date ||= Subscriptions::DatesService
           .new_instance(subscription, Time.current, current_usage: true)
           .end_of_period + 1.day
+      end
+
+      # NOTE: `rotation_date` is the old subscription's end-of-period timestamp shifted by a day,
+      #       so it lands on the end of the day (`T23:59:59`). The downgraded subscription actually
+      #       starts at the *beginning* of that day, so we normalize to the start of the day in the
+      #       customer timezone. Without this, `started_at` (and the serialized current billing period)
+      #       would be reported one day's worth of seconds late.
+      def next_subscription_started_at(subscription)
+        rotation_date(subscription)
+          .in_time_zone(subscription.customer.applicable_timezone)
+          .beginning_of_day
       end
     end
   end

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -60,4 +60,50 @@ RSpec.describe Types::Subscriptions::Object do
     expect(subject).to have_field(:activation_rules).of_type("[SubscriptionActivationRule!]!")
     expect(subject).to have_field(:cancelation_reason).of_type("CancelationReasonEnum")
   end
+
+  # BIL-97: for a subscription that has not started yet (e.g. a scheduled downgrade), the billing
+  # period resolvers used to anchor on Time.current — before started_at — collapsing both bounds onto
+  # started_at and skewing period_end_date. They must report the real first period.
+  context "when the subscription starts in the future" do
+    let(:plan) { create(:plan, interval: "monthly", pay_in_advance: true) }
+    let(:future_start) { Time.zone.parse("2026-07-03T00:00:00Z") }
+    let(:subscription) do
+      create(
+        :subscription,
+        :anniversary,
+        plan:,
+        status: :active,
+        subscription_at: future_start,
+        started_at: future_start,
+        activated_at: future_start,
+        created_at: future_start
+      )
+    end
+
+    around { |example| travel_to(Time.zone.parse("2026-06-04T10:00:00Z")) { example.run } }
+
+    describe "#current_billing_period_started_at" do
+      subject { run_graphql_field("Subscription.currentBillingPeriodStartedAt", subscription) }
+
+      it "returns the start of the first real billing period" do
+        expect(subject.iso8601).to eq("2026-07-03T00:00:00Z")
+      end
+    end
+
+    describe "#current_billing_period_ending_at" do
+      subject { run_graphql_field("Subscription.currentBillingPeriodEndingAt", subscription) }
+
+      it "returns the end of the first real billing period instead of collapsing onto started_at" do
+        expect(subject.iso8601).to eq("2026-08-02T23:59:59Z")
+      end
+    end
+
+    describe "#period_end_date" do
+      subject { run_graphql_field("Subscription.periodEndDate", subscription) }
+
+      it "returns the first period end, not a period that precedes the subscription start" do
+        expect(subject.to_date).to eq(Date.parse("2026-08-02"))
+      end
+    end
+  end
 end

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -61,9 +61,8 @@ RSpec.describe Types::Subscriptions::Object do
     expect(subject).to have_field(:cancelation_reason).of_type("CancelationReasonEnum")
   end
 
-  # BIL-97: for a subscription that has not started yet (e.g. a scheduled downgrade), the billing
-  # period resolvers used to anchor on Time.current — before started_at — collapsing both bounds onto
-  # started_at and skewing period_end_date. They must report the real first period.
+  # For a subscription that has not started yet (e.g. a scheduled downgrade), the billing period
+  # resolvers must report its real first period rather than collapsing both bounds onto started_at.
   context "when the subscription starts in the future" do
     let(:plan) { create(:plan, interval: "monthly", pay_in_advance: true) }
     let(:future_start) { Time.zone.parse("2026-07-03T00:00:00Z") }

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -61,8 +61,6 @@ RSpec.describe Types::Subscriptions::Object do
     expect(subject).to have_field(:cancelation_reason).of_type("CancelationReasonEnum")
   end
 
-  # For a subscription that has not started yet (e.g. a scheduled downgrade), the billing period
-  # resolvers must report its real first period rather than collapsing both bounds onto started_at.
   context "when the subscription starts in the future" do
     let(:plan) { create(:plan, interval: "monthly", pay_in_advance: true) }
     let(:future_start) { Time.zone.parse("2026-07-03T00:00:00Z") }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -593,6 +593,34 @@ RSpec.describe Subscription do
     end
   end
 
+  describe "#billing_reference_time" do
+    around { |example| travel_to(Time.zone.parse("2026-06-04T10:00:00Z")) { example.run } }
+
+    context "when the subscription has already started" do
+      let(:subscription) { build(:subscription, started_at: Time.zone.parse("2026-03-03T00:00:00Z")) }
+
+      it "returns the current time" do
+        expect(subscription.billing_reference_time).to eq(Time.current)
+      end
+    end
+
+    context "when the subscription starts in the future" do
+      let(:subscription) { build(:subscription, started_at: Time.zone.parse("2026-07-03T00:00:00Z")) }
+
+      it "returns started_at" do
+        expect(subscription.billing_reference_time).to eq(subscription.started_at)
+      end
+    end
+
+    context "when started_at is nil" do
+      let(:subscription) { build(:subscription, started_at: nil) }
+
+      it "falls back to the current time" do
+        expect(subscription.billing_reference_time).to eq(Time.current)
+      end
+    end
+  end
+
   describe "#initial_started_at" do
     let(:customer) { create(:customer) }
     let(:subscription) do

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1428,8 +1428,8 @@ RSpec.describe Api::V1::InvoicesController do
     end
 
     context "with a scheduled downgrade (projection)" do
-      # End-to-end guard for BIL-97: POST /invoices/preview must serialize the pending (downgrade)
-      # subscription's real first billing period, not collapse both bounds onto its started_at.
+      # POST /invoices/preview must serialize the pending (downgrade) subscription's real first
+      # billing period, not collapse both bounds onto its started_at.
       let(:customer) { create(:customer, organization:, external_id: "downgrade_customer") }
       let(:current_plan) do
         create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 1000)

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1428,8 +1428,6 @@ RSpec.describe Api::V1::InvoicesController do
     end
 
     context "with a scheduled downgrade (projection)" do
-      # POST /invoices/preview must serialize the pending (downgrade) subscription's real first
-      # billing period, not collapse both bounds onto its started_at.
       let(:customer) { create(:customer, organization:, external_id: "downgrade_customer") }
       let(:current_plan) do
         create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 1000)
@@ -1482,7 +1480,6 @@ RSpec.describe Api::V1::InvoicesController do
           expect(pending_plan[:started_at]).to eq("2026-07-03T00:00:00.000Z")
           expect(pending_plan[:current_billing_period_started_at]).to eq("2026-07-03T00:00:00Z")
           expect(pending_plan[:current_billing_period_ending_at]).to eq("2026-08-02T23:59:59Z")
-          # Regression guard: the two bounds must not collapse onto the same value.
           expect(pending_plan[:current_billing_period_started_at])
             .not_to eq(pending_plan[:current_billing_period_ending_at])
         end

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1426,5 +1426,67 @@ RSpec.describe Api::V1::InvoicesController do
         end
       end
     end
+
+    context "with a scheduled downgrade (projection)" do
+      # End-to-end guard for BIL-97: POST /invoices/preview must serialize the pending (downgrade)
+      # subscription's real first billing period, not collapse both bounds onto its started_at.
+      let(:customer) { create(:customer, organization:, external_id: "downgrade_customer") }
+      let(:current_plan) do
+        create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 1000)
+      end
+      let(:next_plan) do
+        create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 500)
+      end
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: current_plan,
+          status: :active,
+          billing_time: "anniversary",
+          subscription_at: Time.zone.parse("2026-03-03"),
+          started_at: Time.zone.parse("2026-03-03")
+        )
+      end
+      let(:next_subscription) do
+        create(
+          :subscription,
+          :pending,
+          customer:,
+          plan: next_plan,
+          billing_time: "anniversary",
+          previous_subscription: subscription,
+          subscription_at: Time.zone.parse("2026-07-03")
+        )
+      end
+      let(:preview_params) do
+        {
+          customer: {external_id: customer.external_id},
+          subscriptions: {external_ids: [subscription.external_id]}
+        }
+      end
+
+      before { next_subscription }
+
+      it "serializes the pending plan's real first billing period" do
+        travel_to(Time.zone.parse("2026-06-04T10:00:00Z")) do
+          subject
+
+          expect(response).to have_http_status(:success)
+
+          subscriptions = json[:invoice][:subscriptions]
+          expect(subscriptions.size).to eq(2)
+
+          pending_plan = subscriptions.find { |s| s[:plan_code] == next_plan.code }
+          expect(pending_plan).to be_present
+          expect(pending_plan[:started_at]).to eq("2026-07-03T00:00:00.000Z")
+          expect(pending_plan[:current_billing_period_started_at]).to eq("2026-07-03T00:00:00Z")
+          expect(pending_plan[:current_billing_period_ending_at]).to eq("2026-08-02T23:59:59Z")
+          # Regression guard: the two bounds must not collapse onto the same value.
+          expect(pending_plan[:current_billing_period_started_at])
+            .not_to eq(pending_plan[:current_billing_period_ending_at])
+        end
+      end
+    end
   end
 end

--- a/spec/scenarios/invoices/preview_spec.rb
+++ b/spec/scenarios/invoices/preview_spec.rb
@@ -139,4 +139,78 @@ describe "Invoice Preview Scenarios", :premium do
       end
     end
   end
+
+  # BIL-97: previewing an invoice while a downgrade is scheduled must serialize the pending plan's
+  # real first billing period, matching the fee boundaries on the same invoice — not collapse both
+  # bounds onto the old subscription's termination timestamp.
+  context "when a downgrade is scheduled" do
+    let(:customer) { create(:customer, organization:) }
+    let(:current_plan) do
+      create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 12_900)
+    end
+    let(:downgrade_plan) do
+      create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 5_000)
+    end
+
+    it "serializes the pending plan's first period, matching its fee boundaries", transaction: false do
+      # Anniversary subscription started on the 3rd.
+      travel_to(DateTime.parse("2026-03-03T08:00:00Z")) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: current_plan.code,
+            billing_time: "anniversary",
+            subscription_at: "2026-03-03T08:00:00Z"
+          }
+        )
+      end
+
+      # Mid-period (current period: Jun 3 -> Jul 2): schedule the downgrade, then preview before the
+      # rotation date. The new plan's first period is Jul 3 -> Aug 2.
+      travel_to(DateTime.parse("2026-06-04T10:00:00Z")) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: downgrade_plan.code,
+            billing_time: "anniversary"
+          }
+        )
+
+        subscription = customer.subscriptions.active.first
+        expect(subscription.plan).to eq(current_plan)
+        expect(subscription.next_subscription.plan).to eq(downgrade_plan)
+
+        post_with_token(
+          organization,
+          "/api/v1/invoices/preview",
+          {
+            customer: {external_id: customer.external_id},
+            subscriptions: {external_ids: [subscription.external_id]}
+          }
+        )
+
+        expect(response).to have_http_status(:success)
+
+        pending_plan = json[:invoice][:subscriptions].find { |s| s[:plan_code] == downgrade_plan.code }
+        expect(pending_plan).to be_present
+        expect(pending_plan[:started_at]).to eq("2026-07-03T00:00:00.000Z")
+        expect(pending_plan[:current_billing_period_started_at]).to eq("2026-07-03T00:00:00Z")
+        expect(pending_plan[:current_billing_period_ending_at]).to eq("2026-08-02T23:59:59Z")
+        # Regression guard: the two bounds must not collapse onto the same value.
+        expect(pending_plan[:current_billing_period_started_at])
+          .not_to eq(pending_plan[:current_billing_period_ending_at])
+
+        # The ticket's invariant: the serialized period must match the fee boundaries for the same
+        # plan on the same invoice.
+        pending_fee = json[:invoice][:fees].find do |fee|
+          fee[:item][:type] == "Subscription" && fee[:item][:code] == downgrade_plan.code
+        end
+        expect(pending_fee).to be_present
+        expect(pending_plan[:current_billing_period_started_at]).to eq(pending_fee[:from_date])
+        expect(pending_plan[:current_billing_period_ending_at]).to eq(pending_fee[:to_date])
+      end
+    end
+  end
 end

--- a/spec/scenarios/invoices/preview_spec.rb
+++ b/spec/scenarios/invoices/preview_spec.rb
@@ -200,8 +200,8 @@ describe "Invoice Preview Scenarios", :premium do
           fee[:item][:type] == "subscription" && fee[:item][:code] == downgrade_plan.code
         end
         expect(pending_fee).to be_present
-        expect(pending_plan[:current_billing_period_started_at]).to eq(pending_fee[:from_date])
-        expect(pending_plan[:current_billing_period_ending_at]).to eq(pending_fee[:to_date])
+        expect(Time.zone.parse(pending_plan[:current_billing_period_started_at])).to eq(Time.zone.parse(pending_fee[:from_date]))
+        expect(Time.zone.parse(pending_plan[:current_billing_period_ending_at])).to eq(Time.zone.parse(pending_fee[:to_date]))
       end
     end
   end

--- a/spec/scenarios/invoices/preview_spec.rb
+++ b/spec/scenarios/invoices/preview_spec.rb
@@ -140,9 +140,6 @@ describe "Invoice Preview Scenarios", :premium do
     end
   end
 
-  # Previewing an invoice while a downgrade is scheduled must serialize the pending plan's real first
-  # billing period, matching the fee boundaries on the same invoice — not collapse both bounds onto
-  # the old subscription's termination timestamp.
   context "when a downgrade is scheduled" do
     let(:customer) { create(:customer, organization:) }
     let(:current_plan) do
@@ -153,7 +150,6 @@ describe "Invoice Preview Scenarios", :premium do
     end
 
     it "serializes the pending plan's first period, matching its fee boundaries", transaction: false do
-      # Anniversary subscription started on the 3rd.
       travel_to(DateTime.parse("2026-03-03T08:00:00Z")) do
         create_subscription(
           {
@@ -166,8 +162,7 @@ describe "Invoice Preview Scenarios", :premium do
         )
       end
 
-      # Mid-period (current period: Jun 3 -> Jul 2): schedule the downgrade, then preview before the
-      # rotation date. The new plan's first period is Jul 3 -> Aug 2.
+      # Current period runs Jun 3 to Jul 2, so the downgrade starts a new period on Jul 3.
       travel_to(DateTime.parse("2026-06-04T10:00:00Z")) do
         create_subscription(
           {
@@ -198,14 +193,11 @@ describe "Invoice Preview Scenarios", :premium do
         expect(pending_plan[:started_at]).to eq("2026-07-03T00:00:00.000Z")
         expect(pending_plan[:current_billing_period_started_at]).to eq("2026-07-03T00:00:00Z")
         expect(pending_plan[:current_billing_period_ending_at]).to eq("2026-08-02T23:59:59Z")
-        # Regression guard: the two bounds must not collapse onto the same value.
         expect(pending_plan[:current_billing_period_started_at])
           .not_to eq(pending_plan[:current_billing_period_ending_at])
 
-        # The ticket's invariant: the serialized period must match the fee boundaries for the same
-        # plan on the same invoice.
         pending_fee = json[:invoice][:fees].find do |fee|
-          fee[:item][:type] == "Subscription" && fee[:item][:code] == downgrade_plan.code
+          fee[:item][:type] == "subscription" && fee[:item][:code] == downgrade_plan.code
         end
         expect(pending_fee).to be_present
         expect(pending_plan[:current_billing_period_started_at]).to eq(pending_fee[:from_date])

--- a/spec/scenarios/invoices/preview_spec.rb
+++ b/spec/scenarios/invoices/preview_spec.rb
@@ -140,9 +140,9 @@ describe "Invoice Preview Scenarios", :premium do
     end
   end
 
-  # BIL-97: previewing an invoice while a downgrade is scheduled must serialize the pending plan's
-  # real first billing period, matching the fee boundaries on the same invoice — not collapse both
-  # bounds onto the old subscription's termination timestamp.
+  # Previewing an invoice while a downgrade is scheduled must serialize the pending plan's real first
+  # billing period, matching the fee boundaries on the same invoice — not collapse both bounds onto
+  # the old subscription's termination timestamp.
   context "when a downgrade is scheduled" do
     let(:customer) { create(:customer, organization:) }
     let(:current_plan) do

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -123,9 +123,6 @@ RSpec.describe ::V1::SubscriptionSerializer do
       )
     end
 
-    # Before the fix, the serializer anchored the dates service on `Time.current`, which is before
-    # `started_at` here, so both billing-period bounds collapsed onto `started_at`. They must instead
-    # describe the real first billing period (2026-07-03 → 2026-08-02), matching the invoice fees.
     it "serializes the real first billing period instead of collapsing both bounds onto started_at" do
       travel_to(Time.zone.parse("2026-06-04T10:00:00Z")) do
         result = JSON.parse(serializer.to_json)

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -107,6 +107,38 @@ RSpec.describe ::V1::SubscriptionSerializer do
     end
   end
 
+  context "when the subscription starts in the future (e.g. a scheduled downgrade in an invoice preview)" do
+    let(:plan) { create(:plan, interval: "monthly", pay_in_advance: true) }
+    let(:future_start) { Time.zone.parse("2026-07-03T00:00:00Z") }
+    let(:subscription) do
+      create(
+        :subscription,
+        :anniversary,
+        plan:,
+        status: :active,
+        subscription_at: future_start,
+        started_at: future_start,
+        activated_at: future_start,
+        created_at: future_start
+      )
+    end
+
+    # Before the fix, the serializer anchored the dates service on `Time.current`, which is before
+    # `started_at` here, so both billing-period bounds collapsed onto `started_at`. They must instead
+    # describe the real first billing period (2026-07-03 → 2026-08-02), matching the invoice fees.
+    it "serializes the real first billing period instead of collapsing both bounds onto started_at" do
+      travel_to(Time.zone.parse("2026-06-04T10:00:00Z")) do
+        result = JSON.parse(serializer.to_json)
+
+        expect(result["subscription"]).to include(
+          "started_at" => "2026-07-03T00:00:00.000Z",
+          "current_billing_period_started_at" => "2026-07-03T00:00:00Z",
+          "current_billing_period_ending_at" => "2026-08-02T23:59:59Z"
+        )
+      end
+    end
+  end
+
   context "when including usage threshold" do
     subject(:serializer) do
       described_class.new(

--- a/spec/services/invoices/preview/find_subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/find_subscriptions_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService do
               expect(subscriptions_result.second).to have_attributes(
                 id: next_subscription.id,
                 status: "active",
-                started_at: end_of_period
+                started_at: end_of_period.beginning_of_day
               )
             end
 


### PR DESCRIPTION
## What changed and why

When a downgrade is scheduled, `POST /invoices/preview` returned the pending (next) subscription with both `current_billing_period_started_at` and `current_billing_period_ending_at` set to the same value: the old subscription's end-of-day termination timestamp (`T23:59:59Z`). The fees on the same invoice already had the correct `from_date` and `to_date`, so the problem was only in how the subscription was serialized.

There were two causes, both in serialization. No fee or billing math changed.

1. `Invoices::Preview::FindSubscriptionsService#adjusted_subscription` set the next subscription's `started_at` to the rotation timestamp `end_of_period + 1.day`, which lands at the end of the day (`T23:59:59Z`). A subscription should start at the beginning of its first day, so it now uses `beginning_of_day` in the customer timezone (`T00:00:00Z`). This also fixes the wrong `started_at` value.

2. `V1::SubscriptionSerializer` and the GraphQL `Types::Subscriptions::Object` resolvers built `Subscriptions::DatesService` from `Time.current`. For a subscription that has not started yet, `Time.current` is before `started_at`, so `charges_from_datetime` and `charges_to_datetime` both fall back to `started_at` and the period collapses. They now use `Subscription#billing_reference_time` (`max(Time.current, started_at)`), so a subscription starting in the future reports its real first period. Nothing changes for subscriptions that have already started. This is also why the fees were already correct: they use the preview's `billing_time`, not `Time.current`.

The same `Time.current` issue affected the GraphQL `current_billing_period_*` resolvers (which the frontend reads) and `period_end_date` (it returned a period before a pending subscription's start). All three now go through `Subscription#billing_reference_time`. These are resolver changes only, with no GraphQL schema change, so there is no codegen.

### Result

```
started_at:                         2026-07-03T00:00:00Z   (was 2026-07-03T23:59:59Z)
current_billing_period_started_at:  2026-07-03T00:00:00Z   (was 2026-07-03T23:59:59Z)
current_billing_period_ending_at:   2026-08-02T23:59:59Z   (was 2026-07-03T23:59:59Z)
```

## Tests

- `spec/scenarios/invoices/preview_spec.rb`: end-to-end test that creates a subscription, schedules a downgrade, previews the invoice, and checks the pending plan's billing period matches its fee boundaries on the same invoice.
- `spec/requests/api/v1/invoices_controller_spec.rb`: request spec covering the preview pipeline for a scheduled downgrade.
- `spec/graphql/types/subscriptions/object_spec.rb`: resolver specs for `current_billing_period_*` and `period_end_date` when the subscription starts in the future.
- `spec/serializers/v1/subscription_serializer_spec.rb`: serializer example for the future-start case.
- `spec/models/subscription_spec.rb`: `#billing_reference_time` for the already-started, future-start, and nil `started_at` cases.
- `spec/services/invoices/preview/find_subscriptions_service_spec.rb`: updated the `started_at` assertion to `beginning_of_day`.

```bash
bundle exec rspec spec/scenarios/invoices/preview_spec.rb \
                  spec/requests/api/v1/invoices_controller_spec.rb \
                  spec/graphql/types/subscriptions/object_spec.rb \
                  spec/serializers/v1/subscription_serializer_spec.rb \
                  spec/models/subscription_spec.rb \
                  spec/services/invoices/preview/find_subscriptions_service_spec.rb
```

## Out of scope

The old subscription's `terminated_at` is left as is (`end_of_period + 1.day`). It feeds the preview `billing_time` and fee boundaries, which are already correct.

## Performance

No impact on hot paths. The changes only touch serialization at preview and read time, with no new queries, loops, or allocations on the event or billing-run path.