### PR TITLE
fix(invoice): reword prorated fee caption to drop usage wording (BIL-192)

### DIFF
--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -39,7 +39,7 @@ en:
       discount_reason: Discount %{tax_rate} portion
       payment_information: "%{payment_label} of %{currency} %{amount} applied"
       standard_payment: Standard payment
-    fee_prorated: The fee is prorated on days of usage, the displayed unit price is an average
+    fee_prorated: The fee is prorated for the period; the displayed unit price is an average
     fees_from_to_date: Fees from %{from_date} to %{to_date}
     free_credits: Free credits
     from_to_date: From %{from_date} to %{to_date}

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_subscription_and_plan_is_paid_in_advance/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_subscription_and_plan_is_paid_in_advance/renders_correctly.html.snap
@@ -166,7 +166,7 @@
             </tr>
             <tr class="fixed-charge-name fee">
               <td class="body-1">Graduated Pay in Arrears Prorated Fixed Charge Fee
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2"></td>
               <td class="body-2"></td>
@@ -261,7 +261,7 @@
             </tr>
             <tr class="fixed-charge-name fee">
               <td class="body-1">Volume Pay in Arrears Prorated Fixed Charge Fee
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2"></td>
               <td class="body-2"></td>
@@ -386,7 +386,7 @@
             <tr class="fee">
               <td>
                 <div class="body-1">Standard Pay in Advance Prorated Fixed Charge Fee</div>
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2">0.5</td>
               <td class="body-2">$100.00</td>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_subscription_and_plan_is_paid_in_arrears/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_subscription_and_plan_is_paid_in_arrears/renders_correctly.html.snap
@@ -175,7 +175,7 @@
             </tr>
             <tr class="fixed-charge-name fee">
               <td class="body-1">Graduated Pay in Arrears Prorated Fixed Charge Fee
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2"></td>
               <td class="body-2"></td>
@@ -270,7 +270,7 @@
             </tr>
             <tr class="fixed-charge-name fee">
               <td class="body-1">Volume Pay in Arrears Prorated Fixed Charge Fee
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2"></td>
               <td class="body-2"></td>
@@ -386,7 +386,7 @@
             <tr class="fee">
               <td>
                 <div class="body-1">Standard Pay in Advance Prorated Fixed Charge Fee</div>
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2">0.5</td>
               <td class="body-2">$100.00</td>

--- a/spec/views/app/views/templates/invoices/v4/__snapshots__/templates_invoices_v4_fixed_charge.slim/with_prorated_fixed_charge/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/v4/__snapshots__/templates_invoices_v4_fixed_charge.slim/with_prorated_fixed_charge/renders_correctly.html.snap
@@ -117,7 +117,7 @@
             <tr class="fee">
               <td>
                 <div class="body-1">Prorated Fixed Charge</div>
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2">0.5</td>
               <td class="body-2">$50.00</td>

--- a/spec/views/app/views/templates/invoices/v4/fixed_charge.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4/fixed_charge.slim_spec.rb
@@ -298,6 +298,11 @@ RSpec.describe "templates/invoices/v4/fixed_charge.slim" do
     it "renders correctly" do
       expect(rendered_template).to match_html_snapshot
     end
+
+    it "displays the proration caption without referring to usage" do
+      expect(rendered_template).to include("The fee is prorated for the period; the displayed unit price is an average")
+      expect(rendered_template).not_to include("prorated on days of usage")
+    end
   end
 
   context "with zero amount fee" do


### PR DESCRIPTION
> **Local validation incomplete:** the runner has no PostgreSQL / Redis / ClickHouse, so the RSpec view specs (which build records via factories) could not be run locally. RuboCop and YAML validation ran and are green. **Validation delegated to CI — please do not review until CI is green** (Mode B per the ai-augmented pilot).

## What & why

The invoice PDF caption for prorated fees was sourced from a single shared i18n key, `invoice.fee_prorated`:

> "The fee is prorated on days of usage, the displayed unit price is an average"

For a prorated **fixed charge**, that wording is misleading: a fixed charge is billed for holding the seat regardless of usage, and the proration is by days the seat is held — so "days of usage" describes a billing mechanic that doesn't apply (BIL-192).

Per **Anna Velentsevich's direction on the ticket (2026-06-18)** — *"let's just change the text to 'The fee is prorated for the period; the displayed unit price is an average'"* — this changes the caption text. The new wording is accurate for both fixed and usage-based prorated fees.

## Changes
- `config/locales/en/invoice.yml` — reword the shared `fee_prorated` value.
- Updated the affected invoice template snapshots (fixed-charge prorated, and the v4 paid-in-advance / paid-in-arrears invoice snapshots that render usage-charge proration captions).
- Added an explicit assertion in `spec/.../v4/fixed_charge.slim_spec.rb` ("with prorated fixed charge") for the new caption and the absence of the old "days of usage" phrasing.

## Scope notes / what was NOT done
- **`fee_prorated` is a shared key.** It is also rendered for usage-based prorated charges (`_charge.slim`, `_default_fee.slim`, `_fee_with_filters.slim`, etc.), so those captions change too. The new text remains accurate for them; this follows Anna's literal "just change the text" rather than introducing a fixed-charge-specific key. Flagging it so a reviewer can object if the usage-charge wording should be preserved separately.
- **English locale only.** The other 8 locales still carry the old translation; this matches the repo convention for text edits (e.g. #4178, which touched only `en`). Translations are managed separately.
- The separate `true_up_details` key ("Minimum spend of … prorated on days of usage") was deliberately **left untouched** — it is out of scope.
- The ticket also mentioned a customer request to make this text *editable*; that is a larger feature and out of scope for this bug fix.

## How to verify locally
```
bundle exec rspec spec/views/app/views/templates/invoices/v4/fixed_charge.slim_spec.rb \
  spec/views/app/views/templates/invoices/v4.slim_spec.rb
```
All snapshots should match and the new "displays the proration caption without referring to usage" example should pass.

## Performance
No hot-path impact — invoice PDF template rendering of a static i18n string only.

Linear: https://linear.app/getlago/issue/BIL-192
