### PR TITLE
feat(purchase_order_number): Add the new field to one-off invoices PDF

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -14,7 +14,8 @@ module Api
           skip_psp: create_params[:skip_psp],
           invoice_custom_section: create_params[:invoice_custom_section] || {},
           payment_method_params: create_params[:payment_method],
-          billing_entity_code: create_params[:billing_entity_code]
+          billing_entity_code: create_params[:billing_entity_code],
+          purchase_order_number: create_params[:purchase_order_number]
         )
 
         if result.success?
@@ -277,6 +278,7 @@ module Api
               :currency,
               :skip_psp,
               :billing_entity_code,
+              :purchase_order_number,
               fees: [
                 :add_on_code,
                 :invoice_display_name,

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -8,6 +8,7 @@ module V1
         billing_entity_code: model.billing_entity.code,
         sequential_id: model.sequential_id,
         number: model.number,
+        purchase_order_number: model.purchase_order_number,
         issuing_date: model.issuing_date&.iso8601,
         payment_due_date: model.payment_due_date&.iso8601,
         net_payment_term: model.net_payment_term,

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -28,6 +28,7 @@ module DataExports
           customer_country
           customer_tax_identification_number
           invoice_number
+          purchase_order_number
           invoice_type
           payment_status
           status
@@ -76,6 +77,7 @@ module DataExports
           serialized_invoice.dig(:customer, :country),
           serialized_invoice.dig(:customer, :tax_identification_number),
           serialized_invoice[:number],
+          serialized_invoice[:purchase_order_number],
           serialized_invoice[:invoice_type],
           serialized_invoice[:payment_status],
           serialized_invoice[:status],

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -218,6 +218,8 @@ html
       }
       .invoice-information-table tr td:first-child {
         padding: 0 16px 0 0;
+        white-space: nowrap;
+        width: 1%;
       }
       .invoice-information-table tr td:last-child {
         width: 55%;
@@ -229,7 +231,6 @@ html
       }
       .invoice-information-table {
         border-collapse: collapse;
-        table-layout: fixed;
         width: 100%;
       }
 
@@ -368,6 +369,10 @@ html
             tr
               td.body-1 = I18n.t('invoice.invoice_number')
               td.body-2 = number
+            - if purchase_order_number.present?
+              tr
+                td.body-1 = I18n.t('invoice.purchase_order_number')
+                td.body-2 = purchase_order_number
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -80,6 +80,7 @@ de:
     prepaid_credits: Prepaid-Guthaben
     prepaid_credits_with_value: Prepaid-Guthaben - %{wallet_name}
     progressive_billing_credit: Nutzung bereits abgerechnet
+    purchase_order_number: Bestellnummer
     quarter: quartal
     quarterly: Vierteljährlich
     reached_usage_threshold: Diese progressive Rechnung wird erstellt, da Ihre kumulierte Nutzung %{usage_amount} erreicht hat und den Schwellenwert von %{threshold_amount} überschritten hat.

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -81,6 +81,7 @@ en:
     prepaid_credits: Prepaid credits
     prepaid_credits_with_value: Prepaid credits - %{wallet_name}
     progressive_billing_credit: Usage already billed
+    purchase_order_number: Purchase Order Number
     quarter: quarter
     quarterly: Quarterly
     reached_usage_threshold: This progressive billing is generated because your cumulative usage has reached %{usage_amount}, exceeding the %{threshold_amount} threshold.

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -79,6 +79,7 @@ es:
     prepaid_credits: Créditos prepagados
     prepaid_credits_with_value: Créditos prepagados - %{wallet_name}
     progressive_billing_credit: Uso ya facturado
+    purchase_order_number: Número de orden de compra
     quarter: trimestre
     quarterly: Trimestral
     reached_usage_threshold: Esta facturación progresiva se genera porque su uso acumulado ha alcanzado los %{usage_amount}, superando el umbral de %{threshold_amount}.

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -80,6 +80,7 @@ fr:
     prepaid_credits: Crédit(s) prépayé(s)
     prepaid_credits_with_value: Crédit(s) prépayé(s) - %{wallet_name}
     progressive_billing_credit: Usage déjà facturé
