### PR TITLE
feat(purchase_order_number): Add purchase_order_number for one-off invoices

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -14,7 +14,8 @@ module Api
           skip_psp: create_params[:skip_psp],
           invoice_custom_section: create_params[:invoice_custom_section] || {},
           payment_method_params: create_params[:payment_method],
-          billing_entity_code: create_params[:billing_entity_code]
+          billing_entity_code: create_params[:billing_entity_code],
+          purchase_order_number: create_params[:purchase_order_number]
         )
 
         if result.success?
@@ -277,6 +278,7 @@ module Api
               :currency,
               :skip_psp,
               :billing_entity_code,
+              :purchase_order_number,
               fees: [
                 :add_on_code,
                 :invoice_display_name,

--- a/app/graphql/mutations/invoices/create.rb
+++ b/app/graphql/mutations/invoices/create.rb
@@ -26,7 +26,8 @@ module Mutations
           voided_invoice_id: args[:voided_invoice_id],
           payment_method_params: args[:payment_method]&.to_h,
           invoice_custom_section: args[:invoice_custom_section],
-          billing_entity_id: args[:billing_entity_id]
+          billing_entity_id: args[:billing_entity_id],
+          purchase_order_number: args[:purchase_order_number]
         )
 
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/types/invoices/create_invoice_input.rb
+++ b/app/graphql/types/invoices/create_invoice_input.rb
@@ -11,6 +11,7 @@ module Types
       argument :fees, [Types::Invoices::FeeInput], required: true
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
+      argument :purchase_order_number, String, required: false
       argument :voided_invoice_id, ID, required: false
     end
   end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -20,6 +20,7 @@ module Types
       field :payment_dispute_losable, Boolean, null: false, method: :payment_dispute_losable?
       field :payment_dispute_lost_at, GraphQL::Types::ISO8601DateTime
       field :payment_status, Types::Invoices::PaymentStatusTypeEnum, null: false
+      field :purchase_order_number, String, null: true
       field :status, Types::Invoices::StatusTypeEnum, null: false
       field :tax_status, Types::Invoices::TaxStatusTypeEnum, null: true
       field :voidable, Boolean, null: false, method: :voidable?

--- a/app/models/concerns/has_purchase_order_number.rb
+++ b/app/models/concerns/has_purchase_order_number.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module HasPurchaseOrderNumber
+  extend ActiveSupport::Concern
+
+  PURCHASE_ORDER_NUMBER_MAX_LENGTH = 255
+
+  included do
+    validates :purchase_order_number,
+      length: {maximum: PURCHASE_ORDER_NUMBER_MAX_LENGTH}, allow_nil: true
+
+    normalizes :purchase_order_number, with: ->(value) { value.strip.presence }
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -154,6 +154,7 @@ class Invoice < ApplicationRecord
   validates :timezone, timezone: true, allow_nil: true
   validates :total_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :payment_dispute_lost_at, absence: true, unless: :payment_dispute_losable?
+  validates :purchase_order_number, length: {maximum: 255}, allow_nil: true
 
   attr_writer :precalculated_offset_amount_cents
 
@@ -705,6 +706,7 @@ end
 #  prepaid_granted_credit_amount_cents     :bigint
 #  prepaid_purchased_credit_amount_cents   :bigint
 #  progressive_billing_credit_amount_cents :bigint           default(0), not null
+#  purchase_order_number                   :string
 #  ready_for_payment_processing            :boolean          default(TRUE), not null
 #  ready_to_be_refreshed                   :boolean          default(FALSE), not null
 #  self_billed                             :boolean          default(FALSE), not null

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,6 +7,7 @@ class Invoice < ApplicationRecord
   include PaperTrailTraceable
   include Sequenced
   include RansackUuidSearch
+  include HasPurchaseOrderNumber
 
   CREDIT_NOTES_MIN_VERSION = 2
   COUPON_BEFORE_VAT_VERSION = 3
@@ -154,7 +155,6 @@ class Invoice < ApplicationRecord
   validates :timezone, timezone: true, allow_nil: true
   validates :total_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :payment_dispute_lost_at, absence: true, unless: :payment_dispute_losable?
-  validates :purchase_order_number, length: {maximum: 255}, allow_nil: true
 
   attr_writer :precalculated_offset_amount_cents
 

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -8,6 +8,7 @@ module V1
         billing_entity_code: model.billing_entity.code,
         sequential_id: model.sequential_id,
         number: model.number,
+        purchase_order_number: model.purchase_order_number,
         issuing_date: model.issuing_date&.iso8601,
         payment_due_date: model.payment_due_date&.iso8601,
         net_payment_term: model.net_payment_term,

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -28,6 +28,7 @@ module DataExports
           customer_country
           customer_tax_identification_number
           invoice_number
