### PR TITLE
[ISSUE-1965] fix(api_logs): allow PATCH http_method

### DIFF
--- a/app/models/clickhouse/api_log.rb
+++ b/app/models/clickhouse/api_log.rb
@@ -14,7 +14,8 @@ module Clickhouse
       get: 1,
       post: 2,
       put: 3,
-      delete: 4
+      delete: 4,
+      patch: 5
     }.freeze
 
     private

--- a/db/clickhouse_migrate/20260624144347_add_patch_to_api_logs_http_method.rb
+++ b/db/clickhouse_migrate/20260624144347_add_patch_to_api_logs_http_method.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: false
+
+class AddPatchToApiLogsHttpMethod < ActiveRecord::Migration[8.0]
+  EXTENDED_HTTP_METHODS = {get: 1, post: 2, put: 3, delete: 4, patch: 5}.freeze
+  ORIGINAL_HTTP_METHODS = {get: 1, post: 2, put: 3, delete: 4}.freeze
+
+  def up
+    safety_assured do
+      modify_http_method_enum(EXTENDED_HTTP_METHODS)
+    end
+  end
+
+  def down
+    safety_assured do
+      modify_http_method_enum(ORIGINAL_HTTP_METHODS)
+    end
+  end
+
+  private
+
+  def modify_http_method_enum(values)
+    execute <<~SQL
+      ALTER TABLE api_logs
+        MODIFY COLUMN http_method #{enum_literal(values)};
+    SQL
+
+    # Kafka engine tables don't support ALTER MODIFY COLUMN, so we drop and
+    # recreate the queue together with the materialized view that bridges it
+    # to api_logs. The data lives in Kafka, so nothing is lost; the consumer
+    # group resumes from its committed offset.
+    execute "DROP TABLE IF EXISTS api_logs_mv"
+    execute "DROP TABLE IF EXISTS api_logs_queue"
+
+    create_table :api_logs_queue, id: false, options: queue_options do |t|
+      t.string :request_id, null: false
+      t.string :organization_id, null: false
+      t.string :api_key_id, null: false
+      t.string :api_version, null: false
+
+      t.string :client, null: false
+      t.string :request_body, null: false, map: true
+      t.string :request_response, map: true
+      t.string :request_path, null: false
+      t.string :request_origin, null: false
+      t.enum :http_method, value: values, null: false
+      t.integer :http_status, null: false
+
+      t.datetime :logged_at, null: false, precision: 3
+      t.datetime :created_at, null: false, precision: 3
+    end
+
+    create_view :api_logs_mv, materialized: true, as: mv_sql, to: "api_logs"
+  end
+
+  def enum_literal(values)
+    pairs = values.map { |k, v| "'#{k}' = #{v}" }.join(", ")
+    "Enum8(#{pairs})"
+  end
+
+  def queue_options
+    <<-SQL
+      Kafka()
+      SETTINGS
+        kafka_broker_list = '#{ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"]}',
+        kafka_topic_list = '#{ENV["LAGO_KAFKA_API_LOGS_TOPIC"]}',
+        kafka_group_name = '#{ENV["LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP"]}',
+        kafka_format = 'JSONEachRow'
+    SQL
+  end
+
+  def mv_sql
+    <<-SQL
+      SELECT
+        request_id,
+        organization_id,
+        api_key_id,
+        api_version,
+        client,
+        request_body,
+        request_response,
+        request_path,
+        request_origin,
+        http_method,
+        http_status,
+        logged_at,
+        created_at
+      FROM api_logs_queue
+    SQL
+  end
+end

--- a/db/clickhouse_migrate/cloud/04_api_logs.sql
+++ b/db/clickhouse_migrate/cloud/04_api_logs.sql
@@ -9,7 +9,7 @@ CREATE TABLE default.api_logs
     `request_response` Map(String, Nullable(String)),
     `request_path` String,
     `request_origin` String,
-    `http_method` Enum8('get' = 1, 'post' = 2, 'put' = 3, 'delete' = 4),
+    `http_method` Enum8('get' = 1, 'post' = 2, 'put' = 3, 'delete' = 4, 'patch' = 5),
     `http_status` UInt32,
     `logged_at` DateTime64(3),
     `created_at` DateTime64(3)

