### PR TITLE
feat(quotes): compute and persist quote mention variables

### DIFF
--- a/app/graphql/types/quote_versions/object.rb
+++ b/app/graphql/types/quote_versions/object.rb
@@ -26,15 +26,22 @@ module Types
 
       dataload_association :organization, :quote
 
-      # Computed live while the version is editable; the frozen snapshot persisted at approval
-      # time is returned once present.
+      # The persisted snapshot is a raw, locale-independent dict (or computed live while the
+      # version is editable). It is localized on every read with the customer's current
+      # locale, so an approved quote re-renders in the customer's current language.
       #
       # Intended for single-record fetches: live computation walks quote -> customer ->
-      # billing_entity, which are not dataloaded beyond :quote. Requesting mention_variables across
-      # a `versions` collection would N+1; dataload that chain here if such an access pattern emerges.
+      # billing_entity, which are not dataloaded beyond :quote. Requesting mention_variables
+      # across a `versions` collection would N+1; dataload that chain here if such an access
+      # pattern emerges.
       def mention_variables
-        object.mention_variables.presence ||
+        raw = object.mention_variables.presence ||
           ::QuoteVersions::ComputeMentionVariablesService.call(quote_version: object).mention_variables
+
+        ::QuoteVersions::MentionVariablesLocalizer.call(
+          mention_variables: raw,
+          locale: object.quote.customer.preferred_document_locale
+        )
       end
     end
   end

--- a/app/graphql/types/quote_versions/object.rb
+++ b/app/graphql/types/quote_versions/object.rb
@@ -12,6 +12,7 @@ module Types
       field :currency, String, null: true
       field :end_date, GraphQL::Types::ISO8601Date, null: true
       field :id, ID, null: false
+      field :mention_variables, GraphQL::Types::JSON, null: false
       field :organization, Types::Organizations::OrganizationType, null: false
       field :quote, Types::Quotes::Object, null: false
       field :share_token, String, null: true
@@ -24,6 +25,13 @@ module Types
       # TODO: field :order_form, Types::OrderForms::Object, null: true
 
       dataload_association :organization, :quote
+
+      # Computed live while the version is editable; the frozen snapshot persisted at approval
+      # time is returned once present.
+      def mention_variables
+        object.mention_variables.presence ||
+          ::QuoteVersions::ComputeMentionVariablesService.call(quote_version: object).mention_variables
+      end
     end
   end
 end

--- a/app/graphql/types/quote_versions/object.rb
+++ b/app/graphql/types/quote_versions/object.rb
@@ -28,6 +28,10 @@ module Types
 
       # Computed live while the version is editable; the frozen snapshot persisted at approval
       # time is returned once present.
+      #
+      # Intended for single-record fetches: live computation walks quote -> customer ->
+      # billing_entity, which are not dataloaded beyond :quote. Requesting mention_variables across
+      # a `versions` collection would N+1; dataload that chain here if such an access pattern emerges.
       def mention_variables
         object.mention_variables.presence ||
           ::QuoteVersions::ComputeMentionVariablesService.call(quote_version: object).mention_variables

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -65,22 +65,23 @@ end
 # Table name: quote_versions
 # Database name: primary
 #
-#  id              :uuid             not null, primary key
-#  approved_at     :datetime
-#  billing_items   :jsonb
-#  content         :text
-#  currency        :string
-#  end_date        :date
-#  share_token     :string
-#  start_date      :date
-#  status          :enum             default("draft"), not null
-#  void_reason     :enum
-#  voided_at       :datetime
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organization_id :uuid             not null
-#  quote_id        :uuid             not null
-#  sequential_id   :integer          not null
+#  id                :uuid             not null, primary key
+#  approved_at       :datetime
+#  billing_items     :jsonb
+#  content           :text
+#  currency          :string
+#  end_date          :date
+#  mention_variables :jsonb
+#  share_token       :string
+#  start_date        :date
+#  status            :enum             default("draft"), not null
+#  void_reason       :enum
+#  voided_at         :datetime
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  organization_id   :uuid             not null
+#  quote_id          :uuid             not null
+#  sequential_id     :integer          not null
 #
 # Indexes
 #

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -22,7 +22,7 @@ module QuoteVersions
         quote_version.update!(
           status: :approved,
           approved_at: Time.current,
-          mention_variables: ComputeMentionVariablesService.call(quote_version:).mention_variables
+          mention_variables: ComputeMentionVariablesService.call!(quote_version:).mention_variables
         )
 
         result.order_form = OrderForms::CreateService.call!(quote_version:).order_form

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -21,7 +21,8 @@ module QuoteVersions
       QuoteVersion.transaction do
         quote_version.update!(
           status: :approved,
-          approved_at: Time.current
+          approved_at: Time.current,
+          mention_variables: ComputeMentionVariablesService.call(quote_version:).mention_variables
         )
 
         result.order_form = OrderForms::CreateService.call!(quote_version:).order_form

