### PR TITLE
fix(events): Correct pay-in-advance fees for events with same timestamp

### DIFF
--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -420,21 +420,19 @@ module Events
         ).rows
       end
 
-      # NOTE: When aggregating in the context of a pay-in-advance event, the upper boundary
-      #       (max_timestamp) is the event's own timestamp. Multiple events can share this exact
-      #       timestamp (e.g. ingested in the same second), in which case they are tie-broken by
-      #       ingestion order (created_at, id) so that each one is assigned a distinct position.
-      #       Otherwise, all events sharing the timestamp would count each other and would all be
-      #       priced as the last unit of the batch.
+      # NOTE: For a pay-in-advance event, the upper boundary is the event's own timestamp.
+      #       Events sharing the same timestamp are tie-broken
+      #       by ingestion order (created_at, id) so each gets a distinct position. Otherwise
+      #       they would all count each other and be priced as the last unit of the batch.
       def apply_to_boundary(scope)
-        pay_in_advance_event_id = boundaries[:max_timestamp] && filters[:event]&.id
+        boundary_event = filters[:event] if boundaries[:max_timestamp]
 
-        if pay_in_advance_event_id
+        if boundary_event&.id
           scope.where(
             "events.timestamp < :to OR (events.timestamp = :to AND (events.created_at, events.id) <= " \
-            "(SELECT pia_event.created_at, pia_event.id FROM events pia_event WHERE pia_event.id = :pay_in_advance_event_id))",
+            "(SELECT boundary_event.created_at, boundary_event.id FROM events boundary_event WHERE boundary_event.id = :boundary_event_id))",
             to: applicable_to_datetime,
-            pay_in_advance_event_id:
+            boundary_event_id: boundary_event.id
           )
         else
           scope.to_datetime(applicable_to_datetime)

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -11,7 +11,7 @@ module Events
         scope = scope.order(timestamp: :asc) if ordered
 
         scope = scope.from_datetime(from_datetime) if force_from || use_from_boundary
-        scope = scope.to_datetime(applicable_to_datetime) if applicable_to_datetime
+        scope = apply_to_boundary(scope) if applicable_to_datetime
 
         if numeric_property
           scope = scope.where(presence_condition)
@@ -418,6 +418,27 @@ module Events
             ]
           )
         ).rows
+      end
+
+      # NOTE: When aggregating in the context of a pay-in-advance event, the upper boundary
+      #       (max_timestamp) is the event's own timestamp. Multiple events can share this exact
+      #       timestamp (e.g. ingested in the same second), in which case they are tie-broken by
+      #       ingestion order (created_at, id) so that each one is assigned a distinct position.
+      #       Otherwise, all events sharing the timestamp would count each other and would all be
+      #       priced as the last unit of the batch.
+      def apply_to_boundary(scope)
+        pay_in_advance_event_id = boundaries[:max_timestamp] && filters[:event]&.id
+
+        if pay_in_advance_event_id
+          scope.where(
+            "events.timestamp < :to OR (events.timestamp = :to AND (events.created_at, events.id) <= " \
+            "(SELECT pia_event.created_at, pia_event.id FROM events pia_event WHERE pia_event.id = :pay_in_advance_event_id))",
+            to: applicable_to_datetime,
+            pay_in_advance_event_id:
+          )
+        else
+          scope.to_datetime(applicable_to_datetime)
+        end
       end
 
       def filters_scope(scope)

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -92,6 +92,71 @@ describe "Pay in advance charges Scenarios", transaction: false do
     end
   end
 
