### PR TITLE
fix(exports): use customer timezone for fee dates

### DIFF
--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -34,8 +34,8 @@ module DataExports
           fee_item_grouped_by
           subscription_external_id
           subscription_plan_code
-          fee_from_date_utc
-          fee_to_date_utc
+          fee_from_date
+          fee_to_date
           fee_amount_currency
           fee_units
           fee_precise_unit_amount
@@ -54,6 +54,7 @@ module DataExports
 
       def serialize_item(invoice, csv)
         serialized_invoice = invoice_serializer_klass.new(invoice).serialize
+        invoice_subscriptions = invoice.invoice_subscriptions.index_by(&:subscription_id)
 
         invoice
           .fees
@@ -70,6 +71,7 @@ module DataExports
           .lazy
           .each do |fee|
             serialized_fee = fee_serializer_klass.new(fee).serialize
+            invoice_subscription = invoice_subscriptions[fee.subscription_id]
 
             serialized_subscription = {
               external_id: fee.subscription&.external_id,
@@ -90,8 +92,8 @@ module DataExports
               serialized_fee.dig(:item, :grouped_by),
               serialized_subscription[:external_id],
               serialized_subscription[:plan_code],
-              serialized_fee[:from_date],
-              serialized_fee[:to_date],
+              invoice_subscription&.charges_from_datetime_in_customer_timezone&.to_date,
+              invoice_subscription&.charges_to_datetime_in_customer_timezone&.to_date,
               serialized_fee[:total_amount_currency],
               serialized_fee[:units],
               serialized_fee[:precise_unit_amount],

--- a/spec/services/data_exports/combine_parts_service_spec.rb
+++ b/spec/services/data_exports/combine_parts_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DataExports::CombinePartsService do
     context "when there is only 1 part" do
       it "adds the correct headers" do
         expected_csv = <<~CSV
-          invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date_utc,fee_to_date_utc,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
+          invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date,fee_to_date,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
           292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
         CSV
 
@@ -58,7 +58,7 @@ RSpec.describe DataExports::CombinePartsService do
 
       it "combines the parts into 1 file in the right order" do
         expected_csv = <<~CSV
-          invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date_utc,fee_to_date_utc,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
+          invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date,fee_to_date,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
           292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
           392ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
         CSV

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -3,65 +3,17 @@
 require "rails_helper"
 
 RSpec.describe DataExports::Csv::InvoiceFees do
-  let(:data_export) do
-    create :data_export, :processing, resource_type: "invoice_fees", resource_query:
-  end
-
+  let(:customer) { create(:customer, timezone:) }
+  let(:plan) { create(:plan, organization: customer.organization) }
+  let(:subscription) { create(:subscription, customer:, plan:, organization: customer.organization) }
+  let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
+  let(:to_utc) { "2024-06-06 12:48:59 UTC" }
+  let(:from_utc) { "2024-05-08 00:00:00 UTC" }
+  let(:timezone) { "UTC" }
   let(:data_export_part) do
     data_export.data_export_parts.create(index: 1, object_ids: [invoice.id], organization_id: data_export.organization_id)
   end
-
-  let(:resource_query) do
-    {
-      currency:,
-      customer_id:,
-      customer_external_id:,
-      invoice_type:,
-      issuing_date_from:,
-      issuing_date_to:,
-      payment_dispute_lost:,
-      payment_overdue:,
-      payment_status:,
-      search_term:,
-      status:
-    }
-  end
-
-  let(:currency) { "EUR" }
-  let(:customer_external_id) { "custext123" }
-  let(:customer_id) { "customer-lago-id-123" }
-  let(:invoice_type) { "credit" }
-  let(:issuing_date_from) { "2023-12-25" }
-  let(:issuing_date_to) { "2024-07-01" }
-  let(:payment_dispute_lost) { false }
-  let(:payment_overdue) { true }
-  let(:payment_status) { "pending" }
-  let(:search_term) { "service ABC" }
-  let(:status) { "finalized" }
-
-  let(:invoice_serializer_klass) { class_double("V1::InvoiceSerializer") }
-  let(:fee_serializer_klass) { class_double("V1::FeeSerializer") }
-  let(:subscription_serializer_klass) { class_double("V1::SubscriptionSerializer") }
-
-  let(:invoice_serializer) do
-    instance_double("V1::InvoiceSerializer", serialize: serialized_invoice)
-  end
-
-  let(:fee_serializer) do
-    instance_double("V1::FeeSerializer", serialize: serialized_fee)
-  end
-
-  let(:invoice) { create :invoice }
-  let(:fee) { create :fee, invoice: }
-
-  let(:serialized_invoice) do
-    {
-      lago_id: "292ef60b-9e0c-42e7-9f50-44d5af4162ec",
-      number: "TWI-2B86-170-001",
-      issuing_date: "2024-06-06"
-    }
-  end
-
+  let(:data_export) { create :data_export, :processing, resource_type: "invoice_fees", resource_query: {} }
   let(:serialized_fee) do
     {
       lago_id: "cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302",
@@ -83,43 +35,93 @@ RSpec.describe DataExports::Csv::InvoiceFees do
       to_date: "2024-06-06T12:48:59+00:00"
     }
   end
+  let(:serialized_invoice) do
+    {
+      lago_id: "292ef60b-9e0c-42e7-9f50-44d5af4162ec",
+      number: "TWI-2B86-170-001",
+      issuing_date: "2024-06-06"
+    }
+  end
+  let(:fee_serializer) { instance_double("V1::FeeSerializer", serialize: serialized_fee) }
+  let(:invoice_serializer) { instance_double("V1::InvoiceSerializer", serialize: serialized_invoice) }
+  let(:fee_serializer_klass) { class_double("V1::FeeSerializer") }
+  let(:invoice_serializer_klass) { class_double("V1::InvoiceSerializer") }
 
-  before do
-    invoice
-    fee
-
-    allow(invoice_serializer_klass)
-      .to receive(:new)
-      .and_return(invoice_serializer)
-
-    allow(fee_serializer_klass)
-      .to receive(:new)
-      .and_return(fee_serializer)
+  describe ".base_headers" do
+    it "uses timezone-agnostic column names" do
+      expect(described_class.base_headers).to include("fee_from_date", "fee_to_date")
+      expect(described_class.base_headers).not_to include("fee_from_date_utc", "fee_to_date_utc")
+    end
   end
 
   describe "#call" do
     subject(:result) do
-      described_class.new(
-        data_export_part:,
-        invoice_serializer_klass:,
-        fee_serializer_klass:
-      ).call
+      described_class.new(data_export_part:, invoice_serializer_klass:, fee_serializer_klass:).call
+    end
+
+    let!(:fee) { create(:fee, invoice:, subscription:, organization: customer.organization, fee_type: :subscription) }
+
+    before do
+      create(:invoice_subscription,
+        invoice:,
+        subscription:,
+        organization: customer.organization,
+        charges_from_datetime: Time.zone.parse(from_utc),
+        charges_to_datetime: Time.zone.parse(to_utc))
+      allow(invoice_serializer_klass).to receive(:new).and_return(invoice_serializer)
+      allow(fee_serializer_klass).to receive(:new).and_return(fee_serializer)
     end
 
     it "generates the correct CSV output" do
       expected_csv = <<~CSV
-        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{models: ""model_1""}",#{fee.subscription.external_id},#{fee.subscription.plan.code},2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
+        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{models: ""model_1""}",#{fee.subscription.external_id},#{fee.subscription.plan.code},2024-05-08,2024-06-06,USD,100.0,10.0,50,10000
       CSV
 
       expect(result).to be_success
 
       file = result.csv_file
       generated_csv = file.read
-
       file.close
       File.unlink(file.path)
 
       expect(generated_csv).to eq(expected_csv)
+    end
+
+    shared_examples "exports fee dates in customer timezone" do
+      it "exports fee dates in the customer's local timezone, not UTC" do
+        result = described_class.new(data_export_part:).call
+
+        file = result.csv_file
+        csv_content = file.read
+        file.close
+        File.unlink(file.path)
+
+        rows = CSV.parse(csv_content)
+        expect(rows.first[13]).to eq(expected_from) # fee_from_date
+        expect(rows.first[14]).to eq(expected_to)   # fee_to_date
+      end
+    end
+
+    context "when the customer has a negative UTC offset" do
+      # America/New_York is UTC-4 in summer. 2026-05-01 03:59 UTC = 2026-04-30 23:59 EDT.
+      let(:timezone) { "America/New_York" }
+      let(:from_utc) { "2026-04-01 04:00:00 UTC" }
+      let(:to_utc) { "2026-05-01 03:59:59 UTC" }
+      let(:expected_from) { "2026-04-01" }
+      let(:expected_to) { "2026-04-30" }
+
+      it_behaves_like "exports fee dates in customer timezone"
+    end
+
+    context "when the customer has a positive UTC offset" do
+      # Asia/Tokyo is UTC+9. 2026-03-31 15:00 UTC = 2026-04-01 00:00 JST.
+      let(:timezone) { "Asia/Tokyo" }
+      let(:from_utc) { "2026-03-31 15:00:00 UTC" }
+      let(:to_utc) { "2026-04-30 14:59:59 UTC" }
+      let(:expected_from) { "2026-04-01" }
+      let(:expected_to) { "2026-04-30" }
+
+      it_behaves_like "exports fee dates in customer timezone"
     end
   end
 end


### PR DESCRIPTION
⚠️ This PR should not be released to the cloud before the 15th of July 2026.

## Context

The advanced invoice export used raw UTC strings from the fee's `properties` JSONB for date columns, showing wrong dates for customers in non-UTC timezones.

## Description

- Use InvoiceSubscription's `charges_from_datetime_in_customer_timezone` and `charges_to_datetime_in_customer_timezone` to convert the period dates to the customer's local timezone.
- Invoice subscriptions are fetched once per invoice.
- Column headers renamed from `fee_from_date_utc` / `fee_to_date_utc` to `fee_from_date` / `fee_to_date`.