### PR TITLE
fix(events): count deduplicated events without JOIN to avoid ClickHouse OOM

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -217,13 +217,41 @@ module Events
 
       def count
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
-          sql = with_ctes(events_cte_queries(deduplicated_columns: %w[value]), <<-SQL)
+          connection.select_value(count_query).to_i
+        end
+      end
+
+      # Counting deduplicated events only needs the number of distinct dedup keys,
+      # not their latest enriched values. We therefore skip the `INNER ANY JOIN`
+      # performed by `events_cte_queries` (which materializes a column for every
+      # event and roughly doubles the memory of the dedup aggregation) and count
+      # the grouped keys directly. This avoids ClickHouse MEMORY_LIMIT_EXCEEDED on
+      # very large subscriptions.
+      #
+      # When the count is filtered (grouped_by_values or matching/ignored filters)
+      # we keep the JOIN-based path so the filter still applies to the latest
+      # enriched row per dedup key (identical semantics).
+      def count_query
+        filtered = grouped_by_values? || matching_filters.present? || ignored_filters.present?
+
+        if !deduplicate || filtered
+          return with_ctes(events_cte_queries(deduplicated_columns: %w[value]), <<-SQL)
             SELECT count()
             FROM events
           SQL
-
-          connection.select_value(sql).to_i
         end
+
+        events_from = (from_datetime if use_from_boundary)
+
+        <<~SQL.squish
+          SELECT count()
+          FROM (
+            SELECT 1
+            FROM events_enriched
+            WHERE #{deduplicated_events_where_sql(from_datetime: events_from, to_datetime: applicable_to_datetime)}
+            GROUP BY #{DEDUP_KEY_COLUMNS.join(", ")}
+          )
+        SQL
       end
 
       def grouped_count(columns = grouped_by)

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
     end
     let(:ts) { subscription.started_at.beginning_of_day + 1.day }
 
