### PR TITLE
fix(void PB): credits fix for voiding PB invoices

### DIFF
--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -102,7 +102,7 @@ module Invoices
         description: "Credit note created due to voided invoice #{invoice.id}",
         credit_amount_cents: credit_amount,
         refund_amount_cents: refund_amount,
-        items: credit_note_items_matching_total_amount(invoice:, total_amount_cents: requested_credit_note_total_amount_cents)
+        items: credit_note_items_matching_requested_amount(invoice:, requested_amount_cents: requested_credit_note_total_amount_cents)
       )
     end
 
@@ -132,12 +132,12 @@ module Invoices
       end
     end
 
-    def credit_note_items_matching_total_amount(invoice:, total_amount_cents:)
+    def credit_note_items_matching_requested_amount(invoice:, requested_amount_cents:)
       base_items = remaining_credit_note_items(invoice:)
-      base_total = estimated_credit_note_total_amount_cents(invoice:, items: base_items).to_f
+      base_total = estimate_credit_note(invoice:, items: base_items).total_amount_cents.to_f
       return [] if base_total.zero?
 
-      ratio = total_amount_cents.to_f / base_total
+      ratio = requested_amount_cents.to_f / base_total
 
       base_items.map do |item|
         {
@@ -145,10 +145,6 @@ module Invoices
           amount_cents: (item[:amount_cents] * ratio)
         }
       end
-    end
-
-    def estimated_credit_note_total_amount_cents(invoice:, items:)
-      estimate_credit_note(invoice:, items:).total_amount_cents
     end
 
     def estimate_credit_note(invoice:, items:)

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -85,41 +85,43 @@ module Invoices
     end
 
     def create_credit_notes!
-      total_amount = credit_amount + refund_amount
+      requested_credit_note_result = create_requested_credit_note! if requested_credit_note_total_amount_cents.positive?
+      create_voided_credit_note_for_remaining_amount! if invoice.reload.creditable_amount_cents.round.positive?
 
-      unless total_amount.zero?
-        estimate_result = estimate_credit_note_for_target_credit(invoice: invoice, target_credit_cents: total_amount)
-
-        result = CreditNotes::CreateService.call!(
-          invoice: invoice,
-          reason: :other,
-          description: "Credit note created due to voided invoice #{invoice.id}",
-          credit_amount_cents: credit_amount,
-          refund_amount_cents: refund_amount,
-          items: estimate_result
-        )
-      end
-
-      remaining_amount = invoice.reload.creditable_amount_cents.round
-      if remaining_amount.positive?
-        estimate_result = estimate_credit_note_for_remaining_credit(invoice:)
-        estimate_result = CreditNotes::EstimateService.call!(invoice: invoice, items: estimate_result)
-
-        credit_note_to_void = CreditNotes::CreateService.call!(
-          invoice: invoice,
-          reason: :other,
-          description: "Credit note created due to voided invoice #{invoice.id}",
-          credit_amount_cents: estimate_result.credit_note.credit_amount_cents,
-          items: estimate_result.credit_note.items.map { |item| {fee_id: item.fee_id, amount_cents: item.amount_cents} }
-        )
-
-        CreditNotes::VoidService.call!(credit_note: credit_note_to_void.credit_note)
-      end
-
-      result
+      requested_credit_note_result
     end
 
-    def estimate_credit_note_for_remaining_credit(invoice:)
+    def requested_credit_note_total_amount_cents
+      credit_amount + refund_amount
+    end
+
+    def create_requested_credit_note!
+      CreditNotes::CreateService.call!(
+        invoice:,
+        reason: :other,
+        description: "Credit note created due to voided invoice #{invoice.id}",
+        credit_amount_cents: credit_amount,
+        refund_amount_cents: refund_amount,
+        items: credit_note_items_matching_total_amount(invoice:, total_amount_cents: requested_credit_note_total_amount_cents)
+      )
+    end
+
+    def create_voided_credit_note_for_remaining_amount!
+      remaining_items = remaining_credit_note_items(invoice:)
+      estimated_credit_note = estimate_credit_note(invoice:, items: remaining_items)
+
+      credit_note_to_void = CreditNotes::CreateService.call!(
+        invoice:,
+        reason: :other,
+        description: "Credit note created due to voided invoice #{invoice.id}",
+        credit_amount_cents: estimated_credit_note.credit_amount_cents,
+        items: credit_note_items_attributes(estimated_credit_note)
+      )
+
+      CreditNotes::VoidService.call!(credit_note: credit_note_to_void.credit_note)
+    end
+
+    def remaining_credit_note_items(invoice:)
       invoice.fees.filter_map do |fee|
         next unless fee.creditable_amount_cents.positive?
 
