### PR TITLE
feat(order-forms): lock when mutating quotes, order forms and orders

### DIFF
--- a/app/jobs/order_forms/expire_order_form_job.rb
+++ b/app/jobs/order_forms/expire_order_form_job.rb
@@ -6,6 +6,8 @@ module OrderForms
 
     unique :until_executed, on_conflict: :log
 
+    retry_on Customers::FailedToAcquireLock, attempts: MAX_LOCK_RETRY_ATTEMPTS, wait: random_lock_retry_delay
+
     def perform(order_form)
       OrderForms::ExpireService.call!(order_form:)
     end

--- a/app/services/order_forms/expire_service.rb
+++ b/app/services/order_forms/expire_service.rb
@@ -16,23 +16,26 @@ module OrderForms
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.forbidden_failure! unless order_forms_enabled?(order_form.organization)
 
-      return result.forbidden_failure!(code: "order_form_is_voided") if order_form.voided?
-      return result.forbidden_failure!(code: "order_form_is_signed") if order_form.signed?
+      OrderForm.transaction do
+        Quotes::LockService.call(quote: order_form.quote_version.quote) do
+          order_form.reload
 
-      if order_form.expired?
-        result.order_form = order_form
-        return result
+          next result.forbidden_failure!(code: "order_form_is_voided") if order_form.voided?
+          next result.forbidden_failure!(code: "order_form_is_signed") if order_form.signed?
+
+          if order_form.expired?
+            result.order_form = order_form
+            next
+          end
+
+          order_form.update!(status: :expired, voided_at: Time.current, void_reason: :expired)
+
+          QuoteVersions::VoidService.call!(quote_version: order_form.quote_version, reason: :cascade_of_expired)
+
+          result.order_form = order_form
+        end
       end
 
-      order_form.assign_attributes(status: :expired, voided_at: Time.current, void_reason: :expired)
-
-      ActiveRecord::Base.transaction do
-        order_form.save!
-
-        QuoteVersions::VoidService.call!(quote_version: order_form.quote_version, reason: :cascade_of_expired)
-      end
-
-      result.order_form = order_form
       result
     end
 

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -23,7 +23,6 @@ module OrderForms
     def call
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.forbidden_failure! unless order_forms_enabled?(order_form.organization)
-      return result.single_validation_failure!(field: :status, error_code: "not_signable") unless order_form.generated?
 
       validate_execution_settings
       return result if result.failure?
@@ -31,27 +30,32 @@ module OrderForms
       attachment = signed_document_attachment
       return result if result.failure?
 
-      order_form.assign_attributes(
-        status: :signed,
-        signed_at: Time.current
-      )
+      OrderForm.transaction do
+        Quotes::LockService.call(quote: order_form.quote_version.quote) do
+          order_form.reload
+          next result.single_validation_failure!(field: :status, error_code: "not_signable") unless order_form.generated?
 
-      ActiveRecord::Base.transaction do
-        order_form.signed_document.attach(attachment) if attachment
-        order_form.save!
+          order_form.assign_attributes(
+            status: :signed,
+            signed_at: Time.current
+          )
+          order_form.signed_document.attach(attachment) if attachment
+          order_form.save!
 
-        result.order = Order.create!(
-          organization: order_form.organization,
-          customer: order_form.customer,
-          order_form:,
-          execution_mode:,
-          execute_at:
-        )
+          result.order = Order.create!(
+            organization: order_form.organization,
+            customer: order_form.customer,
+            order_form:,
+            execution_mode:,
+            execute_at:
+          )
 
-        # TODO: Enqueue Orders::ExecuteOrderJob.perform_after_commit(result.order) when execution_mode == "execute_in_lago"
+          # TODO: Enqueue Orders::ExecuteOrderJob.perform_after_commit(result.order) when execution_mode == "execute_in_lago"
+
+          result.order_form = order_form
+        end
       end
 
-      result.order_form = order_form
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/order_forms/void_service.rb
+++ b/app/services/order_forms/void_service.rb
@@ -20,21 +20,24 @@ module OrderForms
     def call
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.forbidden_failure! unless order_forms_enabled?(order_form.organization)
-      return result.single_validation_failure!(field: :status, error_code: "not_voidable") unless order_form.generated?
 
