### PR TITLE
fix(customers): Improve customers query

### DIFF
--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -59,10 +59,6 @@ class CustomersQuery < BaseQuery
     Customer.where(organization:).where(id: matching_ids_by_search)
   end
 
-  # Rather than a single OR across the searchable columns (which the planner
-  # evaluates as a per-row filter and cannot serve from the per-column trgm GIN
-  # indexes), build one branch per column and UNION them so each branch uses its
-  # own index, then filter the main scope by the resulting ids.
   def matching_ids_by_search
     search_base = Customer.where(organization:)
     search_base = search_base.with_discarded if filters.with_deleted

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -63,8 +63,10 @@ class CustomersQuery < BaseQuery
     search_base = Customer.where(organization:)
     search_base = search_base.with_discarded if filters.with_deleted
 
+    escaped_term = "%#{Customer.sanitize_sql_like(search_term)}%"
+
     branches = SEARCHABLE_FIELDS.map do |field|
-      search_base.where("customers.#{field} ILIKE ?", "%#{search_term}%").select(:id)
+      search_base.where("customers.#{field} ILIKE ?", escaped_term).select(:id)
     end
 
     union_sql = branches.map(&:to_sql).join(" UNION ")

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -19,10 +19,12 @@ class CustomersQuery < BaseQuery
     :has_customer_type
   ]
 
+  SEARCHABLE_FIELDS = %i[name firstname lastname legal_name external_id email].freeze
+
   def call
     return result unless validate_filters.success?
 
-    customers = base_scope.result
+    customers = base_scope
 
     customers = with_customer_type(customers) if filters.customer_type.present? || filters.key?(:has_customer_type)
     customers = with_account_type(customers) if filters.account_type.present?
@@ -52,7 +54,25 @@ class CustomersQuery < BaseQuery
   end
 
   def base_scope
-    Customer.where(organization:).ransack(search_params)
+    return Customer.where(organization:) if search_term.blank?
+
+    Customer.where(organization:).where(id: matching_ids_by_search)
+  end
+
+  # Rather than a single OR across the searchable columns (which the planner
+  # evaluates as a per-row filter and cannot serve from the per-column trgm GIN
+  # indexes), build one branch per column and UNION them so each branch uses its
+  # own index, then filter the main scope by the resulting ids.
+  def matching_ids_by_search
+    search_base = Customer.where(organization:)
+    search_base = search_base.with_discarded if filters.with_deleted
+
+    branches = SEARCHABLE_FIELDS.map do |field|
+      search_base.where("customers.#{field} ILIKE ?", "%#{search_term}%").select(:id)
+    end
+
+    union_sql = branches.map(&:to_sql).join(" UNION ")
+    Customer.unscoped.from("(#{union_sql}) AS customers").select(:id)
   end
 
   def with_currencies(scope)
@@ -88,20 +108,6 @@ class CustomersQuery < BaseQuery
     end
 
     scope
-  end
-
-  def search_params
-    return if search_term.blank?
-
-    {
-      m: "or",
-      name_cont: search_term,
-      firstname_cont: search_term,
-      lastname_cont: search_term,
-      legal_name_cont: search_term,
-      external_id_cont: search_term,
-      email_cont: search_term
-    }
   end
 
   def with_has_tax_identification_number(scope)

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -251,6 +251,40 @@ RSpec.describe CustomersQuery do
         expect(returned_ids).to eq([customer_first.id])
       end
     end
+
+    context "when the term matches several customers across different fields" do
+      let(:search_term) { "example" }
+
+      it "returns all matching customers without duplicates" do
+        expect(returned_ids).to match_array([customer_first.id, customer_second.id, customer_third.id])
+      end
+    end
+
+    context "when the term matches no customer" do
+      let(:search_term) { "nonexistent" }
+
+      it "returns no customer" do
+        expect(returned_ids).to be_empty
+      end
+    end
+
+    context "when a matching customer is discarded" do
+      let(:search_term) { "defgh" }
+
+      before { customer_first.discard! }
+
+      it "excludes the discarded customer by default" do
+        expect(returned_ids).to be_empty
+      end
+
+      context "with with_deleted filter" do
+        let(:filters) { {with_deleted: true} }
+
+        it "returns the discarded customer" do
+          expect(returned_ids).to eq([customer_first.id])
+        end
+      end
+    end
   end
 
   context "when filtering by countries" do

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -268,6 +268,14 @@ RSpec.describe CustomersQuery do
       end
     end
 
+    context "when the term contains LIKE wildcards" do
+      let(:search_term) { "d_fgh" }
+
+      it "matches the wildcards literally" do
+        expect(returned_ids).to be_empty
+      end
+    end
+
     context "when a matching customer is discarded" do
       let(:search_term) { "defgh" }
 


### PR DESCRIPTION
## Context

- The customer list search (`CustomersQuery`) was slow on large organizations despite having trigram GIN indexes on all six searchable columns (`name, firstname, lastname, legal_name, external_id, email`).

- The bottleneck was the query shape, not missing indexes. Ransack generated a single `OR` across the six ILIKE columns:

```SQL
  WHERE organization_id = ?
    AND (name ILIKE ? OR firstname ILIKE ? OR ... OR email ILIKE ?)
  ORDER BY created_at DESC LIMIT 20
```

- With this shape the planner overestimates how many rows match, abandons the trigram indexes, and instead walks an ordering index in `created_at DESC`, applying the `OR` as a per-row filter — scanning a large fraction of the org's customers before collecting a page. The GIN indexes go unused.

## Change

- Rewrote the search to a `UNION` of one branch per column. Each branch filters on a single indexed column, so the planner can serve it directly from that column's trigram GIN index; the results are unioned and the main scope is filtered by the resulting ids.

  - base_scope returns the plain org scope when there's no search term, otherwise `WHERE id IN (<union>)`.
  - Added `matching_ids_by_search` building the per-column `UNION`.
  - `with_deleted` is preserved: branches add `with_discarded` when set, and the outer wrapper uses `Customer.unscoped` so the id-only union isn't re-scoped on `deleted_at`.
  - Removed the now-unused search_params ransack helper.