### PR TITLE
feat(orders): create order at order form signing

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -65,6 +65,7 @@ class Customer < ApplicationRecord
   has_many :daily_usages
   has_many :quotes
   has_many :order_forms
+  has_many :orders
   has_many :wallets
   has_many :wallet_transactions, through: :wallets
   has_many :payment_provider_customers,

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class Order < ApplicationRecord
+  include Sequenced
+
+  STATUSES = {
+    created: "created",
+    executed: "executed"
+  }.freeze
+
+  EXECUTION_MODES = {
+    execute_in_lago: "execute_in_lago",
+    order_only: "order_only"
+  }.freeze
+
+  before_save :ensure_number
+
+  belongs_to :organization
+  belongs_to :customer
+  belongs_to :order_form
+  has_one :quote_version, through: :order_form
+  has_one :quote, through: :quote_version
+
+  enum :status, STATUSES,
+    default: :created,
+    validate: true
+  enum :execution_mode, EXECUTION_MODES,
+    instance_methods: false,
+    validate: {allow_nil: true}
+
+  validates :execution_mode, presence: true, if: -> { executed? || execute_at.present? }
+
+  sequenced(
+    scope: ->(order) { order.organization.orders },
+    lock_key: ->(order) { order.organization_id }
+  )
+
+  private
+
+  def ensure_number
+    return if number.present?
+    return if sequential_id.blank?
+
+    time = created_at || Time.current
+    formatted_sequential_id = format("%04d", sequential_id)
+    self.number = "OR-#{time.strftime("%Y")}-#{formatted_sequential_id}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: orders
+# Database name: primary
+#
+#  id              :uuid             not null, primary key
+#  execute_at      :datetime
+#  executed_at     :datetime
+#  execution_mode  :enum
+#  number          :string           not null
+#  status          :enum             default("created"), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  customer_id     :uuid             not null
+#  order_form_id   :uuid             not null
+#  organization_id :uuid             not null
+#  sequential_id   :integer          not null
+#
+# Indexes
+#
+#  index_orders_on_customer_id                        (customer_id)
+#  index_orders_on_order_form_id                      (order_form_id) UNIQUE
+#  index_orders_on_organization_id_and_created_at     (organization_id,created_at)
+#  index_orders_on_organization_id_and_status         (organization_id,status)
+#  index_unique_orders_on_organization_number         (organization_id,number) UNIQUE
+#  index_unique_orders_on_organization_sequential_id  (organization_id,sequential_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (order_form_id => order_forms.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -25,6 +25,7 @@ class OrderForm < ApplicationRecord
   belongs_to :customer
   belongs_to :quote_version
   has_one :quote, through: :quote_version
+  has_one :order
 
   has_one_attached :signed_document
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -78,6 +78,7 @@ class Organization < ApplicationRecord
   has_many :quotes
   has_many :quote_versions
   has_many :order_forms
+  has_many :orders
   has_many :activity_logs, class_name: "Clickhouse::ActivityLog"
   has_many :features, class_name: "Entitlement::Feature"
   has_many :privileges, class_name: "Entitlement::Privilege"

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -42,7 +42,13 @@ module OrderForms
         order_form.signed_document.attach(attachment) if attachment
         order_form.save!
 
-        # TODO: Create the Order here using execution_mode/execute_at
+        result.order = Order.create!(
+          organization: order_form.organization,
+          customer: order_form.customer,
+          order_form:,
+          execution_mode:,
+          execute_at:
+        )
 
         # TODO: Enqueue Orders::ExecuteOrderJob.perform_after_commit(result.order) when execution_mode == "execute_in_lago"
       end
@@ -51,6 +57,8 @@ module OrderForms
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::RecordNotUnique
+      result.single_validation_failure!(field: :order_form_id, error_code: "value_already_exist")
     end
 
     private

