### PR TITLE
[ING-316] feat(multi-billing-entity): backfill wallet transactions billing entity

### DIFF
--- a/app/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job.rb
+++ b/app/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module DatabaseMigrations
+  # Post-release backfill: reads still fall back to the wallet/customer billing entity
+  # (Wallet#billing_entity), so this is safe to run whenever and is not an upgrade blocker today.
+  # When that fallback is removed, running this becomes mandatory and must be documented as a
+  # pre-upgrade step in the bridge-version migration guide.
   class BackfillWalletTransactionsBillingEntityJob < ApplicationJob
     queue_as :low_priority
     unique :until_executed

--- a/app/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job.rb
+++ b/app/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillWalletTransactionsBillingEntityJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1_000
+
+    def perform(batch_number = 1)
+      result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        WITH batch AS (
+          SELECT wt.id,
+                 COALESCE(i.billing_entity_id, w.billing_entity_id, c.billing_entity_id) AS resolved_billing_entity_id
+          FROM wallet_transactions wt
+          JOIN wallets w ON w.id = wt.wallet_id
+          JOIN customers c ON c.id = w.customer_id
+          LEFT JOIN invoices i ON i.id = wt.invoice_id
+          WHERE wt.billing_entity_id IS NULL
+          LIMIT #{BATCH_SIZE}
+        )
+        UPDATE wallet_transactions wt
+        SET billing_entity_id = batch.resolved_billing_entity_id
+        FROM batch
+        WHERE wt.id = batch.id
+      SQL
+
+      if result.cmd_tuples.positive?
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished backfilling wallet_transactions billing_entity")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job.rb
+++ b/app/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job.rb
@@ -11,11 +11,10 @@ module DatabaseMigrations
       result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
         WITH batch AS (
           SELECT wt.id,
-                 COALESCE(i.billing_entity_id, w.billing_entity_id, c.billing_entity_id) AS resolved_billing_entity_id
+                 COALESCE(w.billing_entity_id, c.billing_entity_id) AS resolved_billing_entity_id
           FROM wallet_transactions wt
           JOIN wallets w ON w.id = wt.wallet_id
           JOIN customers c ON c.id = w.customer_id
-          LEFT JOIN invoices i ON i.id = wt.invoice_id
           WHERE wt.billing_entity_id IS NULL
           LIMIT #{BATCH_SIZE}
         )

--- a/lib/tasks/migrations/wallet_transactions.rake
+++ b/lib/tasks/migrations/wallet_transactions.rake
@@ -27,7 +27,7 @@ namespace :migrations do
     stalled_checks = 0
 
     while count > 0
-      sleep 30
+      Kernel.sleep 5
       puts "\n#### Checking status ####"
 
       previous_count = count

--- a/lib/tasks/migrations/wallet_transactions.rake
+++ b/lib/tasks/migrations/wallet_transactions.rake
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+namespace :migrations do
+  desc "Backfill billing_entity_id on existing wallet transactions"
+  task backfill_wallet_transactions_billing_entity: :environment do
+    Rails.logger.level = Logger::Severity::ERROR
+
+    # Every wallet transaction resolves to a billing entity (customers.billing_entity_id
+    # is NOT NULL), so a plain index-backed count of NULL rows is an accurate progress signal.
+    count_sql = "SELECT COUNT(*) FROM wallet_transactions WHERE billing_entity_id IS NULL"
+
+    puts "##################################\nStarting wallet transactions billing entity backfill"
+    puts "\n#### Checking for resources to fill ####"
+
+    count = ActiveRecord::Base.connection.select_value(count_sql).to_i
+
+    if count > 0
+      pp "  -> #{count} wallet transactions to backfill"
+      puts "\n#### Enqueue job in the low_priority queue ####"
+      pp "- Enqueuing DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob"
+      pp "- Make sure a Sidekiq worker is draining the low_priority queue"
+      DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob.perform_later
+    else
+      pp "  -> Nothing to do"
+    end
+
+    stalled_checks = 0
+
+    while count > 0
+      sleep 30
+      puts "\n#### Checking status ####"
+
+      previous_count = count
+      count = ActiveRecord::Base.connection.select_value(count_sql).to_i
+
+      if count < previous_count
+        stalled_checks = 0
+        pp "  -> #{count} remaining"
+      elsif count.zero?
+        pp "  -> Done"
+      else
+        stalled_checks += 1
+        pp "  -> #{count} remaining, no progress (#{stalled_checks})"
+        if stalled_checks >= 10
+          abort "No progress after #{stalled_checks} checks. Is a Sidekiq worker draining the low_priority queue?"
+        end
+      end
+    end
+
+    puts "\n#### All good! ####"
+  end
+end

