### PR TITLE
feat(orders): update order mutation

### DIFF
--- a/app/graphql/mutations/orders/update.rb
+++ b/app/graphql/mutations/orders/update.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Orders
+    class Update < BaseMutation
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "orders:update"
+
+      graphql_name "UpdateOrder"
+      description "Update an order's execution settings"
+
+      input_object_class Types::Orders::UpdateInput
+
+      type Types::Orders::Object
+
+      def resolve(**args)
+        order = current_organization.orders.find_by(id: args[:id])
+        result = ::Orders::UpdateService.call(order:, params: args.except(:id))
+
+        result.success? ? result.order : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -152,6 +152,8 @@ module Types
 
     field :void_order_form, mutation: Mutations::OrderForms::Void
 
+    field :update_order, mutation: Mutations::Orders::Update
+
     field :download_payment_receipt, mutation: Mutations::PaymentReceipts::Download
     field :download_xml_payment_receipt, mutation: Mutations::PaymentReceipts::DownloadXml
     field :resend_payment_receipt_email, mutation: Mutations::PaymentReceipts::ResendEmail

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -13,6 +13,7 @@ module Types
 
       field :billing_snapshot, GraphQL::Types::JSON, null: false
       field :currency, String, null: true
+      field :execute_at, GraphQL::Types::ISO8601DateTime, null: true
       field :executed_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :customer, Types::Customers::Object, null: false

--- a/app/graphql/types/orders/update_input.rb
+++ b/app/graphql/types/orders/update_input.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class UpdateInput < Types::BaseInputObject
+      description "Update Order input arguments"
+
+      argument :execute_at, GraphQL::Types::ISO8601DateTime, required: false
+      argument :execution_mode, Types::Orders::ExecutionModeEnum, required: false
+      argument :id, ID, required: true
+    end
+  end
+end

--- a/app/services/order_forms/execution_settings_validation.rb
+++ b/app/services/order_forms/execution_settings_validation.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module OrderForms
+  module ExecutionSettingsValidation
+    extend ActiveSupport::Concern
+
+    private
+
+    def validate_execution_mode(execution_mode:, execute_at:)
+      return if execution_mode.blank? && execute_at.blank?
+
+      if execution_mode.blank?
+        return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
+      end
+
+      return if Order::EXECUTION_MODES.value?(execution_mode.to_s)
+
+      result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
+    end
+
+    def validate_execute_at(execute_at:)
+      return if execute_at.blank?
+      return if Utils::Datetime.future_date?(execute_at)
+
+      result.single_validation_failure!(field: :execute_at, error_code: "invalid_date")
+    end
+  end
+end

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -3,6 +3,7 @@
 module OrderForms
   class MarkAsSignedService < BaseService
     include OrderForms::Premium
+    include OrderForms::ExecutionSettingsValidation
 
     Result = BaseResult[:order_form, :order]
 
@@ -68,29 +69,10 @@ module OrderForms
     attr_reader :order_form, :signed_document, :execution_mode, :execute_at
 
     def validate_execution_settings
-      validate_execution_mode
+      validate_execution_mode(execution_mode:, execute_at:)
       return if result.failure?
 
-      validate_execute_at
-    end
-
-    def validate_execution_mode
-      return if execution_mode.blank? && execute_at.blank?
-
-      if execution_mode.blank?
-        return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
-      end
-
-      return if Order::EXECUTION_MODES.value?(execution_mode)
-
-      result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
-    end
-
-    def validate_execute_at
-      return if execute_at.blank?
-      return if Utils::Datetime.future_date?(execute_at)
-
-      result.single_validation_failure!(field: :execute_at, error_code: "invalid_date")
+      validate_execute_at(execute_at:)
     end
 
     def signed_document_attachment

--- a/app/services/orders/update_service.rb
+++ b/app/services/orders/update_service.rb
@@ -3,6 +3,7 @@
 module Orders
   class UpdateService < BaseService
     include OrderForms::Premium
+    include OrderForms::ExecutionSettingsValidation
 
     Result = BaseResult[:order]
 
@@ -23,7 +24,10 @@ module Orders
       Order.transaction do
         Quotes::LockService.call(quote: order.quote) do
           order.reload
