### PR TITLE
fix: prevent double-charge from open Stripe checkout sessions

### DIFF
--- a/app/jobs/payment_intents/expire_job.rb
+++ b/app/jobs/payment_intents/expire_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PaymentIntents
+  class ExpireJob < ApplicationJob
+    queue_as "providers"
+
+    retry_on ::Stripe::RateLimitError, ::Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 5
+
+    def perform(invoice)
+      PaymentIntents::ExpireService.call!(invoice:)
+    end
+  end
+end

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -22,14 +22,15 @@ end
 # Table name: payment_intents
 # Database name: primary
 #
-#  id              :uuid             not null, primary key
-#  expires_at      :datetime         not null
-#  payment_url     :string
-#  status          :integer          default("active"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  invoice_id      :uuid             not null
-#  organization_id :uuid             not null
+#  id                  :uuid             not null, primary key
+#  expires_at          :datetime         not null
+#  payment_url         :string
+#  status              :integer          default("active"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  invoice_id          :uuid             not null
+#  organization_id     :uuid             not null
+#  provider_session_id :string
 #
 # Indexes
 #

--- a/app/services/invoices/payments/already_paid_error.rb
+++ b/app/services/invoices/payments/already_paid_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    # Raised right before an off-session charge when the payable has already been settled
+    # by another payment path (e.g. a hosted checkout session). Signals the caller to abort
+    # the charge without delivering an error webhook or scheduling a retry.
+    class AlreadyPaidError < StandardError; end
+  end
+end

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -69,6 +69,11 @@ module Invoices
         Integrations::Aggregator::Payments::CreateJob.perform_later(payment:) if result.payment.should_sync_payment?
 
         result
+      rescue Invoices::Payments::AlreadyPaidError
+        # NOTE: The invoice was settled by another payment so we can drop the unused pending payment
+        result.payment&.destroy if result.payment&.provider_payment_id.nil?
+        result.payment = nil
+        result
       rescue BaseService::ServiceFailure => e
         result.payment = e.result.payment
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -95,6 +95,8 @@ module Invoices
         )
 
         result
+      rescue ::Stripe::InvalidRequestError # the other ones are on the retry job
+        result
       end
 
       private

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -39,7 +39,14 @@ module Invoices
         payment.error_code = stripe_payment.error_code if stripe_payment.error_code
         payment.save!
 
-        deliver_webhook if payable_payment_status.to_sym == :succeeded
+        if payable_payment_status.to_sym == :succeeded
+          deliver_webhook
+
+          # The invoice is paid lets expire/cancel any still-open checkout session
+          if PaymentIntent.active.exists?(invoice: payment.payable)
+            PaymentIntents::ExpireJob.perform_later(payment.payable)
+          end
+        end
 
         if status.to_s == "failed" && result.invoice.payments.excluding(result.payment).where(status: :requires_action).any?
           # We don't update the invoice status because it's likely the webhook of a failed payment
@@ -70,10 +77,31 @@ module Invoices
         )
 
         result.payment_url = res["url"]
+        result.provider_session_id = res["id"]
 
         result
       rescue ::Stripe::CardError, ::Stripe::InvalidRequestError, ::Stripe::AuthenticationError, Stripe::PermissionError => e
         result.third_party_failure!(third_party: PROVIDER_NAME, error_code: e.code, error_message: e.message)
+      end
+
+      # NOTE: Expires the hosted Stripe Checkout open Session so it can no longer be paid.
+      def expire_payment_url(payment_intent)
+        return result if payment_intent.provider_session_id.blank?
+
+        session = ::Stripe::Checkout::Session.retrieve(
+          payment_intent.provider_session_id,
+          {api_key: stripe_api_key}
+        )
+
+        return result unless session.status == "open"
+
+        ::Stripe::Checkout::Session.expire(
+          payment_intent.provider_session_id,
+          {},
+          {api_key: stripe_api_key}
+        )
+
+        result
       end
 
       private

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -39,14 +39,7 @@ module Invoices
         payment.error_code = stripe_payment.error_code if stripe_payment.error_code
         payment.save!
 
-        if payable_payment_status.to_sym == :succeeded
-          deliver_webhook
-
-          # The invoice is paid lets expire/cancel any still-open checkout session
-          if PaymentIntent.active.exists?(invoice: payment.payable)
-            PaymentIntents::ExpireJob.perform_later(payment.payable)
-          end
-        end
+        deliver_webhook if payable_payment_status.to_sym == :succeeded
 
         if status.to_s == "failed" && result.invoice.payments.excluding(result.payment).where(status: :requires_action).any?
           # We don't update the invoice status because it's likely the webhook of a failed payment

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -83,11 +83,7 @@ module Invoices
       update_hubspot_invoice if invoice.should_update_hubspot_invoice?
     end
 
