### PR TITLE
[ING-310] fix(metadata): Reject non-string metadata values

### DIFF
--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -31,7 +31,8 @@ module Metadata
           errors.add(:value, "key '#{key}' must be a String up to #{MAX_KEY_LENGTH} characters")
         end
 
-        unless val.nil? || (val.is_a?(String) && val.length <= MAX_VALUE_LENGTH)
+        valid_value = val.nil? || (val.is_a?(String) && val.length <= MAX_VALUE_LENGTH)
+        unless valid_value
           errors.add(:value, "value for key '#{key}' must be empty or a String up to #{MAX_VALUE_LENGTH} characters")
         end
       end

--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -31,7 +31,7 @@ module Metadata
           errors.add(:value, "key '#{key}' must be a String up to #{MAX_KEY_LENGTH} characters")
         end
 
-        if val.present? && !(val.is_a?(String) && val.length <= MAX_VALUE_LENGTH)
+        unless val.nil? || (val.is_a?(String) && val.length <= MAX_VALUE_LENGTH)
           errors.add(:value, "value for key '#{key}' must be empty or a String up to #{MAX_VALUE_LENGTH} characters")
         end
       end

--- a/spec/models/metadata/item_metadata_spec.rb
+++ b/spec/models/metadata/item_metadata_spec.rb
@@ -130,6 +130,49 @@ RSpec.describe Metadata::ItemMetadata do
           expect(item_metadata.errors[:value].join).to include("value for key 'foo' must be empty or a String up to 255 characters")
         end
       end
+
+      context "when value is a non-string leaf for every owner type" do
+        let(:owner) do
+          case owner_type
+          when :credit_note then create(:credit_note, invoice:, customer:, organization:)
+          when :wallet then create(:wallet, organization:)
+          when :plan then create(:plan, organization:)
+          end
+        end
+
+        [:credit_note, :wallet, :plan].each do |type|
+          context "when owner is a #{type}" do
+            let(:owner_type) { type }
+
+            context "when value is false" do
+              let(:value) { {"foo" => false} }
+
+              it "adds an error" do
+                expect(item_metadata).not_to be_valid
+                expect(item_metadata.errors[:value].join).to include("value for key 'foo' must be empty or a String up to 255 characters")
+              end
+            end
+
+            context "when value is an empty array" do
+              let(:value) { {"foo" => []} }
+
+              it "adds an error" do
+                expect(item_metadata).not_to be_valid
+                expect(item_metadata.errors[:value].join).to include("value for key 'foo' must be empty or a String up to 255 characters")
+              end
+            end
+
+            context "when value is an empty hash" do
+              let(:value) { {"foo" => {}} }
+
+              it "adds an error" do
+                expect(item_metadata).not_to be_valid
+                expect(item_metadata.errors[:value].join).to include("value for key 'foo' must be empty or a String up to 255 characters")
+              end
+            end
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context

`Metadata::ItemMetadata` is the shared metadata model for `CreditNote`, `Wallet`, and `Plan`. Its `value_correctness` validation gates the per-value string check on `val.present?`. Because `present?` is false for any blank value, `false`, empty arrays, and empty hashes skip the string check and are wrongly accepted, while `true`, `0`, numbers, and non-empty arrays/hashes are rejected (inconsistent). Through the REST API (`params.permit(metadata: {})`) this lets non-string JSON leaf values be persisted, which then pollute the `exports_*` warehouse views (they get surfaced as `"false"`/`"[]"`/`"{}"`). A DB CHECK constraint already blocks top-level non-object values, so the remaining gap is strictly these non-string leaf values.

## Description

This PR adds regression specs that assert a metadata leaf value of `false`, an empty array, or an empty hash is rejected for all three owner types. The specs are intentionally pushed while red so the failure is visible in CI before the fix lands. `nil` and empty-string leaf values stay valid.

The fix follows in a second commit, replacing the `present?` guard with an explicit type check (`val.nil? || (val.is_a?(String) && ...)`) so only `nil` and strings up to the length limit pass.

## Test plan

- [ ] `spec/models/metadata/item_metadata_spec.rb` fails on the new false/empty-array/empty-hash cases before the fix
- [ ] `spec/models/metadata/item_metadata_spec.rb` is green after the fix, with the existing nil and empty-string cases still valid
- [ ] `spec/db/views/exports_credit_notes_spec.rb` stays green
