### PR TITLE
fix(billable_metrics): Serialize concurrent updates with row lock

### DIFF
--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -55,7 +55,7 @@ module BillableMetricFilters
         end
       end
 
-      BillableMetricFilters::RefreshDraftInvoicesJob.perform_later(billable_metric.id)
+      BillableMetricFilters::RefreshDraftInvoicesJob.perform_after_commit(billable_metric.id)
 
       result
     end

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -23,37 +23,37 @@ module BillableMetrics
         return result.forbidden_failure!
       end
 
-      billable_metric.name = params[:name] if params.key?(:name)
-      billable_metric.description = params[:description] if params.key?(:description)
+      billable_metric.with_lock do
+        billable_metric.name = params[:name] if params.key?(:name)
+        billable_metric.description = params[:description] if params.key?(:description)
 
-      ActiveRecord::Base.transaction do
         if params.key?(:filters)
           BillableMetricFilters::CreateOrUpdateBatchService.call(
             billable_metric:,
             filters_params: params[:filters].map { |f| f.to_h.with_indifferent_access }
           ).raise_if_error!
         end
-      end
 
-      # NOTE: Only name and description are editable if billable metric
-      #       is attached to a plan
-      unless billable_metric.attached_to_plan?
-        billable_metric.code = params[:code] if params.key?(:code)
-        billable_metric.aggregation_type = params[:aggregation_type]&.to_sym if params.key?(:aggregation_type)
-        billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)
-        billable_metric.field_name = params[:field_name] if params.key?(:field_name)
-        billable_metric.recurring = params[:recurring] if params.key?(:recurring)
-        billable_metric.rounding_function = params[:rounding_function] if params.key?(:rounding_function)
-        billable_metric.rounding_precision = params[:rounding_precision] if params.key?(:rounding_precision)
-        billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)
-        billable_metric.expression = params[:expression] if params.key?(:expression)
+        # NOTE: Only name and description are editable if billable metric
+        #       is attached to a plan
+        unless billable_metric.attached_to_plan?
+          billable_metric.code = params[:code] if params.key?(:code)
+          billable_metric.aggregation_type = params[:aggregation_type]&.to_sym if params.key?(:aggregation_type)
+          billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)
+          billable_metric.field_name = params[:field_name] if params.key?(:field_name)
+          billable_metric.recurring = params[:recurring] if params.key?(:recurring)
+          billable_metric.rounding_function = params[:rounding_function] if params.key?(:rounding_function)
+          billable_metric.rounding_precision = params[:rounding_precision] if params.key?(:rounding_precision)
+          billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)
+          billable_metric.expression = params[:expression] if params.key?(:expression)
 
-        if params.key?(:expression) || params.key?(:field_name)
-          BillableMetrics::ExpressionCacheService.expire_cache(organization.id, billable_metric.code)
+          if params.key?(:expression) || params.key?(:field_name)
+            BillableMetrics::ExpressionCacheService.expire_cache(organization.id, billable_metric.code)
+          end
         end
-      end
 
-      billable_metric.save!
+        billable_metric.save!
+      end
 
       SendWebhookJob.perform_after_commit("billable_metric.updated", billable_metric)
 

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
     end
 
     it "enqueues the refresh draft invoices job" do
-      expect { service }.to have_enqueued_job(BillableMetricFilters::RefreshDraftInvoicesJob)
+      expect { service }.to have_enqueued_job_after_commit(BillableMetricFilters::RefreshDraftInvoicesJob)
         .with(billable_metric.id)
     end
 

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe BillableMetrics::UpdateService do
       expect(SendWebhookJob).to have_been_enqueued.with("billable_metric.updated", billable_metric)
     end
 
+    it "uses with_lock to prevent race conditions" do
+      allow(billable_metric).to receive(:with_lock).and_call_original
+      described_class.call(billable_metric:, params:)
+
+      expect(billable_metric).to have_received(:with_lock)
+    end
+
     context "with filters arguments" do
       let(:filters) do
         [
@@ -83,6 +90,26 @@ RSpec.describe BillableMetrics::UpdateService do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
         expect(result.error.messages[:name]).to eq(["value_is_mandatory"])
+      end
+    end
+
+    context "when the filters change but a metric attribute is invalid" do
+      let(:existing_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[US EU]) }
+      let(:params) { {name: nil, filters: [{key: "region", values: %w[US]}]} }
+
+      before { existing_filter }
+
+      it "rolls back the filter changes" do
+        result = described_class.call(billable_metric:, params:)
+
+        expect(result).not_to be_success
+        expect(existing_filter.reload.values).to eq(%w[US EU])
+      end
+
+      it "does not enqueue the refresh draft invoices job" do
+        described_class.call(billable_metric:, params:)
+
+        expect(BillableMetricFilters::RefreshDraftInvoicesJob).not_to have_been_enqueued
       end
     end
 

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -47,9 +47,8 @@ RSpec.describe BillableMetrics::UpdateService do
     end
 
     it "enqueues a billable_metric.updated webhook" do
-      described_class.call(billable_metric:, params:)
-
-      expect(SendWebhookJob).to have_been_enqueued.with("billable_metric.updated", billable_metric)
+      expect { described_class.call(billable_metric:, params:) }.to have_enqueued_job_after_commit(SendWebhookJob)
+        .with("billable_metric.updated", billable_metric)
     end
 
     it "uses with_lock to prevent race conditions" do
@@ -159,6 +158,32 @@ RSpec.describe BillableMetrics::UpdateService do
           rounding_function: "ceil",
           rounding_precision: 2
         )
+      end
+    end
+
+    context "with two threads racing on the same invoice", transaction: false do
+      let(:params) { {filters: [{key: "region", values: %w[US]}]} }
+
+      before do
+        allow(billable_metric).to receive(:save!).and_wrap_original do |original, *args|
+          sleep(0.05)
+          original.call(*args)
+        end
+      end
+
+      it "serializes the requests and creates the filter exactly once" do
+        results = Concurrent::Array.new
+
+        threads = Array.new(2) do
+          Thread.new do
+            results << described_class.call(billable_metric:, params:)
+          end
+        end
+
+        threads.each(&:join)
+
+        expect(results.count(&:success?)).to eq(2)
+        expect(billable_metric.filters.where(key: "region").count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## Context
Concurrent `PUT` requests updating the same billable metric could interleave and corrupt its filters.

- Two simultaneous requests each diffed incoming filters against stale state, producing duplicate filters or partially applied changes.
- Simultaneous same requests do heavy work, running expensive DB queries in parallel.
- Because the billable_metric save was outside the filter transaction, a failure in one half did not roll back the other - the update was not atomic.

## Description
- Added a pessimistic row lock on the billable metric, so concurrent updates of the same metric are serialized.
- Moved `billable_metric.save!` inside a transaction for atomicity -  any failure now rolls back.
- Switched the draft-invoice refresh in `CreateOrUpdateBatchService` from `perform_later` to `perform_after_commit`, so the refresh is only enqueued once the transaction has actually committed.