### PR TITLE
feat(fc-units-override): units-only write branch on subscription creation

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -3,6 +3,7 @@
 module Subscriptions
   class CreateService < BaseService
     include Subscriptions::Concerns::BillingEntityResolutionConcern
+    include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
 
     Result = BaseResult[:subscription, :payment_method]
 
@@ -131,7 +132,7 @@ module Subscriptions
       new_subscription = Subscription.new(
         organization_id: customer.organization_id,
         customer:,
-        plan: params.key?(:plan_overrides) ? override_plan(plan) : plan,
+        plan: target_plan_for_new_subscription,
         subscription_at:,
         name:,
         external_id:,
@@ -145,6 +146,12 @@ module Subscriptions
       if params.key?(:payment_method)
         new_subscription.payment_method_type = params[:payment_method][:payment_method_type] if params[:payment_method].key?(:payment_method_type)
         new_subscription.payment_method_id = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
+      end
+
+      if units_only_plan_overrides_change?
+        new_subscription.status = :pending
+        new_subscription.save!
+        create_fixed_charge_units_overrides(new_subscription)
       end
 
       timezone = customer.applicable_timezone
@@ -234,6 +241,34 @@ module Subscriptions
 
     def override_plan(plan)
       Plans::OverrideService.call(plan:, params: params[:plan_overrides].to_h.with_indifferent_access).plan
+    end
+
+    def target_plan_for_new_subscription
+      return plan if units_only_plan_overrides_change?
+      return override_plan(plan) if params.key?(:plan_overrides)
+
+      plan
+    end
+
+    def units_only_plan_overrides_change?
+      return @units_only_plan_overrides_change if defined?(@units_only_plan_overrides_change)
+
+      @units_only_plan_overrides_change = !plan.parent_id &&
+        params.key?(:plan_overrides) &&
+        units_only_fixed_charges_plan_overrides?(params[:plan_overrides])
+    end
+
+    def create_fixed_charge_units_overrides(subscription)
+      params[:plan_overrides][:fixed_charges].each do |entry|
+        entry = entry.to_h.symbolize_keys
+
+        ::Subscription::FixedChargeUnitsOverride.create!(
+          subscription:,
+          fixed_charge: plan.fixed_charges.find(entry[:id]),
+          organization: subscription.organization,
+          units: entry[:units]
+        )
+      end
     end
 
     def payment_method

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -436,48 +436,35 @@ RSpec.describe Subscriptions::CreateService do
         fixed_charge2
       end
 
-      it "creates the subscription with overridden plan" do
+      it "creates the subscription on the parent plan and writes a units override row" do
         result = create_service.call
 
         expect(result).to be_success
         expect(result.subscription).to be_active
-        expect(result.subscription.plan.parent_id).to eq(plan.id)
+        expect(result.subscription.plan).to eq(plan)
+        expect(result.subscription.plan.parent_id).to be_nil
 
-        # Both fixed charges should be overridden in the new plan
-        overridden_plan = result.subscription.plan
-        expect(overridden_plan.fixed_charges.count).to eq(2)
-
-        fc1_override = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge1.id)
-        fc2_override = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge2.id)
-
-        expect(fc1_override).to be_present
-        expect(fc1_override.units).to eq(5) # Original units (not specified in override)
-        expect(fc2_override).to be_present
-        expect(fc2_override.units).to eq(100) # Overridden units
+        override = result.subscription.fixed_charge_units_overrides.sole
+        expect(override.fixed_charge).to eq(fixed_charge2)
+        expect(override.units).to eq(100)
       end
 
-      it "creates fixed charge events with timestamp = subscription.started_at for active subscription" do
+      it "emits fixed charge events with the override units for the active subscription" do
         result = create_service.call
 
         expect(result).to be_success
 
         subscription = result.subscription
-        expect(subscription.fixed_charge_events.count).to eq(2)
-
-        overridden_plan = subscription.plan
-        fc1_override = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge1.id)
-        fc2_override = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge2.id)
-
         expect(subscription.fixed_charge_events.pluck(:fixed_charge_id, :units, :timestamp)).to contain_exactly(
-          [fc1_override.id, 5, be_within(1.second).of(subscription.started_at)],
-          [fc2_override.id, 100, be_within(1.second).of(subscription.started_at)]
+          [fixed_charge1.id, 5, be_within(1.second).of(subscription.started_at)],
+          [fixed_charge2.id, 100, be_within(1.second).of(subscription.started_at)]
         )
       end
 
       context "when subscription starts in the future" do
         let(:subscription_at) { 7.days.from_now }
 
-        it "creates pending subscription with overridden plan but does not create fixed charge events" do
+        it "creates a pending subscription on the parent plan with the override row and no fixed charge events" do
           result = create_service.call
 
           expect(result).to be_success
@@ -485,20 +472,95 @@ RSpec.describe Subscriptions::CreateService do
           subscription = result.subscription
           expect(subscription).to be_pending
           expect(subscription.started_at).to be_nil
