### PR TITLE
[ING-309] fix(wallets): Enqueue wallet refresh on update

### DIFF
--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -68,7 +68,7 @@ module Wallets
           Customers::RefreshWalletJob.perform_after_commit(wallet.customer)
         end
 
-        InvoiceCustomSections::AttachToResourceService.call(resource: wallet, params:)
+        InvoiceCustomSections::AttachToResourceService.call!(resource: wallet, params:)
         SendWebhookJob.perform_after_commit("wallet.updated", wallet)
       end
 

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -68,10 +68,9 @@ module Wallets
           Customers::RefreshWalletJob.perform_after_commit(wallet.customer)
         end
 
+        InvoiceCustomSections::AttachToResourceService.call(resource: wallet, params:)
         SendWebhookJob.perform_after_commit("wallet.updated", wallet)
       end
-
-      InvoiceCustomSections::AttachToResourceService.call(resource: wallet, params:)
 
       result.wallet = wallet
       result

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -63,12 +63,14 @@ module Wallets
 
         update_metadata!
 
-        wallet.customer.flag_wallets_for_refresh if needs_refresh?
+        if needs_refresh?
+          wallet.customer.flag_wallets_for_refresh
+          Customers::RefreshWalletJob.perform_after_commit(wallet.customer)
+        end
       end
 
       InvoiceCustomSections::AttachToResourceService.call(resource: wallet, params:)
       SendWebhookJob.perform_later("wallet.updated", wallet)
-      Customers::RefreshWalletJob.perform_after_commit(wallet.customer) if needs_refresh?
 
       result.wallet = wallet
       result

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -62,11 +62,13 @@ module Wallets
         wallet.save!
 
         update_metadata!
+
+        wallet.customer.flag_wallets_for_refresh if needs_refresh?
       end
 
       InvoiceCustomSections::AttachToResourceService.call(resource: wallet, params:)
       SendWebhookJob.perform_later("wallet.updated", wallet)
-      Customers::RefreshWalletsService.call(customer: wallet.customer) if needs_refresh?
+      Customers::RefreshWalletJob.perform_after_commit(wallet.customer) if needs_refresh?
 
       result.wallet = wallet
       result

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -67,10 +67,11 @@ module Wallets
           wallet.customer.flag_wallets_for_refresh
           Customers::RefreshWalletJob.perform_after_commit(wallet.customer)
         end
+
+        SendWebhookJob.perform_after_commit("wallet.updated", wallet)
       end
 
       InvoiceCustomSections::AttachToResourceService.call(resource: wallet, params:)
-      SendWebhookJob.perform_later("wallet.updated", wallet)
 
       result.wallet = wallet
       result

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -41,8 +41,11 @@ RSpec.describe Wallets::UpdateService do
       expect(wallet.paid_top_up_min_amount_cents).to eq(1_00)
       expect(wallet.paid_top_up_max_amount_cents).to eq(1_000_00)
 
-      expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
       expect(Utils::ActivityLog).to have_produced("wallet.updated").after_commit.with(wallet)
+    end
+
+    it "sends a `wallet.updated` webhook" do
+      expect { result }.to have_enqueued_job_after_commit(SendWebhookJob).with("wallet.updated", Wallet)
     end
 
     it "flags the customer wallets for refresh and enqueues a refresh job" do

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -45,47 +45,44 @@ RSpec.describe Wallets::UpdateService do
       expect(Utils::ActivityLog).to have_produced("wallet.updated").after_commit.with(wallet)
     end
 
-    it "calls Customers::RefreshWalletsService" do
-      allow(Customers::RefreshWalletsService).to receive(:call)
-      subject
-
-      expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:)
-      expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
+    it "flags the customer wallets for refresh and enqueues a refresh job" do
+      expect { result }.to have_enqueued_job_after_commit(Customers::RefreshWalletJob).with(customer)
+      expect(customer.reload).to be_awaiting_wallet_refresh
     end
 
-    describe "Customers::RefreshWalletsService gating" do
-      before { allow(Customers::RefreshWalletsService).to receive(:call) }
-
-      shared_examples "calls refresh" do
-        it "calls Customers::RefreshWalletsService" do
+    describe "wallet refresh gating" do
+      shared_examples "flags refresh" do
+        it "flags the customer wallets for refresh and enqueues a refresh job" do
+          expect { result }.to have_enqueued_job_after_commit(Customers::RefreshWalletJob).with(customer)
           expect(result).to be_success
-          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:)
+          expect(customer.reload).to be_awaiting_wallet_refresh
         end
       end
 
-      shared_examples "does not call refresh" do
-        it "does not call Customers::RefreshWalletsService" do
+      shared_examples "does not flag refresh" do
+        it "does not flag the customer wallets for refresh nor enqueue a refresh job" do
+          expect { result }.not_to have_enqueued_job(Customers::RefreshWalletJob)
           expect(result).to be_success
