### PR TITLE
[ING-252] fix(cache): expire on metric deletion

### DIFF
--- a/app/services/events/delete_for_metric_service.rb
+++ b/app/services/events/delete_for_metric_service.rb
@@ -83,9 +83,7 @@ module Events
     end
 
     def expire_charge_caches(subscription_ids)
-      Subscription.where(id: subscription_ids).find_each do |subscription|
-        Subscriptions::ChargeCacheService.expire_for_subscription(subscription)
-      end
+      Subscriptions::ChargeCacheService.expire_for_subscriptions(subscription_ids)
     end
 
     def async_delete_clickhouse(table, date_field, external_subscription_ids)

--- a/app/services/events/delete_for_metric_service.rb
+++ b/app/services/events/delete_for_metric_service.rb
@@ -26,6 +26,7 @@ module Events
 
         delete_postgres_events(subscription_ids, external_subscription_ids)
         delete_clickhouse_events(external_subscription_ids) if clickhouse_enabled
+        expire_charge_caches(subscription_ids)
       end
 
       result
@@ -78,6 +79,12 @@ module Events
     def delete_clickhouse_events(external_subscription_ids)
       CLICKHOUSE_TABLES.each do |table, date_field|
         async_delete_clickhouse(table, date_field, external_subscription_ids)
+      end
+    end
+
+    def expire_charge_caches(subscription_ids)
+      Subscription.where(id: subscription_ids).find_each do |subscription|
+        Subscriptions::ChargeCacheService.expire_for_subscription(subscription)
       end
     end
 

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -4,9 +4,19 @@ module Subscriptions
   class ChargeCacheService < CacheService
     CACHE_KEY_VERSION = "1"
 
+    def self.expire_for_subscriptions(subscription_ids)
+      Subscription
+        .where(id: subscription_ids)
+        .preload(plan: {charges: :filters})
+        .find_each do |subscription|
+          subscription.plan.charges.each do |charge|
+            expire_for_subscription_charge(subscription:, charge:)
+          end
+        end
+    end
+
     def self.expire_for_subscription(subscription)
-      subscription.plan.charges.includes(:filters)
-        .find_each { expire_for_subscription_charge(subscription:, charge: it) }
+      expire_for_subscriptions([subscription.id])
     end
 
     def self.expire_for_subscription_charge(subscription:, charge:)

--- a/spec/services/events/delete_for_metric_service_spec.rb
+++ b/spec/services/events/delete_for_metric_service_spec.rb
@@ -73,6 +73,42 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
       end
     end
 
+    context "with charge-usage cache invalidation" do
+      it "expires the charge-usage cache for each affected subscription" do
+        allow(Subscriptions::ChargeCacheService).to receive(:expire_for_subscription).and_call_original
+
+        service.call
+
+        expect(Subscriptions::ChargeCacheService)
+          .to have_received(:expire_for_subscription)
+          .with(having_attributes(id: subscription.id))
+      end
+
+      context "when a cached usage value has already been written", cache: :memory do
+        let(:cache_key) do
+          [
+            "charge-usage",
+            Subscriptions::ChargeCacheService::CACHE_KEY_VERSION,
+            charge.id,
+            subscription.id,
+            charge.updated_at.iso8601
+          ].join("/")
+        end
+
+        before do
+          Rails.cache.write(cache_key, '[{"amount_cents":3000}]')
+        end
+
+        it "invalidates the cached usage so a subsequent read recomputes without the deleted metric" do
+          expect(Rails.cache.exist?(cache_key)).to be true
+
+          service.call
+
+          expect(Rails.cache.exist?(cache_key)).to be false
+        end
+      end
+    end
+
     context "with clickhouse events" do
       include_context "with clickhouse availability"
 

--- a/spec/services/events/delete_for_metric_service_spec.rb
+++ b/spec/services/events/delete_for_metric_service_spec.rb
@@ -74,14 +74,14 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
     end
 
     context "with charge-usage cache invalidation" do
-      it "expires the charge-usage cache for each affected subscription" do
-        allow(Subscriptions::ChargeCacheService).to receive(:expire_for_subscription).and_call_original
+      it "expires the charge-usage cache for each (subscription, charge) of each affected subscription" do
+        allow(Subscriptions::ChargeCacheService).to receive(:expire_for_subscription_charge).and_call_original
 
         service.call
 
         expect(Subscriptions::ChargeCacheService)
-          .to have_received(:expire_for_subscription)
-          .with(having_attributes(id: subscription.id))
+          .to have_received(:expire_for_subscription_charge)
+          .with(subscription: having_attributes(id: subscription.id), charge: having_attributes(id: charge.id))
       end
 
       context "when a cached usage value has already been written", cache: :memory do

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Subscriptions::ChargeCacheService do
       end
     end
 
-    it "loads plan, charges and filters in a constant number of queries", :aggregate_failures do
+    it "loads plan, charges and filters in a constant number of queries" do
       ids = [subscription.id, other_subscription.id]
 
       query_count = 0

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -34,4 +34,53 @@ RSpec.describe Subscriptions::ChargeCacheService do
       expect(Rails.cache).to have_received(:delete).with(cache_service.cache_key)
     end
   end
