### PR TITLE
[ING-322] misc(clickhouse): Returns sum and count in 1 query

### DIFF
--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -14,16 +14,16 @@ module BillableMetrics
       def compute_aggregation(options: {})
         return empty_result if should_bypass_aggregation?
 
-        aggregation = event_store.sum
+        sum_result = event_store.sum
 
         if options[:is_pay_in_advance] && options[:is_current_usage]
-          handle_in_advance_current_usage(aggregation)
+          handle_in_advance_current_usage(sum_result.value)
         else
-          result.aggregation = aggregation
+          result.aggregation = sum_result.value
         end
 
         result.pay_in_advance_aggregation = compute_pay_in_advance_aggregation
-        result.count = event_store.count
+        result.count = sum_result.events_count
 
         if presentation_by.present?
           result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by)

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -14,8 +14,11 @@ module BillableMetrics
         return empty_result if should_bypass_aggregation?
 
         result.aggregation = event_store.weighted_sum(initial_value:).ceil(20)
-        result.count = event_store.count
-        result.variation = event_store.sum || 0
+
+        sum_result = event_store.sum
+
+        result.count = sum_result.events_count
+        result.variation = sum_result.value || 0
         result.total_aggregated_units = result.variation
         result.options = {}
 
@@ -165,7 +168,7 @@ module BillableMetrics
 
         breakdowns = presentation_by.present? ? event_store.grouped_sum(uniq_grouped_by_and_presentation_by) : []
 
-        @latest_value_from_events = [BigDecimal(event_store.sum), breakdowns]
+        @latest_value_from_events = [BigDecimal(event_store.sum(with_count: false).value), breakdowns]
       end
 
       def grouped_latest_values

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -35,7 +35,7 @@ module BillableMetrics
         event_store.use_from_boundary = false
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
-        persisted_sum = event_store.sum
+        persisted_sum = event_store.sum(with_count: false).value
         return [] if persisted_sum.zero?
 
         [

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -160,7 +160,7 @@ module BillableMetrics
 
       def recurring_value(grouped_by_values: nil)
         store = persisted_event_store_instance
-        raw_sum = store.with_grouped_by_values(grouped_by_values) { store.sum }
+        raw_sum = store.with_grouped_by_values(grouped_by_values) { store.sum(with_count: false).value }
 
         return nil if raw_sum.nil? || raw_sum.zero?
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -3,6 +3,11 @@
 module Events
   module Stores
     class BaseStore
+      AggregationResult = Data.define(
+        :value,
+        :events_count
+      )
+
       def initialize(subscription:, boundaries:, code: nil, filters: {}, deduplicate: false)
         @code = code
         @subscription = subscription
@@ -76,7 +81,7 @@ module Events
         raise NotImplementedError
       end
 
-      def sum
+      def sum(with_count: true)
         raise NotImplementedError
       end
 
@@ -164,6 +169,13 @@ module Events
           to_datetime + 1.day,
           current_usage: subscription.terminated? && subscription.upgraded?
         ).charges_duration_in_days
+      end
+
+      def build_aggregation_result(row)
+        AggregationResult.new(
+          value: row["value"] || 0,
+          events_count: row["events_count"].presence&.to_i
+        )
       end
     end
   end

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -514,14 +514,16 @@ module Events
         end
       end
 
-      def sum
+      def sum(with_count: true)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
-            SELECT sum(events.decimal_value)
+            SELECT
+              sum(events.decimal_value) as value,
+              #{with_count ? "count()" : "null"} as events_count
             FROM events
           SQL
 
-          connection.select_value(sql) || 0
+          build_aggregation_result(connection.select_one(sql))
         end
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -479,14 +479,16 @@ module Events
         end
       end
 
-      def sum
+      def sum(with_count: true)
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
-            SELECT sum(events.decimal_value)
+            SELECT
+              sum(events.decimal_value) as value,
+              #{with_count ? "count()" : "null"} as events_count
             FROM events
           SQL
 
-          connection.select_value(sql) || 0
+          build_aggregation_result(connection.select_one(sql))
         end
       end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -229,8 +229,11 @@ module Events
         prepare_grouped_result(results)
       end
 
-      def sum
-        events.sum("(#{sanitized_property_name})::numeric")
+      def sum(with_count: true)
+        AggregationResult.new(
+          value: events.sum("(#{sanitized_property_name})::numeric"),
+          events_count: with_count ? events.count : nil
+        )
       end
 
       def grouped_sum(columns = grouped_by)

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1320,7 +1320,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       end
 
       it "returns the sum of event properties" do