+          purchase_order_number
           invoice_type
           payment_status
           status
@@ -76,6 +77,7 @@ module DataExports
           serialized_invoice.dig(:customer, :country),
           serialized_invoice.dig(:customer, :tax_identification_number),
           serialized_invoice[:number],
+          serialized_invoice[:purchase_order_number],
           serialized_invoice[:invoice_type],
           serialized_invoice[:payment_status],
           serialized_invoice[:status],

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -2,7 +2,7 @@
 
 module Invoices
   class CreateOneOffService < BaseService
-    def initialize(customer:, currency:, fees:, timestamp:, skip_psp: false, voided_invoice_id: nil, payment_method_params: nil, invoice_custom_section: {}, billing_entity_id: nil, billing_entity_code: nil)
+    def initialize(customer:, currency:, fees:, timestamp:, skip_psp: false, voided_invoice_id: nil, payment_method_params: nil, invoice_custom_section: {}, billing_entity_id: nil, billing_entity_code: nil, purchase_order_number: nil)
       @customer = customer
       @currency = currency || customer&.currency
       @fees = fees
@@ -13,6 +13,7 @@ module Invoices
       @invoice_custom_section = invoice_custom_section
       @billing_entity_id = billing_entity_id
       @billing_entity_code = billing_entity_code
+      @purchase_order_number = purchase_order_number
 
       super(nil)
     end
@@ -95,7 +96,7 @@ module Invoices
     private
 
     attr_accessor :timestamp, :currency, :customer, :fees, :invoice, :skip_psp, :voided_invoice_id, :payment_method_params, :invoice_custom_section
-    attr_reader :billing_entity_id, :billing_entity_code, :billing_entity
+    attr_reader :billing_entity_id, :billing_entity_code, :billing_entity, :purchase_order_number
 
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
@@ -108,6 +109,9 @@ module Invoices
       invoice_result.raise_if_error!
 
       @invoice = invoice_result.invoice
+      # NOTE: Persisted immediately so the value survives the tax-deferred path,
+      #       which skips the later `invoice.save!`.
+      @invoice.update!(purchase_order_number:) unless purchase_order_number.nil?
     end
 
     def resolve_billing_entity

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -218,6 +218,8 @@ html
       }
       .invoice-information-table tr td:first-child {
         padding: 0 16px 0 0;
+        white-space: nowrap;
+        width: 1%;
       }
       .invoice-information-table tr td:last-child {
         width: 55%;
@@ -229,7 +231,6 @@ html
       }
       .invoice-information-table {
         border-collapse: collapse;
-        table-layout: fixed;
         width: 100%;
       }
 
@@ -368,6 +369,10 @@ html
             tr
               td.body-1 = I18n.t('invoice.invoice_number')
               td.body-2 = number
+            - if purchase_order_number.present?
+              tr
+                td.body-1 = I18n.t('invoice.purchase_order_number')
+                td.body-2 = purchase_order_number
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -80,6 +80,7 @@ de:
     prepaid_credits: Prepaid-Guthaben
     prepaid_credits_with_value: Prepaid-Guthaben - %{wallet_name}
     progressive_billing_credit: Nutzung bereits abgerechnet
+    purchase_order_number: Bestellnummer
     quarter: quartal
     quarterly: Vierteljährlich
     reached_usage_threshold: Diese progressive Rechnung wird erstellt, da Ihre kumulierte Nutzung %{usage_amount} erreicht hat und den Schwellenwert von %{threshold_amount} überschritten hat.

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -81,6 +81,7 @@ en:
     prepaid_credits: Prepaid credits
     prepaid_credits_with_value: Prepaid credits - %{wallet_name}
     progressive_billing_credit: Usage already billed
+    purchase_order_number: Purchase Order Number
     quarter: quarter
     quarterly: Quarterly
     reached_usage_threshold: This progressive billing is generated because your cumulative usage has reached %{usage_amount}, exceeding the %{threshold_amount} threshold.

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -79,6 +79,7 @@ es:
     prepaid_credits: Créditos prepagados
     prepaid_credits_with_value: Créditos prepagados - %{wallet_name}
     progressive_billing_credit: Uso ya facturado
+    purchase_order_number: Número de orden de compra
     quarter: trimestre
     quarterly: Trimestral
     reached_usage_threshold: Esta facturación progresiva se genera porque su uso acumulado ha alcanzado los %{usage_amount}, superando el umbral de %{threshold_amount}.

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -80,6 +80,7 @@ fr:
     prepaid_credits: Crédit(s) prépayé(s)
     prepaid_credits_with_value: Crédit(s) prépayé(s) - %{wallet_name}
     progressive_billing_credit: Usage déjà facturé
