### PR TITLE
[ING-299] fix(pay-in-advance): subscription entity

### DIFF
--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -82,6 +82,7 @@ module Invoices
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
         customer:,
+        billing_entity: subscription.billing_entity,
         invoice_type: :subscription,
         currency: subscription.plan_amount_currency,
         datetime: Time.zone.at(timestamp),

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -159,6 +159,34 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService do
       expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
     end
 
+    context "when the subscription has its own billing entity (different from the customer's)" do
+      let(:customer_billing_entity) { create(:billing_entity, organization:, code: "acme_us") }
+      let(:subscription_billing_entity) { create(:billing_entity, organization:, code: "acme_eu") }
+      let(:customer) { create(:customer, organization:, billing_entity: customer_billing_entity) }
+      let(:subscription) { create(:subscription, customer:, plan:, billing_entity: subscription_billing_entity) }
+
+      it "stamps the invoice with the subscription's billing entity, not the customer's" do
+        result = invoice_service.call
+
+        expect(result).to be_success
+        expect(result.invoice.billing_entity_id).to eq(subscription_billing_entity.id)
+        expect(result.invoice.billing_entity_id).not_to eq(customer_billing_entity.id)
+      end
+    end
+
+    context "when the subscription has no explicit billing entity" do
+      let(:customer_billing_entity) { create(:billing_entity, organization:, code: "acme_us") }
+      let(:customer) { create(:customer, organization:, billing_entity: customer_billing_entity) }
+      let(:subscription) { create(:subscription, customer:, plan:, billing_entity: nil) }
+
+      it "falls back to the customer's billing entity" do
+        result = invoice_service.call
+
+        expect(result).to be_success
+        expect(result.invoice.billing_entity_id).to eq(customer_billing_entity.id)
+      end
+    end
+
     it "enqueues GenerateDocumentsJob with email false" do
       expect do
         invoice_service.call


### PR DESCRIPTION
## Context

Pay-in-advance charge invoices were being stamped with the **customer's** default `billing_entity_id` even when the subscription had an explicit different binding. Every charge-driven event on a multi-entity subscription produced invoices under the wrong entity, breaking per-entity gapless invoice sequencing and routing downstream payment / dunning to the wrong entity.

The regular periodic billing path (`Invoices::SubscriptionService#invoice_billing_entity`) was already wired correctly. Pay-in-advance was the only invoice creation path still missing the thread-through.

**Closes ING-299**, surfaced by S17 / S86 in the Multi-Currency + Multi-Entity QA plan, sister regression of the F4 milestone work.

## The fix

`Invoices::CreatePayInAdvanceChargeService#create_generating_invoice` now passes `billing_entity: subscription.billing_entity` into `Invoices::CreateGeneratingService`. One line:

```diff
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
         customer:,
+        billing_entity: subscription.billing_entity,
         invoice_type: :subscription,
         currency: subscription.plan_amount_currency,
         …
```

`Subscription#billing_entity` already inherits via `super || customer&.billing_entity` (`subscription.rb:107-109`), so the NULL-binding case keeps falling back to the customer's default and the change is a no-op there. Only subscriptions with an explicit binding shift to the new behaviour — which is the bug we're fixing.

No model change, no migration, no change to `Invoices::CreateGeneratingService`'s own `billing_entity || customer.billing_entity` fallback (we just stop relying on it as the primary source on this path).

## Tests

`spec/services/invoices/create_pay_in_advance_charge_service_spec.rb` — two new contexts:

- **`when the subscription has its own billing entity (different from the customer's)`** — asserts `invoice.billing_entity_id` matches the subscription's, not the customer's. Was RED before the fix.
- **`when the subscription has no explicit billing entity`** — asserts the fallback to the customer's billing entity. Was GREEN before the fix; kept as a regression guard so a future refactor can't silently break inherit semantics.

Verified locally:

```
lago exec api bundle exec rspec \
  spec/services/invoices/create_pay_in_advance_charge_service_spec.rb \
  spec/services/invoices/create_generating_service_spec.rb \
  spec/services/invoices/subscription_service_spec.rb \
  spec/services/fees/create_pay_in_advance_service_spec.rb
```

126 examples, 0 failures.

## How to test manually

1. Org with `multi_entity_billing` enabled.
2. Customer whose default billing entity is `acme_us`.
3. Plan with a pay-in-advance, invoiceable charge (`pay_in_advance: true, invoiceable: true`).
4. Subscription on that plan with `billing_entity_code: acme_eu` (explicitly different from the customer's default).
5. Send a usage event on the metric.
6. Inspect the resulting invoice.

Before this branch: `invoice.billing_entity.code == "acme_us"`. On this branch: `invoice.billing_entity.code == "acme_eu"`.

For the inherit case, repeat the same steps without `billing_entity_code` on the subscription — invoice should remain `acme_us`, unchanged from before.


## Notes

- Backwards compatible. Customers whose subscriptions don't explicitly bind a billing entity see no change — their invoices still resolve to the customer's default via the inherit chain.
- Mirrors the pattern already used by the periodic billing path, so the two invoice creation paths now agree on how they source `billing_entity`.
