### PR TITLE
perf(billable_metrics): Force index scan for billable_metric.plans existence check

### DIFF
--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -25,7 +25,7 @@ module Types
 
       field :has_active_subscriptions, Boolean, null: false
       field :has_draft_invoices, Boolean, null: false
-      field :has_plans, Boolean, null: false
+      field :has_plans, Boolean, null: false, method: :attached_to_plan?
       field :has_subscriptions, Boolean, null: false
 
       field :rounding_function, Types::BillableMetrics::RoundingFunctionEnum, null: true
@@ -51,10 +51,6 @@ module Types
 
       def has_draft_invoices
         object.invoices.draft.exists?
-      end
-
-      def has_plans
-        object.plans.exists?
       end
 
       def integration_mappings(integration_id: nil)

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -88,6 +88,14 @@ class BillableMetric < ApplicationRecord
     AGGREGATION_TYPES_PAYABLE_IN_ADVANCE.include?(aggregation_type.to_sym)
   end
 
+  # NOTE: Replaces billable_metric.plans.exists?
+  #       to force planner to use Index Scan (index_charges_on_billable_metric_id) instead of Seq Scan on charges
+  def attached_to_plan?
+    charges
+      .where("EXISTS (SELECT 1 FROM plans WHERE plans.id = charges.plan_id AND plans.deleted_at IS NULL)")
+      .exists?
+  end
+
   private
 
   def should_have_field_name?

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -37,7 +37,7 @@ module BillableMetrics
 
       # NOTE: Only name and description are editable if billable metric
       #       is attached to a plan
-      unless billable_metric.plans.exists?
+      unless billable_metric.attached_to_plan?
         billable_metric.code = params[:code] if params.key?(:code)
         billable_metric.aggregation_type = params[:aggregation_type]&.to_sym if params.key?(:aggregation_type)
         billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)


### PR DESCRIPTION
## Context
`billable_metric.plans.exists?` generates a has_many :through query that omits `charges.deleted_at IS NULL`. Because the only index on `charges.billable_metric_id` is partial (WHERE deleted_at IS NULL), it's ineligible for this query and executes a Seq Scan on the charges table. 
When a billable metric has no plans, it results in a full table scan and poor performance (up to 29s just for this check).

## Description

### EXPLAIN ANALYZE
<details>
<summary>Original query</summary>

```
Limit  (cost=0.42..196.04 rows=1 width=4) (actual time=45.409..45.411 rows=0 loops=1)
    Buffers: shared hit=5847 read=5770
    ->  Nested Loop  (cost=0.42..19561.93 rows=100 width=4) (actual time=45.407..45.408 rows=0 loops=1)
          Buffers: shared hit=5847 read=5770
          ->  Seq Scan on charges  (cost=0.00..19117.67 rows=100 width=16) (actual time=45.406..45.407 rows=0 loops=1)
                Filter: (billable_metric_id = 'e52881bf-1a46-4c01-8732-d00374780f80'::uuid)
                Rows Removed by Filter: 600054
                Buffers: shared hit=5847 read=5770
          ->  Index Only Scan using plans_pkey on plans  (cost=0.42..4.44 rows=1 width=16) (never executed)
                Index Cond: (id = charges.plan_id)
                Heap Fetches: 0
  Planning:
    Buffers: shared hit=152 read=12
  Planning Time: 2.755 ms
  Execution Time: 45.448 ms
```
</details>


<details>
<summary>Improved query</summary>

```
Limit  (cost=0.85..13.31 rows=1 width=4) (actual time=0.008..0.008 rows=0 loops=1)
    Buffers: shared hit=3
    ->  Nested Loop  (cost=0.85..1246.42 rows=100 width=4) (actual time=0.007..0.007 rows=0 loops=1)
          Buffers: shared hit=3
          ->  Index Scan using index_charges_on_billable_metric_id on charges  (cost=0.42..406.17 rows=100 width=16) (actual time=0.007..0.007 rows=0 loops=1)
                Index Cond: (billable_metric_id = 'e52881bf-1a46-4c01-8732-d00374780f80'::uuid)
                Buffers: shared hit=3
          ->  Index Scan using plans_pkey on plans  (cost=0.42..8.40 rows=1 width=16) (never executed)
                Index Cond: (id = charges.plan_id)
                Filter: (deleted_at IS NULL)
  Planning:
    Buffers: shared hit=19
  Planning Time: 0.177 ms
  Execution Time: 0.023 ms
```
</details>