+    purchase_order_number: Numéro de bon de commande
     quarter: trimestre
     quarterly: trimestriellement
     reached_usage_threshold: Cette facturation progressive est générée car votre usage cumulé a atteint %{usage_amount}, dépassant le seuil de %{threshold_amount}.

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -80,6 +80,7 @@ it:
     prepaid_credits: Crediti prepagati
     prepaid_credits_with_value: Crediti prepagati - %{wallet_name}
     progressive_billing_credit: Uso già fatturato
+    purchase_order_number: Numero d'ordine d'acquisto
     quarter: trimestre
     quarterly: Trimestrale
     reached_usage_threshold: Questa fatturazione progressiva è generata poiché il tuo utilizzo cumulato ha raggiunto %{usage_amount}, superando la soglia di %{threshold_amount}.

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -80,6 +80,7 @@ nb:
     prepaid_credits: Forskuddsbetalte kreditter
     prepaid_credits_with_value: Forhåndsbetalte kreditter - %{wallet_name}
     progressive_billing_credit: Bruk allerede fakturert
+    purchase_order_number: Bestillingsnummer
     quarter: kvartal
     quarterly: Kvartalsvis
     reached_usage_threshold: Denne progressive faktureringen er generert fordi din akkumulerte bruk har nådd %{usage_amount}, og overskredet terskelen på %{threshold_amount}.

--- a/config/locales/pt-BR/invoice.yml
+++ b/config/locales/pt-BR/invoice.yml
@@ -80,6 +80,7 @@ pt-BR:
     prepaid_credits: Créditos pré-pagos
     prepaid_credits_with_value: Créditos pré-pagos - %{wallet_name}
     progressive_billing_credit: Uso já faturado
+    purchase_order_number: Número do pedido de compra
     quarter: trimestre
     quarterly: Trimestral
     reached_usage_threshold: Esta cobrança progressiva é gerada porque seu uso cumulativo atingiu %{usage_amount}, excedendo o limite de %{threshold_amount}.

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -79,6 +79,7 @@ sv:
     prepaid_credits: Förbetald kontobalans
     prepaid_credits_with_value: Förbetald kontobalans - %{wallet_name}
     progressive_billing_credit: Redan fakturerad användning
+    purchase_order_number: Inköpsordernummer
     quarter: kvartal
     quarterly: Kvartalsvis
     reached_usage_threshold: Denna progressiva fakturering skapas eftersom din ackumulerade användning har nått %{usage_amount} och överstiger %{threshold_amount} tröskeln.

--- a/config/locales/zh-TW/invoice.yml
+++ b/config/locales/zh-TW/invoice.yml
@@ -80,6 +80,7 @@ zh-TW:
     prepaid_credits: 預付點數
     prepaid_credits_with_value: 預付點數 - %{wallet_name}
     progressive_billing_credit: 已計費的使用量
+    purchase_order_number: 採購訂單編號
     quarter: 季
     quarterly: 每季
     reached_usage_threshold: 此累進計費因您的累積使用量已達到 %{usage_amount}，超過 %{threshold_amount} 的門檻而產生。

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -118,6 +118,30 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
+    context "with a purchase_order_number" do
+      let(:create_params) do
+        {
+          external_customer_id: customer_external_id,
+          currency: "EUR",
+          purchase_order_number: "  PO-12345  ",
+          fees: [
+            {
+              add_on_code: add_on_first.code,
+              unit_amount_cents: 1200,
+              units: 2
+            }
+          ]
+        }
+      end
+
+      it "creates an invoice with the normalized purchase order number" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoice][:purchase_order_number]).to eq("PO-12345")
+      end
+    end
+
     context "when multi_entity_billing feature flag is enabled" do
       let(:other_billing_entity) { create(:billing_entity, organization:) }
 

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       "billing_entity_code" => invoice.billing_entity.code,
       "sequential_id" => invoice.sequential_id,
       "number" => invoice.number,
