### PR TITLE
perf(features): Speed up and preload `subscriptions_count` calculations

### DIFF
--- a/app/graphql/resolvers/entitlement/features_resolver.rb
+++ b/app/graphql/resolvers/entitlement/features_resolver.rb
@@ -26,7 +26,10 @@ module Resolvers
           }
         )
 
-        result.features.includes(:privileges)
+        ::Entitlement::Feature.preload_subscriptions_count(
+          current_organization,
+          result.features.includes(:privileges)
+        )
       end
     end
   end

--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -18,13 +18,32 @@ module Entitlement
     validates :name, length: {maximum: 255}
     validates :description, length: {maximum: 600}
 
+    attr_writer :subscriptions_count
+
     def self.ransackable_attributes(_auth_object = nil)
       %w[code name description]
     end
 
     def subscriptions_count
+      return @subscriptions_count if defined?(@subscriptions_count)
+
       base_scope = Subscription.joins(:plan).where(status: [:active, :pending])
       base_scope.where(plan: plans).or(base_scope.where(plan: {parent: plans})).count
+    end
+
+    def self.preload_subscriptions_count(organization, features)
+      subscriptions_count = SubscriptionsCountQuery.call(
+        organization:,
+        filters: {
+          feature_ids: features.map(&:id)
+        }
+      )
+
+      features.each do |feature|
+        feature.subscriptions_count = subscriptions_count[feature.id] || 0
+      end
+
+      features
     end
   end
 end

--- a/app/queries/entitlement/feature/subscriptions_count_query.rb
+++ b/app/queries/entitlement/feature/subscriptions_count_query.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Entitlement
+  class Feature
+    class SubscriptionsCountQuery < BaseQuery
+      Result = BaseResult[:features]
+      Filters = BaseFilters[:feature_ids]
+
+      def call
+        result = ActiveRecord::Base.connection.exec_query(
+          subscriptions_count_query
+        )
+
+        result.each_with_object({}) do |row, hash|
+          hash[row["feature_id"]] = row["count"]
+        end
+      end
+
+      private
+
+      def subscriptions_count_query
+        ActiveRecord::Base.sanitize_sql_array([
+          subscriptions_count_sql,
+          filters.feature_ids,
+          organization.id
+        ])
+      end
+
+      def subscriptions_count_sql
+        <<~SQL
+          WITH
+            plan_features AS (
+              SELECT
+                plan_id,
+                entitlement_feature_id
+              FROM
+                entitlement_entitlements
+              WHERE
+                plan_id IS NOT NULL
+                AND entitlement_feature_id IN (?)
+            ),
+            plan_subscriptions AS (
+              SELECT
+                coalesce(plans.parent_id, plan_id) AS plan_id,
+                count(*)
+              FROM
+                subscriptions
+                INNER JOIN plans ON plans.id = subscriptions.plan_id
+              WHERE
+                plans.deleted_at IS NULL
+                AND plans.organization_id = ?
+                AND subscriptions.status IN (0, 1)
+              GROUP BY
+                coalesce(plans.parent_id, plan_id)
+            )
+          SELECT
+            plan_features.entitlement_feature_id AS feature_id,
+            SUM(plan_subscriptions.count) AS count
+          FROM
+            plan_features
+            INNER JOIN plan_subscriptions ON plan_features.plan_id = plan_subscriptions.plan_id
+          GROUP BY
+            plan_features.entitlement_feature_id
+        SQL
+      end
+    end
+  end
+end

--- a/spec/models/entitlement/feature_spec.rb
+++ b/spec/models/entitlement/feature_spec.rb
@@ -27,19 +27,60 @@ RSpec.describe Entitlement::Feature do
   end
 
   describe "#subscriptions_count" do
