### PR TITLE
fix(Clickhouse): Handle memory issues for pay in advance events

### DIFF
--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -4,7 +4,21 @@ module Fees
   class CreatePayInAdvanceJob < ApplicationJob
     queue_as :default
 
+    # Random jitter (in seconds) added to every retry so parallel failed jobs
+    # don't retry in lockstep and overload Clickhouse again at the same instant.
+    RETRY_JITTER = 1..15
+
     retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
+
+    # Increasing backoff (a few seconds, then longer and longer) plus jitter, to give
+    # Clickhouse time to recover from too many high-usage parallel calls.
+    retry_on Events::Stores::Clickhouse::MemoryLimitError,
+      wait: ->(executions) { Fees::CreatePayInAdvanceJob.retry_wait(executions) },
+      attempts: 25
+
+    def self.retry_wait(executions)
+      (executions**4) + rand(RETRY_JITTER)
+    end
 
     unique :until_executed, on_conflict: :log
 

--- a/app/services/events/stores/clickhouse/memory_limit_error.rb
+++ b/app/services/events/stores/clickhouse/memory_limit_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      class MemoryLimitError < StandardError; end
+    end
+  end
+end

--- a/app/services/events/stores/utils/clickhouse_connection.rb
+++ b/app/services/events/stores/utils/clickhouse_connection.rb
@@ -5,6 +5,7 @@ module Events
     module Utils
       class ClickhouseConnection
         MAX_RETRIES = 3
+        MEMORY_ERROR_CODE = "MEMORY_LIMIT_EXCEEDED"
 
         def self.with_retry(&)
           attempts = 0
@@ -13,7 +14,9 @@ module Events
             attempts += 1
 
             yield
-          rescue Errno::ECONNRESET, ActiveRecord::ActiveRecordError, NoMethodError
+          rescue Errno::ECONNRESET, ActiveRecord::ActiveRecordError, NoMethodError => e
+            raise Events::Stores::Clickhouse::MemoryLimitError, e.message if memory_limit_error?(e)
+
             if attempts < MAX_RETRIES
               sleep(0.05)
               retry
@@ -29,13 +32,21 @@ module Events
           begin
             attempts += 1
             ::Clickhouse::BaseRecord.with_connection(&)
-          rescue Errno::ECONNRESET, ActiveRecord::ActiveRecordError, NoMethodError
+          rescue Errno::ECONNRESET, ActiveRecord::ActiveRecordError, NoMethodError => e
+            raise Events::Stores::Clickhouse::MemoryLimitError, e.message if memory_limit_error?(e)
+
             if attempts < MAX_RETRIES
               sleep(0.05)
               retry
             end
             raise
           end
+        end
+
+        def self.memory_limit_error?(error)
+          return false unless error.is_a?(ActiveRecord::ActiveRecordError)
+
+          error.message.include?(MEMORY_ERROR_CODE)
         end
       end
     end

--- a/spec/jobs/fees/create_pay_in_advance_job_spec.rb
+++ b/spec/jobs/fees/create_pay_in_advance_job_spec.rb
@@ -17,4 +17,35 @@ RSpec.describe Fees::CreatePayInAdvanceJob do
 
     expect(Fees::CreatePayInAdvanceService).to have_received(:call)
   end
+
+  describe ".retry_wait" do
+    it "grows polynomially and adds the jitter on each retry" do
+      allow(described_class).to receive(:rand).and_return(7)
+
+      expect(described_class.retry_wait(1)).to eq(8)  # 1**4 + 7
+      expect(described_class.retry_wait(2)).to eq(23) # 2**4 + 7
+      expect(described_class.retry_wait(3)).to eq(88) # 3**4 + 7
+    end
+
+    it "keeps the jitter within RETRY_JITTER" do
+      jitters = Array.new(50) { described_class.retry_wait(1) - (1**4) }
+
+      expect(jitters).to all(be_between(described_class::RETRY_JITTER.min, described_class::RETRY_JITTER.max))
+    end
+  end
+
+  describe "retry_on" do
+    before do
+      allow(Fees::CreatePayInAdvanceService).to receive(:call)
+        .and_raise(Events::Stores::Clickhouse::MemoryLimitError)
+    end
+
+    it "retries on a Clickhouse memory limit error" do
+      assert_performed_jobs(25, only: [described_class]) do
+        expect do
+          described_class.perform_later(charge:, event:)
+        end.to raise_error(Events::Stores::Clickhouse::MemoryLimitError)
+      end
+    end
+  end
 end

