### PR TITLE
[ING-256] fix(progressive-billing): plan currency

### DIFF
--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -77,7 +77,7 @@ module Invoices
       invoice_result = CreateGeneratingService.call(
         customer: subscription.customer,
         invoice_type: :progressive_billing,
-        currency: sorted_usage_thresholds.first.currency,
+        currency: subscription.plan.amount_currency,
         datetime: Time.zone.at(timestamp)
       ) do |invoice|
         CreateInvoiceSubscriptionService

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -225,6 +225,20 @@ RSpec.describe Invoices::ProgressiveBillingService, transaction: false do
       expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
     end
 
+    context "when the subscription overrides the plan's currency" do
+      let(:organization) { create(:organization) }
+      let(:plan) { create(:plan, organization:, amount_currency: "USD") }
+      let(:override_plan) { create(:plan, organization:, parent: plan, amount_currency: "EUR") }
+      let(:subscription) { create(:subscription, plan: override_plan, customer:, started_at: timestamp - 1.week) }
+
+      it "uses the subscription's plan currency, not the threshold's parent-plan currency" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.invoice.currency).to eq("EUR")
+      end
+    end
+
     context "with lago_premium", :premium do
       it "enqueues an GenerateDocumentsJob with email true" do
         expect { create_service.call }


### PR DESCRIPTION
## Context

`POST` events that crossed a usage threshold on a subscription whose plan currency differed from the customer's default — typically a subscription created with `plan_overrides: { amount_currency: 'EUR' }` on top of a USD parent plan — produced progressive billing invoices in the **wrong currency**. The invoice came back tagged with the customer's default currency (or the parent plan's currency, whichever the threshold's `currency` method resolved to), and the threshold's `amount_cents` was interpreted in that same wrong currency. Concrete risk: a €50 threshold crossed by €50 of EUR usage would generate a USD invoice without any conversion, misbilling the customer.

Progressive billing was the last invoice path that still had this bug. Pay-in-advance charges (S20) and termination proration (S13) already source the currency from the subscription's actual plan and have been correct for some time. This brings progressive billing in line.

## The fix

`Invoices::ProgressiveBillingService#create_generating_invoice` now reads the currency from `subscription.plan.amount_currency` — the plan the subscription is actually running on, including any plan-override child plan — instead of `sorted_usage_thresholds.first.currency`, which delegated to `UsageThreshold#currency` and ultimately to the **parent** plan when the threshold was attached to it. One line:

```diff
-        currency: sorted_usage_thresholds.first.currency,
+        currency: subscription.plan.amount_currency,
```

The threshold's `amount_cents` value is unchanged on disk and is now interpreted in the subscription's plan currency. This matches the semantics S22 in the QA plan asks for, and it matches the pay-in-advance / termination behaviour.

## Why no model-level change

I considered fixing `UsageThreshold#currency` so the model itself returns the right currency for the override case. Two reasons not to:

- The second fallback in that chain (`subscription&.plan_amount_currency`) is reachable — `Subscription` declares `delegate :amount_currency, to: :plan, prefix: true` — and serves a legitimate case where the threshold is attached directly to a subscription instead of a plan. The chain isn't dead code.
- Making the model correct for the parent-plan-with-override case requires threading the consuming subscription into a method that doesn't have it. That's a broader refactor than this bug needs.

The call-site fix in `ProgressiveBillingService` is sufficient for ING-256 and is the same pattern S20 and S13 already use.

## Tests

`spec/services/invoices/progressive_billing_service_spec.rb` — new `when the subscription overrides the plan's currency` context. Sets up a USD parent plan, an EUR child plan with `parent: usd_plan`, and a subscription on the EUR child. Asserts the resulting invoice's `currency == "EUR"`. The context redeclares `let(:organization)` to break the `organization → plan → organization` cycle that appears when the override pattern is layered on top of the shared `let` graph.

## How to test manually

Reproduce the original bug scenario:

1. Org with `multi_currency` enabled.
2. USD-default customer.
3. Plan with `usage_thresholds: [{ amount_cents: 5000, recurring: false }]`.
4. Subscription on that plan with `plan_overrides: { amount_currency: 'EUR' }`.
5. Send usage events sufficient to cross the threshold.
6. Wait for the progressive billing invoice (`invoice_type == 'progressive_billing'`).

Expected on this branch: `invoice.currency == "EUR"`, threshold treated as €50. Before this change: `invoice.currency == "USD"`, threshold treated as $50.

## Follow-up

In ruby-client-test, remove the `pending` line on `spec/scenarios/invoices/multi_currency_invoices_spec.rb:53` once this PR ships. Separate repo, separate PR — out of scope here.

## Notes

- Backwards compatible. Subscriptions whose plan currency matches the threshold's plan currency (the common case, no override in play) keep producing invoices in the same currency as before — both sides of the change resolve to the same value.
- No change to `UsageThreshold#currency`. No change to `LifetimeUsage` currency computation (it was already correct, which is why threshold-crossing detection upstream kept working).
