### PR TITLE
refactor(fc-units-override): extract WriteService and split detection…

### DIFF
--- a/app/services/subscriptions/concerns/fixed_charge_units_override_detection_concern.rb
+++ b/app/services/subscriptions/concerns/fixed_charge_units_override_detection_concern.rb
@@ -55,39 +55,6 @@ module Subscriptions
         (entry.keys - PLAN_OVERRIDES_FIXED_CHARGE_ALLOWED_KEYS).empty?
       end
 
-      # When a subscription that carries units override rows receives a change
-      # that requires a plan override (any non-units field), the override rows
-      # must be promoted into the resulting override plan or the customer
-      # silently snaps back to the plan-level units. Each calling service
-      # invokes this before falling through to `Plans::OverrideService`:
-      # discards the override rows on the subscription and returns a
-      # fixed_charges params array combining the caller's existing entries
-      # with a synthetic entry per discarded override (units carried forward)
-      # so `Plans::OverrideService` builds the override plan with the
-      # customer's actual seat counts already in place. The caller's explicit
-      # params win when both an existing entry and an override row exist for
-      # the same fixed_charge.
-      def promote_units_overrides_to_fixed_charges_params(existing_params = [])
-        overrides = subscription.fixed_charge_units_overrides.to_a
-        return existing_params if overrides.empty?
-
-        params_by_id = existing_params.each_with_object({}) do |entry, acc|
-          entry = normalize_hash(entry)
-          acc[entry[:id]] = entry if entry && entry[:id]
-        end
-
-        overrides.each do |override|
-          params_by_id[override.fixed_charge_id] ||= {
-            id: override.fixed_charge_id,
-            units: override.units
-          }
-        end
-
-        overrides.each(&:discard!)
-
-        params_by_id.values
-      end
-
       def normalize_hash(value)
         return nil if value.nil?
         return value.symbolize_keys if value.is_a?(Hash)

--- a/app/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern.rb
+++ b/app/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module Concerns
+    # Promotes a subscription's existing units override rows into the
+    # `fixed_charges` params passed to `Plans::OverrideService` so a
+    # subsequent change that requires a plan override (any non-units field)
+    # builds the override plan with the customer's actual seat counts
+    # already in place.
+    #
+    # Without this promotion the override rows would be orphaned by the
+    # plan override — they reference the parent fixed_charges, not the
+    # newly created override fixed_charges — and the customer would
+    # silently snap back to the plan-level units on the next billing
+    # cycle.
+    #
+    # The host service is expected to expose a `subscription` reader.
+    module FixedChargeUnitsOverridePromotionConcern
+      extend ActiveSupport::Concern
+
+      private
+
+      # Discards the subscription's override rows and returns a
+      # fixed_charges params array combining the caller's existing entries
+      # with a synthetic entry per discarded override (units carried
+      # forward). The caller's explicit entry wins when both an existing
+      # entry and an override row exist for the same fixed_charge.
+      # When the subscription has no override rows, returns the input
+      # unchanged.
+      def promote_units_overrides_to_fixed_charges_params(existing_params = [])
+        overrides = subscription.fixed_charge_units_overrides.to_a
+        return existing_params if overrides.empty?
+
+        params_by_id = existing_params.each_with_object({}) do |entry, acc|
+          entry = entry.to_h.symbolize_keys if entry.respond_to?(:to_h)
+          acc[entry[:id]] = entry if entry.is_a?(Hash) && entry[:id]
+        end
+
+        overrides.each do |override|
+          params_by_id[override.fixed_charge_id] ||= {
+            id: override.fixed_charge_id,
+            units: override.units
+          }
+        end
+
+        overrides.each(&:discard!)
+
+        params_by_id.values
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/fixed_charge_units_overrides/write_service.rb
+++ b/app/services/subscriptions/fixed_charge_units_overrides/write_service.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module FixedChargeUnitsOverrides
+    # Writes (or updates) one Subscription::FixedChargeUnitsOverride row for
+    # the given (subscription, fixed_charge) pair, emits a FixedChargeEvent
+    # for the subscription, and — when `apply_units_immediately` is set on a
+    # pay-in-advance fixed charge — dispatches the mid-period delta billing
+    # job after the surrounding transaction commits.
+    #
+    # The service is the shared building block for the two write surfaces
+    # that record units-only overrides mid-cycle: the dedicated subscription
+    # fixed_charge endpoint (`UpdateOrOverrideFixedChargeService`) and the
+    # subscription update endpoint (`UpdateService`). Subscription creation
+    # has different lifecycle constraints (events emit through the
+    # activation path) and writes override rows directly without this
+    # service.
+    #
+    class WriteService < BaseService
+      Result = BaseResult[:units_override]
+
+      def initialize(subscription:, fixed_charge:, units:, apply_units_immediately: false, timestamp: nil)
+        @subscription = subscription
+        @fixed_charge = fixed_charge
+        @units = units
+        @apply_units_immediately = !!apply_units_immediately
+        @timestamp = (timestamp || Time.current.to_i).to_i
+        super
+      end
+
+      def call
+        ActiveRecord::Base.transaction do
+          units_override = ::Subscription::FixedChargeUnitsOverride.find_or_initialize_by(
+            subscription:,
+            fixed_charge:
+          )
+          units_override.organization = subscription.organization
+          units_override.units = units
+          units_override.save!
+
+          FixedCharges::EmitEventsService.call!(
+            fixed_charge:,
+            subscription:,
+            apply_units_immediately:,
+            timestamp:
+          )
+
+          if apply_units_immediately && fixed_charge.pay_in_advance? && subscription.active?
+            after_commit do
+              Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
+            end
+          end
+
+          result.units_override = units_override
+        end
+
+        result
+      end
+
+      private
+
+      attr_reader :subscription, :fixed_charge, :units, :apply_units_immediately, :timestamp
+    end
+  end
+end

