### PR TITLE
feat(products): add rate card REST endpoints

### DIFF
--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class RateCardsController < Api::BaseController
+      def create
+        if create_params.key?(:product_filter_code) && product && product_filter.nil?
+          return not_found_error(resource: "product_filter")
+        end
+
+        result = ::RateCards::CreateService.call(
+          product:,
+          params: create_params
+            .except(:product_code, :product_filter_code)
+            .to_h.deep_symbolize_keys
+            .merge(product_filter_id: product_filter&.id)
+        )
+
+        if result.success?
+          render_rate_card(result.rate_card)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def update
+        rate_card = current_organization.rate_cards.find_by(code: params[:code])
+        result = ::RateCards::UpdateService.call(
+          rate_card:,
+          params: update_params.to_h.deep_symbolize_keys
+        )
+
+        if result.success?
+          render_rate_card(result.rate_card)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def destroy
+        rate_card = current_organization.rate_cards.find_by(code: params[:code])
+        result = ::RateCards::DestroyService.call(rate_card:)
+
+        if result.success?
+          render_rate_card(result.rate_card)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        rate_card = current_organization.rate_cards.find_by(code: params[:code])
+
+        return not_found_error(resource: "rate_card") unless rate_card
+
+        render_rate_card(rate_card)
+      end
+
+      def index
+        result = ::RateCardsQuery.call(
+          organization: current_organization,
+          search_term: params[:search_term],
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters: {
+            product_id: params[:product_id],
+            product_filter_id: params[:product_filter_id]
+          }
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.rate_cards,
+              ::V1::RateCardSerializer,
+              collection_name: "rate_cards",
+              meta: pagination_metadata(result.rate_cards)
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      private
+
+      def product
+        @product ||= current_organization.products.find_by(code: create_params[:product_code])
+      end
+
+      def product_filter
+        return nil unless product && create_params[:product_filter_code]
+
+        @product_filter ||= product.filters.find_by(code: create_params[:product_filter_code])
+      end
+
+      def create_params
+        params.require(:rate_card).permit(
+          :product_code,
+          :product_filter_code,
+          :name,
+          :code,
+          :description,
+          :currency,
+          :billing_timing,
+          :proration,
+          :display_on_invoice,
+          :regroup_paid_fees,
+          :applied_pricing_unit_code,
+          :wallet_targetable,
+          rates: [
+            :code,
+            :effective_datetime,
+            :rate_model,
+            :min_amount_cents,
+            :billing_interval_count,
+            :billing_interval_unit,
+            :applied_pricing_unit_conversion_rate,
+            {rate_properties: {}}
+          ]
+        )
+      end
+
+      def update_params
+        params.require(:rate_card).permit(
+          :name,
+          :description,
+          :currency,
+          :billing_timing,
+          :proration,
+          :display_on_invoice,
+          :regroup_paid_fees,
+          :applied_pricing_unit_code,
+          :wallet_targetable
+        )
+      end
+
+      def render_rate_card(rate_card)
+        render(json: ::V1::RateCardSerializer.new(rate_card, root_name: "rate_card", includes: %i[rates]))
+      end
+
+      def resource_name
+        "rate_card"
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V2
     class RateCardsController < Api::BaseController
       def create
-        if create_params.key?(:product_filter_code) && product && product_filter.nil?
+        if create_params[:product_filter_code].present? && product && product_filter.nil?
           return not_found_error(resource: "product_filter")
         end
 
@@ -24,7 +24,6 @@ module Api
       end
 
       def update
-        rate_card = current_organization.rate_cards.find_by(code: params[:code])
         result = ::RateCards::UpdateService.call(
           rate_card:,
           params: update_params.to_h.deep_symbolize_keys
@@ -38,7 +37,6 @@ module Api
       end
 
       def destroy
-        rate_card = current_organization.rate_cards.find_by(code: params[:code])
         result = ::RateCards::DestroyService.call(rate_card:)
 
         if result.success?
@@ -49,8 +47,6 @@ module Api
       end
 
       def show
-        rate_card = current_organization.rate_cards.find_by(code: params[:code])
-
         return not_found_error(resource: "rate_card") unless rate_card
 
         render_rate_card(rate_card)
@@ -76,7 +72,7 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.rate_cards,
+              result.rate_cards.includes(:product, :product_filter, :rates),
               ::V1::RateCardSerializer,
               collection_name: "rate_cards",
               meta: pagination_metadata(result.rate_cards)
@@ -89,12 +85,16 @@ module Api
 
       private
 
+      def rate_card
+        @rate_card ||= current_organization.rate_cards.find_by(code: params[:code])
+      end
+
       def product
         @product ||= current_organization.products.find_by(code: create_params[:product_code])
       end
 
       def product_filter
-        return nil unless product && create_params[:product_filter_code]
+        return nil unless product && create_params[:product_filter_code].present?
 
         @product_filter ||= product.filters.find_by(code: create_params[:product_filter_code])
       end

--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -129,6 +129,7 @@ module Api
       def update_params
         params.require(:rate_card).permit(
           :name,
+          :code,
           :description,
           :currency,
           :billing_timing,

--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -115,7 +115,7 @@ module Api
           :wallet_targetable,
           rates: [
             :code,
-            :effective_datetime,
+            :effective_from,
             :rate_model,
             :min_amount_cents,
             :billing_interval_count,

--- a/app/controllers/api/v2/rate_cards_controller.rb
+++ b/app/controllers/api/v2/rate_cards_controller.rb
@@ -66,7 +66,10 @@ module Api
           },
           filters: {
             product_id: params[:product_id],
-            product_filter_id: params[:product_filter_id]
+            product_filter_id: params[:product_filter_id],
+            code: params[:code],
+            product_code: params[:product_code],
+            product_filter_code: params[:product_filter_code]
           }
         )
 
@@ -138,7 +141,7 @@ module Api
       end
 
       def render_rate_card(rate_card)
-        render(json: ::V1::RateCardSerializer.new(rate_card, root_name: "rate_card", includes: %i[rates]))
+        render(json: ::V1::RateCardSerializer.new(rate_card, root_name: "rate_card", includes: %i[active_rate]))
       end
 
       def resource_name

--- a/app/graphql/types/rate_cards/update_input.rb
+++ b/app/graphql/types/rate_cards/update_input.rb
@@ -9,6 +9,7 @@ module Types
 
       argument :applied_pricing_unit_code, String, required: false
       argument :billing_timing, Types::RateCards::BillingTimingEnum, required: false
+      argument :code, String, required: false
       argument :currency, Types::CurrencyEnum, required: false
       argument :description, String, required: false
       argument :display_on_invoice, Boolean, required: false

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -7,7 +7,7 @@ class ApiKey < ApplicationRecord
     activity_log add_on analytic api_log billable_metric coupon applied_coupon credit_note customer_usage
     customer event fee invoice organization order order_form payment payment_receipt payment_request payment_method plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
-    billing_entity alert feature security_log quote product_category product
+    billing_entity alert feature security_log quote product_category product rate_card
   ].freeze
 
   MODES = %w[read write].freeze

--- a/app/services/rate_cards/update_service.rb
+++ b/app/services/rate_cards/update_service.rb
@@ -47,6 +47,11 @@ module RateCards
         end
       end
 
+      # Code is identity: editable until the card is in a plan or subscription.
+      if params.key?(:code) && params[:code]&.strip != rate_card.code && rate_card.attached_to_plan_or_subscription?
+        return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
+      end
+
       assign_attributes
       rate_card.save!
 
@@ -61,6 +66,7 @@ module RateCards
     attr_reader :rate_card, :params
 
     def assign_attributes
+      rate_card.code = params[:code]&.strip if params.key?(:code)
       rate_card.name = params[:name] if params.key?(:name)
       rate_card.description = params[:description] if params.key?(:description)
       rate_card.currency = params[:currency] if params.key?(:currency)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,7 @@ Rails.application.routes.draw do
         resources :filters, param: :code, code: /.*/, only: %i[index show create update destroy], controller: "products/filters"
       end
       resources :product_categories, param: :code, code: /.*/, only: %i[index show create update destroy]
+      resources :rate_cards, param: :code, code: /.*/, only: %i[index show create update destroy]
     end
   end
   resources :webhooks, only: [] do

--- a/schema.graphql
+++ b/schema.graphql
@@ -14812,6 +14812,7 @@ input UpdateRateCardInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  code: String
   currency: CurrencyEnum
   description: String
   displayOnInvoice: Boolean

--- a/schema.json
+++ b/schema.json
@@ -79379,6 +79379,18 @@
               "deprecationReason": null
             },
             {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "currency",
               "description": null,
               "type": {

--- a/spec/requests/api/v2/rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Api::V2::RateCardsController do
           rates: [
             {
               code: "launch_price",
-              effective_from: 1.minute.ago.beginning_of_day.iso8601,
+              effective_from: 1.minute.ago.to_date.iso8601,
               rate_model: "standard",
               rate_properties: {amount: "0.05"},
               billing_interval_count: 1,
@@ -58,7 +58,7 @@ RSpec.describe Api::V2::RateCardsController do
             },
             {
               code: "standard_price",
-              effective_from: 1.month.from_now.beginning_of_day.iso8601,
+              effective_from: 1.month.from_now.to_date.iso8601,
               rate_model: "standard",
               rate_properties: {amount: "0.07"},
               billing_interval_unit: "month"
@@ -82,7 +82,7 @@ RSpec.describe Api::V2::RateCardsController do
             code: "standard",
             currency: "EUR",
             rates: [
-              {code: "bad", effective_from: Time.current.beginning_of_day.iso8601, rate_model: "standard", rate_properties: {}, billing_interval_unit: "month"}
+              {code: "bad", effective_from: Time.current.to_date.iso8601, rate_model: "standard", rate_properties: {}, billing_interval_unit: "month"}
             ]
           }
         end

--- a/spec/requests/api/v2/rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Api::V2::RateCardsController do
           rates: [
             {
               code: "launch_price",
-              effective_datetime: 1.minute.ago.iso8601,
+              effective_from: 1.minute.ago.beginning_of_day.iso8601,
               rate_model: "standard",
               rate_properties: {amount: "0.05"},
               billing_interval_count: 1,
@@ -58,7 +58,7 @@ RSpec.describe Api::V2::RateCardsController do
             },
             {
               code: "standard_price",
-              effective_datetime: 1.month.from_now.iso8601,
+              effective_from: 1.month.from_now.beginning_of_day.iso8601,
               rate_model: "standard",
               rate_properties: {amount: "0.07"},
               billing_interval_unit: "month"
@@ -82,7 +82,7 @@ RSpec.describe Api::V2::RateCardsController do
             code: "standard",
             currency: "EUR",
             rates: [
-              {code: "bad", effective_datetime: Time.current.iso8601, rate_model: "standard", rate_properties: {}, billing_interval_unit: "month"}
+              {code: "bad", effective_from: Time.current.beginning_of_day.iso8601, rate_model: "standard", rate_properties: {}, billing_interval_unit: "month"}
             ]
           }
         end
@@ -180,7 +180,7 @@ RSpec.describe Api::V2::RateCardsController do
     include_examples "requires API permission", "rate_card", "read"
 
     it "returns the rate card with its rates count and active rate" do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.day.ago)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.day.ago.beginning_of_day)
 
       subject
 

--- a/spec/requests/api/v2/rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards_controller_spec.rb
@@ -179,11 +179,15 @@ RSpec.describe Api::V2::RateCardsController do
 
     include_examples "requires API permission", "rate_card", "read"
 
-    it "returns the rate card" do
+    it "returns the rate card with its rates count and active rate" do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.day.ago)
+
       subject
 
       expect(response).to have_http_status(:success)
       expect(json[:rate_card][:lago_id]).to eq(rate_card.id)
+      expect(json[:rate_card][:rates_count]).to eq(1)
+      expect(json[:rate_card][:active_rate][:status]).to eq("active")
     end
 
     context "when the rate card belongs to another organization" do
@@ -215,6 +219,16 @@ RSpec.describe Api::V2::RateCardsController do
 
     context "with a product_id filter" do
       let(:query_params) { "?product_id=#{product.id}" }
+
+      it "returns only the rate cards of that product" do
+        subject
+
+        expect(json[:rate_cards].map { it[:lago_id] }).to eq([rate_card.id])
+      end
+    end
+
+    context "with a product_code filter" do
+      let(:query_params) { "?product_code=#{product.code}" }
 
       it "returns only the rate cards of that product" do
         subject

--- a/spec/requests/api/v2/rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards_controller_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::RateCardsController do
+  let(:organization) { create(:organization) }
+  let(:product) { create(:product, organization:) }
+
+  describe "POST /api/v2/rate_cards" do
+    subject { post_with_token(organization, "/api/v2/rate_cards", {rate_card: create_params}) }
+
+    let(:create_params) do
+      {
+        product_code: product.code,
+        name: "Standard",
+        code: "standard",
+        currency: "EUR"
+      }
+    end
+
+    include_examples "requires API permission", "rate_card", "write"
+
+    it "creates the rate card" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_card][:lago_id]).to be_present
+      expect(json[:rate_card][:product_code]).to eq(product.code)
+      expect(json[:rate_card][:code]).to eq("standard")
+      expect(json[:rate_card][:currency]).to eq("EUR")
+    end
+
+    context "when the product does not exist" do
+      let(:create_params) { {product_code: "unknown", name: "Standard", code: "standard", currency: "EUR"} }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("product")
+      end
+    end
+
+    context "with nested rates" do
+      let(:create_params) do
+        {
+          product_code: product.code,
+          name: "Standard",
+          code: "standard",
+          currency: "EUR",
+          rates: [
+            {
+              code: "launch_price",
+              effective_datetime: 1.minute.ago.iso8601,
+              rate_model: "standard",
+              rate_properties: {amount: "0.05"},
+              billing_interval_count: 1,
+              billing_interval_unit: "month"
+            },
+            {
+              code: "standard_price",
+              effective_datetime: 1.month.from_now.iso8601,
+              rate_model: "standard",
+              rate_properties: {amount: "0.07"},
+              billing_interval_unit: "month"
+            }
+          ]
+        }
+      end
+
+      it "creates the card with its rates in one call" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:rate_card][:rates_count]).to eq(2)
+      end
+
+      context "when a nested rate is invalid" do
+        let(:create_params) do
+          {
+            product_code: product.code,
+            name: "Standard",
+            code: "standard",
+            currency: "EUR",
+            rates: [
+              {code: "bad", effective_datetime: Time.current.iso8601, rate_model: "standard", rate_properties: {}, billing_interval_unit: "month"}
+            ]
+          }
+        end
+
+        it "rolls the whole create back with prefixed error keys" do
+          subject
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json.dig(:error_details, :"rates.rate_properties")).to be_present
+          expect(RateCard.count).to eq(0)
+        end
+      end
+    end
+
+    context "with a product_filter_code" do
+      let(:product_filter) { create(:product_filter, organization:, product:) }
+      let(:create_params) do
+        {
+          product_code: product.code,
+          product_filter_code: product_filter.code,
+          name: "Standard",
+          code: "standard",
+          currency: "EUR"
+        }
+      end
+
+      it "creates a filter-scoped rate card" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:rate_card][:product_filter_code]).to eq(product_filter.code)
+      end
+
+      context "when the filter does not exist" do
+        let(:create_params) do
+          {
+            product_code: product.code,
+            product_filter_code: "unknown",
+            name: "Standard",
+            code: "standard",
+            currency: "EUR"
+          }
+        end
+
+        it "returns a not found error" do
+          subject
+
+          expect(response).to be_not_found_error("product_filter")
+        end
+      end
+    end
+
+    context "when the currency is invalid" do
+      let(:create_params) { {product_code: product.code, name: "Standard", code: "standard", currency: "ABC"} }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "PUT /api/v2/rate_cards/:code" do
+    subject { put_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}", {rate_card: update_params}) }
+
+    let(:rate_card) { create(:rate_card, organization:, product:, name: "Before") }
+    let(:update_params) { {name: "After"} }
+
+    include_examples "requires API permission", "rate_card", "write"
+
+    it "updates the rate card" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_card][:name]).to eq("After")
+    end
+
+    context "when the rate card does not exist" do
+      subject { put_with_token(organization, "/api/v2/rate_cards/unknown", {rate_card: update_params}) }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("rate_card")
+      end
+    end
+  end
+
+  describe "GET /api/v2/rate_cards/:code" do
+    subject { get_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}") }
+
+    let(:rate_card) { create(:rate_card, organization:, product:) }
+
+    include_examples "requires API permission", "rate_card", "read"
+
+    it "returns the rate card" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_card][:lago_id]).to eq(rate_card.id)
+    end
+
+    context "when the rate card belongs to another organization" do
+      let(:rate_card) { create(:rate_card) }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("rate_card")
+      end
+    end
+  end
+
+  describe "GET /api/v2/rate_cards" do
+    subject { get_with_token(organization, "/api/v2/rate_cards#{query_params}") }
+
+    let(:query_params) { "" }
+    let!(:rate_card) { create(:rate_card, organization:, product:, name: "Matching") }
+    let!(:other) { create(:rate_card, organization:, name: "Other") }
+
+    include_examples "requires API permission", "rate_card", "read"
+
+    it "returns the rate cards" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_cards].map { it[:lago_id] }).to match_array([rate_card.id, other.id])
+    end
+
+    context "with a product_id filter" do
+      let(:query_params) { "?product_id=#{product.id}" }
+
+      it "returns only the rate cards of that product" do
+        subject
+
+        expect(json[:rate_cards].map { it[:lago_id] }).to eq([rate_card.id])
+      end
+    end
+
+    context "with a search term" do
+      let(:query_params) { "?search_term=Matching" }
+
+      it "returns only the matching rate cards" do
+        subject
+
+        expect(json[:rate_cards].map { it[:lago_id] }).to eq([rate_card.id])
+      end
+    end
+  end
+
+  describe "DELETE /api/v2/rate_cards/:code" do
+    subject { delete_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}") }
+
+    let(:rate_card) { create(:rate_card, organization:, product:) }
+
+    include_examples "requires API permission", "rate_card", "write"
+
+    it "soft deletes the rate card" do
+      expect { subject }.to change { rate_card.reload.discarded? }.from(false).to(true)
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_card][:lago_id]).to eq(rate_card.id)
+    end
+
+    context "when the rate card does not exist" do
+      subject { delete_with_token(organization, "/api/v2/rate_cards/unknown") }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("rate_card")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards_controller_spec.rb
@@ -133,6 +133,25 @@ RSpec.describe Api::V2::RateCardsController do
           expect(response).to be_not_found_error("product_filter")
         end
       end