--- a/app/services/quote_versions/compute_mention_variables_service.rb
+++ b/app/services/quote_versions/compute_mention_variables_service.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  class ComputeMentionVariablesService < BaseService
+    Result = BaseResult[:mention_variables]
+
+    def initialize(quote_version:)
+      @quote_version = quote_version
+      super
+    end
+
+    def call
+      I18n.with_locale(locale) do
+        result.mention_variables = {
+          "customer_name" => customer.name,
+          "customer_email" => customer.email,
+          "organization_name" => organization.name,
+          "organization_logo" => organization.logo_url,
+          "billing_entity_name" => billing_entity&.name,
+          "billing_entity_legal_name" => billing_entity&.legal_name,
+          "billing_entity_address" => billing_entity_address,
+          "billing_entity_tax_id" => billing_entity&.tax_identification_number,
+          "billing_entity_email" => billing_entity&.email,
+          "quote_number" => quote.number,
+          "quote_date" => format_date(quote.created_at),
+          "quote_version" => quote_version.version.to_s,
+          "quote_currency" => quote_version.currency,
+          "commercial_terms_term_duration" => term_duration,
+          "commercial_terms_start_date" => format_date(quote_version.start_date),
+          "commercial_terms_payment_terms" => payment_terms
+        }
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :quote_version
+
+    delegate :quote, to: :quote_version
+    delegate :customer, :organization, to: :quote
+    delegate :billing_entity, to: :customer
+
+    def locale
+      @locale ||= customer.preferred_document_locale
+    end
+
+    def billing_entity_address
+      return if billing_entity.nil?
+
+      address = Addressing::Address.new(
+        address_line1: billing_entity.address_line1.to_s,
+        address_line2: billing_entity.address_line2.to_s,
+        locality: billing_entity.city.to_s,
+        postal_code: billing_entity.zipcode.to_s,
+        administrative_area: billing_entity.state.to_s,
+        country_code: billing_entity.country.to_s,
+        locale: locale.to_s
+      )
+
+      Addressing::DefaultFormatter.new.format(address, locale: locale.to_s, html: false).presence
+    end
+
+    def payment_terms
+      term = customer.applicable_net_payment_term
+      return if term.blank?
+
+      I18n.t("quote_version.mention_variables.payment_terms", count: term)
+    end
+
+    # Picks the largest whole unit between the two dates (years, then months, then
+    # days). A 12-month span renders as "1 year".
+    def term_duration
+      start_date = quote_version.start_date
+      end_date = quote_version.end_date
+      return if start_date.blank? || end_date.blank?
+
+      months = whole_months_between(start_date, end_date)
+
+      if months < 1
+        translate_term_duration(:days, (end_date - start_date).to_i)
+      elsif (months % 12).zero?
+        translate_term_duration(:years, months / 12)
+      else
+        translate_term_duration(:months, months)
+      end
+    end
+
+    # Whole calendar months between two dates, rounding down a partial trailing month.
+    def whole_months_between(from, to)
+      months = (to.year * 12 + to.month) - (from.year * 12 + from.month)
+      (to.day < from.day) ? months - 1 : months
+    end
+
+    def translate_term_duration(unit, count)
+      I18n.t("quote_version.mention_variables.term_duration.#{unit}", count:)
+    end
+
+    # Datetimes are resolved in the customer timezone before extracting the date; the locale-aware
+    # format is defined under `date.formats.default` for each supported locale.
+    def format_date(value)
+      return if value.blank?
+
+      date = value.respond_to?(:in_time_zone) ? value.in_time_zone(customer.applicable_timezone).to_date : value
+      I18n.l(date, format: :default)
+    end
+  end
+end

--- a/app/services/quote_versions/compute_mention_variables_service.rb
+++ b/app/services/quote_versions/compute_mention_variables_service.rb
@@ -10,26 +10,24 @@ module QuoteVersions
     end
 
     def call
-      I18n.with_locale(locale) do
-        result.mention_variables = {
-          "customer_name" => customer.name,
-          "customer_email" => customer.email,
-          "organization_name" => organization.name,
-          "organization_logo" => organization.logo_url,
-          "billing_entity_name" => billing_entity&.name,
-          "billing_entity_legal_name" => billing_entity&.legal_name,
-          "billing_entity_address" => billing_entity_address,
-          "billing_entity_tax_id" => billing_entity&.tax_identification_number,
-          "billing_entity_email" => billing_entity&.email,
-          "quote_number" => quote.number,
-          "quote_date" => format_date(quote.created_at),
-          "quote_version" => quote_version.version.to_s,
-          "quote_currency" => quote_version.currency,
-          "commercial_terms_term_duration" => term_duration,
-          "commercial_terms_start_date" => format_date(quote_version.start_date),
-          "commercial_terms_payment_terms" => payment_terms
-        }
-      end
+      result.mention_variables = {
+        "customer_name" => customer.name,
+        "customer_email" => customer.email,
+        "organization_name" => organization.name,
+        "organization_logo" => organization.logo_url,
+        "billing_entity_name" => billing_entity&.name,
+        "billing_entity_legal_name" => billing_entity&.legal_name,
+        "billing_entity_address" => billing_entity_address,
+        "billing_entity_tax_id" => billing_entity&.tax_identification_number,
+        "billing_entity_email" => billing_entity&.email,
+        "quote_number" => quote.number,
+        "quote_date" => quote_date,
+        "quote_version" => quote_version.version.to_s,
+        "quote_currency" => quote_version.currency,
+        "commercial_terms_term_duration" => term_duration,
+        "commercial_terms_start_date" => quote_version.start_date&.iso8601,
+        "commercial_terms_payment_terms" => customer.applicable_net_payment_term
+      }
 
       result
     end
