### PR TITLE
[ING-312] misc(daily_usage): Allow fill_history task to ask for a list of subscriptions

### DIFF
--- a/lib/task_prompt.rb
+++ b/lib/task_prompt.rb
@@ -26,6 +26,11 @@ module TaskPrompt
     organization
   end
 
+  def self.ask_for_subscription_ids
+    input = ask("Subscription IDs to refill (comma or space separated, leave blank to fill a whole organization): ")
+    input.split(/[\s,]+/).reject(&:empty?)
+  end
+
   def self.ask_for_timestamp_range
     from_time = ask_for_timestamp("From timestamp (UTC, e.g. 2026-01-01 00:00:00): ")
     to_time = ask_for_timestamp("To timestamp (UTC, e.g. 2026-01-31 23:59:59): ")

--- a/lib/tasks/daily_usages.rake
+++ b/lib/tasks/daily_usages.rake
@@ -12,6 +12,8 @@ namespace :daily_usages do
 
     organization = TaskPrompt.ask_for_organization
 
+    subscription_ids = TaskPrompt.ask_for_subscription_ids
+
     default_from_date = DailyUsage::DEFAULT_HISTORY_DAYS.days.ago.to_date
     from_date = TaskPrompt.ask_for_date("From date (YYYY-MM-DD)", default: default_from_date)
 
@@ -20,6 +22,7 @@ namespace :daily_usages do
       .where.not(started_at: nil)
       .where("terminated_at IS NULL OR terminated_at >= ?", from_date)
       .includes(customer: :organization)
+    subscriptions = subscriptions.where(id: subscription_ids) if subscription_ids.present?
 
     # ----- recon (read-only) -----
     sub_count = subscriptions.count
@@ -34,6 +37,7 @@ namespace :daily_usages do
     puts ""
     puts "----- recon -----"
     puts "organization          : #{organization.name} (#{organization.id})"
+    puts "requested subs        : #{subscription_ids.present? ? subscription_ids.size : "all"}"
     puts "subs in scope         : #{sub_count}"
     puts "existing daily_usages : #{daily_usages_count}"
     puts "days in backfill range: #{days} (#{from_date} .. #{Date.current})"

--- a/spec/lib/tasks/daily_usages_rake_spec.rb
+++ b/spec/lib/tasks/daily_usages_rake_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "daily_usages:fill_history" do # rubocop:disable RSpec/DescribeCl
   end
 
   context "when organization has no subscriptions in scope" do
-    before { stub_stdin(organization.id, "y", "") }
+    before { stub_stdin(organization.id, "y", "", "") }
 
     it "finishes without enqueueing any job" do
       expect { task.invoke }.not_to raise_error
@@ -58,7 +58,7 @@ RSpec.describe "daily_usages:fill_history" do # rubocop:disable RSpec/DescribeCl
     end
 
     context "when user confirms deletion with the default date" do
-      before { stub_stdin(organization.id, "y", "", "y", "y") }
+      before { stub_stdin(organization.id, "y", "", "", "y", "y") }
 
       it "deletes existing daily_usages in scope" do
         task.invoke
@@ -81,7 +81,7 @@ RSpec.describe "daily_usages:fill_history" do # rubocop:disable RSpec/DescribeCl
     end
 
     context "when user declines deletion but continues" do
-      before { stub_stdin(organization.id, "y", "", "n", "y") }
+      before { stub_stdin(organization.id, "y", "", "", "n", "y") }
 
       it "keeps existing daily_usages" do
         task.invoke
@@ -96,7 +96,7 @@ RSpec.describe "daily_usages:fill_history" do # rubocop:disable RSpec/DescribeCl
     end
 
     context "when user enters a custom date" do
-      before { stub_stdin(organization.id, "y", "2026-01-15", "y", "y") }
+      before { stub_stdin(organization.id, "y", "", "2026-01-15", "y", "y") }
 
       it "uses the entered date as from_date" do
         task.invoke
@@ -106,7 +106,7 @@ RSpec.describe "daily_usages:fill_history" do # rubocop:disable RSpec/DescribeCl
     end
 
     context "when user enters an invalid date" do
-      before { stub_stdin(organization.id, "y", "not-a-date") }
+      before { stub_stdin(organization.id, "y", "", "not-a-date") }
 
       it "aborts" do
         expect { task.invoke }.to raise_error(SystemExit)
@@ -115,12 +115,38 @@ RSpec.describe "daily_usages:fill_history" do # rubocop:disable RSpec/DescribeCl
     end
 
     context "when user declines the final confirmation" do
-      before { stub_stdin(organization.id, "y", "", "y", "n") }
+      before { stub_stdin(organization.id, "y", "", "", "y", "n") }
 
       it "aborts without deleting or enqueueing" do
         expect { task.invoke }.to raise_error(SystemExit)
         expect(DailyUsage.where(id: existing_usage.id)).to exist
         expect(DailyUsages::FillHistoryJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when a subscription list is provided" do
+      before { stub_stdin(organization.id, "y", active_sub.id, "", "y", "y") }
+
+      it "only enqueues a FillHistoryJob for the provided subscriptions" do
+        task.invoke
+        expect(DailyUsages::FillHistoryJob).to have_received(:perform_later)
+          .with(subscription: active_sub, from_date: DailyUsage::DEFAULT_HISTORY_DAYS.days.ago.to_date)
+        expect(DailyUsages::FillHistoryJob).not_to have_received(:perform_later)
+          .with(subscription: terminated_sub, from_date: anything)
+      end
+    end
+
+    context "when multiple subscription ids are provided" do
+      before { stub_stdin(organization.id, "y", "#{active_sub.id}, #{terminated_sub.id}", "", "y", "y") }
+
+      it "enqueues a FillHistoryJob for each provided subscription" do
+        task.invoke
+        expect(DailyUsages::FillHistoryJob).to have_received(:perform_later)
+          .with(subscription: active_sub, from_date: DailyUsage::DEFAULT_HISTORY_DAYS.days.ago.to_date)
+        expect(DailyUsages::FillHistoryJob).to have_received(:perform_later)
+          .with(subscription: terminated_sub, from_date: DailyUsage::DEFAULT_HISTORY_DAYS.days.ago.to_date)
+        expect(DailyUsages::FillHistoryJob).not_to have_received(:perform_later)
+          .with(subscription: pending_sub, from_date: anything)
       end
     end
   end


### PR DESCRIPTION
## Description

This PR is related to https://github.com/getlago/lago-api/pull/5694. It adds a new prompt to request an optional list of subscription to reprocess instead of all the active and terminated after the `from_date`