### PR TITLE
feat(fc-units-override): units-only write branch on the dedicated endpoint

### DIFF
--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -62,7 +62,7 @@ module Subscriptions
         timestamp:
       )
 
-      if apply_units_immediately && parent_fixed_charge.pay_in_advance?
+      if apply_units_immediately && parent_fixed_charge.pay_in_advance? && subscription.active?
         after_commit do
           Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
         end

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -3,6 +3,7 @@
 module Subscriptions
   class UpdateOrOverrideFixedChargeService < BaseService
     include Concerns::PlanOverrideConcern
+    include Concerns::FixedChargeUnitsOverrideDetectionConcern
 
     Result = BaseResult[:fixed_charge]
 
@@ -21,13 +22,7 @@ module Subscriptions
       return result.not_found_failure!(resource: "fixed_charge") unless fixed_charge
 
       ActiveRecord::Base.transaction do
-        parent_fixed_charge = fixed_charge.parent_or_self
-        target_plan = ensure_plan_override(params: plan_override_params(parent_fixed_charge))
-        target_fixed_charge = find_or_create_fixed_charge_override(parent_fixed_charge, target_plan)
-
-        publish_invoice_pay_in_advance_job(target_fixed_charge)
-
-        result.fixed_charge = target_fixed_charge
+        result.fixed_charge = units_only_change? ? override_units_only : override_via_plan
       end
 
       result
@@ -40,6 +35,51 @@ module Subscriptions
     private
 
     attr_reader :subscription, :fixed_charge, :params, :subscription_plan_parent_present
+
+    def units_only_change?
+      return false if subscription.plan.parent_id
+
+      units_only_fixed_charge_params?(params)
+    end
+
+    def override_units_only
+      apply_units_immediately = !!params[:apply_units_immediately]
+      timestamp = Time.current.to_i
+      parent_fixed_charge = fixed_charge.parent_or_self
+
+      override = ::Subscription::FixedChargeUnitsOverride.find_or_initialize_by(
+        subscription:,
+        fixed_charge: parent_fixed_charge
+      )
+      override.organization = subscription.organization
+      override.units = params[:units]
+      override.save!
+
+      FixedCharges::EmitEventsService.call!(
+        fixed_charge: parent_fixed_charge,
+        subscription:,
+        apply_units_immediately:,
+        timestamp:
+      )
+
+      if apply_units_immediately && parent_fixed_charge.pay_in_advance?
+        after_commit do
+          Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+        end
+      end
+
+      parent_fixed_charge
+    end
+
+    def override_via_plan
+      parent_fixed_charge = fixed_charge.parent_or_self
+      target_plan = ensure_plan_override(params: plan_override_params(parent_fixed_charge))
+      target_fixed_charge = find_or_create_fixed_charge_override(parent_fixed_charge, target_plan)
+
+      publish_invoice_pay_in_advance_job(target_fixed_charge)
+
+      target_fixed_charge
+    end
 
     def plan_override_params(parent_fixed_charge)
       return {} if subscription_plan_parent_present

--- a/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
+++ b/spec/scenarios/fixed_charges/pay_in_advance_units_change_spec.rb
@@ -1445,33 +1445,27 @@ describe "Pay in advance fixed charge units change mid-period", :premium do
         end
       end
 
-      it "creates a plan override with the new units" do
-        child_plan = subscription.reload.plan
-        expect(child_plan.parent_id).to eq(plan.id)
+      it "writes a per-subscription units override row without cloning the plan" do
+        subscription.reload
+        expect(subscription.plan).to eq(plan)
+        expect(plan.fixed_charges.reload).to contain_exactly(fixed_charge)
 
-        child_fixed_charge = child_plan.fixed_charges.first
-        expect(child_fixed_charge.parent_id).to eq(fixed_charge.id)
-        expect(child_fixed_charge.units).to eq(15)
+        override = Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+        expect(override).to be_present
+        expect(override.units).to eq(15)
       end
 
-      it "creates a single FixedChargeEvent on the override with units=15 at the update time" do
-        child_fixed_charge = subscription.reload.plan.fixed_charges.first
-        events = FixedChargeEvent.where(subscription:, fixed_charge: child_fixed_charge).order(:created_at)
+      it "appends a FixedChargeEvent on the parent fixed_charge with units=15 at the update time" do
+        events = FixedChargeEvent.where(subscription:, fixed_charge:).order(:created_at)
 
