### PR TITLE
invoice: reword prorated fee caption to drop "usage"

### DIFF
--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -38,7 +38,7 @@ de:
       discount_reason: Rabatt %{tax_rate} Anteil
       payment_information: "%{payment_label} von %{currency} %{amount} angewendet"
       standard_payment: Standardzahlung
-    fee_prorated: Die Gebühr wird anteilig nach Nutzungstagen berechnet, der angezeigte Stückpreis ist ein Durchschnitt
+    fee_prorated: Die Gebühr wird anteilig für den Zeitraum berechnet; der angezeigte Stückpreis ist ein Durchschnitt
     fees_from_to_date: Gebühren vom %{from_date} bis %{to_date}
     free_credits: Kostenloses Guthaben
     from_to_date: Vom %{from_date} bis %{to_date}

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -39,7 +39,7 @@ en:
       discount_reason: Discount %{tax_rate} portion
       payment_information: "%{payment_label} of %{currency} %{amount} applied"
       standard_payment: Standard payment
-    fee_prorated: The fee is prorated on days of usage, the displayed unit price is an average
+    fee_prorated: The fee is prorated for the period; the displayed unit price is an average
     fees_from_to_date: Fees from %{from_date} to %{to_date}
     free_credits: Free credits
     from_to_date: From %{from_date} to %{to_date}

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -37,7 +37,7 @@ es:
       discount_reason: Descuento del %{tax_rate}
       payment_information: "%{payment_label} de %{currency} %{amount} aplicado"
       standard_payment: Pago estándar
-    fee_prorated: La tarifa se prorratea según los días de uso, el precio unitario mostrado es un promedio
+    fee_prorated: La tarifa se prorratea por el período; el precio unitario mostrado es un promedio
     fees_from_to_date: Cargos desde %{from_date} hasta %{to_date}
     free_credits: Créditos gratuitos
     from_to_date: Desde %{from_date} hasta %{to_date}

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -38,7 +38,7 @@ fr:
       discount_reason: Remise %{tax_rate} part
       payment_information: "%{payment_label} de %{currency} %{amount} appliqué"
       standard_payment: Paiement standard
-    fee_prorated: Les frais sont calculés au prorata des jours d'utilisation, le prix unitaire affiché est une moyenne
+    fee_prorated: Les frais sont calculés au prorata de la période ; le prix unitaire affiché est une moyenne
     fees_from_to_date: Frais de conso. du %{from_date} au %{to_date}
     free_credits: Crédits gratuits
     from_to_date: Du %{from_date} au %{to_date}

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -38,7 +38,7 @@ it:
       discount_reason: Sconto %{tax_rate} parte
       payment_information: "%{payment_label} di %{currency} %{amount} applicato"
       standard_payment: Pagamento standard
-    fee_prorated: La tariffa è calcolata in base ai giorni di utilizzo, il prezzo unitario visualizzato è una media
+    fee_prorated: La tariffa è calcolata in proporzione al periodo; il prezzo unitario visualizzato è una media
     fees_from_to_date: Tariffe dal %{from_date} al %{to_date}
     free_credits: Crediti gratuiti
     from_to_date: Dal %{from_date} al %{to_date}

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -38,7 +38,7 @@ nb:
       discount_reason: Rabatt %{tax_rate} andel
       payment_information: "%{payment_label} på %{currency} %{amount} brukt"
       standard_payment: Standardbetaling
-    fee_prorated: Avgiften beregnes forholdsmessig etter brukerdager, den viste enhetsprisen er et gjennomsnitt
+    fee_prorated: Avgiften beregnes forholdsmessig for perioden; den viste enhetsprisen er et gjennomsnitt
     fees_from_to_date: Gebyrer fra %{from_date} til %{to_date}
     free_credits: Gratis kreditter
     from_to_date: Fra %{from_date} til %{to_date}

--- a/config/locales/pt-BR/invoice.yml
+++ b/config/locales/pt-BR/invoice.yml
@@ -38,7 +38,7 @@ pt-BR:
       discount_reason: Desconto da parte de %{tax_rate}
       payment_information: "%{payment_label} de %{currency} %{amount} aplicado"
       standard_payment: Pagamento padrão
-    fee_prorated: A taxa é proporcional aos dias de uso, o preço unitário exibido é uma média
+    fee_prorated: A taxa é proporcional ao período; o preço unitário exibido é uma média
     fees_from_to_date: Taxas de %{from_date} até %{to_date}
     free_credits: Créditos gratuitos
     from_to_date: De %{from_date} até %{to_date}

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -37,7 +37,7 @@ sv:
       discount_reason: Rabatt %{tax_rate} andel
       payment_information: "%{payment_label} på %{currency} %{amount} tillämpad"
       standard_payment: Standardbetaling
