### PR TITLE
feat(fc-units-override): promote sub-level overrides on plan-overridefallthrough

### DIFF
--- a/app/services/subscriptions/concerns/fixed_charge_units_override_detection_concern.rb
+++ b/app/services/subscriptions/concerns/fixed_charge_units_override_detection_concern.rb
@@ -55,6 +55,39 @@ module Subscriptions
         (entry.keys - PLAN_OVERRIDES_FIXED_CHARGE_ALLOWED_KEYS).empty?
       end
 
+      # When a subscription that carries units override rows receives a change
+      # that requires a plan override (any non-units field), the override rows
+      # must be promoted into the resulting override plan or the customer
+      # silently snaps back to the plan-level units. Each calling service
+      # invokes this before falling through to `Plans::OverrideService`:
+      # discards the override rows on the subscription and returns a
+      # fixed_charges params array combining the caller's existing entries
+      # with a synthetic entry per discarded override (units carried forward)
+      # so `Plans::OverrideService` builds the override plan with the
+      # customer's actual seat counts already in place. The caller's explicit
+      # params win when both an existing entry and an override row exist for
+      # the same fixed_charge.
+      def promote_units_overrides_to_fixed_charges_params(existing_params = [])
+        overrides = subscription.fixed_charge_units_overrides.to_a
+        return existing_params if overrides.empty?
+
+        params_by_id = existing_params.each_with_object({}) do |entry, acc|
+          entry = normalize_hash(entry)
+          acc[entry[:id]] = entry if entry && entry[:id]
+        end
+
+        overrides.each do |override|
+          params_by_id[override.fixed_charge_id] ||= {
+            id: override.fixed_charge_id,
+            units: override.units
+          }
+        end
+
+        overrides.each(&:discard!)
+
+        params_by_id.values
+      end
+
       def normalize_hash(value)
         return nil if value.nil?
         return value.symbolize_keys if value.is_a?(Hash)

--- a/app/services/subscriptions/concerns/fixed_charge_units_override_detection_concern.rb
+++ b/app/services/subscriptions/concerns/fixed_charge_units_override_detection_concern.rb
@@ -2,24 +2,6 @@
 
 module Subscriptions
   module Concerns
-    # Pure params-shape predicates that decide whether a request is eligible
-    # for the units-only override write path (writing one row to
-    # subscription_fixed_charge_units_overrides instead of cloning the plan).
-    #
-    # The two shapes handled here:
-    #
-    # - `plan_overrides` envelope (subscription create/update with
-    #   `plan_overrides.fixed_charges`): match when only the `fixed_charges`
-    #   key is present, the array is non-empty, and every entry contains only
-    #   `id`, `units`, and optionally `apply_units_immediately`.
-    # - Dedicated subscription-scoped fixed_charge endpoint
-    #   (`UpdateOrOverrideFixedChargeService`): match when the top-level
-    #   params contain `units` and optionally `apply_units_immediately`, and
-    #   nothing else (the fixed_charge identity comes from the URL).
-    #
-    # The cloned-plan guard (`subscription.plan.parent_id` is set) is
-    # enforced by each calling service against the subscription it holds,
-    # not here — these predicates only inspect params.
     module FixedChargeUnitsOverrideDetectionConcern
       extend ActiveSupport::Concern
 
@@ -55,18 +37,6 @@ module Subscriptions
         (entry.keys - PLAN_OVERRIDES_FIXED_CHARGE_ALLOWED_KEYS).empty?
       end
 
-      # When a subscription that carries units override rows receives a change
-      # that requires a plan override (any non-units field), the override rows
-      # must be promoted into the resulting override plan or the customer
-      # silently snaps back to the plan-level units. Each calling service
-      # invokes this before falling through to `Plans::OverrideService`:
-      # discards the override rows on the subscription and returns a
-      # fixed_charges params array combining the caller's existing entries
-      # with a synthetic entry per discarded override (units carried forward)
-      # so `Plans::OverrideService` builds the override plan with the
-      # customer's actual seat counts already in place. The caller's explicit
-      # params win when both an existing entry and an override row exist for
-      # the same fixed_charge.
       def promote_units_overrides_to_fixed_charges_params(existing_params = [])
         overrides = subscription.fixed_charge_units_overrides.to_a
         return existing_params if overrides.empty?

