### PR TITLE
BIL 184 DE XRechnung

### DIFF
--- a/app/serializers/e_invoices/credit_notes/ubl/builder.rb
+++ b/app/serializers/e_invoices/credit_notes/ubl/builder.rb
@@ -16,7 +16,7 @@ module EInvoices
           xml.comment "UBL Version and Customization"
           xml["cbc"].UBLVersionID "2.1"
           xml["cbc"].CustomizationID customization_id
-          xml["cbc"].ProfileID profile_id if profile_id
+          xml["cbc"].ProfileID PEPPOL_BIS_BILLING_PROFILE if de_billing_entity?
 
           Ubl::Header.serialize(xml:, resource:, type_code: CREDIT_NOTE, notes:)
           Ubl::BillingReference.serialize(xml:, resource: invoice)

--- a/app/serializers/e_invoices/credit_notes/ubl/builder.rb
+++ b/app/serializers/e_invoices/credit_notes/ubl/builder.rb
@@ -16,6 +16,7 @@ module EInvoices
           xml.comment "UBL Version and Customization"
           xml["cbc"].UBLVersionID "2.1"
           xml["cbc"].CustomizationID customization_id
+          xml["cbc"].ProfileID profile_id if profile_id
 
           Ubl::Header.serialize(xml:, resource:, type_code: CREDIT_NOTE, notes:)
           Ubl::BillingReference.serialize(xml:, resource: invoice)

--- a/app/serializers/e_invoices/credit_notes/ubl/builder.rb
+++ b/app/serializers/e_invoices/credit_notes/ubl/builder.rb
@@ -15,7 +15,7 @@ module EInvoices
         xml.CreditNote(CREDIT_NOTE_NAMESPACES) do
           xml.comment "UBL Version and Customization"
           xml["cbc"].UBLVersionID "2.1"
-          xml["cbc"].CustomizationID "urn:cen.eu:en16931:2017"
+          xml["cbc"].CustomizationID customization_id
 
           Ubl::Header.serialize(xml:, resource:, type_code: CREDIT_NOTE, notes:)
           Ubl::BillingReference.serialize(xml:, resource: invoice)

--- a/app/serializers/e_invoices/invoices/ubl/builder.rb
+++ b/app/serializers/e_invoices/invoices/ubl/builder.rb
@@ -16,7 +16,7 @@ module EInvoices
           xml.comment "UBL Version and Customization"
           xml["cbc"].UBLVersionID "2.1"
           xml["cbc"].CustomizationID customization_id
-          xml["cbc"].ProfileID profile_id if profile_id
+          xml["cbc"].ProfileID PEPPOL_BIS_BILLING_PROFILE if de_billing_entity?
 
           Ubl::Header.serialize(xml:, resource:, type_code: invoice_type_code)
           Ubl::SupplierParty.serialize(xml:, resource:, options: supplier_party_options)

--- a/app/serializers/e_invoices/invoices/ubl/builder.rb
+++ b/app/serializers/e_invoices/invoices/ubl/builder.rb
@@ -16,6 +16,7 @@ module EInvoices
           xml.comment "UBL Version and Customization"
           xml["cbc"].UBLVersionID "2.1"
           xml["cbc"].CustomizationID customization_id
+          xml["cbc"].ProfileID profile_id if profile_id
 
           Ubl::Header.serialize(xml:, resource:, type_code: invoice_type_code)
           Ubl::SupplierParty.serialize(xml:, resource:, options: supplier_party_options)

--- a/app/serializers/e_invoices/invoices/ubl/builder.rb
+++ b/app/serializers/e_invoices/invoices/ubl/builder.rb
@@ -15,7 +15,7 @@ module EInvoices
         xml.Invoice(INVOICE_NAMESPACES) do
           xml.comment "UBL Version and Customization"
           xml["cbc"].UBLVersionID "2.1"
-          xml["cbc"].CustomizationID "urn:cen.eu:en16931:2017"
+          xml["cbc"].CustomizationID customization_id
 
           Ubl::Header.serialize(xml:, resource:, type_code: invoice_type_code)
           Ubl::SupplierParty.serialize(xml:, resource:, options: supplier_party_options)

