### PR TITLE
invoice-preview: fix downgrade billing period on the plan_code path

### DIFF
--- a/app/services/invoices/preview/find_subscriptions_service.rb
+++ b/app/services/invoices/preview/find_subscriptions_service.rb
@@ -65,12 +65,10 @@ module Invoices
           .end_of_period + 1.day
       end
 
-      # rotation_date lands at the end of the day, but the new subscription starts at the beginning
-      # of that day in the customer timezone.
       def next_subscription_started_at(subscription)
-        rotation_date(subscription)
-          .in_time_zone(subscription.customer.applicable_timezone)
-          .beginning_of_day
+        Subscriptions::DatesService
+          .new_instance(subscription, Time.current, current_usage: true)
+          .next_period_started_at
       end
     end
   end

--- a/app/services/invoices/preview/find_subscriptions_service.rb
+++ b/app/services/invoices/preview/find_subscriptions_service.rb
@@ -48,27 +48,17 @@ module Invoices
       attr_reader :subscriptions
 
       def adjusted_subscription(subscription)
-        subscription.terminated_at = rotation_date(subscription)
+        date_service = Subscriptions::DatesService.new_instance(subscription, Time.current, current_usage: true)
+
+        subscription.terminated_at = date_service.end_of_period + 1.day
         subscription.status = :terminated
 
         subscription.next_subscription.assign_attributes(
           status: :active,
-          started_at: next_subscription_started_at(subscription)
+          started_at: date_service.next_period_started_at
         )
 
         subscription
-      end
-
-      def rotation_date(subscription)
-        @rotation_date ||= Subscriptions::DatesService
-          .new_instance(subscription, Time.current, current_usage: true)
-          .end_of_period + 1.day
-      end
-
-      def next_subscription_started_at(subscription)
-        Subscriptions::DatesService
-          .new_instance(subscription, Time.current, current_usage: true)
-          .next_period_started_at
       end
     end
   end

--- a/app/services/invoices/preview/subscription_plan_change_service.rb
+++ b/app/services/invoices/preview/subscription_plan_change_service.rb
@@ -63,22 +63,21 @@ module Invoices
         )
       end
 
-      # For a downgrade, termination_date is the end-of-day rotation timestamp, but the new
-      # subscription starts at the beginning of that day in the customer timezone.
       def new_subscription_started_at
         return Time.current if upgrade?
 
-        termination_date.in_time_zone(customer.applicable_timezone).beginning_of_day
+        date_service.next_period_started_at
       end
 
       def termination_date
-        @termination_date ||= if upgrade?
-          Time.current
-        else
-          Subscriptions::DatesService
-            .new_instance(current_subscription, Time.current, current_usage: true)
-            .end_of_period + 1.day
-        end
+        return Time.current if upgrade?
+
+        date_service.end_of_period + 1.day
+      end
+
+      def date_service
+        @date_service ||= Subscriptions::DatesService
+          .new_instance(current_subscription, Time.current, current_usage: true)
       end
 
       def upgrade?

--- a/app/services/invoices/preview/subscription_plan_change_service.rb
+++ b/app/services/invoices/preview/subscription_plan_change_service.rb
@@ -58,9 +58,17 @@ module Invoices
           billing_time: current_subscription.billing_time,
           ending_at: current_subscription.ending_at,
           status: :active,
-          started_at: upgrade? ? Time.current : termination_date,
+          started_at: new_subscription_started_at,
           created_at: Time.current
         )
+      end
+
+      # For a downgrade, termination_date is the end-of-day rotation timestamp, but the new
+      # subscription starts at the beginning of that day in the customer timezone.
+      def new_subscription_started_at
+        return Time.current if upgrade?
+
+        termination_date.in_time_zone(customer.applicable_timezone).beginning_of_day
       end
 
       def termination_date

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -168,6 +168,13 @@ module Subscriptions
       customer_timezone_shift(end_utc, end_of_day: true)
     end
 