--- a/app/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern.rb
+++ b/app/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module Concerns
+    module FixedChargeUnitsOverridePromotionConcern
+      extend ActiveSupport::Concern
+
+      private
+
+      def promote_units_overrides_to_fixed_charges_params(existing_params = [])
+        overrides = subscription.fixed_charge_units_overrides.to_a
+        return existing_params if overrides.empty?
+
+        params_by_id = existing_params.each_with_object({}) do |entry, acc|
+          entry = entry.to_h.symbolize_keys if entry.respond_to?(:to_h)
+          acc[entry[:id]] = entry if entry.is_a?(Hash) && entry[:id]
+        end
+
+        overrides.each do |override|
+          params_by_id[override.fixed_charge_id] ||= {
+            id: override.fixed_charge_id,
+            units: override.units
+          }
+        end
+
+        overrides.each(&:discard!)
+
+        params_by_id.values
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/fixed_charge_units_overrides/write_service.rb
+++ b/app/services/subscriptions/fixed_charge_units_overrides/write_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module FixedChargeUnitsOverrides
+    class WriteService < BaseService
+      Result = BaseResult[:units_override]
+
+      def initialize(subscription:, fixed_charge:, units:, apply_units_immediately: false, timestamp: nil)
+        @subscription = subscription
+        @fixed_charge = fixed_charge
+        @units = units
+        @apply_units_immediately = !!apply_units_immediately
+        @timestamp = (timestamp || Time.current.to_i).to_i
+        super
+      end
+
+      def call
+        ActiveRecord::Base.transaction do
+          units_override = ::Subscription::FixedChargeUnitsOverride.find_or_initialize_by(
+            subscription:,
+            fixed_charge:
+          )
+          units_override.organization = subscription.organization
+          units_override.units = units
+          units_override.save!
+
+          FixedCharges::EmitEventsService.call!(
+            fixed_charge:,
+            subscription:,
+            apply_units_immediately:,
+            timestamp:
+          )
+
+          if apply_units_immediately && fixed_charge.pay_in_advance? && subscription.active?
+            after_commit do
+              Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+            end
+          end
+
+          result.units_override = units_override
+        end
+
+        result
+      end
+
+      private
+
+      attr_reader :subscription, :fixed_charge, :units, :apply_units_immediately, :timestamp
+    end
+  end
+end

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -73,7 +73,7 @@ module Subscriptions
 
     def override_via_plan
       parent_fixed_charge = fixed_charge.parent_or_self
-      target_plan = ensure_plan_override(params: plan_override_params(parent_fixed_charge))
+      target_plan = ensure_plan_override(params: promoted_plan_override_params(parent_fixed_charge))
       target_fixed_charge = find_or_create_fixed_charge_override(parent_fixed_charge, target_plan)
 
       publish_invoice_pay_in_advance_job(target_fixed_charge)
@@ -85,6 +85,16 @@ module Subscriptions
       return {} if subscription_plan_parent_present
 
       {fixed_charges: [params.merge(id: parent_fixed_charge.id)]}
+    end
+
+    # Seed the override plan with the customer's existing units override rows so
+    # they survive the clone, while the user's current change wins for the
+    # fixed_charge being edited. The seeded units are applied during clone
+    # creation; find_or_create_fixed_charge_override reloads (no second event).
+    def promoted_plan_override_params(parent_fixed_charge)
+      base_entries = plan_override_params(parent_fixed_charge)[:fixed_charges] || []
+      promoted_fixed_charges = promote_units_overrides_to_fixed_charges_params(base_entries)
+      promoted_fixed_charges.any? ? {fixed_charges: promoted_fixed_charges} : {}
     end
 
     def find_or_create_fixed_charge_override(parent_fixed_charge, target_plan)

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -4,6 +4,7 @@ module Subscriptions
   class UpdateOrOverrideFixedChargeService < BaseService
     include Concerns::PlanOverrideConcern
     include Concerns::FixedChargeUnitsOverrideDetectionConcern
+    include Concerns::FixedChargeUnitsOverridePromotionConcern
 
     Result = BaseResult[:fixed_charge]
 
@@ -43,30 +44,14 @@ module Subscriptions
     end
 
     def override_units_only
-      apply_units_immediately = !!params[:apply_units_immediately]
-      timestamp = Time.current.to_i
       parent_fixed_charge = fixed_charge.parent_or_self
 