+  describe "with count_agg / graduated when events are ingested in the same second" do
+    it "assigns each event its own marginal amount" do
+      ### 24 january: Create subscription.
+      jan24 = DateTime.new(2023, 1, 24)
+
+      travel_to(jan24) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code
+          }
+        )
+      end
+
+      charge = create(
+        :graduated_charge,
+        :pay_in_advance,
+        invoiceable: false,
+        plan:,
+        billable_metric:,
+        properties: {
+          graduated_ranges: [
+            {from_value: 0, to_value: 2, per_unit_amount: "0", flat_amount: "0"},
+            {from_value: 3, to_value: nil, per_unit_amount: "2", flat_amount: "0"}
+          ]
+        }
+      )
+
+      subscription = customer.subscriptions.first
+
+      ### 15 february: Ingest 3 events sharing the same timestamp.
+      # All events are persisted before any fee is calculated, so each fee must
+      # be priced at its own position in the graduated ranges (0, 0, 2), not all
+      # of them as the last unit of the batch.
+      feb15 = DateTime.new(2023, 2, 15)
+
+      travel_to(feb15) do
+        expect do
+          api_call do
+            post_with_token(
+              organization,
+              "/api/v1/events/batch",
+              {
+                events: Array.new(3) do
+                  {
+                    code: billable_metric.code,
+                    transaction_id: SecureRandom.uuid,
+                    external_subscription_id: subscription.external_id,
+                    timestamp: feb15.to_i
+                  }
+                end
+              }
+            )
+          end
+        end.to change { subscription.reload.fees.count }.from(0).to(3)
+
+        fees = subscription.fees.where(charge:)
+        expect(fees.map(&:pay_in_advance_event_transaction_id).uniq.count).to eq(3)
+        expect(fees.map(&:units)).to all(eq(1))
+        expect(fees.map(&:amount_cents).sort).to eq([0, 0, 200])
+      end
+    end
+  end
+
   describe "with unique_count_agg / standard" do
     let(:aggregation_type) { "unique_count_agg" }
     let(:field_name) { "unique_id" }

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -136,4 +136,76 @@ RSpec.describe Events::Stores::PostgresStore do
       end
     end
   end
+
+  describe "#count" do
+    context "when the upper boundary is a pay-in-advance event (max_timestamp)" do
+      let(:billable_metric) { create(:billable_metric) }
+      let(:organization) { billable_metric.organization }
+      let(:customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, customer:, started_at: DateTime.parse("2023-03-15")) }
+      let(:timestamp) { subscription.started_at + 1.day }
+
+      let(:previous_event) { create_event(timestamp: timestamp - 1.hour, created_at: timestamp - 1.hour) }
+      let(:next_event) { create_event(timestamp: timestamp + 1.hour, created_at: timestamp + 1.hour) }
+
+      def create_event(timestamp:, created_at:)
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp:,
+          created_at:
+        )
+      end
+
+      def store_for(event)
+        described_class.new(
+          code: billable_metric.code,
+          subscription:,
+          boundaries: {
+            from_datetime: subscription.started_at.beginning_of_day,
+            to_datetime: subscription.started_at.end_of_month.end_of_day,
+            max_timestamp: event.timestamp
+          },
+          filters: {event: Events::CommonFactory.new_instance(source: event)}
+        )
+      end
+
+      before do
+        previous_event
+        next_event
+      end
+
+      it "assigns a distinct position to each event sharing the boundary timestamp" do
+        tied_events = (1..3).map { |i| create_event(timestamp:, created_at: timestamp + i.seconds) }
+
+        expect(tied_events.map { |event| store_for(event).count }).to eq([2, 3, 4])
+      end
+
+      it "assigns distinct positions when created_at is also tied" do
+        tied_events = (1..3).map { create_event(timestamp:, created_at: timestamp) }
+
+        expect(tied_events.map { |event| store_for(event).count }).to match_array([2, 3, 4])
+      end
+
+      it "counts all events sharing the timestamp when no event filter is given" do
+        create_event(timestamp:, created_at: timestamp + 1.second)
+        create_event(timestamp:, created_at: timestamp + 2.seconds)
+
+        event_store = described_class.new(
+          code: billable_metric.code,
+          subscription:,
+          boundaries: {
+            from_datetime: subscription.started_at.beginning_of_day,
+            to_datetime: subscription.started_at.end_of_month.end_of_day,
+            max_timestamp: timestamp
+          },
+          filters: {}
+        )
+
+        expect(event_store.count).to eq(3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

A customer reported incorrect amounts on `fee.created` webhooks when sending multiple pay-in-advance events for the same graduated charge within the same second.
Each pay-in-advance event is priced as a marginal cost: `amount(total_units) − amount(total_units − 1)`, where total_units comes from a count of events with `timestamp <= event.timestamp` (max_timestamp is the event's own timestamp). When N events share the same timestamp, they are all persisted before any fee is computed, so every concurrent fee calculation counts N and prices each event as the last unit of the batch.

Example: graduated pricing 0–2 units = 0€, 3+ = 2€, with 3 simultaneous events:

| | Event 1 | Event 2 | Event 3 | Total |
| --------------- | ---------------  | ------------------ | ------------------ | ------------------ |
| Expected | 0€  | 0€ | 2€ | 2€ |
| Actual (bug) | 2€ | 2€ | 2€ | 6€ |

## Description

In Events::Stores::PostgresStore, the pay-in-advance upper boundary is changed from timestamp <= T to a strict total order over events. Events sharing the boundary timestamp are tie-broken by ingestion order (created_at, id), so each event is assigned a distinct position
