### PR TITLE
[ING-327][ING-335][ING-329] misc(clickhouse): Apply AggregationResult to unique_count query

### DIFF
--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -13,7 +13,7 @@ module BillableMetrics
       def compute_aggregation(options: {})
         return empty_result if should_bypass_aggregation?
 
-        aggregation = event_store.unique_count.ceil(5)
+        aggregation = event_store.unique_count.value.ceil(5)
 
         if options[:is_pay_in_advance] && options[:is_current_usage]
           handle_in_advance_current_usage(aggregation)
@@ -24,7 +24,7 @@ module BillableMetrics
         result.pay_in_advance_aggregation = BigDecimal(compute_pay_in_advance_aggregation)
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by).map(&:to_grouped_hash)
           result.pay_in_advance_breakdowns = build_pay_in_advance_breakdowns(value: result.pay_in_advance_aggregation)
         end
 
@@ -49,21 +49,21 @@ module BillableMetrics
 
         result.aggregations = aggregations.map do |aggregation|
           group_result = BaseService::Result.new
-          group_result.grouped_by = aggregation[:groups]
+          group_result.grouped_by = aggregation.groups
 
           if options[:is_pay_in_advance] && options[:is_current_usage]
-            handle_in_advance_current_usage(aggregation[:value], target_result: group_result)
+            handle_in_advance_current_usage(aggregation.value, target_result: group_result)
           else
-            group_result.aggregation = aggregation[:value]
+            group_result.aggregation = aggregation.value
           end
 
-          group_result.count = aggregation[:value]
+          group_result.count = aggregation.events_count
           group_result.options = {running_total: running_total(options, aggregation: group_result.aggregation)}
           group_result
         end
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by).map(&:to_grouped_hash)
         end
 
         result

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -19,7 +19,7 @@ module BillableMetrics
         # For charges that are pay in advance on billing date we always bill full amount
         return aggregation_without_proration if event.nil? && options[:is_pay_in_advance] && !options[:is_current_usage]
 
-        aggregation = event_store.prorated_unique_count.ceil(5)
+        aggregation = event_store.prorated_unique_count.value.ceil(5)
         result.full_units_number = aggregation_without_proration.aggregation if event.nil?
 
         if options[:is_current_usage]
@@ -34,7 +34,7 @@ module BillableMetrics
         end
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by).map(&:to_grouped_hash)
           result.pay_in_advance_breakdowns = build_pay_in_advance_breakdowns(value: aggregation_without_proration.pay_in_advance_aggregation)
         end
 
@@ -62,19 +62,19 @@ module BillableMetrics
         return empty_results if aggregations.blank?
 
         result.aggregations = aggregations.map do |aggregation|
-          aggregation_value = aggregation[:value].ceil(5)
+          aggregation_value = aggregation.value.ceil(5)
 
           group_result_without_proration = aggregation_without_proration.aggregations.find do |agg|
-            agg.grouped_by == aggregation[:groups]
+            agg.grouped_by == aggregation.groups
           end
 
           unless group_result_without_proration
             group_result_without_proration = empty_results.aggregations.first
-            group_result_without_proration.grouped_by = aggregation[:groups]
+            group_result_without_proration.grouped_by = aggregation.groups
           end
 
           group_result = BaseService::Result.new
-          group_result.grouped_by = aggregation[:groups]
+          group_result.grouped_by = aggregation.groups
           group_result.full_units_number = group_result_without_proration&.aggregation || 0
 
           if options[:is_current_usage]
@@ -95,7 +95,7 @@ module BillableMetrics
         end
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_unique_count(uniq_grouped_by_and_presentation_by).map(&:to_grouped_hash)
         end
 
         result

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -206,6 +206,23 @@ module Events
           events_count: with_count ? (row && row["events_count"]).to_i : nil
         )
       end
