### PR TITLE
chore(payments): Replace Ransack by UNIONS sub queries for search

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -161,6 +161,7 @@ end
 # Indexes
 #
 #  idx_on_organization_id_provider_payment_id_gin_trgm_2bcf073c0b  (organization_id,provider_payment_id) USING gin
+#  index_payments_by_cursor                                        (organization_id,created_at DESC,id)
 #  index_payments_on_customer_id                                   (customer_id)
 #  index_payments_on_invoice_id                                    (invoice_id)
 #  index_payments_on_organization_id                               (organization_id)

--- a/app/queries/payments_query.rb
+++ b/app/queries/payments_query.rb
@@ -30,10 +30,46 @@ class PaymentsQuery < BaseQuery
 
     return scope if search_term.blank?
 
-    by_attributes = scope.ransack(search_params).result
-    return by_attributes unless search_term.match?(BaseQuery::UUID_REGEX)
+    scope.where(id: matching_ids_by_search)
+  end
 
-    scope.where(id: by_attributes.select(:id)).or(scope.where(id: search_term))
+  def matching_ids_by_search
+    escaped_term = "%#{Payment.sanitize_sql_like(search_term)}%"
+    search_base = Payment.where(organization:)
+
+    branches = [
+      search_base.where("payments.provider_payment_id ILIKE ?", escaped_term).select(:id),
+      search_base.where("payments.reference ILIKE ?", escaped_term).select(:id)
+    ]
+
+    branches << search_base.where(id: search_term).select(:id) if search_term.match?(BaseQuery::UUID_REGEX)
+
+    if filters.invoice_id.blank?
+      branches << search_base.where(payable_type: "Invoice", payable_id: matching_invoice_ids).select(:id)
+    end
+
+    if filters.external_customer_id.blank?
+      branches << search_base.where(customer_id: matching_customer_ids).select(:id)
+    end
+
+    union_sql = branches.map(&:to_sql).join(" UNION ")
+    Payment.unscoped.from("(#{union_sql}) AS payments").select(:id)
+  end
+
+  def matching_invoice_ids
+    escaped_term = "%#{Invoice.sanitize_sql_like(search_term)}%"
+    organization.invoices.where("invoices.number ILIKE ?", escaped_term).select(:id)
+  end
+
+  def matching_customer_ids
+    escaped_term = "%#{Customer.sanitize_sql_like(search_term)}%"
+
+    branches = %i[name firstname lastname external_id email].map do |field|
+      organization.customers.where("customers.#{field} ILIKE ?", escaped_term).select(:id)
+    end
+
+    union_sql = branches.map(&:to_sql).join(" UNION ")
+    Customer.unscoped.from("(#{union_sql}) AS customers").select(:id)
   end
 
   def visible_payable_condition
@@ -54,34 +90,6 @@ class PaymentsQuery < BaseQuery
         organization_id: organization.id
       }
     ])
-  end
-
-  def search_params
-    return if search_term.blank?
-
-    terms = {
-      m: "or",
-      provider_payment_id_cont: search_term,
-      reference_cont: search_term
-    }
-
-    # Add payable search terms if not filtering by specific invoice
-    if filters.invoice_id.blank?
-      terms[:invoice_number_cont] = search_term
-    end
-
-    # Add customer search terms if not filtering by specific customer
-    if filters.external_customer_id.blank?
-      terms.merge!(
-        customer_name_cont: search_term,
-        customer_firstname_cont: search_term,
-        customer_lastname_cont: search_term,
-        customer_external_id_cont: search_term,
-        customer_email_cont: search_term
-      )
-    end
-
-    terms
   end
 
   def apply_filters(scope)

--- a/db/migrate/20260611122002_add_payments_cursor_index.rb
+++ b/db/migrate/20260611122002_add_payments_cursor_index.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddPaymentsCursorIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :payments,
+      [:organization_id, :created_at, :id],
+      order: {created_at: :desc, id: :asc},
+      name: :index_payments_by_cursor,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -473,6 +473,7 @@ DROP INDEX IF EXISTS public.index_payments_on_organization_id_reference_gin_trgm
 DROP INDEX IF EXISTS public.index_payments_on_organization_id;
 DROP INDEX IF EXISTS public.index_payments_on_invoice_id;
 DROP INDEX IF EXISTS public.index_payments_on_customer_id;
+DROP INDEX IF EXISTS public.index_payments_by_cursor;
 DROP INDEX IF EXISTS public.index_payment_requests_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_requests_on_dunning_campaign_id;
 DROP INDEX IF EXISTS public.index_payment_requests_on_customer_id;
@@ -9129,6 +9130,13 @@ CREATE INDEX index_payment_requests_on_organization_id ON public.payment_request
 
 
 --
+-- Name: index_payments_by_cursor; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_payments_by_cursor ON public.payments USING btree (organization_id, created_at DESC, id);
+
+
+--
 -- Name: index_payments_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12590,6 +12598,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260611122002'),
 ('20260609173731'),
 ('20260609165032'),
 ('20260609161044'),

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PaymentsQuery do
   end
 
   context "with search_term" do
-    let(:customer) { create(:customer, firstname: "first", lastname: "last", external_id: "external_c_id", email: "email@example.com", name: "The name") }
+    let(:customer) { create(:customer, organization:, firstname: "first", lastname: "last", external_id: "external_c_id", email: "email@example.com", name: "The name") }
     let(:invoice) { create(:invoice, :finalized, organization:, customer:, number: "number-test-123") }
     let(:invoice3) { create(:invoice, :finalized, organization:, customer:) }
     let(:payment_one) { create(:payment, payable: invoice) }


### PR DESCRIPTION
## Context

  The payments list search combined every searchable field into a single Ransack
  `OR` query (provider payment id, reference, invoice number, and customer
  fields). PostgreSQL cannot use the per-column GIN trigram indexes when all the
  `ILIKE` predicates are OR'd together across different columns and joined tables,
  so the search degrades to sequential scans as the payments table grows. This
  applies the same UNION strategy already used in `CustomersQuery`.

  ## Description

  Replace the Ransack OR with a UNION of single-field branches, each referencing
  one column directly so the planner can pick the matching index:

  - `provider_payment_id` and `reference` ILIKE branches (use the payments GIN
    trigram indexes)
  - exact `id` equality, added only when the term is a full UUID
  - invoice number match via an organization-scoped subquery (uses the invoice
    number index)
  - customer match via a nested UNION over name/firstname/lastname/external_id/
    email on the organization's customers (uses the customer indexes)
- Added an index for cursor (targeting the `ORDER BY` of the search query)

  This also corrects a scoping difference: the old Ransack customer search joined
  `payments.customer` without an organization filter and could match customers in
  other organizations.