### PR TITLE
fix(subscription): switch to cancellation_reason column

### DIFF
--- a/app/graphql/types/subscriptions/cancellation_reason_enum.rb
+++ b/app/graphql/types/subscriptions/cancellation_reason_enum.rb
@@ -2,7 +2,7 @@
 
 module Types
   module Subscriptions
-    class CancelationReasonEnum < Types::BaseEnum
+    class CancellationReasonEnum < Types::BaseEnum
       Subscription::CANCELLATION_REASONS.each_key do |reason|
         value reason
       end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -58,7 +58,7 @@ module Types
 
       field :activated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :activation_rules, [Types::Subscriptions::ActivationRuleType], null: false
-      field :cancelation_reason, Types::Subscriptions::CancelationReasonEnum, null: true
+      field :cancellation_reason, Types::Subscriptions::CancellationReasonEnum, null: true
 
       def next_plan
         object.next_subscription&.plan

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,7 +4,7 @@ class Subscription < ApplicationRecord
   include PaperTrailTraceable
   include RansackUuidSearch
 
-  self.ignored_columns += %w[incompleted_at]
+  self.ignored_columns += %w[incompleted_at cancelation_reason]
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :plan, -> { with_discarded }
@@ -72,7 +72,6 @@ class Subscription < ApplicationRecord
   enum :billing_time, BILLING_TIME
   enum :on_termination_credit_note, ON_TERMINATION_CREDIT_NOTES, prefix: true
   enum :on_termination_invoice, ON_TERMINATION_INVOICES, prefix: true
-  enum :cancelation_reason, CANCELLATION_REASONS, prefix: true
   enum :cancellation_reason, CANCELLATION_REASONS
 
   validates :on_termination_credit_note, absence: true, if: -> { plan&.pay_in_arrears? }
@@ -334,7 +333,6 @@ end
 #  id                           :uuid             not null, primary key
 #  activated_at                 :datetime
 #  billing_time                 :integer          default("calendar"), not null
-#  cancelation_reason           :enum
 #  canceled_at                  :datetime
 #  cancellation_reason          :enum
 #  consolidate_invoice          :boolean          default(TRUE), not null

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -41,7 +41,7 @@ module V1
       payload = payload.merge(applied_invoice_custom_sections) if include?(:applied_invoice_custom_sections)
 
       if organization.feature_flag_enabled?(:payment_gated_subscriptions)
-        payload[:cancelation_reason] = model.cancelation_reason
+        payload[:cancellation_reason] = model.cancellation_reason
         payload[:activated_at] = model.activated_at&.iso8601
         payload[:activation_rules] = model.activation_rules.map do |rule|
           ::V1::Subscriptions::ActivationRuleSerializer.new(rule).serialize

--- a/app/services/subscriptions/activation_rules/expire_service.rb
+++ b/app/services/subscriptions/activation_rules/expire_service.rb
@@ -24,7 +24,7 @@ module Subscriptions
           invoice.closed!
 
           ResolveSubscriptionStatusService.call!(subscription:)
-          subscription.update!(cancelation_reason: :timeout)
+          subscription.update!(cancellation_reason: :timeout)
 
           enqueue_psp_cancel(invoice)
           enqueue_recredit_jobs(invoice)

--- a/app/services/subscriptions/activation_rules/payment/resolve_service.rb
+++ b/app/services/subscriptions/activation_rules/payment/resolve_service.rb
@@ -54,7 +54,7 @@ module Subscriptions
           EvaluateService.call!(rule: payment_rule, status: :failed)
           invoice.closed!
           ActivationRules::ResolveSubscriptionStatusService.call!(subscription:)
-          subscription.update!(cancelation_reason: :payment_failed)
+          subscription.update!(cancellation_reason: :payment_failed)
 
           after_commit do
             enqueue_recredit_jobs

--- a/schema.graphql
+++ b/schema.graphql
@@ -1006,7 +1006,7 @@ enum BillingTimeEnum {
   calendar
 }
 
