### PR TITLE
feat(einvoicing): Prefer legal_name for buyer

### DIFF
--- a/app/serializers/e_invoices/cii/trade_agreement.rb
+++ b/app/serializers/e_invoices/cii/trade_agreement.rb
@@ -40,7 +40,7 @@ module EInvoices
             end
           end
           xml["ram"].BuyerTradeParty do
-            xml["ram"].Name customer.name
+            xml["ram"].Name customer.legal_name || customer.name
             xml["ram"].PostalTradeAddress do
               xml["ram"].PostcodeCode customer.zipcode
               xml["ram"].LineOne customer.address_line1

--- a/spec/serializers/e_invoices/cii/trade_agreement_spec.rb
+++ b/spec/serializers/e_invoices/cii/trade_agreement_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe EInvoices::Cii::TradeAgreement do
   let(:customer) do
     create(:customer,
       organization:,
-      name: "Its Mii")
+      name: "Its Mii",
+      legal_name: nil)
   end
   let(:billing_entity) do
     create(:billing_entity,
@@ -93,9 +94,21 @@ RSpec.describe EInvoices::Cii::TradeAgreement do
     context "when buyer information" do
       let(:buyer_root) { "#{root}/ram:BuyerTradeParty" }
 
-      it "have the name" do
-        expect(subject).to contains_xml_node("#{buyer_root}/ram:Name")
-          .with_value(customer.name)
+      context "when customer has no legal_name" do
+        it "falls back to the customer name" do
+          expect(customer.legal_name).to be_nil
+          expect(subject).to contains_xml_node("#{buyer_root}/ram:Name")
+            .with_value(customer.name)
+        end
+      end
+
+      context "when customer has a legal_name" do
+        before { customer.update(legal_name: "Mii Industries SARL") }
+
+        it "uses the legal_name instead of the name" do
+          expect(subject).to contains_xml_node("#{buyer_root}/ram:Name")
+            .with_value(customer.legal_name)
+        end
       end
 
       context "when address info" do


### PR DESCRIPTION
## Context

The CII `TradeAgreement` serializer was emitting the customer's display name for the `BuyerTradeParty/ram:Name` node even when the customer had a `legal_name` on file. The seller side already prefers `billing_entity.legal_name`, so generated CII documents had asymmetric treatment of the two parties and could carry a non-legal name on the buyer side.

## Fix

Buyer Name now falls back from `customer.legal_name` to `customer.name`, matching the seller side.

```ruby
# app/serializers/e_invoices/cii/trade_agreement.rb
xml["ram"].Name customer.legal_name || customer.name
```

## Tests

`spec/serializers/e_invoices/cii/trade_agreement_spec.rb`:

- The existing buyer-name example was implicitly exercising only the fallback path (the customer factory provides no `legal_name`). It is now renamed to make that intent explicit and guarded with `expect(customer.legal_name).to be_nil`, so a future factory change can't silently turn it into a duplicate of the new case.
- A new nested `when customer has a legal_name` context overrides the customer with a non-nil `legal_name` and asserts the serializer emits it instead of `name`.

```
lago exec api bundle exec rspec spec/serializers/e_invoices/cii/trade_agreement_spec.rb
```
