### PR TITLE
fix(order_forms): stop using not_allowed_failure! in quotes & order forms services

### DIFF
--- a/app/services/order_forms/create_service.rb
+++ b/app/services/order_forms/create_service.rb
@@ -14,7 +14,7 @@ module OrderForms
     def call
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
-      return result.not_allowed_failure!(code: "quote_version_not_approved") unless quote_version.approved?
+      return result.single_validation_failure!(field: :quote_version, error_code: "not_approved") unless quote_version.approved?
 
       order_form = OrderForm.create!(
         organization: quote_version.organization,

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -23,7 +23,7 @@ module OrderForms
     def call
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.forbidden_failure! unless order_forms_enabled?(order_form.organization)
-      return result.not_allowed_failure!(code: "not_signable") unless order_form.generated?
+      return result.single_validation_failure!(field: :status, error_code: "not_signable") unless order_form.generated?
 
       validate_execution_settings
       return result if result.failure?

--- a/app/services/order_forms/void_service.rb
+++ b/app/services/order_forms/void_service.rb
@@ -20,7 +20,7 @@ module OrderForms
     def call
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.forbidden_failure! unless order_forms_enabled?(order_form.organization)
-      return result.not_allowed_failure!(code: "not_voidable") unless order_form.generated?
+      return result.single_validation_failure!(field: :status, error_code: "not_voidable") unless order_form.generated?
 
       order_form.assign_attributes(
         status: :voided,

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -16,7 +16,7 @@ module QuoteVersions
     def call
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
-      return result.not_allowed_failure!(code: "inappropriate_state") unless approvable?
+      return result.single_validation_failure!(field: :status, error_code: "not_approvable") unless approvable?
 
       QuoteVersion.transaction do
         quote_version.update!(

--- a/app/services/quote_versions/update_service.rb
+++ b/app/services/quote_versions/update_service.rb
@@ -17,7 +17,7 @@ module QuoteVersions
     def call
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
-      return result.not_allowed_failure!(code: "inappropriate_state") unless editable?
+      return result.single_validation_failure!(field: :status, error_code: "not_editable") unless editable?
 
       quote_version.update!(
         params.slice(

--- a/app/services/quote_versions/void_service.rb
+++ b/app/services/quote_versions/void_service.rb
@@ -18,7 +18,7 @@ module QuoteVersions
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.single_validation_failure!(field: :void_reason, error_code: "invalid") unless valid_reason?
-      return result.not_allowed_failure!(code: "inappropriate_state") unless voidable?
+      return result.single_validation_failure!(field: :status, error_code: "not_voidable") unless voidable?
 
       quote_version.update!(
         status: :voided,

--- a/spec/graphql/mutations/order_forms/mark_as_signed_spec.rb
+++ b/spec/graphql/mutations/order_forms/mark_as_signed_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Mutations::OrderForms::MarkAsSigned do
         variables: {input: {id: order_form.id}}
       )
 
-      expect_graphql_error(result:, message: "Method Not Allowed")
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {status: ["not_signable"]})
     end
   end
 

--- a/spec/graphql/mutations/order_forms/void_spec.rb
+++ b/spec/graphql/mutations/order_forms/void_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Mutations::OrderForms::Void do
         variables: {input: {id: order_form.id}}
       )
 
-      expect_graphql_error(result:, message: "Method Not Allowed")
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {status: ["not_voidable"]})
     end
   end
 

--- a/spec/graphql/mutations/quote_versions/approve_spec.rb
+++ b/spec/graphql/mutations/quote_versions/approve_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Mutations::QuoteVersions::Approve do
   context "when quote version is not in draft state", :premium do
     let(:quote_version) { create(:quote_version, :voided, organization: membership.organization) }
 
-    it "returns a not allowed error" do
+    it "returns a validation error" do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: membership.organization,
@@ -86,7 +86,7 @@ RSpec.describe Mutations::QuoteVersions::Approve do
         variables: {input:}
       )
 
-      expect_graphql_error(result:, message: "inappropriate_state")
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {status: ["not_approvable"]})
     end
   end
 end

--- a/spec/graphql/mutations/quote_versions/update_spec.rb
+++ b/spec/graphql/mutations/quote_versions/update_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Mutations::QuoteVersions::Update do
   context "when quote version is not in draft state", :premium do
     let(:quote_version) { create(:quote_version, :voided, organization: membership.organization) }
 
-    it "returns a not allowed error" do
+    it "returns a validation error" do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: membership.organization,
@@ -96,7 +96,7 @@ RSpec.describe Mutations::QuoteVersions::Update do
         variables: {input:}
       )
 
-      expect_graphql_error(result:, message: "inappropriate_state")
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {status: ["not_editable"]})
     end
   end
 end