-enum CancelationReasonEnum {
+enum CancellationReasonEnum {
   payment_failed
   timeout
 }
@@ -11513,8 +11513,8 @@ type Subscription {
   activityLogs: [ActivityLog!]
   billingEntityId: ID
   billingTime: BillingTimeEnum
-  cancelationReason: CancelationReasonEnum
   canceledAt: ISO8601DateTime
+  cancellationReason: CancellationReasonEnum
   charges: [Charge!]
   consolidateInvoice: Boolean!
   createdAt: ISO8601DateTime!

--- a/schema.json
+++ b/schema.json
@@ -5777,7 +5777,7 @@
         },
         {
           "kind": "ENUM",
-          "name": "CancelationReasonEnum",
+          "name": "CancellationReasonEnum",
           "description": null,
           "fields": null,
           "inputFields": null,
@@ -62439,24 +62439,24 @@
               "deprecationReason": null
             },
             {
-              "name": "cancelationReason",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "ENUM",
-                "name": "CancelationReasonEnum",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "canceledAt",
               "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cancellationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "CancellationReasonEnum",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
           createSubscription(input: $input) {
             id
             status
-            cancelationReason
+            cancellationReason
             activationRules {
               id
               type
@@ -259,7 +259,7 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
 
       expect(result_data).to include(
         "status" => "pending",
-        "cancelationReason" => nil
+        "cancellationReason" => nil
       )
       expect(result_data["activationRules"].size).to eq(1)
       expect(result_data["activationRules"].first).to include(

--- a/spec/graphql/types/subscriptions/cancellation_reason_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/cancellation_reason_enum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Types::Subscriptions::CancelationReasonEnum do
+RSpec.describe Types::Subscriptions::CancellationReasonEnum do
   it "exposes all enum values" do
     expect(described_class.values.keys).to match_array(%w[payment_failed timeout])
   end

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Types::Subscriptions::Object do
 
     expect(subject).to have_field(:activated_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:activation_rules).of_type("[SubscriptionActivationRule!]!")
-    expect(subject).to have_field(:cancelation_reason).of_type("CancelationReasonEnum")
+    expect(subject).to have_field(:cancellation_reason).of_type("CancellationReasonEnum")
   end
 
   context "when the subscription starts in the future" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Subscription do
         .backed_by_column_of_type(:enum)
         .with_values(generate: "generate", skip: "skip")
         .with_prefix(:on_termination_invoice)
-      expect(subject).to define_enum_for(:cancelation_reason)
+      expect(subject).to define_enum_for(:cancellation_reason)
         .backed_by_column_of_type(:enum)
         .with_values(payment_failed: "payment_failed", timeout: "timeout")
     end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -761,7 +761,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
 
           expect(response).to have_http_status(:ok)
           expect(json[:subscription][:status]).to eq("pending")
-          expect(json[:subscription][:cancelation_reason]).to be_nil
+          expect(json[:subscription][:cancellation_reason]).to be_nil
           expect(json[:subscription][:activated_at]).to be_nil
           expect(json[:subscription][:activation_rules].size).to eq(1)
           expect(json[:subscription][:activation_rules].first).to include(
@@ -804,7 +804,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           expect(subscription.activation_rules.count).to eq(1)
 
           expect(json[:subscription]).not_to have_key(:activation_rules)
-          expect(json[:subscription]).not_to have_key(:cancelation_reason)
+          expect(json[:subscription]).not_to have_key(:cancellation_reason)
           expect(json[:subscription]).not_to have_key(:activated_at)
         end
       end
@@ -1813,7 +1813,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           expect(subscription.activation_rules.count).to eq(1)
 
           expect(json[:subscription]).not_to have_key(:activation_rules)
-          expect(json[:subscription]).not_to have_key(:cancelation_reason)
+          expect(json[:subscription]).not_to have_key(:cancellation_reason)
           expect(json[:subscription]).not_to have_key(:activated_at)
         end
       end

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -122,7 +122,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
 
       subscription.reload
       expect(subscription).to be_canceled
-      expect(subscription.cancelation_reason).to eq("payment_failed")
+      expect(subscription.cancellation_reason).to eq("payment_failed")
       expect(subscription.activated_at).to be_nil
       expect(subscription.activation_rules.sole).to be_failed
 
@@ -334,7 +334,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
       )
     end
 
-    it "expires the gated subscription with cancelation_reason: timeout" do
+    it "expires the gated subscription with cancellation_reason: timeout" do
       # Stage 1: Create gated subscription
       create_subscription(subscription_params)
       perform_all_enqueued_jobs
@@ -355,7 +355,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
 
       subscription.reload
       expect(subscription).to be_canceled
-      expect(subscription.cancelation_reason).to eq("timeout")
+      expect(subscription.cancellation_reason).to eq("timeout")
       expect(subscription.activation_rules.sole).to be_expired
 
       expect(invoice.reload).to be_closed
@@ -696,7 +696,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
       previous_subscription.reload
       new_subscription.reload
       expect(new_subscription).to be_canceled
-      expect(new_subscription.cancelation_reason).to eq("payment_failed")
+      expect(new_subscription.cancellation_reason).to eq("payment_failed")
       expect(new_subscription.activation_rules.sole).to be_failed
       expect(previous_subscription).to be_active
       expect(invoice.reload).to be_closed
@@ -846,7 +846,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
       previous_subscription.reload
       new_subscription.reload
       expect(new_subscription).to be_canceled
-      expect(new_subscription.cancelation_reason).to eq("payment_failed")
+      expect(new_subscription.cancellation_reason).to eq("payment_failed")
       expect(new_subscription.activation_rules.sole).to be_failed
       expect(previous_subscription).to be_active
       expect(invoice.reload).to be_closed

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -255,16 +255,16 @@ RSpec.describe ::V1::SubscriptionSerializer do
       create(
         :subscription,
         organization:,
-        cancelation_reason: Subscription::CANCELLATION_REASONS[:payment_failed],
+        cancellation_reason: Subscription::CANCELLATION_REASONS[:payment_failed],
         activated_at:
       )
     end
 
-    it "serializes cancelation_reason and activated_at" do
+    it "serializes cancellation_reason and activated_at" do
       result = JSON.parse(serializer.to_json)
 
       expect(result["subscription"]).to include(
-        "cancelation_reason" => Subscription::CANCELLATION_REASONS[:payment_failed],
+        "cancellation_reason" => Subscription::CANCELLATION_REASONS[:payment_failed],
         "activated_at" => activated_at.iso8601
       )
     end
@@ -301,7 +301,7 @@ RSpec.describe ::V1::SubscriptionSerializer do
     it "does not serialize feature-flagged fields" do
       result = JSON.parse(serializer.to_json)
 
-      expect(result["subscription"]).not_to have_key("cancelation_reason")
+      expect(result["subscription"]).not_to have_key("cancellation_reason")
       expect(result["subscription"]).not_to have_key("activated_at")
       expect(result["subscription"]).not_to have_key("activation_rules")
     end

--- a/spec/services/subscriptions/activation_rules/expire_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/expire_service_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe Subscriptions::ActivationRules::ExpireService do
       expect(invoice.reload).to be_closed
     end
 
-    it "cancels the subscription with cancelation_reason: timeout" do
+    it "cancels the subscription with cancellation_reason: timeout" do
       result
 
       expect(subscription.reload).to be_canceled
-      expect(subscription.cancelation_reason).to eq("timeout")
+      expect(subscription.cancellation_reason).to eq("timeout")
     end
 
     it "enqueues a PSP cancel job for the pending payment" do
@@ -142,7 +142,7 @@ RSpec.describe Subscriptions::ActivationRules::ExpireService do
 
       expect(payment_rule.reload).to be_expired
       expect(subscription.reload).to be_canceled
-      expect(subscription.cancelation_reason).to eq("timeout")
+      expect(subscription.cancellation_reason).to eq("timeout")
       expect(invoice.reload).to be_closed
     end
 

--- a/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
+++ b/spec/services/subscriptions/activation_rules/payment/resolve_service_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Subscriptions::ActivationRules::Payment::ResolveService do
       result
 
       expect(subscription.reload).to be_canceled
-      expect(subscription.cancelation_reason).to eq("payment_failed")
+      expect(subscription.cancellation_reason).to eq("payment_failed")
     end
 
     it "sends a subscription.canceled webhook" do


### PR DESCRIPTION
## Context

PR 1 added the correctly-named `cancellation_reason` column alongside the typo'd `cancelation_reason`. This is the middle step of the expand/contract rename: switch the application to the new column and make ActiveRecord forget the old one ever existed, so PR 3 can drop the column without any deploy race.

## Description

* Services (`Subscriptions::ActivationRules::ExpireService`, `Subscriptions::ActivationRules::Payment::ResolveService`), `V1::SubscriptionSerializer`, and the GraphQL `Subscription` object now read and write `cancellation_reason`.
* The `CancelationReasonEnum` GraphQL class is renamed to `CancellationReasonEnum`. The GraphQL field is exposed under `cancellationReason`. This is a breaking API rename, but only the development customer account consumes it today.
* `Subscription.ignored_columns` includes the old `cancelation_reason` so the schema cache no longer reflects it. The old `enum` declaration is removed. The DB column is left in place until PR 3.
* Tests updated accordingly.