### PR TITLE
chore(customers): Add missing index for search query

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -439,6 +439,7 @@ end
 #
 # Indexes
 #
+#  index_customers_by_cursor                                    (organization_id,created_at DESC,id)
 #  index_customers_on_account_type                              (account_type)
 #  index_customers_on_applied_dunning_campaign_id               (applied_dunning_campaign_id)
 #  index_customers_on_awaiting_wallet_refresh                   (awaiting_wallet_refresh)

--- a/db/migrate/20260611162947_add_customers_cursor_index.rb
+++ b/db/migrate/20260611162947_add_customers_cursor_index.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddCustomersCursorIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :customers,
+      [:organization_id, :created_at, :id],
+      order: {created_at: :desc, id: :asc},
+      name: :index_customers_by_cursor,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -683,6 +683,7 @@ DROP INDEX IF EXISTS public.index_customers_on_account_type;
 DROP INDEX IF EXISTS public.index_customers_invoice_custom_sections_on_organization_id;
 DROP INDEX IF EXISTS public.index_customers_invoice_custom_sections_on_customer_id;
 DROP INDEX IF EXISTS public.index_customers_invoice_custom_sections_on_billing_entity_id;
+DROP INDEX IF EXISTS public.index_customers_by_cursor;
 DROP INDEX IF EXISTS public.index_customer_metadata_on_organization_id;
 DROP INDEX IF EXISTS public.index_customer_metadata_on_customer_id_and_key;
 DROP INDEX IF EXISTS public.index_customer_metadata_on_customer_id;
@@ -7684,6 +7685,13 @@ CREATE INDEX index_customer_metadata_on_organization_id ON public.customer_metad
 
 
 --
+-- Name: index_customers_by_cursor; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_customers_by_cursor ON public.customers USING btree (organization_id, created_at DESC, id);
+
+
+--
 -- Name: index_customers_invoice_custom_sections_on_billing_entity_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12616,6 +12624,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260611162947'),
 ('20260611122002'),
 ('20260609173731'),
 ('20260609165032'),


### PR DESCRIPTION
## Description

- Add `index_customers_by_cursor` on `customers (organization_id, created_at DESC, id ASC)`oncurrently

- With the index, the planner switches to an ordered index walk that stops at the page size: 11.4 ms / 4,027 buffers → 0.1 ms / 23 buffers on a 150k-customer organization (EXPLAIN ANALYZE, production-scale dataset).