### PR TITLE
[ING-235] feat(wallets): add grants_target_top_up column

### DIFF
--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -113,6 +113,7 @@ end
 #  id                                  :uuid             not null, primary key
 #  expiration_at                       :datetime
 #  granted_credits                     :decimal(30, 5)   default(0.0), not null
+#  grants_target_top_up                :boolean
 #  ignore_paid_top_up_limits           :boolean          default(FALSE), not null
 #  interval                            :integer          default("weekly")
 #  invoice_requires_successful_payment :boolean          default(FALSE), not null

--- a/db/migrate/20260617072554_add_grants_target_top_up_to_recurring_transaction_rules.rb
+++ b/db/migrate/20260617072554_add_grants_target_top_up_to_recurring_transaction_rules.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGrantsTargetTopUpToRecurringTransactionRules < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recurring_transaction_rules, :grants_target_top_up, :boolean
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5053,7 +5053,8 @@ CREATE TABLE public.recurring_transaction_rules (
     transaction_name character varying(255),
     payment_method_id uuid,
     payment_method_type public.payment_method_types DEFAULT 'provider'::public.payment_method_types NOT NULL,
-    skip_invoice_custom_sections boolean DEFAULT false NOT NULL
+    skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
+    grants_target_top_up boolean
 );
 
 
@@ -12786,6 +12787,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260617145515'),
+('20260617072554'),
 ('20260616160703'),
 ('20260616155032'),
 ('20260615181440'),


### PR DESCRIPTION
## Context

Target recurring transaction rules always create a paid top-up. To let them grant free credits instead ([ING-235](https://linear.app/getlago/issue/ING-235)), the schema needs a flag. Shipping the column on its own, ahead of the code that reads it, lets it deploy first.

## Changes

- Add a nullable boolean `grants_target_top_up` to `recurring_transaction_rules`.

Nullable on purpose: target rules carry `true`/`false`, non-target rules stay `nil`. No backfill; absent values are read as `false`.

The behaviour that reads this column lands in #5755.