--- a/app/serializers/e_invoices/ubl/base_serializer.rb
+++ b/app/serializers/e_invoices/ubl/base_serializer.rb
@@ -21,6 +21,20 @@ module EInvoices
       }.merge(COMMON_NAMESPACES).freeze
 
       DATEFORMAT = "%Y-%m-%d"
+
+      EN16931_PROFILE = "urn:cen.eu:en16931:2017"
+      XRECHNUNG_3_0_PROFILE = "#{EN16931_PROFILE}#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0".freeze
+
+      private
+
+      def customization_id
+        case resource.billing_entity.country.try(:upcase)
+        when "DE"
+          XRECHNUNG_3_0_PROFILE
+        else
+          EN16931_PROFILE
+        end
+      end
     end
   end
 end

--- a/app/serializers/e_invoices/ubl/base_serializer.rb
+++ b/app/serializers/e_invoices/ubl/base_serializer.rb
@@ -24,6 +24,7 @@ module EInvoices
 
       EN16931_PROFILE = "urn:cen.eu:en16931:2017"
       XRECHNUNG_3_0_PROFILE = "#{EN16931_PROFILE}#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0".freeze
+      PEPPOL_BIS_BILLING_PROFILE = "urn:fdc:peppol.eu:2017:poacc:billing:01:1.0"
 
       private
 
@@ -33,6 +34,13 @@ module EInvoices
           XRECHNUNG_3_0_PROFILE
         else
           EN16931_PROFILE
+        end
+      end
+
+      def profile_id
+        case resource.billing_entity.country.try(:upcase)
+        when "DE"
+          PEPPOL_BIS_BILLING_PROFILE
         end
       end
     end

--- a/app/serializers/e_invoices/ubl/base_serializer.rb
+++ b/app/serializers/e_invoices/ubl/base_serializer.rb
@@ -28,20 +28,12 @@ module EInvoices
 
       private
 
-      def customization_id
-        case resource.billing_entity.country.try(:upcase)
-        when "DE"
-          XRECHNUNG_3_0_PROFILE
-        else
-          EN16931_PROFILE
-        end
+      def de_billing_entity?
+        resource.billing_entity.country.try(:upcase) == "DE"
       end
 
-      def profile_id
-        case resource.billing_entity.country.try(:upcase)
-        when "DE"
-          PEPPOL_BIS_BILLING_PROFILE
-        end
+      def customization_id
+        de_billing_entity? ? XRECHNUNG_3_0_PROFILE : EN16931_PROFILE
       end
     end
   end

--- a/app/serializers/e_invoices/ubl/customer_party.rb
+++ b/app/serializers/e_invoices/ubl/customer_party.rb
@@ -9,6 +9,7 @@ module EInvoices
         xml.comment "Customer Party"
         xml["cac"].AccountingCustomerParty do
           xml["cac"].Party do
+            xml["cbc"].EndpointID customer.email, schemeID: "EM" if customer.email.present?
             xml["cac"].PostalAddress do
               xml["cbc"].StreetName customer.address_line1
               xml["cbc"].AdditionalStreetName customer.address_line2 if customer.address_line2.present?

--- a/app/serializers/e_invoices/ubl/customer_party.rb
+++ b/app/serializers/e_invoices/ubl/customer_party.rb
@@ -11,7 +11,7 @@ module EInvoices
           xml["cac"].Party do
             xml["cac"].PostalAddress do
               xml["cbc"].StreetName customer.address_line1
-              xml["cbc"].AdditionalStreetName customer.address_line2
+              xml["cbc"].AdditionalStreetName customer.address_line2 if customer.address_line2.present?
               xml["cbc"].CityName customer.city
               xml["cbc"].PostalZone customer.zipcode
               xml["cac"].Country do

--- a/app/serializers/e_invoices/ubl/customer_party.rb
+++ b/app/serializers/e_invoices/ubl/customer_party.rb
@@ -22,6 +22,10 @@ module EInvoices
             xml["cac"].PartyLegalEntity do
               xml["cbc"].RegistrationName customer.name
             end