--- a/app/services/subscriptions/fixed_charge_units_overrides/write_service.rb
+++ b/app/services/subscriptions/fixed_charge_units_overrides/write_service.rb
@@ -2,20 +2,6 @@
 
 module Subscriptions
   module FixedChargeUnitsOverrides
-    # Writes (or updates) one Subscription::FixedChargeUnitsOverride row for
-    # the given (subscription, fixed_charge) pair, emits a FixedChargeEvent
-    # for the subscription, and — when `apply_units_immediately` is set on a
-    # pay-in-advance fixed charge — dispatches the mid-period delta billing
-    # job after the surrounding transaction commits.
-    #
-    # The service is the shared building block for the two write surfaces
-    # that record units-only overrides mid-cycle: the dedicated subscription
-    # fixed_charge endpoint (`UpdateOrOverrideFixedChargeService`) and the
-    # subscription update endpoint (`UpdateService`). Subscription creation
-    # has different lifecycle constraints (events emit through the
-    # activation path) and writes override rows directly without this
-    # service.
-    #
     class WriteService < BaseService
       Result = BaseResult[:units_override]
 

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -4,6 +4,7 @@ module Subscriptions
   class UpdateOrOverrideFixedChargeService < BaseService
     include Concerns::PlanOverrideConcern
     include Concerns::FixedChargeUnitsOverrideDetectionConcern
+    include Concerns::FixedChargeUnitsOverridePromotionConcern
 
     Result = BaseResult[:fixed_charge]
 
@@ -43,30 +44,14 @@ module Subscriptions
     end
 
     def override_units_only
-      apply_units_immediately = !!params[:apply_units_immediately]
-      timestamp = Time.current.to_i
       parent_fixed_charge = fixed_charge.parent_or_self
 