--- a/spec/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob do
+  subject(:perform_job) { described_class.perform_now }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:, organization:) }
+
+  context "when a wallet transaction has no billing entity" do
+    let(:wallet_transaction) { create(:wallet_transaction, wallet:, organization:, billing_entity: nil) }
+
+    it "backfills it from the customer billing entity" do
+      wallet_transaction
+
+      expect { perform_job }.to change { wallet_transaction.reload.billing_entity_id }
+        .from(nil).to(customer.billing_entity_id)
+    end
+
+    context "when the wallet has its own billing entity" do
+      let(:wallet_billing_entity) { create(:billing_entity, organization:) }
+      let(:wallet) { create(:wallet, customer:, organization:, billing_entity: wallet_billing_entity) }
+
+      it "prefers the wallet billing entity over the customer one" do
+        expect(wallet_billing_entity.id).not_to eq(customer.billing_entity_id)
+        wallet_transaction
+
+        perform_job
+
+        expect(wallet_transaction.reload.billing_entity_id).to eq(wallet_billing_entity.id)
+      end
+    end
+
+    context "when the transaction is attached to an invoice" do
+      let(:invoice_billing_entity) { create(:billing_entity, organization:) }
+      let(:invoice) { create(:invoice, customer:, organization:, billing_entity: invoice_billing_entity) }
+      let(:wallet_transaction) { create(:wallet_transaction, wallet:, organization:, invoice:, billing_entity: nil) }
+
+      it "prefers the invoice billing entity over the wallet and customer ones" do
+        expect(invoice_billing_entity.id).not_to eq(customer.billing_entity_id)
+        wallet_transaction
+
+        perform_job
+
+        expect(wallet_transaction.reload.billing_entity_id).to eq(invoice_billing_entity.id)
+      end
+    end
+  end
+
+  context "when a wallet transaction already has a billing entity" do
+    let(:billing_entity) { create(:billing_entity, organization:) }
+    let(:wallet_transaction) { create(:wallet_transaction, wallet:, organization:, billing_entity:) }
+
+    it "leaves it untouched" do
+      wallet_transaction
+
+      expect { perform_job }.not_to change { wallet_transaction.reload.billing_entity_id }
+    end
+  end
+
+  context "when there is more work after the batch" do
+    before { stub_const("#{described_class}::BATCH_SIZE", 1) }
+
+    it "enqueues the next batch" do
+      create(:wallet_transaction, wallet:, organization:, billing_entity: nil)
+      create(:wallet_transaction, wallet:, organization:, billing_entity: nil)
+
+      expect { perform_job }.to have_enqueued_job(described_class)
+    end
+  end
+
+  context "when there is no pending work" do
+    it "does not enqueue another batch" do
+      expect { perform_job }.not_to have_enqueued_job(described_class)
+    end
+  end
+end

--- a/spec/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_wallet_transactions_billing_entity_job_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob do
       let(:invoice) { create(:invoice, customer:, organization:, billing_entity: invoice_billing_entity) }
       let(:wallet_transaction) { create(:wallet_transaction, wallet:, organization:, invoice:, billing_entity: nil) }
 
-      it "prefers the invoice billing entity over the wallet and customer ones" do
+      it "ignores the invoice billing entity and uses the customer one" do
         expect(invoice_billing_entity.id).not_to eq(customer.billing_entity_id)
         wallet_transaction
 
         perform_job
 
-        expect(wallet_transaction.reload.billing_entity_id).to eq(invoice_billing_entity.id)
+        expect(wallet_transaction.reload.billing_entity_id).to eq(customer.billing_entity_id)
       end
     end
   end

--- a/spec/lib/tasks/migrations/wallet_transactions_rake_spec.rb
+++ b/spec/lib/tasks/migrations/wallet_transactions_rake_spec.rb
@@ -32,9 +32,11 @@ RSpec.describe "migrations:backfill_wallet_transactions_billing_entity" do # rub
 
   context "when there is nothing to backfill" do
     it "reports nothing to do without enqueuing the job" do
-      expect(DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob).not_to receive(:perform_later)
+      allow(DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob).to receive(:perform_later)
 
       expect { task.invoke }.to output(/Nothing to do/).to_stdout
+
+      expect(DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob).not_to have_received(:perform_later)
     end
   end
 end

--- a/spec/lib/tasks/migrations/wallet_transactions_rake_spec.rb
+++ b/spec/lib/tasks/migrations/wallet_transactions_rake_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "migrations:backfill_wallet_transactions_billing_entity" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["migrations:backfill_wallet_transactions_billing_entity"] }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:, organization:) }
+
+  before do
+    Rake.application.rake_require("tasks/migrations/wallet_transactions")
+    Rake::Task.define_task(:environment)
+    task.reenable
+
+    allow(Kernel).to receive(:sleep)
+  end
+
+  context "when wallet transactions are missing a billing entity" do
+    let(:wallet_transaction) { create(:wallet_transaction, wallet:, organization:, billing_entity: nil) }
+
+    it "backfills them from the customer billing entity" do
+      wallet_transaction
+
+      expect { perform_enqueued_jobs { task.invoke } }.to output(/All good/).to_stdout
+
+      expect(wallet_transaction.reload.billing_entity_id).to eq(customer.billing_entity_id)
+    end
+  end
+
+  context "when there is nothing to backfill" do
+    it "reports nothing to do without enqueuing the job" do
+      expect(DatabaseMigrations::BackfillWalletTransactionsBillingEntityJob).not_to receive(:perform_later)
+
+      expect { task.invoke }.to output(/Nothing to do/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Context

`billing_entity_id` was added to wallet transactions in #5623 and is set for new transactions, but older ones were left empty. Reads already fall back to the wallet's or customer's billing entity, so nothing is broken today. This just fills in the column so it can be relied on and queried directly.

## What it does

Fills the missing billing entity on existing wallet transactions, in the background and in small batches, so it stays safe on large datasets. We resolve it the same way new transactions do: the wallet's billing entity, falling back to the customer's.

It does not run on its own: you start it with a rake task when you are ready, and it can be safely re-run.

## Running it

```
bundle exec rake migrations:backfill_wallet_transactions_billing_entity
```

It runs on the `low_priority` queue, so make sure a worker is picking that up. It is light on the database; once it finishes, run `ANALYZE wallet_transactions`.