+      "purchase_order_number" => invoice.purchase_order_number,
       "issuing_date" => invoice.issuing_date.iso8601,
       "payment_due_date" => invoice.payment_due_date.iso8601,
       "net_payment_term" => invoice.net_payment_term,

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
         tax_identification_number: "123456789"
       },
       number: "INV123",
+      purchase_order_number: "PO-12345",
       invoice_type: "credit",
       payment_status: "pending",
       status: "finalized",
@@ -96,7 +97,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
 
     it "generates the correct CSV output" do
       expected_csv = <<~CSV
-        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999
+        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999
       CSV
 
       expect(result).to be_success
@@ -115,7 +116,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
 
       it "adds billing_entity_code to the csv" do
         expected_csv = <<~CSV
-          invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999,the-test-bil-ent
+          invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999,the-test-bil-ent
         CSV
 
         expect(result).to be_success

--- a/spec/services/data_exports/process_part_service_spec.rb
+++ b/spec/services/data_exports/process_part_service_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe DataExports::ProcessPartService do
         tax_identification_number: "123456789"
       },
       number: "INV123",
+      purchase_order_number: "PO-12345",
       invoice_type: "credit",
       payment_status: "pending",
       status: "finalized",
@@ -56,7 +57,7 @@ RSpec.describe DataExports::ProcessPartService do
   describe "#call" do
     it "processes the part" do
       expected_csv = <<~CSV
-        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334
+        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334
       CSV
       expect(result).to be_success
       expect(result.data_export_part.csv_lines).to eq(expected_csv)

--- a/spec/views/app/views/templates/invoices/v4/one_off.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4/one_off.slim_spec.rb
@@ -195,4 +195,68 @@ RSpec.describe "templates/invoices/v4/one_off.slim" do
       expect(rendered_template).to match_html_snapshot
     end
   end
+
+  context "with a purchase order number" do
+    let(:add_on) { create(:add_on, organization:, name: "Setup Fee") }
+    let(:add_on_fee) do
+      create(
+        :one_off_fee,
+        invoice:,
+        add_on:,
+        amount_cents: 10000,
+        amount_currency: "USD",
+        units: 1,
+        unit_amount_cents: 10000,
+        invoice_display_name: "Setup Fee"
+      )
+    end
+
+    let(:invoice) do
+      create(
+        :invoice,
+        customer:,
+        organization:,
+        number: "LAGO-202509-OO-PO",
+        payment_due_date: Date.parse("2025-09-15"),
+        issuing_date: Date.parse("2025-09-01"),
+        invoice_type: :one_off,
+        total_amount_cents: 10000,
+        currency: "USD",
+        fees_amount_cents: 10000,
+        sub_total_excluding_taxes_amount_cents: 10000,
+        sub_total_including_taxes_amount_cents: 10000,
+        coupons_amount_cents: 0,
+        purchase_order_number: "PO-12345"
+      )
+    end
+
+    before { add_on_fee }
+
+    it "renders the purchase order number under the invoice number" do
+      expect(rendered_template).to include("Purchase Order Number")
+      expect(rendered_template).to include("PO-12345")
+    end
+  end
+
+  context "without a purchase order number" do
+    let(:add_on) { create(:add_on, organization:, name: "Setup Fee") }
+    let(:add_on_fee) do
+      create(
+        :one_off_fee,
+        invoice:,
+        add_on:,
+        amount_cents: 10000,
+        amount_currency: "USD",
+        units: 1,
+        unit_amount_cents: 10000,
+        invoice_display_name: "Setup Fee"
+      )
+    end
+
+    before { add_on_fee }
+
+    it "does not render the purchase order number row" do
+      expect(rendered_template).not_to include("Purchase Order Number")
+    end
+  end
 end


### PR DESCRIPTION
## Context
Root PR: #5763

The new field `purchase_order_number` should be displayed on the invoice PDF if the PO number is defined.

## Description

- Add `purchase_order_number` to the PDF template (only one-off invoices in this scope).
- Update locales
