### PR TITLE
feat(subscriptions): Add external_id filter to Subscriptions search

### DIFF
--- a/app/controllers/concerns/subscription_index.rb
+++ b/app/controllers/concerns/subscription_index.rb
@@ -8,7 +8,7 @@ module SubscriptionIndex
     billing_entities = current_organization.all_billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
     return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count
 
-    filters = params.permit(:plan_code, :overriden, :overridden, :currency, status: [])
+    filters = params.permit(:plan_code, :overriden, :overridden, :currency, :external_id, status: [])
     filters[:status] = ["active"] if filters[:status].blank?
     filters[:external_customer_id] = external_customer_id
     filters[:billing_entity_ids] = billing_entities&.ids

--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -12,6 +12,7 @@ module Resolvers
     argument :billing_entity_ids, [ID], required: false
     argument :currency, String, required: false
     argument :external_customer_id, String, required: false
+    argument :external_id, String, required: false
     argument :limit, Integer, required: false
     argument :overriden, Boolean, required: false
     argument :page, Integer, required: false
@@ -21,12 +22,32 @@ module Resolvers
 
     type Types::Subscriptions::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil, plan_code: nil, status: nil, external_customer_id: nil, overriden: nil, search_term: nil, currency: nil, billing_entity_ids: nil)
+    def resolve(
+      page: nil,
+      limit: nil,
+      plan_code: nil,
+      status: nil,
+      external_id: nil,
+      external_customer_id: nil,
+      overriden: nil,
+      search_term: nil,
+      currency: nil,
+      billing_entity_ids: nil
+    )
       # In FE we include next subscription in the list, so we need to exclude subscriptions with previous subscription from the list
       result = SubscriptionsQuery.call(
         organization: current_organization,
         pagination: {page:, limit:},
-        filters: {plan_code:, status:, external_customer_id:, overriden:, currency:, billing_entity_ids:, exclude_next_subscriptions: true},
+        filters: {
+          plan_code:,
+          status:,
+          external_id:,
+          external_customer_id:,
+          overriden:,
+          currency:,
+          billing_entity_ids:,
+          exclude_next_subscriptions: true
+        },
         search_term:
       )
 

--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -3,6 +3,7 @@
 class SubscriptionsQuery < BaseQuery
   Result = BaseResult[:subscriptions]
   Filters = BaseFilters[
+    :external_id,
     :external_customer_id,
     :plan_code,
     :status,
@@ -29,6 +30,7 @@ class SubscriptionsQuery < BaseQuery
     )
 
     subscriptions = with_billing_entity_ids(subscriptions) if filters.billing_entity_ids.present?
+    subscriptions = with_external_id(subscriptions) if filters.external_id
     subscriptions = with_external_customer(subscriptions) if filters.external_customer_id
     subscriptions = with_plan_code(subscriptions) if filters.plan_code
     subscriptions = with_overridden(subscriptions) unless overridden_filter.nil?
@@ -53,6 +55,7 @@ class SubscriptionsQuery < BaseQuery
 
   def search_params
     return if search_term.blank?
+    return if filters.external_id
 
     terms = {
       m: "or",
@@ -72,6 +75,10 @@ class SubscriptionsQuery < BaseQuery
       customer_external_id_cont: search_term,
       customer_email_cont: search_term
     )
