### PR TITLE
misc(billable_metrics): Delete using created_at

### DIFF
--- a/app/services/events/delete_for_metric_service.rb
+++ b/app/services/events/delete_for_metric_service.rb
@@ -34,7 +34,11 @@ module Events
     private
 
     BATCH_SIZE = 10_000
-    CLICKHOUSE_TABLES = %w[events_raw events_enriched events_enriched_expanded].freeze
+    CLICKHOUSE_TABLES = {
+      events_raw: :ingested_at,
+      events_enriched: :enriched_at,
+      events_enriched_expanded: :enriched_at
+    }.freeze
     CLICKHOUSE_MUTATIONS_SYNC = "0" # Async
 
     attr_reader :billable_metric, :deleted_at
@@ -57,7 +61,7 @@ module Events
         organization_id: organization_id,
         code: code,
         subscription_id: subscription_ids
-      ).where("events.timestamp <= ?", deleted_at)
+      ).where("events.created_at <= ?", deleted_at)
         .in_batches.update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
 
       # Delete events using the new `external_subscription_id`
@@ -65,23 +69,23 @@ module Events
         organization_id: organization_id,
         code: code,
         external_subscription_id: external_subscription_ids
-      ).where("events.timestamp <= ?", deleted_at)
+      ).where("events.created_at <= ?", deleted_at)
         .in_batches.update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
     end
 
     # Delete clickhouse events using async mutations to avoid blocking or
     # timeouts when the metric is attached to a large number of events.
     def delete_clickhouse_events(external_subscription_ids)
-      CLICKHOUSE_TABLES.each do |table|
-        async_delete_clickhouse(table, external_subscription_ids)
+      CLICKHOUSE_TABLES.each do |table, date_field|
+        async_delete_clickhouse(table, date_field, external_subscription_ids)
       end
     end
 
-    def async_delete_clickhouse(table, external_subscription_ids)
+    def async_delete_clickhouse(table, date_field, external_subscription_ids)
       sql = ::Clickhouse::BaseRecord.sanitize_sql_array([
         "ALTER TABLE #{table} DELETE " \
           "WHERE organization_id = ? AND code = ? " \
-          "AND external_subscription_id IN (?) AND timestamp <= ? " \
+          "AND external_subscription_id IN (?) AND #{date_field} <= ? " \
           "SETTINGS mutations_sync = #{CLICKHOUSE_MUTATIONS_SYNC}",
         organization_id,
         code,

--- a/spec/services/events/delete_for_metric_service_spec.rb
+++ b/spec/services/events/delete_for_metric_service_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
   let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
 
   let(:event_timestamp) { (billable_metric.deleted_at || Time.current) - 1.minute }
-  let(:event) { create(:event, code: billable_metric.code, subscription_id: subscription.id, organization_id: billable_metric.organization_id, timestamp: event_timestamp) }
-  let(:not_impacted_event) { create(:event, subscription_id: subscription.id, organization_id: billable_metric.organization_id, timestamp: event_timestamp) }
+  let(:event) { create(:event, code: billable_metric.code, subscription_id: subscription.id, organization_id: billable_metric.organization_id, timestamp: event_timestamp, created_at: event_timestamp) }
+  let(:not_impacted_event) { create(:event, subscription_id: subscription.id, organization_id: billable_metric.organization_id, timestamp: event_timestamp, created_at: event_timestamp) }
 
   before do
     charge
@@ -29,8 +29,8 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
     end
 
     context "with new-style external_subscription based events" do
-      let(:event) { create(:event, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id, timestamp: event_timestamp) }
-      let(:not_impacted_event) { create(:event, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id, timestamp: event_timestamp) }
+      let(:event) { create(:event, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id, timestamp: event_timestamp, created_at: event_timestamp) }
+      let(:not_impacted_event) { create(:event, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id, timestamp: event_timestamp, created_at: event_timestamp) }
 
       it "deletes related events" do
         expect { service.call }.to change { event.reload.deleted_at }.from(nil).to(billable_metric.deleted_at)
@@ -48,13 +48,13 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
       end
     end
 
-    context "when event timestamp is after billable_metric deletion" do
+    context "when event is received after billable_metric deletion" do
       let(:event) do
         create(
           :event,
           code: billable_metric.code,
           subscription_id: subscription.id,
-          timestamp: billable_metric.deleted_at + 1.hour
+          created_at: billable_metric.deleted_at + 1.hour
         )
       end
 
@@ -82,7 +82,7 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
           organization_id: billable_metric.organization_id,
           code: billable_metric.code,
           external_subscription_id: subscription.external_id,
-          timestamp: event_timestamp
+          ingested_at: event_timestamp
         )
       end
 
@@ -91,7 +91,7 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
           :clickhouse_events_raw,
           organization_id: billable_metric.organization_id,
           external_subscription_id: SecureRandom.uuid,
-          timestamp: event_timestamp
+          ingested_at: event_timestamp
         )
       end
 
@@ -101,7 +101,7 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
           organization_id: billable_metric.organization_id,
           code: billable_metric.code,
           external_subscription_id: subscription.external_id,
-          timestamp: event_timestamp
+          enriched_at: event_timestamp
         )
       end
 
@@ -110,7 +110,7 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
           :clickhouse_events_enriched,
           organization_id: billable_metric.organization_id,
           external_subscription_id: SecureRandom.uuid,
-          timestamp: event_timestamp
+          enriched_at: event_timestamp
         )
       end
 
@@ -120,7 +120,7 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
           organization_id: billable_metric.organization_id,
           code: billable_metric.code,
           external_subscription_id: subscription.external_id,
-          timestamp: event_timestamp
+          enriched_at: event_timestamp
         )
       end
 
@@ -129,7 +129,7 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
           :clickhouse_events_enriched_expanded,
           organization_id: billable_metric.organization_id,
           external_subscription_id: SecureRandom.uuid,
-          timestamp: event_timestamp
+          enriched_at: event_timestamp
         )
       end
 
@@ -180,7 +180,7 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
             organization_id: billable_metric.organization_id,
             code: billable_metric.code,
             external_subscription_id: subscription.external_id,
-            timestamp: billable_metric.deleted_at + 1.hour
+            ingested_at: billable_metric.deleted_at + 1.hour
           )
         end
 


### PR DESCRIPTION
## Description

This PR updates the `Events::DeleteForMetricService` to use `created_at` (and related `ingested_at` & `enriched_at`) timestamp instead of `events.timestamp` as time reference when removing events records.