--- a/db/migrate/20260611145341_create_orders.rb
+++ b/db/migrate/20260611145341_create_orders.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class CreateOrders < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :order_status, %w[created executed]
+    create_enum :order_execution_mode, %w[execute_in_lago order_only]
+
+    create_table :orders, id: :uuid do |t|
+      t.references :organization,
+        null: false,
+        foreign_key: true,
+        index: false, # covered by the composite unique indexes below
+        type: :uuid
+      t.references :customer,
+        null: false,
+        foreign_key: true,
+        type: :uuid
+      t.references :order_form,
+        null: false,
+        foreign_key: true,
+        index: {unique: true},
+        type: :uuid
+
+      t.string :number, null: false
+      t.integer :sequential_id, null: false
+
+      t.enum :status,
+        enum_type: :order_status,
+        null: false,
+        default: "created"
+      t.enum :execution_mode, enum_type: :order_execution_mode
+
+      t.datetime :execute_at
+      t.datetime :executed_at
+
+      t.timestamps
+
+      t.check_constraint "sequential_id > 0",
+        name: "orders_constraint_sequential_id_positive"
+      t.index [:organization_id, :sequential_id],
+        unique: true,
+        name: "index_unique_orders_on_organization_sequential_id"
+      t.index [:organization_id, :number],
+        unique: true,
+        name: "index_unique_orders_on_organization_number"
+      t.index [:organization_id, :status]
+      t.index [:organization_id, :created_at]
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -13,6 +13,7 @@ ALTER TABLE IF EXISTS ONLY public.membership_roles DROP CONSTRAINT IF EXISTS mem
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_ff75b29299;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_ff548a9f4c;
 ALTER TABLE IF EXISTS ONLY public.fixed_charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_fea16bf2e7;
+ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS fk_rails_fe8af6535c;
 ALTER TABLE IF EXISTS ONLY public.dunning_campaign_thresholds DROP CONSTRAINT IF EXISTS fk_rails_fd84cdb7c6;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS fk_rails_fd60209637;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_fd399a23d3;
@@ -91,6 +92,7 @@ ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_r
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_b974dac270;
 ALTER TABLE IF EXISTS ONLY public.presentation_breakdowns DROP CONSTRAINT IF EXISTS fk_rails_b8f3cabc8e;
 ALTER TABLE IF EXISTS ONLY public.subscription_activation_rules DROP CONSTRAINT IF EXISTS fk_rails_b749d2045d;
+ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS fk_rails_b687c6e23a;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_b61aa73940;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_b50dc82c1e;
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_b3864df641;
@@ -225,6 +227,7 @@ ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_3f7be5debc;
 ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF EXISTS fk_rails_3ec3563cf3;
 ALTER TABLE IF EXISTS ONLY public.entitlement_privileges DROP CONSTRAINT IF EXISTS fk_rails_3e4df02771;
+ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS fk_rails_3dad120da9;
 ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_3d568ff9de;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_3cfe1d68d7;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_3c7c3920c0;
@@ -389,6 +392,8 @@ DROP INDEX IF EXISTS public.index_unique_quote_versions_on_share_token;
 DROP INDEX IF EXISTS public.index_unique_quote_versions_on_quote_sequential_id;
 DROP INDEX IF EXISTS public.index_unique_quote_versions_on_quote_active_status;
 DROP INDEX IF EXISTS public.index_unique_quote_owners_on_quote_user;
+DROP INDEX IF EXISTS public.index_unique_orders_on_organization_sequential_id;
+DROP INDEX IF EXISTS public.index_unique_orders_on_organization_number;
 DROP INDEX IF EXISTS public.index_unique_order_forms_on_organization_sequential_id;
 DROP INDEX IF EXISTS public.index_unique_order_forms_on_organization_number;
 DROP INDEX IF EXISTS public.index_unique_applied_to_organization_per_organization;
@@ -502,6 +507,10 @@ DROP INDEX IF EXISTS public.index_password_resets_on_token;
 DROP INDEX IF EXISTS public.index_organizations_on_slug;
 DROP INDEX IF EXISTS public.index_organizations_on_hmac_key;
 DROP INDEX IF EXISTS public.index_organizations_on_api_key;
+DROP INDEX IF EXISTS public.index_orders_on_organization_id_and_status;
+DROP INDEX IF EXISTS public.index_orders_on_organization_id_and_created_at;
+DROP INDEX IF EXISTS public.index_orders_on_order_form_id;
+DROP INDEX IF EXISTS public.index_orders_on_customer_id;
 DROP INDEX IF EXISTS public.index_order_forms_on_quote_version_id;
 DROP INDEX IF EXISTS public.index_order_forms_on_organization_id_and_status;
 DROP INDEX IF EXISTS public.index_order_forms_on_organization_id_and_expires_at;
@@ -920,6 +929,7 @@ ALTER TABLE IF EXISTS ONLY public.payment_methods DROP CONSTRAINT IF EXISTS paym
 ALTER TABLE IF EXISTS ONLY public.payment_intents DROP CONSTRAINT IF EXISTS payment_intents_pkey;
 ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS password_resets_pkey;
 ALTER TABLE IF EXISTS ONLY public.organizations DROP CONSTRAINT IF EXISTS organizations_pkey;
