### PR TITLE
Bil 183 enable de e invoicing

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -154,6 +154,10 @@ class BillingEntity < ApplicationRecord
       )
   end
 
+  def eligible_for_einvoicing?
+    einvoicing && EINVOICING_COUNTRIES.include?(country.try(:upcase))
+  end
+
   private
 
   def generate_document_number_prefix

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -14,7 +14,7 @@ class BillingEntity < ApplicationRecord
     "payment_receipt.created"
   ]
 
-  EINVOICING_COUNTRIES = %w[FR].map(&:upcase)
+  EINVOICING_COUNTRIES = %w[FR DE].map(&:upcase)
 
   SUBSCRIPTION_INVOICE_ISSUING_DATE_ANCHORS = {
     current_period_end: "current_period_end",

--- a/app/services/credit_notes/generate_pdf_service.rb
+++ b/app/services/credit_notes/generate_pdf_service.rb
@@ -72,7 +72,7 @@ module CreditNotes
     end
 
     def should_generate_cii_einvoice_xml?
-      credit_note.billing_entity.einvoicing && BillingEntity::EINVOICING_COUNTRIES.include?(credit_note.billing_entity.country.try(:upcase))
+      credit_note.billing_entity.eligible_for_einvoicing?
     end
 
     def should_generate_pdf?

--- a/app/services/credit_notes/generate_xml_service.rb
+++ b/app/services/credit_notes/generate_xml_service.rb
@@ -62,7 +62,7 @@ module CreditNotes
     end
 
     def e_invoicing_enabled?
-      credit_note.billing_entity.einvoicing && BillingEntity::EINVOICING_COUNTRIES.include?(credit_note.billing_entity.country.try(:upcase))
+      credit_note.billing_entity.eligible_for_einvoicing?
     end
   end
 end

--- a/app/services/invoices/generate_pdf_service.rb
+++ b/app/services/invoices/generate_pdf_service.rb
@@ -101,7 +101,7 @@ module Invoices
     end
 
     def should_generate_cii_einvoice_xml?
-      invoice.billing_entity.einvoicing && BillingEntity::EINVOICING_COUNTRIES.include?(invoice.billing_entity.country.try(:upcase))
+      invoice.billing_entity.eligible_for_einvoicing?
     end
 
     def charge?

--- a/app/services/invoices/generate_xml_service.rb
+++ b/app/services/invoices/generate_xml_service.rb
@@ -62,7 +62,7 @@ module Invoices
     end
 
     def e_invoicing_enabled?
-      invoice.billing_entity.einvoicing && BillingEntity::EINVOICING_COUNTRIES.include?(invoice.billing_entity.country.try(:upcase))
+      invoice.billing_entity.eligible_for_einvoicing?
     end
   end
 end

--- a/app/services/payment_receipts/generate_pdf_service.rb
+++ b/app/services/payment_receipts/generate_pdf_service.rb
@@ -70,7 +70,7 @@ module PaymentReceipts
     end
 
     def should_generate_cii_einvoice_xml?
-      payment_receipt.billing_entity.einvoicing && BillingEntity::EINVOICING_COUNTRIES.include?(payment_receipt.billing_entity.country.try(:upcase))
+      payment_receipt.billing_entity.eligible_for_einvoicing?
     end
 
     def should_generate_pdf?

--- a/app/services/payment_receipts/generate_xml_service.rb
+++ b/app/services/payment_receipts/generate_xml_service.rb
@@ -61,7 +61,7 @@ module PaymentReceipts
     end
 
     def e_invoicing_enabled?
-      payment_receipt.billing_entity.einvoicing && BillingEntity::EINVOICING_COUNTRIES.include?(payment_receipt.billing_entity.country.try(:upcase))
+      payment_receipt.billing_entity.eligible_for_einvoicing?
     end
   end
 end

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe BillingEntity do
     context "with a supported country" do
       let(:country) { "fr" }
 
-      it "is not valid" do
+      it "is valid" do
         expect(billing_entity).to be_valid
       end
     end

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -242,11 +242,10 @@ RSpec.describe BillingEntities::UpdateService do
     end
 
     context "when enable einvoicing" do
+      before { billing_entity.update(einvoicing: true) }
+
       context "when country is not supported" do
         let(:country) { "BR" }
-        let(:einvoicing) { true }
-
-        before { billing_entity.update(einvoicing: true) }
 
         it "returns an error" do
           result = update_service.call
@@ -258,15 +257,24 @@ RSpec.describe BillingEntities::UpdateService do
 
       context "when country is nil" do
         let(:country) { nil }
-        let(:einvoicing) { true }
-
-        before { billing_entity.update(einvoicing: true) }
 
         it "returns an error" do
           result = update_service.call
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages[:einvoicing]).to eq(["country_must_be_present"])
+        end
+      end
+
+      context "when country is supported" do
+        let(:country) { "DE" }
+
+        it "enables einvoicing on the billing entity" do
+          result = update_service.call
+
+          expect(result).to be_success
+          expect(result.billing_entity.einvoicing).to be true
+          expect(result.billing_entity.country).to eq(country)
         end
       end
     end


