### PR TITLE
fix(quotes): use customer display_name in mentions

### DIFF
--- a/app/services/quote_versions/compute_mention_variables_service.rb
+++ b/app/services/quote_versions/compute_mention_variables_service.rb
@@ -11,7 +11,7 @@ module QuoteVersions
 
     def call
       result.mention_variables = {
-        "customer_name" => customer.name,
+        "customer_name" => customer.display_name,
         "customer_email" => customer.email,
         "organization_name" => organization.name,
         "organization_logo" => organization.logo_url,

--- a/spec/graphql/types/quote_versions/object_spec.rb
+++ b/spec/graphql/types/quote_versions/object_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Types::QuoteVersions::Object do
     let(:required_permission) { "quotes:view" }
     let(:membership) { create(:membership) }
     let(:organization) { membership.organization }
-    let(:customer) { create(:customer, organization:, name: "Mistral AI") }
+    let(:customer) do
+      create(:customer, organization:, name: "Hooli", legal_name: "Hooli Inc", firstname: "Gavin", lastname: "Belson")
+    end
     let(:quote) { create(:quote, organization:, customer:) }
 
     let(:query) do
@@ -56,24 +58,24 @@ RSpec.describe Types::QuoteVersions::Object do
       before { create(:quote_version, quote:, organization:) }
 
       it "computes the variables live" do
-        expect(execute).to include("customer_name" => "Mistral AI")
+        expect(execute).to include("customer_name" => "Hooli Inc - Gavin Belson")
       end
     end
 
     context "when the version is approved" do
       before do
-        create(:quote_version, :approved, quote:, organization:, mention_variables: {"customer_name" => "Snapshot AI"})
+        create(:quote_version, :approved, quote:, organization:, mention_variables: {"customer_name" => "Pied Piper"})
       end
 
       it "returns the persisted snapshot, ignoring later changes" do
-        customer.update!(name: "Renamed AI")
+        customer.update!(name: "Aviato")
 
-        expect(execute).to eq("customer_name" => "Snapshot AI")
+        expect(execute).to eq("customer_name" => "Pied Piper")
       end
     end
 
     context "when the approved snapshot holds locale-sensitive variables" do
-      let(:customer) { create(:customer, organization:, name: "Mistral AI", document_locale: "en") }
+      let(:customer) { create(:customer, organization:, name: "Hooli", document_locale: "en") }
 
       before do
         create(

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe QuoteVersions::ApproveService do
       it "persists the raw computed mention variables snapshot" do
         expect(result).to be_success
         expect(result.quote_version.reload.mention_variables).to include(
-          "customer_name" => quote.customer.name,
+          "customer_name" => quote.customer.display_name,
           "quote_number" => quote.number,
           "commercial_terms_start_date" => "2026-01-01",
           "commercial_terms_term_duration" => {"unit" => "years", "count" => 1}

--- a/spec/services/quote_versions/compute_mention_variables_service_spec.rb
+++ b/spec/services/quote_versions/compute_mention_variables_service_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
     create(
       :billing_entity,
       organization:,
-      name: "Mistral AI SAS",
-      legal_name: "Mistral AI SAS",
+      name: "Globex SARL",
+      legal_name: "Globex SARL",
       tax_identification_number: "FR12345678901",
-      email: "billing@mistral.ai",
+      email: "billing@globex.example",
       address_line1: "4 rue de la Paix",
       address_line2: nil,
       zipcode: "75002",
@@ -30,8 +30,11 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
       :customer,
       organization:,
       billing_entity:,
-      name: "Mistral AI",
-      email: "procurement@mistral.ai",
+      name: "Hooli",
+      legal_name: "Hooli Inc",
+      firstname: "Gavin",
+      lastname: "Belson",
+      email: "procurement@hooli.example",
       net_payment_term: customer_net_payment_term,
       document_locale: customer_document_locale
     )
@@ -61,15 +64,15 @@ RSpec.describe QuoteVersions::ComputeMentionVariablesService do
     it "computes the raw, locale-independent mention variables dictionary" do
       expect(result).to be_success
       expect(variables).to include(
-        "customer_name" => "Mistral AI",
-        "customer_email" => "procurement@mistral.ai",
+        "customer_name" => "Hooli Inc - Gavin Belson",
+        "customer_email" => "procurement@hooli.example",
         "organization_name" => "Lago",
         "organization_logo" => organization.logo_url,
-        "billing_entity_name" => "Mistral AI SAS",
-        "billing_entity_legal_name" => "Mistral AI SAS",
+        "billing_entity_name" => "Globex SARL",
+        "billing_entity_legal_name" => "Globex SARL",
         "billing_entity_address" => raw_address,
         "billing_entity_tax_id" => "FR12345678901",
-        "billing_entity_email" => "billing@mistral.ai",
+        "billing_entity_email" => "billing@globex.example",
         "quote_number" => quote.number,
         "quote_version" => quote_version.version.to_s,
         "quote_currency" => "EUR",

--- a/spec/services/quote_versions/mention_variables_localizer_spec.rb
+++ b/spec/services/quote_versions/mention_variables_localizer_spec.rb
@@ -76,18 +76,18 @@ RSpec.describe QuoteVersions::MentionVariablesLocalizer do
     end
 
     context "with locale-independent values" do
-      let(:mention_variables) { {"customer_name" => "Mistral AI", "quote_currency" => "EUR"} }
+      let(:mention_variables) { {"customer_name" => "Hooli Inc - Gavin Belson", "quote_currency" => "EUR"} }
 
       it "passes them through unchanged" do
-        expect(localized).to eq("customer_name" => "Mistral AI", "quote_currency" => "EUR")
+        expect(localized).to eq("customer_name" => "Hooli Inc - Gavin Belson", "quote_currency" => "EUR")
       end
     end
 
     context "with a partial dictionary" do
-      let(:mention_variables) { {"customer_name" => "Mistral AI"} }
+      let(:mention_variables) { {"customer_name" => "Hooli Inc - Gavin Belson"} }
 
       it "only returns the keys present" do
-        expect(localized).to eq("customer_name" => "Mistral AI")
+        expect(localized).to eq("customer_name" => "Hooli Inc - Gavin Belson")
       end
     end
 


### PR DESCRIPTION
Shows the customer's full name on quotes instead of just their short name.

I also took the opportunity to change unfortunate mentions of customer names in specs in favor of fictional ones.