### PR TITLE
feat(multi-entity): add logic to handle eu taxes when billing entity changes

### DIFF
--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -97,8 +97,10 @@ module Customers
       #       external_id,
       #       account_type,
       #       billing_entity_id (gated by editable? unless multi_entity_billing flag is enabled)
+      billing_entity_changed = false
       if args.key?(:billing_entity_code) && allow_billing_entity_update?
         customer.billing_entity = billing_entity
+        billing_entity_changed = customer.billing_entity_id_changed?
       end
 
       if customer.editable?
@@ -148,15 +150,25 @@ module Customers
         customer.error_details.tax_error.delete_all if @address_changed
         customer.reload
 
+        tax_attributes_changed = original_tax_values.any? { |key, value| args.key?(key) && args[key] != value }
+
         eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: false,
-          tax_attributes_changed: original_tax_values.any? { |key, value| args.key?(key) && args[key] != value }
+          tax_attributes_changed: tax_attributes_changed || billing_entity_changed
         )
 
         if eu_tax_code_result.success?
           args[:tax_codes] ||= []
           args[:tax_codes] = (args[:tax_codes] + [eu_tax_code_result.tax_code]).uniq
+        end
+
+        # NOTE: EU-managed taxes (lago_eu_*) belong to the previous billing entity. When the
+        #       billing entity changes and no new EU tax applies (new entity does not manage
+        #       EU taxes, or a VIES check is still pending), reset them so the customer falls
+        #       back to the new billing entity's taxes.
+        if billing_entity_changed && args[:tax_codes].nil?
+          args[:tax_codes] = customer.taxes.where.not("code ILIKE ?", "lago_eu%").pluck(:code)
         end
 
         if args[:tax_codes]

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -46,8 +46,10 @@ module Customers
       ActiveRecord::Base.transaction do
         original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
 
+        billing_entity_changed = false
         if new_customer || (params.key?(:billing_entity_code) && allow_billing_entity_update?(customer))
           customer.billing_entity = billing_entity
+          billing_entity_changed = !new_customer && customer.billing_entity_id_changed?
         end
         customer.name = params[:name] if params.key?(:name)
         customer.country = params[:country]&.upcase if params.key?(:country)
@@ -96,15 +98,25 @@ module Customers
         customer.save!
         customer.error_details.tax_error.delete_all if address_changed
 
+        tax_attributes_changed = original_tax_values.any? { |key, value| params.key?(key) && params[key] != value }
+
         eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: new_customer,
-          tax_attributes_changed: original_tax_values.any? { |key, value| params.key?(key) && params[key] != value }
+          tax_attributes_changed: tax_attributes_changed || billing_entity_changed
         )
 
         if eu_tax_code_result.success?
           params[:tax_codes] ||= []
           params[:tax_codes] = (params[:tax_codes] + [eu_tax_code_result.tax_code]).uniq
+        end
+
+        # NOTE: EU-managed taxes (lago_eu_*) belong to the previous billing entity. When the
+        #       billing entity changes and no new EU tax applies (new entity does not manage
+        #       EU taxes, or a VIES check is still pending), reset them so the customer falls
+        #       back to the new billing entity's taxes.
+        if billing_entity_changed && !params.key?(:tax_codes)
+          params[:tax_codes] = customer.taxes.where.not("code ILIKE ?", "lago_eu%").pluck(:code)
         end
 
         if params.key?(:tax_codes)

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -632,6 +632,101 @@ RSpec.describe Customers::UpdateService do
       end
     end
 
