### PR TITLE
fix(subscriptions): Fix UpdateOrOverrideFixedChargeService with apply_units_immediately

### DIFF
--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -57,6 +57,14 @@ class FixedCharge < ApplicationRecord
     subscription_units_overrides.find_by(subscription:)&.units || units
   end
 
+  def parent_or_self
+    if parent_id
+      parent
+    else
+      self
+    end
+  end
+
   # When upgrading a subscription with fixed_charges paid_in_advance,
   # this exact charge might have already been paid at the beginning of billing period.
   # in case of prorating, we need to deduct the prorated amount (remaining of the billing_period)

--- a/app/services/subscriptions/concerns/plan_override_concern.rb
+++ b/app/services/subscriptions/concerns/plan_override_concern.rb
@@ -7,7 +7,7 @@ module Subscriptions
 
       private
 
-      def ensure_plan_override
+      def ensure_plan_override(params: {})
         current_plan = subscription.plan
 
         if current_plan.parent_id
@@ -15,7 +15,7 @@ module Subscriptions
         else
           override_result = Plans::OverrideService.call!(
             plan: current_plan,
-            params: {},
+            params:,
             subscription:
           )
           subscription.update!(plan: override_result.plan)

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -10,6 +10,7 @@ module Subscriptions
       @subscription = subscription
       @fixed_charge = fixed_charge
       @params = params
+      @subscription_plan_parent_present = subscription&.plan&.parent_id.present?
 
       super
     end
@@ -20,8 +21,11 @@ module Subscriptions
       return result.not_found_failure!(resource: "fixed_charge") unless fixed_charge
 
       ActiveRecord::Base.transaction do
-        target_plan = ensure_plan_override
-        target_fixed_charge = find_or_create_fixed_charge_override(target_plan)
+        parent_fixed_charge = fixed_charge.parent_or_self
+        target_plan = ensure_plan_override(params: plan_override_params(parent_fixed_charge))
+        target_fixed_charge = find_or_create_fixed_charge_override(parent_fixed_charge, target_plan)
+
+        publish_invoice_pay_in_advance_job(target_fixed_charge)
 
         result.fixed_charge = target_fixed_charge
       end
@@ -35,24 +39,23 @@ module Subscriptions
 
     private
 
-    attr_reader :subscription, :fixed_charge, :params
+    attr_reader :subscription, :fixed_charge, :params, :subscription_plan_parent_present
 
-    def find_or_create_fixed_charge_override(target_plan)
-      parent_fixed_charge = find_parent_fixed_charge
+    def plan_override_params(parent_fixed_charge)
+      return {} if subscription_plan_parent_present
+
+      {fixed_charges: [params.merge(id: parent_fixed_charge.id)]}
+    end
+
+    def find_or_create_fixed_charge_override(parent_fixed_charge, target_plan)
       existing_override = target_plan.fixed_charges.find_by(parent_id: parent_fixed_charge.id)
+
+      return existing_override.reload unless subscription_plan_parent_present
 
       if existing_override
         update_fixed_charge_override(existing_override)
       else
         create_fixed_charge_override(parent_fixed_charge, target_plan)
-      end
-    end
-
-    def find_parent_fixed_charge
-      if fixed_charge.parent_id
-        fixed_charge.parent
-      else
-        fixed_charge
       end
     end
 
@@ -88,6 +91,14 @@ module Subscriptions
       end
 
       existing_fixed_charge.reload
+    end
+
+    def publish_invoice_pay_in_advance_job(target_fixed_charge)
+      return unless params.key?(:units)
+      return unless params[:apply_units_immediately]
+      return unless target_fixed_charge.pay_in_advance?
+
+      Invoices::CreatePayInAdvanceFixedChargesJob.perform_after_commit(subscription, Time.current.to_i)
     end
   end
 end

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -50,7 +50,13 @@ module Subscriptions
     def find_or_create_fixed_charge_override(parent_fixed_charge, target_plan)
       existing_override = target_plan.fixed_charges.find_by(parent_id: parent_fixed_charge.id)
 
-      return existing_override.reload unless subscription_plan_parent_present
+      unless subscription_plan_parent_present
+        if existing_override
+          return existing_override.reload
+        end
+
+        return create_fixed_charge_override(parent_fixed_charge, target_plan)
+      end
 
       if existing_override
         update_fixed_charge_override(existing_override)

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -241,6 +241,25 @@ RSpec.describe FixedCharge do
     end
   end
 
