### PR TITLE
[ING-338] fix(events): batch CH delete per metric

### DIFF
--- a/app/services/events/delete_for_metric_service.rb
+++ b/app/services/events/delete_for_metric_service.rb
@@ -35,6 +35,7 @@ module Events
     private
 
     BATCH_SIZE = 10_000
+    CLICKHOUSE_BATCH_SIZE = BATCH_SIZE / 2
     CLICKHOUSE_TABLES = {
       events_raw: :ingested_at,
       events_enriched: :enriched_at,
@@ -76,9 +77,14 @@ module Events
 
     # Delete clickhouse events using async mutations to avoid blocking or
     # timeouts when the metric is attached to a large number of events.
+    # The id list is sliced into clickhouse_batch_size chunks before being
+    # inlined into the ALTER TABLE … DELETE statement so each query stays
+    # under ClickHouse's max_query_size (default 256 KiB).
     def delete_clickhouse_events(external_subscription_ids)
-      CLICKHOUSE_TABLES.each do |table, date_field|
-        async_delete_clickhouse(table, date_field, external_subscription_ids)
+      external_subscription_ids.each_slice(CLICKHOUSE_BATCH_SIZE) do |slice|
+        CLICKHOUSE_TABLES.each do |table, date_field|
+          async_delete_clickhouse(table, date_field, slice)
+        end
       end
     end
 

--- a/spec/services/events/delete_for_metric_service_spec.rb
+++ b/spec/services/events/delete_for_metric_service_spec.rb
@@ -209,6 +209,27 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
           .to eq(1)
       end
 
+      context "when the subscription list exceeds CLICKHOUSE_BATCH_SIZE" do
+        # delete_clickhouse_events slices the id list into CLICKHOUSE_BATCH_SIZE
+        # chunks before inlining it into the ALTER TABLE … DELETE statement,
+        # so a query never blows past ClickHouse's `max_query_size`. Stubbing
+        # the constant to 1 forces two subscriptions to be sliced across two
+        # CH queries per table × three tables = 6 calls.
+        let(:second_subscription) { create(:subscription, customer: subscription.customer, plan: subscription.plan) }
+
+        before do
+          second_subscription
+          stub_const("#{described_class}::CLICKHOUSE_BATCH_SIZE", 1)
+          allow(::Clickhouse::BaseRecord.connection).to receive(:execute).and_call_original
+        end
+
+        it "slices the IN(?) list into CLICKHOUSE_BATCH_SIZE chunks" do
+          service.call
+
+          expect(::Clickhouse::BaseRecord.connection).to have_received(:execute).exactly(6).times
+        end
+      end
+
       context "with clickhouse events received after the metric deletion" do
         let(:late_ch_event) do
           create(


### PR DESCRIPTION
## Context

When a billable metric is destroyed, Events::DeleteForMetricService walks every subscription that ever consumed it in pages of BATCH_SIZE (10_000) and issues an ALTER TABLE … DELETE per ClickHouse table, inlining the page's external_subscription_id list into the WHERE … IN (?) clause. At ~10k uuid-shaped ids the SQL string exceeds ClickHouse's default `max_query_size` (256 KiB) and the mutation fails with `Code: 62. DB::Exception: Max query size exceeded … (SYNTAX_ERROR)`. Reproduced on a metric tied to 86_814 subscriptions.

## Description

Introduces a CLICKHOUSE_BATCH_SIZE constant (BATCH_SIZE / 2) and slices the id list with each_slice before each ALTER TABLE … DELETE is emitted, so every CH query stays comfortably under the limit. The Postgres batch size stays at 10_000 — only ClickHouse needs the tighter slice because of its parser limit, and the PG throughput shouldn't pay for a CH-specific constraint. Mutations remain async (mutations_sync = 0), so the extra round-trips are enqueue-only and cheap.

Adds a spec context that stubs CLICKHOUSE_BATCH_SIZE to 1 with two subscriptions on the same charge, asserting the connection emits six DELETE statements (2 slices × 3 tables) instead of three. Lock prevents a regression to a single oversized query.