-          next result.single_validation_failure!(field: :status, error_code: "not_editable") unless order.created?
+          unless order.created?
+            result.single_validation_failure!(field: :status, error_code: "not_editable")
+            result.raise_if_error!
+          end
 
           order.assign_attributes(params.slice(:execution_mode, :execute_at))
           order.save!
@@ -35,6 +39,8 @@ module Orders
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
     end
 
     private
@@ -50,30 +56,10 @@ module Orders
     end
 
     def validate_execution_settings
-      validate_execution_mode
+      validate_execution_mode(execution_mode: effective_execution_mode, execute_at: effective_execute_at)
       return if result.failure?
 
-      validate_execute_at
-    end
-
-    def validate_execution_mode
-      return if effective_execution_mode.blank? && effective_execute_at.blank?
-
-      if effective_execution_mode.blank?
-        return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
-      end
-
-      return if Order::EXECUTION_MODES.value?(effective_execution_mode.to_s)
-
-      result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
-    end
-
-    def validate_execute_at
-      return unless params.key?(:execute_at)
-      return if params[:execute_at].blank?
-      return if Utils::Datetime.future_date?(params[:execute_at])
-
-      result.single_validation_failure!(field: :execute_at, error_code: "invalid_date")
+      validate_execute_at(execute_at: params[:execute_at])
     end
   end
 end

--- a/app/services/orders/update_service.rb
+++ b/app/services/orders/update_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Orders
+  class UpdateService < BaseService
+    include OrderForms::Premium
+
+    Result = BaseResult[:order]
+
+    def initialize(order:, params:)
+      @order = order
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "order") unless order
+      return result.forbidden_failure! unless order_forms_enabled?(order.organization)
+
+      validate_execution_settings
+      return result if result.failure?
+
+      Order.transaction do
+        Quotes::LockService.call(quote: order.quote) do
+          order.reload
+          next result.single_validation_failure!(field: :status, error_code: "not_editable") unless order.created?
+
+          order.assign_attributes(params.slice(:execution_mode, :execute_at))
+          order.save!
+
+          result.order = order
+        end
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :order, :params
+
+    def effective_execution_mode
+      params.key?(:execution_mode) ? params[:execution_mode] : order.execution_mode
+    end
+
+    def effective_execute_at
+      params.key?(:execute_at) ? params[:execute_at] : order.execute_at
+    end
+
+    def validate_execution_settings
+      validate_execution_mode
+      return if result.failure?
+
+      validate_execute_at
+    end
+
+    def validate_execution_mode
+      return if effective_execution_mode.blank? && effective_execute_at.blank?
+
+      if effective_execution_mode.blank?
+        return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
+      end
+
+      return if Order::EXECUTION_MODES.value?(effective_execution_mode.to_s)
+
+      result.single_validation_failure!(field: :execution_mode, error_code: "value_is_invalid")
+    end
+
+    def validate_execute_at
+      return unless params.key?(:execute_at)
+      return if params[:execute_at].blank?
+      return if Utils::Datetime.future_date?(params[:execute_at])
+
+      result.single_validation_failure!(field: :execute_at, error_code: "invalid_date")
+    end
+  end
+end

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -154,6 +154,8 @@ orders:
   view:
     - finance
     - manager
+  update:
+    - manager
 organization:
   view:
     - finance