-      override = ::Subscription::FixedChargeUnitsOverride.find_or_initialize_by(
+      Subscriptions::FixedChargeUnitsOverrides::WriteService.call!(
         subscription:,
-        fixed_charge: parent_fixed_charge
-      )
-      override.organization = subscription.organization
-      override.units = params[:units]
-      override.save!
-
-      FixedCharges::EmitEventsService.call!(
         fixed_charge: parent_fixed_charge,
-        subscription:,
-        apply_units_immediately:,
-        timestamp:
+        units: params[:units],
+        apply_units_immediately: params[:apply_units_immediately]
       )
-
-      if apply_units_immediately && parent_fixed_charge.pay_in_advance? && subscription.active?
-        after_commit do
-          Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
-        end
-      end
 
       parent_fixed_charge
     end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -175,10 +175,18 @@ module Subscriptions
       else
         Plans::OverrideService.call!(
           plan: current_plan,
-          params: params[:plan_overrides].to_h.with_indifferent_access,
+          params: plan_override_params_with_promoted_units,
           subscription:
         )
       end
+    end
+
+    def plan_override_params_with_promoted_units
+      override_params = params[:plan_overrides].to_h.with_indifferent_access
+      override_params[:fixed_charges] = promote_units_overrides_to_fixed_charges_params(
+        override_params[:fixed_charges] || []
+      )
+      override_params
     end
 
     def units_only_plan_overrides_change?

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -4,6 +4,7 @@ module Subscriptions
   class UpdateService < BaseService
     include Subscriptions::Concerns::BillingEntityResolutionConcern
     include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
+    include Subscriptions::Concerns::FixedChargeUnitsOverridePromotionConcern
 
     Result = BaseResult[:subscription, :payment_method]
 
@@ -204,28 +205,14 @@ module Subscriptions
         entry = entry.to_h.symbolize_keys
         fixed_charge = subscription.plan.fixed_charges.find_by(id: entry[:id])
         result.not_found_failure!(resource: "fixed_charge").raise_if_error! unless fixed_charge
-        apply_units_immediately = !!entry[:apply_units_immediately]
 
-        override = ::Subscription::FixedChargeUnitsOverride.find_or_initialize_by(
+        Subscriptions::FixedChargeUnitsOverrides::WriteService.call!(
           subscription:,
-          fixed_charge:
-        )
-        override.organization = subscription.organization
-        override.units = entry[:units]
-        override.save!
-
-        FixedCharges::EmitEventsService.call!(
           fixed_charge:,
-          subscription:,
-          apply_units_immediately:,
+          units: entry[:units],
+          apply_units_immediately: entry[:apply_units_immediately],
           timestamp:
         )
-
-        if apply_units_immediately && fixed_charge.pay_in_advance? && subscription.active?
-          after_commit do
-            Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
-          end
-        end
       end
     end
 

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -210,7 +210,7 @@ module Subscriptions
           subscription:,
           fixed_charge:,
           units: entry[:units],
-          apply_units_immediately: entry[:apply_units_immediately],
+          apply_units_immediately: !!entry[:apply_units_immediately],
           timestamp:
         )
       end

--- a/spec/scenarios/fixed_charges/plan_update_preserves_subscription_overrides_spec.rb
+++ b/spec/scenarios/fixed_charges/plan_update_preserves_subscription_overrides_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Plan-level fixed_charge update preserves per-subscription unit overrides", :premium do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      amount_cents: 0,
+      interval: "monthly",
+      pay_in_advance: true
+    )
+  end
+
+  # Pay-in-advance, $10 per unit, 10 units by default.
+  let(:fixed_charge) do
+    create(
+      :fixed_charge,
+      plan:,
+      add_on:,
+      units: 10,
+      properties: {amount: "10"},
+      prorated: false,
+      pay_in_advance: true
+    )
+  end
+
+  let(:customer_a) { create(:customer, organization:, timezone: "UTC", external_id: "cust-a") }
+  let(:customer_b) { create(:customer, organization:, timezone: "UTC", external_id: "cust-b") }
+
+  let(:subscription_a) { customer_a.subscriptions.sole }
+  let(:subscription_b) { customer_b.subscriptions.sole }
+
+  let(:subscription_date) { DateTime.new(2024, 3, 1) }
+
+  before do
+    fixed_charge
+
+    travel_to subscription_date do
+      # Sub A: no override (will bill at plan default = 10 units)
+      create_subscription({
+        external_customer_id: customer_a.external_id,
+        external_id: "sub_a",
+        plan_code: plan.code,
+        billing_time: "calendar"
+      })
+
+      # Sub B: units-only plan_overrides → override row written, initial bill at 15 units
+      create_subscription({
+        external_customer_id: customer_b.external_id,
+        external_id: "sub_b",
+        plan_code: plan.code,
+        billing_time: "calendar",
+        plan_overrides: {
+          fixed_charges: [{id: fixed_charge.id, units: 15}]
+        }
+      })
+    end
+
+    travel_to subscription_date + 1.minute do
+      perform_all_enqueued_jobs
+    end
+  end
+
+  it "delivers the plan-level update to sub A only; sub B keeps its override on both the mid-period invoice and the next billing cycle" do
+    # Initial invoices reflect each subscription's own units
+    expect(subscription_a.invoices.sole.fees.fixed_charge.sole.amount_cents).to eq(10_000) # 10 * $10
+    expect(subscription_b.invoices.sole.fees.fixed_charge.sole.amount_cents).to eq(15_000) # 15 * $10
+
+    # Plan-level update: units 7 with apply_units_immediately
+    travel_to subscription_date + 5.days do
+      update_plan(
+        plan,
+        {
+          fixed_charges: [{
+            id: fixed_charge.id,
+            units: 7,
+            apply_units_immediately: true,
+            properties: {amount: "10"}
+          }]
+        }
+      )
+      perform_all_enqueued_jobs
+    end
+
+    # Sub A: new event at 7 + a zero-amount mid-period invoice (paid 10, new is 7 → no refund)
+    a_events = FixedChargeEvent.where(subscription: subscription_a, fixed_charge:).order(:created_at)
+    expect(a_events.map(&:units)).to eq([10, 7])
+
+    a_invoices = subscription_a.reload.invoices.order(:created_at)
+    expect(a_invoices.count).to eq(2)
+    expect(a_invoices.last.fees.fixed_charge.sole.amount_cents).to eq(0)
+
+    # Sub B: no new event, no new invoice — override preserved
+    b_events = FixedChargeEvent.where(subscription: subscription_b, fixed_charge:).order(:created_at)
+    expect(b_events.map(&:units)).to eq([15])
+    expect(subscription_b.reload.invoices.count).to eq(1)
+    expect(subscription_b.fixed_charge_units_overrides.sole.units).to eq(15)
+
+    # Next billing cycle — sub A bills at 7, sub B bills at 15
+    travel_to subscription_date.next_month do
+      BillSubscriptionJob.perform_now([subscription_a], Time.current, invoicing_reason: :subscription_periodic)
+      BillSubscriptionJob.perform_now([subscription_b], Time.current, invoicing_reason: :subscription_periodic)
+      perform_all_enqueued_jobs
+    end
+
+    next_cycle_invoice_a = subscription_a.reload.invoices.order(:created_at).last
+    expect(next_cycle_invoice_a.fees.fixed_charge.sole).to have_attributes(
+      units: 7,
+      amount_cents: 7_000
+    )
+
+    next_cycle_invoice_b = subscription_b.reload.invoices.order(:created_at).last
+    expect(next_cycle_invoice_b.fees.fixed_charge.sole).to have_attributes(
+      units: 15,
+      amount_cents: 15_000
+    )
+  end
+end

