### PR TITLE
feat(payment-gated-subs): always serialize fields

### DIFF
--- a/app/controllers/concerns/subscription_index.rb
+++ b/app/controllers/concerns/subscription_index.rb
@@ -23,7 +23,7 @@ module SubscriptionIndex
 
     if result.success?
       subscriptions = result.subscriptions
-        .includes(:plan, previous_subscription: :plan, next_subscriptions: :plan, customer: :billing_entity)
+        .includes(:plan, :activation_rules, previous_subscription: :plan, next_subscriptions: :plan, customer: :billing_entity)
 
       render(
         json: ::CollectionSerializer.new(

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -29,7 +29,9 @@ module V1
         on_termination_credit_note: model.on_termination_credit_note,
         on_termination_invoice: model.on_termination_invoice,
         progressive_billing_disabled: model.progressive_billing_disabled,
-        consolidate_invoice: model.consolidate_invoice
+        consolidate_invoice: model.consolidate_invoice,
+        cancellation_reason: model.cancellation_reason,
+        activated_at: model.activated_at&.iso8601
       }
 
       payload = payload.merge(customer:) if include?(:customer)
@@ -39,16 +41,7 @@ module V1
       payload = payload.merge(usage_threshold:) if include?(:usage_threshold)
       payload = payload.merge(applicable_usage_thresholds) if include?(:applicable_usage_thresholds)
       payload = payload.merge(applied_invoice_custom_sections) if include?(:applied_invoice_custom_sections)
-
-      if organization.feature_flag_enabled?(:payment_gated_subscriptions)
-        payload[:cancellation_reason] = model.cancellation_reason
-        payload[:activated_at] = model.activated_at&.iso8601
-        payload[:activation_rules] = model.activation_rules.map do |rule|
-          ::V1::Subscriptions::ActivationRuleSerializer.new(rule).serialize
-        end
-      end
-
-      payload
+      payload.merge(activation_rules)
     end
 
     private
@@ -76,6 +69,14 @@ module V1
           :plan,
           default: %i[charges usage_thresholds applicable_usage_thresholds taxes minimum_commitment]
         )
+      ).serialize
+    end
+
+    def activation_rules
+      ::CollectionSerializer.new(
+        model.activation_rules,
+        ::V1::Subscriptions::ActivationRuleSerializer,
+        collection_name: "activation_rules"
       ).serialize
     end
 

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -794,21 +794,6 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         end
       end
 
-      context "when feature flag is disabled" do
-        it "persists rules but does not include them in response" do
-          subject
-
-          expect(response).to have_http_status(:ok)
-
-          subscription = Subscription.find(json[:subscription][:lago_id])
-          expect(subscription.activation_rules.count).to eq(1)
-
-          expect(json[:subscription]).not_to have_key(:activation_rules)
-          expect(json[:subscription]).not_to have_key(:cancellation_reason)
-          expect(json[:subscription]).not_to have_key(:activated_at)
-        end
-      end
-
       context "with invalid rule type" do
         let(:params) do
           {
@@ -1800,21 +1785,6 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
             expect(response).to have_http_status(:success)
             expect(json[:subscription][:activation_rules].first[:timeout_hours]).to eq(0)
           end
-        end
-      end
-
-      context "when feature flag is disabled" do
-        it "persists rules but does not include them in response" do
-          subject
-
-          expect(response).to have_http_status(:success)
-
-          subscription.reload
-          expect(subscription.activation_rules.count).to eq(1)
-
-          expect(json[:subscription]).not_to have_key(:activation_rules)
-          expect(json[:subscription]).not_to have_key(:cancellation_reason)
-          expect(json[:subscription]).not_to have_key(:activated_at)
         end
       end
 

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -296,14 +296,4 @@ RSpec.describe ::V1::SubscriptionSerializer do
       end
     end
   end
-
-  context "when payment_gated_subscriptions feature flag is disabled" do
-    it "does not serialize feature-flagged fields" do
-      result = JSON.parse(serializer.to_json)
-
-      expect(result["subscription"]).not_to have_key("cancellation_reason")
-      expect(result["subscription"]).not_to have_key("activated_at")
-      expect(result["subscription"]).not_to have_key("activation_rules")
-    end
-  end
 end


### PR DESCRIPTION
## Context

The subscription serializer gated cancellation_reason, activated_at, and activation_rules behind the payment_gated_subscriptions feature flag. As the feature reaches public launch, these fields belong in the standard subscription payload for every consumer, and the published OpenAPI spec and regenerated client libraries expect them unconditionally rather than depending on a per-organization flag.

## Description

- Move cancellation_reason and activated_at into the core serialized payload so they are always present.
- Always serialize activation_rules, using CollectionSerializer in place of the inline map.
- Drop the payment_gated_subscriptions feature-flag branch and the spec example asserting the fields were hidden when the flag was disabled.
