### PR TITLE
perf(subscriptions): Add covering index on subscriptions for `plan_id` and `status`

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -375,6 +375,7 @@ end
 #  index_subscriptions_on_organization_id                      (organization_id)
 #  index_subscriptions_on_payment_method_id                    (payment_method_id)
 #  index_subscriptions_on_plan_id                              (plan_id)
+#  index_subscriptions_on_plan_id_and_status                   (plan_id,status)
 #  index_subscriptions_on_previous_subscription_id_and_status  (previous_subscription_id,status)
 #  index_subscriptions_on_started_at                           (started_at)
 #  index_subscriptions_on_started_at_and_ending_at             (started_at,ending_at)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -375,7 +375,7 @@ end
 #  index_subscriptions_on_organization_id                      (organization_id)
 #  index_subscriptions_on_payment_method_id                    (payment_method_id)
 #  index_subscriptions_on_plan_id                              (plan_id)
-#  index_subscriptions_on_plan_id_and_status                   (plan_id,status)
+#  index_subscriptions_on_plan_id_and_status                   (plan_id,status) WHERE (status = ANY (ARRAY[0, 1]))
 #  index_subscriptions_on_previous_subscription_id_and_status  (previous_subscription_id,status)
 #  index_subscriptions_on_started_at                           (started_at)
 #  index_subscriptions_on_started_at_and_ending_at             (started_at,ending_at)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -366,6 +366,7 @@ end
 # Indexes
 #
 #  idx_on_organization_id_subscription_at_created_at_id        (organization_id,subscription_at DESC NULLS LAST,created_at DESC,id)
+#  index_pending_active_subscriptions_on_plan_id_and_status    (plan_id,status) WHERE (status = ANY (ARRAY[0, 1]))
 #  index_subscriptions_on_billing_entity_id                    (billing_entity_id)
 #  index_subscriptions_on_customer_id                          (customer_id)
 #  index_subscriptions_on_ending_at_active                     (ending_at) WHERE ((status = 1) AND (ending_at IS NOT NULL))
@@ -375,7 +376,6 @@ end
 #  index_subscriptions_on_organization_id                      (organization_id)
 #  index_subscriptions_on_payment_method_id                    (payment_method_id)
 #  index_subscriptions_on_plan_id                              (plan_id)
-#  index_subscriptions_on_plan_id_and_status                   (plan_id,status) WHERE (status = ANY (ARRAY[0, 1]))
 #  index_subscriptions_on_previous_subscription_id_and_status  (previous_subscription_id,status)
 #  index_subscriptions_on_started_at                           (started_at)
 #  index_subscriptions_on_started_at_and_ending_at             (started_at,ending_at)

--- a/db/migrate/20260619065327_add_index_on_subscriptions_for_plan_id_and_status.rb
+++ b/db/migrate/20260619065327_add_index_on_subscriptions_for_plan_id_and_status.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexOnSubscriptionsForPlanIdAndStatus < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscriptions, [:plan_id, :status], algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/migrate/20260619065327_add_index_on_subscriptions_for_plan_id_and_status.rb
+++ b/db/migrate/20260619065327_add_index_on_subscriptions_for_plan_id_and_status.rb
@@ -4,6 +4,10 @@ class AddIndexOnSubscriptionsForPlanIdAndStatus < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   def change
-    add_index :subscriptions, [:plan_id, :status], algorithm: :concurrently, if_not_exists: true
+    add_index :subscriptions,
+      [:plan_id, :status],
+      where: "status IN (0, 1)",
+      algorithm: :concurrently,
+      if_not_exists: true
   end
 end

--- a/db/migrate/20260619065327_add_index_on_subscriptions_for_plan_id_and_status.rb
+++ b/db/migrate/20260619065327_add_index_on_subscriptions_for_plan_id_and_status.rb
@@ -7,6 +7,7 @@ class AddIndexOnSubscriptionsForPlanIdAndStatus < ActiveRecord::Migration[8.0]
     add_index :subscriptions,
       [:plan_id, :status],
       where: "status IN (0, 1)",
+      name: :index_pending_active_subscriptions_on_plan_id_and_status,
       algorithm: :concurrently,
       if_not_exists: true
   end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -405,7 +405,6 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_status;
 DROP INDEX IF EXISTS public.index_subscriptions_on_started_at_and_ending_at;
 DROP INDEX IF EXISTS public.index_subscriptions_on_started_at;
 DROP INDEX IF EXISTS public.index_subscriptions_on_previous_subscription_id_and_status;