+    purchase_order_number: Numéro de bon de commande
     quarter: trimestre
     quarterly: trimestriellement
     reached_usage_threshold: Cette facturation progressive est générée car votre usage cumulé a atteint %{usage_amount}, dépassant le seuil de %{threshold_amount}.

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -80,6 +80,7 @@ it:
     prepaid_credits: Crediti prepagati
     prepaid_credits_with_value: Crediti prepagati - %{wallet_name}
     progressive_billing_credit: Uso già fatturato
+    purchase_order_number: Numero d'ordine d'acquisto
     quarter: trimestre
     quarterly: Trimestrale
     reached_usage_threshold: Questa fatturazione progressiva è generata poiché il tuo utilizzo cumulato ha raggiunto %{usage_amount}, superando la soglia di %{threshold_amount}.

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -80,6 +80,7 @@ nb:
     prepaid_credits: Forskuddsbetalte kreditter
     prepaid_credits_with_value: Forhåndsbetalte kreditter - %{wallet_name}
     progressive_billing_credit: Bruk allerede fakturert
+    purchase_order_number: Bestillingsnummer
     quarter: kvartal
     quarterly: Kvartalsvis
     reached_usage_threshold: Denne progressive faktureringen er generert fordi din akkumulerte bruk har nådd %{usage_amount}, og overskredet terskelen på %{threshold_amount}.

--- a/config/locales/pt-BR/invoice.yml
+++ b/config/locales/pt-BR/invoice.yml
@@ -80,6 +80,7 @@ pt-BR:
     prepaid_credits: Créditos pré-pagos
     prepaid_credits_with_value: Créditos pré-pagos - %{wallet_name}
     progressive_billing_credit: Uso já faturado
+    purchase_order_number: Número do pedido de compra
     quarter: trimestre
     quarterly: Trimestral
     reached_usage_threshold: Esta cobrança progressiva é gerada porque seu uso cumulativo atingiu %{usage_amount}, excedendo o limite de %{threshold_amount}.

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -79,6 +79,7 @@ sv:
     prepaid_credits: Förbetald kontobalans
     prepaid_credits_with_value: Förbetald kontobalans - %{wallet_name}
     progressive_billing_credit: Redan fakturerad användning
+    purchase_order_number: Inköpsordernummer
     quarter: kvartal
     quarterly: Kvartalsvis
     reached_usage_threshold: Denna progressiva fakturering skapas eftersom din ackumulerade användning har nått %{usage_amount} och överstiger %{threshold_amount} tröskeln.

--- a/config/locales/zh-TW/invoice.yml
+++ b/config/locales/zh-TW/invoice.yml
@@ -80,6 +80,7 @@ zh-TW:
     prepaid_credits: 預付點數
     prepaid_credits_with_value: 預付點數 - %{wallet_name}
     progressive_billing_credit: 已計費的使用量
+    purchase_order_number: 採購訂單編號
     quarter: 季
     quarterly: 每季
     reached_usage_threshold: 此累進計費因您的累積使用量已達到 %{usage_amount}，超過 %{threshold_amount} 的門檻而產生。

--- a/db/migrate/20260622113747_add_purchase_order_number_to_invoices.rb
+++ b/db/migrate/20260622113747_add_purchase_order_number_to_invoices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPurchaseOrderNumberToInvoices < ActiveRecord::Migration[8.0]
+  def change
+    add_column :invoices, :purchase_order_number, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3717,6 +3717,7 @@ CREATE TABLE public.invoices (
     prepaid_purchased_credit_amount_cents bigint,
     payment_method_id uuid,
     skip_automatic_payment boolean,
+    purchase_order_number character varying,
     CONSTRAINT check_organizations_on_net_payment_term CHECK ((net_payment_term >= 0))
 );
 