-    it "returns the number of subscriptions" do
-      expect(subject.subscriptions_count).to eq(0)
-      entitlement = create(:entitlement, feature: subject)
-      create(:subscription, plan: entitlement.plan)
-      create(:subscription, :pending, plan: entitlement.plan)
-      create(:subscription, :terminated, plan: entitlement.plan)
-      create(:subscription, :canceled, plan: entitlement.plan)
-      expect(subject.subscriptions_count).to eq(2)
-      create(:subscription, plan: create(:plan, parent: entitlement.plan))
-      create(:subscription, :pending, plan: create(:plan, parent: entitlement.plan))
-      create(:subscription, :terminated, plan: create(:plan, parent: entitlement.plan))
-      create(:subscription, :canceled, plan: create(:plan, parent: entitlement.plan))
-      expect(subject.subscriptions_count).to eq(4)
+    context "when subscriptions_count is not preloaded" do
+      it "calculates the number of subscriptions" do
+        expect(subject.subscriptions_count).to eq(0)
+        entitlement = create(:entitlement, feature: subject)
+        create(:subscription, plan: entitlement.plan)
+        create(:subscription, :pending, plan: entitlement.plan)
+        create(:subscription, :terminated, plan: entitlement.plan)
+        create(:subscription, :canceled, plan: entitlement.plan)
+        expect(subject.subscriptions_count).to eq(2)
+        create(:subscription, plan: create(:plan, parent: entitlement.plan))
+        create(:subscription, :pending, plan: create(:plan, parent: entitlement.plan))
+        create(:subscription, :terminated, plan: create(:plan, parent: entitlement.plan))
+        create(:subscription, :canceled, plan: create(:plan, parent: entitlement.plan))
+        expect(subject.subscriptions_count).to eq(4)
+      end
+    end
+
+    context "when subscriptions_count is preloaded" do
+      before { subject.subscriptions_count = 100 }
+
+      it "returns the preloaded value" do
+        expect(subject.subscriptions_count).to eq(100)
+      end
+    end
+  end
+
+  describe ".preload_subscriptions_count" do
+    subject { described_class.preload_subscriptions_count(organization, features) }
+
+    let(:organization) { build(:organization) }
+
+    let(:feature1) { build_stubbed(:feature, organization:) }
+    let(:feature2) { build_stubbed(:feature, organization:) }
+    let(:feature3) { build_stubbed(:feature, organization:) }
+
+    let(:features) { [feature1, feature2, feature3] }
+
+    let(:subscriptions_count) do
+      {
+        feature2.id => 5,
+        feature3.id => 10
+      }
+    end
+
+    before do
+      allow(Entitlement::Feature::SubscriptionsCountQuery).to receive(:call).and_return(subscriptions_count)
+    end
+
+    it "preloads subscriptions_count values and sets them to features" do
+      subject
+
+      expect(feature1.subscriptions_count).to eq(0)
+      expect(feature2.subscriptions_count).to eq(5)
+      expect(feature3.subscriptions_count).to eq(10)
     end
   end
 end

--- a/spec/queries/entitlement/feature/subscriptions_count_query_spec.rb
+++ b/spec/queries/entitlement/feature/subscriptions_count_query_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Entitlement::Feature::SubscriptionsCountQuery do
+  subject { described_class.new(organization:, filters: {feature_ids:}) }
+
+  let(:organization) { create(:organization) }
+
+  let(:empty_plan) { create(:plan, organization:) }
+  let(:plan1) { create(:plan, organization:) }
+  let(:plan2) { create(:plan, organization:) }
+  let(:plan3) { create(:plan, organization:, parent: plan2) }
+
+  let(:feature1) { create(:feature, organization:) }
+  let(:feature2) { create(:feature, organization:) }
+  let(:feature3) { create(:feature, organization:) }
+  let(:feature4) { create(:feature, organization:) }
+  let(:feature5) { create(:feature, organization:) }
+
+  let(:feature_ids) do
+    [
+      feature1.id,
+      feature2.id,
+      feature3.id,
+      feature4.id,
+      feature5.id
+    ]
+  end
+
+  before do
+    create(:subscription, organization:, plan: plan1)
+    create(:subscription, :pending, organization:, plan: plan1)
+    create(:subscription, :terminated, organization:, plan: plan1)
+
+    create(:subscription, organization:, plan: plan2)
+    create(:subscription, :pending, organization:, plan: plan2)
+    create(:subscription, :canceled, organization:, plan: plan2)
+
+    create(:subscription, organization:, plan: plan3)
+    create(:subscription, :incomplete, organization:, plan: plan3)
+
+    create(:entitlement, organization:, feature: feature2, plan: empty_plan)
+    create(:entitlement, organization:, feature: feature3, plan: plan1)
+    create(:entitlement, organization:, feature: feature4, plan: plan2)
+    create(:entitlement, organization:, feature: feature5, plan: plan1)
+    create(:entitlement, organization:, feature: feature5, plan: plan2)
+  end
+
+  describe "#call" do
+    it "returns features subscriptions_count" do
+      result = subject.call
+
+      expect(result).to eq({
+        feature3.id => 2,
+        feature4.id => 3,
+        feature5.id => 5
+      })
+    end
+  end
+end


