### PR TITLE
feat(purchase_order_number): Add the new field to REST API

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -14,7 +14,8 @@ module Api
           skip_psp: create_params[:skip_psp],
           invoice_custom_section: create_params[:invoice_custom_section] || {},
           payment_method_params: create_params[:payment_method],
-          billing_entity_code: create_params[:billing_entity_code]
+          billing_entity_code: create_params[:billing_entity_code],
+          purchase_order_number: create_params[:purchase_order_number]
         )
 
         if result.success?
@@ -277,6 +278,7 @@ module Api
               :currency,
               :skip_psp,
               :billing_entity_code,
+              :purchase_order_number,
               fees: [
                 :add_on_code,
                 :invoice_display_name,

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -118,6 +118,30 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
+    context "with a purchase_order_number" do
+      let(:create_params) do
+        {
+          external_customer_id: customer_external_id,
+          currency: "EUR",
+          purchase_order_number: "  PO-12345  ",
+          fees: [
+            {
+              add_on_code: add_on_first.code,
+              unit_amount_cents: 1200,
+              units: 2
+            }
+          ]
+        }
+      end
+
+      it "creates an invoice with the normalized purchase order number" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoice][:purchase_order_number]).to eq("PO-12345")
+      end
+    end
+
     context "when multi_entity_billing feature flag is enabled" do
       let(:other_billing_entity) { create(:billing_entity, organization:) }
 


### PR DESCRIPTION
## Context

Root PR: #5763

We need to be able to set the purchase_order_number through the REST API.

## Description

Add purchase_order_number to InvoicesController#create
