### PR TITLE
fix(invoices): tax regenerated invoices on credited subtotal

### DIFF
--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -64,7 +64,8 @@ module Credits
     attr_reader :invoice
 
     def apply_credit_to_fees(progressive_billing_invoice)
-      invoice_fees = invoice.fees.charge.to_a
+      # Use the loaded association so the credit stays visible to the caller's in-memory fees.
+      invoice_fees = invoice.fees.select(&:charge?)
       progressive_billing_invoice.fees.charge.each do |progressive_fee|
         fee = invoice_fees.find { |f|
           f.charge_id == progressive_fee.charge_id &&

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -83,6 +83,16 @@ Rspec.describe Credits::ProgressiveBillingService do
         expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(0)
       end
 
+      it "applies the credit to the already-loaded fees association without a reload" do
+        invoice.fees.load
+
+        credit_service.call
+
+        cached_fee = invoice.fees.find { |fee| fee.id == subscription_fee1.id }
+        expect(cached_fee.precise_coupons_amount_cents).to eq(20)
+        expect(cached_fee.sub_total_excluding_taxes_amount_cents).to eq(cached_fee.amount_cents - 20)
+      end
+
       context "when progressive billing credits are greater than amount cents" do
         let(:subscription_fee1) { create(:charge_fee, invoice:, subscription:, amount_cents: 19) }
 


### PR DESCRIPTION
## Context

When an invoice that carries a progressive billing credit is regenerated from a voided invoice (`Invoices::RegenerateFromVoidedService`), the regenerated invoice computed taxes on the **full fee amounts** instead of the credited subtotal. In production this surfaced as a regenerated invoice showing a ~57% tax rate where the correct rate was 17% — taxes were charged on `fees_amount_cents` (e.g. 13160) rather than on the progressive-billing-credited base (3914).

Root cause is an ActiveRecord association-cache inconsistency. `Credits::ProgressiveBillingService#apply_credit_to_fees` read the fees through `invoice.fees.charge`, which chains a scope and therefore issues a **fresh query**, returning different `Fee` instances than the ones already loaded on `invoice.fees`. It mutated and saved those fresh instances (so the database was correct), but the invoice's already-loaded `fees` association still held the pre-credit values (`precise_coupons_amount_cents = 0`).

The regular billing path (`Invoices::CalculateFeesService`) never materializes `invoice.fees` before crediting, so it was unaffected. The regeneration path does — `#adjust_fees` iterates `regenerated_invoice.fees` — so by the time `Invoices::ComputeAmountsFromFees` / `Invoices::ApplyTaxesService` read each fee's `sub_total_excluding_taxes_amount_cents` (`amount_cents − precise_coupons_amount_cents`), the stale cache yielded the full amount, inflating both the per-fee tax and the invoice `taxes_rate`.

## Description

- `Credits::ProgressiveBillingService#apply_credit_to_fees` now selects charge fees from the **loaded association** (`invoice.fees.select(&:charge?)`) instead of re-querying with `invoice.fees.charge`. The credit is applied to the same `Fee` instances the caller holds, so downstream tax computation reads the credited subtotal. The DB result is unchanged; only the in-memory consistency is fixed. The fix lives in the shared service so every caller (regeneration, normal billing, the progressive-billing generator) benefits and no future caller can hit the stale cache.