### PR TITLE
chore(clock): Isolate clock analytics under an env var if needed

### DIFF
--- a/app/jobs/clock/compute_all_daily_usages_job.rb
+++ b/app/jobs/clock/compute_all_daily_usages_job.rb
@@ -4,6 +4,16 @@ module Clock
   class ComputeAllDailyUsagesJob < ClockJob
     unique :until_executed, on_conflict: :log
 
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
+        :clock_worker
+      elsif ActiveModel::Type::Boolean.new.cast(ENV["LAGO_REDIS_ANALYTICS_ENABLED"])
+        :analytics
+      else
+        :clock
+      end
+    end
+
     def perform
       DailyUsages::ComputeAllService.call(timestamp: Time.current)
     end

--- a/app/jobs/clock_job.rb
+++ b/app/jobs/clock_job.rb
@@ -8,6 +8,8 @@ class ClockJob < ApplicationJob
   queue_as do
     if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
       :clock_worker
+    elsif ActiveModel::Type::Boolean.new.cast(ENV["LAGO_REDIS_ANALYTICS_ENABLED"])
+      :analytics
     else
       :clock
     end

--- a/app/jobs/clock_job.rb
+++ b/app/jobs/clock_job.rb
@@ -8,8 +8,6 @@ class ClockJob < ApplicationJob
   queue_as do
     if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
       :clock_worker
-    elsif ActiveModel::Type::Boolean.new.cast(ENV["LAGO_REDIS_ANALYTICS_ENABLED"])
-      :analytics
     else
       :clock
     end

--- a/clock.rb
+++ b/clock.rb
@@ -168,10 +168,12 @@ module Clockwork
     end
   end
 
-  every(1.hour, "schedule:compute_daily_usage", at: "*:15") do
-    Clock::ComputeAllDailyUsagesJob
-      .set(sentry: {"slug" => "lago_compute_daily_usage", "cron" => "15 */1 * * *"})
-      .perform_later
+  unless ActiveModel::Type::Bolean.new.cast(ENV["LAGO_REDIS_ANALYTICS_ENABLED"])
+    every(1.hour, "schedule:compute_daily_usage", at: "*:15") do
+      Clock::ComputeAllDailyUsagesJob
+        .set(sentry: {"slug" => "lago_compute_daily_usage", "cron" => "15 */1 * * *"})
+        .perform_later
+    end
   end
 
   every(1.hour, "schedule:process_dunning_campaigns", at: "*:45") do

--- a/clock_analytics.rb
+++ b/clock_analytics.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "clockwork"
+require "./config/boot"
+require "./config/environment"
+
+module Clockwork
+  handler do |job, time|
+    puts "Running #{job} at #{time}" # rubocop:disable Rails/Output
+  end
+
+  error_handler do |error|
+    Rails.logger.error(error.message)
+    Rails.logger.error(error.backtrace.join("\n"))
+
+    Sentry.capture_exception(error)
+  end
+
+  # NOTE: All clocks run every hour to take customer timezones into account
+
+  if ActiveModel::Type::Bolean.new.cast(ENV["LAGO_REDIS_ANALYTICS_ENABLED"])
+    every(1.hour, "schedule:compute_daily_usage", at: "*:15") do
+      Clock::ComputeAllDailyUsagesJob
+        .set(sentry: {"slug" => "lago_compute_daily_usage", "cron" => "15 */1 * * *"})
+        .perform_later
+    end
+  end
+end

--- a/scripts/start.clock.analytics.sh
+++ b/scripts/start.clock.analytics.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec bundle exec clockwork ./clock_analytics.rb


### PR DESCRIPTION
## Context

- We want to add a dedicated Redis instance for analytics jobs, to avoid impacting billing performances
- Sharding with Sidekiq is not that easy and recommended and need more conception https://github.com/sidekiq/sidekiq/wiki/Sharding
- Isolating all analytics jobs with an other `REDIS_URL` is the fastest and best option right now

## Changes

- Add a `LAGO_REDIS_ANALYTICS_ENABLED` env var
- Add a `clock_analytics.rb` file that only take cares of the dialy usage for now
- Move Daily Usage clock job on `analytics` queue so the analytics worker will take care of it, since it will be running on an isolated Redis instance, we can't use the default clock and clock worker, the job would never be performed.