### PR TITLE
fix(charges): Make filter cascade resilient to stale billable metric filters

### DIFF
--- a/app/services/charge_filters/cascade_service.rb
+++ b/app/services/charge_filters/cascade_service.rb
@@ -59,6 +59,10 @@ module ChargeFilters
     def create_child_filter(child_charge)
       return if find_child_filter(child_charge)
 
+      # NOTE: Resolve against the current state of the billable metric filters
+      # to avoid any changes that may have occurred since the job was enqueued
+      return if resolved_filter_values.empty?
+
       ActiveRecord::Base.transaction do
         child_filter = child_charge.filters.new(
           organization_id: child_charge.organization_id,
@@ -70,16 +74,32 @@ module ChargeFilters
         )
         child_filter.save!
 
-        filter_values.each do |key, values|
-          billable_metric_filter = child_charge.billable_metric.filters.find_by(key:)
-
+        resolved_filter_values.each do |billable_metric_filter, values|
           child_filter.values.create!(
-            billable_metric_filter_id: billable_metric_filter&.id,
+            billable_metric_filter_id: billable_metric_filter.id,
             organization_id: child_charge.organization_id,
             values:
           )
         end
       end
+    end
+
+    def resolved_filter_values
+      @resolved_filter_values ||= filter_values.filter_map do |key, values|
+        billable_metric_filter = billable_metric_filters_by_key[key]
+        next if billable_metric_filter.nil?
+
+        valid_values = values & billable_metric_filter.values
+        next if valid_values.empty?
+
+        [billable_metric_filter, valid_values]
+      end
+    end
+
+    def billable_metric_filters_by_key
+      @billable_metric_filters_by_key ||= charge.billable_metric.filters
+        .where(key: filter_values.keys)
+        .index_by(&:key)
     end
 
     def destroy_child_filter(child_charge)

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -155,6 +155,59 @@ RSpec.describe ChargeFilters::CascadeService do
           expect { service }.not_to change { child_charge.filters.reload.count }
         end
       end
+
+      context "when the billable metric filter key no longer exists" do
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "create",
+            filter_values: {"country" => ["fr"]},
+            new_properties: {"amount" => "20"},
+            invoice_display_name: "FR country"
+          )
+        end
+
+        it "does not create a child filter" do
+          expect { service }.not_to change { child_charge.filters.reload.count }
+          expect(service).to be_success
+        end
+      end
+
+      context "when the billable metric filter values were trimmed" do
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "create",
+            filter_values: {"region" => %w[eu apac]},
+            new_properties: {"amount" => "20"},
+            invoice_display_name: "EU region"
+          )
+        end
+
+        it "creates the filter with only the values still allowed" do
+          expect { service }.to change { child_charge.filters.reload.count }.by(1)
+
+          new_filter = child_charge.filters.find_by(invoice_display_name: "EU region")
+          expect(new_filter.to_h).to eq({"region" => ["eu"]})
+        end
+      end
+
+      context "when none of the snapshot values are still allowed" do
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "create",
+            filter_values: {"region" => ["apac"]},
+            new_properties: {"amount" => "20"},
+            invoice_display_name: "APAC region"
+          )
+        end
+
+        it "does not create a child filter" do
+          expect { service }.not_to change { child_charge.filters.reload.count }
+          expect(service).to be_success
+        end
+      end
     end
 
     context "with destroy action" do


### PR DESCRIPTION
`ChargeFilters::CascadeJob` carries a snapshot of a parent charge filter (`key => values`) taken when the job is enqueued, then replicates it onto child charges. A concurrent billable metric update can discard a filter key or trim its allowed values before the job runs. The cascade then resolved the key against the now-stale state, passed a `nil` `billable_metric_filter_id`, and the `ChargeFilterValue` failed validation (`relation_must_exist, value_is_invalid`), sending the job to the dead set.

Resolve the snapshot against the billable metric's current filters before creating child filter values.