### PR TITLE
feat(usage): surface charge code in current usage

### DIFF
--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -63,6 +63,7 @@ module V1
       def charge_data(fee)
         {
           lago_id: fee.charge_id,
+          code: fee.charge.code,
           charge_model: fee.charge.charge_model,
           invoice_display_name: fee.charge.invoice_display_name
         }

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Api::V1::Customers::UsageController do
       expect(charge_usage[:billable_metric][:name]).to eq(metric.name)
       expect(charge_usage[:billable_metric][:code]).to eq(metric.code)
       expect(charge_usage[:billable_metric][:aggregation_type]).to eq("count_agg")
+      expect(charge_usage[:charge][:code]).to eq(charge.code)
       expect(charge_usage[:charge][:charge_model]).to eq("graduated")
       expect(charge_usage[:units]).to eq("4.0")
       expect(charge_usage[:amount_cents]).to eq(5)

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
       "amount_currency" => "EUR",
       "charge" => {
         "lago_id" => charge.id,
+        "code" => charge.code,
         "charge_model" => charge.charge_model,
         "invoice_display_name" => charge.invoice_display_name
       },
@@ -206,6 +207,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
         "amount_currency" => "EUR",
         "charge" => {
           "lago_id" => charge.id,
+          "code" => charge.code,
           "charge_model" => charge.charge_model,
           "invoice_display_name" => charge.invoice_display_name
         },


### PR DESCRIPTION
## Context

The unfiltered `GET /customers/:id/current_usage` response returned `billable_metric.code` but not `charge.code`. When Lago auto-suffixes charge codes for uniqueness, customers had no way to discover the value to pass to `filter_by_charge_code` without a separate plan fetch. The charge id (`charge.lago_id`) was already present in the response, so only the code was missing.

## Description

The charge `code` was added to the `charge` payload of `ChargeUsageSerializer`, next to the existing `lago_id`. The filter is now self-documenting.

`ChargeUsageSerializer` is shared, so past usage (`GET .../past_usage`) and the persisted daily usage snapshots (`DailyUsages::ComputeService`, `FillHistoryService`, `FillFromInvoiceService`) gain the field too. This is additive: `DailyUsages::ComputeDiffService` only mutates numeric fields and indexes charges by `lago_id`, carrying the current snapshot's `charge` hash through untouched, so existing and mixed old/new snapshot diffs are unaffected. `ProjectedChargeUsageSerializer` is a separate class and was intentionally left unchanged.

### How to verify

```
lago exec api bundle exec rspec \
  spec/serializers/v1/customers/charge_usage_serializer_spec.rb \
  spec/requests/api/v1/customers/usage_controller_spec.rb
```

The request spec asserts `charge_usage[:charge][:code]` is returned by the endpoint.

Closes ING-340