### PR TITLE
[ING-320] misc (invoices): add migration for backfilling prepaid credits breakdown

### DIFF
--- a/app/jobs/database_migrations/backfill_prepaid_credit_breakdown_job.rb
+++ b/app/jobs/database_migrations/backfill_prepaid_credit_breakdown_job.rb
@@ -45,14 +45,21 @@ module DatabaseMigrations
     end
 
     # Invoices the live code would compute a breakdown for, not yet filled:
-    # prepaid credit was applied, breakdown is empty, the customer is fully
-    # traceable, and there are consumption rows to aggregate.
+    #   * the invoice is settled (finalized or voided), not draft/failed/pending/etc.
+    #   * prepaid credit was applied and the breakdown is empty
+    #   * the customer is fully traceable
+    #   * there are consumption rows to aggregate
+    #   * those rows reconcile: total consumed == prepaid_credit_amount_cents.
+    #     A mismatch means the consumption ledger is inconsistent for this invoice,
+    #     so we skip it rather than write a wrong (and unbalanced) breakdown.
     def self.candidates(organization_id = nil)
       scope = Invoice
+        .where(status: %i[finalized voided])
         .where(prepaid_granted_credit_amount_cents: nil, prepaid_purchased_credit_amount_cents: nil)
         .where("prepaid_credit_amount_cents > 0")
         .where.not(customer_id: Wallet.where(traceable: false).select(:customer_id))
         .where(id: consumed_invoice_ids)
+        .where("prepaid_credit_amount_cents = (#{total_consumed_sql})")
       scope = scope.where(organization_id:) if organization_id
       scope
     end
@@ -67,6 +74,17 @@ module DatabaseMigrations
         .where.not(invoice_id: nil)
         .where(id: WalletTransactionConsumption.select(:outbound_wallet_transaction_id))
         .select(:invoice_id)
+    end
+
+    # Total amount consumed across all of an invoice's outbound transactions —
+    # used to verify the consumption ledger reconciles with prepaid_credit_amount_cents.
+    def self.total_consumed_sql
+      <<~SQL.squish
+        SELECT COALESCE(SUM(c.consumed_amount_cents), 0)
+        FROM wallet_transaction_consumptions c
+        JOIN wallet_transactions out_wt ON out_wt.id = c.outbound_wallet_transaction_id
+        WHERE out_wt.invoice_id = invoices.id
+      SQL
     end
 
     # Set-based assignment: each column sums the consumed amount of its bucket for