--- a/spec/services/events/stores/utils/clickhouse_connection_spec.rb
+++ b/spec/services/events/stores/utils/clickhouse_connection_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::Utils::ClickhouseConnection do
+  let(:memory_error_message) do
+    "Code: 241. DB::Exception: (total) memory limit exceeded: would use 1.00 GiB (MEMORY_LIMIT_EXCEEDED)"
+  end
+
+  before { allow(described_class).to receive(:sleep) }
+
+  describe ".with_retry" do
+    it "returns the block result on success" do
+      expect(described_class.with_retry { "value" }).to eq("value")
+    end
+
+    it "retries up to MAX_RETRIES on a transient error then raises it" do
+      attempts = 0
+
+      expect do
+        described_class.with_retry do
+          attempts += 1
+          raise ActiveRecord::ActiveRecordError, "boom"
+        end
+      end.to raise_error(ActiveRecord::ActiveRecordError, "boom")
+
+      expect(attempts).to eq(described_class::MAX_RETRIES)
+      expect(described_class).to have_received(:sleep).with(0.05).twice
+    end
+
+    it "re-raises a memory limit error as MemoryLimitError without retrying" do
+      attempts = 0
+
+      expect do
+        described_class.with_retry do
+          attempts += 1
+          raise ActiveRecord::ActiveRecordError, memory_error_message
+        end
+      end.to raise_error(Events::Stores::Clickhouse::MemoryLimitError, memory_error_message)
+
+      expect(attempts).to eq(1)
+      expect(described_class).not_to have_received(:sleep)
+    end
+  end
+
+  describe ".connection_with_retry" do
+    let(:connection) { Object.new }
+
+    before do
+      allow(::Clickhouse::BaseRecord).to receive(:with_connection).and_yield(connection)
+    end
+
+    it "yields the connection and returns the block result on success" do
+      expect(described_class.connection_with_retry { |conn| conn }).to eq(connection)
+    end
+
+    it "retries up to MAX_RETRIES on a transient error then raises it" do
+      attempts = 0
+
+      expect do
+        described_class.connection_with_retry do |_conn|
+          attempts += 1
+          raise ActiveRecord::ActiveRecordError, "boom"
+        end
+      end.to raise_error(ActiveRecord::ActiveRecordError, "boom")
+
+      expect(attempts).to eq(described_class::MAX_RETRIES)
+      expect(described_class).to have_received(:sleep).with(0.05).twice
+    end
+
+    it "re-raises a memory limit error as MemoryLimitError without retrying" do
+      attempts = 0
+
+      expect do
+        described_class.connection_with_retry do |_conn|
+          attempts += 1
+          raise ActiveRecord::ActiveRecordError, memory_error_message
+        end
+      end.to raise_error(Events::Stores::Clickhouse::MemoryLimitError, memory_error_message)
+
+      expect(attempts).to eq(1)
+      expect(described_class).not_to have_received(:sleep)
+    end
+  end
+
+  describe ".memory_limit_error?" do
+    it "is true for an ActiveRecord error mentioning the memory limit code" do
+      error = ActiveRecord::ActiveRecordError.new(memory_error_message)
+
+      expect(described_class.memory_limit_error?(error)).to be(true)
+    end
+
+    it "is false for an ActiveRecord error with an unrelated message" do
+      error = ActiveRecord::ActiveRecordError.new("Code: 159. DB::Exception: Timeout exceeded")
+
+      expect(described_class.memory_limit_error?(error)).to be(false)
+    end
+
+    it "is false for a non-ActiveRecord error mentioning the memory limit code" do
+      error = StandardError.new(memory_error_message)
+
+      expect(described_class.memory_limit_error?(error)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Sometimes, a lot of `Events::PayInAdvanceJob` are failing in sequence with error similar to 

```
ActiveRecord::ActiveRecordError
Response code: 500: (ActiveRecord::ActiveRecordError)
Code: 241. DB::Exception: (total) memory limit exceeded: would use XXX GiB (attempt to allocate chunk of 0.00 B), current RSS: XXX GiB, maximum: XXX GiB. (MEMORY_LIMIT_EXCEEDED)
```

This kind of error happen when Clickhouse is receiving too many parallel intensive queries and is unable to scale up quickly.

Today the failing jobs end-up in the Sidekiq dead queue and have to be reprocessed manually.

## Description

This PR catches the errors, and add a retry logic on the `Events::PayInAdvanceJob`.

The retry uses a custom wait lambda that keeps the increasing backoff (`executions**4`) but adds an absolute random jitter (`RETRY_JITTER = 1..15 seconds`). The main goal is to give Clickhouse the time to recover and to avoid retrying all parallel failed attempt in a too close delayl