-    fee_prorated: Avgiften är proraterad för användningsdagar, det visade enhetspriset är ett genomsnitt
+    fee_prorated: Avgiften är proraterad för perioden; det visade enhetspriset är ett genomsnitt
     fees_from_to_date: Avgifter från %{from_date} till %{to_date}
     free_credits: Gratis krediter
     from_to_date: Från %{from_date} till %{to_date}

--- a/config/locales/zh-TW/invoice.yml
+++ b/config/locales/zh-TW/invoice.yml
@@ -39,7 +39,7 @@ zh-TW:
       discount_reason: 折扣 %{tax_rate} 部分
       payment_information: 已套用 %{currency} %{amount} 的%{payment_label}
       standard_payment: 標準付款
-    fee_prorated: 費用依使用天數按比例計算，顯示的單價為平均值
+    fee_prorated: 費用依期間按比例計算，顯示的單價為平均值
     fees_from_to_date: 費用期間：%{from_date} 至 %{to_date}
     from_to_date: "%{from_date} 至 %{to_date}"
     graduated:

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_subscription_and_plan_is_paid_in_advance/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_subscription_and_plan_is_paid_in_advance/renders_correctly.html.snap
@@ -166,7 +166,7 @@
             </tr>
             <tr class="fixed-charge-name fee">
               <td class="body-1">Graduated Pay in Arrears Prorated Fixed Charge Fee
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2"></td>
               <td class="body-2"></td>
@@ -261,7 +261,7 @@
             </tr>
             <tr class="fixed-charge-name fee">
               <td class="body-1">Volume Pay in Arrears Prorated Fixed Charge Fee
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2"></td>
               <td class="body-2"></td>
@@ -386,7 +386,7 @@
             <tr class="fee">
               <td>
                 <div class="body-1">Standard Pay in Advance Prorated Fixed Charge Fee</div>
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2">0.5</td>
               <td class="body-2">$100.00</td>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_subscription_and_plan_is_paid_in_arrears/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_subscription_and_plan_is_paid_in_arrears/renders_correctly.html.snap
@@ -175,7 +175,7 @@
             </tr>
             <tr class="fixed-charge-name fee">
               <td class="body-1">Graduated Pay in Arrears Prorated Fixed Charge Fee
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2"></td>
               <td class="body-2"></td>
@@ -270,7 +270,7 @@
             </tr>
             <tr class="fixed-charge-name fee">
               <td class="body-1">Volume Pay in Arrears Prorated Fixed Charge Fee
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2"></td>
               <td class="body-2"></td>
@@ -386,7 +386,7 @@
             <tr class="fee">
               <td>
                 <div class="body-1">Standard Pay in Advance Prorated Fixed Charge Fee</div>
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2">0.5</td>
               <td class="body-2">$100.00</td>

--- a/spec/views/app/views/templates/invoices/v4/__snapshots__/templates_invoices_v4_fixed_charge.slim/with_prorated_fixed_charge/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/v4/__snapshots__/templates_invoices_v4_fixed_charge.slim/with_prorated_fixed_charge/renders_correctly.html.snap
@@ -117,7 +117,7 @@
             <tr class="fee">
               <td>
                 <div class="body-1">Prorated Fixed Charge</div>
-                <div class="body-3">The fee is prorated on days of usage, the displayed unit price is an average</div>
+                <div class="body-3">The fee is prorated for the period; the displayed unit price is an average</div>
               </td>
               <td class="body-2">0.5</td>
               <td class="body-2">$50.00</td>

--- a/spec/views/app/views/templates/invoices/v4/fixed_charge.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4/fixed_charge.slim_spec.rb
@@ -298,6 +298,11 @@ RSpec.describe "templates/invoices/v4/fixed_charge.slim" do
     it "renders correctly" do
       expect(rendered_template).to match_html_snapshot
     end
+
+    it "displays the proration caption without referring to usage" do
+      expect(rendered_template).to include("The fee is prorated for the period; the displayed unit price is an average")
+      expect(rendered_template).not_to include("prorated on days of usage")
+    end
   end
 
   context "with zero amount fee" do


### PR DESCRIPTION
The shared fee_prorated caption said "prorated on days of usage," which is wrong for fixed charges. Reworded to "prorated for the period," across all locales.