### PR TITLE
feat(products): add the product catalog data model

### DIFF
--- a/app/models/concerns/catalog_attachable.rb
+++ b/app/models/concerns/catalog_attachable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CatalogAttachable
+  def attached_to_plan_or_subscription?
+    plan_applied_rate_cards.exists? || subscription_applied_rate_cards.exists?
+  end
+end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -21,6 +21,9 @@ class Fee < ApplicationRecord
   belongs_to :organization
   belongs_to :billing_entity
   belongs_to :fixed_charge, -> { with_discarded }, optional: true
+  # Fees are historical records: they must resolve their pricing source
+  # even after the rate is discarded.
+  belongs_to :rate_card_rate, -> { with_discarded }, optional: true
 
   has_one :adjusted_fee, dependent: :nullify
   has_one :billable_metric, -> { with_discarded }, through: :charge
@@ -45,7 +48,7 @@ class Fee < ApplicationRecord
   monetize :unit_amount_cents, disable_validation: true, allow_nil: true, with_model_currency: :currency
 
   # TODO: Deprecate add_on type in the near future
-  FEE_TYPES = %i[charge add_on subscription credit commitment fixed_charge].freeze
+  FEE_TYPES = %i[charge add_on subscription credit commitment fixed_charge product].freeze
   PAYMENT_STATUS = %i[pending succeeded failed refunded].freeze
 
   enum :fee_type, FEE_TYPES
@@ -414,6 +417,7 @@ end
 #  original_fee_id                     :uuid
 #  pay_in_advance_event_id             :uuid
 #  pay_in_advance_event_transaction_id :string
+#  rate_card_rate_id                   :uuid
 #  subscription_id                     :uuid
 #  true_up_parent_fee_id               :uuid
 #
@@ -436,6 +440,7 @@ end
 #  index_fees_on_organization_id_and_created_at_and_id  (organization_id,created_at,id) WHERE (deleted_at IS NULL)
 #  index_fees_on_original_fee_id                        (original_fee_id)
 #  index_fees_on_pay_in_advance_event_transaction_id    (pay_in_advance_event_transaction_id) WHERE (deleted_at IS NULL)
+#  index_fees_on_rate_card_rate_id                      (rate_card_rate_id)
 #  index_fees_on_subscription_id                        (subscription_id)
 #  index_fees_on_true_up_parent_fee_id                  (true_up_parent_fee_id)
 #
@@ -450,6 +455,7 @@ end
 #  fk_rails_...  (invoice_id => invoices.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (original_fee_id => fees.id)
+#  fk_rails_...  (rate_card_rate_id => rate_card_rates.id)
 #  fk_rails_...  (subscription_id => subscriptions.id)
 #  fk_rails_...  (true_up_parent_fee_id => fees.id)
 #

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -24,6 +24,7 @@ class Fee < ApplicationRecord
   # Fees are historical records: they must resolve their pricing source
   # even after the rate is discarded.
   belongs_to :rate_card_rate, -> { with_discarded }, optional: true
+  belongs_to :rate_override, -> { with_discarded }, optional: true
 
   has_one :adjusted_fee, dependent: :nullify
   has_one :billable_metric, -> { with_discarded }, through: :charge
@@ -418,6 +419,7 @@ end
 #  pay_in_advance_event_id             :uuid
 #  pay_in_advance_event_transaction_id :string
 #  rate_card_rate_id                   :uuid
+#  rate_override_id                    :uuid
 #  subscription_id                     :uuid
 #  true_up_parent_fee_id               :uuid
 #
@@ -441,6 +443,7 @@ end
 #  index_fees_on_original_fee_id                        (original_fee_id)
 #  index_fees_on_pay_in_advance_event_transaction_id    (pay_in_advance_event_transaction_id) WHERE (deleted_at IS NULL)
 #  index_fees_on_rate_card_rate_id                      (rate_card_rate_id)
+#  index_fees_on_rate_override_id                       (rate_override_id)
 #  index_fees_on_subscription_id                        (subscription_id)
 #  index_fees_on_true_up_parent_fee_id                  (true_up_parent_fee_id)
 #
@@ -456,6 +459,7 @@ end
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (original_fee_id => fees.id)
 #  fk_rails_...  (rate_card_rate_id => rate_card_rates.id)
+#  fk_rails_...  (rate_override_id => rate_overrides.id)
 #  fk_rails_...  (subscription_id => subscriptions.id)
 #  fk_rails_...  (true_up_parent_fee_id => fees.id)
 #

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -28,6 +28,8 @@ class Plan < ApplicationRecord
   has_many :coupons, through: :coupon_targets
   has_many :invoices, through: :subscriptions
   has_many :usage_thresholds
+  has_many :applied_rate_cards, class_name: "PlanRateCard"
+  has_many :products, through: :applied_rate_cards
 
   has_many :applied_taxes, class_name: "Plan::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class PlanRateCard < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+  belongs_to :plan
+  belongs_to :rate_card
+
+  has_one :product, through: :rate_card
+
+  validates :rate_card_id, uniqueness: {scope: :plan_id, conditions: -> { where(deleted_at: nil) }}
+
+  default_scope -> { kept }
+end
+
+# == Schema Information
+#
+# Table name: plan_rate_cards
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  deleted_at      :datetime
+#  units           :decimal(30, 10)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  plan_id         :uuid             not null
+#  rate_card_id    :uuid             not null
+#
+# Indexes
+#
+#  index_plan_rate_cards_on_deleted_at                (deleted_at)
+#  index_plan_rate_cards_on_organization_id           (organization_id)
+#  index_plan_rate_cards_on_plan_id                   (plan_id)
+#  index_plan_rate_cards_on_plan_id_and_rate_card_id  (plan_id,rate_card_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_plan_rate_cards_on_rate_card_id              (rate_card_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (plan_id => plans.id)
+#  fk_rails_...  (rate_card_id => rate_cards.id)
+#

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -26,7 +26,7 @@ end
 #
 #  id              :uuid             not null, primary key
 #  deleted_at      :datetime
-#  units           :decimal(30, 10)
+#  units           :decimal(, )
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :uuid             not null

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -11,7 +11,7 @@ class PlanRateCard < ApplicationRecord
   belongs_to :rate_card
 
   has_one :product, through: :rate_card
-  # Phases are an ordered sequence; heap order is not deterministic.
+
   has_many :rate_phases, -> { order(:position) }
 
   validates :rate_card_id, uniqueness: {scope: :plan_id, conditions: -> { where(deleted_at: nil) }}

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -11,6 +11,8 @@ class PlanRateCard < ApplicationRecord
   belongs_to :rate_card
 
   has_one :product, through: :rate_card
+  # Phases are an ordered sequence; heap order is not deterministic.
+  has_many :rate_phases, -> { order(:position) }
 
   validates :rate_card_id, uniqueness: {scope: :plan_id, conditions: -> { where(deleted_at: nil) }}
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -17,6 +17,8 @@ class Product < ApplicationRecord
   belongs_to :add_on, -> { with_discarded }, optional: true
   belongs_to :charge, -> { with_discarded }, optional: true
 
+  has_many :filters, class_name: "ProductFilter"
+
   enum :product_type, PRODUCT_TYPES, validate: true
 
   validates :name, presence: true
@@ -40,9 +42,11 @@ class Product < ApplicationRecord
   private
 
   def validate_billable_metric_presence
-    if usage? && billable_metric_id.blank?
+    has_billable_metric = billable_metric_id.present? || billable_metric.present?
+
+    if usage? && !has_billable_metric
       errors.add(:billable_metric, :blank)
-    elsif fixed? && billable_metric_id.present?
+    elsif fixed? && has_billable_metric
       errors.add(:billable_metric, :present)
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,6 +3,7 @@
 class Product < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
+  include CatalogAttachable
 
   self.discard_column = :deleted_at
 
@@ -40,10 +41,6 @@ class Product < ApplicationRecord
 
   def invoice_name
     invoice_display_name.presence || name
-  end
-
-  def attached_to_plan_or_subscription?
-    plan_applied_rate_cards.exists? || subscription_applied_rate_cards.exists?
   end
 
   private

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+class Product < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  PRODUCT_TYPES = {
+    usage: "usage",
+    fixed: "fixed"
+  }.freeze
+
+  belongs_to :organization
+  belongs_to :product_category, optional: true
+  belongs_to :billable_metric, -> { with_discarded }, optional: true
+  belongs_to :add_on, -> { with_discarded }, optional: true
+  belongs_to :charge, -> { with_discarded }, optional: true
+
+  enum :product_type, PRODUCT_TYPES, validate: true
+
+  validates :name, presence: true
+  validates :code,
+    presence: true,
+    uniqueness: {scope: :organization_id, conditions: -> { where(deleted_at: nil) }}
+
+  validate :validate_billable_metric_presence
+  validate :validate_add_on_charge_exclusivity
+
+  default_scope -> { kept }
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name code]
+  end
+
+  def invoice_name
+    invoice_display_name.presence || name
+  end
+
+  private
+
+  def validate_billable_metric_presence
+    if usage? && billable_metric_id.blank?
+      errors.add(:billable_metric, :blank)
+    elsif fixed? && billable_metric_id.present?
+      errors.add(:billable_metric, :present)
+    end
+  end
+
+  def validate_add_on_charge_exclusivity
+    return if add_on_id.blank? || charge_id.blank?
+
+    errors.add(:base, :add_on_and_charge_mutually_exclusive)
+  end
+end
+
+# == Schema Information
+#
+# Table name: products
+# Database name: primary
+#
+#  id                   :uuid             not null, primary key
+#  code                 :string           not null
+#  deleted_at           :datetime
+#  description          :text
+#  invoice_display_name :string
+#  name                 :string           not null
+#  product_type         :enum             not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  add_on_id            :uuid
+#  billable_metric_id   :uuid
+#  charge_id            :uuid
+#  organization_id      :uuid             not null
+#  product_category_id           :uuid
+#
+# Indexes
+#
+#  index_products_on_add_on_id                 (add_on_id)
+#  index_products_on_billable_metric_id        (billable_metric_id)
+#  index_products_on_charge_id                 (charge_id)
+#  index_products_on_deleted_at                (deleted_at)
+#  index_products_on_organization_id           (organization_id)
+#  index_products_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#  index_products_on_product_category_id                (product_category_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (add_on_id => add_ons.id)
+#  fk_rails_...  (billable_metric_id => billable_metrics.id)
+#  fk_rails_...  (charge_id => charges.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (product_category_id => product_categories.id)
+#

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -83,7 +83,7 @@ end
 #  billable_metric_id   :uuid
 #  charge_id            :uuid
 #  organization_id      :uuid             not null
-#  product_category_id           :uuid
+#  product_category_id  :uuid
 #
 # Indexes
 #
@@ -93,7 +93,7 @@ end
 #  index_products_on_deleted_at                (deleted_at)
 #  index_products_on_organization_id           (organization_id)
 #  index_products_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
-#  index_products_on_product_category_id                (product_category_id)
+#  index_products_on_product_category_id       (product_category_id)
 #
 # Foreign Keys
 #

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -19,6 +19,7 @@ class Product < ApplicationRecord
 
   has_many :filters, class_name: "ProductFilter"
   has_many :rate_cards
+  has_many :plan_applied_rate_cards, through: :rate_cards
 
   enum :product_type, PRODUCT_TYPES, validate: true
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -20,6 +20,7 @@ class Product < ApplicationRecord
   has_many :filters, class_name: "ProductFilter"
   has_many :rate_cards
   has_many :plan_applied_rate_cards, through: :rate_cards
+  has_many :subscription_applied_rate_cards, through: :rate_cards
 
   enum :product_type, PRODUCT_TYPES, validate: true
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -18,6 +18,7 @@ class Product < ApplicationRecord
   belongs_to :charge, -> { with_discarded }, optional: true
 
   has_many :filters, class_name: "ProductFilter"
+  has_many :rate_cards
 
   enum :product_type, PRODUCT_TYPES, validate: true
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -42,6 +42,10 @@ class Product < ApplicationRecord
     invoice_display_name.presence || name
   end
 
+  def attached_to_plan_or_subscription?
+    plan_applied_rate_cards.exists? || subscription_applied_rate_cards.exists?
+  end
+
   private
 
   def validate_billable_metric_presence

--- a/app/models/product_category.rb
+++ b/app/models/product_category.rb
@@ -9,6 +9,8 @@ class ProductCategory < ApplicationRecord
   belongs_to :organization
 
   has_many :products
+  has_many :plan_applied_rate_cards, through: :products
+  has_many :subscription_applied_rate_cards, through: :products
 
   validates :name, presence: true
   validates :code,
@@ -23,6 +25,10 @@ class ProductCategory < ApplicationRecord
 
   def invoice_name
     invoice_display_name.presence || name
+  end
+
+  def attached_to_plan_or_subscription?
+    plan_applied_rate_cards.exists? || subscription_applied_rate_cards.exists?
   end
 end
 

--- a/app/models/product_category.rb
+++ b/app/models/product_category.rb
@@ -8,6 +8,8 @@ class ProductCategory < ApplicationRecord
 
   belongs_to :organization
 
+  has_many :products
+
   validates :name, presence: true
   validates :code,
     presence: true,

--- a/app/models/product_category.rb
+++ b/app/models/product_category.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class ProductCategory < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+
+  validates :name, presence: true
+  validates :code,
+    presence: true,
+    uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :organization_id}
+
+  default_scope -> { kept }
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name code]
+  end
+
+  def invoice_name
+    invoice_display_name.presence || name
+  end
+end
+
+# == Schema Information
+#
+# Table name: product_categories
+# Database name: primary
+#
+#  id                   :uuid             not null, primary key
+#  code                 :string           not null
+#  deleted_at           :datetime
+#  description          :string
+#  invoice_display_name :string
+#  name                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  organization_id      :uuid             not null
+#
+# Indexes
+#
+#  index_product_categories_on_deleted_at                (deleted_at)
+#  index_product_categories_on_organization_id           (organization_id)
+#  index_product_categories_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/product_category.rb
+++ b/app/models/product_category.rb
@@ -3,6 +3,7 @@
 class ProductCategory < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
+  include CatalogAttachable
 
   self.discard_column = :deleted_at
 
@@ -25,10 +26,6 @@ class ProductCategory < ApplicationRecord
 
   def invoice_name
     invoice_display_name.presence || name
-  end
-
-  def attached_to_plan_or_subscription?
-    plan_applied_rate_cards.exists? || subscription_applied_rate_cards.exists?
   end
 end
 

--- a/app/models/product_filter.rb
+++ b/app/models/product_filter.rb
@@ -52,12 +52,12 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  organization_id      :uuid             not null
-#  product_id      :uuid             not null
+#  product_id           :uuid             not null
 #
 # Indexes
 #
-#  index_product_filters_on_deleted_at                (deleted_at)
-#  index_product_filters_on_organization_id           (organization_id)
+#  index_product_filters_on_deleted_at           (deleted_at)
+#  index_product_filters_on_organization_id      (organization_id)
 #  index_product_filters_on_product_id           (product_id)
 #  index_product_filters_on_product_id_and_code  (product_id,code) UNIQUE WHERE (deleted_at IS NULL)
 #

--- a/app/models/product_filter.rb
+++ b/app/models/product_filter.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class ProductFilter < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+  belongs_to :product
+
+  validates :name, presence: true
+  validates :code,
+    presence: true,
+    uniqueness: {scope: :product_id, conditions: -> { where(deleted_at: nil) }}
+
+  # created_at keeps the list order stable across renames (updated_at would
+  # reorder on every touch).
+  default_scope -> { kept.order(created_at: :asc) }
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name code]
+  end
+
+  def invoice_name
+    invoice_display_name.presence || name
+  end
+end
+
+# == Schema Information
+#
+# Table name: product_filters
+# Database name: primary
+#
+#  id                   :uuid             not null, primary key
+#  code                 :string           not null
+#  deleted_at           :datetime
+#  description          :string
+#  invoice_display_name :string
+#  name                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  organization_id      :uuid             not null
+#  product_id      :uuid             not null
+#
+# Indexes
+#
+#  index_product_filters_on_deleted_at                (deleted_at)
+#  index_product_filters_on_organization_id           (organization_id)
+#  index_product_filters_on_product_id           (product_id)
+#  index_product_filters_on_product_id_and_code  (product_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (product_id => products.id)
+#

--- a/app/models/product_filter.rb
+++ b/app/models/product_filter.rb
@@ -19,8 +19,6 @@ class ProductFilter < ApplicationRecord
     presence: true,
     uniqueness: {scope: :product_id, conditions: -> { where(deleted_at: nil) }}
 
-  # created_at keeps the list order stable across renames (updated_at would
-  # reorder on every touch).
   default_scope -> { kept.order(created_at: :asc) }
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/product_filter.rb
+++ b/app/models/product_filter.rb
@@ -12,6 +12,8 @@ class ProductFilter < ApplicationRecord
   has_many :values, class_name: "ProductFilterValue"
   has_many :billable_metric_filters, through: :values
 
+  delegate :attached_to_plan_or_subscription?, to: :product
+
   validates :name, presence: true
   validates :code,
     presence: true,

--- a/app/models/product_filter.rb
+++ b/app/models/product_filter.rb
@@ -9,6 +9,9 @@ class ProductFilter < ApplicationRecord
   belongs_to :organization
   belongs_to :product
 
+  has_many :values, class_name: "ProductFilterValue"
+  has_many :billable_metric_filters, through: :values
+
   validates :name, presence: true
   validates :code,
     presence: true,
@@ -24,6 +27,12 @@ class ProductFilter < ApplicationRecord
 
   def invoice_name
     invoice_display_name.presence || name
+  end
+
+  def to_h
+    @to_h ||= values.each_with_object({}) do |filter_value, result|
+      (result[filter_value.billable_metric_filter.key] ||= []) << filter_value.value
+    end.freeze
   end
 end
 

--- a/app/models/product_filter_value.rb
+++ b/app/models/product_filter_value.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class ProductFilterValue < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+  belongs_to :product_filter, -> { with_discarded }
+  belongs_to :billable_metric_filter, -> { with_discarded }
+
+  # A NULL value selects the key alone: the filter matches any event carrying
+  # the key. An empty string is still invalid — absence is expressed by nil.
+  validates :value, presence: true, allow_nil: true
+  validates :value,
+    uniqueness: {scope: [:product_filter_id, :billable_metric_filter_id], conditions: -> { where(deleted_at: nil) }}
+  validate :validate_value_inclusion
+
+  # created_at keeps the values order stable across edits.
+  default_scope -> { kept.order(created_at: :asc) }
+
+  delegate :key, to: :billable_metric_filter
+
+  private
+
+  def validate_value_inclusion
+    return if value.blank?
+    return if billable_metric_filter&.values&.include?(value) # rubocop:disable Performance/InefficientHashSearch
+
+    errors.add(:value, :inclusion)
+  end
+end
+
+# == Schema Information
+#
+# Table name: product_filter_values
+# Database name: primary
+#
+#  id                        :uuid             not null, primary key
+#  deleted_at                :datetime
+#  value                     :string           not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  billable_metric_filter_id :uuid             not null
+#  organization_id           :uuid             not null
+#  product_filter_id    :uuid             not null
+#
+# Indexes
+#
+#  idx_pif_values_on_filter_metric_filter_and_value               (product_filter_id,billable_metric_filter_id,value) UNIQUE WHERE (deleted_at IS NULL)
+#  index_product_filter_values_on_billable_metric_filter_id  (billable_metric_filter_id)
+#  index_product_filter_values_on_deleted_at                 (deleted_at)
+#  index_product_filter_values_on_organization_id            (organization_id)
+#  index_product_filter_values_on_product_filter_id     (product_filter_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (billable_metric_filter_id => billable_metric_filters.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (product_filter_id => product_filters.id)
+#

--- a/app/models/product_filter_value.rb
+++ b/app/models/product_filter_value.rb
@@ -17,7 +17,6 @@ class ProductFilterValue < ApplicationRecord
     uniqueness: {scope: [:product_filter_id, :billable_metric_filter_id], conditions: -> { where(deleted_at: nil) }}
   validate :validate_value_inclusion
 
-  # created_at keeps the values order stable across edits.
   default_scope -> { kept.order(created_at: :asc) }
 
   delegate :key, to: :billable_metric_filter

--- a/app/models/product_filter_value.rb
+++ b/app/models/product_filter_value.rb
@@ -39,20 +39,20 @@ end
 #
 #  id                        :uuid             not null, primary key
 #  deleted_at                :datetime
-#  value                     :string           not null
+#  value                     :string
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  billable_metric_filter_id :uuid             not null
 #  organization_id           :uuid             not null
-#  product_filter_id    :uuid             not null
+#  product_filter_id         :uuid             not null
 #
 # Indexes
 #
-#  idx_pif_values_on_filter_metric_filter_and_value               (product_filter_id,billable_metric_filter_id,value) UNIQUE WHERE (deleted_at IS NULL)
+#  idx_pif_values_on_filter_metric_filter_and_value          (product_filter_id,billable_metric_filter_id,value) UNIQUE NULLS NOT DISTINCT WHERE (deleted_at IS NULL)
 #  index_product_filter_values_on_billable_metric_filter_id  (billable_metric_filter_id)
 #  index_product_filter_values_on_deleted_at                 (deleted_at)
 #  index_product_filter_values_on_organization_id            (organization_id)
-#  index_product_filter_values_on_product_filter_id     (product_filter_id)
+#  index_product_filter_values_on_product_filter_id          (product_filter_id)
 #
 # Foreign Keys
 #

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -54,9 +54,6 @@ class RateCard < ApplicationRecord
     errors.add(:product_filter, :does_not_belong_to_product)
   end
 
-  # Hiding fees from the invoice only exists for advance cards
-  # (v1: Charge#validate_invoiceable_unless_pay_in_advance). An arrears fee
-  # has no instant-charge path, so a hidden one would never surface anywhere.
   def validate_display_on_invoice
     return if advance? || display_on_invoice?
 
@@ -65,8 +62,6 @@ class RateCard < ApplicationRecord
 
   # Usage proration spreads a recurring quantity across the period, so it
   # needs a recurring metric — and not weighted_sum, which prorates by design
-  # (v1: Charge#validate_prorated). Fixed products prorate by calendar time
-  # instead and carry no metric, so they are exempt.
   def validate_proration
     return unless proration?
     return unless product&.usage?

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -20,6 +20,8 @@ class RateCard < ApplicationRecord
   belongs_to :product
   belongs_to :product_filter, optional: true
 
+  has_many :rates, class_name: "RateCardRate"
+
   enum :billing_timing, BILLING_TIMINGS, validate: true
   enum :regroup_paid_fees, REGROUP_PAID_FEES, validate: {allow_nil: true}
 

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -21,6 +21,7 @@ class RateCard < ApplicationRecord
   belongs_to :product_filter, optional: true
 
   has_many :rates, class_name: "RateCardRate"
+  has_many :plan_applied_rate_cards, class_name: "PlanRateCard"
 
   enum :billing_timing, BILLING_TIMINGS, validate: true
   enum :regroup_paid_fees, REGROUP_PAID_FEES, validate: {allow_nil: true}

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -22,6 +22,7 @@ class RateCard < ApplicationRecord
 
   has_many :rates, class_name: "RateCardRate"
   has_many :plan_applied_rate_cards, class_name: "PlanRateCard"
+  has_many :subscription_applied_rate_cards, class_name: "SubscriptionRateCard"
 
   enum :billing_timing, BILLING_TIMINGS, validate: true
   enum :regroup_paid_fees, REGROUP_PAID_FEES, validate: {allow_nil: true}

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -42,6 +42,7 @@ class RateCard < ApplicationRecord
   validates :currency, presence: true, inclusion: {in: currency_list, allow_nil: true}
   validate :validate_filter_belongs_to_item
   validate :validate_display_on_invoice
+  validate :validate_proration
 
   default_scope -> { kept }
 
@@ -60,6 +61,21 @@ class RateCard < ApplicationRecord
     return if advance? || display_on_invoice?
 
     errors.add(:display_on_invoice, :not_allowed_for_billing_timing)
+  end
+
+  # Usage proration spreads a recurring quantity across the period, so it
+  # needs a recurring metric — and not weighted_sum, which prorates by design
+  # (v1: Charge#validate_prorated). Fixed products prorate by calendar time
+  # instead and carry no metric, so they are exempt.
+  def validate_proration
+    return unless proration?
+    return unless product&.usage?
+
+    metric = product.billable_metric
+    return if metric.nil?
+
+    errors.add(:proration, :requires_recurring_metric) unless metric.recurring?
+    errors.add(:proration, :not_allowed_for_aggregation_type) if metric.weighted_sum_agg?
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -4,6 +4,7 @@ class RateCard < ApplicationRecord
   include PaperTrailTraceable
   include Currencies
   include Discard::Model
+  include CatalogAttachable
 
   self.discard_column = :deleted_at
 
@@ -48,10 +49,6 @@ class RateCard < ApplicationRecord
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name code]
-  end
-
-  def attached_to_plan_or_subscription?
-    plan_applied_rate_cards.exists? || subscription_applied_rate_cards.exists?
   end
 end
 

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -49,6 +49,10 @@ class RateCard < ApplicationRecord
   def self.ransackable_attributes(_auth_object = nil)
     %w[name code]
   end
+
+  def attached_to_plan_or_subscription?
+    plan_applied_rate_cards.exists? || subscription_applied_rate_cards.exists?
+  end
 end
 
 # == Schema Information

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -75,16 +75,16 @@ end
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  organization_id           :uuid             not null
-#  product_filter_id    :uuid
-#  product_id           :uuid             not null
+#  product_filter_id         :uuid
+#  product_id                :uuid             not null
 #
 # Indexes
 #
 #  index_rate_cards_on_deleted_at                (deleted_at)
 #  index_rate_cards_on_organization_id           (organization_id)
 #  index_rate_cards_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
