### PR TITLE
[ING-330] misc(clickhouse): Returns grouped_sum with count in 1 query

### DIFF
--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -26,7 +26,7 @@ module BillableMetrics
         result.count = sum_result.events_count
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash)
           result.pay_in_advance_breakdowns = build_pay_in_advance_breakdowns(value: event_value)
         end
 
@@ -50,26 +50,15 @@ module BillableMetrics
         aggregations = event_store.grouped_sum
         return empty_results if aggregations.blank?
 
-        counts = event_store.grouped_count
-
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash)
         end
 
-        merged_hash = {}
-        aggregations.each do |aggregation|
-          merged_hash[aggregation[:groups]] = {aggregation: aggregation[:value]}
-        end
-        counts.each do |count|
-          next unless merged_hash[count[:groups]]
-          merged_hash[count[:groups]] = merged_hash[count[:groups]].merge({count: count[:value]})
-        end
-
-        result.aggregations = merged_hash.map do |groups, merged_aggregation_count|
+        result.aggregations = aggregations.map do |aggregation|
           group_result = BaseService::Result.new
-          group_result.grouped_by = groups
+          group_result.grouped_by = aggregation.groups
 
-          aggregation_value = merged_aggregation_count[:aggregation]
+          aggregation_value = aggregation.value
 
           if options[:is_pay_in_advance] && options[:is_current_usage]
             handle_in_advance_current_usage(aggregation_value, target_result: group_result)
@@ -77,7 +66,7 @@ module BillableMetrics
             group_result.aggregation = aggregation_value
           end
 
-          group_result.count = merged_aggregation_count[:count] || 0
+          group_result.count = aggregation.events_count
           group_result.options = {running_total: running_total(options, grouped_by_values: group_result.grouped_by)}
           group_result
         end

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -48,8 +48,7 @@ module BillableMetrics
         aggregations = event_store.grouped_weighted_sum(initial_values: grouped_latest_values)
         return empty_results if aggregations.blank?
 
-        counts = event_store.grouped_count
-        sums = event_store.grouped_sum
+        sum_results = event_store.grouped_sum
 
         latest_values = []
         last_events = []
@@ -73,8 +72,10 @@ module BillableMetrics
 
           aggregation_value = aggregation[:value]
           group_result.aggregation = aggregation_value
-          group_result.count = counts.find { |c| c[:groups] == aggregation[:groups] }&.[](:value) || 0
-          group_result.variation = sums.find { |c| c[:groups] == aggregation[:groups] }&.[](:value) || 0
+
+          group_sum = sum_results.find { |c| c.groups == aggregation[:groups] }
+          group_result.count = group_sum&.events_count || 0
+          group_result.variation = group_sum&.value || 0
           group_result.total_aggregated_units = group_result.variation
 
           if billable_metric.recurring?
@@ -166,7 +167,7 @@ module BillableMetrics
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
-        breakdowns = presentation_by.present? ? event_store.grouped_sum(uniq_grouped_by_and_presentation_by) : []
+        breakdowns = presentation_by.present? ? event_store.grouped_sum(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash) : []
 
         @latest_value_from_events = [BigDecimal(event_store.sum(with_count: false).value), breakdowns]
       end
@@ -228,9 +229,9 @@ module BillableMetrics
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
-        breakdowns = presentation_by.present? ? event_store.grouped_sum(uniq_grouped_by_and_presentation_by) : []
+        breakdowns = presentation_by.present? ? event_store.grouped_sum(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash) : []
 
-        [event_store.grouped_sum, breakdowns]
+        [event_store.grouped_sum(with_count: false).map(&:to_grouped_hash), breakdowns]
       end
     end
   end

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -36,7 +36,7 @@ module BillableMetrics
         result.count = aggregation_without_proration.count
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash)
           result.pay_in_advance_breakdowns = build_pay_in_advance_breakdowns(value: event_value)
         end
 
@@ -97,7 +97,7 @@ module BillableMetrics
         end
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_sum(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash)
         end
 
         result

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -8,6 +8,18 @@ module Events
         :events_count
       )
 