-        # Expectation: one event on the child fixed_charge with the new
-        # 15 units, anchored at "now" (apply_units_immediately: true).
-        #
-        # Observed on main: TWO events on the child fixed_charge:
-        #   1. units=10 anchored at the next-period boundary, created by
-        #      Plans::OverrideService cloning fixed_charges with
-        #      apply_units_immediately defaulting to false.
-        #   2. units=15 anchored at "now", created by the subsequent
-        #      update_fixed_charge_override step.
-        # The stale units=10 event at the next-period boundary is what
-        # the aggregation reads for the next billing cycle.
-        expect(events.count).to eq(1)
-        expect(events.first.units).to eq(15)
-        expect(events.first.timestamp).to be_within(5.seconds).of(subscription_date + 1.hour)
+        # Two events on the parent fixed_charge:
+        #   1. units=10 from subscription creation.
+        #   2. units=15 at the update time, emitted by the units-only fast
+        #      path on UpdateOrOverrideFixedChargeService.
+        expect(events.count).to eq(2)
+        update_event = events.last
+        expect(update_event.units).to eq(15)
+        expect(update_event.timestamp).to be_within(5.seconds).of(subscription_date + 1.hour)
       end
 
       it "generates a mid-period delta invoice for 5 units (15 - 10)" do

--- a/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
+++ b/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Subscription fixed charge units override via subscription endpoint", :premium do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, timezone: "UTC") }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      amount_cents: 0,
+      interval: "monthly",
+      pay_in_advance: true
+    )
+  end
+
+  let(:fixed_charge) do
+    create(
+      :fixed_charge,
+      plan:,
+      add_on:,
+      units: 10,
+      properties: {amount: "10"},
+      prorated: false,
+      pay_in_advance: true
+    )
+  end
+
+  let(:subscription_date) { DateTime.new(2024, 3, 1) }
+  let(:subscription) { customer.subscriptions.first }
+
+  before do
+    fixed_charge
+
+    travel_to subscription_date do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: "sub_#{customer.external_id}",
+          plan_code: plan.code,
+          billing_time: "calendar"
+        }
+      )
+    end
+
+    travel_to subscription_date + 1.minute do
+      perform_all_enqueued_jobs
+    end
+  end
+
+  it "records the override row, skips plan/fixed_charge cloning, and emits an event with the override units" do
+    travel_to subscription_date + 5.days do
+      update_subscription_fixed_charge(
+        subscription,
+        fixed_charge.code,
+        {
+          units: 15,
+          apply_units_immediately: true
+        }
+      )
+
+      perform_all_enqueued_jobs
+    end
+
+    expect(subscription.reload.plan_id).to eq(plan.id)
+    expect(Plan.where(parent_id: plan.id)).to be_empty
+    expect(FixedCharge.where(parent_id: fixed_charge.id)).to be_empty
+
+    override = subscription.fixed_charge_units_overrides.sole
+    expect(override.fixed_charge).to eq(fixed_charge)
+    expect(override.units).to eq(15)
+
+    events = FixedChargeEvent.where(subscription:, fixed_charge:).order(:created_at)
+    expect(events.count).to eq(2)
+    expect(events.last.units).to eq(15)
+  end
+end

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -616,7 +616,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
       expect(subscription).to be_incomplete
       expect(subscription.invoices.count).to eq(1)
 
