### PR TITLE
feat(orders): GraphQL read resolvers

### DIFF
--- a/app/graphql/resolvers/order_resolver.rb
+++ b/app/graphql/resolvers/order_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class OrderResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "orders:view"
+
+    description "Query a single order"
+
+    argument :id, ID, required: true, description: "Uniq ID of the order"
+
+    type Types::Orders::Object, null: true
+
+    def resolve(id:)
+      current_organization.orders.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: "order")
+    end
+  end
+end

--- a/app/graphql/resolvers/orders_resolver.rb
+++ b/app/graphql/resolvers/orders_resolver.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class OrdersResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "orders:view"
+
+    description "Query orders"
+
+    argument :customer_id, [ID], required: false
+    argument :executed_at_from, GraphQL::Types::ISO8601DateTime, required: false
+    argument :executed_at_to, GraphQL::Types::ISO8601DateTime, required: false
+    argument :execution_mode, [Types::Orders::ExecutionModeEnum], required: false
+    argument :limit, Integer, required: false
+    argument :number, [String], required: false
+    argument :order_form_number, [String], required: false
+    argument :order_type, [Types::Quotes::OrderTypeEnum], required: false
+    argument :owner_id, [ID], required: false
+    argument :page, Integer, required: false
+    argument :quote_number, [String], required: false
+    argument :search_term, String, required: false
+    argument :status, [Types::Orders::StatusEnum], required: false
+
+    type Types::Orders::Object.collection_type, null: false
+
+    def resolve( # rubocop:disable Metrics/ParameterLists
+      customer_id: nil,
+      executed_at_from: nil,
+      executed_at_to: nil,
+      execution_mode: nil,
+      limit: nil,
+      number: nil,
+      order_form_number: nil,
+      order_type: nil,
+      owner_id: nil,
+      page: nil,
+      quote_number: nil,
+      search_term: nil,
+      status: nil
+    )
+      result = OrdersQuery.call(
+        organization: current_organization,
+        pagination: {page:, limit:},
+        filters: {
+          status:,
+          order_type:,
+          execution_mode:,
+          customer_id:,
+          number:,
+          order_form_number:,
+          quote_number:,
+          owner_id:,
+          executed_at_from:,
+          executed_at_to:
+        },
+        search_term:
+      )
+
+      result.orders
+    end
+  end
+end

--- a/app/graphql/types/order_forms/object.rb
+++ b/app/graphql/types/order_forms/object.rb
@@ -18,12 +18,14 @@ module Types
       field :signed_document_url, String, null: true
 
       field :customer, Types::Customers::Object, null: false
+      field :organization, Types::Organizations::OrganizationType, null: false
       field :quote, Types::Quotes::Object, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       dataload_association :customer
+      dataload_association :organization
       dataload_association :quote
     end
   end

--- a/app/graphql/types/order_forms/status_enum.rb
+++ b/app/graphql/types/order_forms/status_enum.rb
@@ -5,7 +5,7 @@ module Types
     class StatusEnum < Types::BaseEnum
       graphql_name "OrderFormStatusEnum"
 
-      OrderForm::STATUSES.keys.each do |type|
+      OrderForm::STATUSES.each_key do |type|
         value type
       end
     end

--- a/app/graphql/types/order_forms/void_reason_enum.rb
+++ b/app/graphql/types/order_forms/void_reason_enum.rb
@@ -5,7 +5,7 @@ module Types
     class VoidReasonEnum < Types::BaseEnum
       graphql_name "OrderFormVoidReasonEnum"
 
-      OrderForm::VOID_REASONS.keys.each do |type|
+      OrderForm::VOID_REASONS.each_key do |type|
         value type
       end
     end

--- a/app/graphql/types/orders/execution_mode_enum.rb
+++ b/app/graphql/types/orders/execution_mode_enum.rb
@@ -5,7 +5,7 @@ module Types
     class ExecutionModeEnum < Types::BaseEnum
       graphql_name "OrderExecutionModeEnum"
 