+ALTER TABLE IF EXISTS ONLY public.orders DROP CONSTRAINT IF EXISTS orders_pkey;
 ALTER TABLE IF EXISTS ONLY public.order_forms DROP CONSTRAINT IF EXISTS order_forms_pkey;
 ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS memberships_pkey;
 ALTER TABLE IF EXISTS ONLY public.membership_roles DROP CONSTRAINT IF EXISTS membership_roles_pkey;
@@ -1035,6 +1045,7 @@ DROP TABLE IF EXISTS public.payment_providers;
 DROP TABLE IF EXISTS public.payment_methods;
 DROP TABLE IF EXISTS public.payment_intents;
 DROP TABLE IF EXISTS public.password_resets;
+DROP TABLE IF EXISTS public.orders;
 DROP TABLE IF EXISTS public.order_forms;
 DROP TABLE IF EXISTS public.memberships;
 DROP TABLE IF EXISTS public.membership_roles;
@@ -1184,8 +1195,10 @@ DROP TYPE IF EXISTS public.quote_order_type;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
 DROP TYPE IF EXISTS public.payment_method_types;
+DROP TYPE IF EXISTS public.order_status;
 DROP TYPE IF EXISTS public.order_form_void_reason;
 DROP TYPE IF EXISTS public.order_form_status;
+DROP TYPE IF EXISTS public.order_execution_mode;
 DROP TYPE IF EXISTS public.invoice_settlement_settlement_type;
 DROP TYPE IF EXISTS public.invoice_custom_section_type;
 DROP TYPE IF EXISTS public.inbound_webhook_status;