-#  index_rate_cards_on_product_filter_id    (product_filter_id)
-#  index_rate_cards_on_product_id           (product_id)
+#  index_rate_cards_on_product_filter_id         (product_filter_id)
+#  index_rate_cards_on_product_id                (product_id)
 #
 # Foreign Keys
 #

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -41,6 +41,7 @@ class RateCard < ApplicationRecord
   # inclusion error fires for a provided-but-unknown currency.
   validates :currency, presence: true, inclusion: {in: currency_list, allow_nil: true}
   validate :validate_filter_belongs_to_item
+  validate :validate_display_on_invoice
 
   default_scope -> { kept }
 
@@ -50,6 +51,15 @@ class RateCard < ApplicationRecord
     return if product_filter.product_id == product_id
 
     errors.add(:product_filter, :does_not_belong_to_product)
+  end
+
+  # Hiding fees from the invoice only exists for advance cards
+  # (v1: Charge#validate_invoiceable_unless_pay_in_advance). An arrears fee
+  # has no instant-charge path, so a hidden one would never surface anywhere.
+  def validate_display_on_invoice
+    return if advance? || display_on_invoice?
+
+    errors.add(:display_on_invoice, :not_allowed_for_billing_timing)
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -13,7 +13,10 @@ class RateCard < ApplicationRecord
     advance: "advance"
   }.freeze
 
+  # none is a real value, not a nil stand-in: the column is NOT NULL so the API
+  # always returns a concrete grouping behaviour.
   REGROUP_PAID_FEES = {
+    none: "none",
     invoice: "invoice"
   }.freeze
 
@@ -26,7 +29,9 @@ class RateCard < ApplicationRecord
   has_many :subscription_applied_rate_cards, class_name: "SubscriptionRateCard"
 
   enum :billing_timing, BILLING_TIMINGS, validate: true
-  enum :regroup_paid_fees, REGROUP_PAID_FEES, validate: {allow_nil: true}
+  # prefix: a bare `none` value would define a RateCard.none scope, which
+  # collides with ActiveRecord::QueryMethods#none.
+  enum :regroup_paid_fees, REGROUP_PAID_FEES, validate: true, prefix: true
 
   validates :name, presence: true
   validates :code,
@@ -67,7 +72,7 @@ end
 #  display_on_invoice        :boolean          default(TRUE), not null
 #  name                      :string           not null
 #  proration                 :boolean          default(FALSE), not null
-#  regroup_paid_fees         :enum
+#  regroup_paid_fees         :enum             default("none"), not null
 #  wallet_targetable         :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class RateCard < ApplicationRecord
+  include PaperTrailTraceable
+  include Currencies
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  BILLING_TIMINGS = {
+    arrears: "arrears",
+    advance: "advance"
+  }.freeze
+
+  REGROUP_PAID_FEES = {
+    invoice: "invoice"
+  }.freeze
+
+  belongs_to :organization
+  belongs_to :product
+  belongs_to :product_filter, optional: true
+
+  enum :billing_timing, BILLING_TIMINGS, validate: true
+  enum :regroup_paid_fees, REGROUP_PAID_FEES, validate: {allow_nil: true}
+
+  validates :name, presence: true
+  validates :code,
+    presence: true,
+    uniqueness: {scope: :organization_id, conditions: -> { where(deleted_at: nil) }}
+  # allow_nil keeps a missing currency on the presence error only; the
+  # inclusion error fires for a provided-but-unknown currency.
+  validates :currency, presence: true, inclusion: {in: currency_list, allow_nil: true}
+  validate :validate_filter_belongs_to_item
+
+  default_scope -> { kept }
+
+  # A card scoped to a filter must price a slice of its own item.
+  def validate_filter_belongs_to_item
+    return if product_filter.nil?
+    return if product_filter.product_id == product_id
+
+    errors.add(:product_filter, :does_not_belong_to_product)
+  end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name code]
+  end
+end
+
+# == Schema Information
+#
+# Table name: rate_cards
+# Database name: primary
+#
+#  id                        :uuid             not null, primary key
+#  applied_pricing_unit_code :string
+#  billing_timing            :enum             default("arrears"), not null
+#  code                      :string           not null
+#  currency                  :string           not null
+#  deleted_at                :datetime
+#  description               :string
+#  display_on_invoice        :boolean          default(TRUE), not null
+#  name                      :string           not null
+#  proration                 :boolean          default(FALSE), not null
+#  regroup_paid_fees         :enum
+#  wallet_targetable         :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  organization_id           :uuid             not null
+#  product_filter_id    :uuid
+#  product_id           :uuid             not null
+#
+# Indexes
+#
+#  index_rate_cards_on_deleted_at                (deleted_at)
+#  index_rate_cards_on_organization_id           (organization_id)
+#  index_rate_cards_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#  index_rate_cards_on_product_filter_id    (product_filter_id)
+#  index_rate_cards_on_product_id           (product_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (product_filter_id => product_filters.id)
+#  fk_rails_...  (product_id => products.id)
+#

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -33,6 +33,8 @@ class RateCardRate < ApplicationRecord
   belongs_to :organization
   belongs_to :rate_card
 
+  has_many :fees
+
   # allow_nil + explicit presence: a missing value reads as value_is_mandatory,
   # an unknown value as value_is_invalid.
   enum :rate_model, RATE_MODELS, validate: {allow_nil: true}

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -96,6 +96,7 @@ end
 #  applied_pricing_unit_conversion_rate :decimal(30, 10)
 #  billing_interval_count               :integer          default(1), not null
 #  billing_interval_unit                :enum             not null
+#  code                                 :string           not null
 #  deleted_at                           :datetime
 #  effective_datetime                   :datetime         not null
 #  min_amount_cents                     :bigint           default(0), not null
@@ -111,6 +112,7 @@ end
 #  index_rate_card_rates_on_deleted_at                           (deleted_at)
 #  index_rate_card_rates_on_organization_id                      (organization_id)
 #  index_rate_card_rates_on_rate_card_id                         (rate_card_id)
+#  index_rate_card_rates_on_rate_card_id_and_code                (rate_card_id,code) UNIQUE WHERE (deleted_at IS NULL)
 #  index_rate_card_rates_on_rate_card_id_and_effective_datetime  (rate_card_id,effective_datetime) UNIQUE WHERE (deleted_at IS NULL)
 #
 # Foreign Keys

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -44,38 +44,38 @@ class RateCardRate < ApplicationRecord
   validates :code, presence: true
   validates :code, uniqueness: {scope: :rate_card_id, conditions: -> { where(deleted_at: nil) }}
   validates :billing_interval_unit, presence: true
-  validates :effective_datetime, presence: true
+  validates :effective_from, presence: true
   validates :rate_model, presence: true
   validates :min_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :billing_interval_count, numericality: {greater_than_or_equal_to: 1}
 
-  validate :validate_effective_datetime_is_appended
+  validate :validate_effective_from_is_appended
   validate :validate_pricing_unit_conversion_rate
 
   default_scope -> { kept }
 
   private
 
-  # Append-only timeline: a new rate's effective_datetime must be strictly greater
+  # Append-only timeline: a new rate's effective_from must be strictly greater
   # than the latest existing rate on the same card. No insertion between rates.
   # The past is immutable, the future is editable: a rate can land anywhere in
   # the pending sequence, but never at or before the rate that already priced
   # elapsed time (the active one).
-  def validate_effective_datetime_is_appended
-    return if effective_datetime.blank?
+  def validate_effective_from_is_appended
+    return if effective_from.blank?
     return if rate_card.blank?
 
     others = rate_card.rates.where.not(id:)
-    if others.where(effective_datetime:).exists?
-      errors.add(:effective_datetime, :value_already_exist)
+    if others.where(effective_from:).exists?
+      errors.add(:effective_from, :value_already_exist)
       return
     end
 
-    active_boundary = others.where(effective_datetime: ..Time.current).maximum(:effective_datetime)
+    active_boundary = others.where(effective_from: ..Time.current).maximum(:effective_from)
     return if active_boundary.blank?
-    return if effective_datetime > active_boundary
+    return if effective_from > active_boundary
 
-    errors.add(:effective_datetime, :must_be_after_active_rate)
+    errors.add(:effective_from, :must_be_after_active_rate)
   end
 
   def validate_pricing_unit_conversion_rate
@@ -97,7 +97,7 @@ end
 #  billing_interval_unit                :enum             not null
 #  code                                 :string           not null
 #  deleted_at                           :datetime
-#  effective_datetime                   :datetime         not null
+#  effective_from                       :datetime         not null
 #  min_amount_cents                     :bigint           default(0), not null
 #  rate_model                           :enum             not null
 #  rate_properties                      :jsonb            not null
@@ -108,11 +108,11 @@ end
 #
 # Indexes
 #
-#  index_rate_card_rates_on_deleted_at                           (deleted_at)
-#  index_rate_card_rates_on_organization_id                      (organization_id)
-#  index_rate_card_rates_on_rate_card_id                         (rate_card_id)
-#  index_rate_card_rates_on_rate_card_id_and_code                (rate_card_id,code) UNIQUE WHERE (deleted_at IS NULL)
-#  index_rate_card_rates_on_rate_card_id_and_effective_datetime  (rate_card_id,effective_datetime) UNIQUE WHERE (deleted_at IS NULL)
+#  index_rate_card_rates_on_deleted_at                       (deleted_at)
+#  index_rate_card_rates_on_organization_id                  (organization_id)
+#  index_rate_card_rates_on_rate_card_id                     (rate_card_id)
+#  index_rate_card_rates_on_rate_card_id_and_code            (rate_card_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#  index_rate_card_rates_on_rate_card_id_and_effective_from  (rate_card_id,effective_from) UNIQUE WHERE (deleted_at IS NULL)
 #
 # Foreign Keys
 #

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+class RateCardRate < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  RATE_MODELS = {
+    standard: "standard",
+    graduated: "graduated",
+    package: "package",
+    percentage: "percentage",
+    volume: "volume",
+    graduated_percentage: "graduated_percentage",
+    custom: "custom",
+    dynamic: "dynamic"
+  }.freeze
+
+  BILLING_INTERVAL_UNITS = {
+    day: "day",
+    week: "week",
+    month: "month",
+    year: "year"
+  }.freeze
+
+  STATUSES = {
+    pending: "pending",
+    active: "active",
+    terminated: "terminated"
+  }.freeze
+
+  belongs_to :organization
+  belongs_to :rate_card
+
+  # allow_nil + explicit presence: a missing value reads as value_is_mandatory,
+  # an unknown value as value_is_invalid.
+  enum :rate_model, RATE_MODELS, validate: {allow_nil: true}
+  enum :billing_interval_unit, BILLING_INTERVAL_UNITS, validate: {allow_nil: true}
+
+  # The code is the rate's stable identifier within its card. It is always
+  # caller-provided — there is no auto-generation.
+  validates :code, presence: true
+  validates :code, uniqueness: {scope: :rate_card_id, conditions: -> { where(deleted_at: nil) }}
+  validates :billing_interval_unit, presence: true
+  validates :effective_datetime, presence: true
+  validates :rate_model, presence: true
+  validates :min_amount_cents, numericality: {greater_than_or_equal_to: 0}
+  validates :billing_interval_count, numericality: {greater_than_or_equal_to: 1}
+
+  validate :validate_effective_datetime_is_appended
+  validate :validate_pricing_unit_conversion_rate
+
+  default_scope -> { kept }
+
+  private
+
+  # Append-only timeline: a new rate's effective_datetime must be strictly greater
+  # than the latest existing rate on the same card. No insertion between rates.
+  # The past is immutable, the future is editable: a rate can land anywhere in
+  # the pending sequence, but never at or before the rate that already priced
+  # elapsed time (the active one).
+  def validate_effective_datetime_is_appended
+    return if effective_datetime.blank?
+    return if rate_card.blank?
+
+    others = rate_card.rates.where.not(id:)
+    if others.where(effective_datetime:).exists?
+      errors.add(:effective_datetime, :value_already_exist)
+      return
+    end
+
+    active_boundary = others.where(effective_datetime: ..Time.current).maximum(:effective_datetime)
+    return if active_boundary.blank?
+    return if effective_datetime > active_boundary
+
+    errors.add(:effective_datetime, :must_be_after_active_rate)
+  end
+
+  def validate_pricing_unit_conversion_rate
+    return if rate_card&.applied_pricing_unit_code.blank?
+    return if applied_pricing_unit_conversion_rate.present?
+
+    errors.add(:applied_pricing_unit_conversion_rate, :blank)
+  end
+end
+
+# == Schema Information
+#
+# Table name: rate_card_rates
+# Database name: primary
+#
+#  id                                   :uuid             not null, primary key
+#  applied_pricing_unit_conversion_rate :decimal(30, 10)
+#  billing_interval_count               :integer          default(1), not null
+#  billing_interval_unit                :enum             not null
+#  deleted_at                           :datetime
+#  effective_datetime                   :datetime         not null
+#  min_amount_cents                     :bigint           default(0), not null
+#  rate_model                           :enum             not null
+#  rate_properties                      :jsonb            not null
+#  created_at                           :datetime         not null
+#  updated_at                           :datetime         not null
+#  organization_id                      :uuid             not null
+#  rate_card_id                         :uuid             not null
+#
+# Indexes
+#
+#  index_rate_card_rates_on_deleted_at                           (deleted_at)
+#  index_rate_card_rates_on_organization_id                      (organization_id)
+#  index_rate_card_rates_on_rate_card_id                         (rate_card_id)
+#  index_rate_card_rates_on_rate_card_id_and_effective_datetime  (rate_card_id,effective_datetime) UNIQUE WHERE (deleted_at IS NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (rate_card_id => rate_cards.id)
+#

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -50,6 +50,7 @@ class RateCardRate < ApplicationRecord
   validates :billing_interval_count, numericality: {greater_than_or_equal_to: 1}
 
   validate :validate_effective_from_is_appended
+  validate :validate_effective_from_granularity
   validate :validate_pricing_unit_conversion_rate
 
   default_scope -> { kept }
@@ -61,6 +62,21 @@ class RateCardRate < ApplicationRecord
   # The past is immutable, the future is editable: a rate can land anywhere in
   # the pending sequence, but never at or before the rate that already priced
   # elapsed time (the active one).
+  # Arrears rates apply per whole day: period math never samples inside a day,
+  # so a time component could only create shadowed rates. One rate per day,
+  # enforced by the unique (rate_card_id, effective_from) index once every
+  # date normalises to midnight. Advance rates keep full instants — they price
+  # per event. REST refuses datetime strings on arrears at the service
+  # boundary; this value check backstops paths where the input is already
+  # coerced (GraphQL's ISO8601 scalar, internal callers).
+  def validate_effective_from_granularity
+    return if effective_from.blank?
+    return unless rate_card&.arrears?
+    return if effective_from == effective_from.beginning_of_day
+
+    errors.add(:effective_from, :must_be_a_date)
+  end
+
   def validate_effective_from_is_appended
     return if effective_from.blank?
     return if rate_card.blank?

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -35,22 +35,23 @@ class RateCardRate < ApplicationRecord
 
   has_many :fees
 
-  # Nil is forbidden by the presence validations below (and NOT NULL in the
-  # schema). allow_nil here only keeps a missing value on the presence error
-  # (value_is_mandatory) instead of also failing inclusion (value_is_invalid).
+  # allow_nil here only keeps a missing value on the presence error
+  # (value_is_mandatory) instead of also failing inclusion (value_is_invalid)
   enum :rate_model, RATE_MODELS, validate: {allow_nil: true}
   enum :billing_interval_unit, BILLING_INTERVAL_UNITS, validate: {allow_nil: true}
 
   validates :code, presence: true
   validates :code, uniqueness: {scope: :rate_card_id, conditions: -> { where(deleted_at: nil) }}
   validates :billing_interval_unit, presence: true
-  validates :effective_from, presence: true
+  # The column is a datetime: an unparseable value casts to nil
+  validates :effective_from, presence: true, if: -> { effective_from_before_type_cast.blank? }
   validates :rate_model, presence: true
   validates :min_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :billing_interval_count, numericality: {greater_than_or_equal_to: 1}
 
   before_validation :normalize_effective_from
 
+  validate :validate_effective_from_parseable
   validate :validate_effective_from_is_appended
   validate :validate_pricing_unit_conversion_rate
 
@@ -58,13 +59,8 @@ class RateCardRate < ApplicationRecord
 
   private
 
-  # Arrears rates apply per whole day: period math never samples inside a day,
-  # so a time component carries no billing meaning and could only create
-  # shadowed rates. It is canonicalized away here — every arrears value lands
-  # on its day's midnight — which makes the unique (rate_card_id,
-  # effective_from) index a one-rate-per-day rule, and a second rate on the
-  # same day an exact duplicate (value_already_exist). Advance rates keep full
-  # instants — they price per event.
+  # Arrears rates apply per whole day, Advance rates keep full
+  # instants — they price per event
   def normalize_effective_from
     return if effective_from.blank?
     return unless rate_card&.arrears?
@@ -72,11 +68,16 @@ class RateCardRate < ApplicationRecord
     self.effective_from = effective_from.beginning_of_day
   end
 
+  def validate_effective_from_parseable
+    return if effective_from.present?
+    return if effective_from_before_type_cast.blank?
+
+    errors.add(:effective_from, :invalid)
+  end
+
   # Append-only timeline: a new rate's effective_from must be strictly greater
   # than the latest existing rate on the same card. No insertion between rates.
-  # The past is immutable, the future is editable: a rate can land anywhere in
-  # the pending sequence, but never at or before the rate that already priced
-  # elapsed time (the active one).
+  # The past is immutable, the future is editable
   def validate_effective_from_is_appended
     return if effective_from.blank?
     return if rate_card.blank?

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -49,34 +49,34 @@ class RateCardRate < ApplicationRecord
   validates :min_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :billing_interval_count, numericality: {greater_than_or_equal_to: 1}
 
+  before_validation :normalize_effective_from
+
   validate :validate_effective_from_is_appended
-  validate :validate_effective_from_granularity
   validate :validate_pricing_unit_conversion_rate
 
   default_scope -> { kept }
 
   private
 
+  # Arrears rates apply per whole day: period math never samples inside a day,
+  # so a time component carries no billing meaning and could only create
+  # shadowed rates. It is canonicalized away here — every arrears value lands
+  # on its day's midnight — which makes the unique (rate_card_id,
+  # effective_from) index a one-rate-per-day rule, and a second rate on the
+  # same day an exact duplicate (value_already_exist). Advance rates keep full
+  # instants — they price per event.
+  def normalize_effective_from
+    return if effective_from.blank?
+    return unless rate_card&.arrears?
+
+    self.effective_from = effective_from.beginning_of_day
+  end
+
   # Append-only timeline: a new rate's effective_from must be strictly greater
   # than the latest existing rate on the same card. No insertion between rates.
   # The past is immutable, the future is editable: a rate can land anywhere in
   # the pending sequence, but never at or before the rate that already priced
   # elapsed time (the active one).
-  # Arrears rates apply per whole day: period math never samples inside a day,
-  # so a time component could only create shadowed rates. One rate per day,
-  # enforced by the unique (rate_card_id, effective_from) index once every
-  # date normalises to midnight. Advance rates keep full instants — they price
-  # per event. REST refuses datetime strings on arrears at the service
-  # boundary; this value check backstops paths where the input is already
-  # coerced (GraphQL's ISO8601 scalar, internal callers).
-  def validate_effective_from_granularity
-    return if effective_from.blank?
-    return unless rate_card&.arrears?
-    return if effective_from == effective_from.beginning_of_day
-
-    errors.add(:effective_from, :must_be_a_date)
-  end
-
   def validate_effective_from_is_appended
     return if effective_from.blank?
     return if rate_card.blank?

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -41,8 +41,6 @@ class RateCardRate < ApplicationRecord
   enum :rate_model, RATE_MODELS, validate: {allow_nil: true}
   enum :billing_interval_unit, BILLING_INTERVAL_UNITS, validate: {allow_nil: true}
 
-  # The code is the rate's stable identifier within its card. It is always
-  # caller-provided — there is no auto-generation.
   validates :code, presence: true
   validates :code, uniqueness: {scope: :rate_card_id, conditions: -> { where(deleted_at: nil) }}
   validates :billing_interval_unit, presence: true

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -35,8 +35,9 @@ class RateCardRate < ApplicationRecord
 
   has_many :fees
 
-  # allow_nil + explicit presence: a missing value reads as value_is_mandatory,
-  # an unknown value as value_is_invalid.
+  # Nil is forbidden by the presence validations below (and NOT NULL in the
+  # schema). allow_nil here only keeps a missing value on the presence error
+  # (value_is_mandatory) instead of also failing inclusion (value_is_invalid).
   enum :rate_model, RATE_MODELS, validate: {allow_nil: true}
   enum :billing_interval_unit, BILLING_INTERVAL_UNITS, validate: {allow_nil: true}
 

--- a/app/models/rate_override.rb
+++ b/app/models/rate_override.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class RateOverride < ApplicationRecord
+  include PaperTrailTraceable
+  include ChargePropertiesValidation
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  # A rate override mirrors the overridable pricing fields of a rate_card_rate.
+  # Structural card fields (currency, billing timing, proration, ...) are never
+  # overridden here and are always inherited from the rate card.
+  RATE_MODELS = RateCardRate::RATE_MODELS
+  BILLING_INTERVAL_UNITS = RateCardRate::BILLING_INTERVAL_UNITS
+
+  belongs_to :organization
+
+  has_one :rate_phase
+  has_many :fees
+
+  enum :rate_model, RATE_MODELS, validate: true
+  enum :billing_interval_unit, BILLING_INTERVAL_UNITS, validate: {allow_nil: true}
+
+  validates :min_amount_cents, numericality: {greater_than_or_equal_to: 0}
+  validates :billing_interval_count, numericality: {greater_than_or_equal_to: 1}, allow_nil: true
+
+  validate :validate_properties
+
+  default_scope -> { kept }
+
+  # The charge validators read pricing data from a `properties` attribute.
+  def properties
+    rate_properties
+  end
+
+  private
+
+  def validate_properties
+    return unless rate_model
+
+    validator = ChargePropertiesValidation::PROPERTIES_VALIDATORS[rate_model.to_sym]
+    validator ||= Charges::Validators::BaseService
+
+    instance = validator.new(charge: self)
+    return if instance.valid?
+
+    instance.result.error.messages.values.flatten.each { errors.add(:rate_properties, it) }
+  end
+end
+
+# == Schema Information
+#
+# Table name: rate_overrides
+# Database name: primary
+#
+#  id                           :uuid             not null, primary key
+#  billing_interval_count       :integer
+#  billing_interval_unit        :enum
+#  deleted_at                   :datetime
+#  min_amount_cents             :bigint           default(0), not null
+#  pricing_unit_conversion_rate :decimal(30, 10)
+#  rate_model                   :enum             not null
+#  rate_properties              :jsonb            not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  organization_id              :uuid             not null
+#
+# Indexes
+#
+#  index_rate_overrides_on_deleted_at       (deleted_at)
+#  index_rate_overrides_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/rate_phase.rb
+++ b/app/models/rate_phase.rb
@@ -48,6 +48,7 @@ end
 #  billing_interval_cycle_count :integer
 #  code                         :string           not null
 #  deleted_at                   :datetime
+#  name                         :string
 #  position                     :integer          not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null

--- a/app/models/rate_phase.rb
+++ b/app/models/rate_phase.rb
@@ -11,9 +11,6 @@ class RatePhase < ApplicationRecord
   belongs_to :subscription_rate_card, optional: true
   belongs_to :rate_override, optional: true
 
-  # The code is the phase's stable identifier within its parent entry:
-  # positions renumber on insert/delete, codes never move. It is always
-  # caller-provided — there is no auto-generation.
   validates :code, presence: true
   validates :code,
     uniqueness: {scope: :plan_rate_card_id, conditions: -> { where(deleted_at: nil) }},

