### PR TITLE
misc(events): Retrieve and aggregate only matching filters

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -10,6 +10,10 @@ enriched_events_aggregation:
   description: "Use the enriched events store for aggregation queries in ClickHouse"
   owners: ["@vincent-pochet"]
 
+event_property_combinations:
+  description: "Resolve exact charge filters from distinct event property combinations during billing period filtering"
+  owners: ["@vincent-pochet"]
+
 wallet_traceability:
   description: "Enable wallet traceability on newly created wallets"
   owners: ["@groyoh", "@D1353L"]

--- a/app/services/charge_filters/event_matching_service.rb
+++ b/app/services/charge_filters/event_matching_service.rb
@@ -18,8 +18,12 @@ module ChargeFilters
         end
       end
 
-      # NOTE: An event could match multiple filters,
-      #       but we must take only the one matching the most properties
+      # NOTE: An event could match multiple filters. Expose the full list so callers
+      #       that need every candidate (e.g. usage pre-filtering) can let the
+      #       aggregation cascade assign the event to the most specific one.
+      result.matching_charge_filters = matching_filters
+
+      # NOTE: When a single filter must be picked, take the one matching the most properties
       result.charge_filter = matching_filters.max_by { |filter| filter.to_h.keys.size }
       result
     end
@@ -30,7 +34,17 @@ module ChargeFilters
 
     # NOTE: Exclude event properties not matching a billable metric filter
     def applicable_event_properties
-      @applicable_event_properties ||= event.properties.slice(*charge.billable_metric.filters.pluck(:key))
+      @applicable_event_properties ||= event.properties.slice(*billable_metric_filter_keys)
+    end
+
+    # NOTE: when filters are already pre-loaded (e.g. usage pre-filtering), reuse the
+    #       loaded association to avoid a query. Otherwise pluck the keys directly.
+    def billable_metric_filter_keys
+      billable_metric = charge.billable_metric
+
+      return billable_metric.filters.map(&:key) if billable_metric.association_cached?(:filters)
+
+      billable_metric.filters.pluck(:key)
     end
 
     def filters

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -44,16 +44,61 @@ module Events
     end
 
     def charges_and_filters
-      return charges_and_filters_from_event_codes unless organization.pre_filter_events?
+      return charges_and_filters_from_events unless organization.pre_filter_events?
 
       charges_and_filters_from_pre_enriched_events
     end
 
-    # Return the list of all charges and filters that matches the event codes received in the period
+    # Return the list of all charges and filters that received usage in the period
     # It also includes the recurring charges and filters
     # The result will be a hash where the key is the charge id and the value is an array of filter ids
     # filter ids also include "nil" as a default filter
-    def charges_and_filters_from_event_codes
+    #
+    # For non-recurring charges, the exact filters are resolved by matching the distinct
+    # property combinations actually present in the events against the charge filters, so
+    # only the filters that received usage are returned.
+    def charges_and_filters_from_events
+      return all_charges_and_filters_from_event_codes unless organization.feature_flag_enabled?(:event_property_combinations)
+
+      combinations = event_store.distinct_codes_and_property_combinations(
+        codes: plan_codes,
+        filter_keys: billable_metric_filter_keys
+      )
+
+      # Stores that cannot extract property combinations (e.g. Clickhouse) fall back to
+      # including every filter of each charge that received events in the period.
+      return all_charges_and_filters_from_event_codes if combinations.nil?
+
+      combinations_by_code = combinations
+        .group_by(&:first)
+        .transform_values { |rows| rows.map(&:last) }
+
+      # Recurring charges must always be billed as usage carries over from previous periods
+      result = recurring_event_charges_and_filters
+
+      non_recurring_charges_with_events(combinations_by_code.keys).each do |charge|
+        code = charge.billable_metric.code
+
+        combinations_by_code[code].each do |properties|
+          event = ::Event.new(code:, properties:)
+          matching = ChargeFilters::EventMatchingService.call(charge:, event:).matching_charge_filters
+
+          # No filter matches: the usage falls into the default bucket.
+          # Otherwise include every matching filter and let the aggregation cascade
+          # assign the event to the most specific one (the others aggregate to zero).
+          if matching.empty?
+            result[charge.id] << nil
+          else
+            matching.each { |filter| result[charge.id] << filter.id }
+          end
+        end
+      end
+
+      result
+    end
+
+    # Return all charges and filters for codes that matches events plus all recurring charges.
+    def all_charges_and_filters_from_event_codes
       plan.charges.joins(:billable_metric).left_joins(:filters)
         .where(billable_metrics: {code: distinct_event_codes})
         .or(plan.charges.joins(:billable_metric).where(billable_metrics: {recurring: true}))