@@ -42,35 +40,29 @@ module QuoteVersions
     delegate :customer, :organization, to: :quote
     delegate :billing_entity, to: :customer
 
-    def locale
-      @locale ||= customer.preferred_document_locale
-    end
-
+    # Structured, locale-independent address parts. Formatting happens at read time in
+    # QuoteVersions::MentionVariablesLocalizer.
     def billing_entity_address
       return if billing_entity.nil?
 
-      address = Addressing::Address.new(
-        address_line1: billing_entity.address_line1.to_s,
-        address_line2: billing_entity.address_line2.to_s,
-        locality: billing_entity.city.to_s,
-        postal_code: billing_entity.zipcode.to_s,
-        administrative_area: billing_entity.state.to_s,
-        country_code: billing_entity.country.to_s,
-        locale: locale.to_s
-      )
-
-      Addressing::DefaultFormatter.new.format(address, locale: locale.to_s, html: false).presence
+      {
+        "address_line1" => billing_entity.address_line1,
+        "address_line2" => billing_entity.address_line2,
+        "locality" => billing_entity.city,
+        "postal_code" => billing_entity.zipcode,
+        "administrative_area" => billing_entity.state,
+        "country_code" => billing_entity.country
+      }
     end
 
-    def payment_terms
-      term = customer.applicable_net_payment_term
-      return if term.blank?
-
-      I18n.t("quote_version.mention_variables.payment_terms", count: term)
+    # The calendar date is frozen as a fact: the datetime is resolved in the customer
+    # timezone, then stored as an ISO date string. Locale formatting is applied at read time.
+    def quote_date
+      quote.created_at.in_time_zone(customer.applicable_timezone).to_date.iso8601
     end
 
-    # Picks the largest whole unit between the two dates (years, then months, then
-    # days). A 12-month span renders as "1 year".
+    # Picks the largest whole unit between the two dates (years, then months, then days)
+    # and returns a raw { "unit", "count" } pair. A 12-month span becomes 1 year.
     def term_duration
       start_date = quote_version.start_date
       end_date = quote_version.end_date
@@ -79,11 +71,11 @@ module QuoteVersions
       months = whole_months_between(start_date, end_date)
 
       if months < 1
-        translate_term_duration(:days, (end_date - start_date).to_i)
+        {"unit" => "days", "count" => (end_date - start_date).to_i}
       elsif (months % 12).zero?
-        translate_term_duration(:years, months / 12)
+        {"unit" => "years", "count" => months / 12}
       else
-        translate_term_duration(:months, months)
+        {"unit" => "months", "count" => months}
       end
     end
 
@@ -91,19 +83,6 @@ module QuoteVersions
     def whole_months_between(from, to)
       months = (to.year * 12 + to.month) - (from.year * 12 + from.month)
       (to.day < from.day) ? months - 1 : months
-    end
-
-    def translate_term_duration(unit, count)
-      I18n.t("quote_version.mention_variables.term_duration.#{unit}", count:)
-    end
-
-    # Datetimes are resolved in the customer timezone before extracting the date; the locale-aware
-    # format is defined under `date.formats.default` for each supported locale.
-    def format_date(value)
-      return if value.blank?
-
-      date = value.respond_to?(:in_time_zone) ? value.in_time_zone(customer.applicable_timezone).to_date : value
-      I18n.l(date, format: :default)
     end
   end
 end