-      Order::EXECUTION_MODES.keys.each do |type|
+      Order::EXECUTION_MODES.each_key do |type|
         value type
       end
     end

--- a/app/graphql/types/orders/execution_mode_enum.rb
+++ b/app/graphql/types/orders/execution_mode_enum.rb
@@ -5,8 +5,8 @@ module Types
     class ExecutionModeEnum < Types::BaseEnum
       graphql_name "OrderExecutionModeEnum"
 
-      ::OrderForms::MarkAsSignedService::EXECUTION_MODES.each do |mode|
-        value mode
+      Order::EXECUTION_MODES.keys.each do |type|
+        value type
       end
     end
   end

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class Object < Types::BaseObject
+      graphql_name "Order"
+
+      field :execution_mode, Types::Orders::ExecutionModeEnum, null: true
+      field :id, ID, null: false
+      field :number, String, null: false
+      field :order_type, Quotes::OrderTypeEnum, null: false
+      field :status, Types::Orders::StatusEnum, null: false
+
+      field :billing_snapshot, GraphQL::Types::JSON, null: false
+      field :currency, String, null: true
+      field :executed_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :execution_record, GraphQL::Types::JSON, null: true
+
+      field :customer, Types::Customers::Object, null: false
+      field :order_form, Types::OrderForms::Object, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -14,7 +14,6 @@ module Types
       field :billing_snapshot, GraphQL::Types::JSON, null: false
       field :currency, String, null: true
       field :executed_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :execution_record, GraphQL::Types::JSON, null: true
 
       field :customer, Types::Customers::Object, null: false
       field :order_form, Types::OrderForms::Object, null: false

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -17,6 +17,7 @@ module Types
 
       field :customer, Types::Customers::Object, null: false
       field :order_form, Types::OrderForms::Object, null: false
+      field :organization, Types::Organizations::OrganizationType, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -21,6 +21,10 @@ module Types
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      dataload_association :customer
+      dataload_association :order_form
+      dataload_association :organization
     end
   end
 end

--- a/app/graphql/types/orders/status_enum.rb
+++ b/app/graphql/types/orders/status_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class StatusEnum < Types::BaseEnum
+      graphql_name "OrderStatusEnum"
+
+      Order::STATUSES.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/orders/status_enum.rb
+++ b/app/graphql/types/orders/status_enum.rb
@@ -5,7 +5,7 @@ module Types
     class StatusEnum < Types::BaseEnum
       graphql_name "OrderStatusEnum"
 
-      Order::STATUSES.keys.each do |type|
+      Order::STATUSES.each_key do |type|
         value type
       end
     end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -75,8 +75,10 @@ module Types
     field :invoices, resolver: Resolvers::InvoicesResolver
     field :memberships, resolver: Resolvers::MembershipsResolver
     field :mrrs, resolver: Resolvers::Analytics::MrrsResolver
+    field :order, resolver: Resolvers::OrderResolver
     field :order_form, resolver: Resolvers::OrderFormResolver
     field :order_forms, resolver: Resolvers::OrderFormsResolver
+    field :orders, resolver: Resolvers::OrdersResolver
     field :organization, resolver: Resolvers::OrganizationResolver
     field :overdue_balances, resolver: Resolvers::Analytics::OverdueBalancesResolver
     field :password_reset, resolver: Resolvers::PasswordResetResolver

--- a/app/graphql/types/quote_versions/status_enum.rb
+++ b/app/graphql/types/quote_versions/status_enum.rb
@@ -3,7 +3,7 @@
 module Types
   module QuoteVersions
     class StatusEnum < Types::BaseEnum
-      QuoteVersion::STATUSES.keys.each do |status|
+      QuoteVersion::STATUSES.each_key do |status|
         value status
       end
     end

--- a/app/graphql/types/quote_versions/void_reason_enum.rb
+++ b/app/graphql/types/quote_versions/void_reason_enum.rb
@@ -3,7 +3,7 @@
 module Types
   module QuoteVersions
     class VoidReasonEnum < Types::BaseEnum
