### PR TITLE
feat(quotes): Add quotes REST API endpoints

### DIFF
--- a/app/contracts/queries/quotes_query_filters_contract.rb
+++ b/app/contracts/queries/quotes_query_filters_contract.rb
@@ -6,6 +6,9 @@ module Queries
       optional(:customers).maybe do
         array(:string, format?: Regex::UUID)
       end
+      optional(:external_customer_ids).maybe do
+        array(:string)
+      end
       optional(:statuses).maybe do
         array(:string, included_in?: QuoteVersion::STATUSES.values)
       end

--- a/app/controllers/api/v1/quote_versions_controller.rb
+++ b/app/controllers/api/v1/quote_versions_controller.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class QuoteVersionsController < Api::BaseController
+      before_action :ensure_feature_flag!
+
+      def show
+        quote_version = current_organization.quote_versions.find_by(id: params[:id])
+        return not_found_error(resource: "quote_version") unless quote_version
+
+        render_quote_version(quote_version)
+      end
+
+      def approve
+        # A nil quote_version is intentional: the service returns a not_found failure.
+        quote_version = current_organization.quote_versions.find_by(id: params[:id])
+
+        result = QuoteVersions::ApproveService.call(quote_version:)
+
+        if result.success?
+          render_quote_version(result.quote_version)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def void
+        # A nil quote_version is intentional: the service returns a not_found failure.
+        quote_version = current_organization.quote_versions.find_by(id: params[:id])
+
+        result = QuoteVersions::VoidService.call(quote_version:, reason: :manual)
+
+        if result.success?
+          render_quote_version(result.quote_version)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def clone
+        # A nil quote_version is intentional: the service returns a not_found failure.
+        quote_version = current_organization.quote_versions.find_by(id: params[:id])
+
+        result = QuoteVersions::CloneService.call(quote_version:)
+
+        if result.success?
+          render_quote_version(result.quote_version)
+        else
+          render_error_response(result)
+        end
+      end
+
+      private
+
+      def ensure_feature_flag!
+        forbidden_error(code: "feature_unavailable") unless current_organization.feature_flag_enabled?(:order_forms)
+      end
+
+      def render_quote_version(quote_version)
+        render(json: ::V1::QuoteVersionSerializer.new(quote_version, root_name: "quote_version", includes: %i[content billing_items]))
+      end
+
+      # API-key scope bucket: ApiKey::RESOURCES has "quote" but no "quote_version",
+      # so quote versions authorize against the "quote" scope. This is intentionally
+      # distinct from the not_found_error "quote_version" resource label.
+      def resource_name
+        "quote"
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/quotes/versions_controller.rb
+++ b/app/controllers/api/v1/quotes/versions_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Quotes
+      class VersionsController < Api::BaseController
+        before_action :ensure_feature_flag!
+        before_action :find_quote
+
+        def index
+          versions = @quote.versions
+            .page(params[:page])
+            .per(params[:per_page] || PER_PAGE)
+
+          render(
+            json: ::CollectionSerializer.new(
+              versions,
+              ::V1::QuoteVersionSerializer,
+              collection_name: "quote_versions",
+              meta: pagination_metadata(versions)
+            )
+          )
+        end
+
+        private
+
+        def ensure_feature_flag!
+          forbidden_error(code: "feature_unavailable") unless current_organization.feature_flag_enabled?(:order_forms)
+        end
+
+        def find_quote
+          @quote = current_organization.quotes.find_by(id: params[:quote_id])
+          not_found_error(resource: "quote") unless @quote
+        end
+
+        def resource_name
+          "quote"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/quotes_controller.rb
+++ b/app/controllers/api/v1/quotes_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class QuotesController < Api::BaseController
+      before_action :ensure_feature_flag!
+
+      def index
+        result = QuotesQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters: index_filters
+        )
+
+        if result.success?
+          quotes = result.quotes.includes(:current_version)
+          render_quotes(quotes, meta: pagination_metadata(result.quotes))
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        quote = current_organization.quotes.find_by(id: params[:id])
+        return not_found_error(resource: "quote") unless quote
+
+        render_quote(quote)
+      end
+
+      private
+
+      def ensure_feature_flag!
+        forbidden_error(code: "feature_unavailable") unless current_organization.feature_flag_enabled?(:order_forms)
+      end
+
+      def index_filters
+        {
+          statuses: Array.wrap(params[:status]).presence,
+          order_types: Array.wrap(params[:order_type]).presence,
+          numbers: Array.wrap(params[:number]).presence,
+          owners: Array.wrap(params[:owner_id]).presence,
+          external_customer_ids: Array.wrap(params[:external_customer_id]).presence,
+          from_date: params[:from_date],
+          to_date: params[:to_date]
+        }
+      end
+
+      def render_quotes(quotes, meta:)
+        render(
+          json: ::CollectionSerializer.new(
+            quotes,
+            ::V1::QuoteSerializer,
+            collection_name: "quotes",
+            meta:
+          )
+        )
+      end
+
+      def render_quote(quote)
+        render(json: ::V1::QuoteSerializer.new(quote, root_name: "quote", includes: %i[owners]))
+      end
+
+      def resource_name
+        "quote"
+      end
+    end
+  end
+end