--- a/app/services/quote_versions/mention_variables_localizer.rb
+++ b/app/services/quote_versions/mention_variables_localizer.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  # Renders a raw, locale-independent mention-variables snapshot into localized display
+  # strings. Pure transform: takes the raw dict plus a locale and returns a new dict.
+  # Not a service (no DB access, no failure modes), so it has no BaseResult. Only the
+  # locale-sensitive keys are transformed; every other key passes through unchanged, and
+  # missing keys or nil values are tolerated.
+  class MentionVariablesLocalizer
+    DATE_KEYS = %w[quote_date commercial_terms_start_date].freeze
+
+    def self.call(mention_variables:, locale:)
+      new(mention_variables:, locale:).call
+    end
+
+    def initialize(mention_variables:, locale:)
+      @mention_variables = mention_variables
+      @locale = locale
+    end
+
+    def call
+      I18n.with_locale(locale) do
+        mention_variables.to_h { |key, value| [key, localize(key, value)] }
+      end
+    end
+
+    private
+
+    attr_reader :mention_variables, :locale
+
+    def localize(key, value)
+      case key
+      when *DATE_KEYS then format_date(value)
+      when "commercial_terms_term_duration" then format_term_duration(value)
+      when "commercial_terms_payment_terms" then format_payment_terms(value)
+      when "billing_entity_address" then format_address(value)
+      else value
+      end
+    end
+
+    def format_date(value)
+      return if value.blank?
+
+      I18n.l(Date.iso8601(value), format: :default)
+    end
+
+    def format_term_duration(value)
+      return if value.blank?
+
+      I18n.t("quote_version.mention_variables.term_duration.#{value["unit"]}", count: value["count"])
+    end
+
+    def format_payment_terms(value)
+      return if value.blank?
+
+      I18n.t("quote_version.mention_variables.payment_terms", count: value)
+    end
+
+    def format_address(value)
+      return if value.blank?
+
+      address = Addressing::Address.new(
+        address_line1: value["address_line1"].to_s,
+        address_line2: value["address_line2"].to_s,
+        locality: value["locality"].to_s,
+        postal_code: value["postal_code"].to_s,
+        administrative_area: value["administrative_area"].to_s,
+        country_code: value["country_code"].to_s,
+        locale: locale.to_s
+      )
+
+      Addressing::DefaultFormatter.new.format(address, locale: locale.to_s, html: false).presence
+    end
+  end
+end

--- a/app/services/quote_versions/mention_variables_localizer.rb
+++ b/app/services/quote_versions/mention_variables_localizer.rb
@@ -30,10 +30,10 @@ module QuoteVersions
 
     def localize(key, value)
       case key
-      when *DATE_KEYS then format_date(value)
       when "commercial_terms_term_duration" then format_term_duration(value)
       when "commercial_terms_payment_terms" then format_payment_terms(value)
       when "billing_entity_address" then format_address(value)
+      when *DATE_KEYS then format_date(value)
       else value
       end
     end

--- a/config/locales/de/quote_version.yml
+++ b/config/locales/de/quote_version.yml
@@ -1,0 +1,15 @@
+---
+de:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days:
+          one: ein Tag
+          other: "%{count} Tage"
+        months:
+          one: ein Monat
+          other: "%{count} Monate"
+        years:
+          one: ein Jahr
+          other: "%{count} Jahre"

--- a/config/locales/en/quote_version.yml
+++ b/config/locales/en/quote_version.yml
@@ -1,0 +1,15 @@
+---
+en:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days:
+          one: 1 day
+          other: "%{count} days"
+        months:
+          one: 1 month
+          other: "%{count} months"
+        years:
+          one: 1 year
+          other: "%{count} years"

--- a/config/locales/es/quote_version.yml
+++ b/config/locales/es/quote_version.yml
@@ -1,0 +1,15 @@
+---
+es:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days:
+          one: un día
+          other: "%{count} días"
+        months:
+          one: un mes
+          other: "%{count} meses"
+        years:
+          one: un año
+          other: "%{count} años"

--- a/config/locales/fr/quote_version.yml
+++ b/config/locales/fr/quote_version.yml
@@ -1,0 +1,15 @@
+---
+fr:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days:
+          one: un jour
+          other: "%{count} jours"
+        months:
+          one: un mois
+          other: "%{count} mois"
+        years:
+          one: un an
+          other: "%{count} ans"

--- a/config/locales/it/quote_version.yml
+++ b/config/locales/it/quote_version.yml
@@ -1,0 +1,15 @@
+---
+it:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days:
+          one: un giorno
+          other: "%{count} giorni"
+        months:
+          one: un mese
+          other: "%{count} mesi"
+        years:
+          one: un anno
+          other: "%{count} anni"

--- a/config/locales/nb/quote_version.yml
+++ b/config/locales/nb/quote_version.yml
@@ -1,0 +1,15 @@
+---
+nb:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days:
+          one: én dag
+          other: "%{count} dager"
+        months:
+          one: én måned
+          other: "%{count} måneder"
+        years:
+          one: ett år
+          other: "%{count} år"

--- a/config/locales/pt-BR/quote_version.yml
+++ b/config/locales/pt-BR/quote_version.yml
@@ -1,0 +1,15 @@
+---
+pt-BR:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days:
+          one: um dia
+          other: "%{count} dias"
+        months:
+          one: um mês
+          other: "%{count} meses"
+        years:
+          one: um ano
+          other: "%{count} anos"

--- a/config/locales/sv/quote_version.yml
+++ b/config/locales/sv/quote_version.yml
@@ -1,0 +1,15 @@
+---
+sv:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days:
+          one: en dag
+          other: "%{count} dagar"
+        months:
+          one: en månad
+          other: "%{count} månader"
+        years:
+          one: ett år
+          other: "%{count} år"

--- a/config/locales/zh-TW/quote_version.yml
+++ b/config/locales/zh-TW/quote_version.yml
@@ -1,0 +1,9 @@
+---
+zh-TW:
+  quote_version:
+    mention_variables:
+      payment_terms: Net %{count}
+      term_duration:
+        days: "%{count}天"
+        months: "%{count}個月"
+        years: "%{count}年"