-      order_form.assign_attributes(
-        status: :voided,
-        voided_at: Time.current,
-        void_reason: :manual
-      )
+      OrderForm.transaction do
+        Quotes::LockService.call(quote: order_form.quote_version.quote) do
+          order_form.reload
+          next result.single_validation_failure!(field: :status, error_code: "not_voidable") unless order_form.generated?
 
-      ActiveRecord::Base.transaction do
-        order_form.save!
+          order_form.update!(
+            status: :voided,
+            voided_at: Time.current,
+            void_reason: :manual
+          )
 
-        QuoteVersions::VoidService.call!(quote_version: order_form.quote_version, reason: :cascade_of_voided)
+          QuoteVersions::VoidService.call!(quote_version: order_form.quote_version, reason: :cascade_of_voided)
+
+          result.order_form = order_form
+        end
       end
 
-      result.order_form = order_form
       result
     end
 

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -17,21 +17,25 @@ module QuoteVersions
     def call
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
-      return result.single_validation_failure!(field: :status, error_code: "not_approvable") unless approvable?
 
       QuoteVersion.transaction do
-        quote_version.update!(
-          status: :approved,
-          approved_at: Time.current,
-          mention_variables: ComputeMentionVariablesService.call!(quote_version:).mention_variables
-        )
+        Quotes::LockService.call(quote: quote_version.quote) do
+          quote_version.reload
+          next result.single_validation_failure!(field: :status, error_code: "not_approvable") unless approvable?
 
-        result.order_form = OrderForms::CreateService.call!(quote_version:, expires_at:).order_form
+          quote_version.update!(
+            status: :approved,
+            approved_at: Time.current,
+            mention_variables: ComputeMentionVariablesService.call!(quote_version:).mention_variables
+          )
+
+          result.order_form = OrderForms::CreateService.call!(quote_version:, expires_at:).order_form
+          result.quote_version = quote_version
+        end
       end
 
       # TODO: SendWebhookJob.perform_after_commit("quote_version.approved", quote_version)
 
-      result.quote_version = quote_version
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -25,16 +25,19 @@ module QuoteVersions
     def call
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
-      return result.single_validation_failure!(field: :status, error_code: "not_clonable") unless clonable?
 
-      cloned = QuoteVersion.transaction do
-        void_active_version!
-        create_next_version(quote_version:)
+      QuoteVersion.transaction do
+        Quotes::LockService.call(quote: quote_version.quote) do
+          quote_version.reload
+          next result.single_validation_failure!(field: :status, error_code: "not_clonable") unless clonable?
+
+          void_active_version!
+          result.quote_version = create_next_version(quote_version:)
+        end
       end
 
-      # TODO: SendWebhookJob.perform_after_commit("quote_version.cloned", cloned)
+      # TODO: SendWebhookJob.perform_after_commit("quote_version.cloned", result.quote_version)
 
-      result.quote_version = cloned
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/quote_versions/void_service.rb
+++ b/app/services/quote_versions/void_service.rb
@@ -18,19 +18,26 @@ module QuoteVersions
       return result.not_found_failure!(resource: "quote_version") unless quote_version
       return result.forbidden_failure! unless order_forms_enabled?(quote_version.organization)
       return result.single_validation_failure!(field: :void_reason, error_code: "invalid") unless valid_reason?
-      return result.single_validation_failure!(field: :status, error_code: "not_voidable") unless voidable?
 
-      quote_version.update!(
-        status: :voided,
-        void_reason: reason,
-        voided_at: Time.current,
-        share_token: nil,
-        approved_at: nil
-      )
+      QuoteVersion.transaction do
+        Quotes::LockService.call(quote: quote_version.quote) do
+          quote_version.reload
+          next result.single_validation_failure!(field: :status, error_code: "not_voidable") unless voidable?
+
+          quote_version.update!(
+            status: :voided,
+            void_reason: reason,
+            voided_at: Time.current,
+            share_token: nil,
+            approved_at: nil
+          )
+
+          result.quote_version = quote_version
+        end
+      end
 
       # TODO: SendWebhookJob.perform_after_commit("quote_version.voided", quote_version)
 
-      result.quote_version = quote_version
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/quotes/lock_service.rb
+++ b/app/services/quotes/lock_service.rb
@@ -31,10 +31,6 @@ module Quotes
       raise Customers::FailedToAcquireLock, "Failed to acquire lock #{lock_key}"
     end
 
