### PR TITLE
feat(products): add the product_catalog flag and example seed

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -37,3 +37,7 @@ multi_connection:
 lazy_charge_usage_cache:
   description: "Validate the charge usage cache lazily at read time (compare cache creation time to the last event) instead of expiring it on every event reception"
   owners: ["@vincent-pochet"]
+
+product_catalog:
+  description: "Use the product catalog (billing v2): product_categories, products, rate cards and plan rate phases"
+  owners: ["@rsempe"]

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -205,6 +205,12 @@ class Organization < ApplicationRecord
     end
   end
 
+  # Product catalog (billing v2) is a rollout feature flag, not a license-gated
+  # premium integration: it is available to any organization, premium or not.
+  def product_catalog_enabled?
+    feature_flag_enabled?(:product_catalog)
+  end
+
   def using_lifetime_usage?
     lifetime_usage_enabled? || progressive_billing_enabled?
   end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -30,6 +30,8 @@ module Plans
         bill_charges_monthly: bill_charges_monthly(args),
         bill_fixed_charges_monthly: bill_fixed_charges_monthly(args)
       )
+      # The pricing type is an organization-level choice, not a per-plan one.
+      plan.pricing_type = "product_catalog" if plan.organization&.product_catalog_enabled?
 
       chargeables_validation_result = Plans::ChargeablesValidationService.call(
         organization: plan.organization,

--- a/db/seeds/30_product_catalog.rb
+++ b/db/seeds/30_product_catalog.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# The product catalog is the v2 billing surface. Seed it on a dedicated
+# organization that has the product_catalog integration enabled, keeping
+# Hooli as the legacy (v1) demo so the two flows never mix.
+gavin = User.find_by!(email: "gavin@hooli.com")
+
+organization = Organization.find_by(name: "Hooli v2") ||
+  Organization.create!(id: "33333333-4444-5555-6666-777777777777", name: "Hooli v2")
+organization.update!(
+  premium_integrations: Organization::PREMIUM_INTEGRATIONS,
+  feature_flags: organization.feature_flags.to_a | ["product_catalog"],
+  invoice_footer: "Hooli v2 is a fictional company on the product catalog."
+)
+
+BillingEntity.find_or_create_by!(organization:, name: "Hooli v2", code: "hooli_v2").update!(
+  email: "gavin@hooli.com",
+  email_settings: BillingEntity::EMAIL_SETTINGS
+)
+
+membership = Membership.find_or_create_by!(user: gavin, organization:)
+MembershipRole.find_or_create_by!(membership:, organization:, role: Role.find_by!(admin: true))
+
+unless organization.api_keys.exists?
+  api_key = organization.api_keys.create!(name: "Hooli v2 Key", permissions: ApiKey.default_permissions)
+  api_key.update_columns(value: "lago_key-hooli-v2-1234567890") # rubocop:disable Rails/SkipsModelValidations
+end
+
+unless ProductCategory.exists?(organization:, code: "cloud_platform")
+  # A billable metric with a filter, to back a usage product and a product filter.
+  api_calls_bm = BillableMetric.find_by(organization:, code: "catalog_api_calls") ||
+    BillableMetrics::CreateService.call!(
+      organization_id: organization.id,
+      name: "API calls",
+      aggregation_type: "count_agg",
+      code: "catalog_api_calls",
+      filters: [{key: "region", values: %w[us eu]}]
+    ).billable_metric
+
+  region_filter = api_calls_bm.filters.find_by(key: "region")
+
+  product_category = ProductCategories::CreateService.call!(
+    organization:,
+    params: {
+      name: "Cloud Platform",
+      code: "cloud_platform",
+      description: "Seeded product catalog example"
+    }
+  ).product_category
+
+  usage_item = Products::CreateService.call!(
+    organization:,
+    params: {
+      name: "API calls",
+      code: "api_calls",
+      product_type: "usage",
+      product_category_id: product_category.id,
+      billable_metric_id: api_calls_bm.id
+    }
+  ).product
+
+  Products::CreateService.call!(
+    organization:,
+    params: {
+      name: "Platform fee",
+      code: "platform_fee",
+      product_type: "fixed",
+      product_category_id: product_category.id
+    }
+  )
+
+  ProductFilters::CreateService.call!(
+    product: usage_item,
+    params: {
+      name: "EU traffic",
+      code: "eu_traffic",
+      values: [{billable_metric_filter_id: region_filter.id, value: "eu"}]
+    }
+  )
+
+  rate_card = RateCards::CreateService.call!(
+    product: usage_item,
+    params: {
+      name: "Standard USD",
+      code: "standard_usd",
+      currency: "USD"
+    }
+  ).rate_card
+
+  RateCardRates::CreateService.call!(
+    rate_card:,
+    params: {
+      code: "rate_1",
+      effective_datetime: 1.month.ago,
+      rate_model: "standard",
+      rate_properties: {amount: "0.01"},
+      billing_interval_unit: "month"
+    }
+  )
+end

--- a/db/seeds/30_product_catalog.rb
+++ b/db/seeds/30_product_catalog.rb
@@ -97,4 +97,17 @@ unless ProductCategory.exists?(organization:, code: "cloud_platform")
       billing_interval_unit: "month"
     }
   )
