### PR TITLE
[ING-334] misc(clickhouse): Apply AggregationResult to grouped_max query

### DIFF
--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -19,7 +19,7 @@ module BillableMetrics
         result.count = max_result.events_count
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_max(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_max(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash)
         end
 
         result.options = options
@@ -34,22 +34,17 @@ module BillableMetrics
         aggregations = event_store.grouped_max
         return empty_results if aggregations.blank?
 
-        counts = event_store.grouped_count
-
         result.aggregations = aggregations.map do |aggregation|
           group_result = BaseService::Result.new
-          group_result.grouped_by = aggregation[:groups]
-          group_result.aggregation = aggregation[:value]
+          group_result.grouped_by = aggregation.groups
+          group_result.aggregation = aggregation.value
           group_result.options = options
-
-          count = counts.find { |c| c[:groups] == aggregation[:groups] } || {}
-          group_result.count = count[:value] || 0
-
+          group_result.count = aggregation.events_count || 0
           group_result
         end
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_max(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_max(uniq_grouped_by_and_presentation_by, with_count: false).map(&:to_grouped_hash)
         end
 
         result

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -85,7 +85,7 @@ module Events
         raise NotImplementedError
       end
 
-      def grouped_max
+      def grouped_max(columns = grouped_by, with_count: true)
         raise NotImplementedError
       end
 

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -444,7 +444,9 @@ module Events
         end
       end
 
-      def grouped_max(columns = grouped_by)
+      def grouped_max(columns = grouped_by, with_count: true)
+        count_select = with_count ? "count()" : "null"
+
         Utils::ClickhouseConnection.connection_with_retry do |connection|
           if columns == grouped_by
             sql = with_ctes(events_cte_queries(
@@ -453,7 +455,8 @@ module Events
             ), <<-SQL)
               SELECT
                 sorted_grouped_by as groups,
-                MAX(events.decimal_value) as value
+                MAX(events.decimal_value) as value,
+                #{count_select} as events_count
               FROM events
               GROUP BY sorted_grouped_by
             SQL
@@ -463,13 +466,14 @@ module Events
             sql = with_ctes(events_cte_queries(deduplicated_columns: %w[decimal_value sorted_properties]), <<-SQL)
               SELECT
                 map(#{map_args.join(", ")}) as groups,
-                MAX(events.decimal_value) as value
+                MAX(events.decimal_value) as value,
+                #{count_select} as events_count
               FROM events
               GROUP BY #{col_expressions.join(", ")}
             SQL
           end
 
-          prepare_grouped_result(connection.select_all(sql))
+          prepare_grouped_aggregated_values(connection.select_all(sql))
         end
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -454,7 +454,7 @@ module Events
         end
       end
 
-      def grouped_max(columns = grouped_by)
+      def grouped_max(columns = grouped_by, with_count: true)
         groups, column_names = grouped_arel_columns(columns)
 
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
@@ -466,12 +466,13 @@ module Events
           sql = with_ctes(ctes_sql, <<-SQL)
             SELECT
               #{column_names},
-              MAX(property)
+              MAX(property),
+              #{with_count ? "count()" : "null"}
             FROM events
             GROUP BY #{column_names}
           SQL
 
-          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
+          prepare_grouped_aggregated_values(connection.select_all(sql).rows, columns: columns)
         end
       end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -215,13 +215,21 @@ module Events
         )
       end
 
-      def grouped_max(columns = grouped_by)
-        results = events
-          .group(columns.map { sanitized_property_name(it) })
-          .maximum("(#{sanitized_property_name})::numeric")
-          .map { |group, value| [group, value].flatten }
+      def grouped_max(columns = grouped_by, with_count: true)
+        groups = columns.map { sanitized_property_name(it) }
 
-        prepare_grouped_result(results, columns: columns)
+        results = events
+          .group(groups)
+          .pluck(
+            Arel.sql(
+              (groups + [
+                "MAX((#{sanitized_property_name})::numeric)",
+                with_count ? "COUNT(*)" : "NULL"
+              ]).join(", ")
+            )
+          )
+
+        prepare_grouped_aggregated_values(results, columns: columns)
       end
 
       def last(with_count: true)

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1158,13 +1158,24 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         event_store.numeric_property = true
       end
 
-      it "returns the max values grouped by the provided group" do
+      it "returns the max values and the events count grouped by the provided group" do
         result = event_store.grouped_max
 
         expect(result).to match_array([
-          {groups: {"region" => nil}, value: 4},
-          {groups: {"region" => "europe"}, value: 5}
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => nil}, value: 4, events_count: 2),
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "europe"}, value: 5, events_count: 3)
         ])
+      end
+
+      context "when with_count is false" do
+        it "returns the max values without the events count" do
+          result = event_store.grouped_max(with_count: false)
+
+          expect(result).to match_array([
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => nil}, value: 4, events_count: nil),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "europe"}, value: 5, events_count: nil)
+          ])
+        end
       end
 
       context "with multiple groups" do
@@ -1174,9 +1185,9 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_max
 
           expect(result).to match_array([
-            {groups: {"country" => "france", "region" => "europe"}, value: 3},
-            {groups: {"country" => nil, "region" => nil}, value: 4},
-            {groups: {"country" => "united kingdom", "region" => "europe"}, value: 5}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "france", "region" => "europe"}, value: 3, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => nil, "region" => nil}, value: 4, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "united kingdom", "region" => "europe"}, value: 5, events_count: 1)
           ])
         end
       end
@@ -1214,8 +1225,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           # - europe, france, <nil>
           # - europe, united kingdom, manchester
           expect(result).to match_array([
-            {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
-            {groups: {"country" => "france", "region" => "europe"}, value: 3}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "united kingdom", "region" => "europe"}, value: -1, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "france", "region" => "europe"}, value: 3, events_count: 3)
           ])
         end
       end
@@ -1818,8 +1829,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_max(["cloud"])
 
           expect(result).to match_array([
-            {groups: {"cloud" => "aws"}, value: 10},
-            {groups: {"cloud" => "gcp"}, value: 12}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "aws"}, value: 10, events_count: 3),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "gcp"}, value: 12, events_count: 1)
           ])
         end
       end
@@ -1837,9 +1848,9 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_max(["agent_name", "cloud"])
 
           expect(result).to match_array([
-            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
-            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7},
-            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 7, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 3, events_count: 1)
           ])
         end
       end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5716, https://github.com/getlago/lago-api/pull/5723 and https://github.com/getlago/lago-api/pull/5730

Today, all aggregation services (except CountService) perform two queries against the event store: one for the aggregation itself, and a second for the number of events involved in the result.

This implementation is inherited from the original Postgres store and works well for that engine. When the Clickhouse store was introduced, the same approach was kept for compatibility. At scale this is not ideal on the Clickhouse side, as it forces the engine to retrieve the same set of records twice, including a second pass over the expensive deduplication CTE.

This PR applies the single-pass approach, already introduced for sum and grouped_sum and other, to the `grouped_max` aggregation.

## Description

`lgrouped_max` now return the existing `GroupedAggregationResult` structures carrying both the value and the events_count.

The `BillableMetrics::Aggregations::MaxService` consumes the new shapes directly and no longer issues a separate count / grouped_count query.

The same approach will be applied to the remaining aggregations in follow-up steps.