--- a/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
+++ b/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
@@ -110,4 +110,93 @@ describe "Subscription fixed charge units override via subscription endpoint", :
 
     expect(subscription.fixed_charge_units_overrides.kept).to be_empty
   end
+
+  it "issues a zero-amount mid-period invoice when units decrease and never refunds" do
+    expect(subscription.invoices.count).to eq(1)
+    expect(subscription.invoices.first.fees.fixed_charge.sole.amount_cents).to eq(10_000)
+
+    travel_to subscription_date + 5.days do
+      update_subscription_fixed_charge(
+        subscription,
+        fixed_charge.code,
+        {units: 5, apply_units_immediately: true}
+      )
+      perform_all_enqueued_jobs
+    end
+
+    invoices = subscription.reload.invoices.order(:created_at)
+    expect(invoices.count).to eq(2)
+
+    decrease_invoice = invoices.last
+    expect(decrease_invoice.fees.fixed_charge.sole.amount_cents).to eq(0)
+    expect(decrease_invoice.fees_amount_cents).to eq(0)
+
+    override = subscription.fixed_charge_units_overrides.sole
+    expect(override.units).to eq(5)
+
+    events = FixedChargeEvent.where(subscription:, fixed_charge:).order(:created_at)
+    expect(events.map(&:units)).to eq([10, 5])
+  end
+
+  it "bills the diff from the highest previously-paid value across a 10 → 5 → 15 sequence" do
+    travel_to subscription_date + 5.days do
+      update_subscription_fixed_charge(subscription, fixed_charge.code, {units: 5, apply_units_immediately: true})
+      perform_all_enqueued_jobs
+    end
+
+    travel_to subscription_date + 10.days do
+      update_subscription_fixed_charge(subscription, fixed_charge.code, {units: 15, apply_units_immediately: true})
+      perform_all_enqueued_jobs
+    end
+
+    invoices = subscription.reload.invoices.order(:created_at)
+    expect(invoices.map { |i| i.fees.fixed_charge.sum(:amount_cents) }).to eq([10_000, 0, 5_000])
+
+    override = subscription.fixed_charge_units_overrides.sole
+    expect(override.units).to eq(15)
+
+    events = FixedChargeEvent.where(subscription:, fixed_charge:).order(:created_at)
+    expect(events.map(&:units)).to eq([10, 5, 15])
+  end
+
+  it "accepts a zero-units override and bills nothing for the rest of the period" do
+    travel_to subscription_date + 5.days do
+      update_subscription_fixed_charge(
+        subscription,
+        fixed_charge.code,
+        {units: 0, apply_units_immediately: true}
+      )
+      perform_all_enqueued_jobs
+    end
+
+    override = subscription.fixed_charge_units_overrides.sole
+    expect(override.units).to eq(0)
+
+    events = FixedChargeEvent.where(subscription:, fixed_charge:).order(:created_at)
+    expect(events.last.units).to eq(0)
+
+    invoices = subscription.reload.invoices.order(:created_at)
+    expect(invoices.count).to eq(2)
+    expect(invoices.last.fees.fixed_charge.sole.amount_cents).to eq(0)
+  end
+
+  it "refuses the units-only branch when the subscription is on an overridden plan and falls through" do
+    overridden_plan = create(:plan, organization:, parent: plan, amount_cents: 0, interval: "monthly", pay_in_advance: true)
+    create(:fixed_charge, plan: overridden_plan, add_on:, parent: fixed_charge, code: fixed_charge.code,
+      units: 10, properties: {amount: "10"}, prorated: false, pay_in_advance: true)
+    subscription.update!(plan: overridden_plan)
+
+    travel_to subscription_date + 5.days do
+      update_subscription_fixed_charge(
+        subscription,
+        fixed_charge.code,
+        {units: 20, apply_units_immediately: true}
+      )
+      perform_all_enqueued_jobs
+    end
+
+    expect(subscription.reload.fixed_charge_units_overrides.kept).to be_empty
+    expect(subscription.plan).to eq(overridden_plan)
+    expect(overridden_plan.fixed_charges.find_by(parent_id: fixed_charge.id).units).to eq(20)
+  end
 end