-    def locked?
-      ActiveRecord::Base.advisory_lock_exists?(lock_key)
-    end
-
     private
 
     attr_reader :quote, :timeout_seconds, :transaction

--- a/app/services/quotes/lock_service.rb
+++ b/app/services/quotes/lock_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Quotes
+  # Acquires a PostgreSQL advisory lock scoped to a quote to serialize mutations across the
+  # whole quote aggregate (quote, quote versions, order forms and orders).
+  #
+  # The lock is reentrant: cascade calls that re-enter the same quote lock (e.g. approve ->
+  # create order form, expire/void -> void version, clone -> void version) yield immediately
+  # within the already-held transaction instead of re-acquiring.
+  #
+  # Usage in jobs:
+  #   retry_on Customers::FailedToAcquireLock,
+  #            attempts: MAX_LOCK_RETRY_ATTEMPTS, wait: random_lock_retry_delay
+  #
+  class LockService < BaseService
+    ACQUIRE_LOCK_TIMEOUT = 5.seconds
+
+    def initialize(quote:, timeout_seconds: ACQUIRE_LOCK_TIMEOUT, transaction: true)
+      @quote = quote
+      @timeout_seconds = timeout_seconds
+      @transaction = transaction
+
+      super
+    end
+
+    def call
+      Quote.with_advisory_lock!(lock_key, timeout_seconds:, transaction:) do
+        yield
+      end
+    rescue WithAdvisoryLock::FailedToAcquireLock
+      raise Customers::FailedToAcquireLock, "Failed to acquire lock #{lock_key}"
+    end
+
+    def locked?
+      ActiveRecord::Base.advisory_lock_exists?(lock_key)
+    end
+
+    private
+
+    attr_reader :quote, :timeout_seconds, :transaction
+
+    def lock_key
+      "quote-#{quote.id}"
+    end
+  end
+end

--- a/spec/services/order_forms/expire_service_spec.rb
+++ b/spec/services/order_forms/expire_service_spec.rb
@@ -47,6 +47,27 @@ RSpec.describe OrderForms::ExpireService do
         end
       end
 
+      context "with concurrent mutations" do
+        it "wraps the work in a per-quote lock" do
+          allow(Quotes::LockService).to receive(:call).and_call_original
+
+          service.call
+
+          expect(Quotes::LockService).to have_received(:call).with(quote: order_form.quote_version.quote).at_least(:once)
+        end
+
+        it "re-checks the status under the lock and skips an order form voided concurrently" do
+          order_form
+          OrderForm.where(id: order_form.id).update_all(status: "voided", void_reason: "manual", voided_at: Time.current)
+
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ForbiddenFailure)
+          expect(result.error.code).to eq("order_form_is_voided")
+        end
+      end
+
       context "when order_form is already expired" do
         let(:order_form) { create(:order_form, :expired, customer:, organization:) }
 

--- a/spec/services/order_forms/expire_service_spec.rb
+++ b/spec/services/order_forms/expire_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe OrderForms::ExpireService do
 
         it "re-checks the status under the lock and skips an order form voided concurrently" do
           order_form
-          OrderForm.where(id: order_form.id).update_all(status: "voided", void_reason: "manual", voided_at: Time.current)
+          OrderForm.find(order_form.id).update!(status: :voided, void_reason: :manual, voided_at: Time.current)
 
           result = service.call
 

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -48,6 +48,27 @@ RSpec.describe OrderForms::MarkAsSignedService do
         end
       end
 
+      context "with concurrent mutations" do
+        it "wraps the work in a per-quote lock" do
+          allow(Quotes::LockService).to receive(:call).and_call_original
+
+          service.call
+
+          expect(Quotes::LockService).to have_received(:call).with(quote: order_form.quote_version.quote).at_least(:once)
+        end
+
+        it "re-checks the status under the lock and refuses signing an order form voided concurrently" do
+          order_form
+          OrderForm.where(id: order_form.id).update_all(status: "voided", void_reason: "manual", voided_at: Time.current)
+
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({status: ["not_signable"]})
+        end
+      end
+
       context "when order_form is not generated" do
         let(:order_form) { create(:order_form, :signed, customer:, organization:, quote:) }
 

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe OrderForms::MarkAsSignedService do
 
         it "re-checks the status under the lock and refuses signing an order form voided concurrently" do
           order_form
