### PR TITLE
feat(purchase_order_number): Add the new field to CSV exports

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -14,7 +14,8 @@ module Api
           skip_psp: create_params[:skip_psp],
           invoice_custom_section: create_params[:invoice_custom_section] || {},
           payment_method_params: create_params[:payment_method],
-          billing_entity_code: create_params[:billing_entity_code]
+          billing_entity_code: create_params[:billing_entity_code],
+          purchase_order_number: create_params[:purchase_order_number]
         )
 
         if result.success?
@@ -277,6 +278,7 @@ module Api
               :currency,
               :skip_psp,
               :billing_entity_code,
+              :purchase_order_number,
               fees: [
                 :add_on_code,
                 :invoice_display_name,

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -8,6 +8,7 @@ module V1
         billing_entity_code: model.billing_entity.code,
         sequential_id: model.sequential_id,
         number: model.number,
+        purchase_order_number: model.purchase_order_number,
         issuing_date: model.issuing_date&.iso8601,
         payment_due_date: model.payment_due_date&.iso8601,
         net_payment_term: model.net_payment_term,

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -28,6 +28,7 @@ module DataExports
           customer_country
           customer_tax_identification_number
           invoice_number
+          purchase_order_number
           invoice_type
           payment_status
           status
@@ -76,6 +77,7 @@ module DataExports
           serialized_invoice.dig(:customer, :country),
           serialized_invoice.dig(:customer, :tax_identification_number),
           serialized_invoice[:number],
+          serialized_invoice[:purchase_order_number],
           serialized_invoice[:invoice_type],
           serialized_invoice[:payment_status],
           serialized_invoice[:status],

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -118,6 +118,30 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
+    context "with a purchase_order_number" do
+      let(:create_params) do
+        {
+          external_customer_id: customer_external_id,
+          currency: "EUR",
+          purchase_order_number: "  PO-12345  ",
+          fees: [
+            {
+              add_on_code: add_on_first.code,
+              unit_amount_cents: 1200,
+              units: 2
+            }
+          ]
+        }
+      end
+
+      it "creates an invoice with the normalized purchase order number" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoice][:purchase_order_number]).to eq("PO-12345")
+      end
+    end
+
     context "when multi_entity_billing feature flag is enabled" do
       let(:other_billing_entity) { create(:billing_entity, organization:) }
 

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       "billing_entity_code" => invoice.billing_entity.code,
       "sequential_id" => invoice.sequential_id,
       "number" => invoice.number,
+      "purchase_order_number" => invoice.purchase_order_number,
       "issuing_date" => invoice.issuing_date.iso8601,
       "payment_due_date" => invoice.payment_due_date.iso8601,
       "net_payment_term" => invoice.net_payment_term,

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
         tax_identification_number: "123456789"
       },
       number: "INV123",
+      purchase_order_number: "PO-12345",
       invoice_type: "credit",
       payment_status: "pending",
       status: "finalized",
@@ -96,7 +97,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
 
     it "generates the correct CSV output" do
       expected_csv = <<~CSV
-        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999
+        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999
       CSV
 
       expect(result).to be_success
@@ -115,7 +116,7 @@ RSpec.describe DataExports::Csv::Invoices, :premium do
 
       it "adds billing_entity_code to the csv" do
         expected_csv = <<~CSV
-          invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999,the-test-bil-ent
+          invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334,999,the-test-bil-ent
         CSV
 
         expect(result).to be_success

--- a/spec/services/data_exports/process_part_service_spec.rb
+++ b/spec/services/data_exports/process_part_service_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe DataExports::ProcessPartService do
         tax_identification_number: "123456789"
       },
       number: "INV123",
+      purchase_order_number: "PO-12345",
       invoice_type: "credit",
       payment_status: "pending",
       status: "finalized",
@@ -56,7 +57,7 @@ RSpec.describe DataExports::ProcessPartService do
   describe "#call" do
     it "processes the part" do
       expected_csv = <<~CSV
-        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334
+        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,PO-12345,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,27511,50000,334
       CSV
       expect(result).to be_success
       expect(result.data_export_part.csv_lines).to eq(expected_csv)


### PR DESCRIPTION
## Context

Root PR: #5763

The new field purchase_order_number should be displayed in the invoices CSV Export.

## Description

Adds a new `purchase_order_number` column