### PR TITLE
[ING-326] misc(clickhouse): Returns max and count in 1 query

### DIFF
--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -13,8 +13,10 @@ module BillableMetrics
       def compute_aggregation(options: {})
         return empty_result if should_bypass_aggregation?
 
-        result.aggregation = event_store.max || 0
-        result.count = event_store.count
+        max_result = event_store.max
+
+        result.aggregation = max_result.value
+        result.count = max_result.events_count
 
         if presentation_by.present?
           result.breakdowns = event_store.grouped_max(uniq_grouped_by_and_presentation_by)
@@ -57,7 +59,7 @@ module BillableMetrics
 
       # Note: include_event_value is ignored as the model does not support in advance billing
       def compute_per_event_aggregation(exclude_event:, include_event_value:)
-        max_value = event_store.max || 0
+        max_value = event_store.max(with_count: false).value
         event_values = event_store.events_values
         max_value_seen = false
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -65,7 +65,7 @@ module Events
         raise NotImplementedError
       end
 
-      def max
+      def max(with_count: true)
         raise NotImplementedError
       end
 

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -427,14 +427,16 @@ module Events
         end
       end
 
-      def max
+      def max(with_count: true)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
-            SELECT max(events.decimal_value)
+            SELECT
+              max(events.decimal_value) as value,
+              #{with_count ? "count()" : "null"} as events_count
             FROM events
           SQL
 
-          connection.select_value(sql)
+          build_aggregation_result(connection.select_one(sql))
         end
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -374,14 +374,16 @@ module Events
         end
       end
 
-      def max
+      def max(with_count: true)
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
-            SELECT max(events.decimal_value)
+            SELECT
+              max(events.decimal_value) as value,
+              #{with_count ? "count()" : "null"} as events_count
             FROM events
           SQL
 
-          connection.select_value(sql)
+          build_aggregation_result(connection.select_one(sql))
         end
       end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -183,8 +183,11 @@ module Events
         prepare_grouped_result(select_all(sql).rows)
       end
 
-      def max
-        events.maximum("(#{sanitized_property_name})::numeric")
+      def max(with_count: true)
+        AggregationResult.new(
+          value: events.maximum("(#{sanitized_property_name})::numeric") || 0,
+          events_count: with_count ? events.count : nil
+        )
       end
 
       def grouped_max(columns = grouped_by)

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1072,7 +1072,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       end
 
       it "returns the max value" do
-        expect(event_store.max).to eq(5)
+        result = event_store.max
+
+        expect(result.value).to eq(5)
+        expect(result.events_count).to eq(5)
       end
 
       context "with grouped_by_values" do
@@ -1080,14 +1083,20 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         let(:events_grouped_by) { ["region"] }
 
         it "returns the max value" do
-          expect(event_store.max).to eq(5)
+          result = event_store.max
+
+          expect(result.value).to eq(5)
+          expect(result.events_count).to eq(3)
         end
 
         context "when grouped_by_values value is nil" do
           let(:grouped_by_values) { {"region" => nil} }
 
           it "returns the max value" do
-            expect(event_store.max).to eq(4)
+            result = event_store.max
+
+            expect(result.value).to eq(4)
+            expect(result.events_count).to eq(2)
           end
         end
       end
@@ -1101,6 +1110,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         before { create_events_for_filters }
 
         it "returns the max value filtered" do
+          result = event_store.max
+
           # We include:
           # - europe, france, <nil> -> 3
           # - europe, france, paris -> 1
@@ -1119,7 +1130,17 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           # - europe, france, cambridge -> -2
           # - europe, united kingdom, manchester -> -1
           # Max value is 3
-          expect(event_store.max).to eq(3)
+          expect(result.value).to eq(3)
+          expect(result.events_count).to eq(4)
+        end
+      end
+
+      context "when with_count is set to false" do
+        it "does not include events_count in the result" do
+          result = event_store.max(with_count: false)
+
+          expect(result.value).to eq(5)
+          expect(result.events_count).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5716

Today, all aggregation services (except CountService) perform two queries to retrieve data from the event store, a first one to get the actual aggregation and a second one to get the number of events involved in this result.

The current implementation is inherited from the initial Postgres store, and works well for this database engine. When the Clickhouse store, the same approach was used to keep the compatibility between the different implementation. At scale, this implementation is not ideal on the clickhouse side as it force the engine to retrieve twice the same set of records before performing the computation.

## Description

This PR introduce a new `AggregationResult` data structure, returned from the `max` aggregation. This structure returns both the `value` for the aggregation and `events_count` for the number of event.
Clickhouse will query them in a single pass, while Postgres will keep performing two queries.

The same approach will be added in next step on all other remaining aggregations