### PR TITLE
fix(tax): derive applied_to_organization from billing entity

### DIFF
--- a/app/controllers/api/v1/taxes_controller.rb
+++ b/app/controllers/api/v1/taxes_controller.rb
@@ -54,10 +54,11 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.taxes,
+              result.taxes.preload(:billing_entities_taxes),
               ::V1::TaxSerializer,
               collection_name: "taxes",
-              meta: pagination_metadata(result.taxes)
+              meta: pagination_metadata(result.taxes),
+              default_billing_entity_id: default_billing_entity_id
             )
           )
         else
@@ -72,7 +73,11 @@ module Api
       end
 
       def render_tax(tax)
-        render(json: ::V1::TaxSerializer.new(tax, root_name: "tax"))
+        render(json: ::V1::TaxSerializer.new(tax, root_name: "tax", default_billing_entity_id: default_billing_entity_id))
+      end
+
+      def default_billing_entity_id
+        @default_billing_entity_id ||= current_organization.default_billing_entity&.id
       end
 
       def resource_name

--- a/app/serializers/v1/tax_serializer.rb
+++ b/app/serializers/v1/tax_serializer.rb
@@ -9,7 +9,7 @@ module V1
         code: model.code,
         rate: model.rate,
         description: model.description,
-        applied_to_organization: model.applied_to_organization,
+        applied_to_organization: applied_to_organization?,
         add_ons_count: 0,
         customers_count: 0,
         plans_count: 0,
@@ -17,6 +17,27 @@ module V1
         commitments_count: 0,
         created_at: model.created_at.iso8601
       }
+    end
+
+    private
+
+    # A tax is considered applied to the organization when it is applied to the
+    # organization's default billing entity. The legacy `applied_to_organization`
+    # column is deprecated and is not kept in sync when taxes are managed directly
+    # on a billing entity.
+    def applied_to_organization?
+      return false if default_billing_entity_id.nil?
+
+      model.billing_entities_taxes.any? do |applied_tax|
+        applied_tax.billing_entity_id == default_billing_entity_id
+      end
+    end
+
+    def default_billing_entity_id
+      return @default_billing_entity_id if defined?(@default_billing_entity_id)
+
+      @default_billing_entity_id =
+        options[:default_billing_entity_id] || model.organization.default_billing_entity&.id
     end
   end
 end

--- a/spec/requests/api/v1/taxes_controller_spec.rb
+++ b/spec/requests/api/v1/taxes_controller_spec.rb
@@ -101,6 +101,18 @@ RSpec.describe Api::V1::TaxesController do
       expect(response).to have_http_status(:success)
       expect(json[:tax][:lago_id]).to eq(tax.id)
       expect(json[:tax][:code]).to eq(tax.code)
+      expect(json[:tax][:applied_to_organization]).to be(false)
+    end
+
+    context "when the tax is applied to the default billing entity" do
+      let(:tax) { create(:tax, :applied_to_billing_entity, organization:) }
+
+      it "returns applied_to_organization as true" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:tax][:applied_to_organization]).to be(true)
+      end
     end
 
     context "when tax does not exist" do
@@ -157,6 +169,18 @@ RSpec.describe Api::V1::TaxesController do
       expect(json[:taxes].count).to eq(1)
       expect(json[:taxes].first[:lago_id]).to eq(tax.id)
       expect(json[:taxes].first[:code]).to eq(tax.code)
+      expect(json[:taxes].first[:applied_to_organization]).to be(false)
+    end
+
+    context "when the tax is applied to the default billing entity" do
+      let!(:tax) { create(:tax, :applied_to_billing_entity, organization:) }
+
+      it "returns applied_to_organization as true" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:taxes].first[:applied_to_organization]).to be(true)
+      end
     end
 
     context "with pagination" do