@@ -130,12 +132,12 @@ module Invoices
       end
     end
 
-    def estimate_credit_note_for_target_credit(invoice:, target_credit_cents:)
-      base_items = estimate_credit_note_for_remaining_credit(invoice:)
-      base_total = credit_note_total_for_items(invoice:, items: base_items).to_f
+    def credit_note_items_matching_total_amount(invoice:, total_amount_cents:)
+      base_items = remaining_credit_note_items(invoice:)
+      base_total = estimated_credit_note_total_amount_cents(invoice:, items: base_items).to_f
       return [] if base_total.zero?
 
-      ratio = target_credit_cents.to_f / base_total
+      ratio = total_amount_cents.to_f / base_total
 
       base_items.map do |item|
         {
@@ -145,17 +147,21 @@ module Invoices
       end
     end
 
-    def credit_note_total_for_items(invoice:, items:)
-      taxes_result = CreditNotes::ApplyTaxesService.call(
-        invoice:,
-        items: items.map do |item|
-          CreditNoteItem.new(fee_id: item[:fee_id], precise_amount_cents: item[:amount_cents])
-        end
-      )
+    def estimated_credit_note_total_amount_cents(invoice:, items:)
+      estimate_credit_note(invoice:, items:).total_amount_cents
+    end
 
-      items.sum { |item| item[:amount_cents] } -
-        taxes_result.coupons_adjustment_amount_cents +
-        taxes_result.precise_taxes_amount_cents
+    def estimate_credit_note(invoice:, items:)
+      CreditNotes::EstimateService.call!(invoice:, items:).credit_note
+    end
+
+    def credit_note_items_attributes(credit_note)
+      credit_note.items.map do |item|
+        {
+          fee_id: item.fee_id,
+          amount_cents: item.amount_cents
+        }
+      end
     end
   end
 end

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -102,7 +102,7 @@ module Invoices
 
       remaining_amount = invoice.reload.creditable_amount_cents.round
       if remaining_amount.positive?
-        estimate_result = estimate_credit_note_for_target_credit(invoice: invoice, target_credit_cents: remaining_amount)
+        estimate_result = estimate_credit_note_for_remaining_credit(invoice:)
         estimate_result = CreditNotes::EstimateService.call!(invoice: invoice, items: estimate_result)
 
         credit_note_to_void = CreditNotes::CreateService.call!(
@@ -119,16 +119,43 @@ module Invoices
       result
     end
 
-    def estimate_credit_note_for_target_credit(invoice:, target_credit_cents:)
-      base_total = invoice.sub_total_including_taxes_amount_cents.to_f
-      ratio = target_credit_cents.to_f / base_total
+    def estimate_credit_note_for_remaining_credit(invoice:)
+      invoice.fees.filter_map do |fee|
+        next unless fee.creditable_amount_cents.positive?
 
-      invoice.fees.map do |fee|
         {
           fee_id: fee.id,
-          amount_cents: (fee.amount_cents * ratio)
+          amount_cents: fee.creditable_amount_cents
         }
       end
+    end
+
+    def estimate_credit_note_for_target_credit(invoice:, target_credit_cents:)
+      base_items = estimate_credit_note_for_remaining_credit(invoice:)
+      base_total = credit_note_total_for_items(invoice:, items: base_items).to_f
+      return [] if base_total.zero?
+
+      ratio = target_credit_cents.to_f / base_total
+
+      base_items.map do |item|
+        {
+          fee_id: item[:fee_id],
+          amount_cents: (item[:amount_cents] * ratio)
+        }
+      end
+    end
+
+    def credit_note_total_for_items(invoice:, items:)
+      taxes_result = CreditNotes::ApplyTaxesService.call(
+        invoice:,
+        items: items.map do |item|
+          CreditNoteItem.new(fee_id: item[:fee_id], precise_amount_cents: item[:amount_cents])
+        end
+      )
+
+      items.sum { |item| item[:amount_cents] } -
+        taxes_result.coupons_adjustment_amount_cents +
+        taxes_result.precise_taxes_amount_cents
     end
   end
 end

--- a/app/services/subscriptions/progressive_billed_amount.rb
+++ b/app/services/subscriptions/progressive_billed_amount.rb
@@ -59,7 +59,7 @@ module Subscriptions
 
       result.to_credit_amount = invoice.fees_amount_cents
       result.to_credit_amount -= invoice.coupons_amount_cents
-      result.to_credit_amount -= invoice.progressive_billing_credits.sum(:amount_cents)
+      result.to_credit_amount -= invoice.progressive_billing_credits.active.sum(:amount_cents)
       result.to_credit_amount -= invoice.credit_notes.where(credit_status: ["available", "consumed"]).sum(:credit_amount_cents)
 
       # if for some reason this goes below zero, it should be zero.

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -216,6 +216,58 @@ RSpec.describe Invoices::VoidService do
           expect(result.error.code).to eq("not_voidable")
         end
       end
+
+      context "when the invoice has progressive billing credits", :premium do
+        let(:params) { {generate_credit_note: true, credit_amount: 200} }
+        let(:organization) { create(:organization) }
+        let(:customer) { create(:customer, organization:) }
+        let(:plan) { create(:plan, organization:) }
+        let(:subscription) { create(:subscription, customer:, organization:, plan:) }
+        let(:invoice) do
+          create(
+            :invoice,
+            customer:,
+            organization:,
+            invoice_type: :subscription,
+            status: :finalized,
+            payment_status: :pending,
+            fees_amount_cents: 400,
+            progressive_billing_credit_amount_cents: 200,
+            sub_total_excluding_taxes_amount_cents: 200,
+            sub_total_including_taxes_amount_cents: 200,
+            total_amount_cents: 200
+          )
+        end
+        let(:charge) { create(:standard_charge, plan:) }
+        let!(:invoice_subscription) do
+          create(:invoice_subscription, invoice:, subscription:, organization:)
+        end
+        let!(:fee) do
+          create(
+            :charge_fee,
+            invoice:,
+            subscription:,
+            charge:,
+            amount_cents: 400,
+            precise_amount_cents: 400,
+            precise_coupons_amount_cents: 0,
+            taxes_amount_cents: 0,
+            taxes_precise_amount_cents: 0
+          )
+        end
+
+        it "creates the requested credit note from the net remaining amount" do
+          result = void_service.call
+
+          expect(result).to be_success
+          expect(result.invoice).to be_voided
+
+          credit_note = invoice.credit_notes.find_by!(credit_status: :available)
+          expect(credit_note.total_amount_cents).to eq(200)
+          expect(credit_note.credit_amount_cents).to eq(200)
+          expect(credit_note.items.sole.amount_cents).to eq(200)
+        end
+      end
     end
 
     describe "guard against concurrent calls" do

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -239,10 +239,10 @@ RSpec.describe Invoices::VoidService do
           )
         end
         let(:charge) { create(:standard_charge, plan:) }
-        let!(:invoice_subscription) do
+        let(:invoice_subscription) do
           create(:invoice_subscription, invoice:, subscription:, organization:)
         end
-        let!(:fee) do
+        let(:fee) do
           create(
             :charge_fee,
             invoice:,
@@ -254,6 +254,11 @@ RSpec.describe Invoices::VoidService do
             taxes_amount_cents: 0,
             taxes_precise_amount_cents: 0
           )
+        end
+
+        before do
+          invoice_subscription
+          fee
         end
 
         it "creates the requested credit note from the net remaining amount" do

--- a/spec/services/subscriptions/progressive_billed_amount_spec.rb
+++ b/spec/services/subscriptions/progressive_billed_amount_spec.rb
@@ -276,6 +276,20 @@ RSpec.describe Subscriptions::ProgressiveBilledAmount do
         expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription)
       end
     end
+
+    context "when the invoice using the progressive billing credit is voided" do
+      let(:amount_to_credit) { 20 }
+
+      before { invoice.update!(status: :voided) }
+
+      it "does not subtract the voided invoice credit" do
+        result = service.call
+        expect(result.progressive_billed_amount).to eq(20)
+        expect(result.progressive_billing_invoice).to eq(progressive_billing_invoice)
+        expect(result.to_credit_amount).to eq(20)
+        expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription)
+      end
+    end
   end
 
   context "with progressive billing invoice that has 100% coupon discount" do


### PR DESCRIPTION
## Context

When voiding a PB invoice, 2 wrong behaviours were spotted:
1) 2 credit notes were issued with weird amounts
2) progressive billing credits, applied on the current invoice, were not "recredited" back

## Description

- Refactored void service
- when calculating applicable credit amount only deduct credits, applied on not voided invoices