--- a/schema.graphql
+++ b/schema.graphql
@@ -8848,6 +8848,16 @@ type Mutation {
   ): OktaIntegration
 
   """
+  Update an order's execution settings
+  """
+  updateOrder(
+    """
+    Parameters for UpdateOrder
+    """
+    input: UpdateOrderInput!
+  ): Order
+
+  """
   Updates an Organization
   """
   updateOrganization(
@@ -9143,6 +9153,7 @@ type Order {
   createdAt: ISO8601DateTime!
   currency: String
   customer: Customer!
+  executeAt: ISO8601DateTime
   executedAt: ISO8601DateTime
   executionMode: OrderExecutionModeEnum
   id: ID!
@@ -9518,6 +9529,7 @@ enum PermissionEnum {
   order_forms_sign
   order_forms_view
   order_forms_void
+  orders_update
   orders_view
   organization_emails_update
   organization_emails_view
@@ -9635,6 +9647,7 @@ type Permissions {
   orderFormsSign: Boolean!
   orderFormsView: Boolean!
   orderFormsVoid: Boolean!
+  ordersUpdate: Boolean!
   ordersView: Boolean!
   organizationEmailsUpdate: Boolean!
   organizationEmailsView: Boolean!
@@ -13266,6 +13279,19 @@ input UpdateOktaIntegrationInput {
   host: String
   id: ID
   organizationName: String
+}
+
+"""
+Update Order input arguments
+"""
+input UpdateOrderInput {
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  executeAt: ISO8601DateTime
+  executionMode: OrderExecutionModeEnum
+  id: ID!
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -42535,6 +42535,35 @@
               "deprecationReason": null
             },
             {
+              "name": "updateOrder",
+              "description": "Update an order's execution settings",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdateOrder",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateOrderInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updateOrganization",
               "description": "Updates an Organization",
               "args": [
@@ -43874,6 +43903,18 @@
                   "name": "Customer",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executeAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -46543,6 +46584,12 @@
               "deprecationReason": null
             },
             {
+              "name": "orders_update",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -47770,6 +47817,22 @@
             },
             {
               "name": "orderFormsVoid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ordersUpdate",
               "description": null,
               "args": [],
               "type": {
@@ -70601,6 +70664,69 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateOrderInput",
+          "description": "Update Order input arguments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "executeAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executionMode",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderExecutionModeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/orders/update_spec.rb
+++ b/spec/graphql/mutations/orders/update_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::Orders::Update do
+  let(:required_permission) { "orders:update" }
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:membership) { create(:membership, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:order) { create(:order, organization:, customer:) }
+
+  let(:mutation) do
+    <<~GQL
+      mutation($input: UpdateOrderInput!) {
+        updateOrder(input: $input) {
+          id
+          status
+          executionMode
+          executeAt
+        }
+      }
+    GQL
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "orders:update"
+
+  it "updates the order execution settings", :premium do
+    execute_at = 1.month.from_now.iso8601
+
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input: {id: order.id, executionMode: "execute_in_lago", executeAt: execute_at}}
+    )
+
+    data = result["data"]["updateOrder"]
+
+    expect(data["id"]).to eq(order.id)
+    expect(data["executionMode"]).to eq("execute_in_lago")
+    expect(data["executeAt"]).to eq(Time.zone.parse(execute_at).iso8601)
+  end
+
+  it "updates only the provided field and leaves the others untouched", :premium do
+    order.update!(execution_mode: "execute_in_lago", execute_at: 1.month.from_now)
+    persisted_execute_at = order.reload.execute_at
+
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input: {id: order.id, executionMode: "order_only"}}
+    )
+
+    data = result["data"]["updateOrder"]
+
+    expect(data["executionMode"]).to eq("order_only")
+    expect(data["executeAt"]).to eq(persisted_execute_at.iso8601)
+  end
+
+  it "returns an error when execute_at is set without execution_mode", :premium do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input: {id: order.id, executeAt: 1.month.from_now.iso8601}}
+    )
+
+    expect_unprocessable_entity(result, details: {executionMode: ["value_is_mandatory"]})
+  end
+
+  it "returns an error when execute_at is in the past", :premium do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input: {id: order.id, executionMode: "execute_in_lago", executeAt: 1.day.ago.iso8601}}
+    )
+
+    expect_unprocessable_entity(result, details: {executeAt: ["invalid_date"]})
+  end
+
+  context "when the order is already executed", :premium do
+    let(:order) { create(:order, :executed_in_lago, organization:, customer:) }
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: order.id, executionMode: "order_only"}}
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {status: ["not_editable"]})
+    end
+  end
+
+  context "when the order is not found", :premium do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: SecureRandom.uuid, executionMode: "order_only"}}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/types/orders/object_spec.rb
+++ b/spec/graphql/types/orders/object_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Types::Orders::Object do
 
     expect(subject).to have_field(:billing_snapshot).of_type("JSON!")
     expect(subject).to have_field(:currency).of_type("String")
+    expect(subject).to have_field(:execute_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:executed_at).of_type("ISO8601DateTime")
 
     expect(subject).to have_field(:customer).of_type("Customer!")