--- a/spec/serializers/v1/tax_serializer_spec.rb
+++ b/spec/serializers/v1/tax_serializer_spec.rb
@@ -16,11 +16,62 @@ RSpec.describe ::V1::TaxSerializer do
       "code" => tax.code,
       "rate" => tax.rate,
       "description" => tax.description,
+      "applied_to_organization" => false,
       "add_ons_count" => 0,
       "customers_count" => 0,
       "plans_count" => 0,
       "charges_count" => 0,
       "created_at" => tax.created_at.iso8601
     )
+  end
+
+  describe "applied_to_organization" do
+    context "when the tax is applied to the default billing entity" do
+      let(:tax) { create(:tax, :applied_to_billing_entity) }
+
+      it "returns true" do
+        result = JSON.parse(serializer.to_json)
+
+        expect(result["tax"]["applied_to_organization"]).to be(true)
+      end
+    end
+
+    context "when the tax is applied to a non-default billing entity" do
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:tax) { create(:tax, :applied_to_billing_entity, organization:, billing_entity:) }
+
+      it "returns false" do
+        result = JSON.parse(serializer.to_json)
+
+        expect(result["tax"]["applied_to_organization"]).to be(false)
+      end
+    end
+
+    context "when only the deprecated applied_to_organization column is set" do
+      let(:tax) { create(:tax, applied_to_organization: true) }
+
+      it "ignores the column and returns false" do
+        result = JSON.parse(serializer.to_json)
+
+        expect(result["tax"]["applied_to_organization"]).to be(false)
+      end
+    end
+
+    context "when the default billing entity id is provided as an option" do
+      subject(:serializer) do
+        described_class.new(tax, root_name: "tax", default_billing_entity_id: billing_entity.id)
+      end
+
+      let(:organization) { create(:organization) }
+      let(:billing_entity) { organization.default_billing_entity }
+      let(:tax) { create(:tax, :applied_to_billing_entity, organization:) }
+
+      it "returns true" do
+        result = JSON.parse(serializer.to_json)
+
+        expect(result["tax"]["applied_to_organization"]).to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

`GET /taxes` returned `applied_to_organization: false` for a tax that was applied to the organization's default billing entity. The flag did not reflect the applied state.

The `V1::TaxSerializer` read the `applied_to_organization` column. That column is deprecated (see the note in the `:tax` factory) and is not kept in sync when a tax is applied to a billing entity through paths other than `Taxes::CreateService` / `Taxes::UpdateService`, for example `PUT /billing_entities/:code` (`BillingEntities::Taxes::ManageTaxesService`) or the apply/remove tax GraphQL mutations. The real source of truth is the `billing_entities_taxes` join on the default billing entity, which `TaxesQuery`'s `applied_to_organization` filter already uses.

## Description

The serializer now derives `applied_to_organization` from whether the tax is applied to the organization's default billing entity, consistent with the query filter and the `:applied_to_billing_entity` factory trait. The deprecated column is no longer read, so already-desynced taxes are reported correctly without a data backfill.

The taxes controller passes the default billing entity id to the serializer and preloads `billing_entities_taxes` on the index to avoid N+1 queries. Reads are the only path touched; the column and the write services are left as-is.

`V1::TaxSerializer` is shared by other serializers (add-on, charge, plan, organization, billing entity, commitment, customer). Those now report the derived value too, which is the same fix. Existing specs for them still pass.

## What was not done

The GraphQL `Types::Taxes::Object` field reads the same deprecated column and has the same latent issue. It is out of scope here (the ticket is about `GET /taxes`) and can be addressed in a follow-up if the UI shows the wrong value.

## How to verify

1. Apply a tax to the default billing entity (e.g. `PUT /billing_entities/:code` with the tax code, or create it via the UI).
2. Call `GET /taxes`.
3. The tax now returns `applied_to_organization: true`.

Specs:
- `lago exec api bundle exec rspec spec/serializers/v1/tax_serializer_spec.rb spec/requests/api/v1/taxes_controller_spec.rb`

Closes ING-337.