-      QuoteVersion::VOID_REASONS.keys.each do |reason|
+      QuoteVersion::VOID_REASONS.each_key do |reason|
         value reason
       end
     end

--- a/app/graphql/types/quotes/order_type_enum.rb
+++ b/app/graphql/types/quotes/order_type_enum.rb
@@ -3,7 +3,7 @@
 module Types
   module Quotes
     class OrderTypeEnum < Types::BaseEnum
-      Quote::ORDER_TYPES.keys.each do |type|
+      Quote::ORDER_TYPES.each_key do |type|
         value type
       end
     end

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -77,7 +77,7 @@ module OrderForms
         return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
       end
 
-      return if Order::EXECUTION_MODES.values.include?(execution_mode)
+      return if Order::EXECUTION_MODES.value?(execution_mode)
 
       result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
     end

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -6,8 +6,6 @@ module OrderForms
 
     Result = BaseResult[:order_form, :order]
 
-    EXECUTION_MODES = %w[execute_in_lago order_only].freeze
-
     def initialize(order_form:, signed_document: nil, execution_mode: nil, execute_at: nil)
       @order_form = order_form
       @signed_document = signed_document
@@ -79,7 +77,7 @@ module OrderForms
         return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
       end
 
-      return if EXECUTION_MODES.include?(execution_mode)
+      return if Order::EXECUTION_MODES.values.include?(execution_mode)
 
       result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
     end

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -150,6 +150,10 @@ order_forms:
     - manager
   void:
     - manager
+orders:
+  view:
+    - finance
+    - manager
 organization:
   view:
     - finance

--- a/schema.graphql
+++ b/schema.graphql
@@ -9110,6 +9110,7 @@ type Order {
   number: String!
   orderForm: OrderForm!
   orderType: OrderTypeEnum!
+  organization: Organization!
   status: OrderStatusEnum!
   updatedAt: ISO8601DateTime!
 }
