### PR TITLE
fix(entitlement): clear privilege removal when re-adding at plan default

### DIFF
--- a/app/services/entitlement/subscription_entitlement_core_update_service.rb
+++ b/app/services/entitlement/subscription_entitlement_core_update_service.rb
@@ -106,9 +106,9 @@ module Entitlement
 
         if plan_val && value_is_the_same?(privilege.value_type, value, plan_val.value)
           sub_val&.discard!
-          subscription.entitlement_removals.where(privilege:).update_all(deleted_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
+          delete_all_privilege_entitlement_removals(privilege)
         elsif sub_val.nil?
-          subscription.entitlement_removals.where(privilege:).update_all(deleted_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
+          delete_all_privilege_entitlement_removals(privilege)
 
           create_entitlement_value(sub_entitlement, privilege, value)
         elsif sub_val && !value_is_the_same?(privilege.value_type, value, sub_val.value)
@@ -119,6 +119,10 @@ module Entitlement
 
     def value_is_the_same?(type, value1, value2)
       Utils::Entitlement.same_value?(type, value1, value2)
+    end
+
+    def delete_all_privilege_entitlement_removals(privilege)
+      subscription.entitlement_removals.where(privilege:).update_all(deleted_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
     end
 
     def create_entitlement_value(entitlement, privilege, value)

--- a/app/services/entitlement/subscription_entitlement_core_update_service.rb
+++ b/app/services/entitlement/subscription_entitlement_core_update_service.rb
@@ -106,6 +106,7 @@ module Entitlement
 
         if plan_val && value_is_the_same?(privilege.value_type, value, plan_val.value)
           sub_val&.discard!
+          subscription.entitlement_removals.where(privilege:).update_all(deleted_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
         elsif sub_val.nil?
           subscription.entitlement_removals.where(privilege:).update_all(deleted_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
 

--- a/spec/services/entitlement/subscription_entitlement_core_update_service_spec.rb
+++ b/spec/services/entitlement/subscription_entitlement_core_update_service_spec.rb
@@ -227,6 +227,27 @@ RSpec.describe Entitlement::SubscriptionEntitlementCoreUpdateService do
         end
       end
 
+      context "when re-adding a removed privilege at the plan default value" do
+        let(:privilege_params) { {seats_max.code => 2} }
+        let(:max_removal) { create(:subscription_feature_removal, privilege: seats_max, subscription:) }
+
+        before { max_removal }
+
+        context "when partial" do
+          let(:partial) { true }
+
+          it "discards the privilege removal so the plan default is restored" do
+            expect(result).to be_success
+            expect(max_removal.reload).to be_discarded
+            expect(subscription.entitlement_removals.where(privilege: seats_max)).not_to exist
+
+            ent = Entitlement::SubscriptionEntitlement.for_subscription(subscription).find { it.code == "seats" }
+            max_priv = ent.privileges.find { it.code == seats_max.code }
+            expect(Utils::Entitlement.cast_value(max_priv.value, max_priv.value_type)).to eq 2
+          end
+        end
+      end
+
       context "when subscription has privilege removals" do
         let(:max_removal) { create(:subscription_feature_removal, privilege: seats_max, subscription:) }
         let(:reset_removal) { create(:subscription_feature_removal, privilege: seats_reset, subscription:) }


### PR DESCRIPTION
When a previously removed subscription privilege is re-added with a value equal to the plan default, `SubscriptionEntitlementCoreUpdateService` discarded any subscription override but left the `SubscriptionFeatureRemoval` in place, so the privilege stayed hidden from the UI and API. Re-adding at a non-default value already cleaned up the removal; this makes the default-value branch do the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)