+
+  describe ".expire_for_subscriptions" do
+    let(:other_subscription) { create(:subscription, plan: subscription.plan) }
+    let(:other_charge) { create(:standard_charge, plan: subscription.plan) }
+
+    before do
+      charge
+      other_charge
+      other_subscription
+    end
+
+    it "expires cache for each (subscription, charge) pair across the supplied ids" do
+      allow(described_class).to receive(:expire_for_subscription_charge).and_call_original
+
+      described_class.expire_for_subscriptions([subscription.id, other_subscription.id])
+
+      [subscription, other_subscription].each do |sub|
+        [charge, other_charge].each do |ch|
+          expect(described_class).to have_received(:expire_for_subscription_charge)
+            .with(subscription: having_attributes(id: sub.id), charge: having_attributes(id: ch.id))
+        end
+      end
+    end
+
+    it "loads plan, charges and filters in a constant number of queries", :aggregate_failures do
+      ids = [subscription.id, other_subscription.id]
+
+      query_count = 0
+      counter = ->(*, payload) { query_count += 1 unless payload[:name]&.include?("SCHEMA") }
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        described_class.expire_for_subscriptions(ids)
+      end
+
+      # 4 expected SELECTs: subscriptions, plans, charges, filters. Add a small
+      # safety margin for incidental loads (e.g. activity log context).
+      expect(query_count).to be <= 6
+    end
+  end
+
+  describe ".expire_for_subscription" do
+    it "delegates to .expire_for_subscriptions with the subscription's id" do
+      allow(described_class).to receive(:expire_for_subscriptions).and_call_original
+
+      described_class.expire_for_subscription(subscription)
+
+      expect(described_class).to have_received(:expire_for_subscriptions).with([subscription.id])
+    end
+  end
 end


### PR DESCRIPTION
## Context

After a billable metric was deleted, recreated with the same code, and the plan's charge re-added — all before the async event-deletion job ran — `current_usage` kept serving the pre-deletion event count for the recreated charge. The cached value survived the eventual event purge, and the only way to clear it was manually resetting the subscription's cache.

**Closes ING-252.**

## Fix

`Events::DeleteForMetricService` now invalidates the charge-usage cache for each affected subscription after its events are deleted (both Postgres and Clickhouse paths). The async tail is the only safe hook — the stale value is written *between* BM deletion and event deletion, so invalidating at sync BM-delete time would be too early.

The orchestration lives in `Subscriptions::ChargeCacheService` as a new bulk class method:

```ruby
def self.expire_for_subscriptions(subscription_ids)
  Subscription
    .where(id: subscription_ids)
    .preload(plan: {charges: :filters})
    .find_each do |subscription|
      subscription.plan.charges.each do |charge|
        expire_for_subscription_charge(subscription:, charge:)
      end
    end
end

def self.expire_for_subscription(subscription)
  expire_for_subscriptions([subscription.id])
end
```

`expire_for_subscription` (singular) now funnels through the bulk path, so every existing caller (events post-process, clickhouse dup cleanup, customer-portal usage setup) picks up the same eager-loaded path for free.

`DeleteForMetricService` is just a delegator:

```ruby
def expire_charge_caches(subscription_ids)
  Subscriptions::ChargeCacheService.expire_for_subscriptions(subscription_ids)
end
```

## Why the eager loading matters

The previous shape of `expire_for_subscription` called `subscription.plan.charges.includes(:filters).find_each` for each subscription — 3 queries each (plan, charges, filters). For a BM deletion affecting N subscriptions that meant ~3N queries on top of the actual event deletion. The new `expire_for_subscriptions` preloads `plan: {charges: :filters}` once per `find_each` batch, so the cost is **4 DB queries per batch regardless of N**.

## Tests

`spec/services/events/delete_for_metric_service_spec.rb` — two new contexts under `with charge-usage cache invalidation`:

- **Spy** — asserts `Subscriptions::ChargeCacheService.expire_for_subscription_charge` is called for the affected (subscription, charge).
- **End-to-end (`cache: :memory`)** — pre-writes a value to the real cache key, runs the service, asserts the key is gone. Proves the round-trip end to end through `Rails.cache`, not just behaviour-stubs it.

`spec/services/subscriptions/charge_cache_service_spec.rb` — two new describe blocks:

- `.expire_for_subscriptions` — coverage across two subscriptions × two charges, plus a **query-budget assertion** (≤ 6 SQL queries via `ActiveSupport::Notifications`) that acts as a regression guard against a future refactor reintroducing the per-subscription re-query.
- `.expire_for_subscription` — delegation check confirming the singular method now funnels through the bulk path.

```
lago exec api bundle exec rspec \
  spec/services/events/delete_for_metric_service_spec.rb \
  spec/services/subscriptions/charge_cache_service_spec.rb
# 17 examples, 0 failures
```
