### PR TITLE
perf(plans): Improve job enqueue performance

### DIFF
--- a/app/jobs/invoices/create_all_pay_in_advance_fixed_charges_job.rb
+++ b/app/jobs/invoices/create_all_pay_in_advance_fixed_charges_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Invoices
+  # NOTE: A plan can have tens of thousands of active subscriptions; iterating
+  #       and enqueuing one job per subscription is delegated to a single job
+  #       to keep synchronous requests fast.
+  class CreateAllPayInAdvanceFixedChargesJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
+        :billing
+      else
+        :default
+      end
+    end
+
+    def perform(plan, timestamp, fixed_charge = nil)
+      subscriptions = plan.subscriptions.active
+      if fixed_charge
+        subscriptions = subscriptions.without_fixed_charge_units_override_for(fixed_charge)
+      end
+
+      subscriptions.find_each do |subscription|
+        Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+      end
+    end
+  end
+end

--- a/app/services/fixed_charges/cascade_child_plan_update_service.rb
+++ b/app/services/fixed_charges/cascade_child_plan_update_service.rb
@@ -47,11 +47,7 @@ module FixedCharges
       end
 
       if plan.fixed_charges.pay_in_advance.exists?
-        after_commit do
-          plan.subscriptions.active.find_each do |subscription|
-            Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
-          end
-        end
+        Invoices::CreateAllPayInAdvanceFixedChargesJob.perform_after_commit(plan, timestamp)
       end
 
       result.plan = plan

--- a/app/services/fixed_charges/update_service.rb
+++ b/app/services/fixed_charges/update_service.rb
@@ -49,13 +49,7 @@ module FixedCharges
           )
 
           if trigger_billing && params[:apply_units_immediately] && fixed_charge.pay_in_advance?
-            plan.subscriptions.active
-              .without_fixed_charge_units_override_for(fixed_charge)
-              .find_each do |subscription|
-                after_commit do
-                  Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
-                end
-              end
+            Invoices::CreateAllPayInAdvanceFixedChargesJob.perform_after_commit(plan, timestamp, fixed_charge)
           end
         end
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -293,14 +293,7 @@ module Plans
     end
 
     def trigger_pay_in_advance_billing
-      plan.subscriptions.active.find_each do |subscription|
-        after_commit do
-          Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(
-            subscription,
-            timestamp
-          )
-        end
-      end
+      Invoices::CreateAllPayInAdvanceFixedChargesJob.perform_after_commit(plan, timestamp)
     end
 
     def sanitize_fixed_charges(plan, args_fixed_charges, created_fixed_charges_ids)

--- a/spec/jobs/invoices/create_all_pay_in_advance_fixed_charges_job_spec.rb
+++ b/spec/jobs/invoices/create_all_pay_in_advance_fixed_charges_job_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::CreateAllPayInAdvanceFixedChargesJob do
+  subject(:perform_now) { described_class.perform_now(plan, timestamp, fixed_charge) }
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:timestamp) { Time.current.to_i }
+  let(:fixed_charge) { nil }
+
+  describe "#perform" do
+    let(:subscription) { create(:subscription, :active, plan:) }
+    let(:pending_subscription) { create(:subscription, :pending, plan:) }
+
+    before do
+      subscription
+      pending_subscription
+    end
+
+    it "enqueues a job for each active subscription of the plan" do
+      perform_now
+
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+        .to have_been_enqueued
+        .with(subscription, timestamp)
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+        .not_to have_been_enqueued
+        .with(pending_subscription, timestamp)
+    end
+
+    context "with a fixed charge" do
+      let(:fixed_charge) { create(:fixed_charge, plan:, pay_in_advance: true) }
+      let(:other_subscription) { create(:subscription, :active, plan:) }
+
+      before do
+        other_subscription
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:)
+      end
+
+      it "skips subscriptions with a units override for the fixed charge" do
+        perform_now
+
+        expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+          .not_to have_been_enqueued
+          .with(subscription, timestamp)
+        expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+          .to have_been_enqueued
+          .with(other_subscription, timestamp)
+      end
+    end
+  end
+end

--- a/spec/services/fixed_charges/cascade_child_plan_update_service_spec.rb
+++ b/spec/services/fixed_charges/cascade_child_plan_update_service_spec.rb
@@ -63,14 +63,19 @@ RSpec.describe FixedCharges::CascadeChildPlanUpdateService do
     end
 
     it "does not schedule invoice creation jobs for pay in advance fixed charges" do
-      expect { result }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+      perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) { result }
+
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob).not_to have_been_enqueued
     end
 
     context "when plan has active subscriptions" do
       let(:subscription) { create(:subscription, :active, plan:) }
 
       it "schedules invoice creation jobs for each active subscription" do
-        expect { result }.to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+        perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) { result }
+
+        expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+          .to have_been_enqueued
           .with(subscription, timestamp)
       end
     end
@@ -191,14 +196,19 @@ RSpec.describe FixedCharges::CascadeChildPlanUpdateService do
     end
 
     it "does not schedule invoice creation jobs for pay in advance fixed charges" do