--- a/app/models/rate_phase.rb
+++ b/app/models/rate_phase.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class RatePhase < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+  belongs_to :plan_rate_card, optional: true
+  belongs_to :subscription_rate_card, optional: true
+
+  # The code is the phase's stable identifier within its parent entry:
+  # positions renumber on insert/delete, codes never move. It is always
+  # caller-provided — there is no auto-generation.
+  validates :code, presence: true
+  validates :code,
+    uniqueness: {scope: :plan_rate_card_id, conditions: -> { where(deleted_at: nil) }},
+    if: :plan_rate_card_id?
+  validates :code,
+    uniqueness: {scope: :subscription_rate_card_id, conditions: -> { where(deleted_at: nil) }},
+    if: :subscription_rate_card_id?
+  validates :position, presence: true, numericality: {greater_than: 0}
+  # nil = indefinite (terminal) phase; a zero-cycle phase would never bill.
+  validates :billing_interval_cycle_count, numericality: {greater_than: 0}, allow_nil: true
+
+  validate :validate_exactly_one_parent
+
+  default_scope -> { kept }
+
+  private
+
+  def validate_exactly_one_parent
+    has_plan_parent = plan_rate_card_id.present? || plan_rate_card.present?
+    has_sub_parent = subscription_rate_card_id.present? || subscription_rate_card.present?
+    return if has_plan_parent ^ has_sub_parent
+
+    errors.add(:base, :exactly_one_parent_required)
+  end
+end
+
+# == Schema Information
+#
+# Table name: rate_phases
+# Database name: primary
+#
+#  id                           :uuid             not null, primary key
+#  billing_interval_cycle_count :integer
+#  code                         :string           not null
+#  deleted_at                   :datetime
+#  position                     :integer          not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  organization_id              :uuid             not null
+#  plan_rate_card_id            :uuid
+#  rate_override_id             :uuid
+#  subscription_rate_card_id    :uuid
+#
+# Indexes
+#
+#  index_rate_phases_on_deleted_at                      (deleted_at)
+#  index_rate_phases_on_organization_id                 (organization_id)
+#  index_rate_phases_on_plan_rate_card_id               (plan_rate_card_id)
+#  index_rate_phases_on_plan_rate_card_id_and_code      (plan_rate_card_id,code) UNIQUE WHERE ((plan_rate_card_id IS NOT NULL) AND (deleted_at IS NULL))
+#  index_rate_phases_on_plan_rate_card_id_and_position  (plan_rate_card_id,position) UNIQUE WHERE ((plan_rate_card_id IS NOT NULL) AND (deleted_at IS NULL))
+#  index_rate_phases_on_sub_rate_card_id_and_code       (subscription_rate_card_id,code) UNIQUE WHERE ((subscription_rate_card_id IS NOT NULL) AND (deleted_at IS NULL))
+#  index_rate_phases_on_sub_rate_card_id_and_position   (subscription_rate_card_id,position) UNIQUE WHERE ((subscription_rate_card_id IS NOT NULL) AND (deleted_at IS NULL))
+#  index_rate_phases_on_subscription_rate_card_id       (subscription_rate_card_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (plan_rate_card_id => plan_rate_cards.id)
+#  fk_rails_...  (subscription_rate_card_id => subscription_rate_cards.id)
+#

--- a/app/models/rate_phase.rb
+++ b/app/models/rate_phase.rb
@@ -9,6 +9,7 @@ class RatePhase < ApplicationRecord
   belongs_to :organization
   belongs_to :plan_rate_card, optional: true
   belongs_to :subscription_rate_card, optional: true
+  belongs_to :rate_override, optional: true
 
   # The code is the phase's stable identifier within its parent entry:
   # positions renumber on insert/delete, codes never move. It is always
@@ -23,6 +24,7 @@ class RatePhase < ApplicationRecord
   validates :position, presence: true, numericality: {greater_than: 0}
   # nil = indefinite (terminal) phase; a zero-cycle phase would never bill.
   validates :billing_interval_cycle_count, numericality: {greater_than: 0}, allow_nil: true
+  validates :rate_override_id, uniqueness: {conditions: -> { where(deleted_at: nil) }}, allow_nil: true
 
   validate :validate_exactly_one_parent
 
@@ -64,6 +66,7 @@ end
 #  index_rate_phases_on_plan_rate_card_id               (plan_rate_card_id)
 #  index_rate_phases_on_plan_rate_card_id_and_code      (plan_rate_card_id,code) UNIQUE WHERE ((plan_rate_card_id IS NOT NULL) AND (deleted_at IS NULL))
 #  index_rate_phases_on_plan_rate_card_id_and_position  (plan_rate_card_id,position) UNIQUE WHERE ((plan_rate_card_id IS NOT NULL) AND (deleted_at IS NULL))
+#  index_rate_phases_on_rate_override_id                (rate_override_id) UNIQUE WHERE ((rate_override_id IS NOT NULL) AND (deleted_at IS NULL))
 #  index_rate_phases_on_sub_rate_card_id_and_code       (subscription_rate_card_id,code) UNIQUE WHERE ((subscription_rate_card_id IS NOT NULL) AND (deleted_at IS NULL))
 #  index_rate_phases_on_sub_rate_card_id_and_position   (subscription_rate_card_id,position) UNIQUE WHERE ((subscription_rate_card_id IS NOT NULL) AND (deleted_at IS NULL))
 #  index_rate_phases_on_subscription_rate_card_id       (subscription_rate_card_id)
@@ -72,5 +75,6 @@ end
 #
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_rate_card_id => plan_rate_cards.id)
+#  fk_rails_...  (rate_override_id => rate_overrides.id)
 #  fk_rails_...  (subscription_rate_card_id => subscription_rate_cards.id)
 #

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -20,6 +20,7 @@ class Subscription < ApplicationRecord
   has_many :invoices, through: :invoice_subscriptions
   has_many :integration_resources, as: :syncable
   has_many :fees
+  has_many :applied_rate_cards, class_name: "SubscriptionRateCard"
   has_many :daily_usages
   has_many :usage_thresholds
   has_many :entitlements, class_name: "Entitlement::Entitlement"

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -167,6 +167,12 @@ class Subscription < ApplicationRecord
     plan.yearly_amount_cents > next_subscription.plan.yearly_amount_cents
   end
 
+  # The anchor a rate card inherits when it is created without one: the
+  # subscription's explicit anchor, else the day the subscription started.
+  def effective_billing_anchor_date
+    billing_anchor_date || (started_at || subscription_at)&.to_date
+  end
+
   def trial_end_date
     return unless plan.has_trial?
 
@@ -337,6 +343,7 @@ end
 #
 #  id                           :uuid             not null, primary key
 #  activated_at                 :datetime
+#  billing_anchor_date          :date
 #  billing_time                 :integer          default("calendar"), not null
 #  canceled_at                  :datetime
 #  cancellation_reason          :enum

--- a/app/models/subscription_rate_card.rb
+++ b/app/models/subscription_rate_card.rb
@@ -45,7 +45,7 @@ end
 #  ended_at            :datetime
 #  next_billing_at     :datetime         not null
 #  started_at          :datetime         not null
-#  units               :decimal(30, 10)
+#  units               :decimal(, )
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  organization_id     :uuid             not null

--- a/app/models/subscription_rate_card.rb
+++ b/app/models/subscription_rate_card.rb
@@ -12,7 +12,6 @@ class SubscriptionRateCard < ApplicationRecord
 
   has_one :product, through: :rate_card
 
-  # Phases are an ordered sequence; heap order is not deterministic.
   has_many :rate_phases, -> { order(:position) }
 
   validates :billing_anchor_date, presence: true

--- a/app/models/subscription_rate_card.rb
+++ b/app/models/subscription_rate_card.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class SubscriptionRateCard < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+  belongs_to :subscription
+  belongs_to :rate_card
+
+  has_one :product, through: :rate_card
+
+  validates :billing_anchor_date, presence: true
+  validates :next_billing_at, presence: true
+  validates :started_at, presence: true
+  validates :rate_card_id, uniqueness: {scope: :subscription_id, conditions: -> { where(deleted_at: nil, ended_at: nil) }}
+
+  validate :validate_started_before_ended
+
+  default_scope -> { kept }
+
+  private
+
+  def validate_started_before_ended
+    return if started_at.blank? || ended_at.blank?
+    return if started_at <= ended_at
+
+    errors.add(:ended_at, :must_be_after_started_at)
+  end
+end
+
+# == Schema Information
+#
+# Table name: subscription_rate_cards
+# Database name: primary
+#
+#  id                  :uuid             not null, primary key
+#  billing_anchor_date :date             not null
+#  deleted_at          :datetime
+#  ended_at            :datetime
+#  next_billing_at     :datetime         not null
+#  started_at          :datetime         not null
+#  units               :decimal(30, 10)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  organization_id     :uuid             not null
+#  rate_card_id        :uuid             not null
+#  subscription_id     :uuid             not null
+#
+# Indexes
+#
+#  index_subscription_rate_cards_on_next_billing_at        (next_billing_at) WHERE ((deleted_at IS NULL) AND (ended_at IS NULL))
+#  index_active_subscription_rate_cards_on_sub_and_card  (subscription_id,rate_card_id) UNIQUE WHERE ((deleted_at IS NULL) AND (ended_at IS NULL))
+#  index_subscription_rate_cards_on_deleted_at           (deleted_at)
+#  index_subscription_rate_cards_on_organization_id      (organization_id)
+#  index_subscription_rate_cards_on_rate_card_id         (rate_card_id)
+#  index_subscription_rate_cards_on_subscription_id      (subscription_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (rate_card_id => rate_cards.id)
+#  fk_rails_...  (subscription_id => subscriptions.id)
+#

--- a/app/models/subscription_rate_card.rb
+++ b/app/models/subscription_rate_card.rb
@@ -12,6 +12,9 @@ class SubscriptionRateCard < ApplicationRecord
 
   has_one :product, through: :rate_card
 
+  # Phases are an ordered sequence; heap order is not deterministic.
+  has_many :rate_phases, -> { order(:position) }
+
   validates :billing_anchor_date, presence: true
   validates :next_billing_at, presence: true
   validates :started_at, presence: true
@@ -51,9 +54,9 @@ end
 #
 # Indexes
 #
-#  index_subscription_rate_cards_on_next_billing_at        (next_billing_at) WHERE ((deleted_at IS NULL) AND (ended_at IS NULL))
 #  index_active_subscription_rate_cards_on_sub_and_card  (subscription_id,rate_card_id) UNIQUE WHERE ((deleted_at IS NULL) AND (ended_at IS NULL))
 #  index_subscription_rate_cards_on_deleted_at           (deleted_at)
+#  index_subscription_rate_cards_on_next_billing_at      (next_billing_at) WHERE ((deleted_at IS NULL) AND (ended_at IS NULL))
 #  index_subscription_rate_cards_on_organization_id      (organization_id)
 #  index_subscription_rate_cards_on_rate_card_id         (rate_card_id)
 #  index_subscription_rate_cards_on_subscription_id      (subscription_id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,6 @@ en:
         missing_graduated_ranges: missing_graduated_ranges
         missing_volume_ranges: missing_volume_ranges
         modification_not_allowed: modification_not_allowed
-        must_be_a_date: must_be_a_date
         must_be_array: must_be_array
         must_be_greater_than_or_equal_min: must_be_greater_than_or_equal_min
         must_be_greater_than_or_equal_threshold: must_be_greater_than_or_equal_threshold

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
         missing_graduated_ranges: missing_graduated_ranges
         missing_volume_ranges: missing_volume_ranges
         modification_not_allowed: modification_not_allowed
+        must_be_a_date: must_be_a_date
         must_be_array: must_be_array
         must_be_greater_than_or_equal_min: must_be_greater_than_or_equal_min
         must_be_greater_than_or_equal_threshold: must_be_greater_than_or_equal_threshold

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
         payment_request_is_already_succeeded: payment_request_is_already_succeeded
         present: value_must_be_blank
         required: relation_must_exist
+        requires_recurring_metric: requires_recurring_metric
         taken: value_already_exist
         too_long: value_is_too_long
         too_short: value_is_too_short

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
         country_code_invalid: not_a_valid_country_code
         country_must_be_present: country_must_be_present
         country_not_supported: country_not_supported
+        does_not_belong_to_product: does_not_belong_to_product
         exclusion: value_is_reserved
         feature_unavailable: feature_unavailable
         file_size_not_less_than: file_too_large

--- a/db/migrate/20260604175126_create_product_categories.rb
+++ b/db/migrate/20260604175126_create_product_categories.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateProductCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :product_categories, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+
+      t.string :code, null: false
+      t.string :name, null: false
+      t.string :description
+      t.string :invoice_display_name
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      t.index [:organization_id, :code],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_product_categories_on_organization_id_and_code"
+    end
+  end
+end

--- a/db/migrate/20260604175459_create_products.rb
+++ b/db/migrate/20260604175459_create_products.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateProducts < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :product_type, %w[usage fixed]
+
+    create_table :products, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :product_category, null: true, foreign_key: true, type: :uuid
+      t.references :billable_metric, null: true, foreign_key: true, type: :uuid
+      t.references :add_on, null: true, foreign_key: true, type: :uuid
+      t.references :charge, null: true, foreign_key: true, type: :uuid
+
+      t.enum :product_type, enum_type: :product_type, null: false
+
+      t.string :code, null: false
+      t.string :name, null: false
+      t.string :invoice_display_name
+      t.text :description
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      t.index [:organization_id, :code],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_products_on_organization_id_and_code"
+    end
+  end
+end

--- a/db/migrate/20260604175731_create_product_filters.rb
+++ b/db/migrate/20260604175731_create_product_filters.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateProductFilters < ActiveRecord::Migration[8.0]
+  def change
+    create_table :product_filters, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :product, null: false, foreign_key: true, type: :uuid
+
+      t.string :name, null: false
+      t.string :code, null: false
+      t.string :description
+      t.string :invoice_display_name
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      t.index [:product_id, :code],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_product_filters_on_product_id_and_code"
+    end
+  end
+end

--- a/db/migrate/20260604180513_create_product_filter_values.rb
+++ b/db/migrate/20260604180513_create_product_filter_values.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateProductFilterValues < ActiveRecord::Migration[8.0]
+  def change
+    create_table :product_filter_values, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :product_filter, null: false, foreign_key: true, type: :uuid
+      t.references :billable_metric_filter, null: false, foreign_key: true, type: :uuid
+
+      # NULL means the filter matches any value of the key (key-only selection)
+      t.string :value
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      # NULLS NOT DISTINCT so two key-only rows (value IS NULL) for the same
+      # key cannot coexist.
+      t.index [:product_filter_id, :billable_metric_filter_id, :value],
+        unique: true,
+        where: "deleted_at IS NULL",
+        nulls_not_distinct: true,
+        name: "idx_pif_values_on_filter_metric_filter_and_value"
+    end
+  end
+end

--- a/db/migrate/20260604181043_create_rate_cards.rb
+++ b/db/migrate/20260604181043_create_rate_cards.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CreateRateCards < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :rate_card_billing_timing, %w[arrears advance]
+    create_enum :rate_card_regroup_paid_fees, %w[invoice]
+
+    create_table :rate_cards, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :product, null: false, foreign_key: true, type: :uuid
+      t.references :product_filter, null: true, foreign_key: true, type: :uuid
+
+      t.string :code, null: false
+      t.string :name, null: false
+      t.string :description
+
+      t.string :currency, null: false
+
+      t.enum :billing_timing, enum_type: :rate_card_billing_timing, null: false, default: "arrears"
+      t.boolean :proration, null: false, default: false
+      t.boolean :display_on_invoice, null: false, default: true
+      t.enum :regroup_paid_fees, enum_type: :rate_card_regroup_paid_fees
+      t.string :applied_pricing_unit_code
+      t.boolean :wallet_targetable
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      t.index [:organization_id, :code],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_rate_cards_on_organization_id_and_code"
+    end
+  end
+end

--- a/db/migrate/20260604181043_create_rate_cards.rb
+++ b/db/migrate/20260604181043_create_rate_cards.rb
@@ -3,7 +3,7 @@
 class CreateRateCards < ActiveRecord::Migration[8.0]
   def change
     create_enum :rate_card_billing_timing, %w[arrears advance]
-    create_enum :rate_card_regroup_paid_fees, %w[invoice]
+    create_enum :rate_card_regroup_paid_fees, %w[none invoice]
 
     create_table :rate_cards, id: :uuid do |t|
       t.references :organization, null: false, foreign_key: true, type: :uuid
@@ -19,7 +19,7 @@ class CreateRateCards < ActiveRecord::Migration[8.0]
       t.enum :billing_timing, enum_type: :rate_card_billing_timing, null: false, default: "arrears"
       t.boolean :proration, null: false, default: false
       t.boolean :display_on_invoice, null: false, default: true
-      t.enum :regroup_paid_fees, enum_type: :rate_card_regroup_paid_fees
+      t.enum :regroup_paid_fees, enum_type: :rate_card_regroup_paid_fees, null: false, default: "none"
       t.string :applied_pricing_unit_code
       t.boolean :wallet_targetable
 

--- a/db/migrate/20260604181339_create_rate_card_rates.rb
+++ b/db/migrate/20260604181339_create_rate_card_rates.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class CreateRateCardRates < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :rate_card_rate_model, %w[standard graduated package percentage volume graduated_percentage custom dynamic]
+    create_enum :rate_card_rate_billing_interval_unit, %w[day week month year]
+
+    create_table :rate_card_rates, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :rate_card, null: false, foreign_key: true, type: :uuid
+
+      # Stable caller-provided identifier within the card.
+      t.string :code, null: false
+      t.datetime :effective_datetime, null: false
+
+      t.enum :rate_model, enum_type: :rate_card_rate_model, null: false
+      t.jsonb :rate_properties, null: false, default: {}
+
+      t.bigint :min_amount_cents, null: false, default: 0
+      t.integer :billing_interval_count, null: false, default: 1
+      t.enum :billing_interval_unit, enum_type: :rate_card_rate_billing_interval_unit, null: false
+
+      t.decimal :applied_pricing_unit_conversion_rate, precision: 30, scale: 10
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      t.index [:rate_card_id, :effective_datetime],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_rate_card_rates_on_rate_card_id_and_effective_datetime"
+      t.index [:rate_card_id, :code],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_rate_card_rates_on_rate_card_id_and_code"
+
+      t.check_constraint "billing_interval_count >= 1",
+        name: "rate_card_rates_billing_interval_count_positive"
+    end
+  end
+end

--- a/db/migrate/20260604181339_create_rate_card_rates.rb
+++ b/db/migrate/20260604181339_create_rate_card_rates.rb
@@ -11,7 +11,7 @@ class CreateRateCardRates < ActiveRecord::Migration[8.0]
 
       # Stable caller-provided identifier within the card.
       t.string :code, null: false
-      t.datetime :effective_datetime, null: false
+      t.datetime :effective_from, null: false
 
       t.enum :rate_model, enum_type: :rate_card_rate_model, null: false
       t.jsonb :rate_properties, null: false, default: {}
@@ -27,10 +27,10 @@ class CreateRateCardRates < ActiveRecord::Migration[8.0]
       t.timestamps
 
       t.index :deleted_at
-      t.index [:rate_card_id, :effective_datetime],
+      t.index [:rate_card_id, :effective_from],
         unique: true,
         where: "deleted_at IS NULL",
-        name: "index_rate_card_rates_on_rate_card_id_and_effective_datetime"
+        name: "index_rate_card_rates_on_rate_card_id_and_effective_from"
       t.index [:rate_card_id, :code],
         unique: true,
         where: "deleted_at IS NULL",

--- a/db/migrate/20260604181654_create_plan_rate_cards.rb
+++ b/db/migrate/20260604181654_create_plan_rate_cards.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreatePlanRateCards < ActiveRecord::Migration[8.0]
+  def change
+    create_table :plan_rate_cards, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :plan, null: false, foreign_key: true, type: :uuid
+      t.references :rate_card, null: false, foreign_key: true, type: :uuid
+
+      t.decimal :units, precision: 30, scale: 10
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      t.index [:plan_id, :rate_card_id],
+        unique: true,
+        where: "deleted_at IS NULL",
+        name: "index_plan_rate_cards_on_plan_id_and_rate_card_id"
+    end
+  end
+end

--- a/db/migrate/20260604181654_create_plan_rate_cards.rb
+++ b/db/migrate/20260604181654_create_plan_rate_cards.rb
@@ -7,7 +7,7 @@ class CreatePlanRateCards < ActiveRecord::Migration[8.0]
       t.references :plan, null: false, foreign_key: true, type: :uuid
       t.references :rate_card, null: false, foreign_key: true, type: :uuid
 
-      t.decimal :units, precision: 30, scale: 10
+      t.decimal :units
 
       t.datetime :deleted_at
 

--- a/db/migrate/20260604181826_create_subscription_rate_cards.rb
+++ b/db/migrate/20260604181826_create_subscription_rate_cards.rb
@@ -12,7 +12,7 @@ class CreateSubscriptionRateCards < ActiveRecord::Migration[8.0]
       t.datetime :started_at, null: false
       t.datetime :ended_at
 
-      t.decimal :units, precision: 30, scale: 10
+      t.decimal :units
 
       t.datetime :deleted_at
 

--- a/db/migrate/20260604181826_create_subscription_rate_cards.rb
+++ b/db/migrate/20260604181826_create_subscription_rate_cards.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CreateSubscriptionRateCards < ActiveRecord::Migration[8.0]
+  def change
+    create_table :subscription_rate_cards, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :subscription, null: false, foreign_key: true, type: :uuid
+      t.references :rate_card, null: false, foreign_key: true, type: :uuid
+
+      t.date :billing_anchor_date, null: false
+      t.datetime :next_billing_at, null: false
+      t.datetime :started_at, null: false
+      t.datetime :ended_at
+
+      t.decimal :units, precision: 30, scale: 10
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      t.index [:subscription_id, :rate_card_id],
+        unique: true,
+        where: "deleted_at IS NULL AND ended_at IS NULL",
+        name: "index_active_subscription_rate_cards_on_sub_and_card"
+      t.index :next_billing_at,
+        where: "deleted_at IS NULL AND ended_at IS NULL",
+        name: "index_subscription_rate_cards_on_next_billing_at"
+
+      t.check_constraint "ended_at IS NULL OR started_at <= ended_at",
+        name: "subscription_rate_cards_started_before_ended"
+    end
+  end
+end

--- a/db/migrate/20260604181958_create_rate_phases.rb
+++ b/db/migrate/20260604181958_create_rate_phases.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class CreateRatePhases < ActiveRecord::Migration[8.0]
+  def change
+    create_table :rate_phases, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :plan_rate_card, null: true, foreign_key: true, type: :uuid
+      t.references :subscription_rate_card, null: true, foreign_key: true, type: :uuid
+
+      # Stable identifier within the parent entry: positions renumber on
+      # insert/delete, codes never move.
+      t.string :code, null: false
+      t.integer :position, null: false
+      t.integer :billing_interval_cycle_count
+
+      # rate_override_id ships now but is only populated in v2 (rate_overrides
+      # does not exist yet), so no foreign key is declared.
+      t.uuid :rate_override_id
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+      t.index [:plan_rate_card_id, :position],
+        unique: true,
+        where: "plan_rate_card_id IS NOT NULL AND deleted_at IS NULL",
+        name: "index_rate_phases_on_plan_rate_card_id_and_position"
+      t.index [:subscription_rate_card_id, :position],
+        unique: true,
+        where: "subscription_rate_card_id IS NOT NULL AND deleted_at IS NULL",
+        name: "index_rate_phases_on_sub_rate_card_id_and_position"
+      t.index [:plan_rate_card_id, :code],
+        unique: true,
+        where: "plan_rate_card_id IS NOT NULL AND deleted_at IS NULL",
+        name: "index_rate_phases_on_plan_rate_card_id_and_code"
+      t.index [:subscription_rate_card_id, :code],
+        unique: true,
+        where: "subscription_rate_card_id IS NOT NULL AND deleted_at IS NULL",
+        name: "index_rate_phases_on_sub_rate_card_id_and_code"
+
+      t.check_constraint "(plan_rate_card_id IS NULL) <> (subscription_rate_card_id IS NULL)",
+        name: "rate_phases_exactly_one_parent"
+    end
+  end
+end

--- a/db/migrate/20260604182138_add_rate_card_rate_to_fees.rb
+++ b/db/migrate/20260604182138_add_rate_card_rate_to_fees.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRateCardRateToFees < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :fees, :rate_card_rate, type: :uuid, null: true, index: {algorithm: :concurrently}
+    add_foreign_key :fees, :rate_card_rates, column: :rate_card_rate_id, validate: false
+  end
+end

--- a/db/migrate/20260604182200_create_rate_overrides.rb
+++ b/db/migrate/20260604182200_create_rate_overrides.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CreateRateOverrides < ActiveRecord::Migration[8.0]
+  def change
+    create_table :rate_overrides, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+
+      t.enum :rate_model, enum_type: :rate_card_rate_model, null: false
+      t.jsonb :rate_properties, null: false, default: {}
+      t.bigint :min_amount_cents, null: false, default: 0
+
+      # null billing interval fields inherit the card's active rate.
+      t.integer :billing_interval_count
+      t.enum :billing_interval_unit, enum_type: :rate_card_rate_billing_interval_unit
+
+      t.decimal :pricing_unit_conversion_rate, precision: 30, scale: 10
+
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index :deleted_at
+    end
+
+    safety_assured do
+      add_foreign_key :rate_phases, :rate_overrides, column: :rate_override_id
+      # An override belongs to exactly one phase: phase duplication copies the
+      # override, sharing would let one edit silently reprice several phases.
+      add_index :rate_phases, :rate_override_id,
+        unique: true,
+        where: "rate_override_id IS NOT NULL AND deleted_at IS NULL"
+    end
+  end
+end

--- a/db/migrate/20260604182300_add_rate_override_to_fees.rb
+++ b/db/migrate/20260604182300_add_rate_override_to_fees.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRateOverrideToFees < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :fees, :rate_override, type: :uuid, null: true, index: {algorithm: :concurrently}
+    add_foreign_key :fees, :rate_overrides, column: :rate_override_id, validate: false
+  end
+end

--- a/db/migrate/20260630122927_add_name_to_rate_phases.rb
+++ b/db/migrate/20260630122927_add_name_to_rate_phases.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNameToRatePhases < ActiveRecord::Migration[8.0]
+  def change
+    add_column :rate_phases, :name, :string
+  end
+end

--- a/db/migrate/20260716173410_validate_fees_rate_card_rate_foreign_key.rb
+++ b/db/migrate/20260716173410_validate_fees_rate_card_rate_foreign_key.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ValidateFeesRateCardRateForeignKey < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    validate_foreign_key :fees, column: :rate_card_rate_id
+  end
+end