+            xml["cac"].Contact do
+              xml["cbc"].Name customer.name
+              xml["cbc"].ElectronicMail customer.email if customer.email.present?
+            end
           end
         end
       end

--- a/app/serializers/e_invoices/ubl/header.rb
+++ b/app/serializers/e_invoices/ubl/header.rb
@@ -19,6 +19,7 @@ module EInvoices
           xml["cbc"].Note note
         end
         xml["cbc"].DocumentCurrencyCode resource.currency
+        xml["cbc"].BuyerReference resource.customer.external_id if de_billing_entity?
       end
 
       private

--- a/app/serializers/e_invoices/ubl/receiver_party.rb
+++ b/app/serializers/e_invoices/ubl/receiver_party.rb
@@ -17,7 +17,7 @@ module EInvoices
           end
           xml["cac"].PostalAddress do
             xml["cbc"].StreetName customer.address_line1
-            xml["cbc"].AdditionalStreetName customer.address_line2
+            xml["cbc"].AdditionalStreetName customer.address_line2 if customer.address_line2.present?
             xml["cbc"].CityName customer.city
             xml["cbc"].PostalZone customer.zipcode
             xml["cac"].Country do

--- a/app/serializers/e_invoices/ubl/sender_party.rb
+++ b/app/serializers/e_invoices/ubl/sender_party.rb
@@ -20,7 +20,7 @@ module EInvoices
           end
           xml["cac"].PostalAddress do
             xml["cbc"].StreetName billing_entity.address_line1
-            xml["cbc"].AdditionalStreetName billing_entity.address_line2
+            xml["cbc"].AdditionalStreetName billing_entity.address_line2 if billing_entity.address_line2.present?
             xml["cbc"].CityName billing_entity.city
             xml["cbc"].PostalZone billing_entity.zipcode
             xml["cac"].Country do

--- a/app/serializers/e_invoices/ubl/supplier_party.rb
+++ b/app/serializers/e_invoices/ubl/supplier_party.rb
@@ -43,6 +43,11 @@ module EInvoices
               xml["cbc"].RegistrationName billing_entity.legal_name
               xml["cbc"].CompanyID billing_entity.tax_identification_number
             end
+            xml["cac"].Contact do
+              xml["cbc"].Name billing_entity.name
+              xml["cbc"].Telephone billing_entity.phone if de_billing_entity?
+              xml["cbc"].ElectronicMail billing_entity.email if billing_entity.email.present?
+            end
           end
         end
       end

--- a/app/serializers/e_invoices/ubl/supplier_party.rb
+++ b/app/serializers/e_invoices/ubl/supplier_party.rb
@@ -21,6 +21,7 @@ module EInvoices
         xml.comment "Supplier Party"
         xml["cac"].AccountingSupplierParty do
           xml["cac"].Party do
+            xml["cbc"].EndpointID billing_entity.email, schemeID: "EM" if billing_entity.email.present?
             xml["cac"].PostalAddress do
               xml["cbc"].StreetName billing_entity.address_line1
               xml["cbc"].AdditionalStreetName billing_entity.address_line2 if billing_entity.address_line2.present?

--- a/app/serializers/e_invoices/ubl/supplier_party.rb
+++ b/app/serializers/e_invoices/ubl/supplier_party.rb
@@ -23,7 +23,7 @@ module EInvoices
           xml["cac"].Party do
             xml["cac"].PostalAddress do
               xml["cbc"].StreetName billing_entity.address_line1
-              xml["cbc"].AdditionalStreetName billing_entity.address_line2
+              xml["cbc"].AdditionalStreetName billing_entity.address_line2 if billing_entity.address_line2.present?
               xml["cbc"].CityName billing_entity.city
               xml["cbc"].PostalZone billing_entity.zipcode
               xml["cac"].Country do

--- a/spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb
@@ -46,6 +46,25 @@ RSpec.describe EInvoices::CreditNotes::Ubl::Builder do
         end
       end
 