-DROP INDEX IF EXISTS public.index_subscriptions_on_plan_id_and_status;
 DROP INDEX IF EXISTS public.index_subscriptions_on_plan_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_organization_id;
@@ -469,6 +468,7 @@ DROP INDEX IF EXISTS public.index_plans_on_bill_fixed_charges_monthly;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_organization_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_customer_id;
 DROP INDEX IF EXISTS public.index_pending_vies_checks_on_billing_entity_id;
+DROP INDEX IF EXISTS public.index_pending_active_subscriptions_on_plan_id_and_status;
 DROP INDEX IF EXISTS public.index_payments_on_provider_payment_id_and_payment_provider_id;
 DROP INDEX IF EXISTS public.index_payments_on_payment_type;
 DROP INDEX IF EXISTS public.index_payments_on_payment_provider_id;
@@ -9356,6 +9356,13 @@ CREATE UNIQUE INDEX index_payments_on_provider_payment_id_and_payment_provider_i
 
 
 --
+-- Name: index_pending_active_subscriptions_on_plan_id_and_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pending_active_subscriptions_on_plan_id_and_status ON public.subscriptions USING btree (plan_id, status) WHERE (status = ANY (ARRAY[0, 1]));
+
+
+--
 -- Name: index_pending_vies_checks_on_billing_entity_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9794,13 +9801,6 @@ CREATE INDEX index_subscriptions_on_payment_method_id ON public.subscriptions US
 --
 
 CREATE INDEX index_subscriptions_on_plan_id ON public.subscriptions USING btree (plan_id);
-
-
---
--- Name: index_subscriptions_on_plan_id_and_status; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_subscriptions_on_plan_id_and_status ON public.subscriptions USING btree (plan_id, status) WHERE (status = ANY (ARRAY[0, 1]));
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -405,6 +405,7 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_status;
 DROP INDEX IF EXISTS public.index_subscriptions_on_started_at_and_ending_at;
 DROP INDEX IF EXISTS public.index_subscriptions_on_started_at;
 DROP INDEX IF EXISTS public.index_subscriptions_on_previous_subscription_id_and_status;
+DROP INDEX IF EXISTS public.index_subscriptions_on_plan_id_and_status;
 DROP INDEX IF EXISTS public.index_subscriptions_on_plan_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_organization_id;
@@ -9796,6 +9797,13 @@ CREATE INDEX index_subscriptions_on_plan_id ON public.subscriptions USING btree 
 
 
 --
