### PR TITLE
Ensure a single PaymentMeans block

### DIFF
--- a/spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb
@@ -136,6 +136,10 @@ RSpec.describe EInvoices::CreditNotes::Ubl::Builder do
         expect(subject).to contains_xml_node("//cac:PaymentMeans/cbc:PaymentMeansCode")
           .with_value(described_class::STANDARD_PAYMENT)
       end
+
+      it "emits exactly one PaymentMeans block" do
+        expect(subject.xpath("//cac:PaymentMeans").length).to eq(1)
+      end
     end
 
     context "when PaymentTerms tag" do

--- a/spec/serializers/e_invoices/invoices/ubl/builder_spec.rb
+++ b/spec/serializers/e_invoices/invoices/ubl/builder_spec.rb
@@ -188,6 +188,20 @@ RSpec.describe EInvoices::Invoices::Ubl::Builder do
       it "has the STANDARD_PAYMENT" do
         expect(subject).to contains_xml_node("//cac:PaymentMeans//cbc:PaymentMeansCode").with_value(1)
       end
+
+      it "emits exactly one PaymentMeans block" do
+        expect(subject.xpath("//cac:PaymentMeans").length).to eq(1)
+      end
+
+      context "with prepaid credit and credit notes applied" do
+        before do
+          invoice.update(net_payment_term: 2, prepaid_credit_amount: 10, credit_notes_amount: 20)
+        end
+
+        it "still emits exactly one PaymentMeans block" do
+          expect(subject.xpath("//cac:PaymentMeans").length).to eq(1)
+        end
+      end
     end
 
     context "when PaymentTerms tag" do


### PR DESCRIPTION
## Summary
  
  Lock down the XRechnung single-`PaymentMeans` invariant with regression specs on both UBL builders — the invoice builder spec also covers the prepaid-credit + credit-note-offset path to ensure those values
  keep flowing into `PaymentTerms` notes rather than leaking into a second `PaymentMeans` block.

  ## Test plan

  - [x] `lago exec api bundle exec rspec spec/serializers/e_invoices/invoices/ubl/builder_spec.rb spec/serializers/e_invoices/credit_notes/ubl/builder_spec.rb`