+
+  # Assign the rate card to a plan so the catalog is wired into an offer.
+  plan = Plans::CreateService.call!({
+    organization_id: organization.id,
+    name: "Growth",
+    code: "growth",
+    amount_currency: "USD"
+  }).plan
+
+  PlanRateCards::CreateService.call!(
+    plan:,
+    params: {rate_card_code: rate_card.code}
+  )
 end

--- a/db/seeds/30_product_catalog.rb
+++ b/db/seeds/30_product_catalog.rb
@@ -91,7 +91,7 @@ unless ProductCategory.exists?(organization:, code: "cloud_platform")
     rate_card:,
     params: {
       code: "rate_1",
-      effective_datetime: 1.month.ago,
+      effective_from: 1.month.ago.beginning_of_day,
       rate_model: "standard",
       rate_properties: {amount: "0.01"},
       billing_interval_unit: "month"

--- a/schema.graphql
+++ b/schema.graphql
@@ -6437,6 +6437,7 @@ enum FeatureFlagEnum {
   order_forms
   payment_gated_subscriptions
   postgres_enriched_events
+  product_catalog
   stripe_shared_payment_token
   wallet_traceability
 }

--- a/schema.json
+++ b/schema.json
@@ -31120,6 +31120,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "product_catalog",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe Api::V1::PlansController do
       end
     end
 
+    context "when the organization uses the product catalog" do
+      let(:create_params) do
+        {
+          name: "Data Growth",
+          code: "data_growth",
+          amount_currency: "USD"
+        }
+      end
+
+      before { organization.enable_feature_flag!(:product_catalog) }
+
+      it "creates a product_catalog plan without the legacy billing fields" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:plan][:lago_id]).to be_present
+        expect(json[:plan][:code]).to eq("data_growth")
+      end
+    end
+
     context "when interval is present" do
       let(:interval) { "weekly" }
 

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -959,4 +959,24 @@ RSpec.describe Plans::CreateService do
       end
     end
   end
+
+  context "when the organization uses the product catalog" do
+    let(:create_args) do
+      {
+        organization_id: organization.id,
+        name: "Catalog plan",
+        code: "catalog_plan",
+        amount_currency: "USD"
+      }
+    end
+
+    before { organization.enable_feature_flag!(:product_catalog) }
+
+    it "creates a product_catalog plan without plan-level billing fields" do
+      result = plans_service.call
+
+      expect(result).to be_success
+      expect(result.plan).to have_attributes(pricing_type: "product_catalog", interval: nil, amount_cents: nil)
+    end
+  end
 end


### PR DESCRIPTION
## Context

The catalog is gated per organization by the `product_catalog` feature flag, and needs demo data to develop and QA against.

## Description

- Add the `product_catalog` feature flag. It is a rollout flag, not a premium integration, so it is available to any organization.
- Seed an example catalog on a dedicated v2 organization (Hooli v2), keeping the legacy Hooli demo untouched so the two pricing engines never mix.
- Seed a plan with an assigned product so the catalog is wired into a sellable offer.
