### PR TITLE
fix(quotes): allow cloning non-approved versions

### DIFF
--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -25,10 +25,10 @@ module QuoteVersions
     def call
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
-      return result.forbidden_failure!(code: "inappropriate_state") unless clonable?
+      return result.single_validation_failure!(field: :status, error_code: "not_clonable") unless clonable?
 
       cloned = QuoteVersion.transaction do
-        void!(quote_version:)
+        void_active_version!
         create_next_version(quote_version:)
       end
 
@@ -39,7 +39,7 @@ module QuoteVersions
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     rescue ActiveRecord::RecordNotUnique
-      result.forbidden_failure!(code: "active_version_exists")
+      result.single_validation_failure!(field: :status, error_code: "active_version_exists")
     rescue CloneError => e
       result.service_failure!(code: "clone_failed", message: e.message, error: e)
     end
@@ -47,10 +47,7 @@ module QuoteVersions
     private
 
     def clonable?
-      return false if quote_version.quote.versions.where(status: :approved).exists?
-
-      active_draft = quote_version.quote.versions.where(status: :draft).first
-      active_draft.nil? || active_draft.id == quote_version.id
+      !quote_version.quote.versions.approved.exists?
     end
 
     def create_next_version(quote_version:)
@@ -65,11 +62,15 @@ module QuoteVersions
       end
     end
 
-    def void!(quote_version:)
-      return if quote_version.voided?
+    def void_active_version!
+      # At most one draft exists per quote. If the version being cloned is that
+      # draft, void it directly; only look it up when cloning a non-draft (e.g.
+      # an older voided version while a newer draft is the active one).
+      active_draft = quote_version.draft? ? quote_version : quote_version.quote.versions.find_by(status: :draft)
+      return if active_draft.nil?
 
       void_result = QuoteVersions::VoidService.new(
-        quote_version: quote_version,
+        quote_version: active_draft,
         reason: :superseded
       ).call
 

--- a/spec/graphql/mutations/quote_versions/clone_spec.rb
+++ b/spec/graphql/mutations/quote_versions/clone_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Mutations::QuoteVersions::Clone do
   context "when quote version is approved", :premium do
     let(:quote_version) { create(:quote_version, :approved, organization: membership.organization) }
 
-    it "returns a not allowed error" do
+    it "returns an unprocessable entity error" do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: membership.organization,
@@ -98,7 +98,33 @@ RSpec.describe Mutations::QuoteVersions::Clone do
         variables: {input:}
       )
 
-      expect_graphql_error(result:, message: "inappropriate_state")
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {status: ["not_clonable"]})
+    end
+  end
+
+  context "when an older version is cloned while a draft is active", :premium do
+    let(:quote) { create(:quote, organization: membership.organization) }
+    let(:quote_version) do
+      QuoteVersion.transaction do
+        older = create(:quote_version, :voided, quote:, organization: membership.organization)
+        create(:quote_version, quote:, organization: membership.organization)
+        older
+      end
+    end
+
+    it "clones the older version into a new draft" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input:}
+      )
+
+      cloned = result["data"]["cloneQuoteVersion"]
+      expect(cloned["status"]).to eq("draft")
+      expect(cloned["id"]).to be_present
+      expect(cloned["id"]).not_to eq(quote_version.id)
     end
   end
 end

--- a/spec/requests/api/v1/quote_versions_controller_spec.rb
+++ b/spec/requests/api/v1/quote_versions_controller_spec.rb
@@ -222,14 +222,34 @@ RSpec.describe Api::V1::QuoteVersionsController do
       expect(json[:quote_version][:lago_id]).not_to eq(quote_version.id)
     end
 
+    context "when a different draft is the active version", :premium do
+      let(:quote_version) do
+        QuoteVersion.transaction do
+          older = create(:quote_version, :voided, quote:, organization:)
+          create(:quote_version, quote:, organization:)
+          older
+        end
+      end
+
+      it "clones the older version and voids the active draft" do
+        active_draft = quote.versions.find_by(status: :draft)
+
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:quote_version][:status]).to eq("draft")
+        expect(json[:quote_version][:lago_id]).not_to eq(quote_version.id)
+        expect(active_draft.reload.status).to eq("voided")
+      end
+    end
+
     context "when an approved version exists", :premium do
       let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
 
-      it "returns forbidden" do
+      it "returns unprocessable entity" do
         subject
 
-        expect(response).to have_http_status(:forbidden)
-        expect(json[:code]).to eq("inappropriate_state")
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe QuoteVersions::CloneService do
 
       it "rejects the clone" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ForbiddenFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_clonable"]})
       end
     end
 
@@ -93,8 +93,8 @@ RSpec.describe QuoteVersions::CloneService do
 
       it "rejects the clone because the quote is locked by an approved version" do
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ForbiddenFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_clonable"]})
       end
     end
 
@@ -108,14 +108,57 @@ RSpec.describe QuoteVersions::CloneService do
       end
       let(:quote_version) { versions.first } # cloning the older voided one
 
-      it "rejects the clone because the active version is not the source" do
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ForbiddenFailure)
-        expect(result.error.code).to eq("inappropriate_state")
+      it "clones the source and voids the active draft" do
+        expect(result).to be_success
+        cloned = result.quote_version
+        expect(cloned.draft?).to eq(true)
+        expect(quote.reload.current_version).to eq(cloned)
 
-        versions.last.reload
-        expect(versions.last.draft?).to eq(true)
-        expect(versions.last.voided_at).to eq(nil)
+        active_draft = versions.last.reload
+        expect(active_draft.voided?).to eq(true)
+        expect(active_draft.void_reason).to eq("superseded")
+        expect(active_draft.voided_at).not_to eq(nil)
+
+        quote_version.reload
+        expect(quote_version.voided?).to eq(true)
+        expect(quote_version.void_reason).to eq("manual")
+      end
+    end
+
+    context "when cloning a middle version while a newer draft is active", :premium do
+      let!(:versions) do
+        QuoteVersion.transaction do
+          v1 = create(:quote_version, :voided, quote:, organization:, sequential_id: 1)
+          v2 = create(:quote_version, :voided, quote:, organization:, sequential_id: 2)
+          v3 = create(:quote_version, quote:, organization:, sequential_id: 3)
+          [v1, v2, v3]
+        end
+      end
+      let(:quote_version) { versions[1] } # cloning V2
+
+      # Documents that the clone takes the next sequential version (max + 1),
+      # not source + 1: voided versions keep their slots, so cloning V2 yields V4.
+      it "assigns the next sequential version (V4)" do
+        expect(result).to be_success
+        expect(result.quote_version.version).to eq(4)
+        expect(versions.last.reload.voided?).to eq(true)
+      end
+    end
+
+    context "when a concurrent write recreates an active version", :premium do
+      let(:quote_version_dup) { quote_version.dup }
+
+      before do
+        allow(quote_version_dup).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique)
+
+        allow(quote_version).to receive(:dup)
+          .and_return(quote_version_dup)
+      end
+
+      it "rejects the clone with a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["active_version_exists"]})
       end
     end
 


### PR DESCRIPTION
Previously, when a `quote` had several versions and one was still a `draft`, trying to clone an older version threw an error. Now you can duplicate **any version** of a `quote`. Doing so creates a fresh `draft` from the version you picked and automatically voids whatever version was currently active, so there's only ever one live version at a time.

**The only case still blocked is when a version has already been approved**: the quote is locked at that point, so duplication isn't allowed until that approval is voided.

I also took the opportunity to return a `single_validation_failure!` instead of a `forbidden_failure!` when the `quote` cannot be cloned. `forbidden` is intended for auth related errors, not business logic ones.