--- a/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
+++ b/spec/scenarios/fixed_charges/subscription_units_override_spec.rb
@@ -50,7 +50,7 @@ describe "Subscription fixed charge units override via subscription endpoint", :
     end
   end
 
-  it "records the override row, skips plan/fixed_charge cloning, and emits an event with the override units" do
+  it "records the override row, skips plan/fixed_charge override creation, and emits an event with the override units" do
     travel_to subscription_date + 5.days do
       update_subscription_fixed_charge(
         subscription,
@@ -75,5 +75,39 @@ describe "Subscription fixed charge units override via subscription endpoint", :
     events = FixedChargeEvent.where(subscription:, fixed_charge:).order(:created_at)
     expect(events.count).to eq(2)
     expect(events.last.units).to eq(15)
+  end
+
+  it "promotes an existing units override row onto the plan override when a subsequent non-units change arrives" do
+    tax = create(:tax, organization:)
+
+    travel_to subscription_date + 5.days do
+      update_subscription_fixed_charge(
+        subscription,
+        fixed_charge.code,
+        {units: 15}
+      )
+      perform_all_enqueued_jobs
+    end
+
+    expect(subscription.fixed_charge_units_overrides.kept.count).to eq(1)
+
+    travel_to subscription_date + 10.days do
+      update_subscription_fixed_charge(
+        subscription,
+        fixed_charge.code,
+        {units: 20, tax_codes: [tax.code]}
+      )
+      perform_all_enqueued_jobs
+    end
+
+    subscription.reload
+    overridden_plan = subscription.plan
+    expect(overridden_plan.parent_id).to eq(plan.id)
+
+    overridden_fixed_charge = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge.id)
+    expect(overridden_fixed_charge.units).to eq(20)
+    expect(overridden_fixed_charge.taxes).to include(tax)
+
+    expect(subscription.fixed_charge_units_overrides.kept).to be_empty
   end
 end

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
     Class.new do
       include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
 
-      public :units_only_fixed_charges_plan_overrides?, :units_only_fixed_charge_params?
+      public :units_only_fixed_charges_plan_overrides?,
+        :units_only_fixed_charge_params?,
+        :promote_units_overrides_to_fixed_charges_params
+
+      attr_accessor :subscription
     end.new
   end
 
@@ -110,6 +114,93 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
 
     context "with an empty hash" do
       it { expect(host.units_only_fixed_charge_params?({})).to be false }
