### PR TITLE
perf(events): scope billing period filter to plan codes

### DIFF
--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -39,10 +39,6 @@ module Events
       event_store.distinct_codes(codes: plan_codes)
     end
 
-    # NOTE: Both event store queries are scoped to the plan's billable metric codes.
-    #       Events with other codes cannot match any of the plan's charges, and the
-    #       code predicate allows the event store to prune data efficiently
-    #       (ClickHouse tables are sorted by organization_id then code).
     def plan_codes
       @plan_codes ||= plan.billable_metrics.distinct.pluck(:code)
     end

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -36,7 +36,15 @@ module Events
     end
 
     def distinct_event_codes
-      event_store.distinct_codes
+      event_store.distinct_codes(codes: plan_codes)
+    end
+
+    # NOTE: Both event store queries are scoped to the plan's billable metric codes.
+    #       Events with other codes cannot match any of the plan's charges, and the
+    #       code predicate allows the event store to prune data efficiently
+    #       (ClickHouse tables are sorted by organization_id then code).
+    def plan_codes
+      @plan_codes ||= plan.billable_metrics.distinct.pluck(:code)
     end
 
     def charges_and_filters
@@ -64,7 +72,7 @@ module Events
     # The result will be a hash where the key is the charge id and the value is an array of filter ids
     # filter ids also include "nil" as a default filter when applicable
     def charges_and_filters_from_pre_enriched_events
-      values = event_store.distinct_charges_and_filters
+      values = event_store.distinct_charges_and_filters(codes: plan_codes)
 
       charge_filter_ids = values.map(&:last).reject(&:blank?)
       charge_ids = values.map(&:first).uniq

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -165,10 +165,6 @@ module Events
         end
       end
 
-      # NOTE: `codes` should be provided whenever the list of possible codes is known
-      #       (eg: the billable metric codes of a plan). The table is sorted by
-      #       (organization_id, code, external_subscription_id, ...), so without a code
-      #       predicate ClickHouse cannot prune granules and scans the whole organization.
       def distinct_charges_and_filters(codes: nil)
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = ::Clickhouse::EventsEnrichedExpanded

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -153,24 +153,31 @@ module Events
       # DEPRECATED: This method will be replaced by distinct_charges_and_filters
       #             to filter the charge and filters in a billing period.
       #             See app/services/events/billing_period_filter_service.rb:42
-      def distinct_codes
+      def distinct_codes(codes: nil)
         Events::Stores::Utils::ClickhouseConnection.with_retry do
-          ::Clickhouse::EventsEnrichedExpanded
+          scope = ::Clickhouse::EventsEnrichedExpanded
             .where(external_subscription_id: subscription.external_id)
             .where(organization_id: subscription.organization_id)
             .where(timestamp: from_datetime..applicable_to_datetime)
-            .pluck("DISTINCT(code)")
+
+          scope = scope.where(code: codes) unless codes.nil?
+          scope.pluck("DISTINCT(code)")
         end
       end
 
-      def distinct_charges_and_filters
+      # NOTE: `codes` should be provided whenever the list of possible codes is known
+      #       (eg: the billable metric codes of a plan). The table is sorted by
+      #       (organization_id, code, external_subscription_id, ...), so without a code
+      #       predicate ClickHouse cannot prune granules and scans the whole organization.
+      def distinct_charges_and_filters(codes: nil)
         Events::Stores::Utils::ClickhouseConnection.with_retry do
-          ::Clickhouse::EventsEnrichedExpanded
+          scope = ::Clickhouse::EventsEnrichedExpanded
             .where(external_subscription_id: subscription.external_id)
             .where(organization_id: subscription.organization_id)
             .where(timestamp: from_datetime..to_datetime)
-            .distinct
-            .pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"))
+
+          scope = scope.where(code: codes) unless codes.nil?
+          scope.distinct.pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"))
         end
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -148,24 +148,30 @@ module Events
         conditions.join(" AND ")
       end
 
-      def distinct_codes
+      # NOTE: `codes` should be provided whenever the list of possible codes is known
+      #       (eg: the billable metric codes of a plan). The table is sorted by
+      #       (organization_id, code, external_subscription_id, ...), so without a code
+      #       predicate ClickHouse cannot prune granules and scans the whole organization.
+      def distinct_codes(codes: nil)
         Events::Stores::Utils::ClickhouseConnection.with_retry do