@@ -12795,6 +12796,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260625095837'),
+('20260622113747'),
 ('20260619065327'),
 ('20260617145515'),
 ('20260617072554'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -3152,6 +3152,7 @@ input CreateInvoiceInput {
   fees: [FeeInput!]!
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
   paymentMethod: PaymentMethodReferenceInput
+  purchaseOrderNumber: String
   voidedInvoiceId: ID
 }
 
@@ -6043,6 +6044,7 @@ input FetchDraftInvoiceTaxesInput {
   fees: [FeeInput!]!
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
   paymentMethod: PaymentMethodReferenceInput
+  purchaseOrderNumber: String
   voidedInvoiceId: ID
 }
 
@@ -6631,6 +6633,7 @@ type Invoice {
   prepaidGrantedCreditAmountCents: BigInt
   prepaidPurchasedCreditAmountCents: BigInt
   progressiveBillingCreditAmountCents: BigInt!
+  purchaseOrderNumber: String
   readyForPaymentProcessing: Boolean!
   refundableAmountCents: BigInt!
   regeneratedInvoiceId: String

--- a/schema.json
+++ b/schema.json
@@ -14061,6 +14061,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "voidedInvoiceId",
               "description": null,
               "type": {
@@ -30301,6 +30313,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "voidedInvoiceId",
               "description": null,
               "type": {
@@ -34652,6 +34676,18 @@
                   "name": "BigInt",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Mutations::Invoices::Create do
           taxesRate,
           invoiceType,
           issuingDate,
+          purchaseOrderNumber,
           appliedTaxes { id taxCode taxRate },
           fees {
             units
@@ -112,6 +113,25 @@ RSpec.describe Mutations::Invoices::Create do
       }
     )
     expect(Invoice.one_off.order(created_at: :desc).first.applied_invoice_custom_sections.pluck(:code)).to eq([section_1.code])
+  end
+
+  it "creates a one-off invoice with a purchase order number" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {
+        input: {
+          customerId: customer.id,
+          currency:,
+          fees:,
+          purchaseOrderNumber: "PO-123"
+        }
+      }
+    )
+
+    expect(result["data"]["createInvoice"]["purchaseOrderNumber"]).to eq("PO-123")
   end
 
   context "when multi_entity_billing feature flag is enabled" do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -87,6 +87,12 @@ RSpec.describe Invoice do
         end
       end
     end
+
+    describe "of purchase order number length" do
+      subject { build(:invoice) }
+
+      it { is_expected.to validate_length_of(:purchase_order_number).is_at_most(255) }
+    end
   end
 
   describe "finalized_at" do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -87,12 +87,10 @@ RSpec.describe Invoice do
         end
       end
     end
+  end
 
-    describe "of purchase order number length" do
-      subject { build(:invoice) }
-
-      it { is_expected.to validate_length_of(:purchase_order_number).is_at_most(255) }
-    end
+  it_behaves_like "a model with a purchase order number" do
+    subject { build(:invoice) }
   end
 
   describe "finalized_at" do

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -118,6 +118,30 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
+    context "with a purchase_order_number" do
+      let(:create_params) do
+        {
+          external_customer_id: customer_external_id,
+          currency: "EUR",
+          purchase_order_number: "  PO-12345  ",
+          fees: [
+            {
+              add_on_code: add_on_first.code,
+              unit_amount_cents: 1200,
+              units: 2
+            }
+          ]
+        }
+      end
+
+      it "creates an invoice with the normalized purchase order number" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoice][:purchase_order_number]).to eq("PO-12345")
+      end
+    end
+
     context "when multi_entity_billing feature flag is enabled" do
       let(:other_billing_entity) { create(:billing_entity, organization:) }
 

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       "billing_entity_code" => invoice.billing_entity.code,
       "sequential_id" => invoice.sequential_id,
       "number" => invoice.number,
+      "purchase_order_number" => invoice.purchase_order_number,
       "issuing_date" => invoice.issuing_date.iso8601,
       "payment_due_date" => invoice.payment_due_date.iso8601,
       "net_payment_term" => invoice.net_payment_term,

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
         tax_identification_number: "123456789"
       },
       number: "INV123",
+      purchase_order_number: "PO-12345",
       invoice_type: "credit",
       payment_status: "pending",
       status: "finalized",
@@ -96,7 +97,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
 
     it "generates the correct CSV output" do
       expected_csv = <<~CSV
-        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999
+        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999
       CSV
 
       expect(result).to be_success
@@ -115,7 +116,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
 
       it "adds billing_entity_code to the csv" do
         expected_csv = <<~CSV
-          invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999,the-test-bil-ent
+          invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999,the-test-bil-ent
         CSV
 
         expect(result).to be_success

--- a/spec/services/data_exports/process_part_service_spec.rb
+++ b/spec/services/data_exports/process_part_service_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe DataExports::ProcessPartService do
         tax_identification_number: "123456789"
       },
       number: "INV123",
+      purchase_order_number: "PO-12345",
       invoice_type: "credit",
       payment_status: "pending",
       status: "finalized",
@@ -56,7 +57,7 @@ RSpec.describe DataExports::ProcessPartService do
   describe "#call" do
     it "processes the part" do
       expected_csv = <<~CSV