--- a/app/queries/quotes_query.rb
+++ b/app/queries/quotes_query.rb
@@ -2,13 +2,14 @@
 
 class QuotesQuery < BaseQuery
   Result = BaseResult[:quotes]
-  Filters = BaseFilters[:customers, :numbers, :statuses, :from_date, :to_date, :owners, :order_types]
+  Filters = BaseFilters[:customers, :external_customer_ids, :numbers, :statuses, :from_date, :to_date, :owners, :order_types]
 
   def call
     return result unless validate_filters.success?
 
     quotes = base_scope
     quotes = with_customer(quotes) if filters.customers.present?
+    quotes = with_external_customers(quotes) if filters.external_customer_ids.present?
     quotes = with_number(quotes) if filters.numbers.present?
     quotes = with_status(quotes) if filters.statuses.present?
     quotes = with_date(quotes) if filters.from_date.present? || filters.to_date.present?
@@ -37,6 +38,10 @@ class QuotesQuery < BaseQuery
 
   def with_customer(scope)
     scope.where(customer_id: filters.customers)
+  end
+
+  def with_external_customers(scope)
+    scope.joins(:customer).where(customers: {external_id: filters.external_customer_ids})
   end
 
   def with_number(scope)

--- a/app/serializers/v1/quote_serializer.rb
+++ b/app/serializers/v1/quote_serializer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module V1
+  class QuoteSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        number: model.number,
+        order_type: model.order_type,
+        lago_customer_id: model.customer_id,
+        lago_subscription_id: model.subscription_id,
+        lago_organization_id: model.organization_id,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }.merge(current_version)
+
+      payload.merge!(owners) if include?(:owners)
+      payload
+    end
+
+    private
+
+    def current_version
+      version = model.current_version
+
+      {
+        current_version: version && ::V1::QuoteVersionSerializer.new(version).serialize
+      }
+    end
+
+    def owners
+      {
+        owners: model.owners.map { |owner| {lago_id: owner.id, email: owner.email} }
+      }
+    end
+  end
+end

--- a/app/serializers/v1/quote_version_serializer.rb
+++ b/app/serializers/v1/quote_version_serializer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module V1
+  class QuoteVersionSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        lago_quote_id: model.quote_id,
+        lago_organization_id: model.organization_id,
+        version: model.version,
+        status: model.status,
+        currency: model.currency,
+        start_date: model.start_date&.iso8601,
+        end_date: model.end_date&.iso8601,
+        void_reason: model.void_reason,
+        approved_at: model.approved_at&.iso8601,
+        voided_at: model.voided_at&.iso8601,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+
+      # content/billing_items are heavy blobs: render them only for single-resource
+      # responses, never in list/embed payloads.
+      payload[:content] = model.content if include?(:content)
+      payload[:billing_items] = model.billing_items if include?(:billing_items)
+
+      # share_token is intentionally omitted from the REST API. It is a bearer capability
+      # with no consumer yet; it should be disclosed only through a purpose-built share
+      # endpoint when the sharing feature lands, not as an ambient read field.
+      payload
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,15 @@ Rails.application.routes.draw do
         post :void, on: :member
       end
 
