### PR TITLE
[ING-294] chore(flags): Remove `non_persistable_charge_cache_optimization` feature flag

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -2,10 +2,6 @@ multiple_payment_methods:
   description: "Allow multiple payment methods per customer"
   owners: ["@lovrocolic", "@mariohd"]
 
-non_persistable_charge_cache_optimization:
-  description: "Optimize current usage cache by not storing non-persistable fees (zero units/amounts/events)"
-  owners: ["@groyoh"]
-
 postgres_enriched_events:
   description: "Turn on events pre-enrichement for organizations using the PG event store"
   owners: ["@vincent-pochet"]

--- a/schema.graphql
+++ b/schema.graphql
@@ -5838,7 +5838,6 @@ enum FeatureFlagEnum {
   multi_currency
   multi_entity_billing
   multiple_payment_methods
-  non_persistable_charge_cache_optimization
   order_forms
   payment_gated_subscriptions
   postgres_enriched_events

--- a/schema.json
+++ b/schema.json
@@ -28354,12 +28354,6 @@
               "deprecationReason": null
             },
             {
-              "name": "non_persistable_charge_cache_optimization",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "postgres_enriched_events",
               "description": null,
               "isDeprecated": false,


### PR DESCRIPTION
## Context

The `non_persistable_charge_cache_optimization` feature flag no longer serves any purpose. The optimization it gated became the default code behavior, and the flag values were cleaned from production organizations in prior work. Its earlier usage in `Fees::ChargeService` and the scenario-spec feature-flag loops were already removed, leaving only the flag definition behind.

## Description

The flag entry was removed from `app/config/feature_flags.yaml`. The GraphQL schema was regenerated, which drops the value from `FeatureFlagEnum` (built dynamically from `FeatureFlag::DEFINITION`) in both `schema.graphql` and `schema.json`. No remaining code or specs referenced the flag.
