### PR TITLE
feat(quotes): accept expires_at on quote approval

### DIFF
--- a/app/controllers/api/v1/quote_versions_controller.rb
+++ b/app/controllers/api/v1/quote_versions_controller.rb
@@ -16,7 +16,7 @@ module Api
         # A nil quote_version is intentional: the service returns a not_found failure.
         quote_version = current_organization.quote_versions.find_by(id: params[:id])
 
-        result = QuoteVersions::ApproveService.call(quote_version:)
+        result = QuoteVersions::ApproveService.call(quote_version:, expires_at: params[:expires_at])
 
         if result.success?
           render_quote_version(result.quote_version)

--- a/app/graphql/mutations/quote_versions/approve.rb
+++ b/app/graphql/mutations/quote_versions/approve.rb
@@ -11,13 +11,14 @@ module Mutations
       graphql_name "ApproveQuoteVersion"
       description "Approve a quote version"
 
+      argument :expires_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :id, ID, required: true
 
       type Types::QuoteVersions::Object
 
       def resolve(**args)
         quote_version = current_organization.quote_versions.find_by(id: args[:id])
-        result = ::QuoteVersions::ApproveService.call(quote_version:)
+        result = ::QuoteVersions::ApproveService.call(quote_version:, expires_at: args[:expires_at])
 
         result.success? ? result.quote_version : result_error(result)
       end

--- a/app/services/order_forms/create_service.rb
+++ b/app/services/order_forms/create_service.rb
@@ -6,8 +6,9 @@ module OrderForms
 
     Result = BaseResult[:order_form]
 
-    def initialize(quote_version:)
+    def initialize(quote_version:, expires_at: nil)
       @quote_version = quote_version
+      @expires_at = expires_at
       super
     end
 
@@ -15,12 +16,14 @@ module OrderForms
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.single_validation_failure!(field: :quote_version, error_code: "not_approved") unless quote_version.approved?
+      return result.single_validation_failure!(field: :expires_at, error_code: "invalid_date") unless valid_expires_at?
 
       order_form = OrderForm.create!(
         organization: quote_version.organization,
         customer: quote_version.quote.customer,
         quote_version:,
-        status: :generated
+        status: :generated,
+        expires_at:
       )
 
       result.order_form = order_form
@@ -33,6 +36,10 @@ module OrderForms
 
     private
 
-    attr_reader :quote_version
+    attr_reader :quote_version, :expires_at
+
+    def valid_expires_at?
+      Validators::ExpirationDateValidator.valid?(expires_at)
+    end
   end
 end

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -4,12 +4,13 @@ module QuoteVersions
   class ApproveService < BaseService
     include OrderForms::Premium
 
-    attr_reader :quote_version
+    attr_reader :quote_version, :expires_at
 
     Result = BaseResult[:quote_version, :order_form]
 
-    def initialize(quote_version:)
+    def initialize(quote_version:, expires_at: nil)
       @quote_version = quote_version
+      @expires_at = expires_at
       super
     end
 
@@ -25,7 +26,7 @@ module QuoteVersions
           mention_variables: ComputeMentionVariablesService.call!(quote_version:).mention_variables
         )
 
-        result.order_form = OrderForms::CreateService.call!(quote_version:).order_form
+        result.order_form = OrderForms::CreateService.call!(quote_version:, expires_at:).order_form
       end
 
       # TODO: SendWebhookJob.perform_after_commit("quote_version.approved", quote_version)
@@ -34,6 +35,8 @@ module QuoteVersions
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue BaseService::ValidationFailure => e
+      e.result
     end
 
     private

--- a/schema.graphql
+++ b/schema.graphql
@@ -792,6 +792,7 @@ input ApproveQuoteVersionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  expiresAt: ISO8601DateTime
   id: ID!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -4163,6 +4163,18 @@
               "deprecationReason": null
             },
             {
+              "name": "expiresAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/quote_versions/approve_spec.rb
+++ b/spec/graphql/mutations/quote_versions/approve_spec.rb
@@ -58,6 +58,41 @@ RSpec.describe Mutations::QuoteVersions::Approve do
     end
   end
 
+  context "with an expiresAt in the future", :premium do
+    let(:expires_at) { 1.month.from_now.iso8601 }
+    let(:input) { {id: quote_version.id, expiresAt: expires_at} }
+
+    it "sets expires_at on the created order form" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input:}
+      )
+
+      expect(result["data"]["approveQuoteVersion"]["status"]).to eq("approved")
+      expect(quote_version.reload.order_form.expires_at).to be_within(1.second).of(Time.zone.parse(expires_at))
+    end
+  end
+
+  context "with an expiresAt in the past", :premium do
+    let(:input) { {id: quote_version.id, expiresAt: 1.day.ago.iso8601} }
+
+    it "returns a validation error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input:}
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {expiresAt: ["invalid_date"]})
+      expect(quote_version.reload.status).to eq("draft")
+    end
+  end
+
   context "when quote version is not found", :premium do
     let(:input) { {id: "00000000-0000-0000-0000-000000000000"} }
 