-          ::Clickhouse::EventsEnriched
+          scope = ::Clickhouse::EventsEnriched
             .where(external_subscription_id: subscription.external_id)
             .where(organization_id: subscription.organization.id)
             .where("events_enriched.timestamp >= ?", from_datetime)
             .where("events_enriched.timestamp <= ?", applicable_to_datetime)
-            .pluck("DISTINCT(code)")
+
+          scope = scope.where(code: codes) unless codes.nil?
+          scope.pluck("DISTINCT(code)")
         end
       end
 
-      def distinct_charges_and_filters
+      def distinct_charges_and_filters(codes: nil)
         # Implementation relies directly on the events_enriched_expanded table,
         # so we delegate the implementation to the ClickhouseEnrichedStore
         Events::Stores::ClickhouseEnrichedStore.new(
           subscription:,
           boundaries:
-        ).distinct_charges_and_filters
+        ).distinct_charges_and_filters(codes:)
       end
 
       def events_values(limit: nil, force_from: false, exclude_event: false)

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -148,10 +148,6 @@ module Events
         conditions.join(" AND ")
       end
 
-      # NOTE: `codes` should be provided whenever the list of possible codes is known
-      #       (eg: the billable metric codes of a plan). The table is sorted by
-      #       (organization_id, code, external_subscription_id, ...), so without a code
-      #       predicate ClickHouse cannot prune granules and scans the whole organization.
       def distinct_codes(codes: nil)
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = ::Clickhouse::EventsEnriched

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -22,20 +22,23 @@ module Events
         filters_scope(scope)
       end
 
-      def distinct_codes
-        Event.where(external_subscription_id: subscription.external_id)
+      def distinct_codes(codes: nil)
+        scope = Event.where(external_subscription_id: subscription.external_id)
           .where(organization_id: subscription.organization.id)
           .from_datetime(from_datetime)
           .to_datetime(applicable_to_datetime)
-          .pluck("DISTINCT(code)")
+
+        scope = scope.where(code: codes) unless codes.nil?
+        scope.pluck("DISTINCT(code)")
       end
 
-      def distinct_charges_and_filters
-        EnrichedEvent.where(organization_id: subscription.organization_id)
+      def distinct_charges_and_filters(codes: nil)
+        scope = EnrichedEvent.where(organization_id: subscription.organization_id)
           .where(subscription_id: subscription.id)
           .where(timestamp: from_datetime..to_datetime)
-          .distinct
-          .pluck(:charge_id, :charge_filter_id)
+
+        scope = scope.where(code: codes) unless codes.nil?
+        scope.distinct.pluck(:charge_id, :charge_filter_id)
       end
 
       def events_values(limit: nil, force_from: false, exclude_event: false)

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -28,8 +28,16 @@ module Events
           .from_datetime(from_datetime)
           .to_datetime(applicable_to_datetime)
 
-        scope = scope.where(code: codes) unless codes.nil?
-        scope.pluck("DISTINCT(code)")
+        if codes.nil?
+          scope.pluck("DISTINCT(code)")
+        else
+          # NOTE: Deduplicating codes requires scanning all the subscription's events
+          #       in the period, which is slow for high-volume subscriptions. When the
+          #       possible codes are known, probe the index once per code instead
+          #       (loose index scan): the cost scales with the number of codes rather
+          #       than the number of events.
+          codes.select { |code| scope.where(code:).exists? }
+        end
       end
 
       def distinct_charges_and_filters(codes: nil)

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -31,11 +31,6 @@ module Events
         if codes.nil?
           scope.pluck("DISTINCT(code)")
         else
-          # NOTE: Deduplicating codes requires scanning all the subscription's events
-          #       in the period, which is slow for high-volume subscriptions. When the
-          #       possible codes are known, probe the index once per code instead
-          #       (loose index scan): the cost scales with the number of codes rather
-          #       than the number of events.
           codes.select { |code| scope.where(code:).exists? }
         end
       end

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -552,6 +552,15 @@ RSpec.describe Events::BillingPeriodFilterService do
           expect(result.charges).to eq({})
         end
       end