+      # NOTE: result of a grouped aggregation. Mirrors AggregationResult but also
+      #       carries the group it belongs to.
+      GroupedAggregationResult = Data.define(
+        :groups,
+        :value,
+        :events_count
+      ) do
+        def to_grouped_hash
+          {groups:, value:}
+        end
+      end
+
       def initialize(subscription:, boundaries:, code: nil, filters: {}, deduplicate: false)
         @code = code
         @subscription = subscription
@@ -85,7 +97,7 @@ module Events
         raise NotImplementedError
       end
 
-      def grouped_sum
+      def grouped_sum(with_count: true)
         raise NotImplementedError
       end
 

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -532,13 +532,16 @@ module Events
         end
       end
 
-      def grouped_sum(columns = grouped_by)
+      def grouped_sum(columns = grouped_by, with_count: true)
+        count_select = with_count ? "count()" : "null"
+
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           if columns == grouped_by
             sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
               SELECT
                 sorted_grouped_by as groups,
-                sum(events.decimal_value) as value
+                sum(events.decimal_value) as value,
+                #{count_select} as events_count
               FROM events
               GROUP BY sorted_grouped_by
             SQL
@@ -548,13 +551,14 @@ module Events
             sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
               SELECT
                 map(#{map_args.join(", ")}) as groups,
-                sum(events.decimal_value) as value
+                sum(events.decimal_value) as value,
+                #{count_select} as events_count
               FROM events
               GROUP BY #{col_expressions.join(", ")}
             SQL
           end
 
-          prepare_grouped_result(connection.select_all(sql))
+          prepare_grouped_aggregated_values(connection.select_all(sql))
         end
       end
 
@@ -928,6 +932,20 @@ module Events
             r[:value] = decimal ? BigDecimal(r[value_key].presence || 0) : r[value_key]
             r.slice!(:groups, :value, :timestamp)
           end
+        end
+      end
+
+      # NOTE: like prepare_grouped_result but each row also carries an events_count
+      #       column, returned as GroupedAggregationResult.
+      def prepare_grouped_aggregated_values(result, decimal: false)
+        result.to_ary.map do |row|
+          r = row.symbolize_keys
+
+          GroupedAggregationResult.new(
+            groups: r[:groups].transform_values(&:presence),
+            value: decimal ? BigDecimal(r[:value].presence || 0) : r[:value],
+            events_count: r[:events_count].presence&.to_i
+          )
         end
       end
     end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -524,7 +524,7 @@ module Events
         end
       end
 
-      def grouped_sum(columns = grouped_by)
+      def grouped_sum(columns = grouped_by, with_count: true)
         groups, column_names = grouped_arel_columns(columns)
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
@@ -536,12 +536,13 @@ module Events
           sql = with_ctes(ctes_sql, <<-SQL)
             SELECT
               #{column_names},
-              sum(events.property)
+              sum(events.property),
+              #{with_count ? "count()" : "null"}
             FROM events
             GROUP BY #{column_names}
           SQL
 
-          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
+          prepare_grouped_aggregated_values(connection.select_all(sql).rows, columns: columns)
         end
       end
 
@@ -834,6 +835,21 @@ module Events
           result[:timestamp] = row[-2] if timestamp
 
           result
+        end
+      end
+
+      # NOTE: Same as prepare_grouped_result but the last two columns of each row are
+      #       the aggregated value and the events count, returned as GroupedAggregationResult.
+      def prepare_grouped_aggregated_values(rows, columns: grouped_by)
+        rows.map do |row|
+          flat = row.flatten
+          groups = flat[...-2].map(&:presence)
+
+          GroupedAggregationResult.new(
+            groups: columns.each_with_object({}).with_index { |(g, res), i| res.merge!(g => groups[i]) },
+            value: flat[-2],
+            events_count: flat[-1].presence&.to_i
+          )
         end
       end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -245,13 +245,21 @@ module Events
         )
       end
 
-      def grouped_sum(columns = grouped_by)
-        results = events
-          .group(columns.map { sanitized_property_name(it) })
-          .sum("(#{sanitized_property_name})::numeric")
-          .map { |group, value| [group, value].flatten }
+      def grouped_sum(columns = grouped_by, with_count: true)
+        groups = columns.map { sanitized_property_name(it) }
 
