### PR TITLE
feat(products): catalog guards, dedup and batching

### DIFF
--- a/app/graphql/sources/attached_to_plan_or_subscription.rb
+++ b/app/graphql/sources/attached_to_plan_or_subscription.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Sources
+  # Batches attached_to_plan_or_subscription? across catalog rows: one grouped
+  # query per applied-card side instead of two EXISTS per row.
+  #
+  # Keyed by the grouping the caller resolves through — a product id for
+  # products and their filters (a filter is attached when its product is), a
+  # product_category id for categories (attached through their products).
+  # Default scopes apply on both the applied cards and the joined models, so
+  # discarded rows stay excluded exactly as in the per-record checks.
+  #
+  # Usage in GraphQL types:
+  #   dataloader.with(Sources::AttachedToPlanOrSubscription, :product).load(object.id)
+  class AttachedToPlanOrSubscription < GraphQL::Dataloader::Source
+    GROUPINGS = {
+      product: [:rate_card, "rate_cards.product_id"],
+      product_category: [{rate_card: :product}, "products.product_category_id"]
+    }.freeze
+
+    def initialize(group_by)
+      @joins, @column = GROUPINGS.fetch(group_by)
+    end
+
+    def fetch(ids)
+      attached = PlanRateCard.joins(@joins).where(@column => ids).distinct.pluck(Arel.sql(@column)) |
+        SubscriptionRateCard.joins(@joins).where(@column => ids).distinct.pluck(Arel.sql(@column))
+
+      ids.map { attached.include?(it) }
+    end
+  end
+end

--- a/app/graphql/sources/count_by_foreign_key.rb
+++ b/app/graphql/sources/count_by_foreign_key.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Sources
+  # Batches per-row COUNT fields into a single grouped query.
+  #
+  # Prevents N+1 queries when a count is requested for several parent records
+  # in one GraphQL query (e.g., `products { filtersCount }`). The model's
+  # default scope applies, so soft-deleted rows stay excluded exactly as in
+  # the per-record `association.count`.
+  #
+  # Usage in GraphQL types:
+  #   dataloader.with(Sources::CountByForeignKey, ProductFilter, :product_id).load(object.id)
+  class CountByForeignKey < GraphQL::Dataloader::Source
+    def initialize(model, foreign_key)
+      @model = model
+      @foreign_key = foreign_key
+    end
+
+    def fetch(ids)
+      # reorder(nil) drops any default-scope ordering, which would otherwise
+      # leak into the GROUP BY and fail.
+      counts = @model.where(@foreign_key => ids).reorder(nil).group(@foreign_key).count
+
+      ids.map { counts.fetch(it, 0) }
+    end
+  end
+end

--- a/app/graphql/types/product_categories/object.rb
+++ b/app/graphql/types/product_categories/object.rb
@@ -14,14 +14,18 @@ module Types
       field :invoice_display_name, String, null: true
       field :name, String, null: false
 
-      field :attached_to_plan_or_subscription, Boolean, null: false, method: :attached_to_plan_or_subscription?
+      field :attached_to_plan_or_subscription, Boolean, null: false
       field :products_count, Integer, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      def attached_to_plan_or_subscription
+        dataloader.with(Sources::AttachedToPlanOrSubscription, :product_category).load(object.id)
+      end
+
       def products_count
-        object.products.count
+        dataloader.with(Sources::CountByForeignKey, Product, :product_category_id).load(object.id)
       end
     end
   end

--- a/app/graphql/types/product_categories/object.rb
+++ b/app/graphql/types/product_categories/object.rb
@@ -14,6 +14,7 @@ module Types
       field :invoice_display_name, String, null: true
       field :name, String, null: false
 
+      field :attached_to_plan_or_subscription, Boolean, null: false, method: :attached_to_plan_or_subscription?
       field :products_count, Integer, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/product_categories/update_input.rb
+++ b/app/graphql/types/product_categories/update_input.rb
@@ -7,6 +7,7 @@ module Types
 
       argument :id, ID, required: true
 
+      argument :code, String, required: false
       argument :description, String, required: false
       argument :invoice_display_name, String, required: false
       argument :name, String, required: false

--- a/app/graphql/types/product_filters/object.rb
+++ b/app/graphql/types/product_filters/object.rb
@@ -11,6 +11,7 @@ module Types
       field :id, ID, null: false
       field :organization, Types::Organizations::OrganizationType
 
+      field :attached_to_plan_or_subscription, Boolean, null: false, method: :attached_to_plan_or_subscription?
       field :code, String, null: false
       field :description, String, null: true
       field :invoice_display_name, String, null: true

--- a/app/graphql/types/product_filters/object.rb
+++ b/app/graphql/types/product_filters/object.rb
@@ -11,7 +11,7 @@ module Types
       field :id, ID, null: false
       field :organization, Types::Organizations::OrganizationType
 
-      field :attached_to_plan_or_subscription, Boolean, null: false, method: :attached_to_plan_or_subscription?
+      field :attached_to_plan_or_subscription, Boolean, null: false
       field :code, String, null: false
       field :description, String, null: true
       field :invoice_display_name, String, null: true
@@ -22,6 +22,12 @@ module Types
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      # A filter is attached when its product is — resolved by product_id so
+      # the batch is shared with the products' own attachment checks.
+      def attached_to_plan_or_subscription
+        dataloader.with(Sources::AttachedToPlanOrSubscription, :product).load(object.product_id)
+      end
     end
   end
 end

--- a/app/graphql/types/product_filters/update_input.rb
+++ b/app/graphql/types/product_filters/update_input.rb
@@ -7,6 +7,7 @@ module Types
 
       argument :id, ID, required: true
 
