### PR TITLE
misc(mailers): Auto retry on Net::OpenTimeout

### DIFF
--- a/app/jobs/send_email_job.rb
+++ b/app/jobs/send_email_job.rb
@@ -36,6 +36,7 @@ class SendEmailJob < ActionMailer::MailDeliveryJob
   retry_on ActiveJob::DeserializationError, wait: :polynomially_longer, attempts: 6
   retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 6
   retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 6
+  retry_on Net::OpenTimeout, wait: :polynomially_longer, attempts: 6
   retry_on Net::SMTPServerBusy, wait: :polynomially_longer, attempts: 25
   retry_on PaymentReceipts::FilesNotReadyError, wait: :polynomially_longer, attempts: 8
 

--- a/spec/jobs/send_email_job_spec.rb
+++ b/spec/jobs/send_email_job_spec.rb
@@ -104,5 +104,32 @@ RSpec.describe SendEmailJob do
       end
     end
   end
+
+  context "with retryable errors" do
+    [
+      [ActiveJob::DeserializationError.allocate, 6],
+      [LagoHttpClient::HttpError.new(500, "error", "https://example.com"), 6],
+      [Net::ReadTimeout, 6],
+      [Net::OpenTimeout, 6],
+      [Net::SMTPServerBusy.new("busy"), 25],
+      [PaymentReceipts::FilesNotReadyError, 8]
+    ].each do |error, attempts|
+      error_class = error.is_a?(Class) ? error : error.class
+
+      context "when a #{error_class.name} error is raised" do
+        before do
+          allow_any_instance_of(ActionMailer::Parameterized::Mailer).to receive(:public_send).and_raise(error) # rubocop:disable RSpec/AnyInstance
+        end
+
+        it "raises a #{error_class.name} error and retries" do
+          assert_performed_jobs(attempts, only: [described_class]) do
+            expect do
+              described_class.perform_later("InvoiceMailer", "created", "deliver_now", args: [], params:)
+            end.to raise_error(error_class)
+          end
+        end
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/AnyInstance


### PR DESCRIPTION
## Description
This PR adds auto retry handling to the `SendEmailJob` in case of `Net::OpenTimeout`.
The test coverage on all retryable error is also improved