+      resources :quotes, only: %i[index show] do
+        resources :versions, only: %i[index], controller: "quotes/versions"
+      end
+      resources :quote_versions, only: %i[show] do
+        post :approve, on: :member
+        post :void, on: :member
+        post :clone, on: :member
+      end
+
       resources :orders, only: %i[show index]
       resources :payments, only: %i[create index show]
       resources :plans, param: :code, code: /.*/ do

--- a/spec/queries/quotes_query_spec.rb
+++ b/spec/queries/quotes_query_spec.rb
@@ -71,6 +71,33 @@ RSpec.describe QuotesQuery do
       end
     end
 
+    describe "external_customer_ids" do
+      context "when filtering by an existing external customer id" do
+        let(:other_customer) { create(:customer, organization:) }
+        let(:other_quote) { create(:quote, :with_version, organization:, customer: other_customer) }
+        let(:filters) { {external_customer_ids: [other_customer.external_id]} }
+
+        before do
+          other_quote
+        end
+
+        it "returns only that customer's quotes" do
+          expect(result).to be_success
+          expect(returned_ids.count).to eq(1)
+          expect(returned_ids).to include(other_quote.id)
+        end
+      end
+
+      context "when filtering by an unknown external customer id" do
+        let(:filters) { {external_customer_ids: ["unknown"]} }
+
+        it "returns no quotes" do
+          expect(result).to be_success
+          expect(returned_ids).to be_empty
+        end
+      end
+    end
+
     describe "statuses" do
       context "when filtering by valid status" do
         let(:filters) { {statuses: ["draft"]} }

