### PR TITLE
feat(products): add rate REST endpoints

### DIFF
--- a/app/controllers/api/v2/rate_cards/rates_controller.rb
+++ b/app/controllers/api/v2/rate_cards/rates_controller.rb
@@ -8,16 +8,18 @@ module Api
         before_action :find_rate, only: %i[show update destroy]
 
         def index
-          rates = rate_card.rates
-            .page(params[:page])
-            .per(params[:per_page] || PER_PAGE)
+          result = ::RateCardRatesQuery.call(
+            organization: current_organization,
+            pagination: {page: params[:page], limit: params[:per_page] || PER_PAGE},
+            filters: {rate_card_id: rate_card.id}
+          )
 
           render(
             json: ::CollectionSerializer.new(
-              rates,
+              result.rate_card_rates,
               ::V1::RateCardRateSerializer,
               collection_name: "rates",
-              meta: pagination_metadata(rates)
+              meta: pagination_metadata(result.rate_card_rates)
             )
           )
         end

--- a/app/controllers/api/v2/rate_cards/rates_controller.rb
+++ b/app/controllers/api/v2/rate_cards/rates_controller.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    module RateCards
+      class RatesController < Api::BaseController
+        before_action :find_rate_card
+        before_action :find_rate, only: %i[show update destroy]
+
+        def index
+          rates = rate_card.rates
+            .page(params[:page])
+            .per(params[:per_page] || PER_PAGE)
+
+          render(
+            json: ::CollectionSerializer.new(
+              rates,
+              ::V1::RateCardRateSerializer,
+              collection_name: "rates",
+              meta: pagination_metadata(rates)
+            )
+          )
+        end
+
+        def show
+          render_rate(rate)
+        end
+
+        def create
+          result = ::RateCardRates::CreateService.call(
+            rate_card:,
+            params: input_params.to_h.deep_symbolize_keys
+          )
+
+          if result.success?
+            render_rate(result.rate_card_rate)
+          else
+            render_error_response(result)
+          end
+        end
+
+        def update
+          result = ::RateCardRates::UpdateService.call(
+            rate_card_rate: rate,
+            params: input_params.to_h.deep_symbolize_keys
+          )
+
+          if result.success?
+            render_rate(result.rate_card_rate)
+          else
+            render_error_response(result)
+          end
+        end
+
+        def destroy
+          result = ::RateCardRates::DestroyService.call(rate_card_rate: rate)
+
+          if result.success?
+            render_rate(result.rate_card_rate)
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        attr_reader :rate_card, :rate
+
+        def find_rate_card
+          @rate_card = current_organization.rate_cards.find_by(code: params[:rate_card_code])
+
+          not_found_error(resource: "rate_card") unless rate_card
+        end
+
+        def find_rate
+          @rate = rate_card.rates.find_by(code: params[:code])
+
+          not_found_error(resource: "rate_card_rate") unless rate
+        end
+
+        def input_params
+          params.require(:rate).permit(
+            :code,
+            :effective_from,
+            :rate_model,
+            :min_amount_cents,
+            :billing_interval_count,
+            :billing_interval_unit,
+            :applied_pricing_unit_conversion_rate,
+            rate_properties: {}
+          )
+        end
+
+        def render_rate(rate)
+          render(json: ::V1::RateCardRateSerializer.new(rate, root_name: "rate"))
+        end
+
+        def resource_name
+          "rate_card"
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/rate_card_rates/update_input.rb
+++ b/app/graphql/types/rate_card_rates/update_input.rb
@@ -10,6 +10,7 @@ module Types
       argument :applied_pricing_unit_conversion_rate, GraphQL::Types::Float, required: false
       argument :billing_interval_count, Integer, required: false
       argument :billing_interval_unit, Types::RateCardRates::BillingIntervalUnitEnum, required: false
+      argument :code, String, required: false
       argument :effective_from, GraphQL::Types::ISO8601DateTime, required: false
       argument :min_amount_cents, GraphQL::Types::BigInt, required: false
       argument :rate_model, Types::RateCardRates::RateModelEnum, required: false

--- a/app/services/rate_card_rates/update_service.rb
+++ b/app/services/rate_card_rates/update_service.rb
@@ -40,6 +40,11 @@ module RateCardRates
         end
       end
 
+      # Code is identity: editable until the card is in a plan or subscription.
+      if params.key?(:code) && params[:code]&.strip != rate_card_rate.code && rate_card_rate.rate_card.attached_to_plan_or_subscription?
+        return result.single_validation_failure!(field: :code, error_code: "attached_to_plan_or_subscription")
+      end
+
       assign_attributes
       rate_card_rate.save!
 
@@ -54,6 +59,7 @@ module RateCardRates
     attr_reader :rate_card_rate, :params
 
     def assign_attributes