-      override = ::Subscription::FixedChargeUnitsOverride.find_or_initialize_by(
+      Subscriptions::FixedChargeUnitsOverrides::WriteService.call!(
         subscription:,
-        fixed_charge: parent_fixed_charge
-      )
-      override.organization = subscription.organization
-      override.units = params[:units]
-      override.save!
-
-      FixedCharges::EmitEventsService.call!(
         fixed_charge: parent_fixed_charge,
-        subscription:,
-        apply_units_immediately:,
-        timestamp:
+        units: params[:units],
+        apply_units_immediately: params[:apply_units_immediately]
       )
-
-      if apply_units_immediately && parent_fixed_charge.pay_in_advance? && subscription.active?
-        after_commit do
-          Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
-        end
-      end
 
       parent_fixed_charge
     end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -4,6 +4,7 @@ module Subscriptions
   class UpdateService < BaseService
     include Subscriptions::Concerns::BillingEntityResolutionConcern
     include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
+    include Subscriptions::Concerns::FixedChargeUnitsOverridePromotionConcern
 
     Result = BaseResult[:subscription, :payment_method]
 
@@ -202,29 +203,14 @@ module Subscriptions
 
       params[:plan_overrides][:fixed_charges].each do |entry|
         entry = entry.to_h.symbolize_keys
-        fixed_charge = subscription.plan.fixed_charges.find(entry[:id])
-        apply_units_immediately = !!entry[:apply_units_immediately]
 
-        override = ::Subscription::FixedChargeUnitsOverride.find_or_initialize_by(
+        Subscriptions::FixedChargeUnitsOverrides::WriteService.call!(
           subscription:,
-          fixed_charge:
-        )
-        override.organization = subscription.organization
-        override.units = entry[:units]
-        override.save!
-
-        FixedCharges::EmitEventsService.call!(
-          fixed_charge:,
-          subscription:,
-          apply_units_immediately:,
+          fixed_charge: subscription.plan.fixed_charges.find(entry[:id]),
+          units: entry[:units],
+          apply_units_immediately: entry[:apply_units_immediately],
           timestamp:
         )
-
-        if apply_units_immediately && fixed_charge.pay_in_advance?
-          after_commit do
-            Invoices::CreatePayInAdvanceFixedChargesJob.perform_later(subscription, timestamp)
-          end
-        end
       end
     end
 

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_detection_concern_spec.rb
@@ -8,10 +8,7 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
       include Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
 
       public :units_only_fixed_charges_plan_overrides?,
-        :units_only_fixed_charge_params?,
-        :promote_units_overrides_to_fixed_charges_params
-
-      attr_accessor :subscription
+        :units_only_fixed_charge_params?
     end.new
   end
 
@@ -114,93 +111,6 @@ RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverrideDetectionConcern
 
     context "with an empty hash" do
       it { expect(host.units_only_fixed_charge_params?({})).to be false }
-    end
-  end
-
-  describe "#promote_units_overrides_to_fixed_charges_params" do
-    let(:organization) { create(:organization) }
-    let(:plan) { create(:plan, organization:) }
-    let(:fc1) { create(:fixed_charge, plan:, organization:, units: 5) }
-    let(:fc2) { create(:fixed_charge, plan:, organization:, units: 10) }
-    let(:subscription) { create(:subscription, plan:) }
-
-    before { host.subscription = subscription }
-
-    context "when the subscription has no override rows" do
-      it "returns the existing params unchanged" do
-        existing = [{id: fc1.id, units: 7}]
-        expect(host.promote_units_overrides_to_fixed_charges_params(existing)).to eq(existing)
-      end
-
-      it "does not touch the database" do
-        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
-        host.promote_units_overrides_to_fixed_charges_params([])
-        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
-      end
-    end
-
-    context "when override rows exist but no existing params are provided" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc2, organization:, units: 22)
-      end
-
-      it "synthesises one entry per override row with the captured units" do
-        result = host.promote_units_overrides_to_fixed_charges_params
-
-        expect(result).to contain_exactly(
-          {id: fc1.id, units: 11},
-          {id: fc2.id, units: 22}
-        )
-      end
-
-      it "discards the override rows" do
-        host.promote_units_overrides_to_fixed_charges_params
-
-        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
-        expect(::Subscription::FixedChargeUnitsOverride.unscoped.where(subscription:).discarded).to exist
-      end
-    end
-
-    context "when caller params already include an entry for an overridden fixed_charge" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
-      end
-
-      it "keeps the caller's entry and discards the override row" do
-        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc1.id, units: 99}])
-
-        expect(result).to contain_exactly({id: fc1.id, units: 99})
-        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
-      end
-    end
-
-    context "when caller params reference different fixed_charges than the overrides" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
-      end
-
-      it "preserves caller entries and adds synthetic entries for the overrides" do
-        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc2.id, units: 50}])
-
-        expect(result).to contain_exactly(
-          {id: fc2.id, units: 50},
-          {id: fc1.id, units: 11}
-        )
-      end
-    end
-
-    context "with string-keyed existing params" do
-      before do
-        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
-      end
-
-      it "normalises string keys and keeps the caller's entry" do
-        result = host.promote_units_overrides_to_fixed_charges_params([{"id" => fc1.id, "units" => 99}])
-
-        # Caller entry wins (we don't mutate it). Returned value preserves its original key style.
-        expect(result.map { |e| e[:id] || e["id"] }).to contain_exactly(fc1.id)
-      end
     end
   end
 end