+    # Start of the billing period that follows the current one, at the beginning of the day in the
+    # customer timezone. `end_of_period` lands at the end of the day, so the next period starts the
+    # following day at 00:00.
+    def next_period_started_at
+      (end_of_period + 1.day).in_time_zone(customer.applicable_timezone).beginning_of_day
+    end
+
     # NOTE: Retrieve the beginning of the previous period based on the billing date
     def previous_beginning_of_period(current_period: false)
       date = base_date

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1537,6 +1537,51 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
+    context "with a not-yet-scheduled downgrade (plan_code)" do
+      let(:customer) { create(:customer, organization:, external_id: "plan_change_customer") }
+      let(:current_plan) do
+        create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 1000)
+      end
+      let(:target_plan) do
+        create(:plan, organization:, interval: "monthly", pay_in_advance: true, amount_cents: 500)
+      end
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: current_plan,
+          status: :active,
+          billing_time: "anniversary",
+          subscription_at: Time.zone.parse("2026-03-03"),
+          started_at: Time.zone.parse("2026-03-03")
+        )
+      end
+      let(:preview_params) do
+        {
+          customer: {external_id: customer.external_id},
+          subscriptions: {external_ids: [subscription.external_id], plan_code: target_plan.code}
+        }
+      end
+
+      before { subscription }
+
+      it "serializes the target plan's real first billing period" do
+        travel_to(Time.zone.parse("2026-06-04T10:00:00Z")) do
+          subject
+
+          expect(response).to have_http_status(:success)
+
+          pending_plan = json[:invoice][:subscriptions].find { |s| s[:plan_code] == target_plan.code }
+          expect(pending_plan).to be_present
+          expect(pending_plan[:started_at]).to eq("2026-07-03T00:00:00.000Z")
+          expect(pending_plan[:current_billing_period_started_at]).to eq("2026-07-03T00:00:00Z")
+          expect(pending_plan[:current_billing_period_ending_at]).to eq("2026-08-02T23:59:59Z")
+          expect(pending_plan[:current_billing_period_started_at])
+            .not_to eq(pending_plan[:current_billing_period_ending_at])
+        end
+      end
+    end
+
     context "when subscription has a minimum commitment and terminated_at is provided" do
       let(:timestamp) { Time.zone.parse("2026-01-15") }
       let(:commitment_customer) { create(:customer, organization:, external_id: "commitment_customer") }

--- a/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService do
 
               expect(subscriptions.second)
                 .to be_new_record
-                .and have_attributes(status: "active", started_at: start_of_next_billing_period, name: target_plan.name, plan: target_plan)
+                .and have_attributes(status: "active", started_at: start_of_next_billing_period.beginning_of_day, name: target_plan.name, plan: target_plan)
             end
 
             it "does not persist any changes to the current subscription" do


### PR DESCRIPTION
## What changed and why

Follow-up to the downgrade invoice-preview fix. That change covered the already-scheduled path (`POST /invoices/preview` with `external_ids`, via `FindSubscriptionsService`). Support found the same symptom on the other path: previewing a not-yet-scheduled downgrade by passing `plan_code` inside the `subscriptions` object (e.g. a checkout flow), which routes to `Invoices::Preview::SubscriptionPlanChangeService`.

There, the new subscription's `started_at` was set to the raw end-of-day rotation timestamp (`…23:59:59Z`) for downgrades, so `current_billing_period_started_at` came back as `…23:59:59Z` and didn't match the fee's `from_date`.

The fix mirrors what `FindSubscriptionsService` already does: for a downgrade, normalize `started_at` to the beginning of the rotation day in the customer timezone. The serializer side (`Subscription#billing_reference_time`) already handles the period once `started_at` is correct, so no change is needed there.

```ruby
def new_subscription_started_at
  return Time.current if upgrade?

  termination_date.in_time_zone(customer.applicable_timezone).beginning_of_day
end
```

`terminated_at` is left as-is (end-of-day rotation timestamp), consistent with the earlier fix.

## Result

```
started_at:                         2026-07-03T00:00:00Z   (was 2026-07-03T23:59:59Z)
current_billing_period_started_at:  2026-07-03T00:00:00Z   (was 2026-07-03T23:59:59Z)
current_billing_period_ending_at:   2026-08-02T23:59:59Z
```

## Tests

- `spec/services/invoices/preview/subscription_plan_change_service_spec.rb`: the downgrade case now expects `started_at` at the beginning of the rotation day.
- `spec/requests/api/v1/invoices_controller_spec.rb`: new request spec for the `plan_code` preview path, asserting the target plan's `current_billing_period_*` on the response.

```bash
bundle exec rspec spec/services/invoices/preview/subscription_plan_change_service_spec.rb \
                  spec/requests/api/v1/invoices_controller_spec.rb
```

Reported by support on BIL-97. Tracked in BIL-158.