### PR TITLE
misc(clock): Add LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS env

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -54,9 +54,11 @@ module Clockwork
 
   if ENV["LAGO_MEMCACHE_SERVERS"].present? || ENV["LAGO_REDIS_CACHE_URL"].present?
     unless ENV["LAGO_DISABLE_WALLET_REFRESH"] == "true"
-      every(5.minutes, "schedule:refresh_wallets_ongoing_balance") do
+      wallet_refresh_interval = ENV["LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS"].presence || 5.minutes
+
+      every(wallet_refresh_interval.to_i.seconds, "schedule:refresh_wallets_ongoing_balance") do
         Clock::RefreshWalletsOngoingBalanceJob
-          .set(sentry: {"slug" => "lago_refresh_wallets_ongoing_balance", "cron" => "*/5 * * * *"})
+          .set(sentry: {"slug" => "lago_refresh_wallets_ongoing_balance", "cron" => "#{wallet_refresh_interval} interval"})
           .perform_later
       end
 

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -397,6 +397,71 @@ describe Clockwork do
     end
   end
 
+  describe "schedule:refresh_wallets_ongoing_balance" do
+    let(:job) { "schedule:refresh_wallets_ongoing_balance" }
+    let(:start_time) { Time.zone.parse("1 Apr 2022 00:01:00") }
+    let(:end_time) { Time.zone.parse("1 Apr 2022 00:31:00") }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("LAGO_REDIS_CACHE_URL").and_return("redis:6379")
+      allow(ENV).to receive(:[]).with("LAGO_DISABLE_WALLET_REFRESH").and_return(nil)
+    end
+
+    it "enqueue a refresh wallets ongoing balance job" do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.second
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(6)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::RefreshWalletsOngoingBalanceJob).to have_been_enqueued
+    end
+
+    context "with a custom refresh interval configured" do
+      before do
+        allow(ENV).to receive(:[]).with("LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS").and_return("150")
+      end
+
+      it 'uses the ENV["LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS"] to set a custom period' do
+        Clockwork::Test.run(
+          file: clock_file,
+          start_time:,
+          end_time:,
+          tick_speed: 1.second
+        )
+
+        expect(Clockwork::Test).to be_ran_job(job)
+        expect(Clockwork::Test.times_run(job)).to eq(12)
+
+        Clockwork::Test.block_for(job).call
+        expect(Clock::RefreshWalletsOngoingBalanceJob).to have_been_enqueued
+
+        expect(ENV).to have_received(:[]).with("LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS")
+      end
+    end
+
+    context "when wallet refresh is disabled" do
+      before { allow(ENV).to receive(:[]).with("LAGO_DISABLE_WALLET_REFRESH").and_return("true") }
+
+      it "does not register the schedule" do
+        Clockwork::Test.run(
+          file: clock_file,
+          start_time:,
+          end_time:,
+          tick_speed: 1.second
+        )
+
+        expect(Clockwork::Test).not_to be_ran_job(job)
+      end
+    end
+  end
+
   describe "schedule:refresh_dedicated_org_wallets" do
     let(:job) { "schedule:refresh_dedicated_org_wallets" }
     let(:start_time) { Time.zone.parse("2025-03-27T00:05:00") }


### PR DESCRIPTION
## Description

This PR adds a new `LAGO_WALLET_ONGOING_BALANCE_REFRESH_INTERVAL_SECONDS` environment variable to make the `Clock::RefreshWalletsOngoingBalanceJob` process interval configurable