### PR DESCRIPTION
## Context

The German e-invoicing project requires that DE billing entities go through the same structured-invoice pipeline France already uses. Today that pipeline is hard-gated by `BillingEntity::EINVOICING_COUNTRIES`, which contains only `"FR"`. This PR opens the gate for Germany and, while there, removes the six-way duplication of the eligibility predicate so future country/format work has one canonical place to read.

**Closes BIL-183.**

## Changes

Two commits, scoped tightly:

**`feat(einvoicing): Enable for Germany`** — adds `"DE"` to `BillingEntity::EINVOICING_COUNTRIES`. This single constant change activates both ZUGFeRD (Factur-X CII embedded in PDF) and the future XRechnung UBL work: both formats are gated by the same list. No serializer or builder code is touched — for ZUGFeRD the existing French pipeline already produces a compliant document, since the German guideline (`urn:cen.eu:en16931:2017`) is identical to France's. XRechnung-specific work lands in follow-up tickets.

**`refactor(einvoicing): Centralize gate`** — extracts the predicate

```ruby
einvoicing && EINVOICING_COUNTRIES.include?(country.try(:upcase))
```

into `BillingEntity#eligible_for_einvoicing?`. The expression was inlined in six `Generate*Service` files (invoice / credit note / payment receipt × PDF / XML). All six now delegate. Semantics are unchanged — nil-country and lowercase-country cases still handled.

## Tests

Updates to the existing specs cover the new shape:

- `spec/models/billing_entity_spec.rb` — corrected a misleading example description on the supported-country branch (the example was already asserting validity; the `it` string still said "is not valid"). The `validate_einvoicing` block continues to cover FR, BR, nil, and the `einvoicing: false` exemption.
- `spec/services/billing_entities/update_service_spec.rb` — adds a positive `when country is supported` context that enables einvoicing on a DE billing entity through the update service. The sibling `before { billing_entity.update(einvoicing: true) }` block and `einvoicing: true` override are hoisted into the parent `when enable einvoicing` context so all three sibling cases share the same setup.
- Every `Generate*Service` spec continues to exercise the gate through the real call path; behaviour for FR is preserved transitively.

Full run of the eight affected specs:

```
lago exec api bundle exec rspec \
  spec/models/billing_entity_spec.rb \
  spec/services/billing_entities/update_service_spec.rb \
  spec/services/invoices/generate_{pdf,xml}_service_spec.rb \
  spec/services/credit_notes/generate_{pdf,xml}_service_spec.rb \
  spec/services/payment_receipts/generate_{pdf,xml}_service_spec.rb
# 150 examples, 0 failures
```

## Follow-up

`BillingEntity#eligible_for_einvoicing?` is currently covered transitively through the six service specs. A direct unit block on `spec/models/billing_entity_spec.rb` (FR / DE / lowercase / BR / nil / `einvoicing: false`) would lock the method's contract independently and survive future refactors of the service callers — happy to add as a small follow-up if you want it on this PR before merge.
