### PR TITLE
fix(flutterwave): resolve invoice from verified tx_ref on charge.completed

### DIFF
--- a/app/services/payment_providers/flutterwave/webhooks/charge_completed_service.rb
+++ b/app/services/payment_providers/flutterwave/webhooks/charge_completed_service.rb
@@ -27,15 +27,17 @@ module PaymentProviders
           verified_transaction = verify_transaction
           return result unless verified_transaction
 
-          payable = find_payable
+          payable = find_payable(verified_reference: verified_transaction[:reference])
           return result unless payable
+
+          @resolved_payable_id = payable.id
 
           payment_service_class.new(payable:).update_payment_status(
             organization_id:,
             status: verified_transaction[:status],
             amount_cents: verified_amount_cents(verified_transaction),
             flutterwave_payment: PaymentProviders::FlutterwaveProvider::FlutterwavePayment.new(
-              id: provider_payment_id,
+              id: @resolved_payable_id,
               status: verified_transaction[:status],
               metadata: build_metadata(verified_transaction)
             )
@@ -76,12 +78,21 @@ module PaymentProviders
           end
         end
 
-        def find_payable
+        def find_payable(verified_reference: nil)
+          payable = find_payable_by_id(provider_payment_id)
+          return payable if payable.present? || verified_reference.blank?
+
+          find_payable_by_id(verified_reference)
+        end
+
+        def find_payable_by_id(id)
+          return if id.blank?
+
           case payable_type
           when "Invoice"
-            Invoice.find_by(id: provider_payment_id)
+            Invoice.find_by(id: id)
           when "PaymentRequest"
-            PaymentRequest.find_by(id: provider_payment_id)
+            PaymentRequest.find_by(id: id)
           end
         end
 
@@ -124,8 +135,7 @@ module PaymentProviders
         end
 
         def build_metadata(verified_transaction)
-          {
-            lago_invoice_id: provider_payment_id,
+          metadata = {
             lago_payable_type: payable_type,
             flutterwave_transaction_id: verified_transaction[:id],
             flw_ref: verified_transaction[:reference],
@@ -134,6 +144,15 @@ module PaymentProviders
             currency: verified_transaction[:currency],
             payment_type: "one-time"
           }
+
+          case payable_type
+          when "Invoice"
+            metadata[:lago_invoice_id] = @resolved_payable_id
+          when "PaymentRequest"
+            metadata[:lago_payable_id] = @resolved_payable_id
+          end
+
+          metadata
         end
 
         def verified_amount_cents(verified_transaction)

--- a/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
@@ -89,6 +89,46 @@ RSpec.describe PaymentProviders::Flutterwave::Webhooks::ChargeCompletedService d
       .and_return(double(success?: true, payment_provider: flutterwave_provider)) # rubocop:disable RSpec/VerifiedDoubles
   end
 
+  describe "#find_payable" do
+    subject(:find_payable) { charge_completed_service.send(:find_payable, verified_reference:) }
+
+    let(:verified_reference) { nil }
+
+    before { invoice }
+
+    context "when webhook meta identifies the invoice" do
+      it "returns the invoice using provider_payment_id" do
+        expect(find_payable).to eq(invoice)
+      end
+    end
+
+    context "when webhook tx_ref does not match the invoice" do
+      let(:payload) do
+        {
+          event: "charge.completed",
+          data: {
+            id: 285959875,
+            tx_ref: "lago_invoice_12345",
+            status: "successful",
+            payment_type: "card"
+          }
+        }
+      end
+
+      it "returns nil without a verified reference" do
+        expect(find_payable).to be_nil
+      end
+
+      context "when verified reference matches the invoice id" do
+        let(:verified_reference) { invoice.id }
+
+        it "returns the invoice using the verified tx_ref" do
+          expect(find_payable).to eq(invoice)
+        end
+      end
+    end
+  end
+
   describe "#call" do
     context "when transaction status is successful" do
       let(:http_client) { instance_double(LagoHttpClient::Client) }
@@ -528,6 +568,207 @@ RSpec.describe PaymentProviders::Flutterwave::Webhooks::ChargeCompletedService d
         result = charge_completed_service.call
 
         expect(result).to be_success
+      end
+    end
+  end
+
+  # End-to-end: ChargeCompletedService → real FlutterwaveService (no mock on payment update).
+  # Only Flutterwave's verify HTTP call is stubbed.
+  describe "integration with Invoices::Payments::FlutterwaveService" do
+    let(:customer) do
+      create(
+        :customer,
+        organization:,
+        payment_provider: "flutterwave",
+        payment_provider_code: flutterwave_provider.code
+      )
+    end
+
+    let(:invoice) do
+      create(
+        :invoice,
+        organization:,
+        customer:,
+        total_amount_cents: 1_000_000,
+        currency: "NGN",
+        payment_status: :pending
+      )
+    end
+
+    let(:flutterwave_customer) { create(:flutterwave_customer, customer:, payment_provider: flutterwave_provider) }
+
+    let(:http_client) { instance_double(LagoHttpClient::Client) }
+
+    let(:verification_response) do
+      {
+        "status" => "success",
+        "data" => {
+          "id" => 285959875,
+          "tx_ref" => invoice.id,
+          "flw_ref" => "LAGO/FLW270177170",
+          "amount" => 10_000,
+          "currency" => "NGN",
+          "charged_amount" => 10_000,
+          "status" => "successful",
+          "payment_type" => "card",
+          "customer" => {
+            "id" => 215604089,
+            "name" => "John Doe",
+            "email" => "customer@example.com"
+          }
+        }
+      }
+    end
+
+    before do
+      flutterwave_customer
+      invoice
+      allow(LagoHttpClient::Client).to receive(:new).and_return(http_client)
+      allow(http_client).to receive(:get).and_return(verification_response)
+    end
+
+    context "when webhook meta identifies the invoice" do
+      let(:payload) do
+        {
+          event: "charge.completed",
+          data: {
+            id: 285959875,
+            tx_ref: invoice.id,
+            flw_ref: "LAGO/FLW270177170",
+            amount: 10_000,
+            currency: "NGN",
+            status: "successful",
+            payment_type: "card",
+            customer: {
+              id: 215604089,
+              name: "John Doe",
+              email: "customer@example.com"
+            },
+            meta: {
+              lago_invoice_id: invoice.id,
+              lago_payable_type: "Invoice"
+            }
+          }
+        }
+      end
+
+      it "creates a payment and marks the invoice as succeeded" do
+        expect { charge_completed_service.call }.to change(Payment, :count).by(1)
+
+        payment = Payment.last
+        expect(payment.payable).to eq(invoice)
+        expect(payment.payable_payment_status).to eq("succeeded")
+        expect(invoice.reload.payment_status).to eq("succeeded")
+      end
+    end
+
+    context "when meta is missing but tx_ref matches the invoice id" do
+      let(:payload) do
+        {
+          event: "charge.completed",
+          data: {
+            id: 285959875,
+            tx_ref: invoice.id,
+            flw_ref: "LAGO/FLW270177170",
+            amount: 10_000,
+            currency: "NGN",
+            status: "successful",
+            payment_type: "card",
+            customer: {
+              id: 215604089,
+              name: "John Doe",
+              email: "customer@example.com"
+            }
+          }
+        }
+      end
+
+      it "creates a payment and marks the invoice as succeeded" do
+        expect { charge_completed_service.call }.to change(Payment, :count).by(1)
+
+        payment = Payment.last
+        expect(payment.payable).to eq(invoice)
+        expect(payment.payable_payment_status).to eq("succeeded")
+        expect(invoice.reload.payment_status).to eq("succeeded")
+      end
+    end
+
+    context "payment confirmation in Lago" do
+      let(:payload) do
+        {
+          event: "charge.completed",
+          data: {
+            id: 285959875,
+            tx_ref: invoice.id,
+            flw_ref: "LAGO/FLW270177170",
+            amount: 10_000,
+            currency: "NGN",
+            status: "successful",
+            payment_type: "card",
+            customer: {
+              id: 215604089,
+              name: "John Doe",
+              email: "customer@example.com"
+            },
+            meta: {
+              lago_invoice_id: invoice.id,
+              lago_payable_type: "Invoice"
+            }
+          }
+        }
+      end
+
+      it "records the payment and marks the invoice as succeeded" do
+        expect(invoice.payment_status).to eq("pending")
+
+        expect { charge_completed_service.call }.to change(Payment, :count).by(1)
+
+        payment = Payment.last
+
+        aggregate_failures do
+          expect(payment.payable).to eq(invoice)
+          expect(payment.payable_payment_status).to eq("succeeded")
+          expect(payment.payment_provider).to eq(flutterwave_provider)
+          expect(invoice.reload.payment_status).to eq("succeeded")
+          expect(invoice.payment_pending?).to be(false)
+        end
+      end
+    end
+
+    context "when webhook tx_ref does not match the invoice but verify succeeds" do
+      let(:payload) do
+        {
+          event: "charge.completed",
+          data: {
+            id: 285959875,
+            tx_ref: "lago_invoice_12345",
+            flw_ref: "LAGO/FLW270177170",
+            amount: 10_000,
+            currency: "NGN",
+            status: "successful",
+            payment_type: "card",
+            customer: {
+              id: 215604089,
+              name: "John Doe",
+              email: "customer@example.com"
+            }
+          }
+        }
+      end
+
+      it "records the payment using the verified tx_ref and marks the invoice as succeeded" do
+        expect(invoice.payment_status).to eq("pending")
+
+        expect { charge_completed_service.call }.to change(Payment, :count).by(1)
+
+        payment = Payment.last
+
+        aggregate_failures do
+          expect(payment.payable).to eq(invoice)
+          expect(payment.payable_payment_status).to eq("succeeded")
+          expect(invoice.reload.payment_status).to eq("succeeded")
+          expect(invoice.payment_pending?).to be(false)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

Reported in [getlago/lago#657](https://github.com/getlago/lago/issues/657): after a successful Flutterwave payment, Lago returns **200 OK** on the `charge.completed` webhook, but the invoice stays **`pending`** and no `Payment` record is created.

Root cause: `ChargeCompletedService` resolves the invoice only from webhook fields (`meta.lago_invoice_id` / `tx_ref`). Lago sends `meta` and `tx_ref: invoice.id` when generating the payment link, but the webhook payload may omit `meta` or include a `tx_ref` that doesn’t match the invoice UUID.

When that happens:

1. Webhook is accepted → **200 OK** (job enqueued)
2. Flutterwave **verify** API succeeds
3. `find_payable` returns `nil` → processing stops silently
4. `Invoices::Payments::FlutterwaveService#update_payment_status` is never called
5. Invoice remains **`pending`**

---

## Description

### Changes

**`PaymentProviders::Flutterwave::Webhooks::ChargeCompletedService`**

- **`find_payable`** — try webhook `provider_payment_id` first; if not found, fall back to `verified_transaction[:reference]` (verify API `tx_ref`)
- **`find_payable_by_id`** — shared lookup for `Invoice` / `PaymentRequest`
- **`@resolved_payable_id`** — store the matched payable id after lookup
- **`build_metadata`** — use `@resolved_payable_id` for `lago_invoice_id` / `lago_payable_id` (not webhook-only ids)
- **`FlutterwavePayment.id`** — use `@resolved_payable_id` so `create_payment` receives the correct invoice reference

### Tests

Added to `charge_completed_service_spec.rb`:

- **`#find_payable` unit tests** — primary lookup, nil without fallback, fallback via verified `tx_ref`
- **Integration specs** — end-to-end through real `Invoices::Payments::FlutterwaveService` (verify HTTP stubbed only), including the case where webhook `tx_ref` is wrong but verify succeeds

### Dependencies

None — no new gems, migrations, or env vars.

---

## Test plan (if separate section)

- [x] `bundle exec rspec spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb`
- [x] `bundle exec rspec spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb -e "find_payable"`
- [x] `bundle exec rspec spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb -e "integration with Invoices::Payments::FlutterwaveService"`