### PR TITLE
fix(subscriptions): avoid charge override N+1

### DIFF
--- a/app/services/charges/override_service.rb
+++ b/app/services/charges/override_service.rb
@@ -14,6 +14,9 @@ module Charges
 
       ActiveRecord::Base.transaction do
         new_charge = charge.dup.tap do |c|
+          c.organization = params[:plan].organization if params[:plan]
+          c.plan = params[:plan] if params[:plan]
+          c.billable_metric = charge.billable_metric
           c.properties = params[:properties] if params.key?(:properties)
           c.min_amount_cents = params[:min_amount_cents] if params.key?(:min_amount_cents)
           c.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
@@ -23,7 +26,7 @@ module Charges
             f.values = filter.values.map(&:dup)
             f
           end
-          c.plan_id = params[:plan_id]
+          c.plan_id = params[:plan_id] unless params[:plan]
         end
         new_charge.save!
 
@@ -36,13 +39,14 @@ module Charges
         end
 
         if charge.applied_pricing_unit
+          applied_pricing_unit = charge.applied_pricing_unit
           conversion_rate = params.dig(:applied_pricing_unit, :conversion_rate).presence
-          conversion_rate ||= charge.applied_pricing_unit.conversion_rate
+          conversion_rate ||= applied_pricing_unit.conversion_rate
 
           AppliedPricingUnits::CreateService.call!(
             charge: new_charge,
             params: {
-              code: charge.pricing_unit.code,
+              code: applied_pricing_unit.pricing_unit.code,
               conversion_rate:
             }
           )

--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -17,6 +17,7 @@ module Plans
 
       ActiveRecord::Base.transaction do
         new_plan = plan.dup.tap do |p|
+          p.organization = plan.organization
           p.amount_cents = params[:amount_cents] if params.key?(:amount_cents)
           p.amount_currency = params[:amount_currency] if params.key?(:amount_currency)
           p.description = params[:description] if params.key?(:description)
@@ -35,8 +36,11 @@ module Plans
         charges_params_by_id = (params[:charges] || []).index_by { |p| p[:id] }
         fixed_charges_params_by_id = (params[:fixed_charges] || []).index_by { |p| p[:id] }
 
-        plan.charges.includes(filters: :values).find_each do |charge|
-          charge_params = (charges_params_by_id[charge.id] || {}).merge(plan_id: new_plan.id)
+        charges = plan.charges
+          .includes(:organization, :billable_metric, {applied_pricing_unit: :pricing_unit}, filters: :values)
+
+        charges.find_each do |charge|
+          charge_params = (charges_params_by_id[charge.id] || {}).merge(plan: new_plan)
           Charges::OverrideService.call(charge:, params: charge_params)
         end
 

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -65,6 +65,25 @@ RSpec.describe Charges::OverrideService do
         expect(new_charge.taxes).to contain_exactly(tax)
       end
 
+      context "when the plan is passed in params" do
+        let(:params) do
+          {
+            id: charge.id,
+            plan:,
+            min_amount_cents: 1000,
+            properties: {amount: "200"}
+          }
+        end
+
+        it "creates the charge on the given plan" do
+          result = override_service.call
+
+          expect(result).to be_success
+          expect(result.charge.plan).to eq(plan)
+          expect(result.charge.organization).to eq(plan.organization)
+        end
+      end
+
       context "with charge filters" do
         let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
 

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -224,6 +224,21 @@ RSpec.describe Plans::OverrideService do
       )
     end
 
+    it "passes the overridden plan to charge overrides" do
+      allow(Charges::OverrideService).to receive(:call).and_call_original
+
+      result = override_service.call
+
+      expect(Charges::OverrideService).to have_received(:call).with(
+        charge:,
+        params: {
+          id: charge.id,
+          min_amount_cents: 1000,
+          plan: result.plan
+        }
+      )
+    end
+
     it "creates fixed charges based from the parent plan" do
       expect { override_service.call }.to change(Plan, :count).by(1)
       plan = Plan.order(:created_at).last


### PR DESCRIPTION
Creating subscriptions with plan overrides clones each plan charge. The cloning path reloaded the same plan, organization, billable metric, and pricing unit associations for every charge, which triggered N+1 queries.

Fixes API-248

Preload the associations needed when overriding plan charges and pass the overridden plan through charge override params. Reuse loaded associations while cloning charges and applied pricing units to avoid repeated lookups.

Add service specs covering the plan override handoff and charge override cloning when a plan object is provided.