+      context "when ProfileID tag" do
+        context "with a non-DE billing entity" do
+          before { invoice.billing_entity.update!(country: "FR") }
+
+          it "does not insert ProfileID" do
+            expect(subject).not_to contains_xml_node("//cbc:ProfileID")
+          end
+        end
+
+        context "with a German billing entity" do
+          before { invoice.billing_entity.update!(country: "DE") }
+
+          it "inserts the Peppol BIS Billing 3.0 ProfileID" do
+            expect(subject).to contains_xml_node("//cbc:ProfileID")
+              .with_value("urn:fdc:peppol.eu:2017:poacc:billing:01:1.0")
+          end
+        end
+      end
+
       it "contains header tags" do
         expect(subject).to contains_xml_node("//cbc:ID").with_value(credit_note.number)
         expect(subject).to contains_xml_node("//cbc:IssueDate").with_value(credit_note.issuing_date)

--- a/spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb
@@ -26,8 +26,24 @@ RSpec.describe EInvoices::CreditNotes::Ubl::Builder do
         expect(subject).to contains_xml_node("//cbc:UBLVersionID").with_value(2.1)
       end
 
-      it "contains CustomizationID tag" do
-        expect(subject).to contains_xml_node("//cbc:CustomizationID").with_value("urn:cen.eu:en16931:2017")
+      context "when CustomizationID tag" do
+        context "with a non-DE billing entity" do
+          before { invoice.billing_entity.update!(country: "FR") }
+
+          it "uses the EN 16931 profile" do
+            expect(subject).to contains_xml_node("//cbc:CustomizationID")
+              .with_value("urn:cen.eu:en16931:2017")
+          end
+        end
+
+        context "with a German billing entity" do
+          before { invoice.billing_entity.update!(country: "DE") }
+
+          it "uses the XRechnung 3.0 profile" do
+            expect(subject).to contains_xml_node("//cbc:CustomizationID")
+              .with_value("urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0")
+          end
+        end
       end
 
       it "contains header tags" do

--- a/spec/serializers/e_invoices/invoices/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/invoices/ubl/builder_spec.rb
@@ -29,8 +29,24 @@ RSpec.describe EInvoices::Invoices::Ubl::Builder do
         expect(subject).to contains_xml_node("//cbc:UBLVersionID").with_value(2.1)
       end
 
-      it "has CustomizationID tag" do
-        expect(subject).to contains_xml_node("//cbc:CustomizationID").with_value("urn:cen.eu:en16931:2017")
+      context "when CustomizationID tag" do
+        context "with a non-DE billing entity" do
+          before { invoice.billing_entity.update!(country: "FR") }
+
+          it "uses the EN 16931 profile" do
+            expect(subject).to contains_xml_node("//cbc:CustomizationID")
+              .with_value("urn:cen.eu:en16931:2017")
+          end
+        end
+
+        context "with a German billing entity" do
+          before { invoice.billing_entity.update!(country: "DE") }
+
+          it "uses the XRechnung 3.0 profile" do
+            expect(subject).to contains_xml_node("//cbc:CustomizationID")
+              .with_value("urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0")
+          end
+        end
       end
 
       it "has ID tag" do

--- a/spec/serializers/e_invoices/invoices/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/invoices/ubl/builder_spec.rb
@@ -49,6 +49,25 @@ RSpec.describe EInvoices::Invoices::Ubl::Builder do
         end
       end
 
+      context "when ProfileID tag" do
+        context "with a non-DE billing entity" do
+          before { invoice.billing_entity.update!(country: "FR") }
+
+          it "does not insert ProfileID" do
+            expect(subject).not_to contains_xml_node("//cbc:ProfileID")
+          end
+        end
+
+        context "with a German billing entity" do
+          before { invoice.billing_entity.update!(country: "DE") }
+
+          it "insert the Peppol BIS Billing 3.0 ProfileID" do
+            expect(subject).to contains_xml_node("//cbc:ProfileID")
+              .with_value("urn:fdc:peppol.eu:2017:poacc:billing:01:1.0")
+          end
+        end
+      end
+
       it "has ID tag" do
         expect(subject).to contains_xml_node("//cbc:ID").with_value(invoice.number)
       end