+
+      # NOTE: Build an AggregationResult for aggregations whose value already
+      #       represents the number of aggregated events (count, unique_count).
+      #       The value is reused as the events_count, avoiding a second count query.
+      def build_aggregation_result_from_value(value)
+        value ||= 0
+        AggregationResult.new(value:, events_count: value)
+      end
+
+      # NOTE: same as build_aggregation_result_from_value but for grouped results:
+      #       wraps {groups:, value:} hashes into GroupedAggregationResult,
+      #       reusing each value as its events_count.
+      def grouped_results_with_value_as_count(rows)
+        rows.map do |row|
+          GroupedAggregationResult.new(groups: row[:groups], value: row[:value], events_count: row[:value])
+        end
+      end
     end
   end
 end

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -307,7 +307,7 @@ module Events
           connection.select_one(sql)
         end
 
-        result["aggregation"]
+        build_aggregation_result_from_value(result["aggregation"])
       end
 
       # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
@@ -343,7 +343,7 @@ module Events
           connection.select_one(sql)
         end
 
-        result["aggregation"]
+        build_aggregation_result_from_value(result["aggregation"])
       end
 
       def prorated_unique_count_breakdown(with_remove: false)
@@ -381,7 +381,9 @@ module Events
             ]
           )
 
-          prepare_grouped_result(connection.select_all(sql), groups_key: :grouped_by, value_key: :aggregation)
+          grouped_results_with_value_as_count(
+            prepare_grouped_result(connection.select_all(sql), groups_key: :grouped_by, value_key: :aggregation)
+          )
         end
       end
 
@@ -399,7 +401,9 @@ module Events
               }
             ]
           )
-          prepare_grouped_result(connection.select_all(sql), groups_key: :grouped_by, value_key: :aggregation)
+          grouped_results_with_value_as_count(
+            prepare_grouped_result(connection.select_all(sql), groups_key: :grouped_by, value_key: :aggregation)
+          )
         end
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -341,7 +341,7 @@ module Events
           connection.select_one(sql)
         end
 
-        result["aggregation"]
+        build_aggregation_result_from_value(result["aggregation"])
       end
 
       # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
@@ -377,7 +377,7 @@ module Events
           connection.select_one(sql)
         end
 
-        result["aggregation"]
+        build_aggregation_result_from_value(result["aggregation"])
       end
 
       def prorated_unique_count_breakdown(with_remove: false)
@@ -415,7 +415,9 @@ module Events
             ]
           )
 
-          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
+          grouped_results_with_value_as_count(
+            prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
+          )
         end
       end
 
@@ -433,7 +435,9 @@ module Events
               }
             ]
           )
-          prepare_grouped_result(connection.select_all(sql).rows)
+          grouped_results_with_value_as_count(
+            prepare_grouped_result(connection.select_all(sql).rows)
+          )
         end
       end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -134,7 +134,7 @@ module Events
         sql = sanitize_sql_for_conditions([query.query])
         result = select_one(sql)
 
-        result["aggregation"]
+        build_aggregation_result_from_value(result["aggregation"])
       end
 
       # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
@@ -159,7 +159,7 @@ module Events
         )
         result = select_one(sql)
 
-        result["aggregation"]
+        build_aggregation_result_from_value(result["aggregation"])
       end
 
       def prorated_unique_count_breakdown(with_remove: false)
@@ -188,7 +188,9 @@ module Events
           [query.grouped_query]
         )
 
-        prepare_grouped_result(select_all(sql).rows, columns: columns)
+        grouped_results_with_value_as_count(
+          prepare_grouped_result(select_all(sql).rows, columns: columns)
+        )
       end
 
       def grouped_prorated_unique_count
@@ -203,7 +205,7 @@ module Events
             }
           ]
         )
-        prepare_grouped_result(select_all(sql).rows)
+        grouped_results_with_value_as_count(prepare_grouped_result(select_all(sql).rows))
       end
 
       def max(with_count: true)

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -596,7 +596,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
         event_store.aggregation_property = billable_metric.field_name
 
-        expect(event_store.unique_count).to eq(4) # 5 events added / 1 removed
+        result = event_store.unique_count
+
+        expect(result.value).to eq(4) # 5 events added / 1 removed
+        expect(result.events_count).to eq(4)
       end
     end
   end
