### PR TITLE
fix(wallet): block zero-value inbound transactions [ING-109]

### DIFF
--- a/app/models/wallet_credit.rb
+++ b/app/models/wallet_credit.rb
@@ -10,6 +10,15 @@ class WalletCredit
     new(wallet:, credit_amount: amount.fdiv(wallet.rate_amount), amount_cents:)
   end
 
+  def self.rounds_to_zero?(wallet:, credit_amount:)
+    return false if credit_amount.blank?
+
+    credit_amount = BigDecimal(credit_amount.to_s).floor(5)
+    return false unless credit_amount.positive?
+
+    new(wallet:, credit_amount:).amount_cents.zero?
+  end
+
   # we'll assume you construct this normally for a wallet and a credit amount
   def initialize(wallet:, credit_amount:, invoiceable: true, amount_cents: nil)
     @wallet = wallet

--- a/app/services/wallet_transactions/recredit_service.rb
+++ b/app/services/wallet_transactions/recredit_service.rb
@@ -15,6 +15,9 @@ module WalletTransactions
 
       return result.not_allowed_failure!(code: "wallet_not_active") unless wallet.active?
 
+      # Only relevant for historical data: zero-rounding amounts are now blocked at creation,
+      # so this guards transactions created before that change. We return a success result so
+      # that voiding an invoice never fails because of such old transactions.
       return result if WalletCredit.rounds_to_zero?(wallet:, credit_amount: wallet_transaction.credit_amount)
 
       transaction_result = WalletTransactions::CreateFromParamsService.call(

--- a/app/services/wallet_transactions/recredit_service.rb
+++ b/app/services/wallet_transactions/recredit_service.rb
@@ -15,6 +15,8 @@ module WalletTransactions
 
       return result.not_allowed_failure!(code: "wallet_not_active") unless wallet.active?
 
+      return result if WalletCredit.rounds_to_zero?(wallet:, credit_amount: wallet_transaction.credit_amount)
+
       transaction_result = WalletTransactions::CreateFromParamsService.call(
         organization: customer.organization,
         params: {

--- a/app/services/wallet_transactions/validate_service.rb
+++ b/app/services/wallet_transactions/validate_service.rb
@@ -42,17 +42,31 @@ module WalletTransactions
     end
 
     def valid_paid_credits_amount?
-      return true if valid_amount?(args[:paid_credits])
+      unless valid_amount?(args[:paid_credits])
+        add_error(field: :paid_credits, error_code: "invalid_paid_credits")
+        add_error(field: :paid_credits, error_code: "invalid_amount")
+        return false
+      end
 
-      add_error(field: :paid_credits, error_code: "invalid_paid_credits")
-      add_error(field: :paid_credits, error_code: "invalid_amount")
+      valid_minimum_monetary_value?(args[:paid_credits], field: :paid_credits)
     end
 
     def valid_granted_credits_amount?
-      return true if valid_amount?(args[:granted_credits])
+      unless valid_amount?(args[:granted_credits])
+        add_error(field: :granted_credits, error_code: "invalid_granted_credits")
+        add_error(field: :granted_credits, error_code: "invalid_amount")
+        return false
+      end
 
-      add_error(field: :granted_credits, error_code: "invalid_granted_credits")
-      add_error(field: :granted_credits, error_code: "invalid_amount")
+      valid_minimum_monetary_value?(args[:granted_credits], field: :granted_credits)
+    end
+
+    def valid_minimum_monetary_value?(credits, field:)
+      return true unless result.current_wallet
+      return true unless WalletCredit.rounds_to_zero?(wallet: result.current_wallet, credit_amount: credits)
+
+      add_error(field:, error_code: "amount_rounds_to_zero")
+      false
     end
 
     def valid_voided_credits_amount?

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -161,6 +161,8 @@ module Wallets
     end
 
     def validate_wallet_initial_amount!(wallet)
+      reject_credits_rounding_to_zero!(wallet)
+
       return unless positive_paid_credit_amount?
 
       Validators::WalletTransactionAmountLimitsValidator.new(
@@ -169,6 +171,15 @@ module Wallets
         credits_amount: paid_credits,
         ignore_validation: params[:ignore_paid_top_up_limits_on_creation]
       ).raise_if_invalid!
+    end
+
+    def reject_credits_rounding_to_zero!(wallet)
+      {paid_credits:, granted_credits:}.each do |field, credits|
+        next unless WalletCredit.rounds_to_zero?(wallet:, credit_amount: credits)
+
+        result.single_validation_failure!(error_code: "amount_rounds_to_zero", field:)
+        result.raise_if_error!
+      end
     end
 
     def positive_paid_credit_amount?

--- a/spec/models/wallet_credit_spec.rb
+++ b/spec/models/wallet_credit_spec.rb
@@ -96,6 +96,40 @@ RSpec.describe WalletCredit do
     end
   end
 
+  describe ".rounds_to_zero?" do
+    subject { described_class.rounds_to_zero?(wallet:, credit_amount:) }
+
+    let(:rate_amount) { 0.01 }
+
+    context "when the credit amount produces a zero monetary value" do
+      let(:credit_amount) { "0.4" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the credit amount produces a non-zero monetary value" do
+      let(:credit_amount) { "1.0" }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when the credit amount is strictly zero" do
+      let(:credit_amount) { "0.0" }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when the wallet uses a three-decimal currency" do
+      let(:currency) { "KWD" }
+      let(:rate_amount) { 0.001 }
+      let(:credit_amount) { "1.0" }
+
+      it "keeps a sub-cent but non-zero value as not rounding to zero" do
+        expect(subject).to be(false)
+      end
+    end
+  end
+
   context "when invoiceable is false" do
     let(:invoiceable) { false }
 

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -334,6 +334,23 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
         end
       end
 
+      context "when granted_credits round to zero monetary value" do
+        let(:rate_amount) { 0.01 }
+        let(:params) do
+          {
+            wallet_id: wallet.id,
+            granted_credits: "0.4"
+          }
+        end
+
+        it "fails and persists no wallet transaction" do
+          expect { result }.not_to change(WalletTransaction, :count)
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:granted_credits]).to eq(["amount_rounds_to_zero"])
+        end
+      end
+
       context "with invalid payment method" do
         let(:payment_method) { create(:payment_method, organization:, customer:) }
         let(:params) do

--- a/spec/services/wallet_transactions/recredit_service_spec.rb
+++ b/spec/services/wallet_transactions/recredit_service_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe WalletTransactions::RecreditService do
       expect(service.call).to be_success
     end
 
+    context "when the credits to restore round to zero monetary value" do
+      let(:wallet) { create(:wallet, rate_amount: "0.01") }
+      let(:wallet_transaction) do
+        create(:wallet_transaction, wallet:, transaction_type: :outbound, credit_amount: 0.4)
+      end
+
+      it "skips the recredit without creating a transaction" do
+        expect { service.call }.not_to change(WalletTransaction.inbound, :count)
+        expect(service.call).to be_success
+      end
+    end
+
     context "when wallet transaction has an invoice" do
       let(:voided_invoice) { create(:invoice, :voided, organization: wallet.organization) }
       let(:wallet_transaction) do

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -133,6 +133,69 @@ RSpec.describe WalletTransactions::ValidateService do
       end
     end
 
+    context "when inbound credits round to zero monetary value" do
+      let(:wallet) { create(:wallet, customer:, rate_amount: "0.01", credits_balance: 10) }
+
+      context "with paid_credits that round to zero" do
+        let(:paid_credits) { "0.4" }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:paid_credits]).to eq(["amount_rounds_to_zero"])
+        end
+      end
+
+      context "with granted_credits that round to zero" do
+        let(:paid_credits) { "0.0" }
+        let(:granted_credits) { "0.4" }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:granted_credits]).to eq(["amount_rounds_to_zero"])
+        end
+      end
+
+      context "when the credits produce a non-zero monetary value" do
+        let(:paid_credits) { "1.0" }
+
+        it "returns true" do
+          expect(validate_service).to be_valid
+          expect(result.error).to be_nil
+        end
+      end
+
+      context "with strictly-zero credits" do
+        let(:paid_credits) { "0.0" }
+        let(:granted_credits) { "0.0" }
+
+        it "returns true and preserves the existing no-op behavior" do
+          expect(validate_service).to be_valid
+          expect(result.error).to be_nil
+        end
+      end
+
+      context "with voided_credits that round to zero" do
+        let(:paid_credits) { "0.0" }
+        let(:granted_credits) { "0.0" }
+        let(:voided_credits) { "0.4" }
+
+        it "returns true since outbound transactions are unaffected" do
+          expect(validate_service).to be_valid
+          expect(result.error).to be_nil
+        end
+      end
+    end
+
+    context "when the wallet uses a three-decimal currency" do
+      let(:wallet) { create(:wallet, customer:, currency: "KWD", rate_amount: "0.001", credits_balance: 10) }
+      let(:paid_credits) { "1.0" }
+
+      it "keeps a sub-cent but non-zero monetary value valid" do
+        expect(validate_service).to be_valid
+        expect(result.error).to be_nil
+      end
+    end
+
     context "with invalid voided_credits" do
       let(:voided_credits) { "foobar" }
 

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -164,6 +164,26 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
+    context "when the initial credits round to zero monetary value" do
+      let(:params) do
+        {
+          name: "New Wallet",
+          customer:,
+          organization_id: organization.id,
+          currency: "EUR",
+          rate_amount: "0.01",
+          granted_credits: "0.4"
+        }
+      end
+
+      it "does not create the wallet and returns a validation error" do
+        expect { service_result }.not_to change(Wallet, :count)
+        expect(service_result).not_to be_success
+        expect(service_result.error).to be_a(BaseService::ValidationFailure)
+        expect(service_result.error.messages[:granted_credits]).to eq(["amount_rounds_to_zero"])
+      end
+    end
+
     context "when customer has reached the wallet limit" do
       before do
         create_list(:wallet, Wallets::ValidateService::MAXIMUM_WALLETS_PER_CUSTOMER, customer:, organization:, status: :active)