@@ -61,6 +106,33 @@ module Events
         .pluck("charges.id", "charge_filters.id")
         .then { group_by_charge_id(it) }
         .then { add_default_filter(it) }
+    end
+
+    # Recurring charges and all their filters (including the default bucket).
+    # They are always returned, even without events, as usage carries over.
+    def recurring_event_charges_and_filters
+      plan.charges.joins(:billable_metric).left_joins(:filters)
+        .where(billable_metrics: {recurring: true})
+        .group("charges.id, charge_filters.id")
+        .pluck("charges.id", "charge_filters.id")
+        .then { group_by_charge_id(it) }
+        .then { add_default_filter(it) }
+    end
+
+    # Non-recurring charges of the plan whose billable metric received events in the period
+    def non_recurring_charges_with_events(codes)
+      plan.charges
+        .joins(:billable_metric)
+        .where(billable_metrics: {code: codes, recurring: false})
+        .includes(billable_metric: :filters, filters: {values: :billable_metric_filter})
+    end
+
+    # Union of every filter key defined across the plan billable metrics
+    def billable_metric_filter_keys
+      @billable_metric_filter_keys ||= BillableMetricFilter
+        .where(billable_metric_id: plan.billable_metrics.select(:id))
+        .distinct
+        .pluck(:key)
     end
 
     # Return the list of charges and filters that matches the event pre enriched in clickhouse or Postgres for the period

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -67,6 +67,10 @@ module Events
         raise NotImplementedError
       end
 
+      def distinct_codes_and_property_combinations(codes:, filter_keys:)
+        nil
+      end
+
       def prorated_events_values(total_duration)
         raise NotImplementedError
       end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -44,6 +44,29 @@ module Events
         scope.distinct.pluck(:charge_id, :charge_filter_id)
       end
 
