### PR TITLE
feat(fc-units-override): add params-shape predicate for units-only overrides

### DIFF
--- a/app/services/subscriptions/concerns/fixed_charge_units_override_detection_concern.rb
+++ b/app/services/subscriptions/concerns/fixed_charge_units_override_detection_concern.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module Concerns
+    # Pure params-shape predicates that decide whether a request is eligible
+    # for the units-only override write path (writing one row to
+    # subscription_fixed_charge_units_overrides instead of cloning the plan).
+    #
+    # The two shapes handled here:
+    #
+    # - `plan_overrides` envelope (subscription create/update with
+    #   `plan_overrides.fixed_charges`): match when only the `fixed_charges`
+    #   key is present, the array is non-empty, and every entry contains only
+    #   `id`, `units`, and optionally `apply_units_immediately`.
+    # - Dedicated subscription-scoped fixed_charge endpoint
+    #   (`UpdateOrOverrideFixedChargeService`): match when the top-level
+    #   params contain `units` and optionally `apply_units_immediately`, and
+    #   nothing else (the fixed_charge identity comes from the URL).
+    #
+    # The cloned-plan guard (`subscription.plan.parent_id` is set) is
+    # enforced by each calling service against the subscription it holds,
+    # not here — these predicates only inspect params.
+    module FixedChargeUnitsOverrideDetectionConcern
+      extend ActiveSupport::Concern
+
+      PLAN_OVERRIDES_FIXED_CHARGE_ALLOWED_KEYS = %i[id units apply_units_immediately].freeze
+      DEDICATED_ENDPOINT_ALLOWED_KEYS = %i[units apply_units_immediately].freeze
+
+      private
+
+      def units_only_fixed_charges_plan_overrides?(plan_overrides)
+        plan_overrides = normalize_hash(plan_overrides)
+        return false unless plan_overrides
+        return false unless plan_overrides.keys == [:fixed_charges]
+
+        fixed_charges = plan_overrides[:fixed_charges]
+        return false unless fixed_charges&.any?
+
+        fixed_charges.all? { |entry| units_only_fixed_charges_entry?(entry) }
+      end
+
+      def units_only_fixed_charge_params?(params)
+        params = normalize_hash(params)
+        return false unless params
+        return false unless params.key?(:units)
+
+        (params.keys - DEDICATED_ENDPOINT_ALLOWED_KEYS).empty?
+      end
+
+      def units_only_fixed_charges_entry?(entry)
+        entry = normalize_hash(entry)
+        return false unless entry
+        return false unless entry.key?(:id) && entry.key?(:units)
+
+        (entry.keys - PLAN_OVERRIDES_FIXED_CHARGE_ALLOWED_KEYS).empty?
+      end
+
+      def normalize_hash(value)
+        return nil if value.nil?
+        return value.symbolize_keys if value.is_a?(Hash)
+        return value.to_h.symbolize_keys if value.respond_to?(:to_h)
+
+        nil
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
   subject(:host) do
     Class.new do
       include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
