### PR TITLE
fix(subscription): drop cancelation_reason column (contract step)

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,7 +4,7 @@ class Subscription < ApplicationRecord
   include PaperTrailTraceable
   include RansackUuidSearch
 
-  self.ignored_columns += %w[incompleted_at cancelation_reason]
+  self.ignored_columns += %w[incompleted_at]
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :plan, -> { with_discarded }

--- a/db/migrate/20260611170450_remove_cancelation_reason_from_subscriptions.rb
+++ b/db/migrate/20260611170450_remove_cancelation_reason_from_subscriptions.rb
@@ -3,7 +3,7 @@
 class RemoveCancelationReasonFromSubscriptions < ActiveRecord::Migration[8.0]
   def change
     safety_assured do
-      remove_column :subscriptions, :cancelation_reason, :subscription_cancelation_reasons
+      remove_column :subscriptions, :cancelation_reason, :subscription_cancelation_reasons # rubocop:disable Lago/NoDropColumnOrTable
       drop_enum :subscription_cancelation_reasons, %w[payment_failed timeout]
     end
   end

--- a/db/migrate/20260611170450_remove_cancelation_reason_from_subscriptions.rb
+++ b/db/migrate/20260611170450_remove_cancelation_reason_from_subscriptions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RemoveCancelationReasonFromSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :subscriptions, :cancelation_reason, :subscription_cancelation_reasons
+      drop_enum :subscription_cancelation_reasons, %w[payment_failed timeout]
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1186,7 +1186,6 @@ DROP TYPE IF EXISTS public.subscription_invoicing_reason;
 DROP TYPE IF EXISTS public.subscription_invoice_issuing_date_anchors;
 DROP TYPE IF EXISTS public.subscription_invoice_issuing_date_adjustments;
 DROP TYPE IF EXISTS public.subscription_cancellation_reasons;
-DROP TYPE IF EXISTS public.subscription_cancelation_reasons;
 DROP TYPE IF EXISTS public.subscription_activation_rule_types;
 DROP TYPE IF EXISTS public.subscription_activation_rule_statuses;
 DROP TYPE IF EXISTS public.quote_void_reason;
@@ -1525,16 +1524,6 @@ CREATE TYPE public.subscription_activation_rule_statuses AS ENUM (
 
 CREATE TYPE public.subscription_activation_rule_types AS ENUM (
     'payment'
-);
-
-
---
--- Name: subscription_cancelation_reasons; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.subscription_cancelation_reasons AS ENUM (
-    'payment_failed',
-    'timeout'
 );
 
 
@@ -3371,7 +3360,6 @@ CREATE TABLE public.subscriptions (
     skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
     progressive_billing_disabled boolean DEFAULT false NOT NULL,
     last_received_event_on date,
-    cancelation_reason public.subscription_cancelation_reasons,
     incompleted_at timestamp(6) without time zone,
     activated_at timestamp(6) without time zone,
     billing_entity_id uuid,
@@ -12775,6 +12763,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260612150749'),
 ('20260612113044'),
+('20260611170450'),
 ('20260611162947'),
 ('20260611145341'),
 ('20260611145039'),
@@ -13802,3 +13791,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+


### PR DESCRIPTION
Final step fixing the typo on subscription `cancellation_reason` column.

### 🚨 This PR must NOT be merged until self-hosted deployments have had time to roll through a released version including PRs:  https://github.com/getlago/lago-api/pull/5709. 🚨 

We need a bridge version to be released before merging this otherwise a self-hosted deployment could pick up all three migrations in one go, drop the column before the live code is loaded, and crash any subscription query.

* Drops the legacy `subscriptions.cancelation_reason` column.
* Drops the orphaned `subscription_cancelation_reasons` PG enum type.
* Removes the matching `ignored_columns` entry from `Subscription`.