### PR TITLE
fix(payment-gated-subs): Restrict subscription termination when next subscription is incomplete and upgrade flag is false

### DIFF
--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -16,8 +16,8 @@ module Subscriptions
 
     def call
       return result.not_found_failure!(resource: "subscription") if subscription.blank?
-      return result.not_allowed_failure!(code: "subscription_incomplete") if subscription.incomplete?
-      return result.not_allowed_failure!(code: "next_subscription_incomplete") if !upgrade && subscription.next_subscription&.incomplete?
+      return result.single_validation_failure!(error_code: "subscription_incomplete") if subscription.incomplete?
+      return result.single_validation_failure!(error_code: "next_subscription_incomplete") if !upgrade && subscription.next_subscription&.incomplete?
 
       ActiveRecord::Base.transaction do
         if subscription.pending?

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -17,6 +17,7 @@ module Subscriptions
     def call
       return result.not_found_failure!(resource: "subscription") if subscription.blank?
       return result.not_allowed_failure!(code: "subscription_incomplete") if subscription.incomplete?
+      return result.not_allowed_failure!(code: "next_subscription_incomplete") if !upgrade && subscription.next_subscription&.incomplete?
 
       ActiveRecord::Base.transaction do
         if subscription.pending?

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -144,6 +144,39 @@ RSpec.describe Subscriptions::TerminateService do
       end
     end
 
+    context "when incomplete next subscription" do
+      let(:subscription) { create(:subscription) }
+      let(:next_subscription) do
+        create(
+          :subscription,
+          previous_subscription: subscription,
+          status: :incomplete
+        )
+      end
+
+      before { next_subscription }
+
+      it "returns a not allowed error" do
+        subject
+
+        expect(result).to be_failure
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("next_subscription_incomplete")
+      end
+
+      context "when called with upgrade: true" do
+        subject(:result) { described_class.call(subscription:, on_termination_credit_note:, upgrade: true) }
+
+        it "terminates the subscription and leaves the next subscription untouched" do
+          subject
+
+          expect(result).to be_success
+          expect(subscription.reload).to be_terminated
+          expect(next_subscription.reload).to be_incomplete
+        end
+      end
+    end
+
     context "when subscription was paid in advance" do
       let(:plan) { create(:plan, :pay_in_advance) }
       let(:subscription) do

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe Subscriptions::TerminateService do
     context "when subscription is incomplete" do
       let(:subscription) { create(:subscription, :incomplete) }
 
-      it "returns a not allowed error" do
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("subscription_incomplete")
+      it "returns a validation error" do
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({base: ["subscription_incomplete"]})
       end
     end
 
@@ -156,12 +156,12 @@ RSpec.describe Subscriptions::TerminateService do
 
       before { next_subscription }
 
-      it "returns a not allowed error" do
+      it "returns a validation error" do
         subject
 
         expect(result).to be_failure
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("next_subscription_incomplete")
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({base: ["next_subscription_incomplete"]})
       end
 
       context "when called with upgrade: true" do


### PR DESCRIPTION
## Context

`Subscriptions::TerminateService` terminated a subscription even when it had a `next_subscription` still in the `incomplete` state, silently canceling that scheduled change while it was awaiting payment/activation.

## Description

Reject the termination up front with a `not_allowed_failure` (code `next_subscription_incomplete`) when the subscription has an incomplete `next_subscription`. The check is skipped on the upgrade path, where the incoming subscription is the `next_subscription` and is expected to be incomplete.
