### PR TITLE
feat(fc-units-override): units-only write branch on subscription update

### DIFF
--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -3,6 +3,7 @@
 module Subscriptions
   class UpdateService < BaseService
     include Subscriptions::Concerns::BillingEntityResolutionConcern
+    include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
 
     Result = BaseResult[:subscription, :payment_method]
 
@@ -73,7 +74,11 @@ module Subscriptions
           subscription.billing_entity = new_billing_entity
         end
 
-        subscription.plan = handle_plan_override.plan if params.key?(:plan_overrides)
+        if units_only_plan_overrides_change?
+          apply_units_only_plan_overrides
+        elsif params.key?(:plan_overrides)
+          subscription.plan = handle_plan_override.plan
+        end
 
         if params.key?(:usage_thresholds)
           UpdateUsageThresholdsService.call!(subscription:, usage_thresholds_params: params[:usage_thresholds], partial: false)
@@ -173,6 +178,45 @@ module Subscriptions
           params: params[:plan_overrides].to_h.with_indifferent_access,
           subscription:
         )
+      end
+    end
+
+    def units_only_plan_overrides_change?
+      return @units_only_plan_overrides_change if defined?(@units_only_plan_overrides_change)
+
+      @units_only_plan_overrides_change = !subscription.plan.parent_id &&
+        params.key?(:plan_overrides) &&
+        units_only_fixed_charges_plan_overrides?(params[:plan_overrides])
+    end
+
+    def apply_units_only_plan_overrides
+      timestamp = Time.current.to_i
+
+      params[:plan_overrides][:fixed_charges].each do |entry|
+        entry = entry.to_h.symbolize_keys
+        fixed_charge = subscription.plan.fixed_charges.find(entry[:id])
+        apply_units_immediately = !!entry[:apply_units_immediately]
+
+        override = ::Subscription::FixedChargeUnitsOverride.find_or_initialize_by(
+          subscription:,
+          fixed_charge:
+        )
+        override.organization = subscription.organization
+        override.units = entry[:units]
+        override.save!
+
+        FixedCharges::EmitEventsService.call!(
+          fixed_charge:,
+          subscription:,
+          apply_units_immediately:,
+          timestamp:
+        )
+
+        if apply_units_immediately && fixed_charge.pay_in_advance?
+          after_commit do
+            Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+          end
+        end
       end
     end
 

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -724,30 +724,24 @@ RSpec.describe Subscriptions::UpdateService do
           subscription
         end
 
-        it "creates override fixed charges for both fixed charges" do
-          expect { update_service.call }.to change(FixedCharge, :count).by(2)
+        it "writes an override row for fc2 and leaves fc1 untouched" do
+          expect { update_service.call }
+            .to not_change(FixedCharge, :count)
+            .and not_change(Plan, :count)
 
-          fc1_override = FixedCharge.find_sole_by(parent_id: fixed_charge1.id)
-          fc2_override = FixedCharge.find_sole_by(parent_id: fixed_charge2.id)
-
-          expect(fc1_override.units).to eq(fixed_charge1.units)
-          expect(fc2_override.units).to eq(300)
+          expect(subscription.fixed_charge_units_overrides.pluck(:fixed_charge_id, :units)).to contain_exactly(
+            [fixed_charge2.id, 300]
+          )
         end
 
-        it "creates 2 fixed charge events with correct timestamps and units" do
+        it "emits one fixed charge event for fc2 at the current time with the override units" do
           travel_to(Time.zone.local(2025, 10, 10, 15, 33)) do # Friday
-            expect { update_service.call }.to change(FixedChargeEvent, :count).by(2)
+            expect { update_service.call }.to change(FixedChargeEvent, :count).by(1)
 
-            fc1_override = FixedCharge.find_sole_by(parent_id: fixed_charge1.id)
-            fc2_override = FixedCharge.find_sole_by(parent_id: fixed_charge2.id)
-
-            next_billing_period_start = Time.zone.local(2025, 10, 13) # Next Monday
-            events = subscription.fixed_charge_events.pluck(%i[fixed_charge_id units timestamp])
-
-            expect(events).to contain_exactly(
-              [fc1_override.id, fixed_charge1.units, be_within(1.second).of(next_billing_period_start)],
-              [fc2_override.id, 300, be_within(1.second).of(Time.current)]
-            )
+            event = subscription.fixed_charge_events.sole
+            expect(event.fixed_charge_id).to eq(fixed_charge2.id)
+            expect(event.units).to eq(300)
+            expect(event.timestamp).to be_within(1.second).of(Time.current)
           end
         end
 
@@ -898,14 +892,15 @@ RSpec.describe Subscriptions::UpdateService do
           subscription
         end
 
-        it "creates override fixed charges for both fixed charges" do
-          expect { update_service.call }.to change(FixedCharge, :count).by(2)
+        it "writes override rows for both fixed charges without cloning the plan" do
+          expect { update_service.call }
+            .to not_change(FixedCharge, :count)
+            .and not_change(Plan, :count)
 
