### PR TITLE
perf(subscriptions): Add GIN indexes for subscription text fields

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -356,20 +356,23 @@ end
 #
 # Indexes
 #
-#  idx_on_organization_id_subscription_at_created_at_id        (organization_id,subscription_at DESC NULLS LAST,created_at DESC,id)
-#  index_subscriptions_on_billing_entity_id                    (billing_entity_id)
-#  index_subscriptions_on_customer_id                          (customer_id)
-#  index_subscriptions_on_ending_at_active                     (ending_at) WHERE ((status = 1) AND (ending_at IS NOT NULL))
-#  index_subscriptions_on_external_id                          (external_id)
-#  index_subscriptions_on_last_received_event_on               (last_received_event_on)
-#  index_subscriptions_on_last_received_event_on_null          (id) WHERE (last_received_event_on IS NULL)
-#  index_subscriptions_on_organization_id                      (organization_id)
-#  index_subscriptions_on_payment_method_id                    (payment_method_id)
-#  index_subscriptions_on_plan_id                              (plan_id)
-#  index_subscriptions_on_previous_subscription_id_and_status  (previous_subscription_id,status)
-#  index_subscriptions_on_started_at                           (started_at)
-#  index_subscriptions_on_started_at_and_ending_at             (started_at,ending_at)
-#  index_subscriptions_on_status                               (status)
+#  idx_on_organization_id_external_id_gin_trgm_ops_fb8058a497      (organization_id,external_id) USING gin
+#  idx_on_organization_id_subscription_at_created_at_id            (organization_id,subscription_at DESC NULLS LAST,created_at DESC,id)
+#  index_subscriptions_on_billing_entity_id                        (billing_entity_id)
+#  index_subscriptions_on_customer_id                              (customer_id)
+#  index_subscriptions_on_ending_at_active                         (ending_at) WHERE ((status = 1) AND (ending_at IS NOT NULL))
+#  index_subscriptions_on_external_id                              (external_id)
+#  index_subscriptions_on_last_received_event_on                   (last_received_event_on)
+#  index_subscriptions_on_last_received_event_on_null              (id) WHERE (last_received_event_on IS NULL)
+#  index_subscriptions_on_organization_id                          (organization_id)
+#  index_subscriptions_on_organization_id_id_varchar_gin_trgm_ops  (organization_id, ((id)::character varying) gin_trgm_ops) USING gin
+#  index_subscriptions_on_organization_id_name_gin_trgm_ops        (organization_id,name) USING gin
+#  index_subscriptions_on_payment_method_id                        (payment_method_id)
+#  index_subscriptions_on_plan_id                                  (plan_id)
+#  index_subscriptions_on_previous_subscription_id_and_status      (previous_subscription_id,status)
+#  index_subscriptions_on_started_at                               (started_at)
+#  index_subscriptions_on_started_at_and_ending_at                 (started_at,ending_at)
+#  index_subscriptions_on_status                                   (status)
 #
 # Foreign Keys
 #

--- a/db/migrate/20260609133104_add_gin_indexes_for_subscription_fields.rb
+++ b/db/migrate/20260609133104_add_gin_indexes_for_subscription_fields.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddGinIndexesForSubscriptionFields < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscriptions, "organization_id, (id::varchar) gin_trgm_ops", using: :gin, algorithm: :concurrently, if_not_exists: true
+    add_index :subscriptions, "organization_id, name gin_trgm_ops", using: :gin, algorithm: :concurrently, if_not_exists: true
+    add_index :subscriptions, "organization_id, external_id gin_trgm_ops", using: :gin, algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -400,6 +400,8 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_started_at;
 DROP INDEX IF EXISTS public.index_subscriptions_on_previous_subscription_id_and_status;
 DROP INDEX IF EXISTS public.index_subscriptions_on_plan_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_payment_method_id;
+DROP INDEX IF EXISTS public.index_subscriptions_on_organization_id_name_gin_trgm_ops;
+DROP INDEX IF EXISTS public.index_subscriptions_on_organization_id_id_varchar_gin_trgm_ops;
 DROP INDEX IF EXISTS public.index_subscriptions_on_organization_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_last_received_event_on_null;
 DROP INDEX IF EXISTS public.index_subscriptions_on_last_received_event_on;