@@ -629,7 +632,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         # 3 => added on 2 day, never removed => 14/31
         # 4 => added on 3 day, never removed => 13/31
         # 5 => added on 4 day, never removed => 12/31
-        expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
+        expect(event_store.prorated_unique_count.value.round(3)).to eq(2.29)
       end
 
       context "with multiple events at the same day" do
@@ -661,7 +664,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           # 3 => added on 2 day, never removed => 14/31
           # 4 => added on 3 day, never removed => 13/31
           # 5 => added on 4 day, never removed => 12/31
-          expect(event_store.prorated_unique_count.round(3)).to eq(1.871) # 16/31 + 3/31 + 14/31 + 13/31 + 12/31
+          expect(event_store.prorated_unique_count.value.round(3)).to eq(1.871) # 16/31 + 3/31 + 14/31 + 13/31 + 12/31
         end
       end
     end
@@ -746,10 +749,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         result = event_store.grouped_unique_count
 
         expect(result).to match_array([
-          {groups: {"city" => nil, "country" => "france", "region" => "europe"}, value: 1},
-          {groups: {"city" => "paris", "country" => "france", "region" => "europe"}, value: 1},
-          {groups: {"city" => "london", "country" => "united kingdom", "region" => "europe"}, value: 1},
-          {groups: {"city" => nil, "country" => nil, "region" => nil}, value: 2}
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"city" => nil, "country" => "france", "region" => "europe"}, value: 1, events_count: 1),
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"city" => "paris", "country" => "france", "region" => "europe"}, value: 1, events_count: 1),
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"city" => "london", "country" => "united kingdom", "region" => "europe"}, value: 1, events_count: 1),
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"city" => nil, "country" => nil, "region" => nil}, value: 2, events_count: 2)
         ])
       end
 
@@ -810,12 +813,12 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
         expect(result.count).to eq(3)
 
-        null_group = result.find { |v| v[:groups]["agent_name"].nil? }
-        expect(null_group[:groups]["other"]).to be_nil
-        expect(null_group[:value].round(3)).to eq(0.935) # 29/31
+        null_group = result.find { |v| v.groups["agent_name"].nil? }
+        expect(null_group.groups["other"]).to be_nil
+        expect(null_group.value.round(3)).to eq(0.935) # 29/31
 
         # NOTE: Events calculation: [1/31, 30/31]
-        expect((result - [null_group]).map { |r| r[:value].round(3) }).to contain_exactly(0.032, 0.968)
+        expect((result - [null_group]).map { |r| r.value.round(3) }).to contain_exactly(0.032, 0.968)
       end
 
       context "with no events" do
@@ -1881,8 +1884,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_unique_count(["cloud"])
 
           expect(result).to match_array([
-            {groups: {"cloud" => "aws"}, value: 3},
-            {groups: {"cloud" => "gcp"}, value: 1}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "aws"}, value: 3, events_count: 3),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "gcp"}, value: 1, events_count: 1)
           ])
         end
       end
@@ -1901,9 +1904,9 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_unique_count(["agent_name", "cloud"])
 
           expect(result).to match_array([
-            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
-            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1},
-            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1, events_count: 1)
           ])
         end
       end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5751

Today, all aggregation services (except CountService) perform two queries against the event store: one for the aggregation itself, and a second for the number of events involved in the result.

This implementation is inherited from the original Postgres store and works well for that engine. When the Clickhouse store was introduced, the same approach was kept for compatibility. At scale this is not ideal on the Clickhouse side, as it forces the engine to retrieve the same set of records twice, including a second pass over the expensive deduplication CTE.

This PR applies the single-pass approach, already introduced for `sum`,  `max`, and `last` to the `unique_count` aggregation.

## Description

`unique_count` and `grouped_unique_count` and their prorated counterparts now return the existing `AggregationResult` / `GroupedAggregationResult` structures carrying both the value and the events_count.

The key differences with already rewritten aggregation is that both `value` and `events_count` return the same value to keep the current behavior. This PR goal is mainly to use the common pattern for unique count even if it does not reduce the number of DB queries

The same approach will be applied to the remaining aggregations in follow-up steps.