+    end
+  end
+
+  describe "#promote_units_overrides_to_fixed_charges_params" do
+    let(:organization) { create(:organization) }
+    let(:plan) { create(:plan, organization:) }
+    let(:fc1) { create(:fixed_charge, plan:, organization:, units: 5) }
+    let(:fc2) { create(:fixed_charge, plan:, organization:, units: 10) }
+    let(:subscription) { create(:subscription, plan:) }
+
+    before { host.subscription = subscription }
+
+    context "when the subscription has no override rows" do
+      it "returns the existing params unchanged" do
+        existing = [{id: fc1.id, units: 7}]
+        expect(host.promote_units_overrides_to_fixed_charges_params(existing)).to eq(existing)
+      end
+
+      it "does not touch the database" do
+        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
+        host.promote_units_overrides_to_fixed_charges_params([])
+        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
+      end
+    end
+
+    context "when override rows exist but no existing params are provided" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc2, organization:, units: 22)
+      end
+
+      it "synthesises one entry per override row with the captured units" do
+        result = host.promote_units_overrides_to_fixed_charges_params
+
+        expect(result).to contain_exactly(
+          {id: fc1.id, units: 11},
+          {id: fc2.id, units: 22}
+        )
+      end
+
+      it "discards the override rows" do
+        host.promote_units_overrides_to_fixed_charges_params
+
+        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
+        expect(::Subscription::FixedChargeUnitsOverride.unscoped.where(subscription:).discarded).to exist
+      end
+    end
+
+    context "when caller params already include an entry for an overridden fixed_charge" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "keeps the caller's entry and discards the override row" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc1.id, units: 99}])
+
+        expect(result).to contain_exactly({id: fc1.id, units: 99})
+        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
+      end
+    end
+
+    context "when caller params reference different fixed_charges than the overrides" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "preserves caller entries and adds synthetic entries for the overrides" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc2.id, units: 50}])
+
+        expect(result).to contain_exactly(
+          {id: fc2.id, units: 50},
+          {id: fc1.id, units: 11}
+        )
+      end
+    end
+
+    context "with string-keyed existing params" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "normalises string keys and keeps the caller's entry" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{"id" => fc1.id, "units" => 99}])
+
+        # Caller entry wins (we don't mutate it). Returned value preserves its original key style.
+        expect(result.map { |e| e[:id] || e["id"] }).to contain_exactly(fc1.id)
+      end
     end
   end
 end

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
@@ -8,10 +8,7 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
       include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
 
       public :units_only_fixed_charges_plan_overrides?,
-        :units_only_fixed_charge_params?,
-        :promote_units_overrides_to_fixed_charges_params
-
-      attr_accessor :subscription
+        :units_only_fixed_charge_params?
     end.new
   end
 
@@ -114,93 +111,6 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
 
     context "with an empty hash" do
       it { expect(host.units_only_fixed_charge_params?({})).to be false }