-        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334
+        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334
       CSV
       expect(result).to be_success
       expect(result.data_export_part.csv_lines).to eq(expected_csv)

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -73,6 +73,17 @@ RSpec.describe Invoices::CreateOneOffService do
       end
     end
 
+    context "when purchase_order_number is passed" do
+      let(:args) { {customer:, timestamp: timestamp.to_i, fees:, currency:, purchase_order_number: "PO-123"} }
+
+      it "stamps the purchase order number on the invoice" do
+        result = described_class.call(**args)
+
+        expect(result).to be_success
+        expect(result.invoice.purchase_order_number).to eq("PO-123")
+      end
+    end
+
     context "with custom sections" do
       let(:section_1) { create(:invoice_custom_section, organization:, code: "section_code_1") }
       let(:args) do

--- a/spec/support/shared_examples/has_purchase_order_number.rb
+++ b/spec/support/shared_examples/has_purchase_order_number.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Shared contract for any model that `include HasPurchaseOrderNumber`.
+# The host group must define `subject` as a buildable instance of the model.
+RSpec.shared_examples "a model with a purchase order number" do
+  describe "purchase_order_number" do
+    it { is_expected.to validate_length_of(:purchase_order_number).is_at_most(255) }
+
+    describe "normalization" do
+      it "trims surrounding whitespace" do
+        subject.purchase_order_number = "  PO-123  "
+        subject.valid?
+        expect(subject.purchase_order_number).to eq("PO-123")
+      end
+
+      it "converts blank to nil" do
+        subject.purchase_order_number = "   "
+        subject.valid?
+        expect(subject.purchase_order_number).to be_nil
+      end
+
+      it "preserves the original case" do
+        subject.purchase_order_number = "  Po-AbC-123 "
+        subject.valid?
+        expect(subject.purchase_order_number).to eq("Po-AbC-123")
+      end
+    end
+  end
+end

--- a/spec/views/app/views/templates/invoices/v4/one_off.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4/one_off.slim_spec.rb
@@ -195,4 +195,68 @@ RSpec.describe "templates/invoices/v4/one_off.slim" do
       expect(rendered_template).to match_html_snapshot
     end
   end
+
+  context "with a purchase order number" do
+    let(:add_on) { create(:add_on, organization:, name: "Setup Fee") }
+    let(:add_on_fee) do
+      create(
+        :one_off_fee,
+        invoice:,
+        add_on:,
+        amount_cents: 10000,
+        amount_currency: "USD",
+        units: 1,
+        unit_amount_cents: 10000,
+        invoice_display_name: "Setup Fee"
+      )
+    end
+
+    let(:invoice) do
+      create(
+        :invoice,
+        customer:,
+        organization:,
+        number: "LAGO-202509-OO-PO",
+        payment_due_date: Date.parse("2025-09-15"),
+        issuing_date: Date.parse("2025-09-01"),
+        invoice_type: :one_off,
+        total_amount_cents: 10000,
+        currency: "USD",
+        fees_amount_cents: 10000,
+        sub_total_excluding_taxes_amount_cents: 10000,
+        sub_total_including_taxes_amount_cents: 10000,
+        coupons_amount_cents: 0,
+        purchase_order_number: "PO-12345"
+      )
+    end
+
+    before { add_on_fee }
+
+    it "renders the purchase order number under the invoice number" do
+      expect(rendered_template).to include("Purchase Order Number")
+      expect(rendered_template).to include("PO-12345")
+    end
+  end
+
+  context "without a purchase order number" do
+    let(:add_on) { create(:add_on, organization:, name: "Setup Fee") }
+    let(:add_on_fee) do
+      create(
+        :one_off_fee,
+        invoice:,
+        add_on:,
+        amount_cents: 10000,
+        amount_currency: "USD",
+        units: 1,
+        unit_amount_cents: 10000,
+        invoice_display_name: "Setup Fee"
+      )
+    end
+
+    before { add_on_fee }
+
+    it "does not render the purchase order number row" do
+      expect(rendered_template).not_to include("Purchase Order Number")
+    end
+  end
 end


### PR DESCRIPTION
## Context
Lago had no dedicated field for a purchase order (PO) number on invoices. Customers worked around it by putting the value into fee descriptions, and it couldn't be surfaced cleanly. This is an initial PR that covers only one-off invoices as the first step of the broader PO initiative.

## Description
- `purchase_order_number` persistence in the `invoices` table.
- Validation and normalization (max length 255, trims whitespaces, converts empty string to nil).
- GraphQL write/read. Without an update action since one-off invoices don't have a draft state, the PO number is stamped.

PRs included:
#5791
#5794
#5801