-      # Mid-gap: the fixed charge is overridden for this subscription only.
+      # Mid-gap: the fixed charge units are overridden for this subscription only.
       travel_to(Time.zone.local(2026, 3, 10, 10)) do
         Subscriptions::UpdateOrOverrideFixedChargeService.call!(
           subscription:,
@@ -627,10 +627,10 @@ describe "Payment Gated Subscription Activation Scenarios" do
       end
 
       subscription.reload
-      expect(subscription.plan.parent).to eq(plan)
+      expect(subscription.plan).to eq(plan)
 
-      override_fixed_charge = subscription.plan.fixed_charges.sole
-      expect(override_fixed_charge.parent).to eq(fixed_charge)
+      override = Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+      expect(override.units).to eq(15)
       expect(subscription.invoices.count).to eq(1)
 
       travel_to(Time.zone.local(2026, 3, 20, 10)) { simulate_stripe_webhook(status: "succeeded") }
@@ -640,7 +640,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
       expect(subscription.invoices.count).to eq(2)
 
       delta_fee = subscription.invoices.order(:created_at).last.fees.fixed_charge.sole
-      expect(delta_fee.fixed_charge).to eq(override_fixed_charge)
+      expect(delta_fee.fixed_charge).to eq(fixed_charge)
       expect(delta_fee.units).to eq(5)
     end
   end

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -264,6 +264,87 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
           expect(result.fixed_charge.taxes).to include(tax)
         end
       end
+
+      context "with units-only params" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 5) }
+        let(:params) { {units: "15"} }
+
+        it "writes a Subscription::FixedChargeUnitsOverride for the (sub, fc) pair" do
+          expect { service.call }
+            .to change(::Subscription::FixedChargeUnitsOverride, :count).by(1)
+
+          override = ::Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+          expect(override.units).to eq(15)
+          expect(override.organization).to eq(subscription.organization)
+        end
+
+        it "does not create a plan override or a fixed_charge override" do
+          expect { service.call }
+            .to not_change(Plan, :count)
+            .and not_change(FixedCharge, :count)
+        end
+
+        it "returns the parent fixed_charge in the result" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.fixed_charge).to eq(fixed_charge)
+        end
+
+        it "emits a fixed charge event with the override units" do
+          service.call
+
+          event = FixedChargeEvent.where(subscription:, fixed_charge:).order(:created_at).last
+          expect(event.units).to eq(15)
+        end
+
+        context "when an override already exists" do
+          before do
+            create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 7)
+          end
+
+          it "updates the existing override row instead of creating a new one" do
+            expect { service.call }
+              .not_to change(::Subscription::FixedChargeUnitsOverride, :count)
+
+            override = ::Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+            expect(override.units).to eq(15)
+          end
+        end
+
+        context "when apply_units_immediately is true on a pay_in_advance fixed_charge" do
+          let(:fixed_charge) do
+            create(:fixed_charge, plan:, organization:, add_on:, units: 5, pay_in_advance: true)
+          end
+          let(:params) { {units: "15", apply_units_immediately: true} }
+
+          it "enqueues the pay-in-advance billing job for the subscription" do
+            expect { service.call }
+              .to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+              .with(subscription, kind_of(Integer))
+          end
+        end
+
+        context "when apply_units_immediately is true but the fixed_charge is pay_in_arrears" do
+          let(:params) { {units: "15", apply_units_immediately: true} }
+
+          it "does not enqueue the pay-in-advance billing job" do
+            expect { service.call }
+              .not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+          end
+        end
+
+        context "when the subscription is already on a cloned plan" do
+          let(:overridden_plan) { create(:plan, organization:, parent: plan) }
+          let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
+
+          it "falls through to the legacy plan-override path" do
+            expect { service.call }
+              .to not_change(::Subscription::FixedChargeUnitsOverride, :count)
+              .and change(FixedCharge, :count).by(1)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

The subscription-scoped fixed_charge endpoint
`PUT /api/v1/subscriptions/:external_id/fixed_charges/:code` currently always clones the plan and creates a fixed_charge override even when the only change is the unit count. For seat-based plans where every customer signs up with a different seat count and adjusts it over time, this produces one duplicate Plan + one duplicate FixedCharge per customer per change. The override table introduced earlier exists to absorb these per-subscription unit edits without cloning anything; this commit wires the dedicated endpoint to that fast path.

## Description

`Subscriptions::UpdateOrOverrideFixedChargeService` now includes the new params-shape concern and branches inside one transaction:

- When the incoming params match the units-only shape (carrying only `units` and optionally `apply_units_immediately`) AND the subscription is not already on a cloned plan, the service writes a `Subscription::FixedChargeUnitsOverride` row for the (subscription, parent fixed_charge) pair and emits a FixedChargeEvent through `FixedCharges::EmitEventsService`. The override row is created or updated via `find_or_initialize_by`, so repeated edits update one row instead of stacking.
- When `apply_units_immediately` is set on a pay-in-advance fixed charge, `Invoices::CreatePayInAdvanceFixedChargesJob` is dispatched in an `after_commit` block so the mid-period delta invoice is generated after the override row is committed.
- Subscriptions already on a cloned plan, or requests carrying any non-units field (properties, tax_codes, invoice_display_name, etc.), fall through to the existing plan-cloning path unchanged.

The params-shape predicate lives in the shared
`FixedChargeUnitsOverrideDetectionConcern`; the cloned-plan guard stays in the service since it inspects subscription state.

Specs cover the new branch at the service level (override created / updated, no plan or fixed_charge clone, event emitted with override units, billing job dispatched for pay-in-advance + apply-immediately, no dispatch for pay-in-arrears, fall-through on cloned-plan subs). A scenario spec exercises the full HTTP path end-to-end and asserts the same outcomes against the real job pipeline.