-      expect { result }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+      perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) { result }
+
+      expect(Invoices::CreatePayInAdvanceFixedChargesJob).not_to have_been_enqueued
     end
 
     context "when plan has active subscriptions" do
       let(:subscription) { create(:subscription, :active, plan:) }
 
       it "schedules invoice creation jobs for each active subscription" do
-        expect { result }.to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+        perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) { result }
+
+        expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+          .to have_been_enqueued
           .with(subscription, timestamp)
       end
     end

--- a/spec/services/fixed_charges/update_service_spec.rb
+++ b/spec/services/fixed_charges/update_service_spec.rb
@@ -287,8 +287,16 @@ RSpec.describe FixedCharges::UpdateService do
 
           let!(:subscription) { create(:subscription, plan:) }
 
-          it "enqueues pay in advance billing job" do
+          it "enqueues a single fan out billing job for the plan" do
             result
+
+            expect(Invoices::CreateAllPayInAdvanceFixedChargesJob)
+              .to have_been_enqueued
+              .with(plan, timestamp, fixed_charge)
+          end
+
+          it "enqueues pay in advance billing job" do
+            perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) { result }
 
             expect(Invoices::CreatePayInAdvanceFixedChargesJob)
               .to have_been_enqueued
@@ -307,7 +315,7 @@ RSpec.describe FixedCharges::UpdateService do
             end
 
             it "does not enqueue the billing job for the overridden subscription" do
-              result
+              perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) { result }
 
               expect(Invoices::CreatePayInAdvanceFixedChargesJob)
                 .not_to have_been_enqueued
@@ -315,7 +323,7 @@ RSpec.describe FixedCharges::UpdateService do
             end
 
             it "still enqueues the billing job for other plan subscriptions" do
-              result
+              perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) { result }
 
               expect(Invoices::CreatePayInAdvanceFixedChargesJob)
                 .to have_been_enqueued
@@ -350,7 +358,7 @@ RSpec.describe FixedCharges::UpdateService do
           it "does not enqueue pay in advance billing job" do
             result
 
-            expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+            expect(Invoices::CreateAllPayInAdvanceFixedChargesJob)
               .not_to have_been_enqueued
           end
         end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -1522,9 +1522,9 @@ RSpec.describe Plans::UpdateService do
 
           before { subscription }
 
-          it "does not enqueue a Invoices::CreatePayInAdvanceFixedChargesJob for active subscriptions" do
+          it "does not enqueue a Invoices::CreateAllPayInAdvanceFixedChargesJob" do
             expect { plans_service.call }
-              .not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+              .not_to have_enqueued_job(Invoices::CreateAllPayInAdvanceFixedChargesJob)
           end
         end
 
@@ -1556,10 +1556,22 @@ RSpec.describe Plans::UpdateService do
 
             before { subscription }
 
-            it "enqueues a Invoices::CreatePayInAdvanceFixedChargesJob for active subscriptions" do
+            it "enqueues a single Invoices::CreateAllPayInAdvanceFixedChargesJob for the plan" do
               freeze_time do
                 expect { plans_service.call }
-                  .to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+                  .to have_enqueued_job(Invoices::CreateAllPayInAdvanceFixedChargesJob)
+                  .with(plan, Time.current.to_i)
+              end
+            end
+
+            it "enqueues a Invoices::CreatePayInAdvanceFixedChargesJob for active subscriptions" do
+              freeze_time do
+                perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) do
+                  plans_service.call
+                end
+
+                expect(Invoices::CreatePayInAdvanceFixedChargesJob)
+                  .to have_been_enqueued
                   .with(subscription, Time.current.to_i)
               end
             end
@@ -1571,8 +1583,11 @@ RSpec.describe Plans::UpdateService do
             before { subscription }
 
             it "does not enqueue a Invoices::CreatePayInAdvanceFixedChargesJob" do
-              expect { plans_service.call }
-                .not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+              perform_enqueued_jobs(only: Invoices::CreateAllPayInAdvanceFixedChargesJob) do
+                plans_service.call
+              end
+
+              expect(Invoices::CreatePayInAdvanceFixedChargesJob).not_to have_been_enqueued
             end
           end
         end


### PR DESCRIPTION
## Context
`PUT /plans/{code}` on a plan with a pay-in-advance fixed charge was performing slow when the plan has thousands active subscriptions.

`Plans::UpdateService#trigger_pay_in_advance_billing` did all of this inside the HTTP request:
  1. `plan.subscriptions.active.find_each` — loads every active subscription.
  2. One `after_commit { Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(...) }` per subscription. All callbacks fire at transaction commit, still inside the request, and each `perform_later` is a synchronous Redis round-trip.

## Description

Moved per-subscription job enqueueing to a dedicated job

## Performance testing
- Plan with pay_in_advance fixed charge'
- 22,500 active subscriptions 

| Scenario | Original latency | Optimized latency |
| --------------- | ---------------  | ------------------ |
| Plans::UpdateService#call | 18.9s (22,500 synchronous enqueues)  | 0.30s (1 enqueue) |