-    # NOTE: Once the invoice is settled, cancel any still-open hosted checkout session so the
-    #       customer cannot also pay it and get charged twice. Hooked here because every settle
-    #       path funnels through this service — the synchronous off-session auto-charge as well
-    #       as provider webhooks. Guarded on an active PaymentIntent so billing-day runs over
-    #       millions of link-less invoices don't flood Sidekiq.
+    # when the invoice is settled, cancel any still-open hosted checkout session
     def expire_open_checkout_urls(old_payment_status)
       return unless invoice.payment_succeeded?
       return if old_payment_status.to_s == "succeeded"

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -74,12 +74,26 @@ module Invoices
         handle_prepaid_credits(params[:payment_status])
         handle_payment_gated_activation(params[:payment_status])
         update_fees_payment_status
+        expire_open_checkout_urls(old_payment_status)
         if old_payment_status != params[:payment_status] && invoice.visible?
           deliver_webhook
           log_activity
         end
       end
       update_hubspot_invoice if invoice.should_update_hubspot_invoice?
+    end
+
+    # NOTE: Once the invoice is settled, cancel any still-open hosted checkout session so the
+    #       customer cannot also pay it and get charged twice. Hooked here because every settle
+    #       path funnels through this service — the synchronous off-session auto-charge as well
+    #       as provider webhooks. Guarded on an active PaymentIntent so billing-day runs over
+    #       millions of link-less invoices don't flood Sidekiq.
+    def expire_open_checkout_urls(old_payment_status)
+      return unless invoice.payment_succeeded?
+      return if old_payment_status.to_s == "succeeded"
+      return unless PaymentIntent.active.exists?(invoice:)
+
+      PaymentIntents::ExpireJob.perform_after_commit(invoice)
     end
 
     def update_fees_payment_status

--- a/app/services/payment_intents/expire_service.rb
+++ b/app/services/payment_intents/expire_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PaymentIntents
+  class ExpireService < BaseService
+    Result = BaseResult[:payment_intents]
+
+    def initialize(invoice:)
+      @invoice = invoice
+      super
+    end
+
+    def call
+      payment_intents = PaymentIntent.active.where(invoice:)
+
+      payment_intents.find_each do |payment_intent|
+        if payment_intent.provider_session_id.present?
+          Invoices::Payments::PaymentProviders::Factory
+            .new_instance(invoice:)
+            .expire_payment_url(payment_intent)
+            .raise_if_error!
+        end
+
+        payment_intent.expired!
+      end
+
+      result.payment_intents = payment_intents
+      result
+    end
+
+    private
+
+    attr_reader :invoice
+  end
+end

--- a/app/services/payment_intents/fetch_service.rb
+++ b/app/services/payment_intents/fetch_service.rb
@@ -26,7 +26,10 @@ module PaymentIntents
           return result.single_validation_failure!(error_code: "payment_provider_error")
         end
 
-        payment_intent.update!(payment_url: payment_url_result.payment_url)
+        payment_intent.update!(
+          payment_url: payment_url_result.payment_url,
+          provider_session_id: payment_url_result.provider_session_id
+        )
       end
 
       result.payment_intent = payment_intent

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -126,9 +126,13 @@ module PaymentProviders
 
         def create_payment_intent
           update_payment_method_id