--- a/spec/requests/api/v1/quote_versions_controller_spec.rb
+++ b/spec/requests/api/v1/quote_versions_controller_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::QuoteVersionsController do
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:) }
+  let(:quote_version) { create(:quote_version, quote:, organization:) }
+
+  describe "GET /api/v1/quote_versions/:id" do
+    subject { get_with_token(organization, "/api/v1/quote_versions/#{quote_version_id}") }
+
+    let(:quote_version_id) { quote_version.id }
+
+    before { quote_version }
+
+    include_examples "requires API permission", "quote", "read"
+
+    it "returns the quote version with full details" do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:quote_version][:lago_id]).to eq(quote_version.id)
+      expect(json[:quote_version][:lago_quote_id]).to eq(quote.id)
+      expect(json[:quote_version][:status]).to eq("draft")
+      expect(json[:quote_version][:version]).to eq(quote_version.version)
+      expect(json[:quote_version].key?(:content)).to be(true)
+      expect(json[:quote_version].key?(:share_token)).to be(false)
+    end
+
+    context "when the quote version does not exist" do
+      let(:quote_version_id) { SecureRandom.uuid }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("quote_version")
+      end
+    end
+
+    context "when the quote version belongs to another organization" do
+      let(:quote_version) { create(:quote_version) }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("quote_version")
+      end
+    end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+  end
+
+  describe "POST /api/v1/quote_versions/:id/approve" do
+    subject { post_with_token(organization, "/api/v1/quote_versions/#{quote_version_id}/approve") }
+
+    let(:quote_version_id) { quote_version.id }
+
+    before { quote_version }
+
+    include_examples "requires API permission", "quote", "write"
+
+    it "approves the quote version", :premium do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:quote_version][:lago_id]).to eq(quote_version.id)
+      expect(json[:quote_version][:status]).to eq("approved")
+    end
+
+    context "when the quote version is not approvable", :premium do
+      let(:quote_version) { create(:quote_version, :voided, quote:, organization:) }
+
+      it "returns method not allowed" do
+        subject
+
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+
+    context "when the quote version does not exist", :premium do
+      let(:quote_version_id) { SecureRandom.uuid }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("quote_version")
+      end
+    end
+
+    context "without a premium license" do
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+  end
+
+  describe "POST /api/v1/quote_versions/:id/void" do
+    subject { post_with_token(organization, "/api/v1/quote_versions/#{quote_version_id}/void") }
+
+    let(:quote_version_id) { quote_version.id }
+
+    before { quote_version }
+
+    include_examples "requires API permission", "quote", "write"
+
+    it "voids the quote version", :premium do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:quote_version][:status]).to eq("voided")
+      expect(json[:quote_version][:void_reason]).to eq("manual")
+    end
+
+    context "when the quote version is not voidable", :premium do
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+      it "returns method not allowed" do
+        subject
+
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+
+    context "when the quote version does not exist", :premium do
+      let(:quote_version_id) { SecureRandom.uuid }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("quote_version")
+      end
+    end
+
+    context "without a premium license" do
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+  end
+
+  describe "POST /api/v1/quote_versions/:id/clone" do
+    subject { post_with_token(organization, "/api/v1/quote_versions/#{quote_version_id}/clone") }
+
+    let(:quote_version_id) { quote_version.id }
+
+    before { quote_version }
+
+    include_examples "requires API permission", "quote", "write"
+
+    it "clones the quote version into a new draft", :premium do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:quote_version][:status]).to eq("draft")
+      expect(json[:quote_version][:lago_id]).not_to eq(quote_version.id)
+    end
+
+    context "when an approved version exists", :premium do
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("inappropriate_state")
+      end
+    end
+
+    context "when the quote version does not exist", :premium do
+      let(:quote_version_id) { SecureRandom.uuid }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("quote_version")
+      end
+    end
+
+    context "without a premium license" do
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/quotes/versions_controller_spec.rb
+++ b/spec/requests/api/v1/quotes/versions_controller_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Quotes::VersionsController do
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+
+  describe "GET /api/v1/quotes/:quote_id/versions" do
+    subject { get_with_token(organization, "/api/v1/quotes/#{quote_id}/versions", params) }
+
+    let(:params) { {} }
+    let(:quote_id) { quote.id }
+    let!(:quote) { create(:quote, organization:, customer:) }
+    let!(:voided_version) { create(:quote_version, :voided, quote:, organization:) }
+    let!(:draft_version) { create(:quote_version, quote:, organization:) }
+
+    include_examples "requires API permission", "quote", "read"
+
+    it "returns the slim quote versions" do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:quote_versions].count).to eq(2)
+      expect(json[:quote_versions].map { |version| version[:lago_id] }).to match_array([voided_version.id, draft_version.id])
+      expect(json[:quote_versions].first.keys).not_to include(:share_token, :content, :billing_items)
+    end
+
+    it "orders versions by sequential_id descending (newest first)" do
+      subject
+
+      expect(json[:quote_versions].map { |version| version[:lago_id] }).to eq([draft_version.id, voided_version.id])
+    end
+
+    it "returns canonical pagination meta" do
+      subject
+
+      expect(json[:meta]).to include(current_page: 1, total_pages: 1, total_count: 2)
+    end
+
+    context "with pagination" do
+      let(:params) { {page: 1, per_page: 1} }
+
+      it "returns paginated versions with meta data" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quote_versions].count).to eq(1)
+        expect(json[:meta]).to include(
+          current_page: 1,
+          next_page: 2,
+          prev_page: nil,
+          total_pages: 2,
+          total_count: 2
+        )
+      end
+    end
+
+    context "when the quote does not exist" do
+      let(:quote_id) { SecureRandom.uuid }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("quote")
+      end
+    end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/quotes_controller_spec.rb
+++ b/spec/requests/api/v1/quotes_controller_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::QuotesController do
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+
+  describe "GET /api/v1/quotes" do
+    subject { get_with_token(organization, "/api/v1/quotes", params) }
+
+    let(:params) { {} }
+    let!(:quote) { create(:quote, organization:, customer:) }
+    let!(:quote_version) { create(:quote_version, quote:, organization:) }
+
+    include_examples "requires API permission", "quote", "read"
+
+    it "returns a list of quotes" do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:quotes].count).to eq(1)
+      expect(json[:quotes].first[:lago_id]).to eq(quote.id)
+      expect(json[:quotes].first[:current_version][:lago_id]).to eq(quote_version.id)
+    end
+
+    it "embeds a slim current version without sensitive or heavy fields" do
+      subject
+
+      expect(json[:quotes].first[:current_version].keys).not_to include(:share_token, :content, :billing_items)
+    end
+
+    it "does not embed owners on the index" do
+      subject
+
+      expect(json[:quotes].first).not_to have_key(:owners)
+    end
+
+    context "when filtering by status" do
+      subject { get_with_token(organization, "/api/v1/quotes", {status: "approved"}) }
+
+      let!(:approved_quote) { create(:quote, organization:, customer:) }
+
+      before { create(:quote_version, :approved, quote: approved_quote, organization:) }
+
+      it "returns only quotes whose current version matches" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quotes].count).to eq(1)
+        expect(json[:quotes].first[:lago_id]).to eq(approved_quote.id)
+      end
+    end
+
+    context "when filtering by order_type" do
+      subject { get_with_token(organization, "/api/v1/quotes", {order_type: "one_off"}) }
+
+      let!(:one_off_quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+
+      it "returns only matching quotes" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quotes].count).to eq(1)
+        expect(json[:quotes].first[:lago_id]).to eq(one_off_quote.id)
+      end
+    end
+
+    context "when filtering by number" do
+      subject { get_with_token(organization, "/api/v1/quotes", {number: quote.number}) }
+
+      before { create(:quote, organization:, customer:) }
+
+      it "returns only the matching quote" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quotes].count).to eq(1)
+        expect(json[:quotes].first[:lago_id]).to eq(quote.id)
+      end
+    end
+
+    context "when filtering by external_customer_id" do
+      subject { get_with_token(organization, "/api/v1/quotes", {external_customer_id: customer.external_id}) }
+
+      before { create(:quote, organization:, customer: create(:customer, organization:)) }
+
+      it "returns only that customer's quotes" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quotes].count).to eq(1)
+        expect(json[:quotes].first[:lago_id]).to eq(quote.id)
+      end
+    end
+
+    context "when filtering by an unknown external_customer_id" do
+      subject { get_with_token(organization, "/api/v1/quotes", {external_customer_id: "unknown"}) }
+
+      it "returns an empty list with canonical pagination meta" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quotes]).to be_empty
+        expect(json[:meta]).to include(current_page: 0, total_pages: 0, total_count: 0)
+      end
+    end
+
+    context "when filtering by owner_id" do
+      subject { get_with_token(organization, "/api/v1/quotes", {owner_id: owner.id}) }
+
+      let(:owner) { create(:membership, organization:).user }
+      let!(:owned_quote) { create(:quote, organization:, customer:) }
+
+      before { create(:quote_owner, quote: owned_quote, organization:, user: owner) }
+
+      it "returns only quotes owned by that user" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quotes].count).to eq(1)
+        expect(json[:quotes].first[:lago_id]).to eq(owned_quote.id)
+      end
+    end
+
+    context "with pagination" do
+      subject { get_with_token(organization, "/api/v1/quotes", {page: 1, per_page: 1}) }
+
+      before { create(:quote, organization:, customer:) }
+
+      it "returns paginated quotes with meta data" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quotes].count).to eq(1)
+        expect(json[:meta]).to include(
+          current_page: 1,
+          next_page: 2,
+          prev_page: nil,
+          total_pages: 2,
+          total_count: 2
+        )
+      end
+    end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+  end
+
+  describe "GET /api/v1/quotes/:id" do
+    subject { get_with_token(organization, "/api/v1/quotes/#{quote_id}") }
+
+    let(:quote_id) { quote.id }
+    let!(:quote) { create(:quote, organization:, customer:) }
+    let!(:quote_version) { create(:quote_version, quote:, organization:) }
+
+    include_examples "requires API permission", "quote", "read"
+
+    it "returns the quote with its current version" do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:quote][:lago_id]).to eq(quote.id)
+      expect(json[:quote][:number]).to eq(quote.number)
+      expect(json[:quote][:current_version][:lago_id]).to eq(quote_version.id)
+    end
+
+    it "includes the owners" do
+      owner = create(:membership, organization:).user
+      create(:quote_owner, quote:, organization:, user: owner)
+
+      subject
+
+      expect(json[:quote][:owners]).to eq([{lago_id: owner.id, email: owner.email}])
+    end
+
+    context "when the quote does not exist" do
+      let(:quote_id) { SecureRandom.uuid }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("quote")
+      end
+    end
+
+    context "when the quote belongs to another organization" do
+      let(:quote) { create(:quote) }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("quote")
+      end
+    end
+
+    context "when the order_forms feature flag is disabled" do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+  end
+end