--- a/db/migrate/20260605170919_add_mention_variables_to_quote_versions.rb
+++ b/db/migrate/20260605170919_add_mention_variables_to_quote_versions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMentionVariablesToQuoteVersions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :quote_versions, :mention_variables, :jsonb
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5000,6 +5000,7 @@ CREATE TABLE public.quote_versions (
     currency character varying,
     start_date date,
     end_date date,
+    mention_variables jsonb,
     CONSTRAINT quote_versions_constraint_approved_at_matches_status CHECK (((status = 'approved'::public.quote_status) = (approved_at IS NOT NULL))),
     CONSTRAINT quote_versions_constraint_sequential_id_positive CHECK ((sequential_id > 0)),
     CONSTRAINT quote_versions_constraint_void_fields_match_status CHECK (((status = 'voided'::public.quote_status) = ((void_reason IS NOT NULL) AND (voided_at IS NOT NULL))))
@@ -12793,6 +12794,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260609161044'),
 ('20260608111837'),
 ('20260608074112'),
+('20260605170919'),
 ('20260604153307'),
 ('20260603121349'),
 ('20260602175438'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -11007,6 +11007,7 @@ type QuoteVersion {
   currency: String
   endDate: ISO8601Date
   id: ID!
+  mentionVariables: JSON!
   organization: Organization!
   quote: Quote!
   shareToken: String

--- a/schema.json
+++ b/schema.json
@@ -60190,6 +60190,22 @@
               "deprecationReason": null
             },
             {
+              "name": "mentionVariables",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization",
               "description": null,
               "args": [],

--- a/spec/graphql/types/quote_versions/object_spec.rb
+++ b/spec/graphql/types/quote_versions/object_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Types::QuoteVersions::Object do
     expect(subject).to have_field(:approved_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:billing_items).of_type("JSON")
     expect(subject).to have_field(:content).of_type("String")
+    expect(subject).to have_field(:mention_variables).of_type("JSON!")
     expect(subject).to have_field(:share_token).of_type("String")
     expect(subject).to have_field(:status).of_type("StatusEnum!")
     expect(subject).to have_field(:version).of_type("Int!")
@@ -22,5 +23,53 @@ RSpec.describe Types::QuoteVersions::Object do
     expect(subject).to have_field(:currency).of_type("String")
     expect(subject).to have_field(:start_date).of_type("ISO8601Date")
     expect(subject).to have_field(:end_date).of_type("ISO8601Date")
+  end
+
+  describe "#mention_variables" do
+    let(:required_permission) { "quotes:view" }
+    let(:membership) { create(:membership) }
+    let(:organization) { membership.organization }
+    let(:customer) { create(:customer, organization:, name: "Mistral AI") }
+    let(:quote) { create(:quote, organization:, customer:) }
+
+    let(:query) do
+      <<~GQL
+        query($quoteId: ID!) {
+          quote(id: $quoteId) {
+            currentVersion { mentionVariables }
+          }
+        }
+      GQL
+    end
+
+    def execute
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {quoteId: quote.id}
+      ).dig("data", "quote", "currentVersion", "mentionVariables")
+    end
+
+    context "when the version is a draft" do
+      before { create(:quote_version, quote:, organization:) }
+
+      it "computes the variables live" do
+        expect(execute).to include("customer_name" => "Mistral AI")
+      end
+    end
+
+    context "when the version is approved" do
+      before do
+        create(:quote_version, :approved, quote:, organization:, mention_variables: {"customer_name" => "Snapshot AI"})
+      end
+
+      it "returns the persisted snapshot, ignoring later changes" do
+        customer.update!(name: "Renamed AI")
+
+        expect(execute).to eq("customer_name" => "Snapshot AI")
+      end
+    end
   end
 end

--- a/spec/graphql/types/quote_versions/object_spec.rb
+++ b/spec/graphql/types/quote_versions/object_spec.rb
@@ -71,5 +71,35 @@ RSpec.describe Types::QuoteVersions::Object do
         expect(execute).to eq("customer_name" => "Snapshot AI")
       end
     end
+
+    context "when the approved snapshot holds locale-sensitive variables" do
+      let(:customer) { create(:customer, organization:, name: "Mistral AI", document_locale: "en") }
+
+      before do
+        create(
+          :quote_version,
+          :approved,
+          quote:,
+          organization:,
+          mention_variables: {"commercial_terms_payment_terms" => 30, "commercial_terms_start_date" => "2026-04-01"}
+        )
+      end
+
+      it "localizes the frozen snapshot in the customer's current locale" do
+        expect(execute).to eq(
+          "commercial_terms_payment_terms" => "Net 30",
+          "commercial_terms_start_date" => "Apr 01, 2026"
+        )
+      end
+
+      it "follows the customer's current locale" do
+        customer.update!(document_locale: "fr")
+
+        expect(execute).to eq(
+          "commercial_terms_payment_terms" => "Net 30",
+          "commercial_terms_start_date" => "1 avr. 2026"
+        )
+      end
+    end
   end
 end

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe QuoteVersions::ApproveService do
 
   let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
   let(:quote) { create(:quote, organization:) }
-  let(:quote_version) { create(:quote_version, quote:, organization:) }
+  let(:quote_version) do
+    create(:quote_version, quote:, organization:, start_date: Date.new(2026, 1, 1), end_date: Date.new(2027, 1, 1))
+  end
 
   describe ".call" do
     let(:result) { approve_service.call }
@@ -31,11 +33,13 @@ RSpec.describe QuoteVersions::ApproveService do
         )
       end
 
-      it "persists the computed mention variables snapshot" do
+      it "persists the raw computed mention variables snapshot" do
         expect(result).to be_success
         expect(result.quote_version.reload.mention_variables).to include(
           "customer_name" => quote.customer.name,
-          "quote_number" => quote.number
+          "quote_number" => quote.number,
+          "commercial_terms_start_date" => "2026-01-01",
+          "commercial_terms_term_duration" => {"unit" => "years", "count" => 1}
         )
       end
     end

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe QuoteVersions::ApproveService do
           status: "generated"
         )
       end