--- a/app/jobs/database_migrations/backfill_prepaid_credit_breakdown_job.rb
+++ b/app/jobs/database_migrations/backfill_prepaid_credit_breakdown_job.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  # Backfills `prepaid_granted_credit_amount_cents` and
+  # `prepaid_purchased_credit_amount_cents` on invoices finalized before the
+  # wallet credit breakdown feature shipped (ING-320).
+  #
+  # The values are aggregated from the historical `wallet_transaction_consumptions`
+  # rows produced by `migrations:wallet_traceability`. No reconstruction happens
+  # here — it applies the exact same rules as the live code
+  # (Credits::AppliedPrepaidCreditsService#calculate_prepaid_credit_breakdown):
+  #
+  #   * granted   = consumed from `granted` inbound transactions
+  #   * purchased = consumed from every other inbound transaction
+  #   * a column is written only when its amount is > 0, otherwise left nil
+  #   * only invoices whose customer is fully traceable are touched
+  #     (mirrors `customer.wallets.all?(&:traceable?)`)
+  #
+  # Selection uses ActiveRecord (readable gate); the write is a single set-based
+  # `update_all` per batch, so it scales (a few queries per batch instead of a
+  # few per invoice). The job re-enqueues itself until nothing is left. It is
+  # idempotent: filled invoices drop out of `candidates`, and the breakdown is
+  # recomputed deterministically from the same rows every time.
+  class BackfillPrepaidCreditBreakdownJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 5_000
+    GRANTED = WalletTransaction.transaction_statuses.fetch("granted")
+
+    def perform(organization_id = nil)
+      batch_ids = self.class.candidates(organization_id).limit(BATCH_SIZE).pluck(:id)
+
+      if batch_ids.empty?
+        Rails.logger.info("Finished backfilling prepaid credit breakdown")
+        return
+      end
+
+      Invoice.where(id: batch_ids).update_all(UPDATE_ASSIGNMENTS) # rubocop:disable Rails/SkipsModelValidations
+      self.class.perform_later(organization_id)
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+
+    # Invoices the live code would compute a breakdown for, not yet filled:
+    # prepaid credit was applied, breakdown is empty, the customer is fully
+    # traceable, and there are consumption rows to aggregate.
+    def self.candidates(organization_id = nil)
+      scope = Invoice
+        .where(prepaid_granted_credit_amount_cents: nil, prepaid_purchased_credit_amount_cents: nil)
+        .where("prepaid_credit_amount_cents > 0")
+        .where.not(customer_id: Wallet.where(traceable: false).select(:customer_id))
+        .where(id: consumed_invoice_ids)
+      scope = scope.where(organization_id:) if organization_id
+      scope
+    end
+
+    def self.pending_count(organization_id = nil)
+      candidates(organization_id).count
+    end
+
+    # Invoice ids that have at least one outbound transaction with consumption rows.
+    def self.consumed_invoice_ids
+      WalletTransaction.outbound
+        .where.not(invoice_id: nil)
+        .where(id: WalletTransactionConsumption.select(:outbound_wallet_transaction_id))
+        .select(:invoice_id)
+    end
+
+    # Set-based assignment: each column sums the consumed amount of its bucket for
+    # the invoice, leaving the column nil when that bucket is zero.
+    def self.bucket_sum_sql(operator)
+      <<~SQL.squish
+        NULLIF((
+          SELECT COALESCE(SUM(c.consumed_amount_cents), 0)
+          FROM wallet_transaction_consumptions c
+          JOIN wallet_transactions out_wt ON out_wt.id = c.outbound_wallet_transaction_id
+          JOIN wallet_transactions in_wt ON in_wt.id = c.inbound_wallet_transaction_id
+          WHERE out_wt.invoice_id = invoices.id
+            AND in_wt.transaction_status #{operator} #{GRANTED}
+        ), 0)
+      SQL
+    end
+
+    UPDATE_ASSIGNMENTS = [
+      "prepaid_granted_credit_amount_cents = #{bucket_sum_sql("=")}",
+      "prepaid_purchased_credit_amount_cents = #{bucket_sum_sql("<>")}"
+    ].join(", ").freeze
+  end
+end

--- a/app/jobs/database_migrations/backfill_prepaid_credit_breakdown_job.rb
+++ b/app/jobs/database_migrations/backfill_prepaid_credit_breakdown_job.rb
@@ -3,7 +3,7 @@
 module DatabaseMigrations
   # Backfills `prepaid_granted_credit_amount_cents` and
   # `prepaid_purchased_credit_amount_cents` on invoices finalized before the
-  # wallet credit breakdown feature shipped (ING-320).
+  # wallet credit breakdown feature shipped (https://github.com/getlago/lago-api/pull/5101).
   #
   # The values are aggregated from the historical `wallet_transaction_consumptions`
   # rows produced by `migrations:wallet_traceability`. No reconstruction happens
@@ -15,12 +15,6 @@ module DatabaseMigrations
   #   * a column is written only when its amount is > 0, otherwise left nil
   #   * only invoices whose customer is fully traceable are touched
   #     (mirrors `customer.wallets.all?(&:traceable?)`)
-  #
-  # Selection uses ActiveRecord (readable gate); the write is a single set-based
-  # `update_all` per batch, so it scales (a few queries per batch instead of a
-  # few per invoice). The job re-enqueues itself until nothing is left. It is
-  # idempotent: filled invoices drop out of `candidates`, and the breakdown is
-  # recomputed deterministically from the same rows every time.
   class BackfillPrepaidCreditBreakdownJob < ApplicationJob
     queue_as :low_priority
     unique :until_executed
@@ -28,7 +22,7 @@ module DatabaseMigrations
     BATCH_SIZE = 5_000
     GRANTED = WalletTransaction.transaction_statuses.fetch("granted")
 
-    def perform(organization_id = nil)
+    def perform(organization_id = nil, batch_number = 1)
       batch_ids = self.class.candidates(organization_id).limit(BATCH_SIZE).pluck(:id)
 
       if batch_ids.empty?