+      rate_card_rate.code = params[:code]&.strip if params.key?(:code)
       rate_card_rate.effective_from = params[:effective_from] if params.key?(:effective_from)
       rate_card_rate.rate_model = params[:rate_model] if params.key?(:rate_model)
       rate_card_rate.rate_properties = params[:rate_properties] if params.key?(:rate_properties)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,7 +212,9 @@ Rails.application.routes.draw do
         resources :filters, param: :code, code: /.*/, only: %i[index show create update destroy], controller: "products/filters"
       end
       resources :product_categories, param: :code, code: /.*/, only: %i[index show create update destroy]
-      resources :rate_cards, param: :code, code: /.*/, only: %i[index show create update destroy]
+      resources :rate_cards, param: :code, code: /.*/, only: %i[index show create update destroy] do
+        resources :rates, param: :code, code: /.*/, only: %i[index show create update destroy], controller: "rate_cards/rates"
+      end
     end
   end
   resources :webhooks, only: [] do

--- a/schema.graphql
+++ b/schema.graphql
@@ -14860,6 +14860,7 @@ input UpdateRateCardRateInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  code: String
   effectiveFrom: ISO8601DateTime
   id: ID!
   minAmountCents: BigInt

--- a/schema.json
+++ b/schema.json
@@ -79645,6 +79645,18 @@
               "deprecationReason": null
             },
             {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "effectiveFrom",
               "description": null,
               "type": {

--- a/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::RateCards::RatesController do
+  let(:organization) { create(:organization) }
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  describe "POST /api/v2/rate_cards/:rate_card_id/rates" do
+    subject { post_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}/rates", {rate: create_params}) }
+
+    let(:create_params) do
+      {
+        code: "launch_price",
+        effective_from: 1.month.from_now.iso8601,
+        rate_model: "standard",
+        rate_properties: {amount: "12"},
+        billing_interval_unit: "month"
+      }
+    end
+
+    include_examples "requires API permission", "rate_card", "write"
+
+    it "appends a rate to the rate card" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate][:lago_id]).to be_present
+      expect(json[:rate][:rate_model]).to eq("standard")
+      expect(json[:rate][:status]).to eq("pending")
+    end
+
+    context "when the rate card does not exist" do
+      subject { post_with_token(organization, "/api/v2/rate_cards/unknown/rates", {rate: create_params}) }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("rate_card")
+      end
+    end
+  end
+
+  describe "PUT /api/v2/rate_cards/:rate_card_id/rates/:code" do
+    subject { put_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}/rates/#{rate.code}", {rate: update_params}) }
+
+    let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now) }
+    let(:update_params) { {min_amount_cents: 500} }
+
+    it "updates the pending rate" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate][:min_amount_cents]).to eq(500)
+    end
+
+    context "when the rate does not exist" do
+      subject { put_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}/rates/unknown", {rate: update_params}) }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("rate_card_rate")
+      end
+    end
+  end
+
+  describe "GET /api/v2/rate_cards/:rate_card_id/rates/:code" do
+    subject { get_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}/rates/#{rate.code}") }
+
+    let(:rate) { create(:rate_card_rate, organization:, rate_card:) }
+
+    include_examples "requires API permission", "rate_card", "read"
+
+    it "returns the rate" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate][:lago_id]).to eq(rate.id)
+    end
+  end
+
+  describe "GET /api/v2/rate_cards/:rate_card_id/rates" do
+    subject { get_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}/rates") }
+
+    let!(:rate) { create(:rate_card_rate, organization:, rate_card:) }
+
+    before { create(:rate_card_rate, organization:) }
+
+    include_examples "requires API permission", "rate_card", "read"
+
+    it "returns only the rates of the rate card" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rates].map { it[:lago_id] }).to eq([rate.id])
+    end
+  end
+
+  describe "DELETE /api/v2/rate_cards/:rate_card_id/rates/:code" do
+    subject { delete_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}/rates/#{rate.code}") }
+
+    context "when the rate is pending" do
+      let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now) }
+
+      it "deletes the rate" do
+        expect { subject }.to change { rate.reload.discarded? }.from(false).to(true)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when the rate is active" do
+      let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.day.ago) }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V2::RateCards::RatesController do
     let(:create_params) do
       {
         code: "launch_price",
-        effective_from: 1.month.from_now.beginning_of_day.iso8601,
+        effective_from: 1.month.from_now.to_date.iso8601,
         rate_model: "standard",
         rate_properties: {amount: "12"},
         billing_interval_unit: "month"
@@ -28,6 +28,47 @@ RSpec.describe Api::V2::RateCards::RatesController do
       expect(json[:rate][:lago_id]).to be_present
       expect(json[:rate][:rate_model]).to eq("standard")
       expect(json[:rate][:status]).to eq("pending")
+    end
+
+    it "returns effective_from as a midnight datetime on an arrears card" do
+      subject
+
+      expect(json[:rate][:effective_from]).to eq(1.month.from_now.beginning_of_day.iso8601)
+    end
+
+    context "when an arrears card receives a datetime string" do
+      before { create_params[:effective_from] = "2026-12-01T17:00:00Z" }
+
+      it "canonicalizes it to its day's midnight" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:rate][:effective_from]).to eq("2026-12-01T00:00:00Z")
+      end
+
+      context "when the day already has a rate" do
+        before { create(:rate_card_rate, organization:, rate_card:, effective_from: Time.zone.parse("2026-12-01")) }
+
+        it "returns a value_already_exist error" do
+          subject
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json.dig(:error_details, :effective_from)).to eq(["value_already_exist"])
+        end
+      end
+    end
+
+    context "with an advance card" do
+      let(:rate_card) { create(:rate_card, organization:, billing_timing: "advance") }
+
+      before { create_params[:effective_from] = "2026-12-01T17:00:00Z" }
+
+      it "accepts a datetime and returns it in full" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:rate][:effective_from]).to eq("2026-12-01T17:00:00Z")
+      end
     end
 
     context "when the rate card does not exist" do

