### PR TITLE
misc(daily_usage): Improve fill_history task

### DIFF
--- a/lib/task_prompt.rb
+++ b/lib/task_prompt.rb
@@ -11,6 +11,10 @@ module TaskPrompt
     abort "Aborted." unless ask(prompt).downcase == "y"
   end
 
+  def self.confirm?(prompt)
+    ask(prompt).downcase == "y"
+  end
+
   def self.ask_for_organization
     organization_id = ask("Organization ID: ")
     organization = Organization.find_by(id: organization_id)
@@ -37,6 +41,20 @@ module TaskPrompt
     abort "Invalid timestamp: #{input}" unless timestamp
 
     timestamp
+  end
+
+  def self.ask_for_date(prompt, default:)
+    input = ask("#{prompt} [#{default}]: ")
+    return default if input.empty?
+
+    date = begin
+      Date.parse(input)
+    rescue ArgumentError
+      nil
+    end
+    abort "Invalid date: #{input}" unless date
+
+    date
   end
 end
 # rubocop:enable Rails/Output,Rails/Exit

--- a/lib/tasks/daily_usages.rake
+++ b/lib/tasks/daily_usages.rake
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
+require_relative "../task_prompt"
+
+# rubocop:disable Rails/Output,Rails/Exit
 namespace :daily_usages do
   desc "Fill past daily usage"
-  task :fill_history, [:organization_id, :days_ago] => :environment do |_task, args|
-    abort "Missing organization_id\n\n" unless args[:organization_id]
-
+  task fill_history: :environment do
     Rails.logger.level = Logger::INFO
 
-    from_date = (args[:days_ago] || DailyUsage::DEFAULT_HISTORY_DAYS).days.ago.to_date
-    organization = Organization.find(args[:organization_id])
+    deletion_batch_size = 10_000
+
+    organization = TaskPrompt.ask_for_organization
+
+    default_from_date = DailyUsage::DEFAULT_HISTORY_DAYS.days.ago.to_date
+    from_date = TaskPrompt.ask_for_date("From date (YYYY-MM-DD)", default: default_from_date)
 
     subscriptions = organization.subscriptions
       .where(status: [:active, :terminated])
@@ -16,8 +21,63 @@ namespace :daily_usages do
       .where("terminated_at IS NULL OR terminated_at >= ?", from_date)
       .includes(customer: :organization)
 
+    # ----- recon (read-only) -----
+    sub_count = subscriptions.count
+    daily_usages = DailyUsage
+      .where(organization_id: organization.id)
+      .where("usage_date >= ?", from_date)
+      .where(subscription_id: subscriptions.select(:id))
+    daily_usages_count = daily_usages.count
+
+    days = (Date.current - from_date).to_i + 1
+
+    puts ""
+    puts "----- recon -----"
+    puts "organization          : #{organization.name} (#{organization.id})"
+    puts "subs in scope         : #{sub_count}"
+    puts "existing daily_usages : #{daily_usages_count}"
+    puts "days in backfill range: #{days} (#{from_date} .. #{Date.current})"
+    puts "-----------------"
+
+    if sub_count.zero?
+      puts "No subscriptions in scope. Nothing to do."
+      next
+    end
+
+    delete_existing = daily_usages_count.positive? &&
+      TaskPrompt.confirm?("Delete the #{daily_usages_count} existing daily_usages above? (y/n): ")
+
+    puts ""
+    puts "This will:"
+    puts "  - Delete the #{daily_usages_count} existing daily_usages above" if delete_existing
+    puts "  - Enqueue a FillHistoryJob for each of the #{sub_count} subscriptions"
+    TaskPrompt.confirm!("Continue? (y/n): ")
+
+    # ----- delete existing daily_usages in batches -----
+    if delete_existing
+      puts ""
+      puts "Deleting existing daily_usages..."
+      delete_start = Time.current
+      deleted_total = 0
+
+      daily_usages.in_batches(of: deletion_batch_size) do |batch|
+        deleted_total += batch.delete_all
+      end
+      puts "deleted #{deleted_total} rows in #{(Time.current - delete_start).round}s"
+    end
+
+    # ----- enqueue FillHistoryJob -----
+    puts ""
+    puts "Enqueueing FillHistoryJob..."
+    enqueue_start = Time.current
+    enqueued = 0
+
     subscriptions.find_each do |subscription|
       DailyUsages::FillHistoryJob.perform_later(subscription:, from_date:)
+      enqueued += 1
     end
+
+    puts "enqueued #{enqueued} jobs in #{(Time.current - enqueue_start).round}s"
   end
 end
+# rubocop:enable Rails/Output,Rails/Exit