+-- Name: index_subscriptions_on_plan_id_and_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscriptions_on_plan_id_and_status ON public.subscriptions USING btree (plan_id, status);
+
+
+--
 -- Name: index_subscriptions_on_previous_subscription_id_and_status; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12785,6 +12793,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260619065327'),
 ('20260617145515'),
 ('20260616160703'),
 ('20260616155032'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9800,7 +9800,7 @@ CREATE INDEX index_subscriptions_on_plan_id ON public.subscriptions USING btree 
 -- Name: index_subscriptions_on_plan_id_and_status; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_subscriptions_on_plan_id_and_status ON public.subscriptions USING btree (plan_id, status);
+CREATE INDEX index_subscriptions_on_plan_id_and_status ON public.subscriptions USING btree (plan_id, status) WHERE (status = ANY (ARRAY[0, 1]));
 
 
 --


### PR DESCRIPTION
## Context

On the Features page, we show the number of subscriptions for each feature. Calculating these counts can be pretty slow and causes the page to time out.

The counting query ends up doing a sequential scan on the subscriptions table to filter by `plan_id` and `status`, since we currently only have separate indexes for those columns.

<details>
<summary>SQL</summary>

```sql
SELECT
	COUNT(*)
FROM
	"subscriptions"
	INNER JOIN "plans" "plan" ON "plan"."id" = "subscriptions"."plan_id"
WHERE
	"subscriptions"."status" IN (0, 1)
	AND (
		"subscriptions"."plan_id" IN (
			SELECT
				"plans"."id"
			FROM
				"plans"
				INNER JOIN "entitlement_entitlements" ON "plans"."id" = "entitlement_entitlements"."plan_id"
			WHERE
				"plans"."deleted_at" IS NULL
				AND "entitlement_entitlements"."deleted_at" IS NULL
				AND "entitlement_entitlements"."entitlement_feature_id" = 'feature-id'
		)
		OR "plan"."parent_id" IN (
			SELECT
				"plans"."id"
			FROM
				"plans"
				INNER JOIN "entitlement_entitlements" ON "plans"."id" = "entitlement_entitlements"."plan_id"
			WHERE
				"plans"."deleted_at" IS NULL
				AND "entitlement_entitlements"."deleted_at" IS NULL
				AND "entitlement_entitlements"."entitlement_feature_id" = 'feature-id'
		)
	)
```
</details>

<details>
<summary>Query Plan</summary>

```sql
Finalize Aggregate  (cost=174827.62..174827.63 rows=1 width=8) (actual time=1036.695..1040.433 rows=1 loops=1)
  ->  Gather  (cost=174827.40..174827.61 rows=2 width=8) (actual time=1036.358..1040.418 rows=3 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        ->  Partial Aggregate  (cost=173827.40..173827.41 rows=1 width=8) (actual time=1012.163..1012.171 rows=1 loops=3)
              ->  Hash Join  (cost=11.71..172104.51 rows=689155 width=0) (actual time=200.602..1009.477 rows=36174 loops=3)
                    Hash Cond: (subscriptions.plan_id = plan.id)
                    Join Filter: ((hashed SubPlan 1) OR (hashed SubPlan 2))
                    Rows Removed by Join Filter: 698924
                    ->  Parallel Seq Scan on subscriptions  (cost=0.00..169353.92 rows=918874 width=16) (actual time=19.809..896.346 rows=735098 loops=3)
                          Filter: (status = ANY ('{0,1}'::integer[]))
                          Rows Removed by Filter: 1
                    ->  Hash  (cost=2.34..2.34 rows=34 width=32) (actual time=0.039..0.040 rows=17 loops=3)
                          Buckets: 1024  Batches: 1  Memory Usage: 9kB
                          ->  Seq Scan on plans plan  (cost=0.00..2.34 rows=34 width=32) (actual time=0.021..0.028 rows=17 loops=3)
                    SubPlan 1
                      ->  Nested Loop  (cost=0.00..4.47 rows=2 width=16) (actual time=0.158..0.166 rows=1 loops=3)
                            Join Filter: (plans.id = entitlement_entitlements.plan_id)
                            Rows Removed by Join Filter: 32
                            ->  Seq Scan on plans  (cost=0.00..2.34 rows=34 width=16) (actual time=0.133..0.137 rows=17 loops=3)
                                  Filter: (deleted_at IS NULL)
                            ->  Materialize  (cost=0.00..1.12 rows=2 width=16) (actual time=0.001..0.001 rows=2 loops=51)
                                  ->  Seq Scan on entitlement_entitlements  (cost=0.00..1.11 rows=2 width=16) (actual time=0.016..0.016 rows=2 loops=3)
                                        Filter: ((deleted_at IS NULL) AND (entitlement_feature_id = 'feature-id'::uuid))
                                        Rows Removed by Filter: 8
                    SubPlan 2
                      ->  Nested Loop  (cost=0.00..4.47 rows=2 width=16) (actual time=0.100..0.112 rows=1 loops=3)
                            Join Filter: (plans_1.id = entitlement_entitlements_1.plan_id)
                            Rows Removed by Join Filter: 32
                            ->  Seq Scan on plans plans_1  (cost=0.00..2.34 rows=34 width=16) (actual time=0.075..0.082 rows=17 loops=3)
                                  Filter: (deleted_at IS NULL)
                            ->  Materialize  (cost=0.00..1.12 rows=2 width=16) (actual time=0.001..0.001 rows=2 loops=51)
                                  ->  Seq Scan on entitlement_entitlements entitlement_entitlements_1  (cost=0.00..1.11 rows=2 width=16) (actual time=0.009..0.010 rows=2 loops=3)
                                        Filter: ((deleted_at IS NULL) AND (entitlement_feature_id = 'feature-id'::uuid))
                                        Rows Removed by Filter: 8
Planning Time: 1.473 ms
JIT:
  Functions: 167
  Options: Inlining false, Optimization false, Expressions true, Deforming true
  Timing: Generation 10.169 ms, Inlining 0.000 ms, Optimization 4.989 ms, Emission 46.231 ms, Total 61.389 ms
Execution Time: 1045.843 ms
```
</details>

## Description

This PR adds a covering index on subscriptions for `plan_id` and `status`. With this index in place, postgres can use the index directly when calculating counts instead of performing a sequential scan.

<details>
<summary>Query Plan</summary>

```sql
Finalize Aggregate  (cost=35658.53..35658.54 rows=1 width=8) (actual time=161.743..163.477 rows=1 loops=1)
  ->  Gather  (cost=35658.32..35658.53 rows=2 width=8) (actual time=161.660..163.474 rows=3 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        ->  Partial Aggregate  (cost=34658.32..34658.33 rows=1 width=8) (actual time=136.295..136.298 rows=1 loops=3)
              ->  Hash Join  (cost=12.14..32935.43 rows=689155 width=0) (actual time=29.681..134.606 rows=36174 loops=3)
                    Hash Cond: (subscriptions.plan_id = plan.id)
                    Join Filter: ((hashed SubPlan 1) OR (hashed SubPlan 2))
                    Rows Removed by Join Filter: 698924
                    ->  Parallel Index Only Scan using index_subscriptions_on_plan_id_and_status on subscriptions  (cost=0.43..30184.84 rows=918874 width=16) (actual time=0.079..50.662 rows=735098 loops=3)
                          Filter: (status = ANY ('{0,1}'::integer[]))
                          Rows Removed by Filter: 1
                          Heap Fetches: 0
                    ->  Hash  (cost=2.34..2.34 rows=34 width=32) (actual time=0.028..0.029 rows=17 loops=3)
                          Buckets: 1024  Batches: 1  Memory Usage: 9kB
                          ->  Seq Scan on plans plan  (cost=0.00..2.34 rows=34 width=32) (actual time=0.011..0.015 rows=17 loops=3)
                    SubPlan 1
                      ->  Nested Loop  (cost=0.00..4.47 rows=2 width=16) (actual time=0.032..0.040 rows=1 loops=3)
                            Join Filter: (plans.id = entitlement_entitlements.plan_id)
                            Rows Removed by Join Filter: 32
                            ->  Seq Scan on plans  (cost=0.00..2.34 rows=34 width=16) (actual time=0.002..0.005 rows=17 loops=3)
                                  Filter: (deleted_at IS NULL)
                            ->  Materialize  (cost=0.00..1.12 rows=2 width=16) (actual time=0.002..0.002 rows=2 loops=51)
                                  ->  Seq Scan on entitlement_entitlements  (cost=0.00..1.11 rows=2 width=16) (actual time=0.023..0.024 rows=2 loops=3)
                                        Filter: ((deleted_at IS NULL) AND (entitlement_feature_id = 'feature-id'::uuid))
                                        Rows Removed by Filter: 8
                    SubPlan 2
                      ->  Nested Loop  (cost=0.00..4.47 rows=2 width=16) (actual time=0.009..0.017 rows=1 loops=3)
                            Join Filter: (plans_1.id = entitlement_entitlements_1.plan_id)
                            Rows Removed by Join Filter: 32
                            ->  Seq Scan on plans plans_1  (cost=0.00..2.34 rows=34 width=16) (actual time=0.002..0.005 rows=17 loops=3)
                                  Filter: (deleted_at IS NULL)
                            ->  Materialize  (cost=0.00..1.12 rows=2 width=16) (actual time=0.000..0.000 rows=2 loops=51)
                                  ->  Seq Scan on entitlement_entitlements entitlement_entitlements_1  (cost=0.00..1.11 rows=2 width=16) (actual time=0.002..0.003 rows=2 loops=3)
                                        Filter: ((deleted_at IS NULL) AND (entitlement_feature_id = 'feature-id'::uuid))"
                                        Rows Removed by Filter: 8
Planning Time: 2.541 ms
Execution Time: 163.822 ms
```
</details>

## Benchmarks

Here are some benchmarks without index (before) and with index (after).

Benchmarking was done with `pgbench` on a database containing **~2.5m** subscriptions. The benchmark used 10 clients and 5 threads, ran for 30 seconds against a warmed-up database. 

```
pgbench --protocol=prepared -c 10 -j 5 -T 30 -h localhost -U lago -d lago -n -f count.sql
```

Solution | TPS | Latency (ms)
-- | -- | --
without index (before) | 5.11 | 1956.213
with index (after) | 15.79 | 633.041