### PR DESCRIPTION
## Context

The Features page shows a `subscriptions_count` for each feature. Right now, each count query takes around 1–2 seconds on a large database with millions of subscriptions and entitlements. Since we run this calculation for every feature, the page can take 30+ seconds to load and often times out.

Currently, when calculating `subscriptions_count` for a feature, we filter subscriptions using two subqueries that check whether a subscription belongs to a plan that has the feature assigned.

```sql
SELECT
	COUNT(*)
FROM
	"subscriptions"
	INNER JOIN "plans" ON "plans"."id" = "subscriptions"."plan_id"
WHERE
	"subscriptions"."status" IN (0, 1)
	AND (
		"subscriptions"."plan_id" IN (
			SELECT
				"plans"."id"
			FROM
				"plans"
				INNER JOIN "entitlement_entitlements" ON "plans"."id" = "entitlement_entitlements"."plan_id"
			WHERE
				"plans"."deleted_at" IS NULL
				AND "entitlement_entitlements"."deleted_at" IS NULL
				AND "entitlement_entitlements"."entitlement_feature_id" = '15cf9f71-b7e8-418c-8c11-ce375c41ca46'
		)
		OR "plans"."parent_id" IN (
			SELECT
				"plans"."id"
			FROM
				"plans"
				INNER JOIN "entitlement_entitlements" ON "plans"."id" = "entitlement_entitlements"."plan_id"
			WHERE
				"plans"."deleted_at" IS NULL
				AND "entitlement_entitlements"."deleted_at" IS NULL
				AND "entitlement_entitlements"."entitlement_feature_id" = '15cf9f71-b7e8-418c-8c11-ce375c41ca46'
		)
	)
```

## Description

Instead, we can simplify the calculation into three steps and write a simple query for each of them:

* For each feature:
  * find all plans that have the feature assigned
   ```sql
	plan_features AS (
  		SELECT
			plan_id,
			entitlement_feature_id
		FROM
			entitlement_entitlements
		WHERE
			plan_id IS NOT NULL
			AND entitlement_feature_id IN (?)
	)
  ```
  * calculate the subscription count for each of those plans
  ```sql
	plan_subscriptions AS (
		SELECT
			coalesce(plans.parent_id, plan_id) AS plan_id,
			count(*)
		FROM
			subscriptions
			INNER JOIN plans ON plans.id = subscriptions.plan_id
		WHERE
			plans.deleted_at IS NULL
			AND plans.organization_id = ?
			AND subscriptions.status IN (0, 1)
		GROUP BY
			coalesce(plans.parent_id, plan_id)
 	 )
  ```
  * sum the counts to get the total subscription count for the feature
  ```sql
	SELECT
		plan_features.entitlement_feature_id AS feature_id,
		sum(plan_subscriptions.count) AS count
	FROM
		plan_features
		INNER JOIN plan_subscriptions ON plan_features.plan_id = plan_subscriptions.plan_id
	GROUP BY
		plan_features.entitlement_feature_id
  ```