@@ -9146,6 +9147,7 @@ type OrderForm {
   expiresAt: ISO8601DateTime
   id: ID!
   number: String!
+  organization: Organization!
   quote: Quote!
   signedAt: ISO8601DateTime
   signedDocumentUrl: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -9106,7 +9106,6 @@ type Order {
   customer: Customer!
   executedAt: ISO8601DateTime
   executionMode: OrderExecutionModeEnum
-  executionRecord: JSON
   id: ID!
   number: String!
   orderForm: OrderForm!
@@ -9478,6 +9477,7 @@ enum PermissionEnum {
   order_forms_sign
   order_forms_view
   order_forms_void
+  orders_view
   organization_emails_update
   organization_emails_view
   organization_integrations_create
@@ -9594,6 +9594,7 @@ type Permissions {
   orderFormsSign: Boolean!
   orderFormsView: Boolean!
   orderFormsVoid: Boolean!
+  ordersView: Boolean!
   organizationEmailsUpdate: Boolean!
   organizationEmailsView: Boolean!
   organizationIntegrationsCreate: Boolean!

--- a/schema.graphql
+++ b/schema.graphql
@@ -9099,9 +9099,40 @@ enum OnTerminationInvoiceEnum {
   skip
 }
 
+type Order {
+  billingSnapshot: JSON!
+  createdAt: ISO8601DateTime!
+  currency: String
+  customer: Customer!
+  executedAt: ISO8601DateTime
+  executionMode: OrderExecutionModeEnum
+  executionRecord: JSON
+  id: ID!
+  number: String!
+  orderForm: OrderForm!
+  orderType: OrderTypeEnum!
+  status: OrderStatusEnum!
+  updatedAt: ISO8601DateTime!
+}
+
 enum OrderByEnum {
   gross_revenue_amount_cents
   net_revenue_amount_cents
+}
+
+"""
+OrderCollection type
+"""
+type OrderCollection {
+  """
+  A collection of paginated OrderCollection
+  """
+  collection: [Order!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
 }
 
 enum OrderExecutionModeEnum {
@@ -9151,6 +9182,11 @@ enum OrderFormVoidReasonEnum {
   expired
   invalid
   manual
+}
+
+enum OrderStatusEnum {
+  created
+  executed
 }
 
 enum OrderTypeEnum {
@@ -10550,6 +10586,16 @@ type Query {
   mrrs(billingEntityId: ID, currency: CurrencyEnum): MrrCollection!
 
   """
+  Query a single order
+  """
+  order(
+    """
+    Uniq ID of the order
+    """
+    id: ID!
+  ): Order
+
+  """
   Query a single order form
   """
   orderForm(
@@ -10563,6 +10609,11 @@ type Query {
   Query order forms
   """
   orderForms(createdAtFrom: ISO8601DateTime, createdAtTo: ISO8601DateTime, customerId: [ID!], expiresAtFrom: ISO8601DateTime, expiresAtTo: ISO8601DateTime, limit: Int, number: [String!], ownerId: [ID!], page: Int, quoteNumber: [String!], searchTerm: String, status: [OrderFormStatusEnum!]): OrderFormCollection!
+
+  """
+  Query orders
+  """
+  orders(customerId: [ID!], executedAtFrom: ISO8601DateTime, executedAtTo: ISO8601DateTime, executionMode: [OrderExecutionModeEnum!], limit: Int, number: [String!], orderFormNumber: [String!], orderType: [OrderTypeEnum!], ownerId: [ID!], page: Int, quoteNumber: [String!], searchTerm: String, status: [OrderStatusEnum!]): OrderCollection!
 
   """
   Query the current organization

--- a/schema.json
+++ b/schema.json
@@ -43774,6 +43774,22 @@
               "deprecationReason": null
             },
             {
+              "name": "organization",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Organization",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "status",
               "description": null,
               "args": [],
@@ -43999,6 +44015,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "organization",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Organization",
                   "ofType": null
                 }
               },

--- a/schema.json
+++ b/schema.json
@@ -43621,6 +43621,209 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Order",
+          "description": null,
+          "fields": [
+            {
+              "name": "billingSnapshot",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Customer",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executionMode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderExecutionModeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executionRecord",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "number",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderForm",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderForm",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrderTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrderStatusEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "OrderByEnum",
           "description": null,
@@ -43641,6 +43844,57 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OrderCollection",
+          "description": "OrderCollection type",
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated OrderCollection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Order",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -43973,6 +44227,29 @@
             },
             {
               "name": "invalid",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderStatusEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executed",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -56713,6 +56990,35 @@
               "deprecationReason": null
             },
             {
+              "name": "order",
+              "description": "Query a single order",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the order",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "orderForm",
               "description": "Query a single order form",
               "args": [
@@ -56936,6 +57242,243 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "OrderFormCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders",
+              "description": "Query orders",
+              "args": [
+                {
+                  "name": "customerId",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "executedAtFrom",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "executedAtTo",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "executionMode",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "OrderExecutionModeEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "number",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderFormNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderType",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "OrderTypeEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "ownerId",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "quoteNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "OrderStatusEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderCollection",
                   "ofType": null
                 }
               },

--- a/schema.json
+++ b/schema.json
@@ -43710,18 +43710,6 @@
               "deprecationReason": null
             },
             {
-              "name": "executionRecord",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "JSON",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id",
               "description": null,
               "args": [],
@@ -46324,6 +46312,12 @@
               "deprecationReason": null
             },
             {
+              "name": "orders_view",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -47551,6 +47545,22 @@
             },
             {
               "name": "orderFormsVoid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ordersView",
               "description": null,
               "args": [],
               "type": {

--- a/spec/graphql/resolvers/order_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_resolver_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::OrderResolver do
+  let(:required_permission) { "orders:view" }
+
+  let(:query) do
+    <<~GQL
+      query($id: ID!) {
+        order(id: $id) {
+          id
+          number
+          status
+          orderType
+          executionRecord
+          createdAt
+          updatedAt
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let(:order) { create(:order, organization:, customer:, order_form:) }
+
+  before { order }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "orders:view"
+
+  it "returns a single order" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables: {id: order.id}
+    )
+
+    data = result["data"]["order"]
+
+    expect(data["id"]).to eq(order.id)
+    expect(data["number"]).to eq(order.number)
+    expect(data["status"]).to eq("created")
+    expect(data["orderType"]).to eq("subscription_creation")
+  end
+
+  context "when order is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {id: SecureRandom.uuid}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/resolvers/order_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_resolver_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Resolvers::OrderResolver do
           number
           status
           orderType
-          executionRecord
           createdAt
           updatedAt
         }

--- a/spec/graphql/resolvers/orders_resolver_spec.rb
+++ b/spec/graphql/resolvers/orders_resolver_spec.rb
@@ -1,0 +1,324 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::OrdersResolver do
+  let(:required_permission) { "orders:view" }
+  let(:query) {}
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let(:order_form_two) { create(:order_form, :signed, organization:, customer:, quote:) }
+  let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, order_type: :one_off) }
+
+  before { create(:order, organization:, customer:, order_form:) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "orders:view"
+
+  context "when listing all orders" do
+    let(:query) do
+      <<~GQL
+        query {
+          orders(limit: 5) {
+            collection {
+              id
+              number
+              status
+              orderType
+            }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns a list of orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by order type" do
+    let(:query) do
+      <<~GQL
+        query($orderType: [OrderTypeEnum!]) {
+          orders(orderType: $orderType, limit: 5) {
+            collection { id orderType }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {orderType: ["one_off"]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+
+  context "when filtering by status" do
+    let(:query) do
+      <<~GQL
+        query($status: [OrderStatusEnum!]) {
+          orders(status: $status, limit: 5) {
+            collection { id status }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {status: ["created"]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by execution_mode" do
+    let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, execution_mode: :order_only) }
+
+    let(:query) do
+      <<~GQL
+        query($executionMode: [OrderExecutionModeEnum!]) {
+          orders(executionMode: $executionMode, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {executionMode: ["order_only"]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+
+  context "when filtering by number" do
+    let(:query) do
+      <<~GQL
+        query($number: [String!]) {
+          orders(number: $number, limit: 5) {
+            collection { id number }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {number: [order_two.number]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+
+  context "when filtering by customer_id" do
+    let(:other_customer) { create(:customer, organization:) }
+    let(:other_quote) { create(:quote, organization:, customer: other_customer) }
+    let(:other_order_form) { create(:order_form, :signed, organization:, customer: other_customer, quote: other_quote) }
+
+    let(:query) do
+      <<~GQL
+        query($customerId: [ID!]) {
+          orders(customerId: $customerId, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before { create(:order, organization:, customer: other_customer, order_form: other_order_form) }
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customerId: [customer.id]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by order_form_number" do
+    let(:query) do
+      <<~GQL
+        query($orderFormNumber: [String!]) {
+          orders(orderFormNumber: $orderFormNumber, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {orderFormNumber: [order_form_two.number]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+
+  context "when filtering by quote_number" do
+    let(:other_customer) { create(:customer, organization:) }
+    let(:other_quote) { create(:quote, organization:, customer: other_customer) }
+    let(:other_order_form) { create(:order_form, :signed, organization:, customer: other_customer, quote: other_quote) }
+
+    let(:query) do
+      <<~GQL
+        query($quoteNumber: [String!]) {
+          orders(quoteNumber: $quoteNumber, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before { create(:order, organization:, customer: other_customer, order_form: other_order_form) }
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {quoteNumber: [quote.number]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by owner_id" do
+    let(:query) do
+      <<~GQL
+        query($ownerId: [ID!]) {
+          orders(ownerId: $ownerId, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    before { QuoteOwner.create!(organization:, quote:, user: membership.user) }
+
+    it "returns only matching orders" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {ownerId: [membership.user.id]}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(2)
+      expect(response["metadata"]["totalCount"]).to eq(2)
+    end
+  end
+
+  context "when filtering by executed_at range" do
+    let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, executed_at: 1.day.ago) }
+
+    let(:query) do
+      <<~GQL
+        query($executedAtFrom: ISO8601DateTime, $executedAtTo: ISO8601DateTime) {
+          orders(executedAtFrom: $executedAtFrom, executedAtTo: $executedAtTo, limit: 5) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "returns only orders within the date range" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {executedAtFrom: 2.days.ago.iso8601, executedAtTo: 1.day.from_now.iso8601}
+      )
+
+      response = result["data"]["orders"]
+
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
+    end
+  end
+end

--- a/spec/graphql/resolvers/orders_resolver_spec.rb
+++ b/spec/graphql/resolvers/orders_resolver_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe Resolvers::OrdersResolver do
   let(:customer) { create(:customer, organization:) }
   let(:quote) { create(:quote, organization:, customer:) }
   let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
-  let(:order_form_two) { create(:order_form, :signed, organization:, customer:, quote:) }
-  let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two, order_type: :one_off) }
+  let(:quote_two) { create(:quote, organization:, customer:) }
+  let(:order_form_two) { create(:order_form, :signed, organization:, customer:, quote: quote_two) }
+  let!(:order_two) { create(:order, organization:, customer:, order_form: order_form_two) }
 
   before { create(:order, organization:, customer:, order_form:) }
 
@@ -53,6 +54,8 @@ RSpec.describe Resolvers::OrdersResolver do
   end
 
   context "when filtering by order type" do
+    let(:quote_two) { create(:quote, organization:, customer:, order_type: :one_off) }
+
     let(:query) do
       <<~GQL
         query($orderType: [OrderTypeEnum!]) {
@@ -229,10 +232,6 @@ RSpec.describe Resolvers::OrdersResolver do
   end
 
   context "when filtering by quote_number" do
-    let(:other_customer) { create(:customer, organization:) }
-    let(:other_quote) { create(:quote, organization:, customer: other_customer) }
-    let(:other_order_form) { create(:order_form, :signed, organization:, customer: other_customer, quote: other_quote) }
-
     let(:query) do
       <<~GQL
         query($quoteNumber: [String!]) {
@@ -244,21 +243,19 @@ RSpec.describe Resolvers::OrdersResolver do
       GQL
     end
 
-    before { create(:order, organization:, customer: other_customer, order_form: other_order_form) }
-
     it "returns only matching orders" do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
         permissions: required_permission,
         query:,
-        variables: {quoteNumber: [quote.number]}
+        variables: {quoteNumber: [quote_two.number]}
       )
 
       response = result["data"]["orders"]
 
-      expect(response["collection"].count).to eq(2)
-      expect(response["metadata"]["totalCount"]).to eq(2)
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
     end
   end
 
@@ -274,7 +271,7 @@ RSpec.describe Resolvers::OrdersResolver do
       GQL
     end
 
-    before { QuoteOwner.create!(organization:, quote:, user: membership.user) }
+    before { QuoteOwner.create!(organization:, quote: quote_two, user: membership.user) }
 
     it "returns only matching orders" do
       result = execute_graphql(
@@ -287,8 +284,8 @@ RSpec.describe Resolvers::OrdersResolver do
 
       response = result["data"]["orders"]
 
-      expect(response["collection"].count).to eq(2)
-      expect(response["metadata"]["totalCount"]).to eq(2)
+      expect(response["collection"].count).to eq(1)
+      expect(response["collection"].first["id"]).to eq(order_two.id)
     end
   end
 

--- a/spec/graphql/types/order_forms/object_spec.rb
+++ b/spec/graphql/types/order_forms/object_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Types::OrderForms::Object do
     expect(subject).to have_field(:voided_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:signed_document_url).of_type("String")
     expect(subject).to have_field(:customer).of_type("Customer!")
+    expect(subject).to have_field(:organization).of_type("Organization!")
     expect(subject).to have_field(:quote).of_type("Quote!")
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")

--- a/spec/graphql/types/orders/execution_mode_enum_spec.rb
+++ b/spec/graphql/types/orders/execution_mode_enum_spec.rb
@@ -4,6 +4,6 @@ require "rails_helper"
 
 RSpec.describe Types::Orders::ExecutionModeEnum do
   it "exposes all enum values" do
-    expect(described_class.values.keys).to match_array(OrderForms::MarkAsSignedService::EXECUTION_MODES)
+    expect(described_class.values.keys).to match_array(Order::EXECUTION_MODES.keys.map(&:to_s))
   end
 end

--- a/spec/graphql/types/orders/execution_mode_enum_spec.rb
+++ b/spec/graphql/types/orders/execution_mode_enum_spec.rb
@@ -4,6 +4,6 @@ require "rails_helper"
 
 RSpec.describe Types::Orders::ExecutionModeEnum do
   it "exposes all enum values" do
-    expect(described_class.values.keys).to match_array(Order::EXECUTION_MODES.keys.map(&:to_s))
+    expect(described_class.values.keys).to match_array(Order::EXECUTION_MODES.values)
   end
 end

--- a/spec/graphql/types/orders/object_spec.rb
+++ b/spec/graphql/types/orders/object_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Types::Orders::Object do
 
     expect(subject).to have_field(:customer).of_type("Customer!")
     expect(subject).to have_field(:order_form).of_type("OrderForm!")
+    expect(subject).to have_field(:organization).of_type("Organization!")
 
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")

--- a/spec/graphql/types/orders/object_spec.rb
+++ b/spec/graphql/types/orders/object_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Orders::Object do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:execution_mode).of_type("OrderExecutionModeEnum")
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:number).of_type("String!")
+    expect(subject).to have_field(:order_type).of_type("OrderTypeEnum!")
+    expect(subject).to have_field(:status).of_type("OrderStatusEnum!")
+
+    expect(subject).to have_field(:billing_snapshot).of_type("JSON!")
+    expect(subject).to have_field(:currency).of_type("String")
+    expect(subject).to have_field(:executed_at).of_type("ISO8601DateTime")
+
+    expect(subject).to have_field(:customer).of_type("Customer!")
+    expect(subject).to have_field(:order_form).of_type("OrderForm!")
+
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+  end
+end

--- a/spec/graphql/types/orders/status_enum_spec.rb
+++ b/spec/graphql/types/orders/status_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Orders::StatusEnum do
+  it "exposes all enum values" do
+    expect(described_class.values.keys).to match_array(Order::STATUSES.keys.map(&:to_s))
+  end
+end

--- a/spec/graphql/types/orders/status_enum_spec.rb
+++ b/spec/graphql/types/orders/status_enum_spec.rb
@@ -4,6 +4,6 @@ require "rails_helper"
 
 RSpec.describe Types::Orders::StatusEnum do
   it "exposes all enum values" do
-    expect(described_class.values.keys).to match_array(Order::STATUSES.keys.map(&:to_s))
+    expect(described_class.values.keys).to match_array(Order::STATUSES.values)
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉 Order Forms lifecycle

## Context

This is PR 4 of 4 in a stacked split. Stacked on the Order REST PR so the shared model, query, and factories are available.

Stack:
- OrderForm REST (#5360)
- OrderForm GraphQL (#5361)
- Order REST (#5720)
- **#this** — Order GraphQL (merges last)

## Description

Add Order read-only GraphQL API:

- `Types::Orders::Object` with customer, order_form, status/type, quote
- `Resolvers::OrderResolver` (single) and `Resolvers::OrdersResolver` (collection with filters)
- Register `order` and `orders` on `QueryType`