@@ -820,6 +822,7 @@ DROP INDEX IF EXISTS public.idx_on_outbound_wallet_transaction_id_cf6ff733c6;
 DROP INDEX IF EXISTS public.idx_on_organization_id_subscription_at_created_at_id;
 DROP INDEX IF EXISTS public.idx_on_organization_id_organization_sequential_id_2387146f54;
 DROP INDEX IF EXISTS public.idx_on_organization_id_external_subscription_id_df3a30d96d;
+DROP INDEX IF EXISTS public.idx_on_organization_id_external_id_gin_trgm_ops_fb8058a497;
 DROP INDEX IF EXISTS public.idx_on_organization_id_e742f77454;
 DROP INDEX IF EXISTS public.idx_on_organization_id_e73219f079;
 DROP INDEX IF EXISTS public.idx_on_organization_id_deleted_at_225e3f789d;
@@ -6660,6 +6663,13 @@ CREATE INDEX idx_on_organization_id_e742f77454 ON public.subscription_fixed_char
 
 
 --
+-- Name: idx_on_organization_id_external_id_gin_trgm_ops_fb8058a497; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_organization_id_external_id_gin_trgm_ops_fb8058a497 ON public.subscriptions USING gin (organization_id, external_id public.gin_trgm_ops);
+
+
+--
 -- Name: idx_on_organization_id_external_subscription_id_df3a30d96d; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9601,6 +9611,20 @@ CREATE INDEX index_subscriptions_on_last_received_event_on_null ON public.subscr
 --
 
 CREATE INDEX index_subscriptions_on_organization_id ON public.subscriptions USING btree (organization_id);
+
+
+--
+-- Name: index_subscriptions_on_organization_id_id_varchar_gin_trgm_ops; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscriptions_on_organization_id_id_varchar_gin_trgm_ops ON public.subscriptions USING gin (organization_id, ((id)::character varying) public.gin_trgm_ops);
+
+
+--
+-- Name: index_subscriptions_on_organization_id_name_gin_trgm_ops; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscriptions_on_organization_id_name_gin_trgm_ops ON public.subscriptions USING gin (organization_id, name public.gin_trgm_ops);
 
 
 --
@@ -12554,6 +12578,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260609133104'),
 ('20260608111837'),
 ('20260608074112'),
 ('20260603121349'),
@@ -13572,3 +13597,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+


### PR DESCRIPTION
## Context

Searching subscriptions with `search_term` can be pretty slow, especially for organizations with a large number of subscriptions. The `search_term` is currently used to search across three subscription fields: `id`, `external_id`, and `name`, on top of other customer and plan fields.

## Description

This PR adds three GIN indexes for those fields. The

## Benchmarks

Here are some benchmarks without index (before) and with index (after):

```sql
SELECT
	*
FROM
	subscriptions
WHERE
	subscriptions.organization_id = '11111111-2222-3333-4444-555555555555'
	AND subscriptions.id IN (
		SELECT
			id
		FROM
			subscriptions
		WHERE
			organization_id = '11111111-2222-3333-4444-555555555555'
			AND id::varchar ILIKE '%fffff396-e75a-4a09-91a0-6c7111536324%'
		UNION
		SELECT
			id
		FROM
			subscriptions
		WHERE
			organization_id = '11111111-2222-3333-4444-555555555555'
			AND name ILIKE '%fffff396-e75a-4a09-91a0-6c7111536324%'
		UNION
		SELECT
			id
		FROM
			subscriptions
		WHERE
			organization_id = '11111111-2222-3333-4444-555555555555'
			AND external_id ILIKE '%fffff396-e75a-4a09-91a0-6c7111536324%'
	)
```

Benchmarking was done with `pgbench` on a database containing **~1.2m** subscriptions. The benchmark used 10 clients and 5 threads, ran for 30 seconds against a warmed-up database. 

```
pgbench --protocol=prepared -c 10 -j 5 -T 30 -h localhost -U lago -d lago -n -f subscriptions.sql
```

Solution | TPS | Latency (ms)
-- | -- | --
without index (before) | 2.13 | 4693.26
with index (after) | 164.94 | 60.63