### PR TITLE
[ING-325][ING-333]  misc(clickhouse): Returns last and count in 1 query

### DIFF
--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -13,11 +13,13 @@ module BillableMetrics
       def compute_aggregation(options: {})
         return empty_result if should_bypass_aggregation?
 
-        result.aggregation = compute_aggregation_value(event_store.last)
-        result.count = event_store.count
+        last_result = event_store.last
+
+        result.aggregation = compute_aggregation_value(last_result.value)
+        result.count = last_result.events_count
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_last(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_last(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash)
         end
 
         result.options = options
@@ -35,20 +37,16 @@ module BillableMetrics
         aggregations = event_store.grouped_last
         return empty_results if aggregations.blank?
 
-        counts = event_store.grouped_count
-
         result.aggregations = aggregations.map do |aggregation|
           group_result = BaseService::Result.new
-          group_result.grouped_by = aggregation[:groups]
-          group_result.aggregation = compute_aggregation_value(aggregation[:value])
-
-          count = counts.find { |c| c[:groups] == aggregation[:groups] } || {}
-          group_result.count = count[:value] || 0
+          group_result.grouped_by = aggregation.groups
+          group_result.aggregation = compute_aggregation_value(aggregation.value)
+          group_result.count = aggregation.events_count || 0
           group_result
         end
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_last(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_last(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash)
         end
 
         result

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -89,11 +89,11 @@ module Events
         raise NotImplementedError
       end
 
-      def last
+      def last(with_count: true)
         raise NotImplementedError
       end
 
-      def grouped_last
+      def grouped_last(with_count: true)
         raise NotImplementedError
       end
 
@@ -191,6 +191,19 @@ module Events
         AggregationResult.new(
           value: row["value"] || 0,
           events_count: row["events_count"].presence&.to_i
+        )
+      end
+
+      # NOTE: Build an AggregationResult for the `last` aggregation. Unlike
+      #       build_aggregation_result it preserves a nil value (no event or no
+      #       value on the last event) instead of defaulting to 0, and tolerates
+      #       an empty row (when LIMIT 1 returns no row, events_count is 0).
+      #       The value is returned as-is from the driver (numeric), consistent
+      #       with sum/max/grouped_* which also don't cast.
+      def build_last_aggregation_result(row, with_count: true)
+        AggregationResult.new(
+          value: row && row["value"],
+          events_count: with_count ? (row && row["events_count"]).to_i : nil
         )
       end
     end

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -469,26 +469,30 @@ module Events
         end
       end
 
-      def last
+      def last(with_count: true)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
-            SELECT decimal_value
+            SELECT
+              decimal_value as value,
+              #{with_count ? "count() OVER ()" : "null"} as events_count
             FROM events
             ORDER BY timestamp DESC
             LIMIT 1
           SQL
 
-          connection.select_value(sql)
+          build_last_aggregation_result(connection.select_one(sql), with_count:)
         end
       end
 
-      def grouped_last(columns = grouped_by)
+      def grouped_last(columns = grouped_by, with_count: true)
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           if columns == grouped_by
+            count_select = with_count ? "count() OVER (PARTITION BY sorted_grouped_by)" : "null"
             sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value]), <<-SQL)
               SELECT
                 DISTINCT ON (sorted_grouped_by) sorted_grouped_by as groups,
-                events.decimal_value as value
+                events.decimal_value as value,
+                #{count_select} as events_count
               FROM events
               ORDER BY sorted_grouped_by, timestamp DESC
             SQL
@@ -496,26 +500,30 @@ module Events
             map_args, = sorted_properties_map_args(columns)
 
             sql = if grouped_by.blank?
