### PR TITLE
perf(serializers): fix N+1 on charge_filters in PlanSerializer

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -24,7 +24,6 @@ module Api
           plan = Plan.includes(
             :usage_thresholds,
             :fixed_charges,
-            charges: {filters: {values: :billable_metric_filter}},
             entitlements: [:feature, values: :privilege]
           ).find(result.plan.id)
 
@@ -42,7 +41,6 @@ module Api
           # Reload to eager-load relationships, like :entitlements
           plan = Plan.with_discarded.includes(
             :usage_thresholds,
-            charges: {filters: {values: :billable_metric_filter}},
             entitlements: [:feature, values: :privilege]
           ).find(result.plan.id)
 
@@ -56,7 +54,6 @@ module Api
         plan = current_organization.plans.parents
           .includes(
             :usage_thresholds,
-            charges: {filters: {values: :billable_metric_filter}},
             entitlements: [:feature, values: :privilege]
           )
           .find_by(code: params[:code])
@@ -85,7 +82,6 @@ module Api
                 :usage_thresholds,
                 :taxes,
                 :minimum_commitment,
-                charges: {filters: {values: :billable_metric_filter}},
                 entitlements: [:feature, values: :privilege]
               ),
               ::V1::PlanSerializer,

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -39,8 +39,14 @@ module V1
     end
 
     def charge_filters
+      filters = if model.filters.loaded?
+        model.filters
+      else
+        model.filters.includes(:charge, values: :billable_metric_filter)
+      end
+
       ::CollectionSerializer.new(
-        model.filters.includes(:charge, values: :billable_metric_filter),
+        filters,
         ::V1::ChargeFilterSerializer,
         collection_name: "filters"
       ).serialize

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -40,7 +40,7 @@ module V1
 
     def charges
       ::CollectionSerializer.new(
-        model.charges.includes(:applied_pricing_unit, :billable_metric, :taxes),
+        model.charges.includes(:applied_pricing_unit, :billable_metric, :taxes, filters: [:charge, {values: :billable_metric_filter}]),
         ::V1::ChargeSerializer,
         collection_name: "charges",
         includes: include?(:taxes) ? %i[taxes] : []


### PR DESCRIPTION
## Context

Any endpoint that serializes a plan with its charges was triggering one
SQL query per charge to load charge_filters. Two confirmed occurrences:

- SendWebhookJob (subscription.started webhooks) - Fixes API-21Y
- Api::V1::SubscriptionsController#create - Fixes API-EU-HH
- Api::V1::PlansController - Fixes API-EU-HR

Both trace back to ChargeSerializer calling model.filters.includes(...)
unconditionally, which bypasses ActiveRecord preloading and issues a
separate SELECT on charge_filters for each charge in the plan.

## Description

Preload filters and their nested associations (charge, values,
billable_metric_filter) at the PlanSerializer level so all filter data
is fetched in batch queries regardless of how many charges the plan has.
In ChargeSerializer, skip the includes call when the association is
already loaded, falling back to eager loading only for standalone charge
serialization (single-charge show/create/update responses).