--- a/db/migrate/20260716173411_validate_fees_rate_override_foreign_key.rb
+++ b/db/migrate/20260716173411_validate_fees_rate_override_foreign_key.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ValidateFeesRateOverrideForeignKey < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    validate_foreign_key :fees, column: :rate_override_id
+  end
+end

--- a/db/migrate/20260803162623_add_billing_anchor_to_subscriptions.rb
+++ b/db/migrate/20260803162623_add_billing_anchor_to_subscriptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBillingAnchorToSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :subscriptions, :billing_anchor_date, :date
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5157,7 +5157,7 @@ CREATE TABLE public.plan_rate_cards (
     organization_id uuid NOT NULL,
     plan_id uuid NOT NULL,
     rate_card_id uuid NOT NULL,
-    units numeric(30,10),
+    units numeric,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -5628,7 +5628,7 @@ CREATE TABLE public.subscription_rate_cards (
     next_billing_at timestamp(6) without time zone NOT NULL,
     started_at timestamp(6) without time zone NOT NULL,
     ended_at timestamp(6) without time zone,
-    units numeric(30,10),
+    units numeric,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -34,6 +34,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF EXISTS fk_rails_ed387e0992;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_ecb466254b;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_eaca9421be;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_eab202bbcf;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ea80151038;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges DROP CONSTRAINT IF EXISTS fk_rails_e95f72749e;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_e8bac9c5bb;
@@ -54,6 +55,7 @@ ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CO
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_db9140d0fd;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8b4a1;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_d9ea200904;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_d9e7580aa8;
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_d9448a540b;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_d9342a8ca7;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_d72a9877be;
@@ -101,6 +103,7 @@ ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.billing_object_connections DROP CONSTRAINT IF EXISTS fk_rails_aed4cbd20b;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS fk_rails_aea6422e6a;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_ac146c9541;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_ac0f020184;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_subscription_activities DROP CONSTRAINT IF EXISTS fk_rails_ab16de0b32;
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_aaa12f7d3e;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT IF EXISTS fk_rails_aa34dd5db6;
@@ -134,6 +137,7 @@ ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_8fa6f0d920;
 ALTER TABLE IF EXISTS ONLY public.applied_pricing_units DROP CONSTRAINT IF EXISTS fk_rails_8e0c3d0c5b;
 ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_8df9bf2b6c;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_8c9cbcf514;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_8c18828b53;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_8c09ee2428;
 ALTER TABLE IF EXISTS ONLY public.invoice_metadata DROP CONSTRAINT IF EXISTS fk_rails_8bb5b094c4;
@@ -318,6 +322,7 @@ ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP
 ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS fk_rails_04388258ff;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_01a4c0c7db;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS fk_rails_019e2289e5;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_00f7aa94fd;
 ALTER TABLE IF EXISTS ONLY public.payment_methods DROP CONSTRAINT IF EXISTS fk_rails_00e7a45b0b;
 DROP TRIGGER IF EXISTS ensure_consistency ON public.roles;
 DROP TRIGGER IF EXISTS before_payment_receipt_insert ON public.payment_receipts;
@@ -459,6 +464,13 @@ DROP INDEX IF EXISTS public.index_quantified_events_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_product_categories_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_product_categories_on_organization_id;
 DROP INDEX IF EXISTS public.index_product_categories_on_deleted_at;
+DROP INDEX IF EXISTS public.index_products_on_product_category_id;
+DROP INDEX IF EXISTS public.index_products_on_organization_id_and_code;
+DROP INDEX IF EXISTS public.index_products_on_organization_id;
+DROP INDEX IF EXISTS public.index_products_on_deleted_at;
+DROP INDEX IF EXISTS public.index_products_on_charge_id;
+DROP INDEX IF EXISTS public.index_products_on_billable_metric_id;
+DROP INDEX IF EXISTS public.index_products_on_add_on_id;
 DROP INDEX IF EXISTS public.index_pricing_units_on_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_units_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_pricing_unit_id;
@@ -946,6 +958,7 @@ ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS quote
 ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS quote_owners_pkey;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
 ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS product_categories_pkey;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS products_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS presentation_breakdowns_pkey;
@@ -1071,6 +1084,7 @@ DROP SEQUENCE IF EXISTS public.quote_owners_id_seq;
 DROP TABLE IF EXISTS public.quote_owners;
 DROP TABLE IF EXISTS public.quantified_events;
 DROP TABLE IF EXISTS public.product_categories;
+DROP TABLE IF EXISTS public.products;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
 DROP TABLE IF EXISTS public.presentation_breakdowns;
@@ -1229,6 +1243,7 @@ DROP TYPE IF EXISTS public.subscription_activation_rule_statuses;
 DROP TYPE IF EXISTS public.quote_void_reason;
 DROP TYPE IF EXISTS public.quote_status;
 DROP TYPE IF EXISTS public.quote_order_type;
+DROP TYPE IF EXISTS public.product_type;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
 DROP TYPE IF EXISTS public.payment_method_types;
@@ -1529,6 +1544,16 @@ CREATE TYPE public.payment_payable_payment_status AS ENUM (
 CREATE TYPE public.payment_type AS ENUM (
     'provider',
     'manual'
+);
+
+
+--
+-- Name: product_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.product_type AS ENUM (
+    'usage',
+    'fixed'
 );
 
 
@@ -5038,6 +5063,28 @@ CREATE TABLE public.pricing_units (
 
 
 --
+-- Name: products; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.products (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    product_category_id uuid,
+    billable_metric_id uuid,
+    add_on_id uuid,
+    charge_id uuid,
+    item_type public.product_type NOT NULL,
+    code character varying NOT NULL,
+    name character varying NOT NULL,
+    invoice_display_name character varying,
+    description text,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: product_categories; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6307,6 +6354,14 @@ ALTER TABLE ONLY public.pricing_unit_usages
 
 ALTER TABLE ONLY public.pricing_units
     ADD CONSTRAINT pricing_units_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: products products_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT products_pkey PRIMARY KEY (id);
 
 
 --
@@ -9782,6 +9837,55 @@ CREATE INDEX index_pricing_units_on_organization_id ON public.pricing_units USIN
 
 
 --
+-- Name: index_products_on_add_on_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_products_on_add_on_id ON public.products USING btree (add_on_id);
+
+
+--
+-- Name: index_products_on_billable_metric_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_products_on_billable_metric_id ON public.products USING btree (billable_metric_id);
+
+
+--
+-- Name: index_products_on_charge_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_products_on_charge_id ON public.products USING btree (charge_id);
+
+
+--
+-- Name: index_products_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_products_on_deleted_at ON public.products USING btree (deleted_at);
+
+
+--
+-- Name: index_products_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_products_on_organization_id ON public.products USING btree (organization_id);
+
+
+--
+-- Name: index_products_on_organization_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_products_on_organization_id_and_code ON public.products USING btree (organization_id, code) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_products_on_product_category_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_products_on_product_category_id ON public.products USING btree (product_category_id);
+
+
+--
 -- Name: index_product_categories_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10676,6 +10780,14 @@ CREATE TRIGGER ensure_consistency BEFORE UPDATE ON public.roles FOR EACH ROW EXE
 
 ALTER TABLE ONLY public.payment_methods
     ADD CONSTRAINT fk_rails_00e7a45b0b FOREIGN KEY (payment_provider_id) REFERENCES public.payment_providers(id);
+
+
+--
+-- Name: products fk_rails_00f7aa94fd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_00f7aa94fd FOREIGN KEY (product_category_id) REFERENCES public.product_categories(id);
 
 
 --
@@ -12151,6 +12263,14 @@ ALTER TABLE ONLY public.usage_monitoring_alerts
 
 
 --
+-- Name: products fk_rails_8c9cbcf514; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_8c9cbcf514 FOREIGN KEY (charge_id) REFERENCES public.charges(id);
+
+
+--
 -- Name: usage_thresholds fk_rails_8df9bf2b6c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12412,6 +12532,14 @@ ALTER TABLE ONLY public.commitments_taxes
 
 ALTER TABLE ONLY public.usage_monitoring_subscription_activities
     ADD CONSTRAINT fk_rails_ab16de0b32 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: products fk_rails_ac0f020184; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_ac0f020184 FOREIGN KEY (add_on_id) REFERENCES public.add_ons(id);
 
 
 --
@@ -12791,6 +12919,14 @@ ALTER TABLE ONLY public.integration_resources
 
 
 --
+-- Name: products fk_rails_d9e7580aa8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_d9e7580aa8 FOREIGN KEY (billable_metric_id) REFERENCES public.billable_metrics(id);
+
+
+--
 -- Name: usage_monitoring_alerts fk_rails_d9ea200904; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12948,6 +13084,14 @@ ALTER TABLE ONLY public.fixed_charges
 
 ALTER TABLE ONLY public.integration_customers
     ADD CONSTRAINT fk_rails_ea80151038 FOREIGN KEY (integration_id) REFERENCES public.integrations(id);
+
+
+--
+-- Name: products fk_rails_eab202bbcf; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_eab202bbcf FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -13218,6 +13362,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260608111837'),
 ('20260608074112'),
 ('20260605170919'),
+('20260604175459'),
 ('20260604175126'),
 ('20260604153307'),
 ('20260603121349'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1720,6 +1720,7 @@ CREATE TYPE public.rate_card_rate_model AS ENUM (
 --
 
 CREATE TYPE public.rate_card_regroup_paid_fees AS ENUM (
+    'none',
     'invoice'
 );
 
@@ -5427,7 +5428,7 @@ CREATE TABLE public.rate_cards (
     billing_timing public.rate_card_billing_timing DEFAULT 'arrears'::public.rate_card_billing_timing NOT NULL,
     proration boolean DEFAULT false NOT NULL,
     display_on_invoice boolean DEFAULT true NOT NULL,
-    regroup_paid_fees public.rate_card_regroup_paid_fees,
+    regroup_paid_fees public.rate_card_regroup_paid_fees DEFAULT 'none'::public.rate_card_regroup_paid_fees NOT NULL,
     applied_pricing_unit_code character varying,
     wallet_targetable boolean,
     deleted_at timestamp(6) without time zone,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -242,6 +242,7 @@ ALTER TABLE IF EXISTS ONLY public.group_properties DROP CONSTRAINT IF EXISTS fk_
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_3ab959bfc4;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_3a303bf667;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS fk_rails_3926855f12;
+ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS fk_rails_37c75ac37a;
 ALTER TABLE IF EXISTS ONLY public.inbound_webhooks DROP CONSTRAINT IF EXISTS fk_rails_36cda06530;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_364213cc3e;
 ALTER TABLE IF EXISTS ONLY public.charge_filter_values DROP CONSTRAINT IF EXISTS fk_rails_3640b4a66a;
@@ -455,6 +456,9 @@ DROP INDEX IF EXISTS public.index_quantified_events_on_external_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_deleted_at;
 DROP INDEX IF EXISTS public.index_quantified_events_on_charge_filter_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_billable_metric_id;
+DROP INDEX IF EXISTS public.index_product_categories_on_organization_id_and_code;
+DROP INDEX IF EXISTS public.index_product_categories_on_organization_id;
+DROP INDEX IF EXISTS public.index_product_categories_on_deleted_at;
 DROP INDEX IF EXISTS public.index_pricing_units_on_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_units_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_pricing_unit_id;
@@ -941,6 +945,7 @@ ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS quotes_pkey;
 ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS quote_versions_pkey;
 ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS quote_owners_pkey;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
+ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS product_categories_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS presentation_breakdowns_pkey;
@@ -1065,6 +1070,7 @@ DROP TABLE IF EXISTS public.quote_versions;
 DROP SEQUENCE IF EXISTS public.quote_owners_id_seq;
 DROP TABLE IF EXISTS public.quote_owners;
 DROP TABLE IF EXISTS public.quantified_events;
+DROP TABLE IF EXISTS public.product_categories;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
 DROP TABLE IF EXISTS public.presentation_breakdowns;
@@ -5032,6 +5038,23 @@ CREATE TABLE public.pricing_units (
 
 
 --
+-- Name: product_categories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.product_categories (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    code character varying NOT NULL,
+    name character varying NOT NULL,
+    description character varying,
+    invoice_display_name character varying,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: quantified_events; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6284,6 +6307,14 @@ ALTER TABLE ONLY public.pricing_unit_usages
 
 ALTER TABLE ONLY public.pricing_units
     ADD CONSTRAINT pricing_units_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: product_categories product_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_categories
+    ADD CONSTRAINT product_categories_pkey PRIMARY KEY (id);
 
 
 --
@@ -9751,6 +9782,27 @@ CREATE INDEX index_pricing_units_on_organization_id ON public.pricing_units USIN
 
 
 --
+-- Name: index_product_categories_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_categories_on_deleted_at ON public.product_categories USING btree (deleted_at);
+
+
+--
+-- Name: index_product_categories_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_categories_on_organization_id ON public.product_categories USING btree (organization_id);
+
+
+--
+-- Name: index_product_categories_on_organization_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_product_categories_on_organization_id_and_code ON public.product_categories USING btree (organization_id, code) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: index_quantified_events_on_billable_metric_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11224,6 +11276,14 @@ ALTER TABLE ONLY public.subscriptions
 
 ALTER TABLE ONLY public.inbound_webhooks
     ADD CONSTRAINT fk_rails_36cda06530 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: product_categories fk_rails_37c75ac37a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_categories
+    ADD CONSTRAINT fk_rails_37c75ac37a FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -13158,6 +13218,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260608111837'),
 ('20260608074112'),
 ('20260605170919'),
+('20260604175126'),
 ('20260604153307'),
 ('20260603121349'),
 ('20260602175438'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3682,7 +3682,8 @@ CREATE TABLE public.subscriptions (
     consolidate_invoice boolean DEFAULT true NOT NULL,
     skip_daily_usage boolean DEFAULT false NOT NULL,
     cancellation_reason public.subscription_cancellation_reasons,
-    purchase_order_number character varying
+    purchase_order_number character varying,
+    billing_anchor_date date
 );
 
 
@@ -14144,6 +14145,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260803162623'),
 ('20260724094543'),
 ('20260724094542'),
 ('20260724094541'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -127,6 +127,7 @@ ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS fk_rails
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_98980b326b;
 ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS fk_rails_9881e28151;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS fk_rails_96fc54cd9a;
+ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS fk_rails_9687dd0c22;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_95df3194c5;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_94cc21031f;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
@@ -266,6 +267,7 @@ ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_2ea4db
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_2dc6171f57;
 ALTER TABLE IF EXISTS ONLY public.ai_conversations DROP CONSTRAINT IF EXISTS fk_rails_2c06a74f41;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_2b35eef34b;
+ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS fk_rails_2a066c7180;
 ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_2908dd8de5;
 ALTER TABLE IF EXISTS ONLY public.billing_object_connections DROP CONSTRAINT IF EXISTS fk_rails_287ffb7123;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_28077d4aa2;
@@ -471,6 +473,10 @@ DROP INDEX IF EXISTS public.index_products_on_deleted_at;
 DROP INDEX IF EXISTS public.index_products_on_charge_id;
 DROP INDEX IF EXISTS public.index_products_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_products_on_add_on_id;
+DROP INDEX IF EXISTS public.index_product_filters_on_product_id_and_code;
+DROP INDEX IF EXISTS public.index_product_filters_on_product_id;
+DROP INDEX IF EXISTS public.index_product_filters_on_organization_id;
+DROP INDEX IF EXISTS public.index_product_filters_on_deleted_at;
 DROP INDEX IF EXISTS public.index_pricing_units_on_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_units_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_pricing_unit_id;
@@ -959,6 +965,7 @@ ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS quote_o
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
 ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS product_categories_pkey;
 ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS products_pkey;
+ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS product_filters_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS presentation_breakdowns_pkey;
@@ -1085,6 +1092,7 @@ DROP TABLE IF EXISTS public.quote_owners;
 DROP TABLE IF EXISTS public.quantified_events;
 DROP TABLE IF EXISTS public.product_categories;
 DROP TABLE IF EXISTS public.products;
+DROP TABLE IF EXISTS public.product_filters;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
 DROP TABLE IF EXISTS public.presentation_breakdowns;
@@ -5063,6 +5071,24 @@ CREATE TABLE public.pricing_units (
 
 
 --
+-- Name: product_filters; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.product_filters (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    product_id uuid NOT NULL,
+    name character varying NOT NULL,
+    code character varying NOT NULL,
+    description character varying,
+    invoice_display_name character varying,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: products; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6354,6 +6380,14 @@ ALTER TABLE ONLY public.pricing_unit_usages
 
 ALTER TABLE ONLY public.pricing_units
     ADD CONSTRAINT pricing_units_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: product_filters product_filters_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_filters
+    ADD CONSTRAINT product_filters_pkey PRIMARY KEY (id);
 
 
 --
@@ -9837,6 +9871,34 @@ CREATE INDEX index_pricing_units_on_organization_id ON public.pricing_units USIN
 
 
 --
+-- Name: index_product_filters_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_filters_on_deleted_at ON public.product_filters USING btree (deleted_at);
+
+
+--
+-- Name: index_product_filters_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_filters_on_organization_id ON public.product_filters USING btree (organization_id);
+
+
+--
+-- Name: index_product_filters_on_product_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_filters_on_product_id ON public.product_filters USING btree (product_id);
+
+
+--
+-- Name: index_product_filters_on_product_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_product_filters_on_product_id_and_code ON public.product_filters USING btree (product_id, code) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: index_products_on_add_on_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11239,6 +11301,14 @@ ALTER TABLE ONLY public.usage_thresholds
 
 
 --
+-- Name: product_filters fk_rails_2a066c7180; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_filters
+    ADD CONSTRAINT fk_rails_2a066c7180 FOREIGN KEY (product_id) REFERENCES public.products(id);
+
+
+--
 -- Name: wallets fk_rails_2b35eef34b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12351,6 +12421,14 @@ ALTER TABLE ONLY public.entitlement_subscription_feature_removals
 
 
 --
+-- Name: product_filters fk_rails_9687dd0c22; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_filters
+    ADD CONSTRAINT fk_rails_9687dd0c22 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: pending_vies_checks fk_rails_96fc54cd9a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13362,6 +13440,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260608111837'),
 ('20260608074112'),
 ('20260605170919'),
+('20260604175731'),
 ('20260604175459'),
 ('20260604175126'),
 ('20260604153307'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -493,7 +493,7 @@ DROP INDEX IF EXISTS public.index_rate_cards_on_product_filter_id;
 DROP INDEX IF EXISTS public.index_rate_cards_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_rate_cards_on_organization_id;
 DROP INDEX IF EXISTS public.index_rate_cards_on_deleted_at;
-DROP INDEX IF EXISTS public.index_rate_card_rates_on_rate_card_id_and_effective_datetime;
+DROP INDEX IF EXISTS public.index_rate_card_rates_on_rate_card_id_and_effective_from;
 DROP INDEX IF EXISTS public.index_rate_card_rates_on_rate_card_id_and_code;
 DROP INDEX IF EXISTS public.index_rate_card_rates_on_rate_card_id;
 DROP INDEX IF EXISTS public.index_rate_card_rates_on_organization_id;
@@ -5398,7 +5398,7 @@ CREATE TABLE public.rate_card_rates (
     organization_id uuid NOT NULL,
     rate_card_id uuid NOT NULL,
     code character varying NOT NULL,
-    effective_datetime timestamp(6) without time zone NOT NULL,
+    effective_from timestamp(6) without time zone NOT NULL,
     rate_model public.rate_card_rate_model NOT NULL,
     rate_properties jsonb DEFAULT '{}'::jsonb NOT NULL,
     min_amount_cents bigint DEFAULT 0 NOT NULL,
@@ -10498,10 +10498,10 @@ CREATE UNIQUE INDEX index_rate_card_rates_on_rate_card_id_and_code ON public.rat
 
 
 --
--- Name: index_rate_card_rates_on_rate_card_id_and_effective_datetime; Type: INDEX; Schema: public; Owner: -
+-- Name: index_rate_card_rates_on_rate_card_id_and_effective_from; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_rate_card_rates_on_rate_card_id_and_effective_datetime ON public.rate_card_rates USING btree (rate_card_id, effective_datetime) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX index_rate_card_rates_on_rate_card_id_and_effective_from ON public.rate_card_rates USING btree (rate_card_id, effective_from) WHERE (deleted_at IS NULL);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -18,6 +18,7 @@ ALTER TABLE IF EXISTS ONLY public.dunning_campaign_thresholds DROP CONSTRAINT IF
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS fk_rails_fd60209637;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_fd399a23d3;
 ALTER TABLE IF EXISTS ONLY public.wallet_targets DROP CONSTRAINT IF EXISTS fk_rails_fbd2b9fccb;
+ALTER TABLE IF EXISTS ONLY public.product_filter_values DROP CONSTRAINT IF EXISTS fk_rails_f99eb07174;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_f98413d404;
 ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS fk_rails_f94f882198;
 ALTER TABLE IF EXISTS ONLY public.billing_entities DROP CONSTRAINT IF EXISTS fk_rails_f66617edcb;
@@ -29,14 +30,17 @@ ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_f232478e56;
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_rails_f228550fda;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRAINT IF EXISTS fk_rails_f18cd04d51;
+ALTER TABLE IF EXISTS ONLY public.subscription_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_f0e6ca6965;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_efe167855e;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_eeb6a32be1;
+ALTER TABLE IF EXISTS ONLY public.plan_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_ee8d423cf4;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_ee2b6f04d9;
 ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF EXISTS fk_rails_ed387e0992;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_ecb466254b;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_eaca9421be;
-ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_eab202bbcf;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ea80151038;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges DROP CONSTRAINT IF EXISTS fk_rails_e95f72749e;
+ALTER TABLE IF EXISTS ONLY public.rate_card_rates DROP CONSTRAINT IF EXISTS fk_rails_e910b02a08;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_e8bac9c5bb;
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails_e88403f4b9;
 ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_e86903e081;
@@ -46,20 +50,22 @@ ALTER TABLE IF EXISTS ONLY public.user_devices DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_e4a58fbcac;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_triggered_alerts DROP CONSTRAINT IF EXISTS fk_rails_e3cf54daac;
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
+ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS fk_rails_e13d306a35;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_de7694c307;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
+ALTER TABLE IF EXISTS ONLY public.rate_cards DROP CONSTRAINT IF EXISTS fk_rails_ddab7acbd0;
 ALTER TABLE IF EXISTS ONLY public.invites DROP CONSTRAINT IF EXISTS fk_rails_dd342449a6;
 ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CONSTRAINT IF EXISTS fk_rails_dc444f5f29;
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_db9140d0fd;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8b4a1;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_d9ea200904;
-ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_d9e7580aa8;
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_d9448a540b;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_d9342a8ca7;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_d72a9877be;
 ALTER TABLE IF EXISTS ONLY public.entitlement_privileges DROP CONSTRAINT IF EXISTS fk_rails_d648e28d9f;
+ALTER TABLE IF EXISTS ONLY public.rate_card_rates DROP CONSTRAINT IF EXISTS fk_rails_d53feb5721;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_d53f825a88;
 ALTER TABLE IF EXISTS ONLY public.idempotency_records DROP CONSTRAINT IF EXISTS fk_rails_d4f02c82b2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transaction_consumptions DROP CONSTRAINT IF EXISTS fk_rails_d4abfdb375;
@@ -100,23 +106,28 @@ ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_b50dc8
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_b3864df641;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_b283a89721;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_b07fc711f7;
+ALTER TABLE IF EXISTS ONLY public.subscription_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_af7294033f;
 ALTER TABLE IF EXISTS ONLY public.billing_object_connections DROP CONSTRAINT IF EXISTS fk_rails_aed4cbd20b;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS fk_rails_aea6422e6a;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_ac146c9541;
-ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_ac0f020184;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_subscription_activities DROP CONSTRAINT IF EXISTS fk_rails_ab16de0b32;
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_aaa12f7d3e;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT IF EXISTS fk_rails_aa34dd5db6;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges DROP CONSTRAINT IF EXISTS fk_rails_aa04ceacf6;
 ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk_rails_a9dc2ea536;
+ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS fk_rails_a9ba49506f;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_a7f20c73bb;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_a710519346;
+ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS fk_rails_a5cd897b6f;
 ALTER TABLE IF EXISTS ONLY public.billing_object_connections DROP CONSTRAINT IF EXISTS fk_rails_a5a0718a08;
 ALTER TABLE IF EXISTS ONLY public.invoice_connections DROP CONSTRAINT IF EXISTS fk_rails_a3fff9bd72;
 ALTER TABLE IF EXISTS ONLY public.group_properties DROP CONSTRAINT IF EXISTS fk_rails_a2d2cb3819;
 ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_a1ab65f1f7;
+ALTER TABLE IF EXISTS ONLY public.rate_cards DROP CONSTRAINT IF EXISTS fk_rails_a026c79cab;
+ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_9f724c2094;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_9f22076477;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_9ea6759859;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_9e90c6f4aa;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_9e3f99b7a2;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_9d8812945e;
 ALTER TABLE IF EXISTS ONLY public.applied_add_ons DROP CONSTRAINT IF EXISTS fk_rails_9c8e276cc0;
@@ -127,7 +138,6 @@ ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS fk_rails
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_98980b326b;
 ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS fk_rails_9881e28151;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS fk_rails_96fc54cd9a;
-ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS fk_rails_9687dd0c22;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_95df3194c5;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_94cc21031f;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
@@ -138,11 +148,11 @@ ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_8fa6f0d920;
 ALTER TABLE IF EXISTS ONLY public.applied_pricing_units DROP CONSTRAINT IF EXISTS fk_rails_8e0c3d0c5b;
 ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_8df9bf2b6c;
-ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_8c9cbcf514;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_8c18828b53;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_8c09ee2428;
 ALTER TABLE IF EXISTS ONLY public.invoice_metadata DROP CONSTRAINT IF EXISTS fk_rails_8bb5b094c4;
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_89e1020aca;
+ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS fk_rails_88c22fb20b;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT IF EXISTS fk_rails_8887954ec7;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_885dc100ef;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_88349fc20a;
@@ -182,7 +192,9 @@ ALTER TABLE IF EXISTS ONLY public.subscriptions_invoice_custom_sections DROP CON
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS fk_rails_6e238f3bfc;
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_6e148ccbb1;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_6d465e6b10;
+ALTER TABLE IF EXISTS ONLY public.rate_overrides DROP CONSTRAINT IF EXISTS fk_rails_6c8a54dfe1;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaigns DROP CONSTRAINT IF EXISTS fk_rails_6c720a8ccd;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_6a4ad694b3;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_699cd1384f;
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_68754484c0;
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_67d4eb3c92;
@@ -207,6 +219,7 @@ ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_5cb2f24c3d;
 ALTER TABLE IF EXISTS ONLY public.payment_receipts DROP CONSTRAINT IF EXISTS fk_rails_5c2e0b6d34;
 ALTER TABLE IF EXISTS ONLY public.error_details DROP CONSTRAINT IF EXISTS fk_rails_5c21eece29;
+ALTER TABLE IF EXISTS ONLY public.subscription_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_5c0e7e8a12;
 ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS fk_rails_5bb40a7bae;
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_5ade8984b1;
 ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS fk_rails_5a4b906a16;
@@ -216,15 +229,19 @@ ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_56b3626631;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_5628a713de;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlement_values DROP CONSTRAINT IF EXISTS fk_rails_533b639bac;
+ALTER TABLE IF EXISTS ONLY public.product_filter_values DROP CONSTRAINT IF EXISTS fk_rails_530173fa8d;
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_52b72c9b0e;
 ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS fk_rails_526379cd99;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_52370612ae;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521b5240ed;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_51ac39a0c6;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_512c4da634;
 ALTER TABLE IF EXISTS ONLY public.billable_metric_filters DROP CONSTRAINT IF EXISTS fk_rails_51077e7c0e;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_50d46d3679;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_4ff087c52e;
+ALTER TABLE IF EXISTS ONLY public.rate_cards DROP CONSTRAINT IF EXISTS fk_rails_4f7ffc3e03;
 ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS fk_rails_4ed54bfec0;
+ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_4cadfc14f3;
 ALTER TABLE IF EXISTS ONLY public.billing_entities DROP CONSTRAINT IF EXISTS fk_rails_4aa58496c3;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_49fcc221b0;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
@@ -247,7 +264,8 @@ ALTER TABLE IF EXISTS ONLY public.group_properties DROP CONSTRAINT IF EXISTS fk_
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_3ab959bfc4;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_3a303bf667;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS fk_rails_3926855f12;
-ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS fk_rails_37c75ac37a;
+ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_37c75ac37a;
+ALTER TABLE IF EXISTS ONLY public.product_filter_values DROP CONSTRAINT IF EXISTS fk_rails_36e9122b3e;
 ALTER TABLE IF EXISTS ONLY public.inbound_webhooks DROP CONSTRAINT IF EXISTS fk_rails_36cda06530;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_364213cc3e;
 ALTER TABLE IF EXISTS ONLY public.charge_filter_values DROP CONSTRAINT IF EXISTS fk_rails_3640b4a66a;
@@ -265,9 +283,9 @@ ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_2fd
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_rails_2fb2147151;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_2ea4db3a4c;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_2dc6171f57;
+ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS fk_rails_2c40f5b85c;
 ALTER TABLE IF EXISTS ONLY public.ai_conversations DROP CONSTRAINT IF EXISTS fk_rails_2c06a74f41;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_2b35eef34b;
-ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS fk_rails_2a066c7180;
 ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_2908dd8de5;
 ALTER TABLE IF EXISTS ONLY public.billing_object_connections DROP CONSTRAINT IF EXISTS fk_rails_287ffb7123;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_28077d4aa2;
@@ -286,12 +304,14 @@ ALTER TABLE IF EXISTS ONLY public.applied_pricing_units DROP CONSTRAINT IF EXIST
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_22af6c6d28;
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_2259c88f26;
 ALTER TABLE IF EXISTS ONLY public.cached_aggregations DROP CONSTRAINT IF EXISTS fk_rails_21eb389927;
+ALTER TABLE IF EXISTS ONLY public.plan_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_21cbfc2122;
 ALTER TABLE IF EXISTS ONLY public.webhook_endpoints DROP CONSTRAINT IF EXISTS fk_rails_21808fa528;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS fk_rails_216ac8a975;
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_20f157fa49;
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_20cc0de4c7;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_1db0057d9b;
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_1d112bf8a0;
+ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS fk_rails_1c069c1c44;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_19c47827ba;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_189f2a3949;
@@ -300,6 +320,7 @@ ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EX
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_150139409e;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_142809fee1;
+ALTER TABLE IF EXISTS ONLY public.plan_rate_cards DROP CONSTRAINT IF EXISTS fk_rails_135fe57b68;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_12d29bc654;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_123667657c;
 ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS fk_rails_10ee148d0d;
@@ -320,11 +341,11 @@ ALTER TABLE IF EXISTS ONLY public.enriched_store_subscription_migrations DROP CO
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_085d1cc97b;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXISTS fk_rails_07b21049f2;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_06b7046ec3;
+ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS fk_rails_050342349f;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_0480ef4ad3;
 ALTER TABLE IF EXISTS ONLY public.invoice_settlements DROP CONSTRAINT IF EXISTS fk_rails_04388258ff;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_01a4c0c7db;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS fk_rails_019e2289e5;
-ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS fk_rails_00f7aa94fd;
 ALTER TABLE IF EXISTS ONLY public.payment_methods DROP CONSTRAINT IF EXISTS fk_rails_00e7a45b0b;
 DROP TRIGGER IF EXISTS ensure_consistency ON public.roles;
 DROP TRIGGER IF EXISTS before_payment_receipt_insert ON public.payment_receipts;
@@ -432,6 +453,11 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_unique;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_on_subscription_id;
 DROP INDEX IF EXISTS public.index_subscriptions_invoice_custom_sections_on_organization_id;
+DROP INDEX IF EXISTS public.index_subscription_rate_cards_on_subscription_id;
+DROP INDEX IF EXISTS public.index_subscription_rate_cards_on_rate_card_id;
+DROP INDEX IF EXISTS public.index_subscription_rate_cards_on_organization_id;
+DROP INDEX IF EXISTS public.index_subscription_rate_cards_on_next_billing_at;
+DROP INDEX IF EXISTS public.index_subscription_rate_cards_on_deleted_at;
 DROP INDEX IF EXISTS public.index_subscription_fixed_charge_units_overrides_on_deleted_at;
 DROP INDEX IF EXISTS public.index_subscription_activation_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_sub_fc_units_overrides_on_sub_id_and_fc_id;
@@ -451,6 +477,27 @@ DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_started_at;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_expiration_at;
+DROP INDEX IF EXISTS public.index_rate_phases_on_subscription_rate_card_id;
+DROP INDEX IF EXISTS public.index_rate_phases_on_sub_rate_card_id_and_position;
+DROP INDEX IF EXISTS public.index_rate_phases_on_sub_rate_card_id_and_code;
+DROP INDEX IF EXISTS public.index_rate_phases_on_rate_override_id;
+DROP INDEX IF EXISTS public.index_rate_phases_on_plan_rate_card_id_and_position;
+DROP INDEX IF EXISTS public.index_rate_phases_on_plan_rate_card_id_and_code;
+DROP INDEX IF EXISTS public.index_rate_phases_on_plan_rate_card_id;
+DROP INDEX IF EXISTS public.index_rate_phases_on_organization_id;
+DROP INDEX IF EXISTS public.index_rate_phases_on_deleted_at;
+DROP INDEX IF EXISTS public.index_rate_overrides_on_organization_id;
+DROP INDEX IF EXISTS public.index_rate_overrides_on_deleted_at;
+DROP INDEX IF EXISTS public.index_rate_cards_on_product_id;
+DROP INDEX IF EXISTS public.index_rate_cards_on_product_filter_id;
+DROP INDEX IF EXISTS public.index_rate_cards_on_organization_id_and_code;
+DROP INDEX IF EXISTS public.index_rate_cards_on_organization_id;
+DROP INDEX IF EXISTS public.index_rate_cards_on_deleted_at;
+DROP INDEX IF EXISTS public.index_rate_card_rates_on_rate_card_id_and_effective_datetime;
+DROP INDEX IF EXISTS public.index_rate_card_rates_on_rate_card_id_and_code;
+DROP INDEX IF EXISTS public.index_rate_card_rates_on_rate_card_id;
+DROP INDEX IF EXISTS public.index_rate_card_rates_on_organization_id;
+DROP INDEX IF EXISTS public.index_rate_card_rates_on_deleted_at;
 DROP INDEX IF EXISTS public.index_quotes_on_subscription_id;
 DROP INDEX IF EXISTS public.index_quotes_on_customer_id;
 DROP INDEX IF EXISTS public.index_quote_versions_on_quote_id;
@@ -463,9 +510,6 @@ DROP INDEX IF EXISTS public.index_quantified_events_on_external_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_deleted_at;
 DROP INDEX IF EXISTS public.index_quantified_events_on_charge_filter_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_billable_metric_id;
-DROP INDEX IF EXISTS public.index_product_categories_on_organization_id_and_code;
-DROP INDEX IF EXISTS public.index_product_categories_on_organization_id;
-DROP INDEX IF EXISTS public.index_product_categories_on_deleted_at;
 DROP INDEX IF EXISTS public.index_products_on_product_category_id;
 DROP INDEX IF EXISTS public.index_products_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_products_on_organization_id;
@@ -477,6 +521,13 @@ DROP INDEX IF EXISTS public.index_product_filters_on_product_id_and_code;
 DROP INDEX IF EXISTS public.index_product_filters_on_product_id;
 DROP INDEX IF EXISTS public.index_product_filters_on_organization_id;
 DROP INDEX IF EXISTS public.index_product_filters_on_deleted_at;
+DROP INDEX IF EXISTS public.index_product_filter_values_on_product_filter_id;
+DROP INDEX IF EXISTS public.index_product_filter_values_on_organization_id;
+DROP INDEX IF EXISTS public.index_product_filter_values_on_deleted_at;
+DROP INDEX IF EXISTS public.index_product_filter_values_on_billable_metric_filter_id;
+DROP INDEX IF EXISTS public.index_product_categories_on_organization_id_and_code;
+DROP INDEX IF EXISTS public.index_product_categories_on_organization_id;
+DROP INDEX IF EXISTS public.index_product_categories_on_deleted_at;
 DROP INDEX IF EXISTS public.index_pricing_units_on_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_units_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_pricing_unit_id;
@@ -496,6 +547,11 @@ DROP INDEX IF EXISTS public.index_plans_on_organization_id;
 DROP INDEX IF EXISTS public.index_plans_on_deleted_at;
 DROP INDEX IF EXISTS public.index_plans_on_created_at;
 DROP INDEX IF EXISTS public.index_plans_on_bill_fixed_charges_monthly;
+DROP INDEX IF EXISTS public.index_plan_rate_cards_on_rate_card_id;
+DROP INDEX IF EXISTS public.index_plan_rate_cards_on_plan_id_and_rate_card_id;
+DROP INDEX IF EXISTS public.index_plan_rate_cards_on_plan_id;
+DROP INDEX IF EXISTS public.index_plan_rate_cards_on_organization_id;
+DROP INDEX IF EXISTS public.index_plan_rate_cards_on_deleted_at;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_organization_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_customer_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_billing_entity_id;
@@ -665,6 +721,8 @@ DROP INDEX IF EXISTS public.index_fees_taxes_on_fee_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_fees_taxes_on_fee_id;
 DROP INDEX IF EXISTS public.index_fees_on_true_up_parent_fee_id;
 DROP INDEX IF EXISTS public.index_fees_on_subscription_id;
+DROP INDEX IF EXISTS public.index_fees_on_rate_override_id;
+DROP INDEX IF EXISTS public.index_fees_on_rate_card_rate_id;
 DROP INDEX IF EXISTS public.index_fees_on_pay_in_advance_event_transaction_id;
 DROP INDEX IF EXISTS public.index_fees_on_original_fee_id;
 DROP INDEX IF EXISTS public.index_fees_on_organization_id_and_created_at_and_id;
@@ -845,6 +903,7 @@ DROP INDEX IF EXISTS public.index_add_ons_taxes_on_add_on_id;
 DROP INDEX IF EXISTS public.index_add_ons_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_add_ons_on_organization_id;
 DROP INDEX IF EXISTS public.index_add_ons_on_deleted_at;
+DROP INDEX IF EXISTS public.index_active_subscription_rate_cards_on_sub_and_card;
 DROP INDEX IF EXISTS public.index_active_storage_variant_records_uniqueness;
 DROP INDEX IF EXISTS public.index_active_storage_blobs_on_key;
 DROP INDEX IF EXISTS public.index_active_storage_attachments_uniqueness;
@@ -866,6 +925,7 @@ DROP INDEX IF EXISTS public.idx_unique_feature_per_subscription;
 DROP INDEX IF EXISTS public.idx_unique_feature_per_plan;
 DROP INDEX IF EXISTS public.idx_subscription_unique;
 DROP INDEX IF EXISTS public.idx_privileges_code_unique_per_feature;
+DROP INDEX IF EXISTS public.idx_pif_values_on_filter_metric_filter_and_value;
 DROP INDEX IF EXISTS public.idx_pay_in_advance_duplication_guard_charge_filter;
 DROP INDEX IF EXISTS public.idx_pay_in_advance_duplication_guard_charge;
 DROP INDEX IF EXISTS public.idx_on_wallet_transaction_id_ac2826109e;
@@ -952,6 +1012,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.taxes DROP CONSTRAINT IF EXISTS taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS subscriptions_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscriptions_invoice_custom_sections DROP CONSTRAINT IF EXISTS subscriptions_invoice_custom_sections_pkey;
+ALTER TABLE IF EXISTS ONLY public.subscription_rate_cards DROP CONSTRAINT IF EXISTS subscription_rate_cards_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS subscription_fixed_charge_units_overrides_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS subscription_activation_rules_pkey;
 ALTER TABLE IF EXISTS ONLY public.schema_migrations DROP CONSTRAINT IF EXISTS schema_migrations_pkey;
@@ -959,18 +1020,24 @@ ALTER TABLE IF EXISTS ONLY public.roles DROP CONSTRAINT IF EXISTS roles_pkey;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS refunds_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS recurring_transaction_rules_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules_invoice_custom_sections DROP CONSTRAINT IF EXISTS recurring_transaction_rules_invoice_custom_sections_pkey;
+ALTER TABLE IF EXISTS ONLY public.rate_phases DROP CONSTRAINT IF EXISTS rate_phases_pkey;
+ALTER TABLE IF EXISTS ONLY public.rate_overrides DROP CONSTRAINT IF EXISTS rate_overrides_pkey;
+ALTER TABLE IF EXISTS ONLY public.rate_cards DROP CONSTRAINT IF EXISTS rate_cards_pkey;
+ALTER TABLE IF EXISTS ONLY public.rate_card_rates DROP CONSTRAINT IF EXISTS rate_card_rates_pkey;
 ALTER TABLE IF EXISTS ONLY public.quotes DROP CONSTRAINT IF EXISTS quotes_pkey;
 ALTER TABLE IF EXISTS ONLY public.quote_versions DROP CONSTRAINT IF EXISTS quote_versions_pkey;
 ALTER TABLE IF EXISTS ONLY public.quote_owners DROP CONSTRAINT IF EXISTS quote_owners_pkey;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
-ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS product_categories_pkey;
 ALTER TABLE IF EXISTS ONLY public.products DROP CONSTRAINT IF EXISTS products_pkey;
 ALTER TABLE IF EXISTS ONLY public.product_filters DROP CONSTRAINT IF EXISTS product_filters_pkey;
+ALTER TABLE IF EXISTS ONLY public.product_filter_values DROP CONSTRAINT IF EXISTS product_filter_values_pkey;
+ALTER TABLE IF EXISTS ONLY public.product_categories DROP CONSTRAINT IF EXISTS product_categories_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS presentation_breakdowns_pkey;
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS plans_taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS plans_pkey;
+ALTER TABLE IF EXISTS ONLY public.plan_rate_cards DROP CONSTRAINT IF EXISTS plan_rate_cards_pkey;
 ALTER TABLE IF EXISTS ONLY public.pending_vies_checks DROP CONSTRAINT IF EXISTS pending_vies_checks_pkey;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS payments_pkey;
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS payment_requests_pkey;
@@ -1078,6 +1145,7 @@ DROP SEQUENCE IF EXISTS public.usage_monitoring_subscription_activities_id_seq;
 DROP TABLE IF EXISTS public.usage_monitoring_subscription_activities;
 DROP TABLE IF EXISTS public.usage_monitoring_alerts;
 DROP TABLE IF EXISTS public.subscriptions_invoice_custom_sections;
+DROP TABLE IF EXISTS public.subscription_rate_cards;
 DROP TABLE IF EXISTS public.subscription_fixed_charge_units_overrides;
 DROP TABLE IF EXISTS public.subscription_activation_rules;
 DROP TABLE IF EXISTS public.schema_migrations;
@@ -1085,17 +1153,23 @@ DROP TABLE IF EXISTS public.roles;
 DROP TABLE IF EXISTS public.refunds;
 DROP TABLE IF EXISTS public.recurring_transaction_rules_invoice_custom_sections;
 DROP TABLE IF EXISTS public.recurring_transaction_rules;
+DROP TABLE IF EXISTS public.rate_phases;
+DROP TABLE IF EXISTS public.rate_overrides;
+DROP TABLE IF EXISTS public.rate_cards;
+DROP TABLE IF EXISTS public.rate_card_rates;
 DROP TABLE IF EXISTS public.quotes;
 DROP TABLE IF EXISTS public.quote_versions;
 DROP SEQUENCE IF EXISTS public.quote_owners_id_seq;
 DROP TABLE IF EXISTS public.quote_owners;
 DROP TABLE IF EXISTS public.quantified_events;
-DROP TABLE IF EXISTS public.product_categories;
 DROP TABLE IF EXISTS public.products;
 DROP TABLE IF EXISTS public.product_filters;
+DROP TABLE IF EXISTS public.product_filter_values;
+DROP TABLE IF EXISTS public.product_categories;
 DROP TABLE IF EXISTS public.pricing_units;
 DROP TABLE IF EXISTS public.pricing_unit_usages;
 DROP TABLE IF EXISTS public.presentation_breakdowns;
+DROP TABLE IF EXISTS public.plan_rate_cards;
 DROP TABLE IF EXISTS public.pending_vies_checks;
 DROP TABLE IF EXISTS public.payment_receipts;
 DROP TABLE IF EXISTS public.payment_providers;
@@ -1248,6 +1322,10 @@ DROP TYPE IF EXISTS public.subscription_cancellation_reasons;
 DROP TYPE IF EXISTS public.subscription_cancelation_reasons;
 DROP TYPE IF EXISTS public.subscription_activation_rule_types;
 DROP TYPE IF EXISTS public.subscription_activation_rule_statuses;
+DROP TYPE IF EXISTS public.rate_card_regroup_paid_fees;
+DROP TYPE IF EXISTS public.rate_card_rate_model;
+DROP TYPE IF EXISTS public.rate_card_rate_billing_interval_unit;
+DROP TYPE IF EXISTS public.rate_card_billing_timing;
 DROP TYPE IF EXISTS public.quote_void_reason;
 DROP TYPE IF EXISTS public.quote_status;
 DROP TYPE IF EXISTS public.quote_order_type;
@@ -1596,6 +1674,53 @@ CREATE TYPE public.quote_void_reason AS ENUM (
     'superseded',
     'cascade_of_expired',
     'cascade_of_voided'
+);
+
+
+--
+-- Name: rate_card_billing_timing; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.rate_card_billing_timing AS ENUM (
+    'arrears',
+    'advance'
+);
+
+
+--
+-- Name: rate_card_rate_billing_interval_unit; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.rate_card_rate_billing_interval_unit AS ENUM (
+    'day',
+    'week',
+    'month',
+    'year'
+);
+
+
+--
+-- Name: rate_card_rate_model; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.rate_card_rate_model AS ENUM (
+    'standard',
+    'graduated',
+    'package',
+    'percentage',
+    'volume',
+    'graduated_percentage',
+    'custom',
+    'dynamic'
+);
+
+
+--
+-- Name: rate_card_regroup_paid_fees; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.rate_card_regroup_paid_fees AS ENUM (
+    'invoice'
 );
 
 
@@ -3429,7 +3554,9 @@ CREATE TABLE public.fees (
     precise_credit_notes_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL,
     fixed_charge_id uuid,
     duplicated_in_advance boolean DEFAULT false,
-    original_fee_id uuid
+    original_fee_id uuid,
+    rate_card_rate_id uuid,
+    rate_override_id uuid
 );
 
 
@@ -5020,6 +5147,22 @@ CREATE TABLE public.pending_vies_checks (
 
 
 --
+-- Name: plan_rate_cards; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.plan_rate_cards (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    plan_id uuid NOT NULL,
+    rate_card_id uuid NOT NULL,
+    units numeric(30,10),
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: presentation_breakdowns; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5071,6 +5214,39 @@ CREATE TABLE public.pricing_units (
 
 
 --
+-- Name: product_categories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.product_categories (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    code character varying NOT NULL,
+    name character varying NOT NULL,
+    description character varying,
+    invoice_display_name character varying,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: product_filter_values; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.product_filter_values (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    product_filter_id uuid NOT NULL,
+    billable_metric_filter_id uuid NOT NULL,
+    value character varying,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: product_filters; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5099,28 +5275,11 @@ CREATE TABLE public.products (
     billable_metric_id uuid,
     add_on_id uuid,
     charge_id uuid,
-    item_type public.product_type NOT NULL,
+    product_type public.product_type NOT NULL,
     code character varying NOT NULL,
     name character varying NOT NULL,
     invoice_display_name character varying,
     description text,
-    deleted_at timestamp(6) without time zone,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: product_categories; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.product_categories (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    organization_id uuid NOT NULL,
-    code character varying NOT NULL,
-    name character varying NOT NULL,
-    description character varying,
-    invoice_display_name character varying,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -5225,6 +5384,94 @@ CREATE TABLE public.quotes (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT quotes_constraint_sequential_id_positive CHECK ((sequential_id > 0))
+);
+
+
+--
+-- Name: rate_card_rates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rate_card_rates (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    rate_card_id uuid NOT NULL,
+    code character varying NOT NULL,
+    effective_datetime timestamp(6) without time zone NOT NULL,
+    rate_model public.rate_card_rate_model NOT NULL,
+    rate_properties jsonb DEFAULT '{}'::jsonb NOT NULL,
+    min_amount_cents bigint DEFAULT 0 NOT NULL,
+    billing_interval_count integer DEFAULT 1 NOT NULL,
+    billing_interval_unit public.rate_card_rate_billing_interval_unit NOT NULL,
+    applied_pricing_unit_conversion_rate numeric(30,10),
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT rate_card_rates_billing_interval_count_positive CHECK ((billing_interval_count >= 1))
+);
+
+
+--
+-- Name: rate_cards; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rate_cards (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    product_id uuid NOT NULL,
+    product_filter_id uuid,
+    code character varying NOT NULL,
+    name character varying NOT NULL,
+    description character varying,
+    currency character varying NOT NULL,
+    billing_timing public.rate_card_billing_timing DEFAULT 'arrears'::public.rate_card_billing_timing NOT NULL,
+    proration boolean DEFAULT false NOT NULL,
+    display_on_invoice boolean DEFAULT true NOT NULL,
+    regroup_paid_fees public.rate_card_regroup_paid_fees,
+    applied_pricing_unit_code character varying,
+    wallet_targetable boolean,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: rate_overrides; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rate_overrides (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    rate_model public.rate_card_rate_model NOT NULL,
+    rate_properties jsonb DEFAULT '{}'::jsonb NOT NULL,
+    min_amount_cents bigint DEFAULT 0 NOT NULL,
+    billing_interval_count integer,
+    billing_interval_unit public.rate_card_rate_billing_interval_unit,
+    pricing_unit_conversion_rate numeric(30,10),
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: rate_phases; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rate_phases (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    plan_rate_card_id uuid,
+    subscription_rate_card_id uuid,
+    code character varying NOT NULL,
+    "position" integer NOT NULL,
+    billing_interval_cycle_count integer,
+    rate_override_id uuid,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    name character varying,
+    CONSTRAINT rate_phases_exactly_one_parent CHECK (((plan_rate_card_id IS NULL) <> (subscription_rate_card_id IS NULL)))
 );
 
 
@@ -5363,6 +5610,27 @@ CREATE TABLE public.subscription_fixed_charge_units_overrides (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT sub_fc_units_overrides_units_non_negative CHECK ((units >= (0)::numeric))
+);
+
+
+--
+-- Name: subscription_rate_cards; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.subscription_rate_cards (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    subscription_id uuid NOT NULL,
+    rate_card_id uuid NOT NULL,
+    billing_anchor_date date NOT NULL,
+    next_billing_at timestamp(6) without time zone NOT NULL,
+    started_at timestamp(6) without time zone NOT NULL,
+    ended_at timestamp(6) without time zone,
+    units numeric(30,10),
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT subscription_rate_cards_started_before_ended CHECK (((ended_at IS NULL) OR (started_at <= ended_at)))
 );
 
 
@@ -6343,6 +6611,14 @@ ALTER TABLE ONLY public.pending_vies_checks
 
 
 --
+-- Name: plan_rate_cards plan_rate_cards_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plan_rate_cards
+    ADD CONSTRAINT plan_rate_cards_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: plans plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6383,6 +6659,22 @@ ALTER TABLE ONLY public.pricing_units
 
 
 --
+-- Name: product_categories product_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_categories
+    ADD CONSTRAINT product_categories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: product_filter_values product_filter_values_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_filter_values
+    ADD CONSTRAINT product_filter_values_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: product_filters product_filters_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6396,14 +6688,6 @@ ALTER TABLE ONLY public.product_filters
 
 ALTER TABLE ONLY public.products
     ADD CONSTRAINT products_pkey PRIMARY KEY (id);
-
-
---
--- Name: product_categories product_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.product_categories
-    ADD CONSTRAINT product_categories_pkey PRIMARY KEY (id);
 
 
 --
@@ -6436,6 +6720,38 @@ ALTER TABLE ONLY public.quote_versions
 
 ALTER TABLE ONLY public.quotes
     ADD CONSTRAINT quotes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rate_card_rates rate_card_rates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_card_rates
+    ADD CONSTRAINT rate_card_rates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rate_cards rate_cards_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_cards
+    ADD CONSTRAINT rate_cards_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rate_overrides rate_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_overrides
+    ADD CONSTRAINT rate_overrides_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rate_phases rate_phases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_phases
+    ADD CONSTRAINT rate_phases_pkey PRIMARY KEY (id);
 
 
 --
@@ -6492,6 +6808,14 @@ ALTER TABLE ONLY public.subscription_activation_rules
 
 ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
     ADD CONSTRAINT subscription_fixed_charge_units_overrides_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: subscription_rate_cards subscription_rate_cards_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_rate_cards
+    ADD CONSTRAINT subscription_rate_cards_pkey PRIMARY KEY (id);
 
 
 --
@@ -7144,6 +7468,13 @@ CREATE UNIQUE INDEX idx_pay_in_advance_duplication_guard_charge_filter ON public
 
 
 --
+-- Name: idx_pif_values_on_filter_metric_filter_and_value; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_pif_values_on_filter_metric_filter_and_value ON public.product_filter_values USING btree (product_filter_id, billable_metric_filter_id, value) NULLS NOT DISTINCT WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: idx_privileges_code_unique_per_feature; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7292,6 +7623,13 @@ CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON public.active_storage_b
 --
 
 CREATE UNIQUE INDEX index_active_storage_variant_records_uniqueness ON public.active_storage_variant_records USING btree (blob_id, variation_digest);
+
+
+--
+-- Name: index_active_subscription_rate_cards_on_sub_and_card; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_active_subscription_rate_cards_on_sub_and_card ON public.subscription_rate_cards USING btree (subscription_id, rate_card_id) WHERE ((deleted_at IS NULL) AND (ended_at IS NULL));
 
 
 --
@@ -8555,6 +8893,20 @@ CREATE INDEX index_fees_on_pay_in_advance_event_transaction_id ON public.fees US
 
 
 --
+-- Name: index_fees_on_rate_card_rate_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fees_on_rate_card_rate_id ON public.fees USING btree (rate_card_rate_id);
+
+
+--
+-- Name: index_fees_on_rate_override_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fees_on_rate_override_id ON public.fees USING btree (rate_override_id);
+
+
+--
 -- Name: index_fees_on_subscription_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9738,6 +10090,41 @@ CREATE INDEX index_pending_vies_checks_on_organization_id ON public.pending_vies
 
 
 --
+-- Name: index_plan_rate_cards_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_plan_rate_cards_on_deleted_at ON public.plan_rate_cards USING btree (deleted_at);
+
+
+--
+-- Name: index_plan_rate_cards_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_plan_rate_cards_on_organization_id ON public.plan_rate_cards USING btree (organization_id);
+
+
+--
+-- Name: index_plan_rate_cards_on_plan_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_plan_rate_cards_on_plan_id ON public.plan_rate_cards USING btree (plan_id);
+
+
+--
+-- Name: index_plan_rate_cards_on_plan_id_and_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_plan_rate_cards_on_plan_id_and_rate_card_id ON public.plan_rate_cards USING btree (plan_id, rate_card_id) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_plan_rate_cards_on_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_plan_rate_cards_on_rate_card_id ON public.plan_rate_cards USING btree (rate_card_id);
+
+
+--
 -- Name: index_plans_on_bill_fixed_charges_monthly; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9871,6 +10258,55 @@ CREATE INDEX index_pricing_units_on_organization_id ON public.pricing_units USIN
 
 
 --
+-- Name: index_product_categories_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_categories_on_deleted_at ON public.product_categories USING btree (deleted_at);
+
+
+--
+-- Name: index_product_categories_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_categories_on_organization_id ON public.product_categories USING btree (organization_id);
+
+
+--
+-- Name: index_product_categories_on_organization_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_product_categories_on_organization_id_and_code ON public.product_categories USING btree (organization_id, code) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_product_filter_values_on_billable_metric_filter_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_filter_values_on_billable_metric_filter_id ON public.product_filter_values USING btree (billable_metric_filter_id);
+
+
+--
+-- Name: index_product_filter_values_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_filter_values_on_deleted_at ON public.product_filter_values USING btree (deleted_at);
+
+
+--
+-- Name: index_product_filter_values_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_filter_values_on_organization_id ON public.product_filter_values USING btree (organization_id);
+
+
+--
+-- Name: index_product_filter_values_on_product_filter_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_product_filter_values_on_product_filter_id ON public.product_filter_values USING btree (product_filter_id);
+
+
+--
 -- Name: index_product_filters_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9945,27 +10381,6 @@ CREATE UNIQUE INDEX index_products_on_organization_id_and_code ON public.product
 --
 
 CREATE INDEX index_products_on_product_category_id ON public.products USING btree (product_category_id);
-
-
---
--- Name: index_product_categories_on_deleted_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_product_categories_on_deleted_at ON public.product_categories USING btree (deleted_at);
-
-
---
--- Name: index_product_categories_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_product_categories_on_organization_id ON public.product_categories USING btree (organization_id);
-
-
---
--- Name: index_product_categories_on_organization_id_and_code; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_product_categories_on_organization_id_and_code ON public.product_categories USING btree (organization_id, code) WHERE (deleted_at IS NULL);
 
 
 --
@@ -10050,6 +10465,153 @@ CREATE INDEX index_quotes_on_customer_id ON public.quotes USING btree (customer_
 --
 
 CREATE INDEX index_quotes_on_subscription_id ON public.quotes USING btree (subscription_id);
+
+
+--
+-- Name: index_rate_card_rates_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_card_rates_on_deleted_at ON public.rate_card_rates USING btree (deleted_at);
+
+
+--
+-- Name: index_rate_card_rates_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_card_rates_on_organization_id ON public.rate_card_rates USING btree (organization_id);
+
+
+--
+-- Name: index_rate_card_rates_on_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_card_rates_on_rate_card_id ON public.rate_card_rates USING btree (rate_card_id);
+
+
+--
+-- Name: index_rate_card_rates_on_rate_card_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_card_rates_on_rate_card_id_and_code ON public.rate_card_rates USING btree (rate_card_id, code) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_rate_card_rates_on_rate_card_id_and_effective_datetime; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_card_rates_on_rate_card_id_and_effective_datetime ON public.rate_card_rates USING btree (rate_card_id, effective_datetime) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_rate_cards_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_cards_on_deleted_at ON public.rate_cards USING btree (deleted_at);
+
+
+--
+-- Name: index_rate_cards_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_cards_on_organization_id ON public.rate_cards USING btree (organization_id);
+
+
+--
+-- Name: index_rate_cards_on_organization_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_cards_on_organization_id_and_code ON public.rate_cards USING btree (organization_id, code) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_rate_cards_on_product_filter_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_cards_on_product_filter_id ON public.rate_cards USING btree (product_filter_id);
+
+
+--
+-- Name: index_rate_cards_on_product_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_cards_on_product_id ON public.rate_cards USING btree (product_id);
+
+
+--
+-- Name: index_rate_overrides_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_overrides_on_deleted_at ON public.rate_overrides USING btree (deleted_at);
+
+
+--
+-- Name: index_rate_overrides_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_overrides_on_organization_id ON public.rate_overrides USING btree (organization_id);
+
+
+--
+-- Name: index_rate_phases_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_phases_on_deleted_at ON public.rate_phases USING btree (deleted_at);
+
+
+--
+-- Name: index_rate_phases_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_phases_on_organization_id ON public.rate_phases USING btree (organization_id);
+
+
+--
+-- Name: index_rate_phases_on_plan_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_phases_on_plan_rate_card_id ON public.rate_phases USING btree (plan_rate_card_id);
+
+
+--
+-- Name: index_rate_phases_on_plan_rate_card_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_phases_on_plan_rate_card_id_and_code ON public.rate_phases USING btree (plan_rate_card_id, code) WHERE ((plan_rate_card_id IS NOT NULL) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_rate_phases_on_plan_rate_card_id_and_position; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_phases_on_plan_rate_card_id_and_position ON public.rate_phases USING btree (plan_rate_card_id, "position") WHERE ((plan_rate_card_id IS NOT NULL) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_rate_phases_on_rate_override_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_phases_on_rate_override_id ON public.rate_phases USING btree (rate_override_id) WHERE ((rate_override_id IS NOT NULL) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_rate_phases_on_sub_rate_card_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_phases_on_sub_rate_card_id_and_code ON public.rate_phases USING btree (subscription_rate_card_id, code) WHERE ((subscription_rate_card_id IS NOT NULL) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_rate_phases_on_sub_rate_card_id_and_position; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rate_phases_on_sub_rate_card_id_and_position ON public.rate_phases USING btree (subscription_rate_card_id, "position") WHERE ((subscription_rate_card_id IS NOT NULL) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_rate_phases_on_subscription_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rate_phases_on_subscription_rate_card_id ON public.rate_phases USING btree (subscription_rate_card_id);
 
 
 --
@@ -10183,6 +10745,41 @@ CREATE INDEX index_subscription_activation_rules_on_organization_id ON public.su
 --
 
 CREATE INDEX index_subscription_fixed_charge_units_overrides_on_deleted_at ON public.subscription_fixed_charge_units_overrides USING btree (deleted_at);
+
+
+--
+-- Name: index_subscription_rate_cards_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscription_rate_cards_on_deleted_at ON public.subscription_rate_cards USING btree (deleted_at);
+
+
+--
+-- Name: index_subscription_rate_cards_on_next_billing_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscription_rate_cards_on_next_billing_at ON public.subscription_rate_cards USING btree (next_billing_at) WHERE ((deleted_at IS NULL) AND (ended_at IS NULL));
+
+
+--
+-- Name: index_subscription_rate_cards_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscription_rate_cards_on_organization_id ON public.subscription_rate_cards USING btree (organization_id);
+
+
+--
+-- Name: index_subscription_rate_cards_on_rate_card_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscription_rate_cards_on_rate_card_id ON public.subscription_rate_cards USING btree (rate_card_id);
+
+
+--
+-- Name: index_subscription_rate_cards_on_subscription_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscription_rate_cards_on_subscription_id ON public.subscription_rate_cards USING btree (subscription_id);
 
 
 --
@@ -10845,14 +11442,6 @@ ALTER TABLE ONLY public.payment_methods
 
 
 --
--- Name: products fk_rails_00f7aa94fd; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.products
-    ADD CONSTRAINT fk_rails_00f7aa94fd FOREIGN KEY (product_category_id) REFERENCES public.product_categories(id);
-
-
---
 -- Name: pending_vies_checks fk_rails_019e2289e5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10882,6 +11471,14 @@ ALTER TABLE ONLY public.invoice_settlements
 
 ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
     ADD CONSTRAINT fk_rails_0480ef4ad3 FOREIGN KEY (fixed_charge_id) REFERENCES public.fixed_charges(id);
+
+
+--
+-- Name: product_filters fk_rails_050342349f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_filters
+    ADD CONSTRAINT fk_rails_050342349f FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -11045,6 +11642,14 @@ ALTER TABLE ONLY public.daily_usages
 
 
 --
+-- Name: plan_rate_cards fk_rails_135fe57b68; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plan_rate_cards
+    ADD CONSTRAINT fk_rails_135fe57b68 FOREIGN KEY (plan_id) REFERENCES public.plans(id);
+
+
+--
 -- Name: invoices_taxes fk_rails_142809fee1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11109,6 +11714,14 @@ ALTER TABLE ONLY public.billing_entities_invoice_custom_sections
 
 
 --
+-- Name: rate_phases fk_rails_1c069c1c44; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_phases
+    ADD CONSTRAINT fk_rails_1c069c1c44 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: applied_usage_thresholds fk_rails_1d112bf8a0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11154,6 +11767,14 @@ ALTER TABLE ONLY public.plans
 
 ALTER TABLE ONLY public.webhook_endpoints
     ADD CONSTRAINT fk_rails_21808fa528 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: plan_rate_cards fk_rails_21cbfc2122; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plan_rate_cards
+    ADD CONSTRAINT fk_rails_21cbfc2122 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -11301,14 +11922,6 @@ ALTER TABLE ONLY public.usage_thresholds
 
 
 --
--- Name: product_filters fk_rails_2a066c7180; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.product_filters
-    ADD CONSTRAINT fk_rails_2a066c7180 FOREIGN KEY (product_id) REFERENCES public.products(id);
-
-
---
 -- Name: wallets fk_rails_2b35eef34b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11322,6 +11935,14 @@ ALTER TABLE ONLY public.wallets
 
 ALTER TABLE ONLY public.ai_conversations
     ADD CONSTRAINT fk_rails_2c06a74f41 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: product_filters fk_rails_2c40f5b85c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_filters
+    ADD CONSTRAINT fk_rails_2c40f5b85c FOREIGN KEY (product_id) REFERENCES public.products(id);
 
 
 --
@@ -11461,10 +12082,18 @@ ALTER TABLE ONLY public.inbound_webhooks
 
 
 --
--- Name: product_categories fk_rails_37c75ac37a; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: product_filter_values fk_rails_36e9122b3e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.product_categories
+ALTER TABLE ONLY public.product_filter_values
+    ADD CONSTRAINT fk_rails_36e9122b3e FOREIGN KEY (billable_metric_filter_id) REFERENCES public.billable_metric_filters(id);
+
+
+--
+-- Name: products fk_rails_37c75ac37a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
     ADD CONSTRAINT fk_rails_37c75ac37a FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
@@ -11645,11 +12274,27 @@ ALTER TABLE ONLY public.billing_entities
 
 
 --
+-- Name: fees fk_rails_4cadfc14f3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fees
+    ADD CONSTRAINT fk_rails_4cadfc14f3 FOREIGN KEY (rate_card_rate_id) REFERENCES public.rate_card_rates(id);
+
+
+--
 -- Name: order_forms fk_rails_4ed54bfec0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.order_forms
     ADD CONSTRAINT fk_rails_4ed54bfec0 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: rate_cards fk_rails_4f7ffc3e03; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_cards
+    ADD CONSTRAINT fk_rails_4f7ffc3e03 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -11674,6 +12319,14 @@ ALTER TABLE ONLY public.payment_provider_customers
 
 ALTER TABLE ONLY public.billable_metric_filters
     ADD CONSTRAINT fk_rails_51077e7c0e FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: products fk_rails_512c4da634; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_512c4da634 FOREIGN KEY (add_on_id) REFERENCES public.add_ons(id);
 
 
 --
@@ -11714,6 +12367,14 @@ ALTER TABLE ONLY public.password_resets
 
 ALTER TABLE ONLY public.applied_usage_thresholds
     ADD CONSTRAINT fk_rails_52b72c9b0e FOREIGN KEY (invoice_id) REFERENCES public.invoices(id);
+
+
+--
+-- Name: product_filter_values fk_rails_530173fa8d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_filter_values
+    ADD CONSTRAINT fk_rails_530173fa8d FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -11786,6 +12447,14 @@ ALTER TABLE ONLY public.add_ons_taxes
 
 ALTER TABLE ONLY public.quotes
     ADD CONSTRAINT fk_rails_5bb40a7bae FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
+
+
+--
+-- Name: subscription_rate_cards fk_rails_5c0e7e8a12; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_rate_cards
+    ADD CONSTRAINT fk_rails_5c0e7e8a12 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -11981,11 +12650,27 @@ ALTER TABLE ONLY public.billing_entities_invoice_custom_sections
 
 
 --
+-- Name: products fk_rails_6a4ad694b3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_6a4ad694b3 FOREIGN KEY (charge_id) REFERENCES public.charges(id);
+
+
+--
 -- Name: dunning_campaigns fk_rails_6c720a8ccd; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.dunning_campaigns
     ADD CONSTRAINT fk_rails_6c720a8ccd FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: rate_overrides fk_rails_6c8a54dfe1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_overrides
+    ADD CONSTRAINT fk_rails_6c8a54dfe1 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -12301,6 +12986,14 @@ ALTER TABLE ONLY public.entitlement_entitlement_values
 
 
 --
+-- Name: rate_phases fk_rails_88c22fb20b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_phases
+    ADD CONSTRAINT fk_rails_88c22fb20b FOREIGN KEY (subscription_rate_card_id) REFERENCES public.subscription_rate_cards(id);
+
+
+--
 -- Name: add_ons_taxes fk_rails_89e1020aca; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12330,14 +13023,6 @@ ALTER TABLE ONLY public.fixed_charges_taxes
 
 ALTER TABLE ONLY public.usage_monitoring_alerts
     ADD CONSTRAINT fk_rails_8c18828b53 FOREIGN KEY (billable_metric_id) REFERENCES public.billable_metrics(id);
-
-
---
--- Name: products fk_rails_8c9cbcf514; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.products
-    ADD CONSTRAINT fk_rails_8c9cbcf514 FOREIGN KEY (charge_id) REFERENCES public.charges(id);
 
 
 --
@@ -12421,14 +13106,6 @@ ALTER TABLE ONLY public.entitlement_subscription_feature_removals
 
 
 --
--- Name: product_filters fk_rails_9687dd0c22; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.product_filters
-    ADD CONSTRAINT fk_rails_9687dd0c22 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
-
-
---
 -- Name: pending_vies_checks fk_rails_96fc54cd9a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12509,6 +13186,14 @@ ALTER TABLE ONLY public.wallet_transactions_invoice_custom_sections
 
 
 --
+-- Name: products fk_rails_9e90c6f4aa; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_9e90c6f4aa FOREIGN KEY (billable_metric_id) REFERENCES public.billable_metrics(id);
+
+
+--
 -- Name: wallet_transactions fk_rails_9ea6759859; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12522,6 +13207,22 @@ ALTER TABLE ONLY public.wallet_transactions
 
 ALTER TABLE ONLY public.credit_note_items
     ADD CONSTRAINT fk_rails_9f22076477 FOREIGN KEY (credit_note_id) REFERENCES public.credit_notes(id);
+
+
+--
+-- Name: fees fk_rails_9f724c2094; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fees
+    ADD CONSTRAINT fk_rails_9f724c2094 FOREIGN KEY (rate_override_id) REFERENCES public.rate_overrides(id);
+
+
+--
+-- Name: rate_cards fk_rails_a026c79cab; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_cards
+    ADD CONSTRAINT fk_rails_a026c79cab FOREIGN KEY (product_filter_id) REFERENCES public.product_filters(id);
 
 
 --
@@ -12557,6 +13258,14 @@ ALTER TABLE ONLY public.billing_object_connections
 
 
 --
+-- Name: rate_phases fk_rails_a5cd897b6f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_phases
+    ADD CONSTRAINT fk_rails_a5cd897b6f FOREIGN KEY (plan_rate_card_id) REFERENCES public.plan_rate_cards(id);
+
+
+--
 -- Name: charges fk_rails_a710519346; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12570,6 +13279,14 @@ ALTER TABLE ONLY public.charges
 
 ALTER TABLE ONLY public.recurring_transaction_rules_invoice_custom_sections
     ADD CONSTRAINT fk_rails_a7f20c73bb FOREIGN KEY (invoice_custom_section_id) REFERENCES public.invoice_custom_sections(id);
+
+
+--
+-- Name: rate_phases fk_rails_a9ba49506f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_phases
+    ADD CONSTRAINT fk_rails_a9ba49506f FOREIGN KEY (rate_override_id) REFERENCES public.rate_overrides(id);
 
 
 --
@@ -12613,14 +13330,6 @@ ALTER TABLE ONLY public.usage_monitoring_subscription_activities
 
 
 --
--- Name: products fk_rails_ac0f020184; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.products
-    ADD CONSTRAINT fk_rails_ac0f020184 FOREIGN KEY (add_on_id) REFERENCES public.add_ons(id);
-
-
---
 -- Name: charges_taxes fk_rails_ac146c9541; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12642,6 +13351,14 @@ ALTER TABLE ONLY public.pricing_unit_usages
 
 ALTER TABLE ONLY public.billing_object_connections
     ADD CONSTRAINT fk_rails_aed4cbd20b FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: subscription_rate_cards fk_rails_af7294033f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_rate_cards
+    ADD CONSTRAINT fk_rails_af7294033f FOREIGN KEY (rate_card_id) REFERENCES public.rate_cards(id);
 
 
 --
@@ -12965,6 +13682,14 @@ ALTER TABLE ONLY public.entitlement_entitlements
 
 
 --
+-- Name: rate_card_rates fk_rails_d53feb5721; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_card_rates
+    ADD CONSTRAINT fk_rails_d53feb5721 FOREIGN KEY (rate_card_id) REFERENCES public.rate_cards(id);
+
+
+--
 -- Name: entitlement_privileges fk_rails_d648e28d9f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12994,14 +13719,6 @@ ALTER TABLE ONLY public.wallets
 
 ALTER TABLE ONLY public.integration_resources
     ADD CONSTRAINT fk_rails_d9448a540b FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
-
-
---
--- Name: products fk_rails_d9e7580aa8; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.products
-    ADD CONSTRAINT fk_rails_d9e7580aa8 FOREIGN KEY (billable_metric_id) REFERENCES public.billable_metrics(id);
 
 
 --
@@ -13045,6 +13762,14 @@ ALTER TABLE ONLY public.invites
 
 
 --
+-- Name: rate_cards fk_rails_ddab7acbd0; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_cards
+    ADD CONSTRAINT fk_rails_ddab7acbd0 FOREIGN KEY (product_id) REFERENCES public.products(id);
+
+
+--
 -- Name: coupon_targets fk_rails_de6b3c3138; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13074,6 +13799,14 @@ ALTER TABLE ONLY public.credit_note_items
 
 ALTER TABLE ONLY public.customer_metadata
     ADD CONSTRAINT fk_rails_dfac602b2c FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: product_categories fk_rails_e13d306a35; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_categories
+    ADD CONSTRAINT fk_rails_e13d306a35 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -13149,6 +13882,14 @@ ALTER TABLE ONLY public.recurring_transaction_rules
 
 
 --
+-- Name: rate_card_rates fk_rails_e910b02a08; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rate_card_rates
+    ADD CONSTRAINT fk_rails_e910b02a08 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: fixed_charges fk_rails_e95f72749e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13162,14 +13903,6 @@ ALTER TABLE ONLY public.fixed_charges
 
 ALTER TABLE ONLY public.integration_customers
     ADD CONSTRAINT fk_rails_ea80151038 FOREIGN KEY (integration_id) REFERENCES public.integrations(id);
-
-
---
--- Name: products fk_rails_eab202bbcf; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.products
-    ADD CONSTRAINT fk_rails_eab202bbcf FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -13205,11 +13938,35 @@ ALTER TABLE ONLY public.usage_monitoring_triggered_alerts
 
 
 --
+-- Name: plan_rate_cards fk_rails_ee8d423cf4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plan_rate_cards
+    ADD CONSTRAINT fk_rails_ee8d423cf4 FOREIGN KEY (rate_card_id) REFERENCES public.rate_cards(id);
+
+
+--
 -- Name: recurring_transaction_rules_invoice_custom_sections fk_rails_eeb6a32be1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.recurring_transaction_rules_invoice_custom_sections
     ADD CONSTRAINT fk_rails_eeb6a32be1 FOREIGN KEY (recurring_transaction_rule_id) REFERENCES public.recurring_transaction_rules(id);
+
+
+--
+-- Name: products fk_rails_efe167855e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT fk_rails_efe167855e FOREIGN KEY (product_category_id) REFERENCES public.product_categories(id);
+
+
+--
+-- Name: subscription_rate_cards fk_rails_f0e6ca6965; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_rate_cards
+    ADD CONSTRAINT fk_rails_f0e6ca6965 FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
 
 
 --
@@ -13301,6 +14058,14 @@ ALTER TABLE ONLY public.fees_taxes
 
 
 --
+-- Name: product_filter_values fk_rails_f99eb07174; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.product_filter_values
+    ADD CONSTRAINT fk_rails_f99eb07174 FOREIGN KEY (product_filter_id) REFERENCES public.product_filters(id);
+
+
+--
 -- Name: wallet_targets fk_rails_fbd2b9fccb; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -13389,6 +14154,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260717163416'),
 ('20260717160544'),
 ('20260717133535'),
+('20260716173411'),
+('20260716173410'),
 ('20260716114156'),
 ('20260715165959'),
 ('20260715142900'),
@@ -13420,6 +14187,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260701083109'),
 ('20260701083108'),
 ('20260701083107'),
+('20260630122927'),
 ('20260625095837'),
 ('20260622113747'),
 ('20260619065327'),
@@ -13440,6 +14208,15 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260608111837'),
 ('20260608074112'),
 ('20260605170919'),
+('20260604182300'),
+('20260604182200'),
+('20260604182138'),
+('20260604181958'),
+('20260604181826'),
+('20260604181654'),
+('20260604181339'),
+('20260604181043'),
+('20260604180513'),
 ('20260604175731'),
 ('20260604175459'),
 ('20260604175126'),
@@ -14462,3 +15239,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/schema.graphql
+++ b/schema.graphql
@@ -6239,6 +6239,7 @@ enum FeeTypesEnum {
   commitment
   credit
   fixed_charge
+  product_item
   subscription
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -6239,7 +6239,7 @@ enum FeeTypesEnum {
   commitment
   credit
   fixed_charge
-  product_item
+  product
   subscription
 }
 

--- a/schema.json
+++ b/schema.json
@@ -31392,6 +31392,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "product_item",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/schema.json
+++ b/schema.json
@@ -31394,7 +31394,7 @@
               "deprecationReason": null
             },
             {
-              "name": "product_item",
+              "name": "product",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/plan_rate_cards.rb
+++ b/spec/factories/plan_rate_cards.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :plan_rate_card do
+    organization
+    plan { association(:plan, organization:) }
+    rate_card { association(:rate_card, organization:) }
+    units { nil }
+  end
+end

--- a/spec/factories/product_categories.rb
+++ b/spec/factories/product_categories.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :product_category do
+    organization
+    name { Faker::Commerce.product_name }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
+    description { "test description" }
+    invoice_display_name { Faker::Commerce.product_name }
+  end
+end

--- a/spec/factories/product_filter_values.rb
+++ b/spec/factories/product_filter_values.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :product_filter_value do
+    organization
+    product_filter { association(:product_filter, organization:) }
+    billable_metric_filter { association(:billable_metric_filter, organization:, values: %w[us eu apac]) }
+    value { billable_metric_filter.values.first }
+  end
+end

--- a/spec/factories/product_filters.rb
+++ b/spec/factories/product_filters.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :product_filter do
+    organization
+    product { association(:product, organization:) }
+    name { Faker::Commerce.department }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
+    description { "test description" }
+    invoice_display_name { Faker::Commerce.department }
+  end
+end

--- a/spec/factories/product_filters.rb
+++ b/spec/factories/product_filters.rb
@@ -8,5 +8,20 @@ FactoryBot.define do
     code { Faker::Alphanumeric.alphanumeric(number: 10) }
     description { "test description" }
     invoice_display_name { Faker::Commerce.department }
+
+    trait :with_values do
+      transient do
+        values_count { 1 }
+      end
+
+      after(:build) do |filter, evaluator|
+        filter.values = build_list(
+          :product_filter_value,
+          evaluator.values_count,
+          organization: filter.organization,
+          product_filter: filter
+        )
+      end
+    end
   end
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :product do
+    organization
+    product_category { association(:product_category, organization:) }
+    name { Faker::Commerce.product_name }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
+    product_type { "usage" }
+    billable_metric { association(:billable_metric, organization:) }
+
+    trait :fixed do
+      product_type { "fixed" }
+      billable_metric { nil }
+    end
+
+    trait :standalone do
+      product_category { nil }
+    end
+  end
+end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -17,5 +17,20 @@ FactoryBot.define do
     trait :standalone do
       product_category { nil }
     end
+
+    trait :with_filters do
+      transient do
+        filters_count { 1 }
+      end
+
+      after(:build) do |product, evaluator|
+        product.filters = build_list(
+          :product_filter,
+          evaluator.filters_count,
+          organization: product.organization,
+          product:
+        )
+      end
+    end
   end
 end

--- a/spec/factories/rate_card_rates.rb
+++ b/spec/factories/rate_card_rates.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rate_card_rate do
+    organization
+    rate_card { association(:rate_card, organization:) }
+    sequence(:code) { |n| "rate#{n}" }
+    effective_datetime { Time.current }
+    rate_model { "standard" }
+    rate_properties { {"amount" => "10"} }
+    min_amount_cents { 0 }
+    billing_interval_count { 1 }
+    billing_interval_unit { "month" }
+  end
+end

--- a/spec/factories/rate_card_rates.rb
+++ b/spec/factories/rate_card_rates.rb
@@ -5,7 +5,9 @@ FactoryBot.define do
     organization
     rate_card { association(:rate_card, organization:) }
     sequence(:code) { |n| "rate#{n}" }
-    effective_from { Time.current }
+    # Midnight so the default passes the arrears date-granularity rule; the
+    # factory's default card is arrears.
+    effective_from { Time.current.beginning_of_day }
     rate_model { "standard" }
     rate_properties { {"amount" => "10"} }
     min_amount_cents { 0 }

--- a/spec/factories/rate_card_rates.rb
+++ b/spec/factories/rate_card_rates.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     organization
     rate_card { association(:rate_card, organization:) }
     sequence(:code) { |n| "rate#{n}" }
-    effective_datetime { Time.current }
+    effective_from { Time.current }
     rate_model { "standard" }
     rate_properties { {"amount" => "10"} }
     min_amount_cents { 0 }

--- a/spec/factories/rate_card_rates.rb
+++ b/spec/factories/rate_card_rates.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     organization
     rate_card { association(:rate_card, organization:) }
     sequence(:code) { |n| "rate#{n}" }
-    # Midnight so the default passes the arrears date-granularity rule; the
+    # Midnight to match what the model canonicalizes arrears values to; the
     # factory's default card is arrears.
     effective_from { Time.current.beginning_of_day }
     rate_model { "standard" }

--- a/spec/factories/rate_cards.rb
+++ b/spec/factories/rate_cards.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rate_card do
+    organization
+    product { association(:product, organization:) }
+    name { Faker::Commerce.product_name }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
+    description { "test description" }
+    currency { "EUR" }
+    billing_timing { "arrears" }
+    proration { false }
+    display_on_invoice { true }
+
+    trait :advance do
+      billing_timing { "advance" }
+    end
+
+    trait :with_filter do
+      product_filter { association(:product_filter, organization:, product:) }
+    end
+  end
+end

--- a/spec/factories/rate_overrides.rb
+++ b/spec/factories/rate_overrides.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rate_override do
+    organization
+    rate_model { "standard" }
+    rate_properties { {"amount" => "10"} }
+    min_amount_cents { 0 }
+    billing_interval_count { nil }
+    billing_interval_unit { nil }
+    pricing_unit_conversion_rate { nil }
+  end
+end

--- a/spec/factories/rate_phases.rb
+++ b/spec/factories/rate_phases.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rate_phase do
+    organization
+    plan_rate_card { association(:plan_rate_card, organization:) }
+    subscription_rate_card { nil }
+    sequence(:code) { |n| "phase#{n}" }
+    position { 1 }
+    billing_interval_cycle_count { nil }
+    rate_override_id { nil }
+
+    trait :subscription_level do
+      plan_rate_card { nil }
+      subscription_rate_card { association(:subscription_rate_card, organization:) }
+    end
+  end
+end

--- a/spec/factories/subscription_rate_cards.rb
+++ b/spec/factories/subscription_rate_cards.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subscription_rate_card do
+    organization
+    subscription { association(:subscription, organization:) }
+    rate_card { association(:rate_card, organization:) }
+    billing_anchor_date { Date.current }
+    next_billing_at { Time.current }
+    started_at { Time.current }
+    ended_at { nil }
+    units { nil }
+  end
+end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Fee do
   it { is_expected.to belong_to(:add_on).optional }
   it { is_expected.to belong_to(:charge).optional }
   it { is_expected.to belong_to(:fixed_charge).optional }
+  it { is_expected.to belong_to(:rate_card_rate).optional }
   it { is_expected.to have_many(:presentation_breakdowns) }
   it { is_expected.to have_one(:fixed_charge_add_on).through(:fixed_charge) }
   it { is_expected.to have_one(:adjusted_fee).dependent(:nullify) }

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Fee do
   it { is_expected.to belong_to(:charge).optional }
   it { is_expected.to belong_to(:fixed_charge).optional }
   it { is_expected.to belong_to(:rate_card_rate).optional }
+  it { is_expected.to belong_to(:rate_override).optional }
   it { is_expected.to have_many(:presentation_breakdowns) }
   it { is_expected.to have_one(:fixed_charge_add_on).through(:fixed_charge) }
   it { is_expected.to have_one(:adjusted_fee).dependent(:nullify) }

--- a/spec/models/plan_rate_card_spec.rb
+++ b/spec/models/plan_rate_card_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanRateCard do
+  subject(:plan_rate_card) { build(:plan_rate_card) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(plan_rate_card).to belong_to(:organization)
+      expect(plan_rate_card).to belong_to(:plan)
+      expect(plan_rate_card).to belong_to(:rate_card)
+      expect(plan_rate_card).to have_one(:product).through(:rate_card)
+    end
+  end
+
+  describe "validations" do
+    describe "uniqueness of (plan, rate_card)" do
+      it "rejects a duplicate plan / rate_card pair" do
+        existing = create(:plan_rate_card)
+        duplicate = build(
+          :plan_rate_card,
+          organization: existing.organization,
+          plan: existing.plan,
+          rate_card: existing.rate_card
+        )
+        duplicate.valid?
+        expect(duplicate.errors.where(:rate_card_id, :taken)).to be_present
+      end
+
+      it "allows a different rate_card on the same plan" do
+        existing = create(:plan_rate_card)
+        other_card = create(:rate_card, organization: existing.organization)
+        sibling = build(
+          :plan_rate_card,
+          organization: existing.organization,
+          plan: existing.plan,
+          rate_card: other_card
+        )
+        expect(sibling).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/plan_rate_card_spec.rb
+++ b/spec/models/plan_rate_card_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe PlanRateCard do
       expect(plan_rate_card).to belong_to(:organization)
       expect(plan_rate_card).to belong_to(:plan)
       expect(plan_rate_card).to belong_to(:rate_card)
+      expect(plan_rate_card).to have_many(:rate_phases).order(:position)
       expect(plan_rate_card).to have_one(:product).through(:rate_card)
     end
   end

--- a/spec/models/product_category_spec.rb
+++ b/spec/models/product_category_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ProductCategory do
     it do
       expect(product_category).to belong_to(:organization)
       expect(product_category).to have_many(:products)
+      expect(product_category).to have_many(:subscription_applied_rate_cards).through(:products)
     end
   end
 
@@ -49,6 +50,32 @@ RSpec.describe ProductCategory do
     it "falls back to name when invoice_display_name is blank" do
       product_category = build_stubbed(:product_category, invoice_display_name: nil, name: "Name")
       expect(product_category.invoice_name).to eq("Name")
+    end
+  end
+
+  describe "#attached_to_plan_or_subscription?" do
+    let(:product_category) { create(:product_category) }
+
+    it "is false when the product_category is not in a plan and none of its items has a subscription" do
+      create(:product, organization: product_category.organization, product_category:)
+
+      expect(product_category.attached_to_plan_or_subscription?).to be(false)
+    end
+
+    it "is true when one of its items is priced on a plan" do
+      item = create(:product, organization: product_category.organization, product_category:)
+      rate_card = create(:rate_card, organization: product_category.organization, product: item)
+      create(:plan_rate_card, organization: product_category.organization, rate_card:)
+
+      expect(product_category.attached_to_plan_or_subscription?).to be(true)
+    end
+
+    it "is true when one of its items has a subscription product" do
+      item = create(:product, organization: product_category.organization, product_category:)
+      rate_card = create(:rate_card, organization: product_category.organization, product: item)
+      create(:subscription_rate_card, organization: product_category.organization, rate_card:)
+
+      expect(product_category.attached_to_plan_or_subscription?).to be(true)
     end
   end
 end

--- a/spec/models/product_category_spec.rb
+++ b/spec/models/product_category_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductCategory do
+  subject(:product_category) { build(:product_category) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(product_category).to belong_to(:organization)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:code) }
+
+    describe "code uniqueness" do
+      it "does not add an error when unique within the organization" do
+        expect(product_category.tap(&:valid?).errors.where(:code, :taken)).not_to be_present
+      end
+
+      it "adds an error when not unique within the organization" do
+        organization = create(:organization)
+        create(:product_category, organization:, code: "shared")
+        duplicate = build(:product_category, organization:, code: "shared")
+        duplicate.valid?
+        expect(duplicate.errors.where(:code, :taken)).to be_present
+      end
+
+      it "allows the same code across organizations" do
+        create(:product_category, code: "shared")
+        other = build(:product_category, organization: create(:organization), code: "shared")
+        other.valid?
+        expect(other.errors.where(:code, :taken)).not_to be_present
+      end
+    end
+  end
+
+  describe "#invoice_name" do
+    it "returns the invoice_display_name when present" do
+      product_category = build_stubbed(:product_category, invoice_display_name: "Display", name: "Name")
+      expect(product_category.invoice_name).to eq("Display")
+    end
+
+    it "falls back to name when invoice_display_name is blank" do
+      product_category = build_stubbed(:product_category, invoice_display_name: nil, name: "Name")
+      expect(product_category.invoice_name).to eq("Name")
+    end
+  end
+end

--- a/spec/models/product_category_spec.rb
+++ b/spec/models/product_category_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ProductCategory do
   describe "associations" do
     it do
       expect(product_category).to belong_to(:organization)
+      expect(product_category).to have_many(:products)
     end
   end
 

--- a/spec/models/product_filter_spec.rb
+++ b/spec/models/product_filter_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe ProductFilter do
     it do
       expect(product_filter).to belong_to(:organization)
       expect(product_filter).to belong_to(:product)
+      expect(product_filter).to have_many(:values).class_name("ProductFilterValue")
+      expect(product_filter).to have_many(:billable_metric_filters).through(:values)
     end
   end
 
@@ -49,6 +51,19 @@ RSpec.describe ProductFilter do
     it "falls back to name when invoice_display_name is blank" do
       filter = build_stubbed(:product_filter, invoice_display_name: nil, name: "Name")
       expect(filter.invoice_name).to eq("Name")
+    end
+  end
+
+  describe "#to_h" do
+    it "groups values by billable metric filter key" do
+      filter = create(:product_filter)
+      region = create(:billable_metric_filter, organization: filter.organization, key: "region", values: %w[us eu])
+      scheme = create(:billable_metric_filter, organization: filter.organization, key: "scheme", values: %w[visa])
+      create(:product_filter_value, product_filter: filter, organization: filter.organization, billable_metric_filter: region, value: "us")
+      create(:product_filter_value, product_filter: filter, organization: filter.organization, billable_metric_filter: region, value: "eu")
+      create(:product_filter_value, product_filter: filter, organization: filter.organization, billable_metric_filter: scheme, value: "visa")
+
+      expect(filter.reload.to_h).to eq("region" => %w[us eu], "scheme" => %w[visa])
     end
   end
 end

--- a/spec/models/product_filter_spec.rb
+++ b/spec/models/product_filter_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductFilter do
+  subject(:product_filter) { build(:product_filter) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(product_filter).to belong_to(:organization)
+      expect(product_filter).to belong_to(:product)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:code) }
+
+    describe "code uniqueness per product" do
+      it "rejects a duplicate code on the same product" do
+        existing = create(:product_filter)
+        duplicate = build(
+          :product_filter,
+          organization: existing.organization,
+          product: existing.product,
+          code: existing.code
+        )
+        duplicate.valid?
+        expect(duplicate.errors.where(:code, :taken)).to be_present
+      end
+
+      it "allows the same code on a different product" do
+        existing = create(:product_filter)
+        other = build(:product_filter, organization: existing.organization, code: existing.code)
+        other.valid?
+        expect(other.errors.where(:code, :taken)).not_to be_present
+      end
+    end
+  end
+
+  describe "#invoice_name" do
+    it "returns the invoice_display_name when present" do
+      filter = build_stubbed(:product_filter, invoice_display_name: "Display", name: "Name")
+      expect(filter.invoice_name).to eq("Display")
+    end
+
+    it "falls back to name when invoice_display_name is blank" do
+      filter = build_stubbed(:product_filter, invoice_display_name: nil, name: "Name")
+      expect(filter.invoice_name).to eq("Name")
+    end
+  end
+end

--- a/spec/models/product_filter_spec.rb
+++ b/spec/models/product_filter_spec.rb
@@ -66,4 +66,17 @@ RSpec.describe ProductFilter do
       expect(filter.reload.to_h).to eq("region" => %w[us eu], "scheme" => %w[visa])
     end
   end
+
+  describe "#attached_to_plan_or_subscription?" do
+    let(:product) { create(:product) }
+    let(:filter) { create(:product_filter, organization: product.organization, product:) }
+
+    it "delegates to the product" do
+      expect(filter.attached_to_plan_or_subscription?).to be(false)
+
+      create(:subscription_rate_card, organization: product.organization, product:)
+
+      expect(filter.attached_to_plan_or_subscription?).to be(true)
+    end
+  end
 end

--- a/spec/models/product_filter_value_spec.rb
+++ b/spec/models/product_filter_value_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductFilterValue do
+  subject(:product_filter_value) { build(:product_filter_value) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(product_filter_value).to belong_to(:organization)
+      expect(product_filter_value).to belong_to(:product_filter)
+      expect(product_filter_value).to belong_to(:billable_metric_filter)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:value).allow_nil }
+
+    describe "value inclusion in the billable metric filter values" do
+      it "is valid when the value belongs to the metric filter values" do
+        expect(product_filter_value).to be_valid
+      end
+
+      it "is valid without a value (key-only selection matches any value)" do
+        product_filter_value.value = nil
+        expect(product_filter_value).to be_valid
+      end
+
+      it "is invalid when the value is not in the metric filter values" do
+        product_filter_value.value = "not-a-known-value"
+        product_filter_value.valid?
+        expect(product_filter_value.errors.added?(:value, :inclusion)).to be(true)
+      end
+    end
+
+    describe "value uniqueness per filter and metric filter" do
+      it "rejects the same value twice for the same filter and key" do
+        existing = create(:product_filter_value)
+        duplicate = build(
+          :product_filter_value,
+          organization: existing.organization,
+          product_filter: existing.product_filter,
+          billable_metric_filter: existing.billable_metric_filter,
+          value: existing.value
+        )
+        duplicate.valid?
+        expect(duplicate.errors.where(:value, :taken)).to be_present
+      end
+
+      it "allows the same value for a different key on the same filter" do
+        existing = create(:product_filter_value)
+        other_key = create(:billable_metric_filter, organization: existing.organization, values: [existing.value])
+        sibling = build(
+          :product_filter_value,
+          organization: existing.organization,
+          product_filter: existing.product_filter,
+          billable_metric_filter: other_key,
+          value: existing.value
+        )
+        sibling.valid?
+        expect(sibling.errors.where(:value, :taken)).not_to be_present
+      end
+    end
+  end
+
+  describe "#key" do
+    it "delegates to the billable metric filter" do
+      expect(product_filter_value.key).to eq(product_filter_value.billable_metric_filter.key)
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Product do
       expect(product).to belong_to(:add_on).optional
       expect(product).to belong_to(:charge).optional
       expect(product).to have_many(:filters).class_name("ProductFilter")
+      expect(product).to have_many(:rate_cards)
     end
   end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Product do
+  subject(:product) { build(:product) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "enums" do
+    it do
+      expect(product).to define_enum_for(:product_type)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_values(usage: "usage", fixed: "fixed")
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(product).to belong_to(:organization)
+      expect(product).to belong_to(:product_category).optional
+      # The subject must be a fixed item: usage items validate billable_metric presence,
+      # which the optional matcher would read as a non-optional association.
+      expect(build(:product, :fixed, :standalone)).to belong_to(:billable_metric).optional
+      expect(product).to belong_to(:add_on).optional
+      expect(product).to belong_to(:charge).optional
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:code) }
+
+    describe "billable_metric presence" do
+      it "requires a billable_metric for usage items" do
+        item = build(:product, billable_metric: nil)
+        item.valid?
+        expect(item.errors.added?(:billable_metric, :blank)).to be(true)
+      end
+
+      it "forbids a billable_metric on fixed items" do
+        item = build(:product, :fixed, billable_metric: create(:billable_metric))
+        item.valid?
+        expect(item.errors.added?(:billable_metric, :present)).to be(true)
+      end
+    end
+
+    describe "add_on / charge exclusivity" do
+      it "rejects setting both add_on and charge" do
+        item = build(:product, add_on: create(:add_on), charge: create(:standard_charge))
+        item.valid?
+        expect(item.errors.added?(:base, :add_on_and_charge_mutually_exclusive)).to be(true)
+      end
+    end
+
+    describe "code uniqueness" do
+      it "rejects a duplicate code within the organization, even across product_categories" do
+        organization = create(:organization)
+        product_category_a = create(:product_category, organization:)
+        product_category_b = create(:product_category, organization:)
+        create(:product, organization:, product_category: product_category_a, code: "shared")
+        duplicate = build(:product, organization:, product_category: product_category_b, code: "shared")
+        duplicate.valid?
+        expect(duplicate.errors.where(:code, :taken)).to be_present
+      end
+
+      it "allows the same code in a different organization" do
+        create(:product, :standalone, code: "shared")
+        item = build(:product, :standalone, code: "shared")
+        item.valid?
+        expect(item.errors.where(:code, :taken)).not_to be_present
+      end
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -75,4 +75,26 @@ RSpec.describe Product do
       end
     end
   end
+
+  describe "#attached_to_plan_or_subscription?" do
+    let(:product) { create(:product) }
+
+    it "is false when no plan or subscription references it" do
+      expect(product.attached_to_plan_or_subscription?).to be(false)
+    end
+
+    it "is true when a plan product references it" do
+      rate_card = create(:rate_card, organization: product.organization, product:)
+      create(:plan_rate_card, organization: product.organization, rate_card:)
+
+      expect(product.attached_to_plan_or_subscription?).to be(true)
+    end
+
+    it "is true when a subscription product references it" do
+      rate_card = create(:rate_card, organization: product.organization, product:)
+      create(:subscription_rate_card, organization: product.organization, rate_card:)
+
+      expect(product.attached_to_plan_or_subscription?).to be(true)
+    end
+  end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Product do
       expect(build(:product, :fixed, :standalone)).to belong_to(:billable_metric).optional
       expect(product).to belong_to(:add_on).optional
       expect(product).to belong_to(:charge).optional
+      expect(product).to have_many(:filters).class_name("ProductFilter")
     end
   end
 

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCardRate do
+  subject(:rate_card_rate) { build(:rate_card_rate) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "enums" do
+    it do
+      expect(rate_card_rate).to define_enum_for(:rate_model)
+        .backed_by_column_of_type(:enum)
+        .validating(allowing_nil: true)
+        .with_values(
+          standard: "standard",
+          graduated: "graduated",
+          package: "package",
+          percentage: "percentage",
+          volume: "volume",
+          graduated_percentage: "graduated_percentage",
+          custom: "custom",
+          dynamic: "dynamic"
+        )
+
+      expect(rate_card_rate).to define_enum_for(:billing_interval_unit)
+        .backed_by_column_of_type(:enum)
+        .validating(allowing_nil: true)
+        .with_values(day: "day", week: "week", month: "month", year: "year")
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(rate_card_rate).to belong_to(:organization)
+      expect(rate_card_rate).to belong_to(:rate_card)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:effective_datetime) }
+    it { is_expected.to validate_presence_of(:rate_model) }
+    it { is_expected.to validate_presence_of(:billing_interval_unit) }
+
+    it { is_expected.to validate_numericality_of(:min_amount_cents).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_numericality_of(:billing_interval_count).is_greater_than_or_equal_to(1) }
+
+    describe "code" do
+      it { is_expected.to validate_presence_of(:code) }
+
+      it "rejects a duplicate code on the same card" do
+        rate = create(:rate_card_rate, code: "launch_price")
+        duplicate = build(
+          :rate_card_rate,
+          rate_card: rate.rate_card,
+          organization: rate.organization,
+          effective_datetime: 1.month.from_now,
+          code: "launch_price"
+        )
+        duplicate.valid?
+
+        expect(duplicate.errors.where(:code, :taken)).to be_present
+      end
+    end
+
+    describe "effective_datetime placement" do
+      let(:rate_card) { create(:rate_card) }
+
+      around { |example| travel_to(Time.zone.parse("2026-06-15")) { example.run } }
+
+      before do
+        create(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-01-01"))
+        create(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-09-01"))
+      end
+
+      it "allows a rate between the active rate and a pending rate" do
+        rate = build(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-07-01"))
+        expect(rate).to be_valid
+      end
+
+      it "allows a rate after the latest pending rate" do
+        rate = build(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-10-01"))
+        expect(rate).to be_valid
+      end
+
+      it "rejects a rate at or before the active rate" do
+        rate = build(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2025-12-01"))
+        rate.valid?
+        expect(rate.errors.added?(:effective_datetime, :must_be_after_active_rate)).to be(true)
+      end
+
+      it "rejects a rate sharing an existing rate timestamp" do
+        rate = build(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-09-01"))
+        rate.valid?
+        expect(rate.errors.added?(:effective_datetime, :value_already_exist)).to be(true)
+      end
+    end
+
+    describe "applied_pricing_unit_conversion_rate" do
+      it "is required when the card carries an applied_pricing_unit_code" do
+        rate_card = create(:rate_card, applied_pricing_unit_code: "credits")
+        rate = build(:rate_card_rate, rate_card:, applied_pricing_unit_conversion_rate: nil)
+        rate.valid?
+        expect(rate.errors.added?(:applied_pricing_unit_conversion_rate, :blank)).to be(true)
+      end
+
+      it "is not required when the card has no applied_pricing_unit_code" do
+        rate = build(:rate_card_rate, applied_pricing_unit_conversion_rate: nil)
+        rate.valid?
+        expect(rate.errors.added?(:applied_pricing_unit_conversion_rate, :blank)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -38,6 +38,36 @@ RSpec.describe RateCardRate do
   end
 
   describe "validations" do
+    describe "effective_from granularity" do
+      it "rejects a time component on an arrears card" do
+        card = create(:rate_card, billing_timing: "arrears")
+        rate = build(:rate_card_rate, rate_card: card, effective_from: "2026-12-01T17:00:00Z")
+        rate.valid?
+        expect(rate.errors.where(:effective_from).map(&:type)).to eq([:must_be_a_date])
+      end
+
+      it "accepts a date and a midnight datetime on an arrears card" do
+        card = create(:rate_card, billing_timing: "arrears")
+
+        expect(build(:rate_card_rate, rate_card: card, effective_from: "2026-12-01")).to be_valid
+        expect(build(:rate_card_rate, rate_card: card, effective_from: "2026-12-01T00:00:00Z")).to be_valid
+      end
+
+      it "accepts a time component on an advance card" do
+        card = create(:rate_card, billing_timing: "advance")
+
+        expect(build(:rate_card_rate, rate_card: card, effective_from: "2026-12-01T17:00:00Z")).to be_valid
+      end
+
+      it "caps arrears at one rate per day through the uniqueness rule" do
+        card = create(:rate_card, billing_timing: "arrears")
+        create(:rate_card_rate, rate_card: card, effective_from: "2026-12-01")
+        duplicate = build(:rate_card_rate, rate_card: card, code: "other", effective_from: "2026-12-01T00:00:00Z")
+        duplicate.valid?
+        expect(duplicate.errors.where(:effective_from, :value_already_exist)).to be_present
+      end
+    end
+
     it { is_expected.to validate_presence_of(:effective_from) }
     it { is_expected.to validate_presence_of(:rate_model) }
     it { is_expected.to validate_presence_of(:billing_interval_unit) }

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -74,6 +74,27 @@ RSpec.describe RateCardRate do
     end
 
     it { is_expected.to validate_presence_of(:effective_from) }
+
+    describe "effective_from parseability" do
+      it "rejects an unparseable value as invalid rather than missing" do
+        rate = build(:rate_card_rate, effective_from: "hello")
+        rate.valid?
+        expect(rate.errors.where(:effective_from).map(&:type)).to eq([:invalid])
+      end
+
+      it "rejects an impossible date as invalid rather than missing" do
+        rate = build(:rate_card_rate, effective_from: "2026-13-45")
+        rate.valid?
+        expect(rate.errors.where(:effective_from).map(&:type)).to eq([:invalid])
+      end
+
+      it "keeps a missing value on the presence error" do
+        rate = build(:rate_card_rate, effective_from: nil)
+        rate.valid?
+        expect(rate.errors.where(:effective_from).map(&:type)).to eq([:blank])
+      end
+    end
+
     it { is_expected.to validate_presence_of(:rate_model) }
     it { is_expected.to validate_presence_of(:billing_interval_unit) }
 

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RateCardRate do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:effective_datetime) }
+    it { is_expected.to validate_presence_of(:effective_from) }
     it { is_expected.to validate_presence_of(:rate_model) }
     it { is_expected.to validate_presence_of(:billing_interval_unit) }
 
@@ -54,7 +54,7 @@ RSpec.describe RateCardRate do
           :rate_card_rate,
           rate_card: rate.rate_card,
           organization: rate.organization,
-          effective_datetime: 1.month.from_now,
+          effective_from: 1.month.from_now,
           code: "launch_price"
         )
         duplicate.valid?
@@ -63,36 +63,36 @@ RSpec.describe RateCardRate do
       end
     end
 
-    describe "effective_datetime placement" do
+    describe "effective_from placement" do
       let(:rate_card) { create(:rate_card) }
 
       around { |example| travel_to(Time.zone.parse("2026-06-15")) { example.run } }
 
       before do
-        create(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-01-01"))
-        create(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-09-01"))
+        create(:rate_card_rate, rate_card:, effective_from: Time.zone.parse("2026-01-01"))
+        create(:rate_card_rate, rate_card:, effective_from: Time.zone.parse("2026-09-01"))
       end
 
       it "allows a rate between the active rate and a pending rate" do
-        rate = build(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-07-01"))
+        rate = build(:rate_card_rate, rate_card:, effective_from: Time.zone.parse("2026-07-01"))
         expect(rate).to be_valid
       end
 
       it "allows a rate after the latest pending rate" do
-        rate = build(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-10-01"))
+        rate = build(:rate_card_rate, rate_card:, effective_from: Time.zone.parse("2026-10-01"))
         expect(rate).to be_valid
       end
 
       it "rejects a rate at or before the active rate" do
-        rate = build(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2025-12-01"))
+        rate = build(:rate_card_rate, rate_card:, effective_from: Time.zone.parse("2025-12-01"))
         rate.valid?
-        expect(rate.errors.added?(:effective_datetime, :must_be_after_active_rate)).to be(true)
+        expect(rate.errors.added?(:effective_from, :must_be_after_active_rate)).to be(true)
       end
 
       it "rejects a rate sharing an existing rate timestamp" do
-        rate = build(:rate_card_rate, rate_card:, effective_datetime: Time.zone.parse("2026-09-01"))
+        rate = build(:rate_card_rate, rate_card:, effective_from: Time.zone.parse("2026-09-01"))
         rate.valid?
-        expect(rate.errors.added?(:effective_datetime, :value_already_exist)).to be(true)
+        expect(rate.errors.added?(:effective_from, :value_already_exist)).to be(true)
       end
     end
 

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -38,31 +38,36 @@ RSpec.describe RateCardRate do
   end
 
   describe "validations" do
-    describe "effective_from granularity" do
-      it "rejects a time component on an arrears card" do
+    describe "effective_from normalization" do
+      it "canonicalizes a time component to midnight on an arrears card" do
         card = create(:rate_card, billing_timing: "arrears")
-        rate = build(:rate_card_rate, rate_card: card, effective_from: "2026-12-01T17:00:00Z")
-        rate.valid?
-        expect(rate.errors.where(:effective_from).map(&:type)).to eq([:must_be_a_date])
+        rate = create(:rate_card_rate, rate_card: card, effective_from: "2026-12-01T17:00:00Z")
+
+        expect(rate.effective_from).to eq(Time.zone.parse("2026-12-01T00:00:00Z"))
       end
 
-      it "accepts a date and a midnight datetime on an arrears card" do
+      it "stores a date and a midnight datetime as midnight on an arrears card" do
         card = create(:rate_card, billing_timing: "arrears")
+        midnight = Time.zone.parse("2026-12-01T00:00:00Z")
 
-        expect(build(:rate_card_rate, rate_card: card, effective_from: "2026-12-01")).to be_valid
-        expect(build(:rate_card_rate, rate_card: card, effective_from: "2026-12-01T00:00:00Z")).to be_valid
+        from_date = create(:rate_card_rate, rate_card: card, effective_from: "2026-12-01")
+        from_datetime = create(:rate_card_rate, rate_card: card, code: "other", effective_from: "2026-12-02T00:00:00Z")
+
+        expect(from_date.effective_from).to eq(midnight)
+        expect(from_datetime.effective_from).to eq(midnight + 1.day)
       end
 
-      it "accepts a time component on an advance card" do
+      it "keeps the full instant on an advance card" do
         card = create(:rate_card, billing_timing: "advance")
+        rate = create(:rate_card_rate, rate_card: card, effective_from: "2026-12-01T17:00:00Z")
 
-        expect(build(:rate_card_rate, rate_card: card, effective_from: "2026-12-01T17:00:00Z")).to be_valid
+        expect(rate.effective_from).to eq(Time.zone.parse("2026-12-01T17:00:00Z"))
       end
 
       it "caps arrears at one rate per day through the uniqueness rule" do
         card = create(:rate_card, billing_timing: "arrears")
         create(:rate_card_rate, rate_card: card, effective_from: "2026-12-01")
-        duplicate = build(:rate_card_rate, rate_card: card, code: "other", effective_from: "2026-12-01T00:00:00Z")
+        duplicate = build(:rate_card_rate, rate_card: card, code: "other", effective_from: "2026-12-01T17:00:00Z")
         duplicate.valid?
         expect(duplicate.errors.where(:effective_from, :value_already_exist)).to be_present
       end

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe RateCard do
       end
     end
 
+    describe "display_on_invoice compatibility" do
+      it "rejects hiding fees on an arrears card" do
+        hidden = build(:rate_card, billing_timing: "arrears", display_on_invoice: false)
+        hidden.valid?
+        expect(hidden.errors.where(:display_on_invoice).map(&:type)).to eq([:not_allowed_for_billing_timing])
+      end
+
+      it "accepts hiding fees on an advance card" do
+        expect(build(:rate_card, billing_timing: "advance", display_on_invoice: false)).to be_valid
+      end
+
+      it "accepts a displayed arrears card" do
+        expect(build(:rate_card, billing_timing: "arrears", display_on_invoice: true)).to be_valid
+      end
+    end
+
     describe "currency inclusion" do
       it "is valid with an accepted currency" do
         expect(build(:rate_card, currency: "USD")).to be_valid

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -70,6 +70,36 @@ RSpec.describe RateCard do
       end
     end
 
+    describe "proration compatibility" do
+      it "rejects proration on a metered metric" do
+        metered = create(:product, billable_metric: create(:billable_metric, recurring: false))
+        card = build(:rate_card, organization: metered.organization, product: metered, proration: true)
+        card.valid?
+        expect(card.errors.where(:proration).map(&:type)).to eq([:requires_recurring_metric])
+      end
+
+      it "rejects proration on a weighted_sum metric" do
+        metric = create(:billable_metric, aggregation_type: "weighted_sum_agg", recurring: true, field_name: "value", weighted_interval: "seconds")
+        product = create(:product, organization: metric.organization, billable_metric: metric)
+        card = build(:rate_card, organization: product.organization, product:, proration: true)
+        card.valid?
+        expect(card.errors.where(:proration).map(&:type)).to eq([:not_allowed_for_aggregation_type])
+      end
+
+      it "accepts proration on a recurring metric" do
+        metric = create(:billable_metric, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
+        product = create(:product, organization: metric.organization, billable_metric: metric)
+
+        expect(build(:rate_card, organization: product.organization, product:, proration: true)).to be_valid
+      end
+
+      it "accepts proration on a fixed product" do
+        product = create(:product, :fixed, :standalone)
+
+        expect(build(:rate_card, organization: product.organization, product:, proration: true)).to be_valid
+      end
+    end
+
     describe "currency inclusion" do
       it "is valid with an accepted currency" do
         expect(build(:rate_card, currency: "USD")).to be_valid

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -88,4 +88,24 @@ RSpec.describe RateCard do
       end
     end
   end
+
+  describe "#attached_to_plan_or_subscription?" do
+    let(:rate_card) { create(:rate_card) }
+
+    it "is false when no plan or subscription references the card" do
+      expect(rate_card.attached_to_plan_or_subscription?).to be(false)
+    end
+
+    it "is true when a plan references the card" do
+      create(:plan_rate_card, organization: rate_card.organization, rate_card:)
+
+      expect(rate_card.attached_to_plan_or_subscription?).to be(true)
+    end
+
+    it "is true when a subscription references the card" do
+      create(:subscription_rate_card, organization: rate_card.organization, rate_card:)
+
+      expect(rate_card.attached_to_plan_or_subscription?).to be(true)
+    end
+  end
 end

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCard do
+  subject(:rate_card) { build(:rate_card) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "enums" do
+    it do
+      expect(rate_card).to define_enum_for(:billing_timing)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_values(arrears: "arrears", advance: "advance")
+
+      expect(rate_card).to define_enum_for(:regroup_paid_fees)
+        .backed_by_column_of_type(:enum)
+        .validating(allowing_nil: true)
+        .with_values(invoice: "invoice")
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(rate_card).to belong_to(:organization)
+      expect(rate_card).to belong_to(:product)
+      expect(rate_card).to belong_to(:product_filter).optional
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:code) }
+
+    describe "filter scoping" do
+      it "rejects a filter belonging to another product" do
+        organization = create(:organization)
+        foreign_filter = create(:product_filter, organization:)
+        rate_card = build(:rate_card, organization:, product_filter: foreign_filter)
+        rate_card.valid?
+
+        expect(rate_card.errors.where(:product_filter, :does_not_belong_to_product)).to be_present
+      end
+
+      it "accepts a filter of the card's own item" do
+        filter = create(:product_filter)
+        rate_card = build(:rate_card, organization: filter.organization, product: filter.product, product_filter: filter)
+
+        expect(rate_card).to be_valid
+      end
+    end
+
+    describe "currency inclusion" do
+      it "is valid with an accepted currency" do
+        expect(build(:rate_card, currency: "USD")).to be_valid
+      end
+
+      it "is invalid with an unknown currency" do
+        rate_card = build(:rate_card, currency: "ABC")
+        rate_card.valid?
+        expect(rate_card.errors.where(:currency, :inclusion)).to be_present
+        expect(rate_card.errors.where(:currency, :blank)).to be_empty
+      end
+
+      it "reports only the presence error when the currency is missing" do
+        rate_card = build(:rate_card, currency: nil)
+        rate_card.valid?
+        expect(rate_card.errors.where(:currency, :blank)).to be_present
+        expect(rate_card.errors.where(:currency, :inclusion)).to be_empty
+      end
+    end
+
+    describe "code uniqueness per organization" do
+      it "rejects a duplicate code within the same organization, even on a different product" do
+        existing = create(:rate_card)
+        duplicate = build(:rate_card, organization: existing.organization, code: existing.code)
+        duplicate.valid?
+        expect(duplicate.errors.where(:code, :taken)).to be_present
+      end
+
+      it "allows the same code in a different organization" do
+        existing = create(:rate_card)
+        other = build(:rate_card, code: existing.code)
+        other.valid?
+        expect(other.errors.where(:code, :taken)).not_to be_present
+      end
+    end
+  end
+end

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe RateCard do
 
       expect(rate_card).to define_enum_for(:regroup_paid_fees)
         .backed_by_column_of_type(:enum)
-        .validating(allowing_nil: true)
-        .with_values(invoice: "invoice")
+        .validating
+        .with_values(none: "none", invoice: "invoice")
+        .with_prefix(:regroup_paid_fees)
+      expect(rate_card.regroup_paid_fees).to eq("none")
     end
   end
 

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe RateCard do
       expect(rate_card).to belong_to(:organization)
       expect(rate_card).to belong_to(:product)
       expect(rate_card).to belong_to(:product_filter).optional
+      expect(rate_card).to have_many(:rates).class_name("RateCardRate")
     end
   end
 

--- a/spec/models/rate_override_spec.rb
+++ b/spec/models/rate_override_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateOverride do
+  subject(:rate_override) { build(:rate_override) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "enums" do
+    it do
+      expect(rate_override).to define_enum_for(:rate_model)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_values(
+          standard: "standard",
+          graduated: "graduated",
+          package: "package",
+          percentage: "percentage",
+          volume: "volume",
+          graduated_percentage: "graduated_percentage",
+          custom: "custom",
+          dynamic: "dynamic"
+        )
+
+      expect(rate_override).to define_enum_for(:billing_interval_unit)
+        .backed_by_column_of_type(:enum)
+        .validating(allowing_nil: true)
+        .with_values(day: "day", week: "week", month: "month", year: "year")
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(rate_override).to belong_to(:organization)
+      expect(rate_override).to have_one(:rate_phase)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_numericality_of(:min_amount_cents).is_greater_than_or_equal_to(0) }
+
+    describe "billing_interval_count" do
+      it "allows nil (inherits the card's active rate)" do
+        expect(build(:rate_override, billing_interval_count: nil)).to be_valid
+      end
+
+      it "rejects a value below 1" do
+        override = build(:rate_override, billing_interval_count: 0)
+        override.valid?
+        expect(override.errors.where(:billing_interval_count)).to be_present
+      end
+    end
+
+    describe "rate_properties" do
+      it "rejects properties that are invalid for the rate model" do
+        override = build(:rate_override, rate_model: "graduated", rate_properties: {})
+        override.valid?
+        expect(override.errors.where(:rate_properties)).to be_present
+      end
+    end
+  end
+end

--- a/spec/models/rate_phase_spec.rb
+++ b/spec/models/rate_phase_spec.rb
@@ -12,11 +12,28 @@ RSpec.describe RatePhase do
       expect(rate_phase).to belong_to(:organization)
       expect(rate_phase).to belong_to(:plan_rate_card).optional
       expect(rate_phase).to belong_to(:subscription_rate_card).optional
+      expect(rate_phase).to belong_to(:rate_override).optional
     end
   end
 
   describe "validations" do
     it { is_expected.to validate_numericality_of(:billing_interval_cycle_count).is_greater_than(0).allow_nil }
+
+    it "rejects two kept phases sharing the same rate_override" do
+      override = create(:rate_override)
+      phase = create(:rate_phase, organization: override.organization, rate_override: override)
+      duplicate = build(
+        :rate_phase,
+        organization: override.organization,
+        plan_rate_card: phase.plan_rate_card,
+        position: 2,
+        code: "other",
+        rate_override: override
+      )
+      duplicate.valid?
+
+      expect(duplicate.errors.where(:rate_override_id, :taken)).to be_present
+    end
 
     it { is_expected.to validate_presence_of(:position) }
     it { is_expected.to validate_numericality_of(:position).is_greater_than(0) }

--- a/spec/models/rate_phase_spec.rb
+++ b/spec/models/rate_phase_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RatePhase do
+  subject(:rate_phase) { build(:rate_phase) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(rate_phase).to belong_to(:organization)
+      expect(rate_phase).to belong_to(:plan_rate_card).optional
+      expect(rate_phase).to belong_to(:subscription_rate_card).optional
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_numericality_of(:billing_interval_cycle_count).is_greater_than(0).allow_nil }
+
+    it { is_expected.to validate_presence_of(:position) }
+    it { is_expected.to validate_numericality_of(:position).is_greater_than(0) }
+
+    describe "code" do
+      it { is_expected.to validate_presence_of(:code) }
+
+      it "rejects a duplicate code on the same parent" do
+        phase = create(:rate_phase, code: "launch")
+        duplicate = build(
+          :rate_phase,
+          plan_rate_card: phase.plan_rate_card,
+          organization: phase.organization,
+          position: 2,
+          code: "launch"
+        )
+        duplicate.valid?
+
+        expect(duplicate.errors.where(:code, :taken)).to be_present
+      end
+    end
+
+    describe "exactly one parent" do
+      it "is valid with only a plan_rate_card" do
+        expect(build(:rate_phase)).to be_valid
+      end
+
+      it "is valid with only a subscription_rate_card" do
+        expect(build(:rate_phase, :subscription_level)).to be_valid
+      end
+
+      it "is invalid with neither parent" do
+        phase = build(:rate_phase, plan_rate_card: nil, subscription_rate_card: nil)
+        phase.valid?
+        expect(phase.errors.added?(:base, :exactly_one_parent_required)).to be(true)
+      end
+
+      it "is invalid with both parents" do
+        phase = build(
+          :rate_phase,
+          plan_rate_card: create(:plan_rate_card),
+          subscription_rate_card: create(:subscription_rate_card)
+        )
+        phase.valid?
+        expect(phase.errors.added?(:base, :exactly_one_parent_required)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/subscription_rate_card_spec.rb
+++ b/spec/models/subscription_rate_card_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe SubscriptionRateCard do
       expect(subscription_rate_card).to belong_to(:organization)
       expect(subscription_rate_card).to belong_to(:subscription)
       expect(subscription_rate_card).to belong_to(:rate_card)
+      expect(subscription_rate_card).to have_many(:rate_phases).order(:position)
       expect(subscription_rate_card).to have_one(:product).through(:rate_card)
     end
   end

--- a/spec/models/subscription_rate_card_spec.rb
+++ b/spec/models/subscription_rate_card_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubscriptionRateCard do
+  subject(:subscription_rate_card) { build(:subscription_rate_card) }
+
+  it_behaves_like "paper_trail traceable"
+
+  describe "associations" do
+    it do
+      expect(subscription_rate_card).to belong_to(:organization)
+      expect(subscription_rate_card).to belong_to(:subscription)
+      expect(subscription_rate_card).to belong_to(:rate_card)
+      expect(subscription_rate_card).to have_one(:product).through(:rate_card)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:billing_anchor_date) }
+    it { is_expected.to validate_presence_of(:next_billing_at) }
+    it { is_expected.to validate_presence_of(:started_at) }
+
+    describe "active uniqueness per (subscription, rate_card)" do
+      it "rejects a second active row for the same subscription and rate card" do
+        existing = create(:subscription_rate_card)
+        duplicate = build(
+          :subscription_rate_card,
+          organization: existing.organization,
+          subscription: existing.subscription,
+          rate_card: existing.rate_card
+        )
+        duplicate.valid?
+        expect(duplicate.errors.where(:rate_card_id, :taken)).to be_present
+      end
+
+      it "allows a new row once the previous one has ended" do
+        existing = create(:subscription_rate_card, started_at: 2.days.ago, ended_at: 1.day.ago)
+        replacement = build(
+          :subscription_rate_card,
+          organization: existing.organization,
+          subscription: existing.subscription,
+          rate_card: existing.rate_card
+        )
+        replacement.valid?
+        expect(replacement.errors.where(:rate_card_id, :taken)).not_to be_present
+      end
+    end
+
+    describe "started_at before ended_at" do
+      it "is valid when ended_at is after started_at" do
+        item = build(:subscription_rate_card, started_at: 2.days.ago, ended_at: 1.day.ago)
+        expect(item).to be_valid
+      end
+
+      it "is invalid when ended_at is before started_at" do
+        item = build(:subscription_rate_card, started_at: 1.day.ago, ended_at: 2.days.ago)
+        item.valid?
+        expect(item.errors.added?(:ended_at, :must_be_after_started_at)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -37,6 +37,26 @@ RSpec.describe Subscription do
     end
   end
 
+  describe "#effective_billing_anchor_date" do
+    it "returns the explicit anchor when set" do
+      subscription = build(:subscription, billing_anchor_date: Date.new(2026, 1, 1), started_at: Time.zone.parse("2026-01-15"))
+
+      expect(subscription.effective_billing_anchor_date).to eq(Date.new(2026, 1, 1))
+    end
+
+    it "falls back to the start date" do
+      subscription = build(:subscription, billing_anchor_date: nil, started_at: Time.zone.parse("2026-01-15"))
+
+      expect(subscription.effective_billing_anchor_date).to eq(Date.new(2026, 1, 15))
+    end
+
+    it "falls back to subscription_at when the subscription has not started" do
+      subscription = build(:subscription, billing_anchor_date: nil, started_at: nil, subscription_at: Time.zone.parse("2026-02-03"))
+
+      expect(subscription.effective_billing_anchor_date).to eq(Date.new(2026, 2, 3))
+    end
+  end
+
   describe "associations" do
     it do
       expect(subject).to belong_to(:customer)


### PR DESCRIPTION
**Stack:** #5652 → #5690 → #5691 → #5707 → #5774 → #5775 → #5823 → #5820 → #5776 → #5779 → #5842 → #5871 → #5836 — **1/13**, merges into `main`.

## Context

Foundational data model for the product catalog (billing v2). It replaces the tight coupling between plans and charges with a composable layer: products are priced by rate cards, attached to plans and subscriptions, and sequenced by rate phases.

Vocabulary: `ProductCategory` (optional grouping) → `Product` (the billable unit) → `ProductFilter` (a slice of a product) → `RateCard` (prices one product or one slice) → `Rate` (effective-dated price on a card)

## Description

- Add `product_categories` — an optional grouping. It has no pricing role; a product can exist without one.
- Add `products` (`usage` | `fixed`) with type-specific validation: usage requires a billable metric, fixed forbids one. `add_on_id`/`charge_id` are nullable migration bridges. Code is unique per organization.
- Add `product_filters` + `product_filter_values`: a filter is a named combination of billable-metric-filter key/values. Values combine with AND across keys and OR within a key; a NULL value matches any value of the key (key-only selection).
- Add `rate_cards`, carrying the billing-semantic fields (currency, billing timing, proration, paid-fee regrouping, pricing unit), scoped either to a whole product or to one of its filter slices.
- Add `rate_card_rates`: effective-dated rates on an append-only timeline. Status (pending/active/terminated) is derived from `effective_datetime`, never stored. Each rate carries a mandatory caller-provided `code`, unique per card.
- Add `plan_rate_cards` — the plan-side attachment, binding a rate card to a plan with a default `units`, one per plan/card pair.
- Add `subscription_rate_cards` — the runtime rows the billing engine scans, with `billing_anchor_date`, `next_billing_at` and a `started_at`/`ended_at` validity window. Rows are versioned: at most one live row per subscription/card pair.
- Add `rate_phases`: the sequencing layer under a plan or subscription attachment (exactly one parent, enforced by check constraint), addressed by a mandatory `code` unique per parent and ordered by `position`.
- Add `rate_overrides`: per-phase price replacements, reusing the rate enums. An override belongs to exactly one phase.
- Add optional `rate_card_rate_id` / `rate_override_id` references and a `product` fee type to `fees`. Both FKs are added `NOT VALID` and validated in follow-up migrations.

Includes models, migrations, factories and model specs for every new entity.