@@ -37,7 +31,7 @@ module DatabaseMigrations
       end
 
       Invoice.where(id: batch_ids).update_all(UPDATE_ASSIGNMENTS) # rubocop:disable Rails/SkipsModelValidations
-      self.class.perform_later(organization_id)
+      self.class.perform_later(organization_id, batch_number + 1)
     end
 
     def lock_key_arguments

--- a/lib/tasks/migrations/backfill_prepaid_credit_breakdown.rake
+++ b/lib/tasks/migrations/backfill_prepaid_credit_breakdown.rake
@@ -2,7 +2,7 @@
 
 # Backfills `prepaid_granted_credit_amount_cents` and
 # `prepaid_purchased_credit_amount_cents` on invoices finalized before the wallet
-# credit breakdown feature shipped (ING-320).
+# credit breakdown feature shipped (https://github.com/getlago/lago-api/pull/5101).
 #
 # The heavy lifting is done by DatabaseMigrations::BackfillPrepaidCreditBreakdownJob,
 # which processes invoices in batches on the low_priority queue and re-enqueues

--- a/lib/tasks/migrations/backfill_prepaid_credit_breakdown.rake
+++ b/lib/tasks/migrations/backfill_prepaid_credit_breakdown.rake
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Backfills `prepaid_granted_credit_amount_cents` and
+# `prepaid_purchased_credit_amount_cents` on invoices finalized before the wallet
+# credit breakdown feature shipped (ING-320).
+#
+# The heavy lifting is done by DatabaseMigrations::BackfillPrepaidCreditBreakdownJob,
+# which processes invoices in batches on the low_priority queue and re-enqueues
+# itself until everything in scope is filled. This rake only previews the work
+# (DRY_RUN) or enqueues the job and polls until it drains.
+#
+# Prerequisite: `migrations:wallet_traceability` must have run for the wallets in
+# scope. This task only fills invoices whose customer is fully traceable and that
+# already have consumption rows to aggregate — exactly what the live code computes.
+#
+# Usage:
+#   # 1. Preview for a single org (no writes):
+#   lago exec api bundle exec rails migrations:backfill_prepaid_credit_breakdown \
+#     DRY_RUN=true ORGANIZATION_ID=<uuid>
+#
+#   # 2. Apply for that org:
+#   lago exec api bundle exec rails migrations:backfill_prepaid_credit_breakdown \
+#     DRY_RUN=false ORGANIZATION_ID=<uuid>
+#
+#   # 3. Apply for everyone (drop ORGANIZATION_ID):
+#   lago exec api bundle exec rails migrations:backfill_prepaid_credit_breakdown \
+#     DRY_RUN=false
+#
+# Env:
+#   DRY_RUN          "false" to enqueue the backfill. Default: true (report only).
+#   ORGANIZATION_ID  Restrict to a single organization. Default: all.
+
+namespace :migrations do
+  desc "Backfill invoice prepaid credit breakdown columns (DRY_RUN=true by default)"
+  task backfill_prepaid_credit_breakdown: :environment do
+    Rails.logger.level = Logger::Severity::ERROR
+
+    org_id = ENV["ORGANIZATION_ID"].presence
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+    job = DatabaseMigrations::BackfillPrepaidCreditBreakdownJob
+
+    puts "##################################"
+    puts "Prepaid credit breakdown backfill"
+    puts "Organization: #{org_id || "all"}, mode: #{dry_run ? "DRY-RUN (report only)" : "BACKFILL (async)"}"
+    puts "=" * 50
+
+    pending = job.pending_count(org_id)
+
+    if dry_run
+      puts "Invoices that would be filled (computable, not set yet): #{pending}"
+      puts "\nRun again with DRY_RUN=false to enqueue the backfill."
+      next
+    end
+
+    if pending.zero?
+      puts "Nothing to backfill ✅"
+      next
+    end
+
+    puts "Enqueuing backfill for #{pending} invoice(s) on the low_priority queue..."
+    job.perform_later(org_id)
+
+    while pending.positive?
+      sleep 5
+      pending = job.pending_count(org_id)
+      puts "  -> #{pending} remaining"
+    end
+
+    puts "\nDone ✅"
+  end
+end