+          payload = payment_intent_payload
+
+          # payable have been settled by another payment path
+          raise Invoices::Payments::AlreadyPaidError if invoice.reload.payment_succeeded?
 
           ::Stripe::PaymentIntent.create(
-            payment_intent_payload,
+            payload,
             {
               api_key: payment_provider.secret_key,
               idempotency_key: "payment-#{payment.id}"

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -74,6 +74,11 @@ module PaymentRequests
         PaymentRequestMailer.with(payment_request: payable).requested.deliver_later if payable.payment_failed?
 
         result
+      rescue Invoices::Payments::AlreadyPaidError
+        # The payment request was settled by another payment so we can drop the unused pending payment
+        result.payment&.destroy if result.payment&.provider_payment_id.nil?
+        result.payment = nil
+        result
       rescue BaseService::ServiceFailure => e
         PaymentRequestMailer.with(payment_request: payable).requested.deliver_later
         result.payment = e.result.payment

--- a/db/migrate/20260612113044_add_provider_session_id_to_payment_intents.rb
+++ b/db/migrate/20260612113044_add_provider_session_id_to_payment_intents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProviderSessionIdToPaymentIntents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :payment_intents, :provider_session_id, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4741,7 +4741,8 @@ CREATE TABLE public.payment_intents (
     status integer DEFAULT 0 NOT NULL,
     expires_at timestamp(6) without time zone NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    provider_session_id character varying
 );
 
 
@@ -12645,6 +12646,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260612150749'),
+('20260612113044'),
 ('20260611162947'),
 ('20260611145039'),
 ('20260611122002'),

--- a/spec/jobs/payment_intents/expire_job_spec.rb
+++ b/spec/jobs/payment_intents/expire_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentIntents::ExpireJob do
+  let(:invoice) { create(:invoice) }
+
+  before do
+    allow(PaymentIntents::ExpireService)
+      .to receive(:call!).with(invoice:).and_return(BaseService::Result.new)
+  end
+
+  it "calls the expire service" do
+    described_class.perform_now(invoice)
+
+    expect(PaymentIntents::ExpireService).to have_received(:call!).with(invoice:)
+  end
+end

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -439,6 +439,24 @@ RSpec.describe Invoices::Payments::CreateService do
       let(:service_call) { create_service.call }
     end
 
+    context "when the provider raises AlreadyPaidError" do
+      before do
+        allow(provider_service).to receive(:call!).and_raise(Invoices::Payments::AlreadyPaidError)
+      end
+
+      it "skips silently and drops the unused pending payment" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.payment).to be_nil
+        expect(invoice.reload.payments).to be_empty
+      end
+
+      it "does not deliver an error webhook" do
+        expect { create_service.call }.not_to have_enqueued_job(SendWebhookJob)
+      end
+    end
+
     context "when provider service raises a service failure" do
       let(:original_error) { ::Stripe::StripeError.new("card declined") }
       let(:result) do

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -231,32 +231,6 @@ RSpec.describe Invoices::Payments::StripeService do
       end.to have_enqueued_job(SendWebhookJob).with("payment.succeeded", Payment)
     end
 
-    context "when an active payment intent exists for the invoice" do
-      before { create(:payment_intent, invoice:) }
-
-      it "enqueues a job to expire the open checkout session" do
-        expect do
-          stripe_service.update_payment_status(
-            organization_id: organization.id,
-            status: "succeeded",
-            stripe_payment:
-          )
-        end.to have_enqueued_job(PaymentIntents::ExpireJob).with(invoice)
-      end
-    end
-
-    context "when no active payment intent exists for the invoice" do
-      it "does not enqueue the expire job" do
-        expect do
-          stripe_service.update_payment_status(
-            organization_id: organization.id,
-            status: "succeeded",
-            stripe_payment:
-          )
-        end.not_to have_enqueued_job(PaymentIntents::ExpireJob)
-      end
-    end
-
     context "when status is failed" do
       let(:stripe_payment) do
         PaymentProviders::StripeProvider::StripePayment.new(

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -168,6 +168,19 @@ RSpec.describe Invoices::Payments::StripeService do
       end
     end
 
+    context "when the session can no longer be expired" do
+      before do
+        allow(::Stripe::Checkout::Session).to receive(:expire)
+          .and_raise(::Stripe::InvalidRequestError.new("not open", {}))
+      end
+
+      it "treats it as a no-op success" do
+        result = stripe_service.expire_payment_url(payment_intent)
+
+        expect(result).to be_success
+      end
+    end
+
     context "when the payment intent has no provider session id" do
       let(:provider_session_id) { nil }
 

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe Invoices::Payments::StripeService do
       expect(::Stripe::Checkout::Session).to have_received(:create)
     end
 
+    it "captures the checkout session id on the result" do
+      allow(::Stripe::Checkout::Session).to receive(:create)
+        .and_return({"url" => "https://example.com", "id" => "cs_123"})
+
+      result = stripe_service.generate_payment_url(payment_intent)
+
+      expect(result.payment_url).to eq("https://example.com")
+      expect(result.provider_session_id).to eq("cs_123")
+    end
+
     describe "#payment_url_payload" do
       let(:payment_url_payload) { stripe_service.__send__(:payment_url_payload, payment_intent) }
 
@@ -127,6 +137,50 @@ RSpec.describe Invoices::Payments::StripeService do
     end
   end
 
+  describe "#expire_payment_url" do
+    let(:payment_intent) { create(:payment_intent, invoice:, provider_session_id:) }
+    let(:provider_session_id) { "cs_123" }
+    let(:session_status) { "open" }
+    let(:stripe_session) { ::Stripe::Checkout::Session.construct_from(status: session_status) }
+
+    before do
+      stripe_payment_provider
+      stripe_customer
+
+      allow(::Stripe::Checkout::Session).to receive(:retrieve).and_return(stripe_session)
+      allow(::Stripe::Checkout::Session).to receive(:expire)
+    end
+
+    it "expires the open checkout session" do
+      stripe_service.expire_payment_url(payment_intent)
+
+      expect(::Stripe::Checkout::Session).to have_received(:expire)
+        .with(provider_session_id, {}, {api_key: stripe_payment_provider.secret_key})
+    end
+
+    context "when the session is no longer open" do
+      let(:session_status) { "complete" }
+
+      it "does not expire the session" do
+        stripe_service.expire_payment_url(payment_intent)
+
+        expect(::Stripe::Checkout::Session).not_to have_received(:expire)
+      end
+    end
+
+    context "when the payment intent has no provider session id" do
+      let(:provider_session_id) { nil }
+
+      it "does nothing and returns success" do
+        result = stripe_service.expire_payment_url(payment_intent)
+
+        expect(result).to be_success
+        expect(::Stripe::Checkout::Session).not_to have_received(:retrieve)
+        expect(::Stripe::Checkout::Session).not_to have_received(:expire)
+      end
+    end
+  end
+
   describe "#update_payment_status" do
     let(:payment) do
       create(
@@ -175,6 +229,32 @@ RSpec.describe Invoices::Payments::StripeService do
           stripe_payment:
         )
       end.to have_enqueued_job(SendWebhookJob).with("payment.succeeded", Payment)
+    end
+
+    context "when an active payment intent exists for the invoice" do
+      before { create(:payment_intent, invoice:) }
+
+      it "enqueues a job to expire the open checkout session" do
+        expect do
+          stripe_service.update_payment_status(
+            organization_id: organization.id,
+            status: "succeeded",
+            stripe_payment:
+          )
+        end.to have_enqueued_job(PaymentIntents::ExpireJob).with(invoice)
+      end
+    end
+
+    context "when no active payment intent exists for the invoice" do
+      it "does not enqueue the expire job" do
+        expect do
+          stripe_service.update_payment_status(
+            organization_id: organization.id,
+            status: "succeeded",
+            stripe_payment:
+          )
+        end.not_to have_enqueued_job(PaymentIntents::ExpireJob)
+      end
     end
 
     context "when status is failed" do

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe Invoices::UpdateService do
       )
     end
 
+    context "when the invoice settles with an open checkout session" do
+      before { create(:payment_intent, invoice:) }
+
+      it "enqueues a job to expire the checkout session" do
+        expect { result }.to have_enqueued_job_after_commit(PaymentIntents::ExpireJob).with(invoice)
+      end
+
+      context "when the invoice was already succeeded" do
+        let(:invoice) { create(:invoice, payment_status: :succeeded) }
+
+        it "does not enqueue the expire job" do
+          expect { result }.not_to have_enqueued_job(PaymentIntents::ExpireJob)
+        end
+      end
+    end
+
+    context "when the invoice settles without an open checkout session" do
+      it "does not enqueue the expire job" do
+        expect { result }.not_to have_enqueued_job(PaymentIntents::ExpireJob)
+      end
+    end
+
     context "when invoices is included in a payment request" do
       let(:customer) do
         create(

--- a/spec/services/payment_intents/expire_service_spec.rb
+++ b/spec/services/payment_intents/expire_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe PaymentIntents::ExpireService do
+  describe ".call" do
+    subject(:result) { described_class.call(invoice:) }
+
+    let(:invoice) { create(:invoice) }
+    let(:payment_provider_service) { instance_double("PaymentProviderService") }
+
+    before do
+      allow(Invoices::Payments::PaymentProviders::Factory)
+        .to receive(:new_instance)
+        .with(invoice:)
+        .and_return(payment_provider_service)
+
+      allow(payment_provider_service)
+        .to receive(:expire_payment_url)
+        .and_return(BaseService::Result.new)
+    end
+
+    context "when an active payment intent has a provider session id" do
+      let!(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: "cs_123") }
+
+      it "expires the provider checkout session and the payment intent" do
+        expect { result }.to change { payment_intent.reload.status }.from("active").to("expired")
+        expect(payment_provider_service).to have_received(:expire_payment_url).with(payment_intent)
+      end
+    end
+
+    context "when an active payment intent has no provider session id" do
+      let!(:payment_intent) { create(:payment_intent, invoice:, provider_session_id: nil) }
+
+      it "expires the payment intent without calling the provider" do
+        expect { result }.to change { payment_intent.reload.status }.from("active").to("expired")
+        expect(payment_provider_service).not_to have_received(:expire_payment_url)
+      end
+    end
+
+    context "when there is no active payment intent" do
+      let!(:expired_intent) { create(:payment_intent, :expired, invoice:, provider_session_id: "cs_123") }
+
+      it "does nothing" do
+        result
+
+        expect(expired_intent.reload.status).to eq("expired")
+        expect(payment_provider_service).not_to have_received(:expire_payment_url)
+      end
+    end
+  end
+end

--- a/spec/services/payment_intents/fetch_service_spec.rb
+++ b/spec/services/payment_intents/fetch_service_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe PaymentIntents::FetchService do
           expect(result.payment_intent.payment_url).to eq(payment_url)
           expect(payment_provider_service).to have_received(:generate_payment_url)
         end
+
+        it "persists the provider session id returned by the provider" do
+          allow(payment_provider_service)
+            .to receive(:generate_payment_url)
+            .and_return(BaseService::Result.new.tap do |r|
+              r.payment_url = payment_url
+              r.provider_session_id = "cs_123"
+            end)
+
+          expect(result.payment_intent.provider_session_id).to eq("cs_123")
+        end
       end
 
       context "when payment provider fails to generate URL" do

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -108,6 +108,15 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
       expect(Stripe::PaymentIntent).to have_received(:create)
     end
 
+    context "when the invoice has already been paid" do
+      before { invoice.update!(payment_status: :succeeded) }
+
+      it "raises AlreadyPaidError and does not create a payment intent" do
+        expect { create_service.call }.to raise_error(Invoices::Payments::AlreadyPaidError)
+        expect(Stripe::PaymentIntent).not_to have_received(:create)
+      end
+    end
+
     context "when multiple payment methods are enabled" do
       let(:default_payment_method) { create(:payment_method, customer:, provider_method_id: "pm_123456") }
 

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -425,6 +425,24 @@ RSpec.describe PaymentRequests::Payments::CreateService do
       end
     end
 
+    context "when the provider raises AlreadyPaidError" do
+      before do
+        allow(provider_service).to receive(:call!).and_raise(Invoices::Payments::AlreadyPaidError)
+      end
+
+      it "skips silently and drops the unused pending payment" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.payment).to be_nil
+        expect(payment_request.reload.payments).to be_empty
+      end
+
+      it "does not send the payment request email" do
+        expect { create_service.call }.not_to have_enqueued_mail(PaymentRequestMailer, :requested)
+      end
+    end
+
     context "when provider service raises a service failure" do
       let(:service_result) do
         BaseService::Result.new.tap do |r|