--- a/spec/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern_spec.rb
+++ b/spec/services/subscriptions/concerns/fixed_charge_units_override_promotion_concern_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::Concerns::FixedChargeUnitsOverridePromotionConcern do
+  subject(:host) do
+    Class.new do
+      include Subscriptions::Concerns::FixedChargeUnitsOverridePromotionConcern
+
+      public :promote_units_overrides_to_fixed_charges_params
+
+      attr_accessor :subscription
+    end.new
+  end
+
+  describe "#promote_units_overrides_to_fixed_charges_params" do
+    let(:organization) { create(:organization) }
+    let(:plan) { create(:plan, organization:) }
+    let(:fc1) { create(:fixed_charge, plan:, organization:, units: 5) }
+    let(:fc2) { create(:fixed_charge, plan:, organization:, units: 10) }
+    let(:subscription) { create(:subscription, plan:) }
+
+    before { host.subscription = subscription }
+
+    context "when the subscription has no override rows" do
+      it "returns the existing params unchanged" do
+        existing = [{id: fc1.id, units: 7}]
+        expect(host.promote_units_overrides_to_fixed_charges_params(existing)).to eq(existing)
+      end
+
+      it "does not touch the database" do
+        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
+        host.promote_units_overrides_to_fixed_charges_params([])
+        expect(::Subscription::FixedChargeUnitsOverride.count).to eq(0)
+      end
+    end
+
+    context "when override rows exist but no existing params are provided" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc2, organization:, units: 22)
+      end
+
+      it "synthesises one entry per override row with the captured units" do
+        result = host.promote_units_overrides_to_fixed_charges_params
+
+        expect(result).to contain_exactly(
+          {id: fc1.id, units: 11},
+          {id: fc2.id, units: 22}
+        )
+      end
+
+      it "discards the override rows" do
+        host.promote_units_overrides_to_fixed_charges_params
+
+        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
+        expect(::Subscription::FixedChargeUnitsOverride.unscoped.where(subscription:).discarded).to exist
+      end
+    end
+
+    context "when caller params already include an entry for an overridden fixed_charge" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "keeps the caller's entry and discards the override row" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc1.id, units: 99}])
+
+        expect(result).to contain_exactly({id: fc1.id, units: 99})
+        expect(::Subscription::FixedChargeUnitsOverride.kept.where(subscription:)).to be_empty
+      end
+    end
+
+    context "when caller params reference different fixed_charges than the overrides" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "preserves caller entries and adds synthetic entries for the overrides" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{id: fc2.id, units: 50}])
+
+        expect(result).to contain_exactly(
+          {id: fc2.id, units: 50},
+          {id: fc1.id, units: 11}
+        )
+      end
+    end
+
+    context "with string-keyed existing params" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge: fc1, organization:, units: 11)
+      end
+
+      it "normalises string keys and keeps the caller's entry" do
+        result = host.promote_units_overrides_to_fixed_charges_params([{"id" => fc1.id, "units" => 99}])
+
+        # Caller entry wins (we don't mutate it). Returned value preserves its original key style.
+        expect(result.map { |e| e[:id] || e["id"] }).to contain_exactly(fc1.id)
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/fixed_charge_units_overrides/write_service_spec.rb
+++ b/spec/services/subscriptions/fixed_charge_units_overrides/write_service_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::FixedChargeUnitsOverrides::WriteService do
+  subject(:write_service) do
+    described_class.new(
+      subscription:,
+      fixed_charge:,
+      units:,
+      apply_units_immediately:,
+      timestamp:
+    )
+  end
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 5) }
+  let(:subscription) { create(:subscription, plan:) }
+  let(:units) { 15 }
+  let(:apply_units_immediately) { false }
+  let(:timestamp) { Time.current.to_i }
+
+  describe "#call" do
+    it "creates a Subscription::FixedChargeUnitsOverride for the (subscription, fixed_charge) pair" do
+      expect { write_service.call }
+        .to change(::Subscription::FixedChargeUnitsOverride, :count).by(1)
+
+      override = ::Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+      expect(override.units).to eq(15)
+      expect(override.organization).to eq(subscription.organization)
+    end
+
+    it "emits a fixed charge event for the subscription with the override units" do
+      expect { write_service.call }.to change(FixedChargeEvent, :count).by(1)
+
+      event = FixedChargeEvent.find_by(subscription:, fixed_charge:)
+      expect(event.units).to eq(15)
+    end
+
+    it "returns the override on the result" do
+      result = write_service.call
+
+      expect(result).to be_success
+      expect(result.units_override).to be_a(::Subscription::FixedChargeUnitsOverride)
+      expect(result.units_override.units).to eq(15)
+    end
+
+    context "when an override already exists for the pair" do
+      before do
+        create(:subscription_fixed_charge_units_override, subscription:, fixed_charge:, organization:, units: 7)
+      end
+
+      it "updates the existing override row rather than creating a new one" do
+        expect { write_service.call }
+          .not_to change(::Subscription::FixedChargeUnitsOverride, :count)
+
+        override = ::Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+        expect(override.units).to eq(15)
+      end
+    end
+
+    context "when apply_units_immediately is true on a pay-in-advance fixed charge" do
+      let(:apply_units_immediately) { true }
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 5, pay_in_advance: true) }
+
+      it "enqueues the pay-in-advance billing job after commit" do
+        expect { write_service.call }
+          .to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+          .with(subscription, timestamp)
+      end
+    end
+
+    context "when apply_units_immediately is true on a pay-in-arrears fixed charge" do
+      let(:apply_units_immediately) { true }
+
+      it "does not enqueue the pay-in-advance billing job" do
+        expect { write_service.call }
+          .not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+      end
+    end
+
+    context "when apply_units_immediately is false on a pay-in-advance fixed charge" do
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, units: 5, pay_in_advance: true) }
+
+      it "does not enqueue the pay-in-advance billing job" do
+        expect { write_service.call }
+          .not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
+      end
+    end
+  end
+end


### PR DESCRIPTION
… concern

The dedicated subscription fixed_charge endpoint and the subscription update endpoint both wrote one Subscription::FixedChargeUnitsOverride row, emitted a FixedChargeEvent, and dispatched the mid-period billing job. The two services carried near-identical copies of that logic.

Extract the shared write into
Subscriptions::FixedChargeUnitsOverrides::WriteService. Both call sites now route through it.

The detection concern (params-shape predicates) had grown to include the promotion helper that captures override rows and merges them into Plans::OverrideService params. The name no longer matched the responsibility, and mixing a pure params-shape predicate set with a DB-mutating helper blurred the concern's boundary.

Move the promotion helper into
FixedChargeUnitsOverridePromotionConcern; the detection concern keeps only the predicates.

## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}

## Context

Include relevant motivation and context.

## Description

Describe your changes in detail.

List any dependencies that are required.
