### PR TITLE
fix(events): Preserve timestamp precision

### DIFF
--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -49,7 +49,7 @@ module Events
         event.external_subscription_id = event_params[:external_subscription_id]
         event.properties = event_params[:properties] || {}
         event.metadata = metadata || {}
-        event.timestamp = Time.zone.at(event_params[:timestamp] ? Float(event_params[:timestamp]) : timestamp)
+        event.timestamp = Time.zone.at(event_params[:timestamp] ? BigDecimal(event_params[:timestamp].to_s) : timestamp)
         event.precise_total_amount_cents = event_params[:precise_total_amount_cents]
 
         expression_result = CalculateExpressionService.call(organization:, event:)

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -20,7 +20,7 @@ module Events
       event.external_subscription_id = params[:external_subscription_id]
       event.properties = params[:properties] || {}
       event.metadata = metadata || {}
-      event.timestamp = Time.zone.at(params[:timestamp] ? Float(params[:timestamp]) : timestamp)
+      event.timestamp = Time.zone.at(params[:timestamp] ? BigDecimal(params[:timestamp].to_s) : timestamp)
       event.precise_total_amount_cents = params[:precise_total_amount_cents]
 
       expression_result = CalculateExpressionService.call(organization:, event:)

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Events::CreateBatchService do
         result = create_batch_service.call
 
         expect(result).to be_success
-        expect(result.events.first.timestamp).to eq(Time.zone.at(timestamp.to_f))
+        expect(result.events.first.timestamp).to eq(Time.zone.at(BigDecimal(timestamp)))
       end
     end
 
@@ -292,6 +292,26 @@ RSpec.describe Events::CreateBatchService do
 
         expect(result).to be_success
         expect(result.events.first.timestamp.iso8601(3)).to eq("2023-09-04T15:45:12.344Z")
+      end
+    end
+
+    context "when timestamp is sent with decimal fractions represented by repeating floats" do
+      let(:timestamps) { %w[1780586634.1 1780586634.2 1780586634.3] }
+      let(:events_params) do
+        build_params(count: timestamps.count) do |event, index|
+          event[:timestamp] = timestamps[index]
+        end
+      end
+
+      it "creates events with the received timestamp precision" do
+        result = create_batch_service.call
+
+        expect(result).to be_success
+        expect(result.events.map { |event| event.timestamp.iso8601(9) }).to eq([
+          "2026-06-04T15:23:54.100000000Z",
+          "2026-06-04T15:23:54.200000000Z",
+          "2026-06-04T15:23:54.300000000Z"
+        ])
       end
     end
 

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Events::CreateService do
         external_subscription_id:,
         transaction_id:,
         code:,
-        timestamp: Time.zone.at(timestamp),
+        timestamp: Time.zone.at(BigDecimal(timestamp.to_s)),
         properties: {"foo" => "bar"},
         precise_total_amount_cents: nil
       )
@@ -98,7 +98,7 @@ RSpec.describe Events::CreateService do
         result = create_service.call
 
         expect(result).to be_success
-        expect(result.event.timestamp).to eq(Time.zone.at(timestamp.to_f))
+        expect(result.event.timestamp).to eq(Time.zone.at(BigDecimal(timestamp)))
       end
     end
 
@@ -110,6 +110,28 @@ RSpec.describe Events::CreateService do
 
         expect(result).to be_success
         expect(result.event.timestamp.iso8601(3)).to eq("2023-09-04T15:45:12.344Z")
+      end
+    end
+
+    context "when timestamp is sent with decimal fractions represented by repeating floats" do
+      let(:timestamps) { %w[1780586634.1 1780586634.2 1780586634.3] }
+
+      it "creates events with the received timestamp precision" do
+        results = timestamps.map do |received_timestamp|
+          described_class.call(
+            organization:,
+            params: create_args.merge(timestamp: received_timestamp, transaction_id: SecureRandom.uuid),
+            timestamp: creation_timestamp,
+            metadata:
+          )
+        end
+
+        expect(results).to all(be_success)
+        expect(results.map { |result| result.event.timestamp.iso8601(9) }).to eq([
+          "2026-06-04T15:23:54.100000000Z",
+          "2026-06-04T15:23:54.200000000Z",
+          "2026-06-04T15:23:54.300000000Z"
+        ])
       end
     end
 


### PR DESCRIPTION
## Context

Event creation converted received epoch timestamps with Float before passing them to Time.zone.at. Decimal fractions such as 1780586634.1 cannot be represented exactly as binary floats, so serialized timestamps using iso8601(9) could become values like 2026-06-04T15:23:54.099999904Z instead of the received 2026-06-04T15:23:54.100000000Z.

## Description

Use BigDecimal when converting event timestamps in single and batch event creation so decimal epoch fractions keep their received precision. Add regression coverage for timestamps ending in .1, .2, and .3 to assert the nanosecond-precision ISO8601 output.