+    context "when the billing entity changes and entities have different EU tax settings" do
+      let(:eu_billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: true) }
+      let(:other_eu_billing_entity) { create(:billing_entity, organization:, country: "DE", eu_tax_management: true) }
+      let(:non_eu_billing_entity) { create(:billing_entity, organization:, country: "US", eu_tax_management: false) }
+
+      let(:fr_tax) { create(:tax, organization:, code: "lago_eu_fr_standard", rate: 20.0) }
+      let(:de_tax) { create(:tax, organization:, code: "lago_eu_de_standard", rate: 19.0) }
+
+      let(:customer) { create(:customer, organization:, billing_entity: source_billing_entity, country: nil, zipcode: nil) }
+
+      let(:update_args) { {id: customer.id, billing_entity_code: target_billing_entity.code} }
+
+      before do
+        fr_tax
+        de_tax
+        create(:customer_applied_tax, organization:, customer:, tax: applied_tax) if applied_tax
+      end
+
+      context "when moving from an EU entity to a non-EU entity" do
+        let(:source_billing_entity) { eu_billing_entity }
+        let(:target_billing_entity) { non_eu_billing_entity }
+        let(:applied_tax) { fr_tax }
+
+        it "resets the EU tax so the customer falls back to the billing entity" do
+          result = customers_service.call
+
+          expect(result).to be_success
+          expect(result.customer.billing_entity).to eq(non_eu_billing_entity)
+          expect(result.customer.taxes).to eq([])
+        end
+      end
+
+      context "when moving from a non-EU entity to an EU entity" do
+        let(:source_billing_entity) { non_eu_billing_entity }
+        let(:target_billing_entity) { eu_billing_entity }
+        let(:applied_tax) { nil }
+
+        it "assigns the new billing entity EU tax" do
+          result = customers_service.call
+
+          expect(result).to be_success
+          expect(result.customer.billing_entity).to eq(eu_billing_entity)
+          expect(result.customer.taxes.pluck(:code)).to eq(["lago_eu_fr_standard"])
+        end
+      end
+
+      context "when moving between two EU entities in different countries" do
+        let(:source_billing_entity) { eu_billing_entity }
+        let(:target_billing_entity) { other_eu_billing_entity }
+        let(:applied_tax) { fr_tax }
+
+        it "re-evaluates the EU tax against the new billing entity" do
+          result = customers_service.call
+
+          expect(result).to be_success
+          expect(result.customer.billing_entity).to eq(other_eu_billing_entity)
+          expect(result.customer.taxes.pluck(:code)).to eq(["lago_eu_de_standard"])
+        end
+      end
+
+      context "when the new EU entity requires a VIES check" do
+        let(:source_billing_entity) { eu_billing_entity }
+        let(:target_billing_entity) { other_eu_billing_entity }
+        let(:applied_tax) { fr_tax }
+
+        let(:customer) do
+          create(:customer, organization:, billing_entity: source_billing_entity, country: nil, zipcode: nil, tax_identification_number: "FR123456789")
+        end
+
+        it "resets the EU tax and schedules a VIES check for the new billing entity" do
+          result = customers_service.call
+
+          expect(result).to be_success
+          expect(result.customer.taxes).to eq([])
+          expect(customer.reload.pending_vies_check).to have_attributes(
+            billing_entity: other_eu_billing_entity,
+            tax_identification_number: "FR123456789"
+          )
+        end
+      end
+
+      context "when the billing entity does not change" do
+        let(:source_billing_entity) { eu_billing_entity }
+        let(:target_billing_entity) { eu_billing_entity }
+        let(:applied_tax) { fr_tax }
+
+        it "keeps the existing customer tax" do
+          result = customers_service.call
+
+          expect(result).to be_success
+          expect(result.customer.taxes.pluck(:code)).to eq(["lago_eu_fr_standard"])
+        end
+      end
+    end
+
     context "when dunning campaign data is provided" do
       let(:customer) do
         create(

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -313,6 +313,49 @@ RSpec.describe Customers::UpsertFromApiService do
     end
   end
 
+  context "when the billing entity changes and entities have different EU tax settings" do
+    let(:eu_billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: true) }
+    let(:non_eu_billing_entity) { create(:billing_entity, organization:, country: "US", eu_tax_management: false) }
+
+    let(:fr_tax) { create(:tax, organization:, code: "lago_eu_fr_standard", rate: 20.0) }
+
+    let(:customer) do
+      create(:customer, organization:, external_id:, billing_entity: source_billing_entity, country: nil, zipcode: nil, tax_identification_number: nil)
+    end
+
+    let(:create_args) { {external_id:, billing_entity_code: target_billing_entity.code} }
+
+    before do
+      fr_tax
+      customer
+      create(:customer_applied_tax, organization:, customer:, tax: fr_tax) if applied_tax
+    end
+
+    context "when moving from an EU entity to a non-EU entity" do
+      let(:source_billing_entity) { eu_billing_entity }
+      let(:target_billing_entity) { non_eu_billing_entity }
+      let(:applied_tax) { true }
+
+      it "resets the EU tax so the customer falls back to the billing entity" do
+        expect(result).to be_success
+        expect(result.customer.billing_entity).to eq(non_eu_billing_entity)
+        expect(result.customer.taxes).to eq([])
+      end
+    end
+
+    context "when moving from a non-EU entity to an EU entity" do
+      let(:source_billing_entity) { non_eu_billing_entity }
+      let(:target_billing_entity) { eu_billing_entity }
+      let(:applied_tax) { false }
+
+      it "assigns the new billing entity EU tax" do
+        expect(result).to be_success
+        expect(result.customer.billing_entity).to eq(eu_billing_entity)
+        expect(result.customer.taxes.pluck(:code)).to eq(["lago_eu_fr_standard"])
+      end
+    end
+  end
+
   context "with customer_type" do
     let(:create_args) do
       {

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -315,9 +315,11 @@ RSpec.describe Customers::UpsertFromApiService do
 
   context "when the billing entity changes and entities have different EU tax settings" do
     let(:eu_billing_entity) { create(:billing_entity, organization:, country: "FR", eu_tax_management: true) }
+    let(:other_eu_billing_entity) { create(:billing_entity, organization:, country: "DE", eu_tax_management: true) }
     let(:non_eu_billing_entity) { create(:billing_entity, organization:, country: "US", eu_tax_management: false) }
 
     let(:fr_tax) { create(:tax, organization:, code: "lago_eu_fr_standard", rate: 20.0) }
+    let(:de_tax) { create(:tax, organization:, code: "lago_eu_de_standard", rate: 19.0) }
 
     let(:customer) do
       create(:customer, organization:, external_id:, billing_entity: source_billing_entity, country: nil, zipcode: nil, tax_identification_number: nil)
@@ -327,14 +329,15 @@ RSpec.describe Customers::UpsertFromApiService do
 
     before do
       fr_tax
+      de_tax
       customer
-      create(:customer_applied_tax, organization:, customer:, tax: fr_tax) if applied_tax
+      create(:customer_applied_tax, organization:, customer:, tax: applied_tax) if applied_tax
     end
 
     context "when moving from an EU entity to a non-EU entity" do
       let(:source_billing_entity) { eu_billing_entity }
       let(:target_billing_entity) { non_eu_billing_entity }
-      let(:applied_tax) { true }
+      let(:applied_tax) { fr_tax }
 
       it "resets the EU tax so the customer falls back to the billing entity" do
         expect(result).to be_success
@@ -346,11 +349,53 @@ RSpec.describe Customers::UpsertFromApiService do
     context "when moving from a non-EU entity to an EU entity" do
       let(:source_billing_entity) { non_eu_billing_entity }
       let(:target_billing_entity) { eu_billing_entity }
-      let(:applied_tax) { false }
+      let(:applied_tax) { nil }
 
       it "assigns the new billing entity EU tax" do
         expect(result).to be_success
         expect(result.customer.billing_entity).to eq(eu_billing_entity)
+        expect(result.customer.taxes.pluck(:code)).to eq(["lago_eu_fr_standard"])
+      end
+    end
+
+    context "when moving between two EU entities in different countries" do
+      let(:source_billing_entity) { eu_billing_entity }
+      let(:target_billing_entity) { other_eu_billing_entity }
+      let(:applied_tax) { fr_tax }
+
+      it "re-evaluates the EU tax against the new billing entity" do
+        expect(result).to be_success
+        expect(result.customer.billing_entity).to eq(other_eu_billing_entity)
+        expect(result.customer.taxes.pluck(:code)).to eq(["lago_eu_de_standard"])
+      end
+    end
+
+    context "when the new EU entity requires a VIES check" do
+      let(:source_billing_entity) { eu_billing_entity }
+      let(:target_billing_entity) { other_eu_billing_entity }
+      let(:applied_tax) { fr_tax }
+
+      let(:customer) do
+        create(:customer, organization:, external_id:, billing_entity: source_billing_entity, country: nil, zipcode: nil, tax_identification_number: "FR123456789")
+      end
+
+      it "resets the EU tax and schedules a VIES check for the new billing entity" do
+        expect(result).to be_success
+        expect(result.customer.taxes).to eq([])
+        expect(result.customer.pending_vies_check).to have_attributes(
+          billing_entity: other_eu_billing_entity,
+          tax_identification_number: "FR123456789"
+        )
+      end
+    end
+
+    context "when the billing entity does not change" do
+      let(:source_billing_entity) { eu_billing_entity }
+      let(:target_billing_entity) { eu_billing_entity }
+      let(:applied_tax) { fr_tax }
+
+      it "keeps the existing customer tax" do
+        expect(result).to be_success
         expect(result.customer.taxes.pluck(:code)).to eq(["lago_eu_fr_standard"])
       end
     end


### PR DESCRIPTION
## Context
Currently, it is possible to attach multiple billing entities to a customer. That said, a customer can have different billing entities assigned to different billing objects.

## Description
This PR handles the case when a customer's billing entity changes, which relates to the EU tax management system. In that case, we should either remove the old taxes from the customer (if the new billing entity is not EU-related) or recompute the taxes.