### PR TITLE
fix(wallet-transactions): surface nested failures on create from params

### DIFF
--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -73,8 +73,8 @@ module WalletTransactions
 
       result.wallet_transactions = transactions
       result
-    rescue BaseService::FailedResult
-      result
+    rescue BaseService::FailedResult => e
+      result.fail_with_error!(e)
     rescue ActiveRecord::StaleObjectError
       if @update_attempts <= MAX_WALLET_UPDATE_ATTEMPTS
         sleep(rand(0.1..0.5))

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -110,6 +110,21 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
       end
     end
 
+    context "when voiding credits on a traceable wallet without trackable inbound balance" do
+      let(:params) { {wallet_id: wallet.id, voided_credits: "3.00"} }
+
+      it "returns a failed result with the underlying validation error" do
+        expect(result).to be_failure
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq(amount_cents: ["exceeds_available_amount"])
+        expect(result.wallet_transactions).to be_nil
+      end
+
+      it "does not create any wallet transaction" do
+        expect { result }.not_to change(WalletTransaction, :count)
+      end
+    end
+
     context "with metadata parameter" do
       let(:metadata) { [{"key" => "valid_value", "value" => "also_valid"}] }
       let(:params) do


### PR DESCRIPTION
Closes ING-321

## Context

`POST /api/v1/wallet_transactions` with only `voided_credits` set returned a **500** (`NoMethodError: undefined method 'map' for nil`) instead of a proper validation error. The real error (`amount_cents: ["exceeds_available_amount"]`) was silently lost.

## Description

Copy the raised error onto the outer result so the failure propagates and the controller renders a proper 422:

```ruby
rescue BaseService::FailedResult => e
  result.fail_with_error!(e)
```