--- a/spec/requests/api/v1/quote_versions_controller_spec.rb
+++ b/spec/requests/api/v1/quote_versions_controller_spec.rb
@@ -78,6 +78,36 @@ RSpec.describe Api::V1::QuoteVersionsController do
       expect(json[:quote_version][:status]).to eq("approved")
     end
 
+    context "with an expires_at in the future", :premium do
+      subject do
+        post_with_token(organization, "/api/v1/quote_versions/#{quote_version_id}/approve", {expires_at:})
+      end
+
+      let(:expires_at) { 1.month.from_now.iso8601 }
+
+      it "sets expires_at on the created order form" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(quote_version.reload.order_form.expires_at).to be_within(1.second).of(Time.zone.parse(expires_at))
+      end
+    end
+
+    context "with an expires_at in the past", :premium do
+      subject do
+        post_with_token(organization, "/api/v1/quote_versions/#{quote_version_id}/approve", {expires_at:})
+      end
+
+      let(:expires_at) { 1.day.ago.iso8601 }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(quote_version.reload.status).to eq("draft")
+      end
+    end
+
     context "when the quote version is not approvable", :premium do
       let(:quote_version) { create(:quote_version, :voided, quote:, organization:) }
 

--- a/spec/services/order_forms/create_service_spec.rb
+++ b/spec/services/order_forms/create_service_spec.rb
@@ -23,8 +23,36 @@ RSpec.describe OrderForms::CreateService do
           organization_id: organization.id,
           customer_id: quote.customer_id,
           quote_version_id: quote_version.id,
-          status: "generated"
+          status: "generated",
+          expires_at: nil
         )
+      end
+    end
+
+    context "when an expires_at in the future is provided", :premium do
+      subject(:create_service) { described_class.new(quote_version:, expires_at:) }
+
+      let(:expires_at) { 1.month.from_now }
+
+      it "sets expires_at on the order form" do
+        expect(result).to be_success
+        expect(result.order_form.expires_at).to be_within(1.second).of(expires_at)
+      end
+    end
+
+    context "when an expires_at in the past is provided", :premium do
+      subject(:create_service) { described_class.new(quote_version:, expires_at:) }
+
+      let(:expires_at) { 1.day.ago }
+
+      it "does not create an order form" do
+        expect { result }.not_to change(OrderForm, :count)
+      end
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq(expires_at: ["invalid_date"])
       end
     end
 

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -44,6 +44,37 @@ RSpec.describe QuoteVersions::ApproveService do
       end
     end
 
+    context "when an expires_at in the future is provided", :premium do
+      subject(:approve_service) { described_class.new(quote_version:, expires_at:) }
+
+      let(:expires_at) { 1.month.from_now }
+
+      it "sets expires_at on the created order form" do
+        expect(result).to be_success
+        expect(result.order_form.expires_at).to be_within(1.second).of(expires_at)
+      end
+    end
+
+    context "when an expires_at in the past is provided", :premium do
+      subject(:approve_service) { described_class.new(quote_version:, expires_at:) }
+
+      let(:expires_at) { 1.day.ago }
+
+      it "does not approve the quote version" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq(expires_at: ["invalid_date"])
+
+        quote_version.reload
+        expect(quote_version.approved?).to eq(false)
+        expect(quote_version.approved_at).to eq(nil)
+      end
+
+      it "does not create an order form" do
+        expect { result }.not_to change(OrderForm, :count)
+      end
+    end
+
     context "when the quote version is voided", :premium do
       let(:quote_version) { create(:quote_version, :voided, quote:, organization:) }
 


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/create-quotes-order-forms

## Context

At `Quote`'s approval time, we need to let users set an expiration date to the linked (and to be created) `OrderForm`.

## Description

This PR adds the optional `expires_at` param to both the REST API approve route and the GraphQL approve mutation.