+  describe "#parent_or_self" do
+    context "when the fixed charge has a parent" do
+      let(:parent) { create(:fixed_charge) }
+      let(:fixed_charge) { create(:fixed_charge, parent:) }
+
+      it "returns the parent fixed charge" do
+        expect(fixed_charge.parent_or_self).to eq(parent)
+      end
+    end
+
+    context "when the fixed charge has no parent" do
+      let(:fixed_charge) { create(:fixed_charge) }
+
+      it "returns itself" do
+        expect(fixed_charge.parent_or_self).to eq(fixed_charge)
+      end
+    end
+  end
+
   describe "#validate_pay_in_advance" do
     context "when charge model is standard" do
       it "is valid with pay_in_advance true" do

--- a/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
+++ b/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
@@ -1403,4 +1403,120 @@ describe "Pay in advance fixed charge units change mid-period", :premium do
       end
     end
   end
+
+  # Bug repro: hitting the dedicated subscription-scoped endpoint
+  # PUT /api/v1/subscriptions/:external_id/fixed_charges/:code with
+  # apply_units_immediately: true silently skips the mid-period delta invoice.
+  # The plan-level endpoint and the plan_overrides path both dispatch
+  # Invoices::CreatePayInAdvanceFixedChargesJob; this one doesn't.
+  describe "when updating subscription fixed charge via the dedicated endpoint" do
+    let(:subscription_date) { DateTime.new(2024, 12, 1) }
+    let(:subscription) { customer.subscriptions.first }
+
+    before do
+      fixed_charge
+
+      travel_to subscription_date do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: "sub_endpoint_#{customer.external_id}",
+            plan_code: plan.code,
+            billing_time: "calendar",
+            subscription_at: subscription_date.iso8601
+          }
+        )
+        perform_all_enqueued_jobs
+      end
+    end
+
+    context "when increasing units to 15 with apply_units_immediately: true" do
+      before do
+        travel_to subscription_date + 1.hour do
+          update_subscription_fixed_charge(
+            subscription,
+            fixed_charge.code,
+            {
+              units: "15",
+              apply_units_immediately: true
+            }
+          )
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it "creates a plan override with the new units" do
+        child_plan = subscription.reload.plan
+        expect(child_plan.parent_id).to eq(plan.id)
+
+        child_fixed_charge = child_plan.fixed_charges.first
+        expect(child_fixed_charge.parent_id).to eq(fixed_charge.id)
+        expect(child_fixed_charge.units).to eq(15)
+      end
+
+      it "creates a single FixedChargeEvent on the override with units=15 at the update time" do
+        child_fixed_charge = subscription.reload.plan.fixed_charges.first
+        events = FixedChargeEvent.where(subscription:, fixed_charge: child_fixed_charge).order(:created_at)
+
+        # Expectation: one event on the child fixed_charge with the new
+        # 15 units, anchored at "now" (apply_units_immediately: true).
+        #
+        # Observed on main: TWO events on the child fixed_charge:
+        #   1. units=10 anchored at the next-period boundary, created by
+        #      Plans::OverrideService cloning fixed_charges with
+        #      apply_units_immediately defaulting to false.
+        #   2. units=15 anchored at "now", created by the subsequent
+        #      update_fixed_charge_override step.
+        # The stale units=10 event at the next-period boundary is what
+        # the aggregation reads for the next billing cycle.
+        expect(events.count).to eq(1)
+        expect(events.first.units).to eq(15)
+        expect(events.first.timestamp).to be_within(5.seconds).of(subscription_date + 1.hour)
+      end
+
+      it "generates a mid-period delta invoice for 5 units (15 - 10)" do
+        invoices = subscription.reload.invoices.order(:created_at)
+
+        # Expected behaviour (matches the plan-level endpoint and the
+        # plan_overrides path on Subscriptions::UpdateService):
+        # 1. Initial invoice (10 units, $100)
+        # 2. Mid-period delta invoice (5 units, $50)
+        #
+        # Current behaviour on main: only the initial invoice exists
+        # because UpdateOrOverrideFixedChargeService never dispatches
+        # Invoices::CreatePayInAdvanceFixedChargesJob.
+        expect(invoices.count).to eq(2)
+
+        initial_invoice = invoices.first
+        expect(initial_invoice.fees.fixed_charge.first.units).to eq(10)
+        expect(initial_invoice.fees.fixed_charge.first.amount_cents).to eq(10_000)
+
+        delta_invoice = invoices.last
+        expect(delta_invoice.fees.fixed_charge.count).to eq(1)
+
+        delta_fee = delta_invoice.fees.fixed_charge.first
+        expect(delta_fee.units).to eq(5)
+        expect(delta_fee.amount_cents).to eq(5_000)
+      end
+
+      it "next regular billing cycle bills the new units (15), not the old (10)" do
+        expect {
+          travel_to subscription_date + 1.month + 1.minute do
+            perform_billing
+          end
+        }.to change { subscription.reload.invoices.count }.by(1)
+
+        next_period_invoice = subscription.reload.invoices.order(:created_at).last
+        next_period_fee = next_period_invoice.fees.fixed_charge.first
+
+        # The stale units=10 event sitting at the next-period boundary
+        # (see the FixedChargeEvent assertion above) is what the aggregation
+        # reads, so next-cycle billing also defaults to 10 units. The gap
+        # is broader than just the missing immediate-billing dispatch —
+        # subsequent periods also under-bill.
+        expect(next_period_fee.units).to eq(15)
+        expect(next_period_fee.amount_cents).to eq(15_000)
+      end
+    end
+  end
 end

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -72,6 +72,17 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
         expect(result.fixed_charge.units).to eq(10)
       end
 