--- a/spec/lib/tasks/daily_usages_rake_spec.rb
+++ b/spec/lib/tasks/daily_usages_rake_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "rake"
+
+RSpec.describe "daily_usages:fill_history" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["daily_usages:fill_history"] }
+  let(:organization) { create(:organization, api_keys: []) }
+
+  before do
+    Rake.application.rake_require("tasks/daily_usages")
+    Rake::Task.define_task(:environment)
+    task.reenable
+
+    allow(DailyUsages::FillHistoryJob).to receive(:perform_later)
+  end
+
+  def stub_stdin(*responses)
+    allow($stdin).to receive(:gets).and_return(*responses.map { |r| "#{r}\n" })
+  end
+
+  context "when organization is not found" do
+    before { stub_stdin("00000000") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when user does not confirm the organization" do
+    before { stub_stdin(organization.id, "n") }
+
+    it "aborts" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when organization has no subscriptions in scope" do
+    before { stub_stdin(organization.id, "y", "") }
+
+    it "finishes without enqueueing any job" do
+      expect { task.invoke }.not_to raise_error
+      expect(DailyUsages::FillHistoryJob).not_to have_received(:perform_later)
+    end
+  end
+
+  context "when organization has subscriptions in scope" do
+    let(:customer) { create(:customer, organization:) }
+    let!(:active_sub) { create(:subscription, customer:, organization:) }
+    let!(:terminated_sub) do
+      create(:subscription, :terminated, customer:, organization:, terminated_at: Time.current)
+    end
+    let!(:pending_sub) { create(:subscription, :pending, customer:, organization:) }
+
+    let!(:existing_usage) do
+      create(:daily_usage, organization:, customer:, subscription: active_sub, usage_date: Date.current)
+    end
+
+    context "when user confirms deletion with the default date" do
+      before { stub_stdin(organization.id, "y", "", "y", "y") }
+
+      it "deletes existing daily_usages in scope" do
+        task.invoke
+        expect(DailyUsage.where(id: existing_usage.id)).not_to exist
+      end
+
+      it "enqueues a FillHistoryJob for active and terminated subscriptions" do
+        task.invoke
+        expect(DailyUsages::FillHistoryJob).to have_received(:perform_later)
+          .with(subscription: active_sub, from_date: DailyUsage::DEFAULT_HISTORY_DAYS.days.ago.to_date)
+        expect(DailyUsages::FillHistoryJob).to have_received(:perform_later)
+          .with(subscription: terminated_sub, from_date: DailyUsage::DEFAULT_HISTORY_DAYS.days.ago.to_date)
+      end
+
+      it "does not enqueue a job for pending subscriptions" do
+        task.invoke
+        expect(DailyUsages::FillHistoryJob).not_to have_received(:perform_later)
+          .with(subscription: pending_sub, from_date: anything)
+      end
+    end
+
+    context "when user declines deletion but continues" do
+      before { stub_stdin(organization.id, "y", "", "n", "y") }
+
+      it "keeps existing daily_usages" do
+        task.invoke
+        expect(DailyUsage.where(id: existing_usage.id)).to exist
+      end
+
+      it "still enqueues the FillHistoryJobs" do
+        task.invoke
+        expect(DailyUsages::FillHistoryJob).to have_received(:perform_later)
+          .with(subscription: active_sub, from_date: DailyUsage::DEFAULT_HISTORY_DAYS.days.ago.to_date)
+      end
+    end
+
+    context "when user enters a custom date" do
+      before { stub_stdin(organization.id, "y", "2026-01-15", "y", "y") }
+
+      it "uses the entered date as from_date" do
+        task.invoke
+        expect(DailyUsages::FillHistoryJob).to have_received(:perform_later)
+          .with(subscription: active_sub, from_date: Date.new(2026, 1, 15))
+      end
+    end
+
+    context "when user enters an invalid date" do
+      before { stub_stdin(organization.id, "y", "not-a-date") }
+
+      it "aborts" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(DailyUsages::FillHistoryJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when user declines the final confirmation" do
+      before { stub_stdin(organization.id, "y", "", "y", "n") }
+
+      it "aborts without deleting or enqueueing" do
+        expect { task.invoke }.to raise_error(SystemExit)
+        expect(DailyUsage.where(id: existing_usage.id)).to exist
+        expect(DailyUsages::FillHistoryJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR improves the `daily_usages:fill_history` rake task:
- It makes it more interactive by asking the user for both the organization and the lower date boundary
- It adds more visual feedback, by displaying the organization ID and name, the number of affected subscription and the number of deleted DailyUsages
- It cleanup the existing DailyUsage before re-enqueing the `DailyUsages::FillHistoryJob`