--- a/spec/serializers/v1/quote_serializer_spec.rb
+++ b/spec/serializers/v1/quote_serializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::QuoteSerializer do
+  subject(:serializer) { described_class.new(quote, root_name: "quote", includes:) }
+
+  let(:quote) { create(:quote) }
+  let(:owner) { create(:membership, organization: quote.organization).user }
+  let!(:quote_version) { create(:quote_version, quote:, organization: quote.organization) }
+  let(:includes) { [] }
+  let(:result) { JSON.parse(serializer.to_json) }
+
+  before { create(:quote_owner, quote:, organization: quote.organization, user: owner) }
+
+  it "serializes the object with its current version" do
+    expect(result["quote"]).to include(
+      "lago_id" => quote.id,
+      "number" => quote.number,
+      "order_type" => quote.order_type,
+      "lago_customer_id" => quote.customer_id,
+      "lago_subscription_id" => quote.subscription_id,
+      "lago_organization_id" => quote.organization_id
+    )
+
+    expect(result["quote"]["current_version"]).to include("lago_id" => quote_version.id)
+  end
+
+  it "does not expose owners by default" do
+    expect(result["quote"]).not_to have_key("owners")
+  end
+
+  context "when owners are included" do
+    let(:includes) { %i[owners] }
+
+    it "exposes the owners" do
+      expect(result["quote"]["owners"]).to eq([{"lago_id" => owner.id, "email" => owner.email}])
+    end
+  end
+end