+
+      it "scopes the event store query to the plan billable metric codes" do
+        event_store = instance_double(Events::Stores::PostgresStore, distinct_codes: [])
+        allow(Events::Stores::StoreFactory).to receive(:new_instance).and_return(event_store)
+
+        filter_service.call
+
+        expect(event_store).to have_received(:distinct_codes).with(codes: [billable_metric.code])
+      end
     end
 
     context "when relying on clickhouse enriched events", clickhouse: true do
@@ -1107,6 +1116,51 @@ RSpec.describe Events::BillingPeriodFilterService do
           expect(result).to be_success
           expect(result.charges).to eq({})
         end
+      end
+
+      context "with enriched events not matching the plan billable metric codes" do
+        let(:events) do
+          [
+            create(
+              :event,
+              organization_id: organization.id,
+              external_subscription_id: subscription.external_id,
+              code: "unknown_code",
+              timestamp: boundaries.charges_from_datetime + 5.days
+            )
+          ]
+        end
+
+        let(:enriched_events) do
+          events.map do |event|
+            create(
+              :enriched_event,
+              event:,
+              subscription:,
+              value: 12,
+              decimal_value: 12.0,
+              charge:
+            )
+          end
+        end
+
+        before { enriched_events }
+
+        it "returns filtered charges" do
+          result = filter_service.call
+
+          expect(result).to be_success
+          expect(result.charges).to eq({})
+        end
+      end
+
+      it "scopes the event store query to the plan billable metric codes" do
+        event_store = instance_double(Events::Stores::PostgresStore, distinct_charges_and_filters: [])
+        allow(Events::Stores::StoreFactory).to receive(:new_instance).and_return(event_store)
+
+        filter_service.call
+
+        expect(event_store).to have_received(:distinct_charges_and_filters).with(codes: [billable_metric.code])
       end
     end
   end

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -1146,7 +1146,7 @@ RSpec.describe Events::BillingPeriodFilterService do
 
         before { enriched_events }
 
-        it "returns filtered charges" do
+        it "returns empty charges" do
           result = filter_service.call
 
           expect(result).to be_success

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -435,6 +435,21 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         it "returns only the distinct event codes matching the provided codes" do
           expect(event_store.distinct_codes(codes: [code, "unknown_code"])).to eq([code])
         end
+
+        context "when an event with a provided code exists outside the period" do
+          before do
+            create_event(
+              timestamp: boundaries[:to_datetime] + 1.day,
+              value: "value",
+              transaction_id: SecureRandom.uuid,
+              code: "out_of_period_code"
+            )
+          end
+
+          it "does not return the code" do
+            expect(event_store.distinct_codes(codes: [code, "out_of_period_code"])).to eq([code])
+          end
+        end
       end
     end
   end

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -430,6 +430,12 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       it "returns the distinct event codes" do
         expect(event_store.distinct_codes).to match_array([code, "other_code"])
       end
+
+      context "when codes are provided" do
+        it "returns only the distinct event codes matching the provided codes" do
+          expect(event_store.distinct_codes(codes: [code, "unknown_code"])).to eq([code])
+        end
+      end
     end
   end
 
@@ -2585,6 +2591,13 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
         it "returns the distinct event codes" do
           expect(event_store.distinct_charges_and_filters).to match_array([[charge.id, nil]])
+        end
+      end
+
+      context "when codes are provided" do
+        it "returns only the charges and filters matching the provided codes" do
+          expect(event_store.distinct_charges_and_filters(codes: [code])).to match_array([[charge.id, charge_filter.id]])
+          expect(event_store.distinct_charges_and_filters(codes: ["unknown_code"])).to eq([])
         end
       end
     end


### PR DESCRIPTION
## Context

Events::BillingPeriodFilterService queries the event store for the distinct codes (or charge/filter pairs) received during the billing period, filtering only on organization_id and external_subscription_id. The ClickHouse events tables are sorted by (organization_id, code, external_subscription_id, ...), so without a code predicate ClickHouse cannot prune granules and scans the organization's entire event history. This query is issued for every usage and billing computation and is the single largest CPU consumer on ClickHouse Cloud.

## Description

Pass the plan's billable metric codes to distinct_codes and distinct_charges_and_filters in all event stores and filter on them. The result is unchanged: both code paths already intersect the event store result with the plan's charges, so events with codes outside the plan could never match a charge. With the code predicate, ClickHouse prunes by the (organization_id, code) sort key prefix and only reads the subscription's own data.