--- a/schema.graphql
+++ b/schema.graphql
@@ -6414,6 +6414,7 @@ Api Logs http method enums
 """
 enum HttpMethodEnum {
   delete
+  patch
   post
   put
 }

--- a/schema.json
+++ b/schema.json
@@ -32835,6 +32835,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "patch",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/spec/graphql/types/api_logs/http_method_enum_spec.rb
+++ b/spec/graphql/types/api_logs/http_method_enum_spec.rb
@@ -4,6 +4,6 @@ require "rails_helper"
 
 RSpec.describe Types::ApiLogs::HttpMethodEnum do
   it "enumerates the correct values" do
-    expect(described_class.values.keys).to match_array(%w[post put delete])
+    expect(described_class.values.keys).to match_array(%w[post put delete patch])
   end
 end

--- a/spec/queries/api_logs_query_spec.rb
+++ b/spec/queries/api_logs_query_spec.rb
@@ -99,6 +99,20 @@ RSpec.describe ApiLogsQuery, clickhouse: true do
       filters = {http_methods: ["other"]}
       expect(described_class.call(organization:, pagination:, filters:).api_logs).to be_empty
     end
+
+    context "with a PATCH api log" do
+      let(:patch_api_log) { create(:clickhouse_api_log, organization:, http_method: "patch") }
+
+      before { patch_api_log }
+
+      it "persists patch into the ClickHouse enum and filters by it" do
+        filters = {http_methods: ["patch"]}
+        api_logs = described_class.call(organization:, pagination:, filters:).api_logs
+
+        expect(api_logs.map(&:request_id)).to contain_exactly(patch_api_log.request_id)
+        expect(api_logs.first.http_method).to eq("patch")
+      end
+    end
   end
 
   context "with http_statuses filter" do

--- a/spec/services/utils/api_log_spec.rb
+++ b/spec/services/utils/api_log_spec.rb
@@ -68,6 +68,27 @@ RSpec.describe Utils::ApiLog do
         )
       end
 
+      context "when the request uses PATCH" do
+        let(:fake_request) do
+          instance_double(
+            "ActionDispatch::Request",
+            user_agent: "RSpec",
+            params: {parameters: [1, 2, 3, 4]},
+            path: "/api/v1/customers/abc",
+            base_url: "https://lago.test",
+            method_symbol: :patch,
+            request_id: "1234"
+          )
+        end
+
+        it "produces a payload with http_method: :patch" do
+          api_log.produce(fake_request, fake_response, organization:)
+
+          expect(karafka_producer).to have_received(:produce_async)
+            .with(hash_including(payload: include('"http_method":"patch"')))
+        end
+      end
+
       context "when request_id is empty" do
         let(:fake_request) do
           instance_double(


### PR DESCRIPTION
## Summary

Adds `patch` to the `http_method` enum on the ClickHouse `api_logs` table so PATCH requests reaching `Utils::ApiLog#produce` are persisted instead of being rejected. ClickPipes was routing them to its dead letter queue on cloud, and the Kafka engine queue table was refusing them on self-hosted, so real PATCH endpoints in the API were silently absent from the logs.

## Changes

`app/models/clickhouse/api_log.rb` adds `patch: 5` to `HTTP_METHODS`. The GraphQL `Types::ApiLogs::HttpMethodEnum` derives its values from this constant, so it picks up `patch` automatically without an explicit edit.

`db/clickhouse_migrate/20260624144347_add_patch_to_api_logs_http_method.rb` is a new ClickHouse migration. It extends the enum on the main `api_logs` MergeTree via `ALTER TABLE … MODIFY COLUMN`, then drops and recreates `api_logs_queue` together with the `api_logs_mv` materialized view that bridges them — Kafka engine tables don't support `MODIFY COLUMN`, so a drop-and-recreate is the only available path. The underlying Kafka topic is untouched and the consumer group resumes from its committed offset on the next start, so no events are lost. The `down` path is symmetric: it ALTERs `api_logs` back to the original 4-value enum and recreates the queue + MV with the original enum signature. The `up`/`down` were both exercised against the test ClickHouse (migrate → rollback → migrate again).

`db/clickhouse_migrate/cloud/04_api_logs.sql` is updated so new cloud environments bootstrap with `'patch' = 5` baked in.

## Notes for review / ops

Existing cloud deployments still need the equivalent DDL (`ALTER TABLE api_logs MODIFY COLUMN …` and a queue/MV recreation) applied to the live ClickHouse to flip ClickPipes from "DLQ" to "ingest" for in-flight PATCH events. That's a one-time ops step outside this repo.

The migration uses `# frozen_string_literal: false` because the underlying `create_view` helper mutates the SQL string it receives — matching the pattern used by the original `create_api_logs_mv.rb` and other MV migrations in the same directory.

## Test plan

- [x] `bin/rails db:migrate:clickhouse RAILS_ENV=test` — migration applies cleanly.
- [x] `bin/rails db:rollback:clickhouse RAILS_ENV=test` — `down` reverts cleanly to the original enum.
- [x] Re-migrated to leave the test DB at the new state.
- [x] `rspec spec/models/clickhouse/api_log_spec.rb spec/services/utils/api_log_spec.rb spec/queries/api_logs_query_spec.rb spec/graphql/types/api_logs spec/graphql/resolvers/api_log{,s}_resolver_spec.rb spec/serializers/v1/api_log_serializer_spec.rb spec/requests/api/v1/api_logs_controller_spec.rb` — all green (86 examples, 0 failures including the two new PATCH-specific tests).

New tests added in this PR:

- `spec/services/utils/api_log_spec.rb` — a request double with `method_symbol: :patch` produces a Kafka payload that includes `"http_method":"patch"`.
- `spec/queries/api_logs_query_spec.rb` — a `clickhouse_api_log` created with `http_method: "patch"` round-trips through the extended ClickHouse enum and is selectable via the `http_methods: ["patch"]` filter. This is the end-to-end proof that the enum migration actually accepts the new value.
- `spec/graphql/types/api_logs/http_method_enum_spec.rb` — assertion updated to include `patch` in the exposed GraphQL enum values.