--- a/spec/serializers/e_invoices/ubl/customer_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/customer_party_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe EInvoices::Ubl::CustomerParty do
           expect(subject).to contains_xml_node("#{xpath}/cbc:AdditionalStreetName").with_value(customer.address_line2)
         end
 
+        context "when address_line2 is blank" do
+          before { customer.update!(address_line2: nil) }
+
+          it "omits AdditionalStreetName" do
+            expect(subject).not_to contains_xml_node("#{xpath}/cbc:AdditionalStreetName")
+          end
+        end
+
         it "expects to have city" do
           expect(subject).to contains_xml_node("#{xpath}/cbc:CityName").with_value(customer.city)
         end

--- a/spec/serializers/e_invoices/ubl/customer_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/customer_party_spec.rb
@@ -36,6 +36,24 @@ RSpec.describe EInvoices::Ubl::CustomerParty do
     end
 
     context "with customer" do
+      context "with EndpointID" do
+        let(:xpath) { "#{root}/cbc:EndpointID" }
+
+        it "emits the buyer email with schemeID EM (BR-CO-25)" do
+          expect(subject).to contains_xml_node(xpath)
+            .with_value(customer.email)
+            .with_attribute("schemeID", "EM")
+        end
+
+        context "when customer has no email" do
+          before { customer.update!(email: nil) }
+
+          it "omits EndpointID" do
+            expect(subject).not_to contains_xml_node(xpath)
+          end
+        end
+      end
+
       context "with PostalAddress" do
         let(:xpath) { "#{root}/cac:PostalAddress" }
 

--- a/spec/serializers/e_invoices/ubl/customer_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/customer_party_spec.rb
@@ -84,6 +84,27 @@ RSpec.describe EInvoices::Ubl::CustomerParty do
         end
       end
 
+      context "with Contact" do
+        let(:xpath) { "#{root}/cac:Contact" }
+
+        it "emits the buyer contact (BR-DE-3)" do
+          expect(subject).to contains_xml_node("#{xpath}/cbc:Name")
+            .with_value(customer.name)
+          expect(subject).to contains_xml_node("#{xpath}/cbc:ElectronicMail")
+            .with_value(customer.email)
+        end
+
+        context "when customer has no email" do
+          before { customer.update!(email: nil) }
+
+          it "still emits Name but omits ElectronicMail" do
+            expect(subject).to contains_xml_node("#{xpath}/cbc:Name")
+              .with_value(customer.name)
+            expect(subject).not_to contains_xml_node("#{xpath}/cbc:ElectronicMail")
+          end
+        end
+      end
+
       context "with PartyLegalEntity" do
         let(:xpath) { "#{root}/cac:PartyLegalEntity" }
 

--- a/spec/serializers/e_invoices/ubl/header_spec.rb
+++ b/spec/serializers/e_invoices/ubl/header_spec.rb
@@ -63,5 +63,41 @@ RSpec.describe EInvoices::Ubl::Header do
       expect(subject).to contains_xml_node("//cbc:DocumentCurrencyCode")
         .with_value(resource.currency)
     end
+
+    context "with BuyerReference tag" do
+      context "with a non-DE billing entity" do
+        before { resource.billing_entity.update!(country: "FR") }
+
+        it "does not emit BuyerReference" do
+          expect(subject).not_to contains_xml_node("//cbc:BuyerReference")
+        end
+      end
+
+      context "with a German billing entity" do
+        before { resource.billing_entity.update!(country: "DE") }
+
+        it "emits BuyerReference with the customer's external_id" do
+          expect(subject).to contains_xml_node("//cbc:BuyerReference")
+            .with_value(resource.customer.external_id)
+        end
+      end
+
+      context "when billing entity country is lowercase" do
+        before { resource.billing_entity.update!(country: "de") }
+
+        it "normalizes and still emits BuyerReference" do
+          expect(subject).to contains_xml_node("//cbc:BuyerReference")
+            .with_value(resource.customer.external_id)
+        end
+      end
+
+      context "when billing entity country is nil" do
+        before { resource.billing_entity.update!(country: nil) }
+
+        it "does not emit BuyerReference" do
+          expect(subject).not_to contains_xml_node("//cbc:BuyerReference")
+        end
+      end
+    end
   end
 end