This lets us calculate all feature counts in a single query that relies mostly on indexes and avoids scanning large subscriptions tables repeatedly.

<details>
<summary>Query Plan</summary>

```sql
GroupAggregate  (cost=451944.03..451944.05 rows=1 width=48) (actual time=1884.442..1884.669)
  Group Key: entitlement_entitlements.entitlement_feature_id
    ->  Sort  (cost=451944.03..451944.03 rows=1 width=24) (actual time=1884.429..1884.627)
      Sort Key: entitlement_entitlements.entitlement_feature_id
      Sort Method: quicksort
      ->  Merge Join  (cost=451519.97..451944.02 rows=1 width=24) (actual time=1421.589..1884.553)
        Merge Cond: (entitlement_entitlements.plan_id = (COALESCE(plans.parent_id, subscriptions.plan_id)))
        ->  Index Scan using index_entitlement_entitlements_on_plan_id on entitlement_entitlements  (cost=0.49..125.81 rows=714 width=32) (actual time=0.028..0.659)
          Index Cond: (plan_id IS NOT NULL)
          Filter: (entitlement_feature_id = ANY ('{...}'::uuid[]))
        ->  Finalize GroupAggregate  (cost=451519.48..451780.00 rows=2913 width=24) (actual time=1421.558..1883.842)
          Group Key: (COALESCE(plans.parent_id, subscriptions.plan_id))
          ->  Gather Merge  (cost=451519.48..451742.30 rows=1714 width=24) (actual time=1421.555..1883.830)
            Workers Planned: 1
            Workers Launched: 1
            ->  Partial GroupAggregate  (cost=450519.47..450549.47 rows=1714 width=24) (actual time=726.367..959.268)
              Group Key: (COALESCE(plans.parent_id, subscriptions.plan_id))
              ->  Sort  (cost=450519.47..450523.76 rows=1714 width=16) (actual time=726.267..845.725)
                Sort Key: (COALESCE(plans.parent_id, subscriptions.plan_id))
                Sort Method: external merge 
                Worker 0:  Sort Method: quicksort
                ->  Nested Loop  (cost=18.93..450427.41 rows=1714 width=16) (actual time=0.302..503.999)
                  ->  Parallel Bitmap Heap Scan on plans  (cost=18.49..4534.73 rows=744 width=32) (actual time=0.193..0.998)
                    Recheck Cond: (organization_id = 'organization-id'::uuid)
                    Filter: (deleted_at IS NULL)
                    ->  Bitmap Index Scan on index_plans_on_organization_id  (cost=0.00..18.18 rows=1300 width=0) (actual time=0.271..0.271)
                      Index Cond: (organization_id = 'organization-id'::uuid)
                  ->  Index Only Scan using index_pending_active_subscriptions_on_plan_id_and_status on subscriptions  (cost=0.43..586.85 rows=1247 width=16) (actual time=0.010..0.410)
                    Index Cond: (plan_id = plans.id)
Planning Time: 12.376 ms
Execution Time: 1907.438 ms
```

</details>

### Plan Overrides

For subscriptions with an overridden plan, entitlements are still defined on the parent plan. Because of that, the plan subscription count calculation attributes subscriptions with overridden plans to their parent plan.

```sql
coalesce(plans.parent_id, plan_id) AS plan_id
```

### Note

`subscriptions_count` currently does not include subscriptions that have entitlement features assigned directly to them. This PR does not address that behavior; support for those subscriptions will be added in a follow-up PR.

## Benchmarks

Here are some benchmarks *before* with 20 separate queries and *after* with one query.

Benchmarking was done with `pgbench` on a database containing **~2.5m** subscriptions and **~4m** entitlements. The benchmark used 10 clients and 5 threads, ran for 30 seconds against a warmed-up database. 

```
pgbench --protocol=prepared -c 10 -j 5 -T 30 -h localhost -U lago -d lago -n -f count.sql
```

Solution | TPS | Latency (ms)
-- | -- | --
before (20 separate queries) | 0.35 | 28173.5
after (1 query) | 19.71 | 507.277