+  end
+
+  def with_external_id(scope)
+    scope.where(external_id: filters.external_id)
   end
 
   def with_external_customer(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -10766,7 +10766,7 @@ type Query {
   """
   Query subscriptions of an organization
   """
-  subscriptions(billingEntityIds: [ID!], currency: String, externalCustomerId: String, limit: Int, overriden: Boolean, page: Int, planCode: String, searchTerm: String, status: [StatusTypeEnum!]): SubscriptionCollection!
+  subscriptions(billingEntityIds: [ID!], currency: String, externalCustomerId: String, externalId: String, limit: Int, overriden: Boolean, page: Int, planCode: String, searchTerm: String, status: [StatusTypeEnum!]): SubscriptionCollection!
 
   """
   Query all Superset dashboards with embedded configuration and guest tokens

--- a/schema.json
+++ b/schema.json
@@ -58293,6 +58293,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "externalId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {

--- a/spec/graphql/resolvers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions_resolver_spec.rb
@@ -115,6 +115,35 @@ RSpec.describe Resolvers::SubscriptionsResolver do
     end
   end
 
+  context "with external_id filter" do
+    let(:subscription) { create(:subscription, customer:, plan:) }
+
+    let(:query) do
+      <<~GQL
+        query {
+          subscriptions(limit: 5, externalId: "#{subscription.external_id}") {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only the subscription with matching external_id" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+      response = result["data"]["subscriptions"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(subscription.id)
+      expect(response["metadata"]["totalCount"]).to eq(1)
+    end
+  end
+
   context "with currency filter" do
     let(:brl_plan) { create(:plan, organization:, amount_currency: "BRL") }
     let!(:brl_subscription) { create(:subscription, customer:, plan: brl_plan) }

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -167,6 +167,28 @@ RSpec.describe SubscriptionsQuery do
     end
   end
 
+  context "with external_id filter" do
+    let(:filters) { {external_id: subscription.external_id} }
+
+    it "applies the filter" do
+      expect(result).to be_success
+      expect(result.subscriptions).to match_array([subscription])
+    end
+
+    context "when search_term is present" do
+      let(:search_term) { subscription.external_id }
+
+      before do
+        create(:subscription, plan:, name: subscription.external_id)
+      end
+
+      it "ignores the search_term" do
+        expect(result).to be_success
+        expect(result.subscriptions).to match_array([subscription])
+      end
+    end
+  end
+
   context "with customer filter" do
     let(:filters) { {external_customer_id: customer.external_id} }
 

--- a/spec/support/shared_examples/subscription_index.rb
+++ b/spec/support/shared_examples/subscription_index.rb
@@ -155,6 +155,26 @@ RSpec.shared_examples "a subscription index endpoint" do
     end
   end
 
+  context "with external_id filter" do
+    let(:params) { {external_id:, status: %i[active terminated]} }
+    let(:external_id) { SecureRandom.uuid }
+
+    let!(:subscriptions) do
+      [
+        create(:subscription, :active, customer:, external_id:),
+        create(:subscription, :terminated, customer:, external_id:)
+      ]
+    end
+
+    it "returns subscriptions matching external_id" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:subscriptions].count).to eq(2)
+      expect(json[:subscriptions].pluck(:lago_id)).to match_array(subscriptions.map(&:id))
+    end
+  end
+
   context "with billing_entity_codes filter" do
     let(:us_entity) { create(:billing_entity, organization:, code: "us") }
     let(:eu_entity) { create(:billing_entity, organization:, code: "eu") }

--- a/spec/support/shared_examples/subscription_index.rb
+++ b/spec/support/shared_examples/subscription_index.rb
@@ -156,13 +156,13 @@ RSpec.shared_examples "a subscription index endpoint" do
   end
 
   context "with external_id filter" do
-    let(:params) { {external_id:, status: %i[active terminated]} }
-    let(:external_id) { SecureRandom.uuid }
+    let(:params) { {external_id: subscription_external_id, status: %i[active terminated]} }
+    let(:subscription_external_id) { SecureRandom.uuid }
 
     let!(:subscriptions) do
       [
-        create(:subscription, :active, customer:, external_id:),
-        create(:subscription, :terminated, customer:, external_id:)
+        create(:subscription, :active, customer:, external_id: subscription_external_id),
+        create(:subscription, :terminated, customer:, external_id: subscription_external_id)
       ]
     end
 


### PR DESCRIPTION
## Context

Searching subscriptions by `external_id` through `search_term` is pretty slow and often ends up timing out.

## Description

This PR adds a dedicated `external_id` filter that uses a simple equality check instead of the broader text search. When `external_id` is provided, `search_term` is ignored since we're looking for a specific subscription.
