### PR TITLE
feat: retry tax job on sequential ID lock

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -14,6 +14,7 @@ module Invoices
       retry_on Net::OpenTimeout, wait: :polynomially_longer, attempts: 6
       retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
       retry_on Customers::FailedToAcquireLock, ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: MAX_LOCK_RETRY_ATTEMPTS
+      retry_on Sequenced::SequenceError, wait: :polynomially_longer, attempts: 15, jitter: 0.75
 
       def perform(invoice:)
         Invoices::ProviderTaxes::PullTaxesAndApplyService.call!(invoice:)

--- a/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob do
     [
       [Customers::FailedToAcquireLock.new("customer-1-prepaid_credit"), 25],
       [ActiveRecord::StaleObjectError.new("Attempted to update a stale object: Wallet."), 25],
+      [Sequenced::SequenceError.new("Unable to acquire lock on the database"), 15],
       [BaseService::ThrottlingError.new, 25],
       [LagoHttpClient::HttpError.new(401, "body", "uri"), 6],
       [OpenSSL::SSL::SSLError.new("OpenSSL::SSL::SSLError"), 6],


### PR DESCRIPTION
## Context

some invoices got stuck in a "generating" state, with the corresponding `Invoices::ProviderTaxes::PullTaxesAndApplyJob` failing in Sidekiq:

> **Error Class** `Sequenced::SequenceError`
> **Error Message** `Unable to acquire lock on the database`

Every other invoice-finalizing job already retries on this error

## Description

Add `retry_on Sequenced::SequenceError