### PR TITLE
credit_note: add metadata query filters to list endpoint

### DIFF
--- a/app/controllers/concerns/credit_note_index.rb
+++ b/app/controllers/concerns/credit_note_index.rb
@@ -48,6 +48,7 @@ module CreditNoteIndex
         invoice_number: params[:invoice_number],
         issuing_date_from: (Date.iso8601(params[:issuing_date_from]) if valid_date?(params[:issuing_date_from])),
         issuing_date_to: (Date.iso8601(params[:issuing_date_to]) if valid_date?(params[:issuing_date_to])),
+        metadata: params[:metadata]&.permit!.to_h,
         reason: params[:reason],
         refund_status: params[:refund_status],
         self_billed: params[:self_billed],

--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -16,7 +16,8 @@ class CreditNotesQuery < BaseQuery
     :credit_status,
     :reason,
     :refund_status,
-    :types
+    :types,
+    :metadata
   ]
 
   def initialize(includes: [], **args)
@@ -39,6 +40,7 @@ class CreditNotesQuery < BaseQuery
     credit_notes = with_issuing_date_range(credit_notes) if filters.issuing_date_from || filters.issuing_date_to
     credit_notes = with_amount_range(credit_notes) if filters.amount_from.present? || filters.amount_to.present?
     credit_notes = with_self_billed_invoice(credit_notes) unless filters.self_billed.nil?
+    credit_notes = with_metadata(credit_notes) if filters.metadata.present?
 
     credit_notes = paginate(credit_notes)
     credit_notes = apply_consistent_ordering(credit_notes)
@@ -150,6 +152,25 @@ class CreditNotesQuery < BaseQuery
 
   def with_billing_entity_ids(scope)
     scope.joins(:invoice).where(invoices: {billing_entity_id: filters.billing_entity_ids})
+  end
+
+  # Filters credit notes by their metadata JSONB. A key with a present value keeps
+  # credit notes whose metadata contains that exact key/value pair (all present
+  # filters must match). A key with a blank value keeps credit notes that do not
+  # carry that key at all (including those with no metadata).
+  def with_metadata(scope)
+    scope = scope.left_joins(:metadata)
+
+    presence_filters = filters.metadata.select { |_key, value| value.present? }
+    absence_filters = filters.metadata.select { |_key, value| value.blank? }
+
+    scope = scope.where("item_metadata.value @> ?", presence_filters.to_json) if presence_filters.present?
+
+    absence_filters.each_key do |key|
+      scope = scope.where("item_metadata.value IS NULL OR NOT jsonb_exists(item_metadata.value, ?)", key)
+    end
+
+    scope
   end
 
   def issuing_date_from

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -483,6 +483,97 @@ RSpec.describe CreditNotesQuery do
     end
   end
 
+  context "when metadata filters applied" do
+    let(:filters) { {metadata:} }
+
+    context "when single filter provided" do
+      context "when value is present" do
+        let(:metadata) { {"Integrated in SAP" => "Yes"} }
+        let(:matching_credit_note) { create(:credit_note, customer:) }
+
+        before do
+          create(:item_metadata, owner: matching_credit_note, organization:, value: {"Integrated in SAP" => "Yes"})
+
+          other_credit_note = create(:credit_note, customer:)
+          create(:item_metadata, owner: other_credit_note, organization:, value: {"Integrated in SAP" => "No"})
+
+          create(:credit_note, customer:)
+        end
+
+        it "returns credit notes with matching metadata filters" do
+          expect(result).to be_success
+          expect(returned_ids).to contain_exactly matching_credit_note.id
+        end
+      end
+
+      context "when value is absent" do
+        let(:metadata) { {"Integrated in SAP" => ""} }
+
+        let!(:matching_credit_notes) do
+          [
+            create(:credit_note, customer:),
+            create(:credit_note, customer:).tap do |credit_note|
+              create(:item_metadata, owner: credit_note, organization:, value: {"Other key" => "value"})
+            end
+          ]
+        end
+
+        before do
+          excluded = create(:credit_note, customer:)
+          create(:item_metadata, owner: excluded, organization:, value: {"Integrated in SAP" => "Yes"})
+        end
+
+        it "returns credit notes without the provided key or without metadata at all" do
+          expect(result).to be_success
+          expect(returned_ids).to match_array matching_credit_notes.pluck(:id)
+        end
+      end
+    end
+
+    context "when multiple filters provided" do
+      let(:metadata) do
+        {
+          "Integrated in SAP" => "Yes",
+          "SAP Document Number" => "9DZNZXLXZZZZ",
+          "Archived" => ""
+        }
+      end
+
+      let!(:matching_credit_note) do
+        create(:credit_note, customer:).tap do |credit_note|
+          create(
+            :item_metadata,
+            owner: credit_note,
+            organization:,
+            value: {"Integrated in SAP" => "Yes", "SAP Document Number" => "9DZNZXLXZZZZ"}
+          )
+        end
+      end
+
+      before do
+        # Matches presence filters but carries the excluded "Archived" key.
+        archived = create(:credit_note, customer:)
+        create(
+          :item_metadata,
+          owner: archived,
+          organization:,
+          value: {"Integrated in SAP" => "Yes", "SAP Document Number" => "9DZNZXLXZZZZ", "Archived" => "true"}
+        )
+
+        # Matches only one of the presence filters.
+        partial = create(:credit_note, customer:)
+        create(:item_metadata, owner: partial, organization:, value: {"Integrated in SAP" => "Yes"})
+
+        create(:credit_note, customer:)
+      end
+
+      it "returns credit notes matching all presence filters and none of the absence filters" do
+        expect(result).to be_success
+        expect(returned_ids).to contain_exactly matching_credit_note.id
+      end
+    end
+  end
+
   context "when search term filter applied" do
     context "with term matching credit note by id" do
       let(:search_term) { matching_credit_note.id.first(10) }

