### PR TITLE
fix(integration-customers): Improve sanitization logic of integration customers

### DIFF
--- a/app/services/integration_customers/create_or_update_batch_service.rb
+++ b/app/services/integration_customers/create_or_update_batch_service.rb
@@ -80,10 +80,47 @@ module IntegrationCustomers
     end
 
     def sanitize_integration_customers
-      updated_int_customers = integration_customers.reject { |m| m[:id].nil? }.map { |m| m[:id] }
-      not_needed_ids = customer.integration_customers.pluck(:id) - updated_int_customers
+      existing_ids = customer.integration_customers.ids
 
-      customer.integration_customers.where(id: not_needed_ids).destroy_all
+      kept_ids = integration_customers.filter_map do |params|
+        id = params[:id].presence
+
+        if id && existing_ids.include?(id)
+          id
+        else
+          existing_integration_customer_id(params)
+        end
+      end
+
+      if kept_ids.empty?
+        customer.integration_customers.destroy_all
+      else
+        customer.integration_customers.where.not(id: kept_ids).destroy_all
+      end
+    end
+
+    def existing_integration_customer_id(params)
+      return if params[:integration_type].blank?
+
+      integration_customer_type = IntegrationCustomers::BaseCustomer.customer_type(params[:integration_type])
+      integration_customer = customer.integration_customers.find_by(type: integration_customer_type)
+
+      integration_customer.id if integration_customer && !switching_connection?(integration_customer, params)
+    rescue NotImplementedError
+      nil
+    end
+
+    def switching_connection?(integration_customer, params)
+      return false if params[:integration_code].blank?
+
+      integration_type = Integrations::BaseIntegration.integration_type(params[:integration_type])
+      integration = Integrations::BaseIntegration.find_by(
+        type: integration_type,
+        code: params[:integration_code],
+        organization_id: customer.organization_id
+      )
+
+      integration.present? && integration.id != integration_customer.integration_id
     end
 
     def skip_creating_integration_customer?

--- a/spec/services/integration_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_batch_service_spec.rb
@@ -271,5 +271,147 @@ RSpec.describe IntegrationCustomers::CreateOrUpdateBatchService do
         end
       end
     end
+
+    context "when re-sending an existing integration customer without its id" do
+      let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
+      let(:integration_code) { integration.code }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { "12345" }
+      let(:new_customer) { false }
+
+      before { integration_customer }
+
+      it "does not enqueue a create job" do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::CreateJob)
+      end
+
+      it "enqueues an update job" do
+        expect { service_call }.to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+
+      it "keeps the same integration customer" do
+        service_call
+
+        expect(customer.reload.integration_customers.pluck(:id)).to eq([integration_customer.id])
+      end
+    end
+
+    context "when re-sending an existing anrok integration customer without its id" do
+      let(:integration) { create(:anrok_integration, organization:) }
+      let(:integration_customer) { create(:anrok_customer, customer:, integration:, external_customer_id: nil) }
+      let(:new_customer) { false }
+      let(:integration_customers) do
+        [
+          {
+            integration_type: "anrok",
+            integration_code: integration.code,
+            sync_with_provider: true,
+            external_customer_id: nil
+          }
+        ]
+      end
+
+      before { integration_customer }
+
+      it "does not enqueue a create job" do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::CreateJob)
+      end
+
+      it "enqueues an update job" do
+        expect { service_call }.to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+
+      it "keeps the same integration customer" do
+        service_call
+
+        expect(customer.reload.integration_customers.pluck(:id)).to eq([integration_customer.id])
+      end
+    end
+
+    context "when re-sending an existing integration customer with a placeholder id" do
+      let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
+      let(:integration_code) { integration.code }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { "12345" }
+      let(:new_customer) { false }
+      let(:integration_customers) do
+        [
+          {
+            id: "00000000-0000-0000-0000-000000000000",
+            integration_type: "netsuite",
+            integration_code:,
+            sync_with_provider:,
+            external_customer_id:,
+            subsidiary_id:
+          }
+        ]
+      end
+
+      before { integration_customer }
+
+      it "does not enqueue a create job" do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::CreateJob)
+      end
+
+      it "enqueues an update job" do
+        expect { service_call }.to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+
+      it "keeps the same integration customer" do
+        service_call
+
+        expect(customer.reload.integration_customers.pluck(:id)).to eq([integration_customer.id])
+      end
+    end
+
+    context "when switching an existing integration customer to another connection of the same type" do
+      let(:integration) { create(:netsuite_integration, organization:, code: "netsuite_old") }
+      let(:new_integration) { create(:netsuite_integration, organization:, code: "netsuite_new") }
+      let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
+      let(:integration_code) { new_integration.code }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { nil }
+      let(:new_customer) { false }
+
+      before do
+        integration_customer
+        new_integration
+      end
+
+      it "enqueues a create job for the new connection" do
+        expect { service_call }.to have_enqueued_job(IntegrationCustomers::CreateJob)
+          .with(hash_including(integration: new_integration))
+      end
+
+      it "removes the link to the old connection" do
+        service_call
+
+        expect(customer.reload.integration_customers.pluck(:id)).to eq([])
+      end
+    end
+
+    context "when re-sending an existing integration customer with an unknown connection code" do
+      let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
+      let(:integration_code) { "unknown-code" }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { "12345" }
+      let(:new_customer) { false }
+
+      before { integration_customer }
+
+      it "does not enqueue a create job" do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::CreateJob)
+      end
+
+      it "does not enqueue an update job" do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+
+      it "keeps the same integration customer" do
+        service_call
+
+        expect(customer.reload.integration_customers.pluck(:id)).to eq([integration_customer.id])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Re-sending a customer's `integration_customers` block on `POST /api/v1/customers` could duplicate provider contacts. Stale-link removal was keyed only on the `id`, so a payload whose `id` didn't match the stored link — e.g. the all-zeros placeholder the Go client sent for an unset id — destroyed the existing link and immediately recreated it, adding a duplicate NetSuite/Anrok contact on every repeat.

## Description

`sanitize_integration_customers` now trusts a payload `id` only when it belongs to one of the customer's links; otherwise it resolves the existing link by integration type, so a missing or wrong `id` no longer orphans it. An entry pointing the same type at a different connection is still treated as a switch and removed. Matching avoids `external_customer_id`, which Anrok links lack until their first invoice sync.