+      argument :code, String, required: false
       argument :description, String, required: false
       argument :invoice_display_name, String, required: false
       argument :name, String, required: false

--- a/app/graphql/types/products/object.rb
+++ b/app/graphql/types/products/object.rb
@@ -11,6 +11,7 @@ module Types
       field :id, ID, null: false
       field :organization, Types::Organizations::OrganizationType
 
+      field :attached_to_plan_or_subscription, Boolean, null: false, method: :attached_to_plan_or_subscription?
       field :code, String, null: false
       field :description, String, null: true
       field :invoice_display_name, String, null: true

--- a/app/graphql/types/products/object.rb
+++ b/app/graphql/types/products/object.rb
@@ -11,7 +11,7 @@ module Types
       field :id, ID, null: false
       field :organization, Types::Organizations::OrganizationType
 
-      field :attached_to_plan_or_subscription, Boolean, null: false, method: :attached_to_plan_or_subscription?
+      field :attached_to_plan_or_subscription, Boolean, null: false
       field :code, String, null: false
       field :description, String, null: true
       field :invoice_display_name, String, null: true
@@ -26,8 +26,12 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      def attached_to_plan_or_subscription
+        dataloader.with(Sources::AttachedToPlanOrSubscription, :product).load(object.id)
+      end
+
       def filters_count
-        object.filters.count
+        dataloader.with(Sources::CountByForeignKey, ProductFilter, :product_id).load(object.id)
       end
     end
   end

--- a/app/graphql/types/products/update_input.rb
+++ b/app/graphql/types/products/update_input.rb
@@ -7,9 +7,11 @@ module Types
 
       argument :id, ID, required: true
 
+      argument :code, String, required: false
       argument :description, String, required: false
       argument :invoice_display_name, String, required: false
       argument :name, String, required: false
+      argument :product_category_id, ID, required: false
     end
   end
 end

--- a/app/models/product_filter.rb
+++ b/app/models/product_filter.rb
@@ -15,9 +15,6 @@ class ProductFilter < ApplicationRecord
 
   delegate :attached_to_plan_or_subscription?, to: :product
 
-  # The values define which events the filter's scoped cards price. They are
-  # frozen only once a subscription bills through one of those cards — until
-  # then a slice redefinition cannot rewrite any live billing.
   def attached_to_subscriptions?
     SubscriptionRateCard.joins(:rate_card).where(rate_cards: {product_filter_id: id}).exists?
   end

--- a/app/models/product_filter.rb
+++ b/app/models/product_filter.rb
@@ -11,8 +11,16 @@ class ProductFilter < ApplicationRecord
 
   has_many :values, class_name: "ProductFilterValue"
   has_many :billable_metric_filters, through: :values
+  has_many :rate_cards
 
   delegate :attached_to_plan_or_subscription?, to: :product
+
+  # The values define which events the filter's scoped cards price. They are
+  # frozen only once a subscription bills through one of those cards — until
+  # then a slice redefinition cannot rewrite any live billing.
+  def attached_to_subscriptions?
+    SubscriptionRateCard.joins(:rate_card).where(rate_cards: {product_filter_id: id}).exists?
+  end
 
   validates :name, presence: true
   validates :code,

--- a/app/services/product_categories/destroy_service.rb
+++ b/app/services/product_categories/destroy_service.rb
@@ -17,6 +17,10 @@ module ProductCategories
     def call
       return result.not_found_failure!(resource: "product_category") unless product_category
 
+      if product_category.attached_to_plan_or_subscription?
+        return result.single_validation_failure!(field: :product_category, error_code: "attached_to_plan_or_subscription")
+      end
+
       ActiveRecord::Base.transaction do
         product_category.products.find_each do |product|
           Products::DestroyService.call!(product:)

--- a/app/services/product_categories/update_service.rb
+++ b/app/services/product_categories/update_service.rb
@@ -22,8 +22,7 @@ module ProductCategories
       product_category.description = params[:description] if params.key?(:description)
       product_category.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
 
-      # NOTE: code can only be edited while the product_category is not yet in a plan or
-      #       subscription; changing it once attached is a validation error.
+      # NOTE: code can only be edited while the product_category is not yet in a plan or subscription
       if params.key?(:code) && params[:code]&.strip != product_category.code && product_category.attached_to_plan_or_subscription?
         return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
       end

--- a/app/services/product_categories/update_service.rb
+++ b/app/services/product_categories/update_service.rb
@@ -24,11 +24,11 @@ module ProductCategories
 
       # NOTE: code can only be edited while the product_category is not yet in a plan or
       #       subscription; changing it once attached is a validation error.
-      if params.key?(:code) && params[:code] != product_category.code && product_category.attached_to_plan_or_subscription?
+      if params.key?(:code) && params[:code]&.strip != product_category.code && product_category.attached_to_plan_or_subscription?
         return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
       end
 
-      product_category.code = params[:code] if params.key?(:code)
+      product_category.code = params[:code]&.strip if params.key?(:code)
 
       product_category.save!
 

--- a/app/services/product_categories/update_service.rb
+++ b/app/services/product_categories/update_service.rb
@@ -21,6 +21,15 @@ module ProductCategories
       product_category.name = params[:name] if params.key?(:name)
       product_category.description = params[:description] if params.key?(:description)
       product_category.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+
+      # NOTE: code can only be edited while the product_category is not yet in a plan or
+      #       subscription; changing it once attached is a validation error.
+      if params.key?(:code) && params[:code] != product_category.code && product_category.attached_to_plan_or_subscription?
+        return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
+      end
+
+      product_category.code = params[:code] if params.key?(:code)
+
       product_category.save!
 
       result.product_category = product_category