+              count_select = with_count ? "count() OVER ()" : "null"
               with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
                 SELECT
                   map(#{map_args.join(", ")}) as groups,
-                  events.decimal_value as value
+                  events.decimal_value as value,
+                  #{count_select} as events_count
                 FROM events
                 ORDER BY timestamp DESC
                 LIMIT 1
               SQL
             else
+              count_select = with_count ? "count() OVER (PARTITION BY sorted_grouped_by)" : "null"
               with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
                 SELECT
                   DISTINCT ON (sorted_grouped_by) map(#{map_args.join(", ")}) as groups,
-                  events.decimal_value as value
+                  events.decimal_value as value,
+                  #{count_select} as events_count
                 FROM events
                 ORDER BY sorted_grouped_by, timestamp DESC
               SQL
             end
           end
 
-          prepare_grouped_result(connection.select_all(sql))
+          prepare_grouped_aggregated_values(connection.select_all(sql))
         end
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -471,17 +471,27 @@ module Events
         end
       end
 
-      def last
-        value = Events::Stores::Utils::ClickhouseConnection.with_retry do
-          events(ordered: true).last&.properties&.[](aggregation_property)
+      def last(with_count: true)
+        Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
+          ctes_sql = events_cte_queries(
+            select: [arel_table[:decimal_value].as("property"), arel_table[:timestamp]],
+            deduplicated_columns: %w[decimal_value properties]
+          )
+
+          sql = with_ctes(ctes_sql, <<-SQL)
+            SELECT
+              property as value,
+              #{with_count ? "count() OVER ()" : "null"} as events_count
+            FROM events
+            ORDER BY events.timestamp DESC
+            LIMIT 1
+          SQL
+
+          build_last_aggregation_result(connection.select_one(sql), with_count:)
         end
-
-        return value unless value
-
-        BigDecimal(value)
       end
 
-      def grouped_last(columns = grouped_by)
+      def grouped_last(columns = grouped_by, with_count: true)
         groups, column_names = grouped_arel_columns(columns)
         distinct_on_names = grouped_by.present? ? grouped_arel_columns.last : nil
 
@@ -492,25 +502,29 @@ module Events
           )
 
           sql = if distinct_on_names
+            count_select = with_count ? "count() OVER (PARTITION BY #{distinct_on_names})" : "null"
             with_ctes(ctes_sql, <<-SQL)
               SELECT
                 DISTINCT ON (#{distinct_on_names}) #{column_names},
-                property
+                property,
+                #{count_select} as events_count
               FROM events
               ORDER BY #{distinct_on_names}, events.timestamp DESC
             SQL
           else
+            count_select = with_count ? "count() OVER ()" : "null"
             with_ctes(ctes_sql, <<-SQL)
               SELECT
                 #{column_names},
-                property
+                property,
+                #{count_select} as events_count
               FROM events
               ORDER BY events.timestamp DESC
               LIMIT 1
             SQL
           end
 
-          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
+          prepare_grouped_aggregated_values(connection.select_all(sql).rows, columns: columns)
         end
       end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -222,30 +222,35 @@ module Events
         prepare_grouped_result(results, columns: columns)
       end
 
-      def last
-        events.order(timestamp: :desc, created_at: :desc).first&.properties&.[](aggregation_property)
+      def last(with_count: true)
+        AggregationResult.new(
+          value: events.order(timestamp: :desc, created_at: :desc).first&.properties&.[](aggregation_property),
+          events_count: with_count ? events.count : nil
+        )
       end
 
-      def grouped_last(columns = grouped_by)
+      def grouped_last(columns = grouped_by, with_count: true)
         sanitized_columns = columns.map { sanitized_property_name(it) }
         distinct_on_columns = grouped_by.present? ? grouped_by.map { sanitized_property_name(it) } : []
 
         sql = if distinct_on_columns.empty?
+          count_select = with_count ? "COUNT(*) OVER ()" : "NULL"
           events
             .order(Arel.sql("events.timestamp DESC, created_at DESC"))
-            .select("#{sanitized_columns.join(", ")}, (#{sanitized_property_name})::numeric AS value")
+            .select("#{sanitized_columns.join(", ")}, (#{sanitized_property_name})::numeric AS value, #{count_select} AS events_count")
             .limit(1)
             .to_sql
         else
+          count_select = with_count ? "COUNT(*) OVER (PARTITION BY #{distinct_on_columns.join(", ")})" : "NULL"
           events
             .order(Arel.sql((distinct_on_columns + ["events.timestamp DESC, created_at DESC"]).join(", ")))
             .select(
-              "DISTINCT ON (#{distinct_on_columns.join(", ")}) #{sanitized_columns.join(", ")}, (#{sanitized_property_name})::numeric AS value"
+              "DISTINCT ON (#{distinct_on_columns.join(", ")}) #{sanitized_columns.join(", ")}, (#{sanitized_property_name})::numeric AS value, #{count_select} AS events_count"
             )
             .to_sql
         end
 
-        prepare_grouped_result(select_all(sql).rows, columns: columns)
+        prepare_grouped_aggregated_values(select_all(sql).rows, columns: columns)
       end
 
       def sum_precise_total_amount_cents

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1226,15 +1226,30 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         event_store.numeric_property = true
       end
 
-      it "returns the last event value" do
-        expect(event_store.last).to eq(5)
+      it "returns the last event value and the events count" do
+        result = event_store.last
+
+        expect(result.value).to eq(5)
+        expect(result.events_count).to eq(5)
+      end
+
+      context "when with_count is false" do
+        it "does not include events_count in the result" do
+          result = event_store.last(with_count: false)
+
+          expect(result.value).to eq(5)
+          expect(result.events_count).to be_nil
+        end
       end
 
       context "when there's no events" do
         let(:events) { [] }
 
-        it "returns nil" do
-          expect(event_store.last).to be_nil
+        it "returns a nil value and a zero count" do
+          result = event_store.last
+
+          expect(result.value).to be_nil
+          expect(result.events_count).to eq(0)
         end
       end
 
@@ -1243,8 +1258,13 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           [create_event(timestamp: subscription_started_at + 1.day, value: nil)]
         end
 
-        it "returns nil" do
-          expect(event_store.last).to be_nil
+        it "returns a nil value" do
+          # NOTE: events_count is intentionally not asserted here: Postgres filters
+          #       out events missing the aggregation property while Clickhouse keeps
+          #       them, so the count of a no-value event differs between stores.
+          result = event_store.last
+
+          expect(result.value).to be_nil
         end
       end
 
@@ -1275,7 +1295,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           # - europe, united kingdom, manchester -> -1 (day +6)
           # - europe, france, cambridge -> -2 (day +7)
           # Last value is -2
-          expect(event_store.last).to eq(-2)
+          result = event_store.last
+
+          expect(result.value).to eq(-2)
+          expect(result.events_count).to eq(4)
         end
       end
     end
@@ -1290,13 +1313,24 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         event_store.numeric_property = true
       end
 
-      it "returns the value attached to each event prorated on the provided duration" do
+      it "returns the last value and the events count for each group" do
         result = event_store.grouped_last
 
         expect(result).to match_array([
-          {groups: {"region" => nil}, value: 4},
-          {groups: {"region" => "europe"}, value: 5}
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => nil}, value: 4, events_count: 2),
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "europe"}, value: 5, events_count: 3)
         ])