+      context "when units is negative" do
+        let(:params) { {units: "-1"} }
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+        end
+      end
+
       context "when updating units with apply_units_immediately" do
         let(:params) do
           {

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -72,6 +72,52 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
         expect(result.fixed_charge.units).to eq(10)
       end
 
+      context "when updating units with apply_units_immediately" do
+        let(:params) do
+          {
+            invoice_display_name: "Overridden Fixed Charge",
+            units: "10",
+            apply_units_immediately: true
+          }
+        end
+
+        context "with a pay in advance fixed charge" do
+          let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, pay_in_advance: true) }
+
+          it "schedules a Invoices::CreatePayInAdvanceFixedChargesJob" do
+            expect { service.call }.to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+          end
+        end
+
+        context "with a pay in arrears fixed charge" do
+          it "does not schedule a Invoices::CreatePayInAdvanceFixedChargesJob" do
+            expect { service.call }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+          end
+        end
+      end
+
+      context "when apply_units_immediately is false" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, pay_in_advance: true) }
+
+        it "does not schedule a Invoices::CreatePayInAdvanceFixedChargesJob" do
+          expect { service.call }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+        end
+      end
+
+      context "when units are not updated" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, pay_in_advance: true) }
+        let(:params) do
+          {
+            invoice_display_name: "Overridden Fixed Charge",
+            apply_units_immediately: true
+          }
+        end
+
+        it "does not schedule a Invoices::CreatePayInAdvanceFixedChargesJob" do
+          expect { service.call }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+        end
+      end
+
       context "when subscription is nil" do
         let(:subscription) { nil }
 

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -166,6 +166,14 @@ module ScenariosHelper
     end
   end
 
+  ### Subscription Fixed Charges
+
+  def update_subscription_fixed_charge(subscription, fixed_charge_code, params, **kwargs)
+    api_call(**kwargs) do
+      put_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}/fixed_charges/#{fixed_charge_code}", {fixed_charge: params})
+    end
+  end
+
   ### Subscription Charge Filters
 
   def create_subscription_charge_filter(subscription, charge_code, params, **kwargs)


### PR DESCRIPTION
Updating fixed-charge units through the subscription-scoped endpoint or GraphQL mutation created a subscription plan override in two steps. The plan clone first emitted a fixed charge event with the old units, then the dedicated fixed charge update emitted a second event with the new units.

This left a stale event at the next billing boundary and skipped the pay-in-advance delta invoice, causing under-billing for subscription fixed charge unit increases.

Pass fixed charge override params into the plan override creation so the cloned fixed charge is created with the target units from the start. Reuse the plan override concern for this path and avoid emitting a second event for newly cloned fixed charges.

Trigger the pay-in-advance fixed charge invoice job when subscription fixed charge units are applied immediately. Add model support for resolving a fixed charge parent and cover the invoice job dispatch conditions in service specs.

Fixes BIL-83