--- a/spec/graphql/mutations/quote_versions/void_spec.rb
+++ b/spec/graphql/mutations/quote_versions/void_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Mutations::QuoteVersions::Void do
   context "when quote version is already voided", :premium do
     let(:quote_version) { create(:quote_version, :voided, organization: membership.organization) }
 
-    it "returns a not allowed error" do
+    it "returns a validation error" do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: membership.organization,
@@ -88,7 +88,7 @@ RSpec.describe Mutations::QuoteVersions::Void do
         variables: {input:}
       )
 
-      expect_graphql_error(result:, message: "inappropriate_state")
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {status: ["not_voidable"]})
     end
   end
 end

--- a/spec/requests/api/v1/order_forms_controller_spec.rb
+++ b/spec/requests/api/v1/order_forms_controller_spec.rb
@@ -111,10 +111,11 @@ RSpec.describe Api::V1::OrderFormsController do
     context "when order form is not signable" do
       let(:order_form) { create(:order_form, :signed, organization:, customer:, quote:) }
 
-      it "returns an error" do
+      it "returns a validation error" do
         subject
 
-        expect(response).to have_http_status(:method_not_allowed)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:status)
       end
     end
 
@@ -303,10 +304,11 @@ RSpec.describe Api::V1::OrderFormsController do
     context "when order form is not voidable", :premium do
       let(:order_form) { create(:order_form, :signed, organization:, customer:) }
 
-      it "returns method not allowed" do
+      it "returns a validation error" do
         subject
 
-        expect(response).to have_http_status(:method_not_allowed)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:status)
       end
     end
 

--- a/spec/services/order_forms/create_service_spec.rb
+++ b/spec/services/order_forms/create_service_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe OrderForms::CreateService do
         expect { result }.not_to change(OrderForm, :count)
       end
 
-      it "returns a method not allowed failure" do
+      it "returns a validation failure" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("quote_version_not_approved")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({quote_version: ["not_approved"]})
       end
     end
 

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -51,36 +51,36 @@ RSpec.describe OrderForms::MarkAsSignedService do
       context "when order_form is not generated" do
         let(:order_form) { create(:order_form, :signed, customer:, organization:, quote:) }
 
-        it "returns a not allowed failure" do
+        it "returns a validation failure" do
           result = service.call
 
           expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq("not_signable")
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({status: ["not_signable"]})
         end
       end
 
       context "when order_form is voided" do
         let(:order_form) { create(:order_form, :voided, customer:, organization:, quote:) }
 
-        it "returns a not allowed failure" do
+        it "returns a validation failure" do
           result = service.call
 
           expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq("not_signable")
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({status: ["not_signable"]})
         end
       end
 
       context "when order_form is expired" do
         let(:order_form) { create(:order_form, :expired, customer:, organization:, quote:) }
 
-        it "returns a not allowed failure" do
+        it "returns a validation failure" do
           result = service.call
 
           expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq("not_signable")
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({status: ["not_signable"]})
         end
       end
 

--- a/spec/services/order_forms/void_service_spec.rb
+++ b/spec/services/order_forms/void_service_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe OrderForms::VoidService do
       context "when the order form is not generated" do
         let(:order_form) { create(:order_form, :signed, customer:, organization:) }
 
-        it "returns a not allowed failure" do
+        it "returns a validation failure" do
           result = service.call
 
           expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq("not_voidable")
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({status: ["not_voidable"]})
         end
       end
 

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe QuoteVersions::ApproveService do
 
       it "does not approve the quote version" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_approvable"]})
 
         quote_version.reload
         expect(quote_version.approved?).to eq(false)
@@ -55,8 +55,8 @@ RSpec.describe QuoteVersions::ApproveService do
 
       it "does not approve the quote version" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_approvable"]})
       end
     end
 

--- a/spec/services/quote_versions/update_service_spec.rb
+++ b/spec/services/quote_versions/update_service_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe QuoteVersions::UpdateService do
 
       it "returns validation failure" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_editable"]})
       end
     end
 
@@ -54,8 +54,8 @@ RSpec.describe QuoteVersions::UpdateService do
 
       it "returns validation failure" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_editable"]})
       end
     end
 

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe QuoteVersions::VoidService do
 
       it "is not voidable" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_voidable"]})
       end
     end
 
@@ -52,10 +52,10 @@ RSpec.describe QuoteVersions::VoidService do
     context "when quote isn't voidable", :premium do
       let(:quote_version) { create(:quote_version, :voided, organization:) }
 
-      it "returns method not allowed" do
+      it "returns a validation failure" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_voidable"]})
       end
     end
 


### PR DESCRIPTION
Clean up PR for the quotes & order forms features. Some services where using `#not_allowed_failure!`, but this service failure renders an `405 not allowed` status code, which is not what we want in those places (we want `422 unprocessable entity`)