-    def insert(transaction_id:, timestamp:, enriched_at:, value: 1)
+    def insert_event(transaction_id:, timestamp:, enriched_at:, value: 1)
       Clickhouse::EventsEnriched.create!(
         transaction_id:,
         organization_id: organization.id,
@@ -277,10 +277,10 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
 
     it "collapses re-enrichment duplicates of the same dedup key into one" do
       txn = SecureRandom.uuid
-      insert(transaction_id: txn, timestamp: ts, enriched_at: 2.minutes.ago)
-      insert(transaction_id: txn, timestamp: ts, enriched_at: 1.minute.ago)
-      insert(transaction_id: txn, timestamp: ts, enriched_at: Time.current)
-      insert(transaction_id: SecureRandom.uuid, timestamp: ts + 1.day, enriched_at: Time.current)
+      insert_event(transaction_id: txn, timestamp: ts, enriched_at: 2.minutes.ago)
+      insert_event(transaction_id: txn, timestamp: ts, enriched_at: 1.minute.ago)
+      insert_event(transaction_id: txn, timestamp: ts, enriched_at: Time.current)
+      insert_event(transaction_id: SecureRandom.uuid, timestamp: ts + 1.day, enriched_at: Time.current)
 
       expect(event_store.count).to eq(2)
       expect(event_store.count).to eq(join_based_count)
@@ -288,16 +288,16 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
 
     it "treats the same transaction_id at different timestamps as distinct events" do
       txn = SecureRandom.uuid
-      insert(transaction_id: txn, timestamp: ts, enriched_at: Time.current)
-      insert(transaction_id: txn, timestamp: ts + 1.hour, enriched_at: Time.current)
+      insert_event(transaction_id: txn, timestamp: ts, enriched_at: Time.current)
+      insert_event(transaction_id: txn, timestamp: ts + 1.hour, enriched_at: Time.current)
 
       expect(event_store.count).to eq(2)
       expect(event_store.count).to eq(join_based_count)
     end
 
     it "excludes events outside the boundaries" do
-      insert(transaction_id: SecureRandom.uuid, timestamp: ts, enriched_at: Time.current)
-      insert(transaction_id: SecureRandom.uuid, timestamp: boundaries[:to_datetime] + 2.days, enriched_at: Time.current)
+      insert_event(transaction_id: SecureRandom.uuid, timestamp: ts, enriched_at: Time.current)
+      insert_event(transaction_id: SecureRandom.uuid, timestamp: boundaries[:to_datetime] + 2.days, enriched_at: Time.current)
 
       expect(event_store.count).to eq(1)
       expect(event_store.count).to eq(join_based_count)

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -138,4 +138,174 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       end
     end
   end
+
+  # Pins the query shape behind #count. The deduplicated + unfiltered count must
+  # avoid the INNER ANY JOIN (which only fetches the value column and caused
+  # ClickHouse OOM on large subscriptions); filtered and non-deduplicated counts
+  # must keep using the JOIN-based path so the filter is applied to the latest
+  # enriched row per dedup key.
+  describe "#count_query" do
+    subject(:event_store) do
+      described_class.new(code: billable_metric.code, subscription:, boundaries:, filters:, deduplicate:)
+    end
+
+    let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
+    let(:organization) { billable_metric.organization }
+    let(:charge) { create(:standard_charge, organization:, billable_metric:) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:, started_at: DateTime.parse("2023-03-15")) }
+    let(:boundaries) do
+      {
+        from_datetime: subscription.started_at.beginning_of_day,
+        to_datetime: subscription.started_at.end_of_month.end_of_day,
+        charges_duration: 31
+      }
+    end
+    let(:deduplicate) { true }
+    let(:filters) { {} }
+
+    context "when deduplicated and unfiltered" do
+      it "counts distinct dedup keys without a JOIN" do
+        sql = event_store.count_query
+
+        expect(sql).not_to include("JOIN")
+        expect(sql).to include("GROUP BY #{described_class::DEDUP_KEY_COLUMNS.join(", ")}")
+      end
+    end
+
+    context "when grouped_by_values is set" do
+      let(:filters) { {grouped_by_values: {"region" => "europe"}} }
+
+      it "uses the JOIN-based deduplication path" do
+        expect(event_store.count_query).to include("INNER ANY JOIN")
+      end
+    end
+
+    context "when matching_filters are set" do
+      let(:filters) { {matching_filters: {"region" => ["europe"]}} }
+
+      it "uses the JOIN-based deduplication path" do
+        expect(event_store.count_query).to include("INNER ANY JOIN")
+      end
+    end
+
+    context "when ignored_filters are set" do
+      let(:filters) { {ignored_filters: [{"region" => ["europe"]}]} }
+
+      it "uses the JOIN-based deduplication path" do
+        expect(event_store.count_query).to include("INNER ANY JOIN")
+      end
+    end
+
+    context "when deduplication is disabled" do
+      let(:deduplicate) { false }
+
+      it "does not build the deduplication CTEs" do
+        sql = event_store.count_query
+
+        expect(sql).not_to include("JOIN")
+        expect(sql).not_to include("latest_enriched")
+      end
+    end
+
+    context "when grouped_by is set without grouped_by_values or filters" do
+      let(:filters) { {grouped_by: ["region"]} }
+
+      it "still uses the JOIN-free fast path (grouped_by alone does not filter a count)" do
+        expect(event_store.count_query).not_to include("JOIN")
+      end
+    end
+
+    context "when use_from_boundary is false" do
+      it "omits the lower timestamp bound without injecting NULL" do
+        event_store.use_from_boundary = false
+        sql = event_store.count_query
+
+        expect(sql).not_to include("JOIN")
+        expect(sql.upcase).not_to include("NULL")
+        expect(sql).not_to include("timestamp >=")
+        expect(sql).to include("timestamp <=")
+      end
+    end
+  end
+
+  # Real-data equivalence: the deduplicated + unfiltered #count uses the JOIN-free
+  # fast path. These assert it returns the SAME number as the original JOIN-based
+  # query on identical data, across re-enrichment duplicates and boundary edges.
+  describe "#count fast-path equivalence with the JOIN-based query" do
+    subject(:event_store) do
+      described_class.new(code: billable_metric.code, subscription:, boundaries:, filters: {}, deduplicate: true)
+    end
+
+    let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
+    let(:organization) { billable_metric.organization }
+    let(:charge) { create(:standard_charge, organization:, billable_metric:) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:, started_at: DateTime.parse("2023-03-15")) }
+    let(:boundaries) do
+      {
+        from_datetime: subscription.started_at.beginning_of_day,
+        to_datetime: subscription.started_at.end_of_month.end_of_day,
+        charges_duration: 31
+      }
+    end
+    let(:ts) { subscription.started_at.beginning_of_day + 1.day }
+
+    def insert(transaction_id:, timestamp:, enriched_at:, value: 1)
+      Clickhouse::EventsEnriched.create!(
+        transaction_id:,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        code: billable_metric.code,
+        timestamp:,
+        properties: {"value" => value},
+        value:,
+        decimal_value: value.to_d,
+        precise_total_amount_cents: value,
+        enriched_at:
+      )
+    end
+
+    def join_based_count
+      sql = event_store.send(
+        :with_ctes,
+        event_store.events_cte_queries(deduplicated_columns: %w[value]),
+        "SELECT count()\nFROM events"
+      )
+      Events::Stores::Utils::ClickhouseConnection.connection_with_retry { |c| c.select_value(sql).to_i }
+    end
+
+    it "collapses re-enrichment duplicates of the same dedup key into one" do
+      txn = SecureRandom.uuid
+      insert(transaction_id: txn, timestamp: ts, enriched_at: 2.minutes.ago)
+      insert(transaction_id: txn, timestamp: ts, enriched_at: 1.minute.ago)
+      insert(transaction_id: txn, timestamp: ts, enriched_at: Time.current)
+      insert(transaction_id: SecureRandom.uuid, timestamp: ts + 1.day, enriched_at: Time.current)
+
+      expect(event_store.count).to eq(2)
+      expect(event_store.count).to eq(join_based_count)
+    end
+
+    it "treats the same transaction_id at different timestamps as distinct events" do
+      txn = SecureRandom.uuid
+      insert(transaction_id: txn, timestamp: ts, enriched_at: Time.current)
+      insert(transaction_id: txn, timestamp: ts + 1.hour, enriched_at: Time.current)
+
+      expect(event_store.count).to eq(2)
+      expect(event_store.count).to eq(join_based_count)
+    end
+
+    it "excludes events outside the boundaries" do
+      insert(transaction_id: SecureRandom.uuid, timestamp: ts, enriched_at: Time.current)
+      insert(transaction_id: SecureRandom.uuid, timestamp: boundaries[:to_datetime] + 2.days, enriched_at: Time.current)
+
+      expect(event_store.count).to eq(1)
+      expect(event_store.count).to eq(join_based_count)
+    end
+
+    it "returns zero when there are no events" do
+      expect(event_store.count).to eq(0)
+      expect(event_store.count).to eq(join_based_count)
+    end
+  end
 end