--- a/spec/serializers/v1/quote_version_serializer_spec.rb
+++ b/spec/serializers/v1/quote_version_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::QuoteVersionSerializer do
+  subject(:serializer) { described_class.new(quote_version, root_name: "quote_version", includes:) }
+
+  let(:quote_version) { create(:quote_version, :approved) }
+  let(:includes) { [] }
+  let(:result) { JSON.parse(serializer.to_json) }
+
+  it "serializes the slim fields" do
+    expect(result["quote_version"]).to include(
+      "lago_id" => quote_version.id,
+      "lago_quote_id" => quote_version.quote_id,
+      "lago_organization_id" => quote_version.organization_id,
+      "version" => quote_version.version,
+      "status" => "approved",
+      "currency" => quote_version.currency,
+      "void_reason" => nil,
+      "approved_at" => quote_version.approved_at.iso8601
+    )
+  end
+
+  it "does not expose content or billing_items by default" do
+    expect(result["quote_version"].keys).not_to include("content", "billing_items")
+  end
+
+  it "never exposes the share_token" do
+    expect(result["quote_version"]).not_to have_key("share_token")
+  end
+
+  context "when content and billing_items are included" do
+    let(:includes) { %i[content billing_items] }
+
+    it "exposes content and billing_items but not the share_token" do
+      expect(result["quote_version"]).to include(
+        "content" => quote_version.content,
+        "billing_items" => quote_version.billing_items
+      )
+      expect(result["quote_version"]).not_to have_key("share_token")
+    end
+  end
+end


### PR DESCRIPTION
Adds read-only and lifecycle REST endpoints for quotes and quote versions.

- `GET /api/v1/quotes` (filters: status, order_type, customer, owner; pagination)
- `GET /api/v1/quotes/:id`
- `GET /api/v1/quotes/:id/versions`
- `GET /api/v1/quote_versions/:id`
- `POST /api/v1/quote_versions/:id/approve`
- `POST /api/v1/quote_versions/:id/void`
- `POST /api/v1/quote_versions/:id/clone`