### PR TITLE
fix(fixed-charges): resolve subscription charge by add-on code

### DIFF
--- a/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
+++ b/app/controllers/api/v1/subscriptions/fixed_charges_controller.rb
@@ -80,8 +80,23 @@ module Api
         end
 
         def find_fixed_charge
-          @fixed_charge = subscription.plan.fixed_charges.find_by(code: params[:code])
+          fixed_charges = subscription.plan.fixed_charges
+          @fixed_charge = fixed_charges.find_by(code: params[:code]) ||
+            find_by_add_on_code(fixed_charges)
           not_found_error(resource: "fixed_charge") unless @fixed_charge
+        end
+
+        # Fixed charge codes are auto-suffixed (e.g. `developer_seats_2`) when
+        # several charges share an add-on, so a caller using the stable add-on
+        # code would get a 404 once the unsuffixed charge is removed. Fall back
+        # to resolving by add-on code, but only when it points to a single
+        # charge to avoid silently picking the wrong one.
+        def find_by_add_on_code(fixed_charges)
+          matches = fixed_charges.joins(:add_on)
+            .where(add_ons: {code: params[:code]})
+            .limit(2)
+            .to_a
+          matches.first if matches.size == 1
         end
       end
     end

--- a/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
@@ -142,6 +142,34 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
       end
     end
 
+    context "when the requested code matches the add-on code of a suffixed charge" do
+      subject { get_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/fixed_charges/developer_seats") }
+
+      let(:add_on) { create(:add_on, organization:, code: "developer_seats") }
+      let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, code: "developer_seats_2") }
+
+      it "resolves the fixed charge by add-on code" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:fixed_charge][:lago_id]).to eq(fixed_charge.id)
+        expect(json[:fixed_charge][:code]).to eq("developer_seats_2")
+        expect(json[:fixed_charge][:add_on_code]).to eq("developer_seats")
+      end
+
+      context "when several charges share that add-on code" do
+        let(:other_fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, code: "developer_seats_3") }
+
+        before { other_fixed_charge }
+
+        it "returns not found error to avoid an ambiguous match" do
+          subject
+
+          expect(response).to be_not_found_error("fixed_charge")
+        end
+      end
+    end
+
     context "when subscription has plan override with fixed charge override" do
       let(:overridden_plan) { create(:plan, organization:, parent: plan) }
       let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }
@@ -220,6 +248,24 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
           subject
 
           expect(response).to be_not_found_error("fixed_charge")
+        end
+      end
+
+      context "when the requested code matches the add-on code of a suffixed charge" do
+        subject do
+          put_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/fixed_charges/developer_seats", {fixed_charge: update_params})
+        end
+
+        let(:add_on) { create(:add_on, organization:, code: "developer_seats") }
+        let(:fixed_charge) { create(:fixed_charge, plan:, organization:, add_on:, code: "developer_seats_2") }
+
+        it "resolves and updates the fixed charge by add-on code" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:fixed_charge][:invoice_display_name]).to eq("Updated Fixed Charge Name")
+          expect(json[:fixed_charge][:units]).to eq("15.0")
+          expect(json[:fixed_charge][:lago_parent_id]).to eq(fixed_charge.id)
         end
       end
 


### PR DESCRIPTION
> **Local validation incomplete:** the runner has no reachable PostgreSQL (the dev DB runs in Docker, which is not running on this runner; per the agent skill I do not provision services myself), so RSpec could not run locally. RuboCop ran locally and is green. **Validation delegated to CI — please do not review until CI is green.**

## What changed and why

Fixes the 404 in [BIL-179](https://linear.app/getlago/issue/BIL-179).

When two fixed charges for the same add-on coexist on a plan, the code generator auto-suffixes the second one (`developer_seats` → `developer_seats_2`, see `FixedCharges::GenerateCodeService`). If the original (unsuffixed) charge is later removed, the surviving charge keeps its suffixed code. The UI/consumers still address the charge by the stable **add-on code** (`developer_seats`), but the subscription `fixed_charges` show/update endpoints looked the charge up only by its literal `code`, returning `404 fixed_charge_not_found`.

The fix makes `Api::V1::Subscriptions::FixedChargesController#find_fixed_charge` fall back to resolving by the add-on's code when no charge matches the literal `:code`. To stay correct, the fallback only resolves when the add-on code points to **exactly one** charge; if several charges share that add-on code (an ambiguous match), it returns the existing 404 so we never silently pick the wrong charge. The literal-code lookup still takes precedence, so existing callers passing the real (possibly suffixed) code are unaffected.

## What was NOT done / out of scope

- **No data migration / re-coding** of existing suffixed charges, and no change to `GenerateCodeService`. The suffixing behavior is intentional (the `(plan_id, code)` unique index requires it); this PR only makes lookup resilient.
- **Plan-scoped endpoint** (`Api::V1::Plans::FixedChargesController`) has the same latent lookup-by-literal-code behavior but is **not** what the ticket repro hits, so it is left untouched to keep the blast radius narrow. Worth a follow-up if product wants symmetric behavior.
- **Frontend** (separate repo) not touched.

## Ambiguity note

If a plan has e.g. `developer_seats_2` and `developer_seats_3` (both for add-on `developer_seats`) and no charge with the literal code `developer_seats`, the add-on-code fallback is ambiguous and the endpoint returns 404 — the caller must use the explicit suffixed code. This is strictly better than today (always 404 for the suffixed case) and avoids guessing.

## Performance

Not a hot path — these are low-traffic subscription config endpoints, not the event ingestion pipeline. The extra query runs only when the literal-code lookup misses, is bounded to one plan's fixed charges, and is `LIMIT 2`.

## How to verify locally

1. Create an add-on `developer_seats`; create a plan with a fixed charge on it; subscribe a customer.
2. Add a second fixed charge for the same add-on (now coded `developer_seats_2`), then remove the original.
3. `PUT /api/v1/subscriptions/<ext_id>/fixed_charges/developer_seats` → now resolves the surviving charge instead of 404.

Or run the request specs:
\`\`\`
bundle exec rspec spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
\`\`\`

New specs cover: resolve-by-add-on-code (GET + PUT) and the ambiguous-match 404 guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)