### PR TITLE
[ING-253] feat(wallets): return billing_entity_code on wallet transactions

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -104,8 +104,8 @@ module Api
 
         return render_error_response(result) unless result.success?
 
-        includes = (direction == :consumptions) ? %i[outbound_wallet_transaction] : %i[inbound_wallet_transaction]
-        preloads = {includes.first => [:billing_entity, {wallet: {customer: :billing_entity}}]}
+wallet_transaction_direction = (direction == :consumptions) ? :outbound_wallet_transaction : :inbound_wallet_transaction
+        includes = {wallet_transaction_direction => [:billing_entity, {wallet: {customer: :billing_entity}}]}
         collection_name = (direction == :consumptions) ? "wallet_transaction_consumptions" : "wallet_transaction_fundings"
 
         render(

--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -41,7 +41,7 @@ module Api
 
         render(
           json: ::CollectionSerializer.new(
-            result.wallet_transactions,
+            result.wallet_transactions.includes(:billing_entity, wallet: {customer: :billing_entity}),
             ::V1::WalletTransactionSerializer,
             collection_name: "wallet_transactions",
             meta: pagination_metadata(result.wallet_transactions)
@@ -105,11 +105,12 @@ module Api
         return render_error_response(result) unless result.success?
 
         includes = (direction == :consumptions) ? %i[outbound_wallet_transaction] : %i[inbound_wallet_transaction]
+        preloads = {includes.first => [:billing_entity, {wallet: {customer: :billing_entity}}]}
         collection_name = (direction == :consumptions) ? "wallet_transaction_consumptions" : "wallet_transaction_fundings"
 
         render(
           json: ::CollectionSerializer.new(
-            result.wallet_transaction_consumptions.includes(includes),
+            result.wallet_transaction_consumptions.includes(preloads),
             ::V1::WalletTransactionConsumptionSerializer,
             collection_name:,
             meta: pagination_metadata(result.wallet_transaction_consumptions),

--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -104,8 +104,8 @@ module Api
 
         return render_error_response(result) unless result.success?
 
-wallet_transaction_direction = (direction == :consumptions) ? :outbound_wallet_transaction : :inbound_wallet_transaction
-        includes = {wallet_transaction_direction => [:billing_entity, {wallet: {customer: :billing_entity}}]}
+        wallet_transaction_direction = (direction == :consumptions) ? :outbound_wallet_transaction : :inbound_wallet_transaction
+        preloads = {wallet_transaction_direction => [:billing_entity, {wallet: [:billing_entity, {customer: :billing_entity}]}]}
         collection_name = (direction == :consumptions) ? "wallet_transaction_consumptions" : "wallet_transaction_fundings"
 
         render(
@@ -114,7 +114,7 @@ wallet_transaction_direction = (direction == :consumptions) ? :outbound_wallet_t
             ::V1::WalletTransactionConsumptionSerializer,
             collection_name:,
             meta: pagination_metadata(result.wallet_transaction_consumptions),
-            includes:
+            includes: [wallet_transaction_direction]
           )
         )
       end

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -9,6 +9,7 @@ module V1
         lago_invoice_id: model.invoice_id,
         lago_credit_note_id: model.credit_note_id,
         lago_voided_invoice_id: model.voided_invoice_id,
+        billing_entity_code: billing_entity_code,
         status: model.status,
         source: model.source,
         transaction_status: model.transaction_status,
@@ -34,6 +35,10 @@ module V1
     end
 
     private
+
+    def billing_entity_code
+      (model.billing_entity || model.wallet.billing_entity)&.code
+    end
 
     def wallet
       {

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -197,6 +197,7 @@ RSpec.describe Api::V1::WalletTransactionsController do
       expect(response).to have_http_status(:success)
       expect(json[:wallet_transactions].count).to eq(2)
       expect(json[:wallet_transactions].first[:lago_id]).to eq(wallet_transaction_second.id)
+      expect(json[:wallet_transactions].first[:billing_entity_code]).to eq(wallet.billing_entity.code)
       expect(json[:wallet_transactions].last[:lago_id]).to eq(wallet_transaction_first.id)
     end
 

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         "lago_invoice_id" => nil,
         "lago_credit_note_id" => nil,
         "lago_voided_invoice_id" => nil,
+        "billing_entity_code" => wallet_transaction.billing_entity.code,
         "status" => wallet_transaction.status,
         "source" => wallet_transaction.source,
         "transaction_status" => wallet_transaction.transaction_status,
@@ -38,6 +39,28 @@ RSpec.describe ::V1::WalletTransactionSerializer do
       )
       expect(result["wallet_transaction"]["payment_method"]["payment_method_id"]).to eq(nil)
       expect(result["wallet_transaction"]["payment_method"]["payment_method_type"]).to eq("provider")
+    end
+  end
+
+  context "when transaction has no snapshotted billing entity" do
+    let(:wallet_transaction) { create(:wallet_transaction, billing_entity: nil) }
+
+    it "serializes the wallet's billing entity code" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["wallet_transaction"]["billing_entity_code"]).to eq(wallet_transaction.wallet.billing_entity.code)
+    end
+  end
+
+  context "when snapshotted billing entity differs from the wallet's current one" do
+    let(:wallet) { create(:wallet) }
+    let(:snapshot_billing_entity) { create(:billing_entity, organization: wallet.organization) }
+    let(:wallet_transaction) { create(:wallet_transaction, wallet:, billing_entity: snapshot_billing_entity) }
+
+    it "serializes the snapshotted billing entity code" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["wallet_transaction"]["billing_entity_code"]).to eq(snapshot_billing_entity.code)
     end
   end
 


### PR DESCRIPTION
## Context

Wallet transactions snapshot their billing entity since #5623, but the API doesn't return it anywhere.

## Changes

- Return `billing_entity_code` on wallet transaction payloads (index, show, consumptions/fundings and the webhooks). It returns the snapshotted entity, falling back to the wallet's one for transactions created before the snapshot existed -- the same entity the transaction settles under.
- Preload the associations on the index and consumption endpoints to avoid N+1 queries.