+
+      context "when the product_filter_code is null" do
+        let(:create_params) do
+          {
+            product_code: product.code,
+            product_filter_code: nil,
+            name: "Standard",
+            code: "standard",
+            currency: "EUR"
+          }
+        end
+
+        it "creates an unfiltered rate card" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:rate_card][:product_filter_code]).to be_nil
+        end
+      end
     end
 
     context "when the currency is invalid" do

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -17,8 +17,34 @@ RSpec.describe RateCards::UpdateService do
     expect(result.rate_card.billing_timing).to eq("advance")
   end
 
-  it "does not change the code" do
-    expect { result }.not_to change { rate_card.reload.code }
+  describe "code editability" do
+    let(:params) { {code: "after"} }
+
+    it "updates the code when the card is not attached" do
+      expect { result }.to change { rate_card.reload.code }.to("after")
+    end
+
+    it "updates the code even when the card has rates" do
+      create(:rate_card_rate, organization:, rate_card:)
+
+      expect { result }.to change { rate_card.reload.code }.to("after")
+    end
+
+    context "when the card is attached to a plan" do
+      before { create(:plan_rate_card, organization:, rate_card:) }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:code]).to eq(["attached_to_plan_or_subscription"])
+      end
+
+      it "still accepts a payload resending the current code" do
+        update_result = described_class.call(rate_card:, params: {name: "renamed", code: rate_card.code})
+
+        expect(update_result).to be_success
+        expect(rate_card.reload.name).to eq("renamed")
+      end
+    end
   end
 
   it "produces an activity log" do


### PR DESCRIPTION
## Description

- Add rate card REST endpoints (index, show, create, update, destroy), addressed by `code`.
- Support creating a card with its rates nested in a single call.
- Filter the list by product, filter slice or code, and expose the card's currently active rate.