-    end
-  end
-
-  describe "#promote_units_overrides_to_fixed_charges_params" do
-    let(:organization) { create(:organization) }
-    let(:plan) { create(:plan, organization:) }
-    let(:fc1) { create(:fixed_charge, plan:, organization:, units: 5) }
-    let(:fc2) { create(:fixed_charge, plan:, organization:, units: 10) }
-    let(:subscription) { create(:subscription, plan:) }
-
-    before { host.subscription = subscription }
-
-    context "when the subscription has no override rows" do
-      it "returns the existing params unchanged" do
-        existing = [{id: fc1.id, units: 7}]
-        expect(host.promote_units_overrides_to_fixed_charges_params(existing)).to eq(existing)
-      end
-
-      it "does not touch the database" do
-        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
-        host.promote_units_overrides_to_fixed_charges_params([])
-        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
-      end
-    end
-
-    context "when override rows exist but no existing params are provided" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc2, organization:, units: 22)
-      end
-
-      it "synthesises one entry per override row with the captured units" do
-        result = host.promote_units_overrides_to_fixed_charges_params
-
-        expect(result).to contain_exactly(
-          {id: fc1.id, units: 11},
-          {id: fc2.id, units: 22}
-        )
-      end
-
-      it "discards the override rows" do
-        host.promote_units_overrides_to_fixed_charges_params
-
-        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
-        expect(::Subscription::FixedChargeUnitsOverride.unscoped.where(subscription:).discarded).to exist
-      end
-    end
-
-    context "when caller params already include an entry for an overridden fixed_charge" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
-      end
-
-      it "keeps the caller's entry and discards the override row" do
-        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc1.id, units: 99}])
-
-        expect(result).to contain_exactly({id: fc1.id, units: 99})
-        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
-      end
-    end
-
-    context "when caller params reference different fixed_charges than the overrides" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
-      end
-
-      it "preserves caller entries and adds synthetic entries for the overrides" do
-        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc2.id, units: 50}])
-
-        expect(result).to contain_exactly(
-          {id: fc2.id, units: 50},
-          {id: fc1.id, units: 11}
-        )
-      end
-    end
-
-    context "with string-keyed existing params" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
-      end
-
-      it "normalises string keys and keeps the caller's entry" do
-        result = host.promote_units_overrides_to_fixed_charges_params([{"id" => fc1.id, "units" => 99}])
-
-        # Caller entry wins (we don't mutate it). Returned value preserves its original key style.
-        expect(result.map { |e| e[:id] || e["id"] }).to contain_exactly(fc1.id)
-      end
     end
   end
 end

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverridePromotionConcern do
+  subject(:host) do
+    Class.new do
+      include Subscriptions::Concerns::FixedChargeUnitsOverridePromotionConcern
+
+      public :promote_units_overrides_to_fixed_charges_params
+
+      attr_accessor :subscription
+    end.new
+  end
+
+  describe "#promote_units_overrides_to_fixed_charges_params" do
+    let(:organization) { create(:organization) }
+    let(:plan) { create(:plan, organization:) }
+    let(:fc1) { create(:fixed_charge, plan:, organization:, units: 5) }
+    let(:fc2) { create(:fixed_charge, plan:, organization:, units: 10) }
+    let(:subscription) { create(:subscription, plan:) }
+
+    before { host.subscription = subscription }
+
+    context "when the subscription has no override rows" do
+      it "returns the existing params unchanged" do
+        existing = [{id: fc1.id, units: 7}]
+        expect(host.promote_units_overrides_to_fixed_charges_params(existing)).to eq(existing)
+      end
+
+      it "does not touch the database" do
+        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
+        host.promote_units_overrides_to_fixed_charges_params([])
+        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
+      end
+    end
+
+    context "when override rows exist but no existing params are provided" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc2, organization:, units: 22)
+      end
+
+      it "synthesises one entry per override row with the captured units" do
+        result = host.promote_units_overrides_to_fixed_charges_params
+
+        expect(result).to contain_exactly(
+          {id: fc1.id, units: 11},
+          {id: fc2.id, units: 22}
+        )
+      end
+
+      it "discards the override rows" do
+        host.promote_units_overrides_to_fixed_charges_params
+
+        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
+        expect(::Subscription::FixedChargeUnitsOverride.unscoped.where(subscription:).discarded).to exist
+      end
+    end
+
+    context "when caller params already include an entry for an overridden fixed_charge" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "keeps the caller's entry and discards the override row" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc1.id, units: 99}])
+
+        expect(result).to contain_exactly({id: fc1.id, units: 99})
+        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
+      end
+    end
+
+    context "when caller params reference different fixed_charges than the overrides" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "preserves caller entries and adds synthetic entries for the overrides" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc2.id, units: 50}])
+
+        expect(result).to contain_exactly(
+          {id: fc2.id, units: 50},
+          {id: fc1.id, units: 11}
+        )
+      end
+    end
+
+    context "with string-keyed existing params" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "normalises string keys and keeps the caller's entry" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{"id" => fc1.id, "units" => 99}])
+
+        # Caller entry wins (we don't mutate it). Returned value preserves its original key style.
+        expect(result.map { |e| e[:id] || e["id"] }).to contain_exactly(fc1.id)
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/fixed_charge_units_overrides/write_service_spec.rb
+++ b/spec/services/subscriptions/fixed_charge_units_overrides/write_service_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::FixedChargeUnitsOverrides::WriteService do
+  subject(:write_service) do
+    described_class.new(
+      subscription:,
+      fixed_charge:,
+      units:,
+      apply_units_immediately:,
+      timestamp:
+    )
+  end
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 5) }
+  let(:subscription) { create(:subscription, plan:) }
+  let(:units) { 15 }
+  let(:apply_units_immediately) { false }
+  let(:timestamp) { Time.current.to_i }
+
+  describe "#call" do
+    it "creates a Subscription::FixedChargeUnitsOverride for the (subscription, fixed_charge) pair" do
+      expect { write_service.call }
+        .to change(::Subscription::FixedChargeUnitsOverride, :count).by(1)
+
+      override = ::Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+      expect(override.units).to eq(15)
+      expect(override.organization).to eq(subscription.organization)
+    end
+
+    it "emits a fixed charge event for the subscription with the override units" do
+      expect { write_service.call }.to change(FixedChargeEvent, :count).by(1)
+
+      event = FixedChargeEvent.find_by(subscription:, fixed_charge:)
+      expect(event.units).to eq(15)
+    end
+
+    it "returns the override on the result" do
+      result = write_service.call
+
+      expect(result).to be_success
+      expect(result.units_override).to be_a(::Subscription::FixedChargeUnitsOverride)
+      expect(result.units_override.units).to eq(15)
+    end
+
+    context "when an override already exists for the pair" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 7)
+      end
+
+      it "updates the existing override row rather than creating a new one" do
+        expect { write_service.call }
+          .not_to change(::Subscription::FixedChargeUnitsOverride, :count)
+
+        override = ::Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+        expect(override.units).to eq(15)
+      end
+    end
+
+    context "when apply_units_immediately is true on a pay-in-advance fixed charge" do
+      let(:apply_units_immediately) { true }
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 5, pay_in_advance: true) }
+
+      it "enqueues the pay-in-advance billing job after commit" do
+        expect { write_service.call }
+          .to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+          .with(subscription, timestamp)
+      end
+    end
+
+    context "when apply_units_immediately is true on a pay-in-arrears fixed charge" do
+      let(:apply_units_immediately) { true }
+
+      it "does not enqueue the pay-in-advance billing job" do
+        expect { write_service.call }
+          .not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+      end
+    end
+
+    context "when apply_units_immediately is false on a pay-in-advance fixed charge" do
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 5, pay_in_advance: true) }
+
+      it "does not enqueue the pay-in-advance billing job" do
+        expect { write_service.call }
+          .not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
           end
         end
 