### PR DESCRIPTION
## Context

`Fees::CreatePayInAdvanceJob` is failing in production with ClickHouse `MEMORY_LIMIT_EXCEEDED` (Sentry API 243, 383 occurrences, escalating). The crash happens in `Events::Stores::ClickhouseStore#count`, reached through
`Charges::PayInAdvanceAggregationService` → `CountService#compute_aggregation` → `event_store.count` for a `count_agg` charge on a very large subscription.

`#count` builds the full two-pass deduplication CTE and runs `SELECT count() FROM events`. The `events` CTE performs an `INNER ANY JOIN` back to `events_enriched` whose only purpose is to fetch the `value` column of the latest enriched row per dedup key. For a count that column is never used, but the JOIN scans `events_enriched` a second time and materializes `value`, roughly doubling the memory of an already-large aggregation. Under worker
concurrency the per-query peaks stack up and cross the server-wide memory limit.

## Description

Count the distinct deduplication keys directly: a single `GROUP BY` over `DEDUP_KEY_COLUMNS` on `events_enriched`, wrapped in `SELECT count()`. No JOIN, no `value` materialization.

This is provably equivalent to the previous query for the unfiltered case: the inner grouping is identical to the `latest_enriched` CTE (same FROM, WHERE and GROUP BY), and the old `INNER ANY JOIN` returned exactly one row per `latest_enriched` row, so both queries equal the number of distinct dedup keys.

The original JOIN-based path is kept for filtered counts (`grouped_by_values`, `matching_filters`, `ignored_filters`) and the non-deduplicated case, so those behaviours are byte-for-byte unchanged. The filtered subsets are small and were never the source of the OOM, so there is no benefit in rewriting them and we avoid any risk to the "filter against the latest enriched row" semantics.

## Validation

Verified on the production subscription from the Sentry report (identical config, full history, ~10.8M events):

| metric       | current (JOIN) | proposed (no JOIN) |
|--------------|----------------|--------------------|
| count        | 10,822,296     | 10,822,296 (match) |
| server time  | 6,620 ms       | 997 ms (~6.6x)     |
| peak memory  | 4.7 GiB        | 3.6 GiB            |
| rows read    | 21,876,048     | 10,938,024 (½)     |
| bytes read   | 3.3 GiB        | 1.6 GiB (½)        |

The "rows read = exactly 2x" confirms the JOIN was re-scanning the table. The real win for API-243 is the combination of lower per-query memory and ~6.6x faster runtime, which removes the concurrent memory pressure that was tripping the server-wide limit.