--- a/app/services/product_filters/create_service.rb
+++ b/app/services/product_filters/create_service.rb
@@ -24,10 +24,10 @@ module ProductFilters
 
       return resolved_values unless resolved_values.success?
 
-      values_validation = ProductFilters::ValidateValuesService.call(product:, values_params: resolved_values.values_params)
-      return values_validation unless values_validation.success?
+      product.with_lock do
+        values_validation = ProductFilters::ValidateValuesService.call(product:, values_params: resolved_values.values_params)
+        return values_validation unless values_validation.success?
 
-      ActiveRecord::Base.transaction do
         product_filter = product.filters.create!(
           organization_id: product.organization_id,
           name: params[:name],

--- a/app/services/product_filters/create_service.rb
+++ b/app/services/product_filters/create_service.rb
@@ -19,7 +19,7 @@ module ProductFilters
       return result.not_found_failure!(resource: "product") unless product
 
       unless product.usage?
-        return result.single_validation_failure!(field: :product, error_code: "invalid_product_type")
+        return result.single_validation_failure!(field: :product, error_code: "not_allowed_for_product_type")
       end
 
       return resolved_values unless resolved_values.success?

--- a/app/services/product_filters/update_service.rb
+++ b/app/services/product_filters/update_service.rb
@@ -22,26 +22,26 @@ module ProductFilters
         return resolved_values unless resolved_values.success?
       end
 
-      # NOTE: the code freezes as soon as the item is in a plan or subscription
-      if product_filter.attached_to_plan_or_subscription? &&
-          params.key?(:code) && params[:code]&.strip != product_filter.code
-        return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
-      end
+      product_filter.product.with_lock do
+        # NOTE: the code freezes as soon as the item is in a plan or subscription
+        if product_filter.attached_to_plan_or_subscription? &&
+            params.key?(:code) && params[:code]&.strip != product_filter.code
+          return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
+        end
 
-      if product_filter.attached_to_subscriptions? && params.key?(:values) && values_changed?
-        return result.single_validation_failure!(field: :values, error_code: "attached_to_subscriptions")
-      end
+        if product_filter.attached_to_subscriptions? && params.key?(:values) && values_changed?
+          return result.single_validation_failure!(field: :values, error_code: "attached_to_subscriptions")
+        end
 
-      if params.key?(:values)
-        values_validation = ProductFilters::ValidateValuesService.call(
-          product: product_filter.product,
-          values_params: resolved_values.values_params,
-          product_filter:
-        )
-        return values_validation unless values_validation.success?
-      end
+        if params.key?(:values)
+          values_validation = ProductFilters::ValidateValuesService.call(
+            product: product_filter.product,
+            values_params: resolved_values.values_params,
+            product_filter:
+          )
+          return values_validation unless values_validation.success?
+        end
 
-      ActiveRecord::Base.transaction do
         product_filter.name = params[:name] if params.key?(:name)
         product_filter.description = params[:description] if params.key?(:description)
         product_filter.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)

--- a/app/services/product_filters/update_service.rb
+++ b/app/services/product_filters/update_service.rb
@@ -23,10 +23,6 @@ module ProductFilters
       end
 
       # NOTE: the code freezes as soon as the item is in a plan or subscription
-      #       (it is the filter's identity); the values only freeze once a
-      #       subscription bills through a card scoped to this filter. Clients
-      #       typically resend the whole payload on edit, so only an actual
-      #       change counts as a structural edit.
       if product_filter.attached_to_plan_or_subscription? &&
           params.key?(:code) && params[:code]&.strip != product_filter.code
         return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
@@ -71,12 +67,9 @@ module ProductFilters
 
     attr_reader :product_filter, :params
 
-    # value.to_s keeps key-only entries (nil) sortable next to valued entries
-    # for the same key — nil <=> String raises. It cannot conflate distinct
-    # entries: an empty-string value is invalid, so "" only ever means nil.
     def values_changed?
-      current = product_filter.values.map { |value| [value.billable_metric_filter_id.to_s, value.value.to_s] }.sort
-      submitted = resolved_values.values_params.map { |value| [value[:billable_metric_filter_id].to_s, value[:value].to_s] }.sort
+      current = product_filter.values.map { |v| [v.billable_metric_filter_id.to_s, v.value.to_s] }.sort
+      submitted = resolved_values.values_params.map { |v| [v[:billable_metric_filter_id].to_s, v[:value].to_s] }.sort
 
       current != submitted
     end

--- a/app/services/product_filters/update_service.rb
+++ b/app/services/product_filters/update_service.rb
@@ -39,7 +39,8 @@ module ProductFilters
       if params.key?(:values)
         values_validation = ProductFilters::ValidateValuesService.call(
           product: product_filter.product,
-          values_params: resolved_values.values_params
+          values_params: resolved_values.values_params,
+          product_filter:
         )
         return values_validation unless values_validation.success?
       end

--- a/app/services/product_filters/update_service.rb
+++ b/app/services/product_filters/update_service.rb
@@ -20,7 +20,23 @@ module ProductFilters
 
       if params.key?(:values)
         return resolved_values unless resolved_values.success?
+      end
 
