### PR TITLE
chore(payments): Remove UUID casting for search

### DIFF
--- a/app/queries/payments_query.rb
+++ b/app/queries/payments_query.rb
@@ -7,7 +7,7 @@ class PaymentsQuery < BaseQuery
   def call
     return result unless validate_filters.success?
 
-    payments = base_scope.result
+    payments = base_scope
     payments = apply_filters(payments)
     payments = paginate(payments)
     payments = apply_consistent_ordering(payments)
@@ -23,11 +23,17 @@ class PaymentsQuery < BaseQuery
   end
 
   def base_scope
-    Payment.where.not(customer_id: nil)
+    scope = Payment.where.not(customer_id: nil)
       .where(organization:)
       .where.not(payable_id: nil)
       .where(visible_payable_condition)
-      .ransack(search_params)
+
+    return scope if search_term.blank?
+
+    by_attributes = scope.ransack(search_params).result
+    return by_attributes unless search_term.match?(BaseQuery::UUID_REGEX)
+
+    scope.where(id: by_attributes.select(:id)).or(scope.where(id: search_term))
   end
 
   def visible_payable_condition
@@ -55,7 +61,6 @@ class PaymentsQuery < BaseQuery
 
     terms = {
       m: "or",
-      id_cont: search_term,
       provider_payment_id_cont: search_term,
       reference_cont: search_term
     }

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe PaymentsQuery do
       end
     end
 
+    context "when search_term is a partial id" do
+      let(:search_term) { payment_one.id.first(13) }
+
+      it "does not match payments on a partial id" do
+        expect(result).to be_success
+        expect(returned_ids).not_to include(payment_one.id)
+      end
+    end
+
+    context "when search_term is a uuid matching no payment" do
+      let(:search_term) { "00000000-0000-0000-0000-000000000000" }
+
+      it "returns an empty result set" do
+        expect(result).to be_success
+        expect(returned_ids).to be_empty
+      end
+    end
+
     context "when search_term is an invoice number" do
       let(:search_term) { invoice.number }
 


### PR DESCRIPTION
## Context

  `PaymentsQuery` searched the `id` column through the `RansackUuidSearch`
  ransacker, which generated `payments.id::varchar ILIKE '%term%'`. Casting
  every row's id to text makes the primary-key index unusable and degrades the
  payments list query at scale. This mirrors the optimization already applied to
  `InvoicesQuery` and `CustomersQuery`.

  ## Description

  - Dropped the `id_cont` term from the ransack search. The `id` is now matched only when the search term is a
  full UUID
  - Because the attribute search joins `customers`, the ransack relation is pushed
  into a subquery (`scope.where(id: by_attributes.select(:id))`) so the UUID
  equality can be OR'd in while keeping both `.or` branches structurally
  compatible.
  - Added specs covering exact-UUID match, a full UUID matching no payment, and a
  partial id no longer matching.
  - Note: partial-id search (substring of a UUID) no longer matches, consistent
  with the invoices change.