-          fc1_override = FixedCharge.find_sole_by(parent_id: fixed_charge1.id)
-          fc2_override = FixedCharge.find_sole_by(parent_id: fixed_charge2.id)
-
-          expect(fc1_override.units).to eq(200)
-          expect(fc2_override.units).to eq(300)
+          expect(subscription.fixed_charge_units_overrides.pluck(:fixed_charge_id, :units)).to contain_exactly(
+            [fixed_charge1.id, 200],
+            [fixed_charge2.id, 300]
+          )
         end
 
         it "does not create fixed charge events for pending subscription" do
@@ -915,9 +910,78 @@ RSpec.describe Subscriptions::UpdateService do
             subscription.reload
 
             expect(subscription).to be_pending
-            expect(subscription.plan.parent_id).to eq(plan.id)
+            expect(subscription.plan).to eq(plan)
             expect(subscription.fixed_charge_events.count).to be_zero
           end
+        end
+      end
+
+      context "with existing units override on the (subscription, fixed_charge) pair", :premium do
+        let(:organization) { membership.organization }
+        let(:plan) { create(:plan, organization:) }
+        let(:fixed_charge) { create(:fixed_charge, plan:, units: 5) }
+        let(:customer) { create(:customer, organization:) }
+        let(:subscription) { create(:subscription, plan:, customer:) }
+        let(:params) do
+          {plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 25}]}}
+        end
+
+        before do
+          fixed_charge
+          subscription
+          create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 10)
+        end
+
+        it "updates the existing override row rather than creating a new one" do
+          expect { update_service.call }
+            .not_to change(::Subscription::FixedChargeUnitsOverride, :count)
+
+          override = ::Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+          expect(override.units).to eq(25)
+        end
+      end
+
+      context "when apply_units_immediately is true on a pay-in-advance fixed charge", :premium do
+        let(:organization) { membership.organization }
+        let(:plan) { create(:plan, organization:) }
+        let(:fixed_charge) { create(:fixed_charge, plan:, units: 5, pay_in_advance: true) }
+        let(:customer) { create(:customer, organization:) }
+        let(:subscription) { create(:subscription, plan:, customer:) }
+        let(:params) do
+          {plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 25, apply_units_immediately: true}]}}
+        end
+
+        before do
+          fixed_charge
+          subscription
+        end
+
+        it "enqueues the pay-in-advance billing job" do
+          expect { update_service.call }
+            .to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+            .with(subscription, kind_of(Integer))
+        end
+      end
+
+      context "when the subscription is already on an overridden plan", :premium do
+        let(:organization) { membership.organization }
+        let(:parent_plan) { create(:plan, organization:) }
+        let(:plan) { create(:plan, organization:, parent: parent_plan) }
+        let(:fixed_charge) { create(:fixed_charge, plan:, units: 5) }
+        let(:customer) { create(:customer, organization:) }
+        let(:subscription) { create(:subscription, plan:, customer:) }
+        let(:params) do
+          {plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 25}]}}
+        end
+
+        before do
+          fixed_charge
+          subscription
+        end
+
+        it "routes through Plans::UpdateService rather than the units-only branch" do
+          expect { update_service.call }
+            .not_to change(::Subscription::FixedChargeUnitsOverride, :count)
         end
       end
     end


### PR DESCRIPTION
## Context

`PUT /api/v1/subscriptions/:id` currently routes any `plan_overrides` through `Plans::OverrideService` (creating a new override plan) or `Plans::UpdateService` (mutating an existing override). When the only change is a units bump on existing fixed charges of a subscription that's still on the parent plan, neither operation is desirable: the plan-clone path duplicates the plan + every fixed_charge per subscription, and the existing-override path doesn't apply because the subscription isn't on an override plan yet. The override table absorbs these requests with one row per change.

## Description

`Subscriptions::UpdateService` now includes the shared params-shape concern and branches inside the existing transaction:

- When `plan_overrides` matches the units-only envelope shape (only the `fixed_charges` key, every entry carrying just `id`, `units`, and optionally `apply_units_immediately`) AND the subscription's plan is not itself an override, the service writes a `Subscription::FixedChargeUnitsOverride` row per entry via `find_or_initialize_by` (so repeated updates update one row rather than stacking), emits a FixedChargeEvent per entry through `FixedCharges::EmitEventsService`, and dispatches `Invoices::CreatePayInAdvanceFixedChargesJob` in an `after_commit` block when `apply_units_immediately` is set on a pay-in-advance fixed charge.
- Mixed-field `plan_overrides`, non-units entry fields, and updates against subscriptions already on an override plan all fall through to the existing `Plans::OverrideService` / `Plans::UpdateService` paths unchanged.

The cloned-plan guard (`subscription.plan.parent_id`) lives in the service alongside the predicate call; the concern stays a pure params-shape predicate.

Specs replace the prior tests that documented the old plan-cloning behaviour on units-only payloads (events on cloned FCs, two override fixed_charges) with assertions for the new branch (override row written, single event for the targeted FC at current time, no plan or fixed_charge clone). New contexts cover the override-update case, the pay-in-advance + apply_units_immediately dispatch, and the fall-through on subscriptions already on an overridden plan. Tests covering non-units payloads continue to assert the legacy clone behaviour unchanged.