+
+      it "persists the computed mention variables snapshot" do
+        expect(result).to be_success
+        expect(result.quote_version.reload.mention_variables).to include(
+          "customer_name" => quote.customer.name,
+          "quote_number" => quote.number
+        )
+      end
     end
 
     context "when the quote version is voided", :premium do

--- a/spec/services/quote_versions/compute_mention_variables_service_spec.rb
+++ b/spec/services/quote_versions/compute_mention_variables_service_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::ComputeMentionVariablesService do
+  subject(:service) { described_class.new(quote_version:) }
+
+  let(:organization) { create(:organization, name: "Lago") }
+  let(:billing_entity) do
+    create(
+      :billing_entity,
+      organization:,
+      name: "Mistral AI SAS",
+      legal_name: "Mistral AI SAS",
+      tax_identification_number: "FR12345678901",
+      email: "billing@mistral.ai",
+      address_line1: "4 rue de la Paix",
+      address_line2: nil,
+      zipcode: "75002",
+      city: "Paris",
+      state: nil,
+      country: "FR",
+      net_payment_term: 30
+    )
+  end
+  let(:customer_net_payment_term) { nil }
+  let(:customer_document_locale) { nil }
+  let(:customer) do
+    create(
+      :customer,
+      organization:,
+      billing_entity:,
+      name: "Mistral AI",
+      email: "procurement@mistral.ai",
+      net_payment_term: customer_net_payment_term,
+      document_locale: customer_document_locale
+    )
+  end
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:start_date) { Date.new(2026, 4, 1) }
+  let(:end_date) { Date.new(2027, 4, 1) }
+  let(:quote_version) do
+    create(:quote_version, quote:, organization:, currency: "EUR", start_date:, end_date:)
+  end
+
+  describe ".call" do
+    let(:result) { service.call }
+    let(:variables) { result.mention_variables }
+
+    it "computes the full mention variables dictionary" do
+      expect(result).to be_success
+      expect(variables).to include(
+        "customer_name" => "Mistral AI",
+        "customer_email" => "procurement@mistral.ai",
+        "organization_name" => "Lago",
+        "organization_logo" => organization.logo_url,
+        "billing_entity_name" => "Mistral AI SAS",
+        "billing_entity_legal_name" => "Mistral AI SAS",
+        "billing_entity_address" => "4 rue de la Paix\n75002 Paris\nFrance",
+        "billing_entity_tax_id" => "FR12345678901",
+        "billing_entity_email" => "billing@mistral.ai",
+        "quote_number" => quote.number,
+        "quote_version" => quote_version.version.to_s,
+        "quote_currency" => "EUR",
+        "commercial_terms_term_duration" => "1 year",
+        "commercial_terms_start_date" => "Apr 01, 2026",
+        "commercial_terms_payment_terms" => "Net 30"
+      )
+      expect(variables["quote_date"]).to be_present
+    end
+
+    context "when the customer overrides the net payment term" do
+      let(:customer_net_payment_term) { 45 }
+
+      it "uses the customer's payment term" do
+        expect(variables["commercial_terms_payment_terms"]).to eq("Net 45")
+      end
+    end
+
+    context "when the customer document locale is French" do
+      let(:customer_document_locale) { "fr" }
+
+      it "localizes the dates, duration, payment terms and address" do
+        expect(variables).to include(
+          "commercial_terms_term_duration" => "un an",
+          "commercial_terms_start_date" => "1 avr. 2026",
+          "commercial_terms_payment_terms" => "Net 30",
+          "billing_entity_address" => "4 rue de la Paix\n75002 Paris\nFrance"
+        )
+      end
+    end
+
+    context "when the term spans whole months" do
+      let(:start_date) { Date.new(2026, 1, 1) }
+      let(:end_date) { Date.new(2026, 4, 1) }
+
+      it "renders the duration in months" do
+        expect(variables["commercial_terms_term_duration"]).to eq("3 months")
+      end
+    end
+
+    context "when the term spans less than a month" do
+      let(:start_date) { Date.new(2026, 1, 1) }
+      let(:end_date) { Date.new(2026, 1, 15) }
+
+      it "renders the duration in days" do
+        expect(variables["commercial_terms_term_duration"]).to eq("14 days")
+      end
+    end
+
+    context "when the end date is missing" do
+      let(:end_date) { nil }
+
+      it "leaves the term duration blank" do
+        expect(variables["commercial_terms_term_duration"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/compute_mention_variables_service_spec.rb
+++ b/spec/services/quote_versions/compute_mention_variables_service_spec.rb
@@ -115,5 +115,23 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
         expect(variables["commercial_terms_term_duration"]).to be_nil
       end
     end
+
+    context "when the term ends on a shorter month-end" do
+      let(:start_date) { Date.new(2026, 1, 31) }
+      let(:end_date) { Date.new(2026, 2, 28) }
+
+      it "rounds down to whole days rather than a month" do
+        expect(variables["commercial_terms_term_duration"]).to eq("28 days")
+      end
+    end
+
+    context "when the term spans more than a year but not a whole multiple" do
+      let(:start_date) { Date.new(2026, 1, 1) }
+      let(:end_date) { Date.new(2027, 2, 1) }
+
+      it "renders the total months rather than years plus months" do
+        expect(variables["commercial_terms_term_duration"]).to eq("13 months")
+      end
+    end
   end
 end

--- a/spec/services/quote_versions/compute_mention_variables_service_spec.rb
+++ b/spec/services/quote_versions/compute_mention_variables_service_spec.rb
@@ -43,11 +43,22 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
     create(:quote_version, quote:, organization:, currency: "EUR", start_date:, end_date:)
   end
 
+  let(:raw_address) do
+    {
+      "address_line1" => "4 rue de la Paix",
+      "address_line2" => nil,
+      "locality" => "Paris",
+      "postal_code" => "75002",
+      "administrative_area" => nil,
+      "country_code" => "FR"
+    }
+  end
+
   describe ".call" do
     let(:result) { service.call }
     let(:variables) { result.mention_variables }
 
-    it "computes the full mention variables dictionary" do
+    it "computes the raw, locale-independent mention variables dictionary" do
       expect(result).to be_success
       expect(variables).to include(
         "customer_name" => "Mistral AI",
@@ -56,36 +67,36 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
         "organization_logo" => organization.logo_url,
         "billing_entity_name" => "Mistral AI SAS",
         "billing_entity_legal_name" => "Mistral AI SAS",
-        "billing_entity_address" => "4 rue de la Paix\n75002 Paris\nFrance",
+        "billing_entity_address" => raw_address,
         "billing_entity_tax_id" => "FR12345678901",
         "billing_entity_email" => "billing@mistral.ai",
         "quote_number" => quote.number,
         "quote_version" => quote_version.version.to_s,
         "quote_currency" => "EUR",
-        "commercial_terms_term_duration" => "1 year",
-        "commercial_terms_start_date" => "Apr 01, 2026",
-        "commercial_terms_payment_terms" => "Net 30"
+        "commercial_terms_term_duration" => {"unit" => "years", "count" => 1},
+        "commercial_terms_start_date" => "2026-04-01",
+        "commercial_terms_payment_terms" => 30
       )
-      expect(variables["quote_date"]).to be_present
+      expect(variables["quote_date"]).to match(/\A\d{4}-\d{2}-\d{2}\z/)
     end
 
     context "when the customer overrides the net payment term" do
       let(:customer_net_payment_term) { 45 }
 
       it "uses the customer's payment term" do
-        expect(variables["commercial_terms_payment_terms"]).to eq("Net 45")
+        expect(variables["commercial_terms_payment_terms"]).to eq(45)
       end
     end
 
     context "when the customer document locale is French" do
       let(:customer_document_locale) { "fr" }
 
-      it "localizes the dates, duration, payment terms and address" do
+      it "still produces locale-independent raw values" do
         expect(variables).to include(
-          "commercial_terms_term_duration" => "un an",
-          "commercial_terms_start_date" => "1 avr. 2026",
-          "commercial_terms_payment_terms" => "Net 30",
-          "billing_entity_address" => "4 rue de la Paix\n75002 Paris\nFrance"
+          "commercial_terms_term_duration" => {"unit" => "years", "count" => 1},
+          "commercial_terms_start_date" => "2026-04-01",
+          "commercial_terms_payment_terms" => 30,
+          "billing_entity_address" => raw_address
         )
       end
     end
@@ -94,8 +105,8 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
       let(:start_date) { Date.new(2026, 1, 1) }
       let(:end_date) { Date.new(2026, 4, 1) }
 
-      it "renders the duration in months" do
-        expect(variables["commercial_terms_term_duration"]).to eq("3 months")
+      it "reports the duration in months" do
+        expect(variables["commercial_terms_term_duration"]).to eq({"unit" => "months", "count" => 3})
       end
     end
 
@@ -103,8 +114,8 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
       let(:start_date) { Date.new(2026, 1, 1) }
       let(:end_date) { Date.new(2026, 1, 15) }
 
-      it "renders the duration in days" do
-        expect(variables["commercial_terms_term_duration"]).to eq("14 days")
+      it "reports the duration in days" do
+        expect(variables["commercial_terms_term_duration"]).to eq({"unit" => "days", "count" => 14})
       end
     end
 
@@ -121,7 +132,7 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
       let(:end_date) { Date.new(2026, 2, 28) }
 
       it "rounds down to whole days rather than a month" do
-        expect(variables["commercial_terms_term_duration"]).to eq("28 days")
+        expect(variables["commercial_terms_term_duration"]).to eq({"unit" => "days", "count" => 28})
       end
     end
 
@@ -129,8 +140,8 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
       let(:start_date) { Date.new(2026, 1, 1) }
       let(:end_date) { Date.new(2027, 2, 1) }
 
-      it "renders the total months rather than years plus months" do
-        expect(variables["commercial_terms_term_duration"]).to eq("13 months")
+      it "reports the total months rather than years plus months" do
+        expect(variables["commercial_terms_term_duration"]).to eq({"unit" => "months", "count" => 13})
       end
     end
   end

--- a/spec/services/quote_versions/mention_variables_localizer_spec.rb
+++ b/spec/services/quote_versions/mention_variables_localizer_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::MentionVariablesLocalizer do
+  describe ".call" do
+    subject(:localized) { described_class.call(mention_variables:, locale:) }
+
+    let(:locale) { :en }
+
+    context "with date variables" do
+      let(:mention_variables) do
+        {"quote_date" => "2026-04-01", "commercial_terms_start_date" => "2026-04-01"}
+      end
+
+      it "formats dates for the locale" do
+        expect(localized).to eq(
+          "quote_date" => "Apr 01, 2026",
+          "commercial_terms_start_date" => "Apr 01, 2026"
+        )
+      end
+
+      context "when the locale is French" do
+        let(:locale) { :fr }
+
+        it "formats dates in French" do
+          expect(localized).to eq(
+            "quote_date" => "1 avr. 2026",
+            "commercial_terms_start_date" => "1 avr. 2026"
+          )
+        end
+      end
+    end
+
+    context "with a term duration" do
+      let(:mention_variables) { {"commercial_terms_term_duration" => {"unit" => "years", "count" => 1}} }
+
+      it "translates the duration" do
+        expect(localized).to eq("commercial_terms_term_duration" => "1 year")
+      end
+
+      context "when the locale is French" do
+        let(:locale) { :fr }
+
+        it "translates the duration in French" do
+          expect(localized).to eq("commercial_terms_term_duration" => "un an")
+        end
+      end
+    end
+
+    context "with payment terms" do
+      let(:mention_variables) { {"commercial_terms_payment_terms" => 30} }
+
+      it "translates the payment terms" do
+        expect(localized).to eq("commercial_terms_payment_terms" => "Net 30")
+      end
+    end
+
+    context "with a billing address" do
+      let(:mention_variables) do
+        {
+          "billing_entity_address" => {
+            "address_line1" => "4 rue de la Paix",
+            "address_line2" => nil,
+            "locality" => "Paris",
+            "postal_code" => "75002",
+            "administrative_area" => nil,
+            "country_code" => "FR"
+          }
+        }
+      end
+
+      it "formats the address" do
+        expect(localized).to eq("billing_entity_address" => "4 rue de la Paix\n75002 Paris\nFrance")
+      end
+    end
+
+    context "with locale-independent values" do
+      let(:mention_variables) { {"customer_name" => "Mistral AI", "quote_currency" => "EUR"} }
+
+      it "passes them through unchanged" do
+        expect(localized).to eq("customer_name" => "Mistral AI", "quote_currency" => "EUR")
+      end
+    end
+
+    context "with a partial dictionary" do
+      let(:mention_variables) { {"customer_name" => "Mistral AI"} }
+
+      it "only returns the keys present" do
+        expect(localized).to eq("customer_name" => "Mistral AI")
+      end
+    end
+
+    context "with blank locale-sensitive values" do
+      let(:mention_variables) do
+        {
+          "commercial_terms_start_date" => nil,
+          "commercial_terms_term_duration" => nil,
+          "commercial_terms_payment_terms" => nil,
+          "billing_entity_address" => nil
+        }
+      end
+
+      it "renders them as nil" do
+        expect(localized).to eq(
+          "commercial_terms_start_date" => nil,
+          "commercial_terms_term_duration" => nil,
+          "commercial_terms_payment_terms" => nil,
+          "billing_entity_address" => nil
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Compute the quote `mention_variables` dictionary on the fly while a quote version is a draft, and persist it as a frozen snapshot when the version is approved. Only the raw content is persisted, translation is always done on the fly.