-          expect(subscription.plan.parent_id).to eq(plan.id)
+          expect(subscription.plan).to eq(plan)
+          expect(subscription.plan.parent_id).to be_nil
 
-          # Plan should have overridden fixed charges
-          overridden_plan = subscription.plan
+          override = subscription.fixed_charge_units_overrides.sole
+          expect(override.fixed_charge).to eq(fixed_charge2)
+          expect(override.units).to eq(100)
+
+          # NO fixed charge events for pending subscription
+          expect(subscription.fixed_charge_events.count).to eq(0)
+        end
+      end
+
+      context "when plan_overrides carries non-units fields (plan-override path)" do
+        let(:params) do
+          {
+            external_customer_id:,
+            plan_code:,
+            name:,
+            external_id:,
+            billing_time:,
+            subscription_at:,
+            subscription_id:,
+            started_at:,
+            plan_overrides: {
+              amount_cents: 12_345,
+              fixed_charges: [
+                {
+                  id: fixed_charge2.id,
+                  units: 100
+                }
+              ]
+            }
+          }
+        end
+
+        it "creates an overridden plan with overridden fixed charges and no override row" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription).to be_active
+          expect(result.subscription.plan.parent_id).to eq(plan.id)
+          expect(result.subscription.fixed_charge_units_overrides).to be_empty
+
+          overridden_plan = result.subscription.plan
           expect(overridden_plan.fixed_charges.count).to eq(2)
 
           fc1_override = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge1.id)
           fc2_override = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge2.id)
 
-          expect(fc1_override.units).to eq(5)
-          expect(fc2_override.units).to eq(100)
+          expect(fc1_override.units).to eq(5) # default carried over
+          expect(fc2_override.units).to eq(100) # overridden
 
-          # NO fixed charge events should be created for pending subscription
-          expect(subscription.fixed_charge_events.count).to eq(0)
+          expect(result.subscription.fixed_charge_events.pluck(:fixed_charge_id, :units, :timestamp)).to contain_exactly(
+            [fc1_override.id, 5, be_within(1.second).of(result.subscription.started_at)],
+            [fc2_override.id, 100, be_within(1.second).of(result.subscription.started_at)]
+          )
+        end
+
+        context "when subscription starts in the future" do
+          let(:subscription_at) { 7.days.from_now }
+
+          it "creates a pending subscription with the overridden plan and no events" do
+            result = create_service.call
+
+            expect(result).to be_success
+
+            subscription = result.subscription
+            expect(subscription).to be_pending
+            expect(subscription.started_at).to be_nil
+            expect(subscription.plan.parent_id).to eq(plan.id)
+
+            overridden_plan = subscription.plan
+            expect(overridden_plan.fixed_charges.count).to eq(2)
+            expect(overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge2.id).units).to eq(100)
+
+            expect(subscription.fixed_charge_events.count).to eq(0)
+          end
+        end
+      end
+
+      context "when the target plan is itself an override" do
+        let(:parent_plan) { create(:plan, organization:, amount_cents: 100, amount_currency: "EUR") }
+        let(:plan) { create(:plan, organization:, parent: parent_plan) }
+
+        it "routes through the plan-override path rather than the units-only branch" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.subscription.fixed_charge_units_overrides).to be_empty
         end
       end
 


### PR DESCRIPTION
## Context

Subscription creation is the highest-volume code path that today overrides the plan and every fixed charge whenever `plan_overrides` is present, even if the only change is the unit count. For seat-based plans this produces one overridden Plan and N overridden FixedCharges per signup, which is unworkable at the scale Mistral is preparing for (~2000 subscriptions, every one starting with its own seat count). This commit routes units-only `plan_overrides.fixed_charges` requests on `POST /api/v1/subscriptions` through the override table instead.

## Description

`Subscriptions::CreateService` now includes the shared params-shape concern and branches inside `create_subscription`:

- When `plan_overrides` matches the units-only envelope shape (only the `fixed_charges` key, every entry carrying just `id`, `units`, and optionally `apply_units_immediately`) AND the target plan is not itself an override, the subscription is built on the parent plan (no plan override created), persisted early with status `pending` so it has an id, and one `Subscription::FixedChargeUnitsOverride` row is written per entry against the parent fixed_charge. The existing lifecycle paths (today / past / future) then run as normal and the events they emit pick up the override units through `effective_units_for`.
- Any other shape (mixed-field `plan_overrides`, non-units entry fields, target plan already an override) falls through to the existing `Plans::OverrideService` path unchanged.

`apply_units_immediately` is allowed by the predicate but intentionally not dispatched on creation. Unlike the mid-period delta case on the dedicated endpoint, the first invoice on a brand-new subscription already bills the override units through the standard activation flow, so adding `Invoices::CreatePayInAdvanceFixedChargesJob` here would either no-op or double-bill.

Specs replace the prior `plan_overrides` tests that documented the old plan-override behaviour on a units-only payload with assertions for the new branch (subscription on parent plan, override row written, events with override units), and add a context that re-establishes parity for the plan-override fall-through path (non-units-only payload).