### PR DESCRIPTION
## Context

Lago has been double-charging invoices when a auto-charge runs against an invoice that also has an active hosted Stripe Checkout Session. Both succeed, producing two separate PaymentIntents with two different idempotency keys — so Stripe captures twice. 

- **Checkout-first then auto-charge**: the customer pays via the URL → Lago's auto-charge fires later and charges the saved card a second time.
- **Auto-charge mid-flight then checkout paid**: the off-session charge is already running at Stripe → the customer pays the still-live URL → second charge.

Stripe can't know the two PaymentIntents belong to the same invoice — only Lago can — and today nothing in the auto-charge path checks whether the invoice is already settled, nor kills open checkout sessions once it is. So both sides of the race stay open.

## Description

Two coordinated mechanisms close the two sides of the race, both treating the Lago invoice as the single source of truth.

### 1. Pre-confirm last-look — `Invoices::Payments::AlreadyPaidError`

`PaymentProviders::Stripe::Payments::CreateService` re-reads `invoice.reload.payment_succeeded?` immediately before `Stripe::PaymentIntent.create` — the tightest point before money moves, after the provider setup calls — and raises `AlreadyPaidError` if the invoice is already fully settled (`payment_succeeded?`, so partially-paid invoices still charge the remainder).

Both `Invoices::Payments::CreateService` and `PaymentRequests::Payments::CreateService` rescue it: skip silently (no error webhook, no retry, no failure email) and destroy the unused, never-charged pending `Payment` so it can't linger or be reused with a stale amount.

### 2. Post-settle expiry — `PaymentIntents::ExpireService` via `ExpireJob`

Hooked into `Invoices::Payments::StripeService#update_payment_status` on transition to `payment_status: :succeeded`. Cancels checkout sessions created mid-auto-charge that the last-look never saw. Enqueued **only when an active `PaymentIntent` exists**

> [!IMPORTANT]
> Scoped to **Stripe**. other providers will be on other pull request one per provider se we can easily test the flow first 