--- a/spec/support/shared_examples/credit_note_index.rb
+++ b/spec/support/shared_examples/credit_note_index.rb
@@ -455,4 +455,25 @@ RSpec.shared_examples "a credit note index endpoint" do
       end
     end
   end
+
+  context "with metadata filters" do
+    let(:params) { {metadata: {"Integrated in SAP" => "Yes"}} }
+
+    let(:invoice) { create(:invoice, organization:, customer:) }
+    let(:matching_credit_note) { create(:credit_note, invoice:, customer:) }
+
+    before do
+      create(:item_metadata, owner: matching_credit_note, organization:, value: {"Integrated in SAP" => "Yes"})
+
+      other_credit_note = create(:credit_note, invoice: create(:invoice, organization:, customer:), customer:)
+      create(:item_metadata, owner: other_credit_note, organization:, value: {"Integrated in SAP" => "No"})
+    end
+
+    it "returns credit notes with matching metadata filters" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:credit_notes].pluck(:lago_id)).to contain_exactly matching_credit_note.id
+    end
+  end
 end


### PR DESCRIPTION
> ⚠️ **Local validation incomplete (Mode B — CI-centric).** PostgreSQL, Redis and ClickHouse were not reachable on the runner (the env points at Docker hostnames `db`/`clickhouse`), so RSpec could not run locally. `bundle exec rubocop` ran and is green on all four changed files. **Validation delegated to CI — please wait for CI to go green before reviewing.**

## What changed and why

Mistral's SAP integration filters the invoices list endpoint by metadata (e.g. `{"Integrated in SAP": "Yes", "SAP Document Number": "9DZNZXLXZZZZ"}`) to find documents not yet integrated, but the **credit notes** list endpoint did not support metadata filtering. This adds it, mirroring the invoices behaviour, so batch integration workflows can identify unprocessed credit notes.

- `app/queries/credit_notes_query.rb` — add `:metadata` to `Filters`, call `with_metadata` when present, and implement it.
- `app/controllers/concerns/credit_note_index.rb` — pass `metadata: params[:metadata]&.permit!.to_h` through to the query (same shape as `InvoiceIndex`).
- Specs for the query (`spec/queries/credit_notes_query_spec.rb`) and the shared request example (`spec/support/shared_examples/credit_note_index.rb`).

### Filtering semantics (matches invoices)
- A key with a **present** value keeps credit notes whose metadata contains that exact key/value pair. Multiple present keys are ANDed.
- A key with a **blank** value (`"key" => ""`) keeps credit notes that do **not** carry that key — including those with no metadata at all.

### Implementation note — storage differs from invoices
Invoices store metadata as **many rows** in `invoice_metadata` (key/value columns), so `InvoicesQuery#with_metadata` uses a grouped `left_joins` with `COUNT(DISTINCT key)`. Credit notes store metadata as a **single JSONB hash** on the polymorphic `item_metadata.value` (`has_one :metadata`). So the filter is simpler and uses JSONB operators directly:
- presence → `item_metadata.value @> '{...}'::jsonb`
- absence → `item_metadata.value IS NULL OR NOT jsonb_exists(item_metadata.value, 'key')`

## Performance notes
This is a paginated list endpoint, **not** on the event-ingestion hot path. The `@>` and `jsonb_exists` operators are both backed by the existing GIN index `index_item_metadata_on_value`. The join is on a `has_one`, so there is no row multiplication (no GROUP BY/DISTINCT needed) and pagination counts stay correct. No N+1, no per-record allocation.

## What was NOT done
- No new migration — `item_metadata` and its GIN index already exist.
- No filters contract added — `CreditNotesQuery` does not run a dry-validation contract today, and the invoices contract does not validate metadata either (it's free-form). Left as-is to stay in scope.
- Serializer untouched — credit notes already return `metadata` in responses.
- No frontend/GraphQL changes (REST-only ticket).

## How to verify locally
```
bundle exec rspec spec/queries/credit_notes_query_spec.rb -e "metadata filters"
bundle exec rspec spec/requests/api/v1/credit_notes_controller_spec.rb -e "metadata filters"
bundle exec rubocop app/queries/credit_notes_query.rb app/controllers/concerns/credit_note_index.rb
```

Linear: [BIL-173](https://linear.app/getlago/issue/BIL-173/add-metadata-query-filters-to-credit-notes-list-endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
