### PR TITLE
fix(plans): Emit plan webhook after entitlements persist

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -18,14 +18,17 @@ module Mutations
         args[:charges].map!(&:to_h)
         args[:fixed_charges]&.map!(&:to_h)
 
-        result = ::Plans::CreateService.call(args.merge(organization_id: current_organization.id))
+        # NOTE: When entitlements are provided, the plan.created webhook is emitted below, after the
+        #       entitlements are persisted, so its payload includes them. Otherwise CreateService emits it.
+        result = ::Plans::CreateService.call(
+          args.merge(organization_id: current_organization.id),
+          send_webhook: entitlements.nil?
+        )
 
         return result_error(result) unless result.success?
 
         plan = result.plan
 
-        # NOTE: send_webhook is false so we don't emit a spurious plan.updated event on top of
-        #       the plan.created already emitted by Plans::CreateService above.
         unless entitlements.nil?
           result = ::Entitlement::PlanEntitlementsUpdateService.call(
             organization: plan.organization,
@@ -34,6 +37,8 @@ module Mutations
             partial: false,
             send_webhook: false
           )
+
+          SendWebhookJob.perform_after_commit("plan.created", plan) if result.success?
         end
 
         result.success? ? plan.reload : result_error(result)

--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -19,12 +19,12 @@ module Mutations
         args[:fixed_charges]&.map!(&:to_h)
         plan = current_organization.plans.find_by(id: args[:id])
 
-        result = ::Plans::UpdateService.call(plan:, params: args)
+        # NOTE: When entitlements are provided, the plan.updated webhook is emitted below, after the
+        #       entitlements are persisted, so its payload includes them. Otherwise UpdateService emits it.
+        result = ::Plans::UpdateService.call(plan:, params: args, send_webhook: entitlements.nil?)
 
         return result_error(result) unless result.success?
 
-        # NOTE: send_webhook is false so we don't duplicate the plan.updated event
-        #       already emitted by Plans::UpdateService above.
         unless entitlements.nil?
           result = ::Entitlement::PlanEntitlementsUpdateService.call(
             organization: plan.organization,
@@ -33,6 +33,8 @@ module Mutations
             partial: false,
             send_webhook: false
           )
+
+          SendWebhookJob.perform_after_commit("plan.updated", plan) if result.success?
         end
 
         result.success? ? plan.reload : result_error(result)

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -4,9 +4,10 @@ module Plans
   class CreateService < BaseService
     Result = BaseResult[:plan]
 
-    def initialize(args)
+    def initialize(args, send_webhook: true)
       @args = args
-      super
+      @send_webhook = send_webhook
+      super()
     end
 
     activity_loggable(
@@ -77,7 +78,7 @@ module Plans
 
       result.plan = plan
       track_plan_created(plan)
-      SendWebhookJob.perform_after_commit("plan.created", plan)
+      SendWebhookJob.perform_after_commit("plan.created", plan) if send_webhook
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
@@ -87,7 +88,7 @@ module Plans
 
     private
 
-    attr_reader :args
+    attr_reader :args, :send_webhook
 
     def create_commitment(plan, args, commitment_type)
       Commitment.create!(

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -4,11 +4,12 @@ module Plans
   class UpdateService < BaseService
     Result = BaseResult[:plan]
 
-    def initialize(plan:, params:, partial_metadata: false)
+    def initialize(plan:, params:, partial_metadata: false, send_webhook: true)
       @plan = plan
       @params = params
       @timestamp = Time.current.to_i
       @partial_metadata = partial_metadata
+      @send_webhook = send_webhook
       super
     end
 
@@ -75,7 +76,7 @@ module Plans
 
       plan.invoices.draft.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
 
-      SendWebhookJob.perform_after_commit("plan.updated", plan)
+      SendWebhookJob.perform_after_commit("plan.updated", plan) if send_webhook
       result.plan = plan.reload
       result
     rescue ActiveRecord::RecordInvalid => e
@@ -86,7 +87,7 @@ module Plans
 
     private
 
-    attr_reader :plan, :params, :timestamp, :partial_metadata
+    attr_reader :plan, :params, :timestamp, :partial_metadata, :send_webhook
 
     delegate :organization, to: :plan
 

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -558,30 +558,46 @@ RSpec.describe Mutations::Plans::Create, :premium do
   end
 
   context "with the plan webhooks" do
+    let(:input_with_entitlements) do
+      {
+        name: "Plan with entitlements",
+        code: "plan_with_entitlements",
+        interval: "monthly",
+        payInAdvance: false,
+        amountCents: 100,
+        amountCurrency: "USD",
+        charges: [],
+        entitlements: [
+          {featureCode: feature.code, privileges: [{privilegeCode: privilege.code, value: "22"}]}
+        ]
+      }
+    end
+
     it "emits plan.created but not plan.updated" do
       execute_graphql(
         current_user: membership.user,
         current_organization: organization,
         permissions: required_permission,
         query: mutation,
-        variables: {
-          input: {
-            name: "Plan with entitlements",
-            code: "plan_with_entitlements",
-            interval: "monthly",
-            payInAdvance: false,
-            amountCents: 100,
-            amountCurrency: "USD",
-            charges: [],
-            entitlements: [
-              {featureCode: feature.code, privileges: [{privilegeCode: privilege.code, value: "22"}]}
-            ]
-          }
-        }
+        variables: {input: input_with_entitlements}
       )
 
       expect(SendWebhookJob).to have_been_enqueued.with("plan.created", Plan.last).once
       expect(SendWebhookJob).not_to have_been_enqueued.with("plan.updated", anything)
+    end
+
+    it "does not emit the webhook from Plans::CreateService so entitlements are persisted first" do
+      allow(::Plans::CreateService).to receive(:call).and_call_original
+
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: input_with_entitlements}
+      )
+
+      expect(::Plans::CreateService).to have_received(:call).with(anything, send_webhook: false)
     end
   end
 

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -517,22 +517,38 @@ RSpec.describe Mutations::Plans::Update do
     end
 
     context "when entitlements are provided", :premium do