--- a/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V2::RateCards::RatesController do
     let(:create_params) do
       {
         code: "launch_price",
-        effective_from: 1.month.from_now.iso8601,
+        effective_from: 1.month.from_now.beginning_of_day.iso8601,
         rate_model: "standard",
         rate_properties: {amount: "12"},
         billing_interval_unit: "month"
@@ -44,7 +44,7 @@ RSpec.describe Api::V2::RateCards::RatesController do
   describe "PUT /api/v2/rate_cards/:rate_card_id/rates/:code" do
     subject { put_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}/rates/#{rate.code}", {rate: update_params}) }
 
-    let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now) }
+    let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day) }
     let(:update_params) { {min_amount_cents: 500} }
 
     it "updates the pending rate" do
@@ -101,7 +101,7 @@ RSpec.describe Api::V2::RateCards::RatesController do
     subject { delete_with_token(organization, "/api/v2/rate_cards/#{rate_card.code}/rates/#{rate.code}") }
 
     context "when the rate is pending" do
-      let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now) }
+      let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day) }
 
       it "deletes the rate" do
         expect { subject }.to change { rate.reload.discarded? }.from(false).to(true)
@@ -110,7 +110,7 @@ RSpec.describe Api::V2::RateCards::RatesController do
     end
 
     context "when the rate is active" do
-      let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.day.ago) }
+      let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.day.ago.beginning_of_day) }
 
       it "returns a validation error" do
         subject

--- a/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
@@ -110,6 +110,17 @@ RSpec.describe Api::V2::RateCards::RatesController do
     let(:rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day) }
     let(:update_params) { {min_amount_cents: 500} }
 
+    context "when updating the code on an unattached card" do
+      let(:update_params) { {code: "renamed"} }
+
+      it "updates the code" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:rate][:code]).to eq("renamed")
+      end
+    end
+
     it "updates the pending rate" do
       subject
 

--- a/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
+++ b/spec/requests/api/v2/rate_cards/rates_controller_spec.rb
@@ -71,6 +71,28 @@ RSpec.describe Api::V2::RateCards::RatesController do
       end
     end
 
+    context "when effective_from is unparseable" do
+      before { create_params[:effective_from] = "hello" }
+
+      it "returns value_is_invalid rather than value_is_mandatory" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :effective_from)).to eq(["value_is_invalid"])
+      end
+    end
+
+    context "when effective_from is omitted" do
+      before { create_params.delete(:effective_from) }
+
+      it "returns value_is_mandatory" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :effective_from)).to eq(["value_is_mandatory"])
+      end
+    end
+
     context "when the rate card does not exist" do
       subject { post_with_token(organization, "/api/v2/rate_cards/unknown/rates", {rate: create_params}) }
 

--- a/spec/services/rate_card_rates/update_service_spec.rb
+++ b/spec/services/rate_card_rates/update_service_spec.rb
@@ -97,6 +97,33 @@ RSpec.describe RateCardRates::UpdateService do
     end
   end
 
+  describe "code editability" do
+    let(:rate_card_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day)
+    end
+    let(:params) { {code: "after"} }
+
+    it "updates the code when the card is not attached" do
+      expect { result }.to change { rate_card_rate.reload.code }.to("after")
+    end
+
+    context "when the card is attached to a plan" do
+      before { create(:plan_rate_card, organization:, rate_card:) }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:code]).to eq(["attached_to_plan_or_subscription"])
+      end
+
+      it "still accepts a payload resending the current code" do
+        update_result = described_class.call(rate_card_rate:, params: {code: rate_card_rate.code, rate_properties: {"amount" => "9"}})
+
+        expect(update_result).to be_success
+        expect(update_result.rate_card_rate.rate_properties).to eq("amount" => "9")
+      end
+    end
+  end
+
   context "when the card is attached to a subscription" do
     let(:params) { {rate_properties: {"amount" => "25"}} }
 


### PR DESCRIPTION
## Description

- Add REST endpoints for the rates on a card: `/api/v2/rate_cards/{code}/rates`.
- Rates are addressed by their own `code`, which is mandatory and caller-provided — no identifiers appear in URLs.
- Appending, updating and deleting a rate respects the append-only timeline: the past is immutable, the future is editable.