-        expect(event_store.sum).to eq(15)
+        result = event_store.sum
+
+        expect(result.value).to eq(15)
+        expect(result.events_count).to eq(5)
       end
 
       if with_event_duplication
@@ -1332,8 +1335,20 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           end
 
           it "takes the event into account" do
-            expect(event_store.sum).to eq(115) # New event value added to the previous one
+            result = event_store.sum
+
+            expect(result.value).to eq(115) # New event value added to the previous one
+            expect(result.events_count).to eq(6)
           end
+        end
+      end
+
+      context "when with_count is set to false" do
+        it "does not include events_count in the result" do
+          result = event_store.sum(with_count: false)
+
+          expect(result.value).to eq(15)
+          expect(result.events_count).to be_nil
         end
       end
 
@@ -1348,14 +1363,20 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         end
 
         it "excludes events before from_datetime by default" do
-          expect(event_store.sum).to eq(15)
+          result = event_store.sum
+
+          expect(result.value).to eq(15)
+          expect(result.events_count).to eq(5)
         end
 
         context "when use_from_boundary is false" do
           before { event_store.use_from_boundary = false }
 
           it "includes events before from_datetime" do
-            expect(event_store.sum).to eq(115)
+            result = event_store.sum
+
+            expect(result.value).to eq(115)
+            expect(result.events_count).to eq(6)
           end
 
           context "when force_from is true" do
@@ -1363,7 +1384,11 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
               # Note: #sum doesn't use force_from directly, it goes through events_cte_queries
               # which respects use_from_boundary. This test verifies the boundary is applied.
               event_store.use_from_boundary = true
-              expect(event_store.sum).to eq(15)
+
+              result = event_store.sum
+
+              expect(result.value).to eq(15)
+              expect(result.events_count).to eq(5)
             end
           end
         end
@@ -1379,8 +1404,11 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         end
 
         it "excludes events after to_datetime" do
+          result = event_store.sum
+
           # Only events with values 1, 2, 3 are within the boundary
-          expect(event_store.sum).to eq(6)
+          expect(result.value).to eq(6)
+          expect(result.events_count).to eq(3)
         end
       end
 
@@ -1395,8 +1423,11 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         end
 
         it "uses max_timestamp instead of to_datetime" do
+          result = event_store.sum
+
           # Only events with values 1, 2, 3 are within the boundary
-          expect(event_store.sum).to eq(6)
+          expect(result.value).to eq(6)
+          expect(result.events_count).to eq(3)
         end
       end
     end
@@ -2523,8 +2554,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
     end
 
     it "includes events from before subscription.started_at" do
-      expect(event_store.count).to eq(7) # 5 from current period + 2 from before
-      expect(event_store.sum).to eq(165) # 15 from current period + 100 + 50 from before
+      result = event_store.sum
+
+      expect(result.events_count).to eq(7) # 5 from current period + 2 from before
+      expect(result.value).to eq(165) # 15 from current period + 100 + 50 from before
     end
 
     context "with charge filters" do
@@ -2555,8 +2588,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       end
 
       it "includes only filtered events from before subscription.started_at" do
-        expect(event_store.count).to eq(3) # 2 from current period + 1 from before
-        expect(event_store.sum).to eq(204) # 4 from current period + 200 from before (999 (asia/japan) doesn't match)
+        result = event_store.sum
+
+        expect(result.events_count).to eq(3) # 2 from current period + 1 from before
+        expect(result.value).to eq(204) # 4 from current period + 200 from before (999 (asia/japan) doesn't match)
       end
     end
   end


### PR DESCRIPTION
## Context

Today, all aggregation services (except CountService) perform two queries to retrieve data from the event store, a first one to get the actual aggregation and a second one to get the number of events involved in this result.

The current implementation is inherited from the initial Postgres store, and works well for this database engine. When the Clickhouse store, the same approach was used to keep the compatibility between the different implementation. At scale, this implementation is not ideal on the clickhouse side as it force the engine to retrieve twice the same set of records before performing the computation.

## Description

This PR introduce a new `AggregationResult` data structure, returned from the `sum` aggregation. This structure returns both the `value` for the aggregation and `events_count` for the number of event.
Clickhouse will query them in a single pass, while Postgres will keep performing two queries.

The same approach will be added in next step on all other aggregations