+      # NOTE: the code freezes as soon as the item is in a plan or subscription
+      #       (it is the filter's identity); the values only freeze once a
+      #       subscription bills through a card scoped to this filter. Clients
+      #       typically resend the whole payload on edit, so only an actual
+      #       change counts as a structural edit.
+      if product_filter.attached_to_plan_or_subscription? &&
+          params.key?(:code) && params[:code] != product_filter.code
+        return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
+      end
+
+      if product_filter.attached_to_subscriptions? && params.key?(:values) && values_changed?
+        return result.single_validation_failure!(field: :values, error_code: "attached_to_subscriptions")
+      end
+
+      if params.key?(:values)
         values_validation = ProductFilters::ValidateValuesService.call(
           product: product_filter.product,
           values_params: resolved_values.values_params
@@ -32,9 +48,10 @@ module ProductFilters
         product_filter.name = params[:name] if params.key?(:name)
         product_filter.description = params[:description] if params.key?(:description)
         product_filter.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+        product_filter.code = params[:code] if params.key?(:code)
         product_filter.save!
 
-        replace_values if params.key?(:values)
+        replace_values if params.key?(:values) && values_changed?
 
         result.product_filter = product_filter
       end
@@ -52,6 +69,13 @@ module ProductFilters
     private
 
     attr_reader :product_filter, :params
+
+    def values_changed?
+      current = product_filter.values.map { |value| [value.billable_metric_filter_id, value.value] }.sort
+      submitted = resolved_values.values_params.map { |value| [value[:billable_metric_filter_id], value[:value]] }.sort
+
+      current != submitted
+    end
 
     def resolved_values
       @resolved_values ||= ProductFilters::ResolveValuesService.call(

--- a/app/services/product_filters/update_service.rb
+++ b/app/services/product_filters/update_service.rb
@@ -70,9 +70,12 @@ module ProductFilters
 
     attr_reader :product_filter, :params
 
+    # value.to_s keeps key-only entries (nil) sortable next to valued entries
+    # for the same key — nil <=> String raises. It cannot conflate distinct
+    # entries: an empty-string value is invalid, so "" only ever means nil.
     def values_changed?
-      current = product_filter.values.map { |value| [value.billable_metric_filter_id, value.value] }.sort
-      submitted = resolved_values.values_params.map { |value| [value[:billable_metric_filter_id], value[:value]] }.sort
+      current = product_filter.values.map { |value| [value.billable_metric_filter_id.to_s, value.value.to_s] }.sort
+      submitted = resolved_values.values_params.map { |value| [value[:billable_metric_filter_id].to_s, value[:value].to_s] }.sort
 
       current != submitted
     end

--- a/app/services/product_filters/update_service.rb
+++ b/app/services/product_filters/update_service.rb
@@ -28,7 +28,7 @@ module ProductFilters
       #       typically resend the whole payload on edit, so only an actual
       #       change counts as a structural edit.
       if product_filter.attached_to_plan_or_subscription? &&
-          params.key?(:code) && params[:code] != product_filter.code
+          params.key?(:code) && params[:code]&.strip != product_filter.code
         return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
       end
 
@@ -49,7 +49,7 @@ module ProductFilters
         product_filter.name = params[:name] if params.key?(:name)
         product_filter.description = params[:description] if params.key?(:description)
         product_filter.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
-        product_filter.code = params[:code] if params.key?(:code)
+        product_filter.code = params[:code]&.strip if params.key?(:code)
         product_filter.save!
 
         replace_values if params.key?(:values) && values_changed?

--- a/app/services/product_filters/validate_values_service.rb
+++ b/app/services/product_filters/validate_values_service.rb
@@ -4,9 +4,7 @@ module ProductFilters
   class ValidateValuesService < BaseService
     Result = BaseResult
 
-    # product_filter is the filter being updated, excluded from the duplicate
-    # scan so resending its own values stays a no-op instead of a
-    # self-collision.
+    # NOTE: product_filter is the filter being updated.
     def initialize(product:, values_params:, product_filter: nil)
       @product = product
       @values_params = values_params
@@ -34,11 +32,6 @@ module ProductFilters
         return result.single_validation_failure!(field: :values, error_code: "key_only_conflicts_with_values")
       end
 
-      # Two filters with the exact same value set price the same event slice:
-      # if both end up carded on a plan, the engine has no way to pick one.
-      # Partial overlaps stay legal — the engine resolves those by precedence.
-      # App-level check only (a product has a handful of filters); if it ever
-      # needs a DB backstop, the path is a values_digest column + unique index.
       if duplicate_value_set?
         return result.single_validation_failure!(field: :values, error_code: "value_already_exist")
       end
@@ -58,8 +51,6 @@ module ProductFilters
       end
     end
 
-    # value.to_s keeps key-only entries (nil) sortable next to valued entries;
-    # an empty-string value is invalid, so "" only ever means nil.
     def normalized(entries)
       entries.map { [it[:billable_metric_filter_id].to_s, it[:value].to_s] }.sort
     end

--- a/app/services/product_filters/validate_values_service.rb
+++ b/app/services/product_filters/validate_values_service.rb
@@ -4,9 +4,13 @@ module ProductFilters
   class ValidateValuesService < BaseService
     Result = BaseResult
 
-    def initialize(product:, values_params:)
+    # product_filter is the filter being updated, excluded from the duplicate
+    # scan so resending its own values stays a no-op instead of a
+    # self-collision.
+    def initialize(product:, values_params:, product_filter: nil)
       @product = product
       @values_params = values_params
+      @product_filter = product_filter
       super
     end
 
@@ -30,11 +34,34 @@ module ProductFilters
         return result.single_validation_failure!(field: :values, error_code: "key_only_conflicts_with_values")
       end
 
+      # Two filters with the exact same value set price the same event slice:
+      # if both end up carded on a plan, the engine has no way to pick one.
+      # Partial overlaps stay legal — the engine resolves those by precedence.
+      # App-level check only (a product has a handful of filters); if it ever
+      # needs a DB backstop, the path is a values_digest column + unique index.
+      if duplicate_value_set?
+        return result.single_validation_failure!(field: :values, error_code: "value_already_exist")
+      end
+
       result
     end
 
     private
 
-    attr_reader :product, :values_params
+    attr_reader :product, :values_params, :product_filter
+
+    def duplicate_value_set?
+      submitted = normalized(values_params)
+
+      product.filters.where.not(id: product_filter&.id).includes(:values).any? do |filter|
+        normalized(filter.values.map { {billable_metric_filter_id: it.billable_metric_filter_id, value: it.value} }) == submitted
+      end
+    end
+
+    # value.to_s keeps key-only entries (nil) sortable next to valued entries;
+    # an empty-string value is invalid, so "" only ever means nil.
+    def normalized(entries)
+      entries.map { [it[:billable_metric_filter_id].to_s, it[:value].to_s] }.sort
+    end
   end
 end

--- a/app/services/products/destroy_service.rb
+++ b/app/services/products/destroy_service.rb
@@ -17,6 +17,10 @@ module Products
     def call
       return result.not_found_failure!(resource: "product") unless product
 
+      if product.attached_to_plan_or_subscription?
+        return result.single_validation_failure!(field: :product, error_code: "attached_to_plan_or_subscription")
+      end
+
       ActiveRecord::Base.transaction do
         ProductFilterValue.where(product_filter_id: product.filters.ids).discard_all!
         product.filters.discard_all!

--- a/app/services/products/update_service.rb
+++ b/app/services/products/update_service.rb
@@ -26,7 +26,7 @@ module Products
       #       not yet in a plan or subscription; changing them once attached is
       #       a validation error.
       if product.attached_to_plan_or_subscription?
-        if params.key?(:code) && params[:code] != product.code
+        if params.key?(:code) && params[:code]&.strip != product.code
           return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
         end
 
@@ -34,7 +34,7 @@ module Products
           return result.single_validation_failure!(field: :product_category, error_code: "attached_to_plan_or_subscription")
         end
       else
-        product.code = params[:code] if params.key?(:code)
+        product.code = params[:code]&.strip if params.key?(:code)
         assign_product_category if params.key?(:product_category_id)
       end
 

--- a/app/services/products/update_service.rb
+++ b/app/services/products/update_service.rb
@@ -21,6 +21,25 @@ module Products
       product.name = params[:name] if params.key?(:name)
       product.description = params[:description] if params.key?(:description)
       product.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+
+      # NOTE: code and product_category attachment can only be edited while the item is
+      #       not yet in a plan or subscription; changing them once attached is
+      #       a validation error.
+      if product.attached_to_plan_or_subscription?
+        if params.key?(:code) && params[:code] != product.code
+          return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
+        end
+
+        if params.key?(:product_category_id) && params[:product_category_id] != product.product_category_id
+          return result.single_validation_failure!(field: :product_category, error_code: "attached_to_plan_or_subscription")
+        end
+      else
+        product.code = params[:code] if params.key?(:code)
+        assign_product_category if params.key?(:product_category_id)
+      end
+
+      return result if result.failure?
+
       product.save!
 
       result.product = product
@@ -32,5 +51,17 @@ module Products
     private
 
     attr_reader :product, :params
+
+    def assign_product_category
+      if params[:product_category_id].blank?
+        product.product_category = nil
+        return
+      end
+
+      product_category = product.organization.product_categories.find_by(id: params[:product_category_id])
+      return result.not_found_failure!(resource: "product_category") unless product_category
+
+      product.product_category = product_category
+    end
   end
 end

--- a/app/services/products/update_service.rb
+++ b/app/services/products/update_service.rb
@@ -22,9 +22,6 @@ module Products
       product.description = params[:description] if params.key?(:description)
       product.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
 
-      # NOTE: code and product_category attachment can only be edited while the item is
-      #       not yet in a plan or subscription; changing them once attached is
-      #       a validation error.
       if product.attached_to_plan_or_subscription?
         if params.key?(:code) && params[:code]&.strip != product.code
           return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")

--- a/schema.graphql
+++ b/schema.graphql
@@ -10656,6 +10656,7 @@ enum PrivilegeValueTypeEnum {
 Base product
 """
 type Product {
+  attachedToPlanOrSubscription: Boolean!
   billableMetric: BillableMetric
   code: String!
   createdAt: ISO8601DateTime!
@@ -10674,6 +10675,7 @@ type Product {
 Base product_category
 """
 type ProductCategory {
+  attachedToPlanOrSubscription: Boolean!
   code: String!
   createdAt: ISO8601DateTime!
   description: String
@@ -10719,6 +10721,7 @@ type ProductCollection {
 Base product filter
 """
 type ProductFilter {
+  attachedToPlanOrSubscription: Boolean!
   code: String!
   createdAt: ISO8601DateTime!
   description: String
@@ -14410,6 +14413,7 @@ input UpdateProductCategoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  code: String
   description: String
   id: ID!
   invoiceDisplayName: String
@@ -14424,6 +14428,7 @@ input UpdateProductFilterInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  code: String
   description: String
   id: ID!
   invoiceDisplayName: String
@@ -14439,10 +14444,12 @@ input UpdateProductInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  code: String
   description: String
   id: ID!
   invoiceDisplayName: String
   name: String
+  productCategoryId: ID
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -54047,6 +54047,22 @@
           "description": "Base product",
           "fields": [
             {
+              "name": "attachedToPlanOrSubscription",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "billableMetric",
               "description": null,
               "args": [],
@@ -54229,6 +54245,22 @@
           "name": "ProductCategory",
           "description": "Base product_category",
           "fields": [
+            {
+              "name": "attachedToPlanOrSubscription",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "code",
               "description": null,
@@ -54474,6 +54506,22 @@
           "name": "ProductFilter",
           "description": "Base product filter",
           "fields": [
+            {
+              "name": "attachedToPlanOrSubscription",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "code",
               "description": null,
@@ -76896,6 +76944,18 @@
               "deprecationReason": null
             },
             {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "description",
               "description": null,
               "type": {
@@ -76965,6 +77025,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -77066,6 +77138,18 @@
               "deprecationReason": null
             },
             {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "description",
               "description": null,
               "type": {
@@ -77095,6 +77179,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "productCategoryId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/product_filters/update_spec.rb
+++ b/spec/graphql/mutations/product_filters/update_spec.rb
@@ -64,6 +64,29 @@ RSpec.describe Mutations::ProductFilters::Update do
     end
   end
 
+  context "when the item is attached and the payload resends code and values unchanged" do
+    before do
+      rate_card = create(:rate_card, organization:, product:)
+      create(:plan_rate_card, organization:, rate_card:)
+    end
+
+    let(:input) do
+      {
+        id: product_filter.id,
+        name: "After",
+        code: product_filter.code,
+        values: [{billableMetricFilterId: region_filter.id, value: "us"}]
+      }
+    end
+
+    it "succeeds" do
+      result_data = execution["data"]["updateProductFilter"]
+
+      expect(result_data["name"]).to eq("After")
+      expect(result_data["values"].map { [it["key"], it["value"]] }).to eq([%w[region us]])
+    end
+  end
+
   context "when the filter belongs to another organization" do
     let(:input) { {id: create(:product_filter).id, name: "After"} }
 

--- a/spec/graphql/sources/attached_to_plan_or_subscription_spec.rb
+++ b/spec/graphql/sources/attached_to_plan_or_subscription_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Sources::AttachedToPlanOrSubscription do
+  let(:organization) { create(:organization) }
+  let(:product) { create(:product, organization:) }
+
+  describe "#fetch" do
+    context "when grouped by product" do
+      subject(:source) { described_class.new(:product) }
+
+      it "flags products carded on a plan or a subscription" do
+        plan_attached = create(:product, organization:)
+        create(:plan_rate_card, organization:, rate_card: create(:rate_card, organization:, product: plan_attached))
+
+        subscription_attached = create(:product, organization:)
+        create(:subscription_rate_card, organization:, rate_card: create(:rate_card, organization:, product: subscription_attached))
+
+        result = source.fetch([plan_attached.id, subscription_attached.id, product.id])
+
+        expect(result).to eq([true, true, false])
+      end
+
+      it "ignores discarded rate cards" do
+        create(:plan_rate_card, organization:, rate_card: create(:rate_card, organization:, product:)).rate_card.discard!
+
+        expect(source.fetch([product.id])).to eq([false])
+      end
+    end
+
+    context "when grouped by product_category" do
+      subject(:source) { described_class.new(:product_category) }
+
+      it "flags categories through their products' cards" do
+        attached_category = create(:product_category, organization:)
+        carded_product = create(:product, organization:, product_category: attached_category)
+        create(:plan_rate_card, organization:, rate_card: create(:rate_card, organization:, product: carded_product))
+
+        empty_category = create(:product_category, organization:)
+
+        result = source.fetch([attached_category.id, empty_category.id])
+
+        expect(result).to eq([true, false])
+      end
+    end
+  end
+end

--- a/spec/graphql/sources/count_by_foreign_key_spec.rb
+++ b/spec/graphql/sources/count_by_foreign_key_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Sources::CountByForeignKey do
+  subject(:source) { described_class.new(ProductFilter, :product_id) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:product) { create(:product, organization:, billable_metric:) }
+
+  describe "#fetch" do
+    it "returns the count per id, zero when nothing matches" do
+      create_pair(:product_filter, organization:, product:)
+      empty_product = create(:product, organization:)
+
+      result = source.fetch([product.id, empty_product.id])
+
+      expect(result).to eq([2, 0])
+    end
+
+    it "does not count discarded rows" do
+      kept = create(:product_filter, organization:, product:)
+      create(:product_filter, organization:, product:).discard!
+
+      result = source.fetch([product.id])
+
+      expect(result).to eq([1])
+      expect(product.filters).to eq([kept])
+    end
+  end
+end

--- a/spec/models/product_filter_spec.rb
+++ b/spec/models/product_filter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ProductFilter do
       expect(product_filter).to belong_to(:product)
       expect(product_filter).to have_many(:values).class_name("ProductFilterValue")
       expect(product_filter).to have_many(:billable_metric_filters).through(:values)
+      expect(product_filter).to have_many(:rate_cards)
     end
   end
 

--- a/spec/services/product_categories/destroy_service_spec.rb
+++ b/spec/services/product_categories/destroy_service_spec.rb
@@ -37,4 +37,18 @@ RSpec.describe ProductCategories::DestroyService do
       expect(result.error.resource).to eq("product_category")
     end
   end
+
+  context "when one of the product_category's items is priced on a plan" do
+    before do
+      item = create(:product, organization:, product_category:)
+      rate_card = create(:rate_card, organization:, product: item)
+      create(:plan_rate_card, organization:, rate_card:)
+    end
+
+    it "returns a validation failure and discards nothing" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:product_category]).to eq(["attached_to_plan_or_subscription"])
+      expect(product_category.reload).not_to be_discarded
+    end
+  end
 end

--- a/spec/services/product_categories/update_service_spec.rb
+++ b/spec/services/product_categories/update_service_spec.rb
@@ -17,8 +17,33 @@ RSpec.describe ProductCategories::UpdateService do
     expect(result.product_category.invoice_display_name).to eq("Display")
   end
 
-  it "does not change the code" do
-    expect { result }.not_to change { product_category.reload.code }
+  describe "code editability" do
+    let(:params) { {code: "after"} }
+
+    it "updates the code when the product_category is not in a plan or subscription" do
+      expect { result }.to change { product_category.reload.code }.to("after")
+    end
+
+    context "when the product_category is attached to a plan" do
+      before do
+        item = create(:product, organization:, product_category:)
+        rate_card = create(:rate_card, organization:, product: item)
+        create(:plan_rate_card, organization:, rate_card:)
+      end
+
+      it "rejects the code change" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:code]).to eq(["attached_to_plan_or_subscription"])
+        expect(product_category.reload.code).to eq("before")
+      end
+
+      it "accepts an unchanged code alongside other updates" do
+        update_result = described_class.call(product_category:, params: {code: "before", name: "renamed"})
+
+        expect(update_result).to be_success
+        expect(product_category.reload.name).to eq("renamed")
+      end
+    end
   end
 
   it "produces an activity log" do

--- a/spec/services/product_filters/create_service_spec.rb
+++ b/spec/services/product_filters/create_service_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ProductFilters::CreateService do
 
     it "returns a validation failure" do
       expect(result).not_to be_success
-      expect(result.error.messages[:product]).to eq(["invalid_product_type"])
+      expect(result.error.messages[:product]).to eq(["not_allowed_for_product_type"])
     end
   end
 

--- a/spec/services/product_filters/create_service_spec.rb
+++ b/spec/services/product_filters/create_service_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe ProductFilters::CreateService do
     end
   end
 
-  context "when the combination is already used on the product" do
+  context "when the value set is already used by another filter on the product" do
     before do
       described_class.call(
         product:,
@@ -147,9 +147,50 @@ RSpec.describe ProductFilters::CreateService do
       )
     end
 
-    it "creates the filter anyway" do
+    it "returns a validation failure" do
+      expect { result }.not_to change(ProductFilter, :count)
+      expect(result).not_to be_success
+      expect(result.error.messages[:values]).to eq(["value_already_exist"])
+    end
+
+    it "detects the duplicate regardless of the values order" do
+      params[:values] = [
+        {billable_metric_filter_id: scheme_filter.id, value: "visa"},
+        {billable_metric_filter_id: region_filter.id, value: "us"}
+      ]
+
+      expect(result).not_to be_success
+      expect(result.error.messages[:values]).to eq(["value_already_exist"])
+    end
+
+    it "accepts a differing value set" do
+      params[:values] = [{billable_metric_filter_id: region_filter.id, value: "us"}]
+
       expect(result).to be_success
-      expect(result.product_filter.to_h).to eq("region" => %w[us], "scheme" => %w[visa])
+    end
+  end
+
+  context "when a key-only filter for the same key already exists" do
+    before do
+      described_class.call(
+        product:,
+        params: params.merge(name: "Existing", code: "existing", values: [{billable_metric_filter_id: region_filter.id}])
+      )
+    end
+
+    it "rejects a second key-only filter but accepts a valued one" do
+      duplicate = described_class.call(
+        product:,
+        params: params.merge(values: [{billable_metric_filter_id: region_filter.id}])
+      )
+      expect(duplicate).not_to be_success
+      expect(duplicate.error.messages[:values]).to eq(["value_already_exist"])
+
+      valued = described_class.call(
+        product:,
+        params: params.merge(values: [{billable_metric_filter_id: region_filter.id, value: "eu"}])
+      )
+      expect(valued).to be_success
     end
   end
 

--- a/spec/services/product_filters/update_service_spec.rb
+++ b/spec/services/product_filters/update_service_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe ProductFilters::UpdateService do
       expect(update_result).to be_success
       expect(product_filter.reload.name).to eq("renamed")
     end
+
+    context "when the payload mixes a key-only entry with a valued entry for the same key" do
+      let(:params) do
+        {
+          values: [
+            {billable_metric_filter_id: region_filter.id},
+            {billable_metric_filter_id: region_filter.id, value: "eu"}
+          ]
+        }
+      end
+
+      it "rejects the values change instead of crashing on the comparison" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:values]).to eq(["attached_to_subscriptions"])
+      end
+    end
   end
 
   it "produces an activity log" do

--- a/spec/services/product_filters/update_service_spec.rb
+++ b/spec/services/product_filters/update_service_spec.rb
@@ -83,6 +83,21 @@ RSpec.describe ProductFilters::UpdateService do
         expect(product_filter.reload.to_h).to eq("region" => %w[eu])
       end
     end
+
+    context "when the new values duplicate another filter on the product" do
+      before do
+        sibling = create(:product_filter, organization:, product:, code: "sibling")
+        create(:product_filter_value, organization:, product_filter: sibling, billable_metric_filter: region_filter, value: "eu")
+      end
+
+      let(:params) { {values: [{billable_metric_filter_id: region_filter.id, value: "eu"}]} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:values]).to eq(["value_already_exist"])
+        expect(product_filter.reload.to_h).to eq("region" => %w[us])
+      end
+    end
   end
 
   context "when a subscription bills through a card scoped to the filter" do
@@ -145,18 +160,6 @@ RSpec.describe ProductFilters::UpdateService do
     it "replaces the existing values" do
       expect(result).to be_success
       expect(result.product_filter.reload.to_h).to eq("region" => %w[eu])
-    end
-
-    context "when the new combination matches another filter on the item" do
-      before do
-        other = create(:product_filter, organization:, product:)
-        create(:product_filter_value, organization:, product_filter: other, billable_metric_filter: region_filter, value: "eu")
-      end
-
-      it "is allowed" do
-        expect(result).to be_success
-        expect(result.product_filter.reload.to_h).to eq("region" => %w[eu])
-      end
     end
 
     context "when values are empty" do

--- a/spec/services/product_filters/update_service_spec.rb
+++ b/spec/services/product_filters/update_service_spec.rb
@@ -29,6 +29,86 @@ RSpec.describe ProductFilters::UpdateService do
     expect { result }.not_to change { product_filter.reload.values.count }
   end
 
+  describe "code editability" do
+    let(:params) { {code: "after"} }
+
+    it "updates the code when the item is not in a plan or subscription" do
+      expect { result }.to change { product_filter.reload.code }.to("after")
+    end
+  end
+
+  context "when the item is attached to a plan" do
+    before do
+      rate_card = create(:rate_card, organization:, product:)
+      create(:plan_rate_card, organization:, rate_card:)
+    end
+
+    let(:params) { {code: "after", values: [{billable_metric_filter_id: region_filter.id, value: "eu"}]} }
+
+    it "rejects the structural change" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:code]).to eq(["attached_to_plan_or_subscription"])
+      expect(product_filter.reload.to_h).to eq("region" => %w[us])
+    end
+
+    it "still updates the display fields without structural params" do
+      update_result = described_class.call(product_filter:, params: {name: "renamed"})
+
+      expect(update_result).to be_success
+      expect(product_filter.reload.name).to eq("renamed")
+    end
+
+    context "when the payload resends the current code and values unchanged" do
+      let(:params) do
+        {
+          name: "renamed",
+          code: product_filter.code,
+          values: [{billable_metric_filter_id: region_filter.id, value: "us"}]
+        }
+      end
+
+      it "succeeds without touching the values" do
+        expect { result }.not_to change { product_filter.values.order(:id).pluck(:id) }
+
+        expect(result).to be_success
+        expect(product_filter.reload.name).to eq("renamed")
+      end
+    end
+
+    context "when only the values actually change" do
+      let(:params) { {values: [{billable_metric_filter_id: region_filter.id, value: "eu"}]} }
+
+      it "replaces the values while no subscription bills through the filter" do
+        expect(result).to be_success
+        expect(product_filter.reload.to_h).to eq("region" => %w[eu])
+      end
+    end
+  end
+
+  context "when a subscription bills through a card scoped to the filter" do
+    before do
+      rate_card = create(:rate_card, organization:, product:, product_filter:)
+      create(:subscription_rate_card, organization:, rate_card:)
+    end
+
+    let(:params) { {values: [{billable_metric_filter_id: region_filter.id, value: "eu"}]} }
+
+    it "rejects the values change" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:values]).to eq(["attached_to_subscriptions"])
+    end
+
+    it "still accepts a payload resending the current values" do
+      update_result = described_class.call(
+        product_filter:,
+        params: {name: "renamed", values: [{billable_metric_filter_id: region_filter.id, value: "us"}]}
+      )
+
+      expect(update_result).to be_success
+      expect(product_filter.reload.name).to eq("renamed")
+    end
+  end
+
   it "produces an activity log" do
     result
     expect(Utils::ActivityLog).to have_produced("product_filter.updated").after_commit.with(product_filter)

--- a/spec/services/products/destroy_service_spec.rb
+++ b/spec/services/products/destroy_service_spec.rb
@@ -46,4 +46,17 @@ RSpec.describe Products::DestroyService do
       expect(result.error.resource).to eq("product")
     end
   end
+
+  context "when the item is attached to a subscription" do
+    before do
+      rate_card = create(:rate_card, organization:, product:)
+      create(:subscription_rate_card, organization:, rate_card:)
+    end
+
+    it "returns a validation failure and discards nothing" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:product]).to eq(["attached_to_plan_or_subscription"])
+      expect(product.reload).not_to be_discarded
+    end
+  end
 end

--- a/spec/services/products/update_service_spec.rb
+++ b/spec/services/products/update_service_spec.rb
@@ -17,8 +17,41 @@ RSpec.describe Products::UpdateService do
     expect(result.product.invoice_display_name).to eq("Display")
   end
 
-  it "does not change the code" do
-    expect { result }.not_to change { product.reload.code }
+  describe "code and product_category editability" do
+    let(:other_product_category) { create(:product_category, organization:) }
+    let(:params) { {code: "after", product_category_id: other_product_category.id} }
+
+    it "updates the code and product_category attachment when not in a plan or subscription" do
+      expect(result).to be_success
+      expect(result.product.code).to eq("after")
+      expect(result.product.product_category).to eq(other_product_category)
+    end
+
+    it "returns a not found failure when the product_category does not exist" do
+      result = described_class.call(product:, params: {product_category_id: "unknown"})
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("product_category")
+    end
+
+    context "when the item is attached to a plan" do
+      before do
+        rate_card = create(:rate_card, organization:, product:)
+        create(:plan_rate_card, organization:, rate_card:)
+      end
+
+      it "rejects the structural change" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:code]).to eq(["attached_to_plan_or_subscription"])
+        expect(product.reload.code).to eq("before")
+      end
+
+      it "accepts unchanged structural fields alongside other updates" do
+        update_result = described_class.call(product:, params: {code: "before", name: "renamed"})
+
+        expect(update_result).to be_success
+        expect(product.reload.name).to eq("renamed")
+      end
+    end
   end
 
   it "produces an activity log" do


### PR DESCRIPTION
## Context

Hardening on top of the catalog services (#6098) and GraphQL surface (#6099): the immutability rules, the review fixes and the list-performance work.

## Description

- Gate structural edits on attachment: a product, category or filter priced by a plan or subscription cannot change identity or be deleted (`attached_to_plan_or_subscription`); filter values freeze once a subscription bills through the filter (`attached_to_subscriptions`).
- Creating a filter on a fixed product fails with `not_allowed_for_product_type`.
- Reject duplicate filter value sets per product (`value_already_exist` on `values`) — two identical slices would be unresolvable for the billing engine; partial overlaps stay legal.
- Batch `filters_count`, `products_count` and `attached_to_plan_or_subscription` through dataloader sources — one grouped query per page instead of per row.



