### PR TITLE
fix(plans): Avoid duplicate plan.updated event from UI

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -24,12 +24,15 @@ module Mutations
 
         plan = result.plan
 
+        # NOTE: send_webhook is false so we don't emit a spurious plan.updated event on top of
+        #       the plan.created already emitted by Plans::CreateService above.
         unless entitlements.nil?
           result = ::Entitlement::PlanEntitlementsUpdateService.call(
             organization: plan.organization,
             plan:,
             entitlements_params: Utils::Entitlement.convert_gql_input_to_params(entitlements),
-            partial: false
+            partial: false,
+            send_webhook: false
           )
         end
 

--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -23,12 +23,15 @@ module Mutations
 
         return result_error(result) unless result.success?
 
+        # NOTE: send_webhook is false so we don't duplicate the plan.updated event
+        #       already emitted by Plans::UpdateService above.
         unless entitlements.nil?
           result = ::Entitlement::PlanEntitlementsUpdateService.call(
             organization: plan.organization,
             plan:,
             entitlements_params: Utils::Entitlement.convert_gql_input_to_params(entitlements),
-            partial: false
+            partial: false,
+            send_webhook: false
           )
         end
 

--- a/app/services/entitlement/plan_entitlements_update_service.rb
+++ b/app/services/entitlement/plan_entitlements_update_service.rb
@@ -6,17 +6,22 @@ module Entitlement
 
     Result = BaseResult[:entitlements]
 
-    def initialize(organization:, plan:, entitlements_params:, partial:)
+    def initialize(organization:, plan:, entitlements_params:, partial:, send_webhook: true)
       @organization = organization
       @plan = plan
       @entitlements_params = entitlements_params.to_h.with_indifferent_access
       @partial = partial
+      @send_webhook = send_webhook
       super
     end
 
+    # NOTE: send_webhook gates the activity log too: both represent the same plan.updated event.
+    #       It is set to false when invoked from the plan create/update mutations, where the plan
+    #       service already emits the plan event, to avoid duplicates.
     activity_loggable(
       action: "plan.updated",
-      record: -> { plan }
+      record: -> { plan },
+      condition: -> { send_webhook }
     )
 
     def call
@@ -27,8 +32,8 @@ module Entitlement
         update_entitlements
       end
 
-      # NOTE: The webhooks is sent even if no changes were made to the plan
-      SendWebhookJob.perform_after_commit("plan.updated", plan)
+      # NOTE: The webhook is sent even if no changes were made to the plan
+      SendWebhookJob.perform_after_commit("plan.updated", plan) if send_webhook
 
       result.entitlements = plan.entitlements.includes(:feature, values: :privilege).reload
       result
@@ -53,7 +58,7 @@ module Entitlement
 
     private
 
-    attr_reader :organization, :plan, :entitlements_params, :partial
+    attr_reader :organization, :plan, :entitlements_params, :partial, :send_webhook
     alias_method :partial?, :partial
 
     def delete_missing_entitlements

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -551,8 +551,37 @@ RSpec.describe Mutations::Plans::Create, :premium do
         organization: organization,
         plan: Plan.last,
         entitlements_params: {},
-        partial: false
+        partial: false,
+        send_webhook: false
       )
+    end
+  end
+
+  context "with the plan webhooks" do
+    it "emits plan.created but not plan.updated" do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            name: "Plan with entitlements",
+            code: "plan_with_entitlements",
+            interval: "monthly",
+            payInAdvance: false,
+            amountCents: 100,
+            amountCurrency: "USD",
+            charges: [],
+            entitlements: [
+              {featureCode: feature.code, privileges: [{privilegeCode: privilege.code, value: "22"}]}
+            ]
+          }
+        }
+      )
+
+      expect(SendWebhookJob).to have_been_enqueued.with("plan.created", Plan.last).once
+      expect(SendWebhookJob).not_to have_been_enqueued.with("plan.updated", anything)
     end
   end
 

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -482,8 +482,58 @@ RSpec.describe Mutations::Plans::Update do
         organization: organization,
         plan:,
         entitlements_params: {},
-        partial: false
+        partial: false,
+        send_webhook: false
       )
+    end
+  end
+
+  context "with the plan.updated webhook" do
+    let(:base_input) do
+      {
+        id: plan.id,
+        name: "Updated plan",
+        code: "updated_plan",
+        interval: "monthly",
+        payInAdvance: false,
+        amountCents: 200,
+        amountCurrency: "EUR",
+        charges: []
+      }
+    end
+
+    context "when entitlements are not provided" do
+      it "enqueues a single plan.updated webhook" do
+        execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {input: base_input}
+        )
+
+        expect(SendWebhookJob).to have_been_enqueued.with("plan.updated", plan).once
+      end
+    end
+
+    context "when entitlements are provided", :premium do
+      it "enqueues a single plan.updated webhook" do
+        execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {
+            input: base_input.merge(
+              entitlements: [
+                {featureCode: feature.code, privileges: [{privilegeCode: privilege.code, value: "22"}]}
+              ]
+            )
+          }
+        )
+
+        expect(SendWebhookJob).to have_been_enqueued.with("plan.updated", plan).once
+      end
     end
   end
 

--- a/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
@@ -49,6 +49,19 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService do
       expect(Utils::ActivityLog).to have_produced("plan.updated").after_commit.with(plan)
     end
 
+    context "when send_webhook is false" do
+      subject(:result) { described_class.call(organization:, plan:, entitlements_params:, partial: false, send_webhook: false) }
+
+      it "does not send the `plan.updated` webhook" do
+        expect { subject }.not_to have_enqueued_job(SendWebhookJob).with("plan.updated", plan)
+      end
+
+      it "does not produce an activity log" do
+        subject
+        expect(Utils::ActivityLog).not_to have_received(:produce)
+      end
+    end
+
     it "creates the entitlement with correct values" do
       result
       entitlement = plan.entitlements.first


### PR DESCRIPTION
## Context

The UI always submits **entitlements** as a non-null array in the `UpdatePlan` mutation, even when nothing entitlement-related changed. This caused both `Plans::UpdateService` and `Entitlement::PlanEntitlementsUpdateService` to emit a `plan.updated` webhook — and produce a `plan.updated` activity log — on every UI save: one with pre-save state and one with post-save state, with no way for consumers to tell which is authoritative.

On **create**, the entitlements service likewise emitted a spurious `plan.updated` on top of the `plan.created` event.

We don't have these issues on the API, because a plan and its entitlements cannot be updated in the same request.

## Description

Add a `send_webhook` option to `Entitlement::PlanEntitlementsUpdateService` (defaulting to `true`, so the standalone REST entitlement endpoints keep emitting their `plan.updated`). The flag gates **both** the webhook and the `plan.updated` activity log, since they represent the same event.

The `CreatePlan` and `UpdatePlan` mutations now call the entitlements service with `send_webhook: false`, so the plan event is emitted exactly once by the plan create/update service, while entitlements are still persisted (including clearing them when an empty array is sent).