### PR TITLE
fix(subscriptions): Show completed downgrade date

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -223,6 +223,9 @@ class Subscription < ApplicationRecord
 
   def downgrade_plan_date
     return unless next_subscription
+    if next_subscription.active? && downgraded?
+      return next_subscription.started_at&.to_date
+    end
     return unless next_subscription.pending?
 
     ::Subscriptions::DatesService.new_instance(self, Time.current)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -771,6 +771,44 @@ RSpec.describe Subscription do
       end
     end
 
+    context "with active downgraded next subscription" do
+      let(:plan) { create(:plan, amount_cents: 200) }
+      let(:next_plan) { create(:plan, amount_cents: 100) }
+      let(:subscription) { create(:subscription, :terminated, plan:) }
+
+      it "returns the date when the plan was downgraded" do
+        create(
+          :subscription,
+          previous_subscription: subscription,
+          plan: next_plan,
+          status: :active,
+          started_at: Time.zone.parse("2022-07-01T00:00:00Z")
+        )
+
+        expect(subscription.downgrade_plan_date).to eq(Date.parse("1 Jul 2022"))
+      end
+    end
+
+    context "with anniversary billing before the downgrade date" do
+      let(:started_at) { Time.zone.parse("2022-06-04T00:00:00Z") }
+      let(:subscription) do
+        create(
+          :subscription,
+          :anniversary,
+          started_at:,
+          subscription_at: started_at
+        )
+      end
+
+      it "returns the next anniversary date" do
+        create(:subscription, previous_subscription: subscription, status: :pending)
+
+        travel_to(Time.zone.parse("2022-07-03T00:00:00Z")) do
+          expect(subscription.downgrade_plan_date).to eq(Date.parse("4 Jul 2022"))
+        end
+      end
+    end
+
     it "returns the date when the plan will be downgraded" do
       current_date = DateTime.parse("20 Jun 2022")
       create(:subscription, previous_subscription: subscription, status: :pending)


### PR DESCRIPTION
### Context

Terminated subscriptions from completed downgrades returned no downgrade date because the next subscription was already active. This caused the app to display an invalid datetime instead of the downgrade date.

### Description

Return the active downgraded subscription start date when the downgrade has already happened, while keeping the existing pending downgrade date calculation. Add model specs for completed downgrades and anniversary billing downgrade dates.
