### PR TITLE
fix(subscription): add cancellation_reason column (expand step)

### DIFF
--- a/app/graphql/types/subscriptions/cancelation_reason_enum.rb
+++ b/app/graphql/types/subscriptions/cancelation_reason_enum.rb
@@ -3,7 +3,7 @@
 module Types
   module Subscriptions
     class CancelationReasonEnum < Types::BaseEnum
-      Subscription::CANCELATION_REASONS.each_key do |reason|
+      Subscription::CANCELLATION_REASONS.each_key do |reason|
         value reason
       end
     end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -58,7 +58,7 @@ class Subscription < ApplicationRecord
     :incomplete
   ].freeze
 
-  CANCELATION_REASONS = {payment_failed: "payment_failed", timeout: "timeout"}.freeze
+  CANCELLATION_REASONS = {payment_failed: "payment_failed", timeout: "timeout"}.freeze
 
   BILLING_TIME = %i[
     calendar
@@ -72,7 +72,8 @@ class Subscription < ApplicationRecord
   enum :billing_time, BILLING_TIME
   enum :on_termination_credit_note, ON_TERMINATION_CREDIT_NOTES, prefix: true
   enum :on_termination_invoice, ON_TERMINATION_INVOICES, prefix: true
-  enum :cancelation_reason, CANCELATION_REASONS
+  enum :cancelation_reason, CANCELLATION_REASONS, prefix: true
+  enum :cancellation_reason, CANCELLATION_REASONS
 
   validates :on_termination_credit_note, absence: true, if: -> { plan&.pay_in_arrears? }
   validates :started_at, presence: true, if: -> { incomplete? }
@@ -335,6 +336,7 @@ end
 #  billing_time                 :integer          default("calendar"), not null
 #  cancelation_reason           :enum
 #  canceled_at                  :datetime
+#  cancellation_reason          :enum
 #  consolidate_invoice          :boolean          default(TRUE), not null
 #  ending_at                    :datetime
 #  last_received_event_on       :date

--- a/db/migrate/20260611145039_add_cancellation_reason_to_subscriptions.rb
+++ b/db/migrate/20260611145039_add_cancellation_reason_to_subscriptions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCancellationReasonToSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :subscription_cancellation_reasons, %w[payment_failed timeout]
+    add_column :subscriptions, :cancellation_reason, :subscription_cancellation_reasons
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1173,6 +1173,7 @@ DROP TYPE IF EXISTS public.subscription_on_termination_credit_note;
 DROP TYPE IF EXISTS public.subscription_invoicing_reason;
 DROP TYPE IF EXISTS public.subscription_invoice_issuing_date_anchors;
 DROP TYPE IF EXISTS public.subscription_invoice_issuing_date_adjustments;
+DROP TYPE IF EXISTS public.subscription_cancellation_reasons;
 DROP TYPE IF EXISTS public.subscription_cancelation_reasons;
 DROP TYPE IF EXISTS public.subscription_activation_rule_types;
 DROP TYPE IF EXISTS public.subscription_activation_rule_statuses;
@@ -1498,6 +1499,16 @@ CREATE TYPE public.subscription_activation_rule_types AS ENUM (
 --
 
 CREATE TYPE public.subscription_cancelation_reasons AS ENUM (
+    'payment_failed',
+    'timeout'
+);
+
+
+--
+-- Name: subscription_cancellation_reasons; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.subscription_cancellation_reasons AS ENUM (
     'payment_failed',
     'timeout'
 );
@@ -3331,7 +3342,8 @@ CREATE TABLE public.subscriptions (
     activated_at timestamp(6) without time zone,
     billing_entity_id uuid,
     consolidate_invoice boolean DEFAULT true NOT NULL,
-    skip_daily_usage boolean DEFAULT false NOT NULL
+    skip_daily_usage boolean DEFAULT false NOT NULL,
+    cancellation_reason public.subscription_cancellation_reasons
 );
 
 
@@ -12625,6 +12637,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260611162947'),
+('20260611145039'),
 ('20260611122002'),
 ('20260609173731'),
 ('20260609165032'),

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe ::V1::SubscriptionSerializer do
       create(
         :subscription,
         organization:,
-        cancelation_reason: Subscription::CANCELATION_REASONS[:payment_failed],
+        cancelation_reason: Subscription::CANCELLATION_REASONS[:payment_failed],
         activated_at:
       )
     end
@@ -264,7 +264,7 @@ RSpec.describe ::V1::SubscriptionSerializer do
       result = JSON.parse(serializer.to_json)
 
       expect(result["subscription"]).to include(
-        "cancelation_reason" => Subscription::CANCELATION_REASONS[:payment_failed],
+        "cancelation_reason" => Subscription::CANCELLATION_REASONS[:payment_failed],
         "activated_at" => activated_at.iso8601
       )
     end


### PR DESCRIPTION
## Context

The `subscriptions.cancelation_reason` column shipped with a typo. The feature is currently used only by a development customer account, its data is small and will be migrated manually after releasing the 2nd PR. Renaming the column directly is unsafe because of the deploy race window: a single migration would either drop the old column before old pods stop running, or surface the new column before new code is rolled out.

## Description

First of three PRs implementing an expand/contract rename:

* New `subscription_cancellation_reasons` PG enum type and matching `subscriptions.cancellation_reason` column. Strictly additive.
* `CANCELATION_REASONS` constant renamed to `CANCELLATION_REASONS`; callers updated. The old `enum :cancelation_reason` declaration is preserved but switched to the renamed constant and prefixed to avoid predicate-method collisions with the new enum.
* No services, serializers or GraphQL fields change behaviour in this step. PR 2 will switch the application to read/write the new column and ignore the old one. PR 3 will drop the old column once self-hosted deployments have had time to roll through this and PR 2.