+      let(:input_with_entitlements) do
+        base_input.merge(
+          entitlements: [
+            {featureCode: feature.code, privileges: [{privilegeCode: privilege.code, value: "22"}]}
+          ]
+        )
+      end
+
       it "enqueues a single plan.updated webhook" do
         execute_graphql(
           current_user: membership.user,
           current_organization: organization,
           permissions: required_permission,
           query: mutation,
-          variables: {
-            input: base_input.merge(
-              entitlements: [
-                {featureCode: feature.code, privileges: [{privilegeCode: privilege.code, value: "22"}]}
-              ]
-            )
-          }
+          variables: {input: input_with_entitlements}
         )
 
         expect(SendWebhookJob).to have_been_enqueued.with("plan.updated", plan).once
+      end
+
+      it "does not emit the webhook from Plans::UpdateService so entitlements are persisted first" do
+        allow(::Plans::UpdateService).to receive(:call).and_call_original
+
+        execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {input: input_with_entitlements}
+        )
+
+        expect(::Plans::UpdateService).to have_received(:call).with(plan:, params: anything, send_webhook: false)
       end
     end
   end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -143,6 +143,15 @@ RSpec.describe Plans::CreateService do
       expect(plan.invoice_display_name).to eq(plan_invoice_display_name)
     end
 
+    context "when send_webhook is false" do
+      it "does not enqueue the plan.created webhook but still produces the activity log" do
+        result = described_class.call(create_args, send_webhook: false)
+
+        expect(SendWebhookJob).not_to have_been_enqueued.with("plan.created", result.plan)
+        expect(Utils::ActivityLog).to have_produced("plan.created").after_commit.with(result.plan)
+      end
+    end
+
     it "does not create minimum commitment" do
       plans_service.call
 

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -170,6 +170,15 @@ RSpec.describe Plans::UpdateService do
       expect(plan.fixed_charges.order(created_at: :asc).second.invoice_display_name).to eq("fixed_charge2")
     end
 
+    context "when send_webhook is false" do
+      it "does not enqueue the plan.updated webhook but still produces the activity log" do
+        described_class.call(plan:, params: update_args, send_webhook: false)
+
+        expect(SendWebhookJob).not_to have_been_enqueued.with("plan.updated", plan)
+        expect(Utils::ActivityLog).to have_produced("plan.updated").after_commit.with(plan)
+      end
+    end
+
     it "marks invoices as ready to be refreshed" do
       subscription = create(:subscription, organization:, plan:)
       invoice = create(:invoice, :draft)


### PR DESCRIPTION
When a plan is created or updated from the UI with entitlements, the single `plan.created`/`plan.updated` webhook was emitted by `Plans::CreateService` and `Plans::UpdateService`, which run before the mutation persists the entitlements through `Entitlement::PlanEntitlementsUpdateService`.