--- a/spec/serializers/e_invoices/ubl/receiver_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/receiver_party_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe EInvoices::Ubl::ReceiverParty do
         expect(subject).to contains_xml_node("#{xpath}/cbc:AdditionalStreetName").with_value(customer.address_line2)
       end
 
+      context "when address_line2 is blank" do
+        before { customer.update!(address_line2: nil) }
+
+        it "omits AdditionalStreetName" do
+          expect(subject).not_to contains_xml_node("#{xpath}/cbc:AdditionalStreetName")
+        end
+      end
+
       it "expects to have city" do
         expect(subject).to contains_xml_node("#{xpath}/cbc:CityName").with_value(customer.city)
       end

--- a/spec/serializers/e_invoices/ubl/sender_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/sender_party_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe EInvoices::Ubl::SenderParty do
         expect(subject).to contains_xml_node("#{xpath}/cbc:AdditionalStreetName").with_value(billing_entity.address_line2)
       end
 
+      context "when address_line2 is blank" do
+        before { billing_entity.update!(address_line2: nil) }
+
+        it "omits AdditionalStreetName" do
+          expect(subject).not_to contains_xml_node("#{xpath}/cbc:AdditionalStreetName")
+        end
+      end
+
       it "expects to have city" do
         expect(subject).to contains_xml_node("#{xpath}/cbc:CityName").with_value(billing_entity.city)
       end

--- a/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe EInvoices::Ubl::SupplierParty do
     end
 
     context "with billing entity" do
+      context "with EndpointID" do
+        let(:xpath) { "#{root}/cbc:EndpointID" }
+
+        it "emits the seller email with schemeID EM (BR-CO-26)" do
+          expect(subject).to contains_xml_node(xpath)
+            .with_value(billing_entity.email)
+            .with_attribute("schemeID", "EM")
+        end
+
+        context "when billing entity has no email" do
+          before { billing_entity.update!(email: nil) }
+
+          it "omits EndpointID" do
+            expect(subject).not_to contains_xml_node(xpath)
+          end
+        end
+      end
+
       context "with PostalAddress" do
         let(:xpath) { "#{root}/cac:PostalAddress" }
 

--- a/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe EInvoices::Ubl::SupplierParty do
           expect(subject).to contains_xml_node("#{xpath}/cbc:AdditionalStreetName").with_value(billing_entity.address_line2)
         end
 
+        context "when address_line2 is blank" do
+          before { billing_entity.update!(address_line2: nil) }
+
+          it "omits AdditionalStreetName" do
+            expect(subject).not_to contains_xml_node("#{xpath}/cbc:AdditionalStreetName")
+          end
+        end
+
         it "expects to have city" do
           expect(subject).to contains_xml_node("#{xpath}/cbc:CityName").with_value(billing_entity.city)
         end

--- a/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
+++ b/spec/serializers/e_invoices/ubl/supplier_party_spec.rb
@@ -108,6 +108,44 @@ RSpec.describe EInvoices::Ubl::SupplierParty do
         end
       end
 