@@ -1383,6 +1396,16 @@ CREATE TYPE public.invoice_settlement_settlement_type AS ENUM (
 
 
 --
+-- Name: order_execution_mode; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.order_execution_mode AS ENUM (
+    'execute_in_lago',
+    'order_only'
+);
+
+
+--
 -- Name: order_form_status; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -1402,6 +1425,16 @@ CREATE TYPE public.order_form_void_reason AS ENUM (
     'manual',
     'expired',
     'invalid'
+);
+
+
+--
+-- Name: order_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.order_status AS ENUM (
+    'created',
+    'executed'
 );
 
 
@@ -4716,6 +4749,27 @@ CREATE TABLE public.order_forms (
 
 
 --
+-- Name: orders; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.orders (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    customer_id uuid NOT NULL,
+    order_form_id uuid NOT NULL,
+    number character varying NOT NULL,
+    sequential_id integer NOT NULL,
+    status public.order_status DEFAULT 'created'::public.order_status NOT NULL,
+    execution_mode public.order_execution_mode,
+    execute_at timestamp(6) without time zone,
+    executed_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT orders_constraint_sequential_id_positive CHECK ((sequential_id > 0))
+);
+
+
+--
 -- Name: password_resets; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5972,6 +6026,14 @@ ALTER TABLE ONLY public.memberships
 
 ALTER TABLE ONLY public.order_forms
     ADD CONSTRAINT order_forms_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: orders orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orders
+    ADD CONSTRAINT orders_pkey PRIMARY KEY (id);
 
 
 --
@@ -8979,6 +9041,34 @@ CREATE UNIQUE INDEX index_order_forms_on_quote_version_id ON public.order_forms 
 
 
 --
+-- Name: index_orders_on_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orders_on_customer_id ON public.orders USING btree (customer_id);
+
+
+--
+-- Name: index_orders_on_order_form_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_orders_on_order_form_id ON public.orders USING btree (order_form_id);
+
+
+--
+-- Name: index_orders_on_organization_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orders_on_organization_id_and_created_at ON public.orders USING btree (organization_id, created_at);
+
+
+--
+-- Name: index_orders_on_organization_id_and_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orders_on_organization_id_and_status ON public.orders USING btree (organization_id, status);
+
+
+--
 -- Name: index_organizations_on_api_key; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9767,6 +9857,20 @@ CREATE UNIQUE INDEX index_unique_order_forms_on_organization_number ON public.or
 --
 
 CREATE UNIQUE INDEX index_unique_order_forms_on_organization_sequential_id ON public.order_forms USING btree (organization_id, sequential_id);
+
+
+--
+-- Name: index_unique_orders_on_organization_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_orders_on_organization_number ON public.orders USING btree (organization_id, number);
+
+
+--
+-- Name: index_unique_orders_on_organization_sequential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_unique_orders_on_organization_sequential_id ON public.orders USING btree (organization_id, sequential_id);
 
 
 --
@@ -10910,6 +11014,14 @@ ALTER TABLE ONLY public.integration_collection_mappings
 
 
 --
+-- Name: orders fk_rails_3dad120da9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orders
+    ADD CONSTRAINT fk_rails_3dad120da9 FOREIGN KEY (customer_id) REFERENCES public.customers(id);
+
+
+--
 -- Name: entitlement_privileges fk_rails_3e4df02771; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11982,6 +12094,14 @@ ALTER TABLE ONLY public.entitlement_entitlements
 
 
 --
+-- Name: orders fk_rails_b687c6e23a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orders
+    ADD CONSTRAINT fk_rails_b687c6e23a FOREIGN KEY (order_form_id) REFERENCES public.order_forms(id);
+
+
+--
 -- Name: subscription_activation_rules fk_rails_b749d2045d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12606,6 +12726,14 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 
 
 --
+-- Name: orders fk_rails_fe8af6535c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orders
+    ADD CONSTRAINT fk_rails_fe8af6535c FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: fixed_charges_taxes fk_rails_fea16bf2e7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12646,6 +12774,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260612150749'),
 ('20260611162947'),
+('20260611145341'),
 ('20260611145039'),
 ('20260611122002'),
 ('20260609173731'),
@@ -13671,4 +13800,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
-

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :order do
+    customer
+    organization { customer&.organization || association(:organization) }
+    order_form { association(:order_form, :signed, organization:, customer:) }
+
+    trait :executed_in_lago do
+      status { :executed }
+      execution_mode { :execute_in_lago }
+      executed_at { Time.current }
+    end
+
+    trait :executed_order_only do
+      status { :executed }
+      execution_mode { :order_only }
+      executed_at { Time.current }
+    end
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Customer do
   it { is_expected.to have_many(:payment_requests) }
   it { is_expected.to have_many(:error_details).dependent(:destroy) }
   it { is_expected.to have_many(:order_forms) }
+  it { is_expected.to have_many(:orders) }
 
   it { is_expected.to have_one(:netsuite_customer) }
   it { is_expected.to have_one(:anrok_customer) }

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe OrderForm do
       expect(order_form).to belong_to(:customer)
       expect(order_form).to belong_to(:quote_version)
       expect(order_form).to have_one(:quote).through(:quote_version)
+      expect(order_form).to have_one(:order)
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order do
+  subject(:order) { build(:order, order_form: nil) }
+
+  describe "enums" do
+    it do
+      expect(order).to define_enum_for(:status)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_values(created: "created", executed: "executed")
+        .with_default(:created)
+
+      expect(order).to define_enum_for(:execution_mode)
+        .backed_by_column_of_type(:enum)
+        .validating(allowing_nil: true)
+        .with_values(execute_in_lago: "execute_in_lago", order_only: "order_only")
+        .without_instance_methods
+    end
+  end
+
+  describe "associations" do
+    it do
+      expect(order).to belong_to(:organization)
+      expect(order).to belong_to(:customer)
+      expect(order).to belong_to(:order_form)
+      expect(order).to have_one(:quote_version).through(:order_form)
+      expect(order).to have_one(:quote).through(:quote_version)
+    end
+  end
+
+  describe "validations" do
+    describe "execution_mode validation" do
+      it "requires execution_mode when execute_at is set" do
+        order = build(:order, execute_at: 1.day.from_now, execution_mode: nil)
+        order.valid?
+        expect(order.errors.added?(:execution_mode, :blank)).to be(true)
+      end
+
+      it "requires execution_mode when executed" do
+        order = build(:order, status: :executed, execution_mode: nil)
+        order.valid?
+        expect(order.errors.added?(:execution_mode, :blank)).to be(true)
+      end
+
+      it "allows a blank execution_mode when created without execute_at" do
+        order = build(:order, execute_at: nil, execution_mode: nil)
+        order.valid?
+        expect(order.errors.added?(:execution_mode, :blank)).to be(false)
+      end
+
+      it "accepts an executed order with each execution mode" do
+        expect(build(:order, :executed_in_lago)).to be_valid
+        expect(build(:order, :executed_order_only)).to be_valid
+      end
+
+      it "allows execution_mode without execute_at" do
+        order = build(:order, execute_at: nil, execution_mode: :order_only)
+        order.valid?
+        expect(order.errors.added?(:execution_mode, :blank)).to be(false)
+      end
+    end
+  end
+
+  describe "sequencing" do
+    it "assigns sequential ids per organization" do
+      organization = create(:organization)
+      customer = create(:customer, organization:)
+      first = create(:order, organization:, customer:)
+      second = create(:order, organization:, customer:)
+      expect([first.sequential_id, second.sequential_id]).to eq([1, 2])
+    end
+
+    it "scopes the sequence per organization" do
+      org_a = create(:organization)
+      org_b = create(:organization)
+      a1 = create(:order, organization: org_a, customer: create(:customer, organization: org_a))
+      b1 = create(:order, organization: org_b, customer: create(:customer, organization: org_b))
+      expect([a1.sequential_id, b1.sequential_id]).to eq([1, 1])
+    end
+  end
+
+  describe "ensure_number callback" do
+    it "assigns a formatted number when sequential_id and created_at are present" do
+      order = create(:order, created_at: Time.zone.local(2020, 1, 2))
+      expect(order.number).to eq("OR-2020-#{format("%04d", order.sequential_id)}")
+    end
+
+    it "uses the current year when created_at is blank on save" do
+      travel_to(Time.zone.local(2026, 6, 1)) do
+        order = create(:order, created_at: nil)
+        expect(order.number).to eq("OR-2026-#{format("%04d", order.sequential_id)}")
+      end
+    end
+
+    it "preserves an explicitly assigned number" do
+      order = create(:order, number: "OR-CUSTOM-0001")
+      expect(order.number).to eq("OR-CUSTOM-0001")
+    end
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Organization do
       expect(subject).to have_one(:enriched_store_migration)
       expect(subject).to have_many(:pending_vies_checks)
       expect(subject).to have_many(:order_forms)
+      expect(subject).to have_many(:orders)
     end
   end
 

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -92,6 +92,19 @@ RSpec.describe OrderForms::MarkAsSignedService do
           expect(result.order_form).to be_signed
           expect(result.order_form.signed_at).to be_present
         end
+
+        it "creates an order" do
+          expect { service.call }.to change(Order, :count).by(1)
+        end
+
+        it "returns the created order" do
+          result = service.call
+
+          expect(result.order).to be_persisted
+          expect(result.order).to be_created
+          expect(result.order.order_form).to eq(order_form)
+          expect(result.order.execution_mode).to be_nil
+        end
       end
 
       context "when a signed_document is provided" do
@@ -166,6 +179,43 @@ RSpec.describe OrderForms::MarkAsSignedService do
           expect { service.call }.not_to change(ActiveStorage::Blob, :count)
         end
 
+        it "rolls back without persisting an order" do
+          expect { service.call }.not_to change(Order, :count)
+        end
+
+        it "returns a validation failure without signing" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(order_form.reload).to be_generated
+        end
+      end
+
+      context "when an order already exists for the order form" do
+        before { create(:order, order_form:, customer:, organization:) }
+
+        it "returns a validation failure without signing" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:order_form_id]).to eq(["value_already_exist"])
+          expect(order_form.reload).to be_generated
+        end
+      end
+
+      context "when order creation fails" do
+        let(:signed_document) { "data:application/pdf;base64,#{Base64.strict_encode64("pdf")}" }
+
+        before do
+          allow(Order).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(Order.new))
+        end
+
+        it "rolls back without persisting a blob" do
+          expect { service.call }.not_to change(ActiveStorage::Blob, :count)
+        end
+
         it "returns a validation failure without signing" do
           result = service.call
 
@@ -179,11 +229,13 @@ RSpec.describe OrderForms::MarkAsSignedService do
         let(:execution_mode) { "execute_in_lago" }
         let(:execute_at) { 1.month.from_now.iso8601 }
 
-        it "signs the order form without acting on them" do
+        it "signs the order form and stores them on the created order" do
           result = service.call
 
           expect(result).to be_success
           expect(result.order_form).to be_signed
+          expect(result.order.execution_mode).to eq("execute_in_lago")
+          expect(result.order.execute_at).to eq(Time.zone.parse(execute_at))
         end
       end
 


### PR DESCRIPTION
## Roadmap Task

👉  [Quotes & Order forms](https://getlago.canny.io/feature-requests/p/create-quotes-order-forms)

## Context

An Order is the immutable record of a signed commercial agreement. It is never created directly: it comes to life when an order form is marked as signed, and is later executed to provision billing in Lago (or exported as-is for external systems).

## Description

- Add the bare-minimum `Order` model and migration: `created`/`executed` statuses, `execution_mode` (`execute_in_lago` / `order_only`) and `execute_at` stored for audit, `OR-YYYY-NNNN` numbering, one order per order form.
- create an `Order` in `OrderForms::MarkAsSignedService` inside the signing transaction.