-          OrderForm.where(id: order_form.id).update_all(status: "voided", void_reason: "manual", voided_at: Time.current)
+          OrderForm.find(order_form.id).update!(status: :voided, void_reason: :manual, voided_at: Time.current)
 
           result = service.call
 

--- a/spec/services/order_forms/void_service_spec.rb
+++ b/spec/services/order_forms/void_service_spec.rb
@@ -35,6 +35,27 @@ RSpec.describe OrderForms::VoidService do
         end
       end
 
+      context "with concurrent mutations" do
+        it "wraps the work in a per-quote lock" do
+          allow(Quotes::LockService).to receive(:call).and_call_original
+
+          service.call
+
+          expect(Quotes::LockService).to have_received(:call).with(quote: order_form.quote_version.quote).at_least(:once)
+        end
+
+        it "re-checks the status under the lock and refuses voiding an order form signed concurrently" do
+          order_form
+          OrderForm.where(id: order_form.id).update_all(status: "signed", signed_at: Time.current)
+
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({status: ["not_voidable"]})
+        end
+      end
+
       context "when the order form is not generated" do
         let(:order_form) { create(:order_form, :signed, customer:, organization:) }
 

--- a/spec/services/order_forms/void_service_spec.rb
+++ b/spec/services/order_forms/void_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe OrderForms::VoidService do
 
         it "re-checks the status under the lock and refuses voiding an order form signed concurrently" do
           order_form
-          OrderForm.where(id: order_form.id).update_all(status: "signed", signed_at: Time.current)
+          OrderForm.find(order_form.id).update!(status: :signed, signed_at: Time.current)
 
           result = service.call
 

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe QuoteVersions::ApproveService do
 
       it "re-checks the status under the lock and refuses a stale approval" do
         quote_version
-        QuoteVersion.where(id: quote_version.id).update_all(status: "voided", void_reason: "manual", voided_at: Time.current)
+        QuoteVersion.find(quote_version.id).update!(status: :voided, void_reason: :manual, voided_at: Time.current)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -44,6 +44,25 @@ RSpec.describe QuoteVersions::ApproveService do
       end
     end
 
+    context "with concurrent mutations", :premium do
+      it "wraps the work in a per-quote lock" do
+        allow(Quotes::LockService).to receive(:call).and_call_original
+
+        result
+
+        expect(Quotes::LockService).to have_received(:call).with(quote: quote_version.quote).at_least(:once)
+      end
+
+      it "re-checks the status under the lock and refuses a stale approval" do
+        quote_version
+        QuoteVersion.where(id: quote_version.id).update_all(status: "voided", void_reason: "manual", voided_at: Time.current)
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_approvable"]})
+      end
+    end
+
     context "when an expires_at in the future is provided", :premium do
       subject(:approve_service) { described_class.new(quote_version:, expires_at:) }
 

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe QuoteVersions::CloneService do
       end
     end
 
+    context "with concurrent mutations", :premium do
+      it "wraps the work in a per-quote lock" do
+        allow(Quotes::LockService).to receive(:call).and_call_original
+
+        result
+
+        expect(Quotes::LockService).to have_received(:call).with(quote: quote_version.quote).at_least(:once)
+      end
+    end
+
     context "when any quote version is already approved", :premium do
       let!(:versions) do
         [create(:quote_version, :approved, quote:, organization:)]

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe QuoteVersions::VoidService do
 
       it "re-checks the status under the lock and refuses a stale void" do
         quote_version
-        QuoteVersion.where(id: quote_version.id).update_all(status: "approved", approved_at: Time.current)
+        QuoteVersion.find(quote_version.id).update!(status: :approved, approved_at: Time.current)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe QuoteVersions::VoidService do
       end
     end
 
+    context "with concurrent mutations", :premium do
+      it "wraps the work in a per-quote lock" do
+        allow(Quotes::LockService).to receive(:call).and_call_original
+
+        result
+
+        expect(Quotes::LockService).to have_received(:call).with(quote: quote_version.quote).at_least(:once)
+      end
+
+      it "re-checks the status under the lock and refuses a stale void" do
+        quote_version
+        QuoteVersion.where(id: quote_version.id).update_all(status: "approved", approved_at: Time.current)
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({status: ["not_voidable"]})
+      end
+    end
+
     context "when quote version is approved", :premium do
       let(:quote_version) { create(:quote_version, :approved, organization:) }
 

