### PR TITLE
misc(daily_usage): Add index on usage_date

### DIFF
--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -41,6 +41,7 @@ end
 #  index_daily_usages_on_customer_id                           (customer_id)
 #  index_daily_usages_on_organization_id                       (organization_id)
 #  index_daily_usages_on_subscription_id                       (subscription_id)
+#  index_daily_usages_on_subscription_id_and_usage_date        (subscription_id,usage_date)
 #  index_daily_usages_on_usage_date                            (usage_date)
 #
 # Foreign Keys

--- a/db/migrate/20260608074112_add_daily_usage_index.rb
+++ b/db/migrate/20260608074112_add_daily_usage_index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddDailyUsageIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_index :daily_usages,
+        [:subscription_id, :usage_date],
+        name: :index_daily_usages_on_subscription_id_and_usage_date,
+        algorithm: :concurrently,
+        if_not_exists: true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -652,6 +652,7 @@ DROP INDEX IF EXISTS public.index_data_exports_on_membership_id;
 DROP INDEX IF EXISTS public.index_data_export_parts_on_organization_id;
 DROP INDEX IF EXISTS public.index_data_export_parts_on_data_export_id;
 DROP INDEX IF EXISTS public.index_daily_usages_on_usage_date;
+DROP INDEX IF EXISTS public.index_daily_usages_on_subscription_id_and_usage_date;
 DROP INDEX IF EXISTS public.index_daily_usages_on_subscription_id;
 DROP INDEX IF EXISTS public.index_daily_usages_on_organization_id;
 DROP INDEX IF EXISTS public.index_daily_usages_on_customer_id;
@@ -7824,6 +7825,13 @@ CREATE INDEX index_daily_usages_on_subscription_id ON public.daily_usages USING 
 
 
 --
+-- Name: index_daily_usages_on_subscription_id_and_usage_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_daily_usages_on_subscription_id_and_usage_date ON public.daily_usages USING btree (subscription_id, usage_date);
+
+
+--
 -- Name: index_daily_usages_on_usage_date; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12538,6 +12546,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260608074112'),
 ('20260603121349'),
 ('20260602092156'),
 ('20260601174030'),


### PR DESCRIPTION
## Description

This PR adds a new index on daily_usages table. It targets the `subscription_id` and `date`. 
Its main goal is to speed-up the backfilling of daily usage via the `DailyUsages::FillHistoryJob`.

NOTE: the existing index on `subscription_id` will be removed in a next step as it is covered as well by this new index.