+      context "with Contact" do
+        let(:xpath) { "#{root}/cac:Contact" }
+
+        it "emits the seller Name and ElectronicMail" do
+          expect(subject).to contains_xml_node("#{xpath}/cbc:Name")
+            .with_value(billing_entity.name)
+          expect(subject).to contains_xml_node("#{xpath}/cbc:ElectronicMail")
+            .with_value(billing_entity.email)
+        end
+
+        context "with a German billing entity" do
+          before { billing_entity.update!(country: "DE", phone: "+49 30 1234-5678") }
+
+          it "emits the billing entity's phone as Telephone" do
+            expect(subject).to contains_xml_node("#{xpath}/cbc:Telephone")
+              .with_value("+49 30 1234-5678")
+          end
+        end
+
+        context "with a non-DE billing entity" do
+          before { billing_entity.update!(country: "FR") }
+
+          it "does not emit Telephone" do
+            expect(subject).not_to contains_xml_node("#{xpath}/cbc:Telephone")
+          end
+        end
+
+        context "when billing entity has no email" do
+          before { billing_entity.update!(email: nil) }
+
+          it "still emits Name but omits ElectronicMail" do
+            expect(subject).to contains_xml_node("#{xpath}/cbc:Name")
+              .with_value(billing_entity.name)
+            expect(subject).not_to contains_xml_node("#{xpath}/cbc:ElectronicMail")
+          end
+        end
+      end
+
       context "with PartyLegalEntity" do
         let(:xpath) { "#{root}/cac:PartyLegalEntity" }
 


### PR DESCRIPTION
## Context

XRechnung 3.0 is the German profile of EN 16931 used to route compliant e-invoices through Peppol. It requires three UBL header changes that France's current output doesn't make: a more specific `CustomizationID`, a `ProfileID` declaring the Peppol BIS Billing 3.0 profile, and a mandatory `cbc:BuyerReference` to identify the buyer for downstream routing. This branch brings the invoice and credit-note UBL builders in line with all three, country-gated so French output is unchanged.

## Changes

Three commits, each tightly scoped to one element:

**`feat(ubl): country-aware CustomizationID`** — `CustomizationID` is now selected by billing entity country. DE emits `urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0` (the XRechnung 3.0 profile string); every other country emits the EN 16931 core `urn:cen.eu:en16931:2017`. The selector lives on `EInvoices::Ubl::BaseSerializer` so both invoice and credit-note builders inherit it, reading from `resource.billing_entity.country`. Profile strings are exposed as `EN16931_PROFILE` and `XRECHNUNG_3_0_PROFILE` constants.

**`feat(ubl): country-aware ProfileID`** — `ProfileID` is now conditionally emitted. DE → `urn:fdc:peppol.eu:2017:poacc:billing:01:1.0` (Peppol BIS Billing 3.0); every other country → no `ProfileID` element at all (preserves current FR behavior). The selector returns `nil` for non-DE; builders skip the XML node on `nil` via `xml["cbc"].ProfileID PEPPOL_BIS_BILLING_PROFILE if de_billing_entity?`. The constant is `PEPPOL_BIS_BILLING_PROFILE`.

**`feat(ubl): BuyerReference for DE`** — `cbc:BuyerReference` is now emitted from the shared `Ubl::Header` serializer when the billing entity is German, sourced from `resource.customer.external_id`. Other countries continue to emit no `BuyerReference`. While there, extracted a single private `de_billing_entity?` predicate into `EInvoices::Ubl::BaseSerializer` so the `BuyerReference` guard, `customization_id`, and the `ProfileID` guard all read the DE check from one place — a future country addition becomes a one-line edit.

## Tests

Specs were extended for every branch:

- `spec/serializers/e_invoices/invoices/ubl/builder_spec.rb` — new `when CustomizationID tag` and `when ProfileID tag` contexts covering FR (EN 16931 / not emitted) and DE (XRechnung 3.0 / Peppol BIS).
- `spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb` — same pair of contexts on the credit-note builder.
- `spec/serializers/e_invoices/ubl/header_spec.rb` — new `with BuyerReference tag` context covering FR (not emitted), DE (emitted with `customer.external_id`), lowercase `de` (normalized), and nil-country (not emitted) — the last two guard the `try(:upcase)` chain.

```
lago exec api bundle exec rspec \
  spec/serializers/e_invoices/invoices/ubl/builder_spec.rb \
  spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb \
  spec/serializers/e_invoices/ubl/header_spec.rb
# 100 examples, 0 failures
```

## Dependencies / follow-ups

- **Depends on:** — https://github.com/getlago/lago-api/pull/5714
- **Future country additions** (IT, ES, NL, …) only need a new branch in `de_billing_entity?` (rename if more countries land) plus a profile constant. Per-element XML emission paths don't need to change.