-          expect(Customers::RefreshWalletsService).not_to have_received(:call)
+          expect(customer.reload).not_to be_awaiting_wallet_refresh
         end
       end
 
       context "when code changes" do
         let(:params) { {id: wallet.id, code: "new_code"} }
 
-        include_examples "calls refresh"
+        include_examples "flags refresh"
       end
 
       context "when priority changes" do
         let(:params) { {id: wallet.id, priority: wallet.priority - 1} }
 
-        include_examples "calls refresh"
+        include_examples "flags refresh"
       end
 
       context "when allowed_fee_types change" do
         let(:params) { {id: wallet.id, applies_to: {fee_types: %w[charge]}} }
 
-        include_examples "calls refresh"
+        include_examples "flags refresh"
       end
 
       context "when a wallet_target is added" do
@@ -94,7 +91,7 @@ RSpec.describe Wallets::UpdateService do
 
         before { CurrentContext.source = "graphql" }
 
-        include_examples "calls refresh"
+        include_examples "flags refresh"
       end
 
       context "when a wallet_target is removed" do
@@ -106,19 +103,19 @@ RSpec.describe Wallets::UpdateService do
           create(:wallet_target, wallet:, billable_metric:)
         end
 
-        include_examples "calls refresh"
+        include_examples "flags refresh"
       end
 
       context "when only name changes" do
         let(:params) { {id: wallet.id, name: "new name"} }
 
-        include_examples "does not call refresh"
+        include_examples "does not flag refresh"
       end
 
       context "when only expiration_at changes" do
         let(:params) { {id: wallet.id, expiration_at: (Time.current + 1.year).iso8601} }
 
-        include_examples "does not call refresh"
+        include_examples "does not flag refresh"
       end
 
       context "when only paid_top_up_* change" do
@@ -130,7 +127,7 @@ RSpec.describe Wallets::UpdateService do
           }
         end
 
-        include_examples "does not call refresh"
+        include_examples "does not flag refresh"
       end
 
       context "when only payment_method changes" do
@@ -144,7 +141,7 @@ RSpec.describe Wallets::UpdateService do
 
         before { payment_method }
 
-        include_examples "does not call refresh"
+        include_examples "does not flag refresh"
       end
 
       context "when only recurring_transaction_rules change", :premium do
@@ -157,19 +154,19 @@ RSpec.describe Wallets::UpdateService do
           }
         end
 
-        include_examples "does not call refresh"
+        include_examples "does not flag refresh"
       end
 
       context "when only metadata changes" do
         let(:params) { {id: wallet.id, metadata: {"foo" => "bar"}} }
 
-        include_examples "does not call refresh"
+        include_examples "does not flag refresh"
       end
 
       context "when client resends a refresh-relevant attribute with the same value (no-op)" do
         let(:params) { {id: wallet.id, code: wallet.code, name: "new name"} }
 
-        include_examples "does not call refresh"
+        include_examples "does not flag refresh"
       end
     end
 

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe Wallets::UpdateService do
         include_examples "flags refresh"
       end
 
+      context "when code changes together with an invoice_custom_section update" do
+        let(:params) do
+          {
+            id: wallet.id,
+            code: "new_code",
+            invoice_custom_section: {skip_invoice_custom_sections: true}
+          }
+        end
+
+        include_examples "flags refresh"
+      end
+
       context "when only name changes" do
         let(:params) { {id: wallet.id, name: "new name"} }
 


### PR DESCRIPTION
## Context

We noticed slow pages on EU: wallet updates were taking more than 10s, up to ~62s. `Wallets::UpdateService` refreshes the customer wallets synchronously when a refresh-relevant attribute changes, and the refresh recomputes the usage of every active subscription, so the response time grows with the number of subscriptions of the customer.

## Changes

- Flag the customer as `awaiting_wallet_refresh` and enqueue `Customers::RefreshWalletJob` after commit, instead of calling `Customers::RefreshWalletsService` synchronously. Same pattern as the wallet increase flow (https://github.com/getlago/lago-api/pull/5631), without `wallet_ids` since these attributes can affect the allocation of all the wallets of the customer.
- The flag and the enqueue are done together inside the update transaction, so they are atomic: both happen on commit, or neither. It also keeps a single `needs_refresh?` evaluation, before `InvoiceCustomSections::AttachToResourceService` can save the wallet again and reset `saved_changes`.
- Move the `wallet.updated` webhook (now with `perform_after_commit`) and the invoice custom sections attach inside the transaction, to align with the create and terminate flows.

| | Before | Now |
|---|---|---|
| Wallet update request | Blocks until the refresh is done (up to ~62s) | Returns immediately |
| Wallets refresh | Synchronous, inside the request | `Customers::RefreshWalletJob`, after commit |
| `ongoing_balance` in the response | Up to date | Last known value, recomputed right after in background |