--- a/spec/jobs/database_migrations/backfill_prepaid_credit_breakdown_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_prepaid_credit_breakdown_job_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe DatabaseMigrations::BackfillPrepaidCreditBreakdownJob do
 
   # Builds an invoice that consumed prepaid credit, with consumption rows linking
   # its outbound transaction to granted/purchased inbound transactions.
-  def create_consumed_invoice(invoice_organization: organization, invoice_customer: customer, granted_cents: 0, purchased_cents: 0)
+  def create_consumed_invoice(invoice_organization: organization, invoice_customer: customer, granted_cents: 0, purchased_cents: 0, status: :finalized, prepaid_credit_amount_cents: granted_cents + purchased_cents)
     wallet = create(:wallet, customer: invoice_customer, organization: invoice_organization, traceable: true)
     invoice = create(:invoice,
       organization: invoice_organization,
       customer: invoice_customer,
-      prepaid_credit_amount_cents: granted_cents + purchased_cents,
+      status:,
+      prepaid_credit_amount_cents:,
       prepaid_granted_credit_amount_cents: nil,
       prepaid_purchased_credit_amount_cents: nil)
 
@@ -61,6 +62,37 @@ RSpec.describe DatabaseMigrations::BackfillPrepaidCreditBreakdownJob do
     it "skips invoices whose customer is not fully traceable" do
       invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200)
       create(:wallet, customer:, organization:, traceable: false)
+
+      described_class.perform_now(organization.id)
+
+      invoice.reload
+      expect(invoice.prepaid_granted_credit_amount_cents).to be_nil
+      expect(invoice.prepaid_purchased_credit_amount_cents).to be_nil
+    end
+
+    it "skips invoices that are not finalized or voided" do
+      invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200, status: :draft)
+
+      described_class.perform_now(organization.id)
+
+      invoice.reload
+      expect(invoice.prepaid_granted_credit_amount_cents).to be_nil
+      expect(invoice.prepaid_purchased_credit_amount_cents).to be_nil
+    end
+
+    it "processes voided invoices" do
+      invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200, status: :voided)
+
+      described_class.perform_now(organization.id)
+
+      invoice.reload
+      expect(invoice.prepaid_granted_credit_amount_cents).to eq(100)
+      expect(invoice.prepaid_purchased_credit_amount_cents).to eq(200)
+    end
+
+    it "skips invoices whose consumption ledger does not reconcile" do
+      # prepaid_credit_amount_cents (500) != consumed total (300) → inconsistent, skip
+      invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200, prepaid_credit_amount_cents: 500)
 
       described_class.perform_now(organization.id)
 