### PR DESCRIPTION
## Context

When you add credits to a wallet, Lago converts them to money using the wallet's rate. If the amount you add is so small that it converts to zero money, the credits become useless:

- **Granted credits:** the credit count goes up, but the money balance doesn't. Spending is based on the money balance, so those credits can never be used.
- **Paid credits:** nothing happens at all, and it would mean charging an invoice for zero.

Today both are allowed. This change rejects them.

## What changed

If someone tries to add a positive amount of credits that converts to zero money, it's now refused with a clear error instead of silently creating a broken transaction. This is checked in the three places credits can be added:

- **Normal top-ups** (API, GraphQL, customer portal, automatic recurring top-ups): the request fails with a validation error.
- **Creating a wallet with a starting balance:** the wallet is not created and the user gets the same error right away.
- **Restoring credits after voiding an invoice:** this is skipped quietly, so voiding an invoice never breaks because of old data.

Credits that are exactly zero, and credits being spent (not added), are untouched.

## Examples

What happens when credits are added, for currencies with different numbers of decimals (checked against the real conversion code):

| Currency | Rate | Credits added | Becomes | Result |
|----------|-----:|--------------:|---------|--------|
| EUR (2 decimals) | 0.01 | 0.4 | EUR 0.00 | Refused |
| EUR (2 decimals) | 0.01 | 1.0 | EUR 0.01 | Allowed |
| JPY (0 decimals) | 1.0 | 0.4 | JPY 0 | Refused |
| JPY (0 decimals) | 1.0 | 1.0 | JPY 1 | Allowed |
| KWD (3 decimals) | 0.001 | 0.4 | 0.000 KWD | Refused |
| KWD (3 decimals) | 0.001 | 1.0 | 0.001 KWD | Allowed |
| any | any | 0 | nothing | Allowed (unchanged) |

We reuse Lago's existing money-conversion code so this works correctly for every currency. The note in the issue suggested multiplying by 100, but that only holds for currencies with 2 decimals (the last KWD row would have been wrongly refused).

## Tests

Added tests for the conversion check, the three entry points above, plus the existing transaction flow. All related tests pass.