+
       public :units_only_fixed_charges_plan_overrides?, :units_only_fixed_charge_params?
     end.new
   end

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern do
+  subject(:host) do
+    Class.new do
+      include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
+      public :units_only_fixed_charges_plan_overrides?, :units_only_fixed_charge_params?
+    end.new
+  end
+
+  describe "#units_only_fixed_charges_plan_overrides?" do
+    context "when the envelope contains only fixed_charges with valid entries" do
+      let(:plan_overrides) { {fixed_charges: [{id: "fc-1", units: 5}]} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be true }
+    end
+
+    context "when an entry also carries apply_units_immediately" do
+      let(:plan_overrides) { {fixed_charges: [{id: "fc-1", units: 5, apply_units_immediately: true}]} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be true }
+    end
+
+    context "with multiple entries that all match" do
+      let(:plan_overrides) { {fixed_charges: [{id: "fc-1", units: 5}, {id: "fc-2", units: 10}]} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be true }
+    end
+
+    context "with string keys (e.g. ActionController params)" do
+      let(:plan_overrides) { {"fixed_charges" => [{"id" => "fc-1", "units" => 5}]} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be true }
+    end
+
+    context "when the envelope is nil" do
+      it { expect(host.units_only_fixed_charges_plan_overrides?(nil)).to be false }
+    end
+
+    context "when the envelope has other top-level keys alongside fixed_charges" do
+      let(:plan_overrides) { {fixed_charges: [{id: "fc-1", units: 5}], amount_cents: 1000} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be false }
+    end
+
+    context "when fixed_charges is missing" do
+      let(:plan_overrides) { {amount_cents: 1000} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be false }
+    end
+
+    context "when fixed_charges is empty" do
+      let(:plan_overrides) { {fixed_charges: []} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be false }
+    end
+
+    context "when an entry is missing id" do
+      let(:plan_overrides) { {fixed_charges: [{units: 5}]} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be false }
+    end
+
+    context "when an entry is missing units" do
+      let(:plan_overrides) { {fixed_charges: [{id: "fc-1"}]} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be false }
+    end
+
+    context "when an entry has unexpected extra keys" do
+      let(:plan_overrides) { {fixed_charges: [{id: "fc-1", units: 5, invoice_display_name: "x"}]} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be false }
+    end
+
+    context "when one entry passes and another fails" do
+      let(:plan_overrides) { {fixed_charges: [{id: "fc-1", units: 5}, {id: "fc-2", units: 10, amount_cents: 1}]} }
+
+      it { expect(host.units_only_fixed_charges_plan_overrides?(plan_overrides)).to be false }
+    end
+  end
+
+  describe "#units_only_fixed_charge_params?" do
+    context "with only units" do
+      it { expect(host.units_only_fixed_charge_params?({units: 5})).to be true }
+    end
+
+    context "with units and apply_units_immediately" do
+      it { expect(host.units_only_fixed_charge_params?({units: 5, apply_units_immediately: true})).to be true }
+    end
+
+    context "with string keys" do
+      it { expect(host.units_only_fixed_charge_params?({"units" => 5})).to be true }
+    end
+
+    context "when params is nil" do
+      it { expect(host.units_only_fixed_charge_params?(nil)).to be false }
+    end
+
+    context "when units is missing" do
+      it { expect(host.units_only_fixed_charge_params?({apply_units_immediately: true})).to be false }
+    end
+
+    context "with unexpected extra keys" do
+      it { expect(host.units_only_fixed_charge_params?({units: 5, invoice_display_name: "x"})).to be false }
+    end
+
+    context "with an empty hash" do
+      it { expect(host.units_only_fixed_charge_params?({})).to be false }
+    end
+  end
+end


### PR DESCRIPTION
## Context

Three subscription write services will route units-only fixed-charge override requests through a new branch that records the override on a dedicated table instead of cloning the plan: subscription creation and update with `plan_overrides`, and the dedicated subscription- scoped fixed_charge endpoint. The routing decision is a pure params-shape check, so it should live in one place rather than being re-implemented at each call site.

The predicate has two natural shapes because the surfaces differ: the `plan_overrides` envelope wraps `fixed_charges` entries that each carry their `id`, while the dedicated endpoint identifies the fixed_charge through the URL and accepts flat top-level params.

## Description

New `Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern` exposes two private predicates:

- `units_only_fixed_charges_plan_overrides?(plan_overrides)` matches when the envelope contains only the `fixed_charges` key, the array is non-empty, and every entry contains only `id`, `units`, and optionally `apply_units_immediately`.
- `units_only_fixed_charge_params?(params)` matches when the flat top-level params contain `units` (required) and optionally `apply_units_immediately`, and nothing else.

Both methods accept symbol- or string-keyed hashes (so they work against `ActionController::Parameters`-derived structures without extra plumbing at call sites).

The cloned-plan guard (subscription already on a plan whose `parent_id` is set) is intentionally not in scope here — that check depends on subscription state and stays with each calling service.

No callers yet; the three write services pick this up in follow-up tasks. The concern lands first so its contract and edge-case behaviour are pinned down before any service depends on it.