+      end
+
+      context "when with_count is false" do
+        it "returns the last value without the events count" do
+          result = event_store.grouped_last(with_count: false)
+
+          expect(result).to match_array([
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => nil}, value: 4, events_count: nil),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "europe"}, value: 5, events_count: nil)
+          ])
+        end
       end
 
       context "with multiple groups" do
@@ -1306,9 +1340,9 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_last
 
           expect(result).to match_array([
-            {groups: {"country" => nil, "region" => nil}, value: 4},
-            {groups: {"country" => "france", "region" => "europe"}, value: 3},
-            {groups: {"country" => "united kingdom", "region" => "europe"}, value: 5}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => nil, "region" => nil}, value: 4, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "france", "region" => "europe"}, value: 3, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "united kingdom", "region" => "europe"}, value: 5, events_count: 1)
           ])
         end
       end
@@ -1346,8 +1380,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           # - europe, france, cambridge
           # - europe, united kingdom, manchester
           expect(result).to match_array([
-            {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
-            {groups: {"country" => "france", "region" => "europe"}, value: -2}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "united kingdom", "region" => "europe"}, value: -1, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "france", "region" => "europe"}, value: -2, events_count: 3)
           ])
         end
       end
@@ -1718,7 +1752,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_last(["cloud"])
 
           expect(result).to match_array([
-            {groups: {"cloud" => "gcp"}, value: 12}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "gcp"}, value: 12, events_count: 2)
           ])
         end
       end
@@ -1736,8 +1770,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_last(["agent_name", "cloud"])
 
           expect(result).to match_array([
-            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
-            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3, events_count: 1)
           ])
         end
       end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5716, https://github.com/getlago/lago-api/pull/5723 and https://github.com/getlago/lago-api/pull/5730

Today, all aggregation services (except CountService) perform two queries against the event store: one for the aggregation itself, and a second for the number of events involved in the result.

This implementation is inherited from the original Postgres store and works well for that engine. When the Clickhouse store was introduced, the same approach was kept for compatibility. At scale this is not ideal on the Clickhouse side, as it forces the engine to retrieve the same set of records twice, including a second pass over the expensive deduplication CTE.

This PR applies the single-pass approach, already introduced for sum and grouped_sum, to the latest (last) aggregation.

## Description

  `last` and `grouped_last` now return the existing `AggregationResult` / `GroupedAggregationResult` structures carrying both the value and the events_count:

  - **Clickhouse** (`ClickhouseStore` and `ClickhouseEnrichedStore`): both `last` and `grouped_last` fold the count   into the value query in a single pass, using count() OVER () (and count() OVER (PARTITION BY …) for the grouped case). This removes the second execution of the deduplication CTE.
  - **Postgres**: grouped_last is single-pass — the per-group count is folded into the existing DISTINCT ON   query via COUNT(*) OVER (PARTITION BY …), which reuses the sort DISTINCT ON already requires. last (non-grouped) intentionally keeps two queries (.first + count): a windowed count would force a full scan and defeat the index-backed ORDER BY … LIMIT 1, and Postgres is not the scale concern this change targets.

LatestService consumes the new shapes directly and no longer issues a separate count / grouped_count query.

The same approach will be applied to the remaining aggregations in follow-up steps.