### PR TITLE
fix(exports): drop orphaned provider customers from exports_customers view

### DIFF
--- a/db/migrate/20260625095837_update_exports_customers_to_version_8.rb
+++ b/db/migrate/20260625095837_update_exports_customers_to_version_8.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateExportsCustomersToVersion8 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :exports_customers, version: 8, revert_to_version: 7
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3193,7 +3193,7 @@ CREATE VIEW public.exports_customers AS
     '[]'::json AS lago_taxes_ids
    FROM ((public.customers c
      LEFT JOIN public.organizations o ON ((o.id = c.organization_id)))
-     LEFT JOIN public.payment_provider_customers ppc ON (((ppc.customer_id = c.id) AND (ppc.deleted_at IS NULL))));
+     LEFT JOIN public.payment_provider_customers ppc ON (((ppc.customer_id = c.id) AND (ppc.deleted_at IS NULL) AND (ppc.payment_provider_id IS NOT NULL))));
 
 
 --
@@ -12793,6 +12793,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260625095837'),
 ('20260619065327'),
 ('20260617145515'),
 ('20260616160703'),

--- a/db/views/exports_customers_v08.sql
+++ b/db/views/exports_customers_v08.sql
@@ -1,0 +1,53 @@
+SELECT
+  c.organization_id,
+  c.id AS lago_id,
+  c.billing_entity_id,
+  c.external_id,
+  c.account_type::text,
+  c.name,
+  c.firstname,
+  c.lastname,
+  c.customer_type::text,
+  c.sequential_id,
+  c.slug,
+  c.created_at,
+  c.updated_at,
+  c.deleted_at,
+  c.country,
+  c.address_line1,
+  c.address_line2,
+  c.state,
+  c.zipcode,
+  c.email,
+  c.city,
+  c.url,
+  c.phone,
+  c.legal_name,
+  c.legal_number,
+  c.currency,
+  c.tax_identification_number,
+  c.timezone,
+  COALESCE(c.timezone, o.timezone, 'UTC') AS applicable_timezone,
+  c.net_payment_term,
+  c.external_salesforce_id,
+  CASE c.finalize_zero_amount_invoice
+    WHEN 0 THEN 'inherit'
+    WHEN 1 THEN 'skip'
+    WHEN 2 THEN 'finalize'
+  END AS finalize_zero_amount_invoice,
+  c.skip_invoice_custom_sections,
+  c.payment_provider,
+  c.payment_provider_code,
+  c.invoice_grace_period,
+  c.vat_rate,
+  COALESCE(c.invoice_grace_period, o.invoice_grace_period) AS applicable_invoice_grace_period,
+  c.document_locale,
+  ppc.provider_customer_id,
+  ppc.settings AS provider_settings,
+  '{}'::json AS metadata,
+  '[]'::json AS lago_taxes_ids
+FROM customers c
+LEFT JOIN organizations o ON o.id = c.organization_id
+LEFT JOIN payment_provider_customers ppc ON ppc.customer_id = c.id
+  AND ppc.deleted_at IS NULL
+  AND ppc.payment_provider_id IS NOT NULL;

--- a/spec/db/views/exports_customers_spec.rb
+++ b/spec/db/views/exports_customers_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "exports_customers view" do # rubocop:disable RSpec/DescribeClass
+  let(:customer) { create(:customer) }
+
+  def rows_for(id)
+    ActiveRecord::Base.connection.select_all(
+      "SELECT * FROM exports_customers WHERE lago_id = #{ActiveRecord::Base.connection.quote(id)}"
+    ).to_a
+  end
+
+  describe "payment_provider_customers join" do
+    context "when the customer has a single live provider customer" do
+      let(:provider) { create(:gocardless_provider, organization: customer.organization) }
+
+      before do
+        create(:gocardless_customer, customer:, payment_provider: provider, provider_customer_id: "gc_live")
+      end
+
+      it "emits one row carrying the provider data" do
+        rows = rows_for(customer.id)
+
+        expect(rows.size).to eq(1)
+        expect(rows.first["provider_customer_id"]).to eq("gc_live")
+      end
+    end
+
+    context "when the customer has an orphaned provider customer plus a live one" do
+      # PaymentProviders::DestroyService nullifies payment_provider_id without
+      # soft-deleting, leaving an orphan row (deleted_at IS NULL). Reconnecting a
+      # different provider then adds a second live row, so the unfiltered join
+      # emitted two rows and broke the BigQuery MERGE.
+      let(:provider) { create(:gocardless_provider, organization: customer.organization) }
+
+      before do
+        create(:stripe_customer, customer:, payment_provider: nil, provider_customer_id: "stripe_orphan")
+        create(:gocardless_customer, customer:, payment_provider: provider, provider_customer_id: "gc_live")
+      end
+
+      it "emits a single row and ignores the orphaned provider customer" do
+        rows = rows_for(customer.id)
+
+        expect(rows.size).to eq(1)
+        expect(rows.first["provider_customer_id"]).to eq("gc_live")
+      end
+    end
+
+    context "when the customer only has an orphaned provider customer" do
+      before do
+        create(:stripe_customer, customer:, payment_provider: nil, provider_customer_id: "stripe_orphan")
+      end
+
+      it "emits one row with null provider columns" do
+        rows = rows_for(customer.id)
+
+        expect(rows.size).to eq(1)
+        expect(rows.first["provider_customer_id"]).to be_nil
+      end
+    end
+
+    context "when the customer has no provider customer" do
+      it "emits one row with null provider columns" do
+        rows = rows_for(customer.id)
+
+        expect(rows.size).to eq(1)
+        expect(rows.first["provider_customer_id"]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

A Prequel synchronization of the `customers` model aborts on the BigQuery write step because the `exports_customers` view returns more than one row per customer. BigQuery's MERGE requires at most one source row per target row:

```
BigQuery Data Processing Failed [PRQL-FGWV]: Attempted to write data with duplicate rows to BigQuery: UPDATE/MERGE must match at most one source row for each target row, invalidQuery
```

The view LEFT JOINs `payment_provider_customers` filtering only on `deleted_at IS NULL`. `PaymentProviders::DestroyService` nullifies `payment_provider_id` via `update_all` instead of soft-deleting the row, so the orphaned row stays live (`deleted_at = NULL`). When the customer later connects a different payment provider, a fresh row is created. The customer now matches the join twice and the view emits two rows.

The model's uniqueness validation is scoped to `type` (`(customer_id, type)` unique where `deleted_at IS NULL`), so the duplicate happens across provider types: an orphaned row of one type plus a live row of another. The unique index blocks two live rows of the same type, so a same-type reconnection does not trigger this.

## Description

This adds an `exports_customers_v08` view that also requires `ppc.payment_provider_id IS NOT NULL` in the join, so orphaned provider customers are excluded and the view emits at most one row per customer. It ships through a migration following the existing `update_exports_customers_to_version_N` pattern.

Note that it may be be possible to have multiple provider customers of different type. This is out of scope.

### How to verify locally

```
lago exec api bundle exec rspec spec/db/views/exports_customers_spec.rb
```

The spec fails on `v07` (the orphan+live case returns two rows, the orphan-only case leaks the orphan's `provider_customer_id`) and passes on `v08`.

Ref: INT-137