-        context "when the subscription is already on a cloned plan" do
+        context "when the subscription is already on an overridden plan" do
           let(:overridden_plan) { create(:plan, organization:, parent: plan) }
           let(:subscription) { create(:subscription, customer:, plan: overridden_plan) }
 
@@ -343,6 +343,36 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
               .to not_change(::Subscription::FixedChargeUnitsOverride, :count)
               .and change(FixedCharge, :count).by(1)
           end
+        end
+      end
+
+      context "when the subscription has existing units overrides and params trigger plan override" do
+        let(:other_fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, units: 8) }
+        let(:params) { {units: "15", tax_codes: [create(:tax, organization:).code]} }
+
+        before do
+          other_fixed_charge
+          create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 11)
+          create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: other_fixed_charge, organization:, units: 22)
+        end
+
+        it "discards the override rows and promotes their units onto the new fixed_charge overrides" do
+          expect { service.call }
+            .to change(Plan, :count).by(1)
+            .and change(FixedCharge, :count).by(2)
+            .and change { ::Subscription::FixedChargeUnitsOverride.kept.where(subscription:).count }.from(2).to(0)
+
+          subscription.reload
+          overridden_plan = subscription.plan
+          expect(overridden_plan.parent_id).to eq(plan.id)
+
+          # The fixed_charge the user updated reflects the user's units (15) plus its tax_codes
+          fc_being_updated = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge.id)
+          expect(fc_being_updated.units).to eq(15)
+
+          # The other fixed_charge that had an override row now carries those units on its plan-override clone
+          other_fc_overridden = overridden_plan.fixed_charges.find_sole_by(parent_id: other_fixed_charge.id)
+          expect(other_fc_overridden.units).to eq(22)
         end
       end
     end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1097,6 +1097,50 @@ RSpec.describe Subscriptions::UpdateService do
             .not_to change(::Subscription::FixedChargeUnitsOverride, :count)
         end
       end
+
+      context "when the subscription has existing units overrides and params trigger plan override", :premium do
+        let(:organization) { membership.organization }
+        let(:plan) { create(:plan, organization:) }
+        let(:fixed_charge1) { create(:fixed_charge, plan:, units: 5) }
+        let(:fixed_charge2) { create(:fixed_charge, plan:, units: 8) }
+        let(:customer) { create(:customer, organization:) }
+        let(:subscription) { create(:subscription, plan:, customer:) }
+        let(:params) do
+          {
+            plan_overrides: {
+              amount_cents: 12_345,
+              fixed_charges: [{id: fixed_charge1.id, units: 99}]
+            }
+          }
+        end
+
+        before do
+          fixed_charge1
+          fixed_charge2
+          subscription
+          create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fixed_charge1, organization:, units: 11)
+          create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fixed_charge2, organization:, units: 22)
+        end
+
+        it "discards the override rows and promotes their units into the new plan override" do
+          expect { update_service.call }
+            .to change(Plan, :count).by(1)
+            .and change { ::Subscription::FixedChargeUnitsOverride.kept.where(subscription:).count }.from(2).to(0)
+
+          subscription.reload
+          overridden_plan = subscription.plan
+          expect(overridden_plan.parent_id).to eq(plan.id)
+          expect(overridden_plan.amount_cents).to eq(12_345)
+
+          # Caller's explicit entry wins on fc1 (99 not the captured 11)
+          fc1_overridden = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge1.id)
+          expect(fc1_overridden.units).to eq(99)
+
+          # fc2 had only an override row, no caller entry — gets the captured units (22)
+          fc2_overridden = overridden_plan.fixed_charges.find_sole_by(parent_id: fixed_charge2.id)
+          expect(fc2_overridden.units).to eq(22)
+        end
+      end
     end
 
     context "with empty params" do


### PR DESCRIPTION
A subscription that already carries Subscription::FixedChargeUnitsOverride rows can later receive a change that forces a full plan override (any non-units field on the dedicated endpoint, or a mixed plan_overrides payload on subscription update). Without intervention the override rows would be orphaned by the override plan — they reference the parent fixed_charges, not the new override fixed_charges — and the customer would silently snap back to plan-level units on the next billing cycle.

Subscriptions::UpdateService and
Subscriptions::UpdateOrOverrideFixedChargeService now capture the existing override rows before falling through to
Plans::OverrideService, discard them, and merge the captured units into the fixed_charges params handed to the override service so the override plan is built with the customer's actual seat counts already in place. Promotion lives on the calling services so Plans::OverrideService stays generic.