--- a/spec/services/quotes/lock_service_spec.rb
+++ b/spec/services/quotes/lock_service_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Quotes::LockService do
+  let(:lock_service) { described_class.new(quote:, timeout_seconds:) }
+  let(:quote) { create(:quote) }
+  let(:timeout_seconds) { 5.seconds }
+
+  describe "#call" do
+    context "when lock can be acquired" do
+      it "takes an advisory lock" do
+        expect(lock_service).not_to be_locked
+
+        lock_service.call do
+          expect(lock_service).to be_locked
+        end
+
+        expect(lock_service).not_to be_locked
+      end
+
+      it "yields the block return value" do
+        expect(lock_service.call { :done }).to eq(:done)
+      end
+    end
+
+    context "when lock cannot be acquired", transaction: false do
+      let(:timeout_seconds) { 0.seconds }
+
+      around do |test|
+        with_advisory_lock("quote-#{quote.id}", lock_released_after: 2.seconds) do
+          test.run
+        end
+      end
+
+      it "raises a Customers::FailedToAcquireLock error" do
+        expect do
+          lock_service.call { nil }
+        end.to raise_error(Customers::FailedToAcquireLock, "Failed to acquire lock quote-#{quote.id}")
+      end
+    end
+  end
+
+  describe "reentrancy" do
+    it "re-enters the same quote lock without blocking and keeps it held" do
+      inner_result = nil
+
+      described_class.call(quote:, timeout_seconds: 0) do
+        # Nested acquisition of the same quote lock succeeds immediately (timeout: 0
+        # would otherwise fail fast) because the gem short-circuits on already_locked?.
+        inner_result = described_class.call(quote:, timeout_seconds: 0) { :inner }
+
+        # The lock is still held after the nested block returns.
+        expect(ActiveRecord::Base.advisory_lock_exists?("quote-#{quote.id}")).to be true
+      end
+
+      expect(inner_result).to eq(:inner)
+    end
+
+    it "allows nesting a lock on a different quote" do
+      other_quote = create(:quote)
+      inner_ran = false
+
+      described_class.call(quote:) do
+        described_class.call(quote: other_quote) { inner_ran = true }
+      end
+
+      expect(inner_ran).to be true
+    end
+  end
+
+  describe "#locked?" do
+    subject { lock_service.locked? }
+
+    context "when the lock is taken" do
+      it "returns true" do
+        lock_service.call do
+          expect(subject).to be true
+        end
+      end
+    end
+
+    context "when the lock is not taken" do
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+end

--- a/spec/services/quotes/lock_service_spec.rb
+++ b/spec/services/quotes/lock_service_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Quotes::LockService do
   describe "#call" do
     context "when lock can be acquired" do
       it "takes an advisory lock" do
-        expect(lock_service).not_to be_locked
+        expect(ActiveRecord::Base.advisory_lock_exists?("quote-#{quote.id}")).to be false
 
         lock_service.call do
-          expect(lock_service).to be_locked
+          expect(ActiveRecord::Base.advisory_lock_exists?("quote-#{quote.id}")).to be true
         end
 
-        expect(lock_service).not_to be_locked
+        expect(ActiveRecord::Base.advisory_lock_exists?("quote-#{quote.id}")).to be false
       end
 
       it "yields the block return value" do
@@ -66,24 +66,6 @@ RSpec.describe Quotes::LockService do
       end
 
       expect(inner_ran).to be true
-    end
-  end
-
-  describe "#locked?" do
-    subject { lock_service.locked? }
-
-    context "when the lock is taken" do
-      it "returns true" do
-        lock_service.call do
-          expect(subject).to be true
-        end
-      end
-    end
-
-    context "when the lock is not taken" do
-      it "returns false" do
-        expect(subject).to be false
-      end
     end
   end
 end


### PR DESCRIPTION
This PR aims to protect the Quotes & Order forms features from concurrent state changes (for example, voiding a quote while someone else is approving the same quote).

I wrapped all the state changes in the feature services into a db advisory lock (`Quote::LockService`.