--- a/spec/jobs/database_migrations/backfill_prepaid_credit_breakdown_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_prepaid_credit_breakdown_job_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabaseMigrations::BackfillPrepaidCreditBreakdownJob do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  # Builds an invoice that consumed prepaid credit, with consumption rows linking
+  # its outbound transaction to granted/purchased inbound transactions.
+  def create_consumed_invoice(invoice_organization: organization, invoice_customer: customer, granted_cents: 0, purchased_cents: 0)
+    wallet = create(:wallet, customer: invoice_customer, organization: invoice_organization, traceable: true)
+    invoice = create(:invoice,
+      organization: invoice_organization,
+      customer: invoice_customer,
+      prepaid_credit_amount_cents: granted_cents + purchased_cents,
+      prepaid_granted_credit_amount_cents: nil,
+      prepaid_purchased_credit_amount_cents: nil)
+
+    outbound = create(:wallet_transaction,
+      wallet:, organization: invoice_organization,
+      transaction_type: :outbound, status: :settled, invoice:)
+
+    {granted: granted_cents, purchased: purchased_cents}.each do |status, cents|
+      next unless cents.positive?
+
+      inbound = create(:wallet_transaction,
+        wallet:, organization: invoice_organization,
+        transaction_type: :inbound, transaction_status: status, status: :settled)
+      create(:wallet_transaction_consumption,
+        organization: invoice_organization,
+        inbound_wallet_transaction: inbound,
+        outbound_wallet_transaction: outbound,
+        consumed_amount_cents: cents)
+    end
+
+    invoice
+  end
+
+  describe "#perform" do
+    it "fills both breakdown columns from consumption data" do
+      invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200)
+
+      described_class.perform_now(organization.id)
+
+      invoice.reload
+      expect(invoice.prepaid_granted_credit_amount_cents).to eq(100)
+      expect(invoice.prepaid_purchased_credit_amount_cents).to eq(200)
+    end
+
+    it "leaves a column nil when its amount is zero" do
+      invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 0)
+
+      described_class.perform_now(organization.id)
+
+      invoice.reload
+      expect(invoice.prepaid_granted_credit_amount_cents).to eq(100)
+      expect(invoice.prepaid_purchased_credit_amount_cents).to be_nil
+    end
+
+    it "skips invoices whose customer is not fully traceable" do
+      invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200)
+      create(:wallet, customer:, organization:, traceable: false)
+
+      described_class.perform_now(organization.id)
+
+      invoice.reload
+      expect(invoice.prepaid_granted_credit_amount_cents).to be_nil
+      expect(invoice.prepaid_purchased_credit_amount_cents).to be_nil
+    end
+
+    it "does not overwrite invoices that already have a breakdown" do
+      invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200)
+      invoice.update_columns(prepaid_granted_credit_amount_cents: 999) # rubocop:disable Rails/SkipsModelValidations
+
+      described_class.perform_now(organization.id)
+
+      invoice.reload
+      expect(invoice.prepaid_granted_credit_amount_cents).to eq(999)
+      expect(invoice.prepaid_purchased_credit_amount_cents).to be_nil
+    end
+
+    it "only processes the given organization" do
+      other_organization = create(:organization)
+      other_customer = create(:customer, organization: other_organization)
+      other_invoice = create_consumed_invoice(
+        invoice_organization: other_organization,
+        invoice_customer: other_customer,
+        granted_cents: 100, purchased_cents: 200
+      )
+
+      described_class.perform_now(organization.id)
+
+      other_invoice.reload
+      expect(other_invoice.prepaid_granted_credit_amount_cents).to be_nil
+      expect(other_invoice.prepaid_purchased_credit_amount_cents).to be_nil
+    end
+
+    it "is idempotent" do
+      invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200)
+
+      described_class.perform_now(organization.id)
+      expect(described_class.pending_count(organization.id)).to eq(0)
+
+      expect { described_class.perform_now(organization.id) }
+        .not_to change { invoice.reload.attributes.slice("prepaid_granted_credit_amount_cents", "prepaid_purchased_credit_amount_cents") }
+    end
+  end
+
+  describe ".pending_count" do
+    it "counts only computable, not-yet-filled invoices in scope" do
+      create_consumed_invoice(granted_cents: 100, purchased_cents: 200)
+
+      expect(described_class.pending_count(organization.id)).to eq(1)
+
+      described_class.perform_now(organization.id)
+      expect(described_class.pending_count(organization.id)).to eq(0)
+    end
+  end
+end

--- a/spec/jobs/database_migrations/backfill_prepaid_credit_breakdown_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_prepaid_credit_breakdown_job_spec.rb
@@ -128,6 +128,19 @@ RSpec.describe DatabaseMigrations::BackfillPrepaidCreditBreakdownJob do
       expect(other_invoice.prepaid_purchased_credit_amount_cents).to be_nil
     end
 
+    it "re-enqueues the next batch with an incremented batch_number" do
+      stub_const("#{described_class}::BATCH_SIZE", 1)
+      create_consumed_invoice(granted_cents: 100, purchased_cents: 200)
+
+      expect { described_class.perform_now(organization.id, 1) }
+        .to have_enqueued_job(described_class).with(organization.id, 2)
+    end
+
+    it "does not re-enqueue when there is no work left" do
+      expect { described_class.perform_now(organization.id) }
+        .not_to have_enqueued_job(described_class)
+    end
+
     it "is idempotent" do
       invoice = create_consumed_invoice(granted_cents: 100, purchased_cents: 200)
 


### PR DESCRIPTION
## Context

Currently, we miss prepaid credits breakdown on historical invoices. Breakdown is only present on invoices created after the release of the feature.

## Description

This PR adds migration for `prepaid_granted_credit_amount_cents` and `prepaid_purchased_credit_amount_cents` bakfill on historical invoices