-        prepare_grouped_result(results, columns: columns)
+        results = events
+          .group(groups)
+          .pluck(
+            Arel.sql(
+              (groups + [
+                "SUM((#{sanitized_property_name})::numeric)",
+                with_count ? "COUNT(*)" : "NULL"
+              ]).join(", ")
+            )
+          )
+
+        prepare_grouped_aggregated_values(results, columns: columns)
       end
 
       def prorated_sum(period_duration:, persisted_duration: nil)
@@ -481,6 +489,20 @@ module Events
           result[:timestamp] = row[-2] if timestamp
 
           result
+        end
+      end
+
+      # NOTE: Same as prepare_grouped_result but the last two columns of each row are
+      #       the aggregated value and the events count, returned as GroupedAggregationResult.
+      def prepare_grouped_aggregated_values(rows, columns: grouped_by)
+        rows.map do |row|
+          groups = row[...-2].map(&:presence)
+
+          GroupedAggregationResult.new(
+            groups: columns.each_with_object({}).with_index { |(g, r), i| r.merge!(g => groups[i]) },
+            value: row[-2],
+            events_count: row[-1]&.to_i
+          )
         end
       end
 

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1488,9 +1488,20 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         result = event_store.grouped_sum
 
         expect(result).to match_array([
-          {groups: {"region" => nil}, value: 6},
-          {groups: {"region" => "europe"}, value: 9}
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => nil}, value: 6, events_count: 2),
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "europe"}, value: 9, events_count: 3)
         ])
+      end
+
+      context "when with_count is false" do
+        it "returns the sum of values without the events count" do
+          result = event_store.grouped_sum(with_count: false)
+
+          expect(result).to match_array([
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => nil}, value: 6, events_count: nil),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "europe"}, value: 9, events_count: nil)
+          ])
+        end
       end
 
       context "with multiple groups" do
@@ -1500,9 +1511,9 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_sum
 
           expect(result).to match_array([
-            {groups: {"country" => nil, "region" => nil}, value: 6},
-            {groups: {"country" => "united kingdom", "region" => "europe"}, value: 5},
-            {groups: {"country" => "france", "region" => "europe"}, value: 4}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => nil, "region" => nil}, value: 6, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "united kingdom", "region" => "europe"}, value: 5, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "france", "region" => "europe"}, value: 4, events_count: 2)
           ])
         end
       end
@@ -1537,8 +1548,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           # - europe, france, cambridge -> -2
           # - europe, united kingdom, manchester -> -1
           expect(result).to match_array([
-            {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
-            {groups: {"country" => "france", "region" => "europe"}, value: 2}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "united kingdom", "region" => "europe"}, value: -1, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "france", "region" => "europe"}, value: 2, events_count: 3)
           ])
         end
       end
@@ -1582,8 +1593,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_sum(["cloud"])
 
           expect(result).to match_array([
-            {groups: {"cloud" => "aws"}, value: 30},
-            {groups: {"cloud" => "gcp"}, value: 12}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "aws"}, value: 30, events_count: 3),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "gcp"}, value: 12, events_count: 1)
           ])
         end
       end
@@ -1601,9 +1612,9 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_sum(["agent_name", "cloud"])
 
           expect(result).to match_array([
-            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
-            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
-            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3, events_count: 1)
           ])
         end
       end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5716 and https://github.com/getlago/lago-api/pull/5723

Today, all aggregation services (except CountService) perform two queries to retrieve data from the event store, a first one to get the actual aggregation and a second one to get the number of events involved in this result.

The current implementation is inherited from the initial Postgres store, and works well for this database engine. When the Clickhouse store, the same approach was used to keep the compatibility between the different implementation. At scale, this implementation is not ideal on the clickhouse side as it force the engine to retrieve twice the same set of records before performing the computation.

## Description

This PR introduce a new `GroupedAggregationResult` data structure, returned from the `grouped_sum` aggregation.
This structure returns for each grouped result, the `groups`, the `value` for the aggregation and `events_count` for the number of event.
Both Clickhouse and `Postgres` will query them in a single pass

The same approach will be added in next step on all other remaining aggregations