--- a/spec/graphql/types/orders/update_input_spec.rb
+++ b/spec/graphql/types/orders/update_input_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Orders::UpdateInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:execute_at).of_type("ISO8601DateTime")
+    expect(subject).to accept_argument(:execution_mode).of_type("OrderExecutionModeEnum")
+    expect(subject).to accept_argument(:id).of_type("ID!")
+  end
+end

--- a/spec/services/orders/update_service_spec.rb
+++ b/spec/services/orders/update_service_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orders::UpdateService do
+  subject(:service) { described_class.new(order:, params:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:order) { create(:order, organization:, customer:) }
+  let(:params) { {execution_mode: "execute_in_lago", execute_at: 1.month.from_now.iso8601} }
+
+  describe "#call" do
+    context "without premium license" do
+      it "returns a forbidden failure" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "with premium license", :premium do
+      context "when order is nil" do
+        let(:order) { nil }
+
+        it "returns a not found failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("order")
+        end
+      end
+
+      context "when the order_forms feature flag is disabled" do
+        let(:organization) { create(:organization) }
+
+        it "returns a forbidden failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        end
+      end
+
+      context "with concurrent mutations" do
+        it "wraps the work in a per-quote lock" do
+          allow(Quotes::LockService).to receive(:call).and_call_original
+
+          service.call
+
+          expect(Quotes::LockService).to have_received(:call).with(quote: order.quote).at_least(:once)
+        end
+      end
+
+      context "when the order is already executed" do
+        let(:order) { create(:order, :executed_in_lago, organization:, customer:) }
+        let(:params) { {execution_mode: "order_only"} }
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({status: ["not_editable"]})
+        end
+      end
+
+      context "when only execution_mode is provided" do
+        let(:params) { {execution_mode: "order_only"} }
+
+        it "updates the execution_mode and leaves execute_at blank" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order.execution_mode).to eq("order_only")
+          expect(result.order.execute_at).to be_nil
+        end
+      end
+
+      context "when execution_mode and execute_at are provided" do
+        let(:params) { {execution_mode: "execute_in_lago", execute_at: 1.month.from_now.iso8601} }
+
+        it "updates both attributes on the order" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order.execution_mode).to eq("execute_in_lago")
+          expect(result.order.execute_at).to eq(Time.zone.parse(params[:execute_at]))
+        end
+      end
+
+      context "when execute_at is provided without execution_mode and the order has none" do
+        let(:params) { {execute_at: 1.month.from_now.iso8601} }
+
+        it "returns a validation failure on execution_mode" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:execution_mode]).to eq(["value_is_mandatory"])
+        end
+      end
+
+      context "when execute_at is provided and the order already has an execution_mode" do
+        let(:order) { create(:order, organization:, customer:, execution_mode: "execute_in_lago") }
+        let(:params) { {execute_at: 1.month.from_now.iso8601} }
+
+        it "updates execute_at and keeps the existing execution_mode" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order.execution_mode).to eq("execute_in_lago")
+          expect(result.order.execute_at).to eq(Time.zone.parse(params[:execute_at]))
+        end
+      end
+
+      context "when execution_mode is invalid" do
+        let(:params) { {execution_mode: "unknown"} }
+
+        it "returns a validation failure on execution_mode" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:execution_mode]).to eq(["value_is_invalid"])
+        end
+      end
+
+      context "when execute_at is in the past" do
+        let(:params) { {execution_mode: "execute_in_lago", execute_at: 1.day.ago.iso8601} }
+
+        it "returns a validation failure on execute_at" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:execute_at]).to eq(["invalid_date"])
+        end
+      end
+
+      context "when clearing execute_at while keeping an execution_mode" do
+        let(:order) { create(:order, organization:, customer:, execution_mode: "execute_in_lago", execute_at: 1.month.from_now) }
+        let(:params) { {execute_at: nil} }
+
+        it "clears execute_at and keeps the execution_mode" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order.execute_at).to be_nil
+          expect(result.order.execution_mode).to eq("execute_in_lago")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a GraphQL mutation to let users edit an Order before execution. An order is mostly immutable, but we let users change those 2 settings linked to how we execute it:

- `execute_at` to schedule the execution at a future date
- `execution_mode` to set if we should handle the billing inside lago or not