### PR TITLE
fix(subscriptions): coerce charge filters properties

### DIFF
--- a/app/graphql/mutations/subscriptions/update_charge.rb
+++ b/app/graphql/mutations/subscriptions/update_charge.rb
@@ -19,6 +19,9 @@ module Mutations
         subscription = current_organization.subscriptions.find_by(id: args[:subscription_id])
         charge = subscription&.plan&.charges&.find_by(code: args[:charge_code])
 
+        args[:properties] = args[:properties].to_h if args[:properties]
+        args[:filters] = args[:filters].map(&:to_h) if args[:filters]
+
         result = ::Subscriptions::UpdateOrOverrideChargeService.call(
           subscription:,
           charge:,

--- a/spec/graphql/mutations/subscriptions/update_charge_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_charge_spec.rb
@@ -119,6 +119,34 @@ RSpec.describe Mutations::Subscriptions::UpdateCharge, :premium do
     end
   end
 
+  context "with filters" do
+    let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:, organization:, key: "region", values: %w[us eu]) }
+    let(:input) do
+      {
+        subscriptionId: subscription.id,
+        chargeCode: charge.code,
+        properties: {amount: "1"},
+        filters: [
+          {
+            invoiceDisplayName: "EU",
+            properties: {amount: "11"},
+            values: {billable_metric_filter.key => %w[eu]}
+          }
+        ]
+      }
+    end
+
+    before { billable_metric_filter }
+
+    it "creates the charge override with its filters" do
+      result_data = subject["data"]["updateSubscriptionCharge"]
+
+      override = Charge.find(result_data["id"])
+      expect(override.filters.count).to eq(1)
+      expect(override.filters.first.properties).to eq("amount" => "11")
+    end
+  end
+
   context "with taxes" do
     let(:tax) { create(:tax, organization:) }
     let(:input) do


### PR DESCRIPTION
Normalize the `filters` arguments to plain hashes with to_h in the mutation before calling the service, matching the plan-level charge mutations.
