### PR TITLE
feat(customers): Add external_id filter to Customers search

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -40,6 +40,7 @@ module Api
           :has_tax_identification_number,
           :has_customer_type,
           :customer_type,
+          :external_id,
           currencies: [],
           countries: [],
           states: [],

--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -21,6 +21,7 @@ module Resolvers
     argument :countries, [Types::CountryCodeEnum], required: false
     argument :currencies, [Types::CurrencyEnum], required: false
     argument :customer_type, Types::Customers::CustomerTypeEnum, required: false
+    argument :external_id, String, required: false
     argument :has_customer_type, Boolean, required: false
     argument :has_tax_identification_number, Boolean, required: false
     argument :metadata, [Types::Customers::Metadata::Filter], required: false

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -4,6 +4,7 @@ class CustomersQuery < BaseQuery
   Result = BaseResult[:customers]
   Filters = BaseFilters[
     :organization_id,
+    :external_id,
     :account_type,
     :billing_entity_ids,
     :with_deleted,
@@ -26,6 +27,7 @@ class CustomersQuery < BaseQuery
 
     customers = base_scope
 
+    customers = with_external_id(customers) if filters.external_id.present?
     customers = with_customer_type(customers) if filters.customer_type.present? || filters.key?(:has_customer_type)
     customers = with_account_type(customers) if filters.account_type.present?
     customers = with_billing_entity_ids(customers) if filters.billing_entity_ids.present?
@@ -54,9 +56,12 @@ class CustomersQuery < BaseQuery
   end
 
   def base_scope
-    return Customer.where(organization:) if search_term.blank?
+    scope = Customer.where(organization:)
 
-    Customer.where(organization:).where(id: matching_ids_by_search)
+    return scope if search_term.blank?
+    return scope if filters.external_id.present?
+
+    scope.where(id: matching_ids_by_search)
   end
 
   def matching_ids_by_search
@@ -71,6 +76,10 @@ class CustomersQuery < BaseQuery
 
     union_sql = branches.map(&:to_sql).join(" UNION ")
     Customer.unscoped.from("(#{union_sql}) AS customers").select(:id)
+  end
+
+  def with_external_id(scope)
+    scope.where(external_id: filters.external_id)
   end
 
   def with_currencies(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -10289,7 +10289,7 @@ type Query {
   """
   Query customers of an organization
   """
-  customers(accountType: [CustomerAccountTypeEnum!], activeSubscriptionsCountFrom: Int, activeSubscriptionsCountTo: Int, billingEntityIds: [ID!], countries: [CountryCode!], currencies: [CurrencyEnum!], customerType: CustomerTypeEnum, hasCustomerType: Boolean, hasTaxIdentificationNumber: Boolean, limit: Int, metadata: [CustomerMetadataFilter!], page: Int, searchTerm: String, states: [String!], withDeleted: Boolean, zipcodes: [String!]): CustomerCollection!
+  customers(accountType: [CustomerAccountTypeEnum!], activeSubscriptionsCountFrom: Int, activeSubscriptionsCountTo: Int, billingEntityIds: [ID!], countries: [CountryCode!], currencies: [CurrencyEnum!], customerType: CustomerTypeEnum, externalId: String, hasCustomerType: Boolean, hasTaxIdentificationNumber: Boolean, limit: Int, metadata: [CustomerMetadataFilter!], page: Int, searchTerm: String, states: [String!], withDeleted: Boolean, zipcodes: [String!]): CustomerCollection!
 
   """
   Query monthly recurring revenues of an organization

--- a/schema.json
+++ b/schema.json
@@ -53898,6 +53898,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "externalId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "hasCustomerType",
                   "description": null,
                   "type": {

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Resolvers::CustomersResolver do
         $activeSubscriptionsCountFrom: Int,
         $activeSubscriptionsCountTo: Int,
         $customerType: CustomerTypeEnum,
+        $externalId: String,
         $hasCustomerType: Boolean,
         $hasTaxIdentificationNumber: Boolean,
         $countries: [CountryCode!],
@@ -37,6 +38,7 @@ RSpec.describe Resolvers::CustomersResolver do
           activeSubscriptionsCountFrom: $activeSubscriptionsCountFrom,
           activeSubscriptionsCountTo: $activeSubscriptionsCountTo,
           customerType: $customerType,
+          externalId: $externalId,
           hasCustomerType: $hasCustomerType,
           hasTaxIdentificationNumber: $hasTaxIdentificationNumber,
           countries: $countries,
@@ -84,6 +86,18 @@ RSpec.describe Resolvers::CustomersResolver do
       result = execute_graphql(current_user: membership.user, query:)
 
       expect_graphql_error(result:, message: "Missing organization id")
+    end
+  end
+
+  context "when filtering by external id" do
+    let(:customer) { create(:customer, organization:) }
+
+    before do
+      customer
+    end
+
+    it "returns the customer with matching external_id" do
+      test_customers_resolver(customer, variables: {externalId: customer.external_id})
     end
   end
 

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -90,6 +90,22 @@ RSpec.describe CustomersQuery do
     expect(returned_ids).to include(customer_third.id)
   end
 
+  context "when filtering by external_id" do
+    let(:filters) { {external_id: customer_first.external_id} }
+
+    it "returns the customer with matching external_id" do
+      expect(result.customers).to match_array([customer_first])
+    end
+
+    context "when search_term is present" do
+      let(:search_term) { customer_second.external_id }
+
+      it "ignores the search_term" do
+        expect(result.customers).to match_array([customer_first])
+      end
+    end
+  end
+
   context "when filtering by customer_type" do
     context "when filtering by company" do
       let(:filters) { {customer_type: "company"} }

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -585,6 +585,19 @@ RSpec.describe Api::V1::CustomersController do
       end
     end
 
+    context "when filtering by external_id" do
+      let(:params) { {external_id: customer.external_id} }
+      let!(:customer) { create(:customer, organization:) }
+
+      it "returns customers with matching external_id" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:customers].count).to eq(1)
+        expect(json[:customers].pluck(:lago_id)).to eq([customer.id])
+      end
+    end
+
     context "when filtering by countries" do
       let(:params) { {countries: ["US", "FR"]} }
 


### PR DESCRIPTION
## Context

Customer text search isn't as slow as subscription search, but since we're adding a dedicated `external_id` filter for subscriptions, it makes sense to add the same for customers to keep the UX consistent.

## Description

This PR adds a dedicated `external_id` filter that uses a simple equality check instead of the broader text search. When `external_id` is provided, `search_term` is ignored since we're looking for a specific customer.