+      # Returns the distinct [code, properties] combinations present in the events of the
+      # period. Only properties present in the filter_keys are considered, so the result holds
+      # only the dimensions that can be matched against charge filters.
+      # An empty hash represents the default (no filter) bucket.
+      def distinct_codes_and_property_combinations(codes:, filter_keys:)
+        scope = Event.where(external_subscription_id: subscription.external_id)
+          .where(organization_id: subscription.organization_id)
+          .where(code: codes)
+          .from_datetime(from_datetime)
+          .to_datetime(applicable_to_datetime)
+
+        scope
+          .select(Arel.sql(<<~SQL.squish))
+            DISTINCT events.code AS code,
+            coalesce((
+              SELECT jsonb_object_agg(props.key, props.value)
+              FROM jsonb_each_text(events.properties) AS props(key, value)
+              WHERE props.key = ANY(#{filter_keys_array_sql(filter_keys)})
+            ), '{}'::jsonb) AS combination
+          SQL
+          .map { |row| [row.code, parse_combination(row)] }
+      end
+
       def events_values(limit: nil, force_from: false, exclude_event: false)
         field_name = sanitized_property_name
         field_name = "(#{field_name})::numeric" if numeric_property
@@ -512,6 +535,20 @@ module Events
 
       def created_at_ordering_column
         "events.created_at"
+      end
+
+      def filter_keys_array_sql(filter_keys)
+        return "ARRAY[]::text[]" if filter_keys.empty?
+
+        quoted = filter_keys.map { ActiveRecord::Base.connection.quote(it) }.join(", ")
+        "ARRAY[#{quoted}]::text[]"
+      end
+
+      def parse_combination(row)
+        combination = row.read_attribute(:combination)
+        return combination if combination.is_a?(Hash)
+
+        combination.present? ? JSON.parse(combination) : {}
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5862,6 +5862,7 @@ Organization Feature Flag Values
 """
 enum FeatureFlagEnum {
   enriched_events_aggregation
+  event_property_combinations
   multi_currency
   multi_entity_billing
   multiple_payment_methods

--- a/schema.json
+++ b/schema.json
@@ -28512,6 +28512,12 @@
               "deprecationReason": null
             },
             {
+              "name": "event_property_combinations",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "wallet_traceability",
               "description": null,
               "isDeprecated": false,

--- a/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
   end
 
   let(:billable_metric_filter) do
-    create(:billable_metric_filter, billable_metric: metric, key: "cloud", values: %w[aws gcp])
+    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
   end
 
   let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
   end
 
   let(:billable_metric_filter) do
-    create(:billable_metric_filter, billable_metric: metric, key: "cloud", values: %w[aws gcp])
+    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
   end
 
   let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }

--- a/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
   end
 
   let(:billable_metric_filter) do
-    create(:billable_metric_filter, billable_metric: metric, key: "cloud", values: %w[aws gcp])
+    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
   end
 
   let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Resolvers::Customers::UsageResolver do
   end
 
   let(:billable_metric_filter) do
-    create(:billable_metric_filter, billable_metric: metric, key: "cloud", values: %w[aws gcp])
+    create(:billable_metric_filter, billable_metric: sum_metric, key: "cloud", values: %w[aws gcp])
   end
 
   let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -397,6 +397,8 @@ RSpec.describe Events::BillingPeriodFilterService do
 
   describe "#call" do
     context "when relying on event codes" do
+      before { organization.enable_feature_flag!(:event_property_combinations) }
+
       it "returns the filtered charge_ids" do
         result = filter_service.call
 
@@ -482,11 +484,63 @@ RSpec.describe Events::BillingPeriodFilterService do
 
           before { charge_filter2 }
 
-          it "returns charges and filters for all billable metrics with matching events" do
+          it "returns the filters that the events can match" do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id, charge_filter2.id, nil)})
+            expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id, charge_filter2.id)})
+          end
+        end
+
+        context "when events only match a subset of the charge filters" do
+          let(:charge_filter) { create(:charge_filter, charge:) }
+          let(:billable_metric_filter) do
+            create(:billable_metric_filter, billable_metric:, key: "region", values: %w[eu us])
+          end
+          let(:charge_filter_value) do
+            create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["eu"])
+          end
+
+          let(:charge_filter_us) { create(:charge_filter, charge:) }
+          let(:charge_filter_us_value) do
+            create(:charge_filter_value, charge_filter: charge_filter_us, billable_metric_filter:, values: ["us"])
+          end
+
+          before { charge_filter_us_value }
+
+          it "returns only the filters that received matching events" do
+            result = filter_service.call
+
+            expect(result).to be_success
+            expect(result.charges).to eq({charge.id => [charge_filter.id]})
+          end
+        end
+
+        context "when an event matches no charge filter" do
+          let(:charge_filter) { create(:charge_filter, charge:) }
+          let(:billable_metric_filter) do
+            create(:billable_metric_filter, billable_metric:, key: "region", values: %w[eu us])
+          end
+          let(:charge_filter_value) do
+            create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["eu"])
+          end
+
+          before do
+            create(
+              :event,
+              organization_id: organization.id,
+              external_subscription_id: subscription.external_id,
+              timestamp: boundaries.charges_from_datetime + 6.days,
+              code: billable_metric.code,
+              properties: {"region" => "us"}
+            )
+          end
+
+          it "returns the default filter for the unmatched usage" do
+            result = filter_service.call
+
+            expect(result).to be_success
+            expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id, nil)})
           end
         end
       end
@@ -554,12 +608,51 @@ RSpec.describe Events::BillingPeriodFilterService do
       end
 
       it "scopes the event store query to the plan billable metric codes" do
-        event_store = instance_double(Events::Stores::PostgresStore, distinct_codes: [])
+        event_store = instance_double(Events::Stores::PostgresStore, distinct_codes_and_property_combinations: [])
         allow(Events::Stores::StoreFactory).to receive(:new_instance).and_return(event_store)
 
         filter_service.call
 
-        expect(event_store).to have_received(:distinct_codes).with(codes: [billable_metric.code])
+        expect(event_store).to have_received(:distinct_codes_and_property_combinations)
+          .with(codes: [billable_metric.code], filter_keys: [])
+      end
+
+      context "when the event_property_combinations feature flag is disabled" do
+        let(:charge_filter) { create(:charge_filter, charge:) }
+        let(:billable_metric_filter) do
+          create(:billable_metric_filter, billable_metric:, key: "region", values: %w[eu us])
+        end
+        let(:charge_filter_value) do
+          create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["eu"])
+        end
+
+        let(:charge_filter_us) { create(:charge_filter, charge:) }
+        let(:charge_filter_us_value) do
+          create(:charge_filter_value, charge_filter: charge_filter_us, billable_metric_filter:, values: ["us"])
+        end
+
+        before do
+          organization.disable_feature_flag!(:event_property_combinations)
+
+          charge_filter_value
+          charge_filter_us_value
+
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            timestamp: boundaries.charges_from_datetime + 5.days,
+            code: billable_metric.code,
+            properties: {"region" => "eu"}
+          )
+        end
+
+        it "falls back to every filter of the charges that received events" do
+          result = filter_service.call
+
+          expect(result).to be_success
+          expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id, charge_filter_us.id, nil)})
+        end
       end
     end
 

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -47,4 +47,93 @@ RSpec.describe Events::Stores::PostgresStore do
       Time.zone.parse(timestamp)
     end
   end
+
+  describe "#distinct_codes_and_property_combinations" do
+    subject(:event_store) { described_class.new(subscription:, boundaries:) }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:, external_id: "sub_id") }
+
+    let(:boundaries) do
+      {
+        from_datetime: Time.zone.parse("2024-01-01 00:00:00"),
+        to_datetime: Time.zone.parse("2024-01-31 23:59:59")
+      }
+    end
+
+    let(:create_event) do
+      lambda do |properties:, timestamp: Time.zone.parse("2024-01-10 00:00:00"), code: "api_calls"|
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code:,
+          timestamp:,
+          properties:
+        )
+      end
+    end
+
+    before do
+      create_event.call(properties: {"region" => "eu", "provider" => "aws"})
+      create_event.call(properties: {"region" => "eu", "provider" => "aws"})
+      create_event.call(properties: {"region" => "us", "provider" => "gcp"})
+      create_event.call(properties: {"region" => "eu", "extra" => "ignored"})
+    end
+
+    it "returns the distinct property combinations sliced to the filter keys" do
+      result = event_store.distinct_codes_and_property_combinations(
+        codes: ["api_calls"],
+        filter_keys: %w[region provider]
+      )
+
+      expect(result).to match_array([
+        ["api_calls", {"region" => "eu", "provider" => "aws"}],
+        ["api_calls", {"region" => "us", "provider" => "gcp"}],
+        ["api_calls", {"region" => "eu"}]
+      ])
+    end
+
+    it "ignores property keys that are not filter keys" do
+      result = event_store.distinct_codes_and_property_combinations(
+        codes: ["api_calls"],
+        filter_keys: ["region"]
+      )
+
+      expect(result).to match_array([
+        ["api_calls", {"region" => "eu"}],
+        ["api_calls", {"region" => "us"}]
+      ])
+    end
+
+    context "when no filter keys are given" do
+      it "returns the default bucket combination" do
+        result = event_store.distinct_codes_and_property_combinations(
+          codes: ["api_calls"],
+          filter_keys: []
+        )
+
+        expect(result).to eq([["api_calls", {}]])
+      end
+    end
+
+    context "with events outside the boundaries" do
+      before do
+        create_event.call(
+          properties: {"region" => "apac", "provider" => "azure"},
+          timestamp: Time.zone.parse("2024-02-05 00:00:00")
+        )
+      end
+
+      it "excludes them from the combinations" do
+        result = event_store.distinct_codes_and_property_combinations(
+          codes: ["api_calls"],
+          filter_keys: %w[region provider]
+        )
+
+        expect(result).not_to include(["api_calls", {"region" => "apac", "provider" => "azure"}])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Postgres usage pre-filtering included all of a charge's filters when its metric saw events, even filters that never matched a real event, leading to a lot of aggregation queries for filters with no usage at all. This is causing major performance issues for plans and subscriptions relying on a lot of charge filters.

## Description

- Add `PostgresStore#distinct_codes_and_property_combinations` to extract the distinct `[code, properties]` combinations seen in the period (the base store returns `nil`, so Clickhouse keeps the old "all filters" fallback).
- `BillingPeriodFilterService` now matches those combinations against charge filters and keeps only the matching ones. The unmatched combinations go to the default bucket. Recurring charges are still always included.
- `ChargeFilters::EventMatchingService` exposes the full `matching_charge_filters` list so the aggregation cascade assigns each event to its most specific filter.
