### PR TITLE
[ING-324][ING-332] misc(clickhouse): Apply AggregationResult to weighted sum queries

### DIFF
--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -13,12 +13,11 @@ module BillableMetrics
       def compute_aggregation(*)
         return empty_result if should_bypass_aggregation?
 
-        result.aggregation = event_store.weighted_sum(initial_value:).ceil(20)
+        weighted_result = event_store.weighted_sum(initial_value:)
 
-        sum_result = event_store.sum
-
-        result.count = sum_result.events_count
-        result.variation = sum_result.value || 0
+        result.aggregation = weighted_result.value.ceil(20)
+        result.count = weighted_result.events_count
+        result.variation = weighted_result.variation
         result.total_aggregated_units = result.variation
         result.options = {}
 
@@ -27,7 +26,7 @@ module BillableMetrics
           result.breakdowns = event_store.grouped_weighted_sum(
             uniq_grouped_by_and_presentation_by,
             initial_values: initial_breakdowns.map(&:with_indifferent_access)
-          )
+          ).map(&:to_grouped_hash)
         end
 
         if billable_metric.recurring?
@@ -48,8 +47,6 @@ module BillableMetrics
         aggregations = event_store.grouped_weighted_sum(initial_values: grouped_latest_values)
         return empty_results if aggregations.blank?
 
-        sum_results = event_store.grouped_sum
-
         latest_values = []
         last_events = []
         if billable_metric.recurring?
@@ -62,25 +59,22 @@ module BillableMetrics
           result.breakdowns = event_store.grouped_weighted_sum(
             uniq_grouped_by_and_presentation_by,
             initial_values: initial_breakdowns.map(&:with_indifferent_access)
-          )
+          ).map(&:to_grouped_hash)
           result.breakdowns = grouped_latest_breakdowns if result.breakdowns.empty?
         end
 
         result.aggregations = aggregations.map do |aggregation|
           group_result = BaseService::Result.new
-          group_result.grouped_by = aggregation[:groups]
+          group_result.grouped_by = aggregation.groups
 
-          aggregation_value = aggregation[:value]
-          group_result.aggregation = aggregation_value
-
-          group_sum = sum_results.find { |c| c.groups == aggregation[:groups] }
-          group_result.count = group_sum&.events_count || 0
-          group_result.variation = group_sum&.value || 0
+          group_result.aggregation = aggregation.value
+          group_result.count = aggregation.events_count
+          group_result.variation = aggregation.variation
           group_result.total_aggregated_units = group_result.variation
 
           if billable_metric.recurring?
-            latest_value = latest_values.find { |c| c[:groups] == aggregation[:groups] }&.[](:value) || 0
-            last_event = last_events.find { |c| c[:groups] == aggregation[:groups] }
+            latest_value = latest_values.find { |c| c[:groups] == aggregation.groups }&.[](:value) || 0
+            last_event = last_events.find { |c| c[:groups] == aggregation.groups }
 
             group_result.total_aggregated_units = latest_value + group_result.variation
             group_result.recurring_updated_at = last_event&.[](:timestamp) || from_datetime

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -20,6 +20,26 @@ module Events
         end
       end
 
+      # NOTE: result of a weighted_sum aggregation. Unlike AggregationResult it also
+      #       carries the variation (sum of the real events) alongside the weighted value.
+      WeightedAggregationResult = Data.define(
+        :value,       # weighted aggregation (units per second)
+        :variation,   # sum of real events (initial_value already subtracted)
+        :events_count
+      )
+
+      # NOTE: grouped variant of WeightedAggregationResult.
+      GroupedWeightedAggregationResult = Data.define(
+        :groups,
+        :value,
+        :variation,
+        :events_count
+      ) do
+        def to_grouped_hash
+          {groups:, value:}
+        end
+      end
+
       def initialize(subscription:, boundaries:, code: nil, filters: {}, deduplicate: false)
         @code = code
         @subscription = subscription
@@ -222,6 +242,39 @@ module Events
         rows.map do |row|
           GroupedAggregationResult.new(groups: row[:groups], value: row[:value], events_count: row[:value])
         end
+      end
+
+      # NOTE: builds a WeightedAggregationResult from the raw query columns.
+      def build_weighted_aggregation_result(value:, variation_with_initial:, rows_count:, initial_value:)
+        WeightedAggregationResult.new(
+          value:,
+          variation: variation_with_initial - (initial_value || 0).to_d, # Subtract initial value from variation
+          events_count: [rows_count - 2, 0].max # Handle zero duration case
+        )
+      end
+
+      # NOTE: Build the { column => value } groups hash used by grouped aggregation results.
+      def build_groups(values, columns: grouped_by)
+        columns.zip(values.map(&:presence)).to_h
+      end
+
+      # NOTE: grouped variant of build_weighted_aggregation_result.
+      def build_grouped_weighted_result(groups:, value:, variation_with_initial:, rows_count:, initial_values:)
+        initial_value = initial_values.find { |iv| iv[:groups] == groups }&.fetch(:value, 0)
+
+        weighted = build_weighted_aggregation_result(
+          value:,
+          variation_with_initial:,
+          rows_count:,
+          initial_value:
+        )
+
+        GroupedWeightedAggregationResult.new(
+          groups:,
+          value: weighted.value,
+          variation: weighted.variation,
+          events_count: weighted.events_count
+        )
       end
     end
   end

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -10,9 +10,12 @@ module Events
 
         def query
           with_ctes(events_cte_sql, <<-SQL)
-            SELECT sum(period_ratio) as aggregation
+            SELECT
+              sum(period_ratio) as aggregation,
+              sum(difference) as variation_with_initial,
+              count() as rows_count
             FROM (
-              SELECT (#{period_ratio_sql}) as period_ratio
+              SELECT (#{period_ratio_sql}) as period_ratio, difference
               FROM events_data
             ) cumulated_ratios
           SQL
@@ -22,11 +25,14 @@ module Events
           with_ctes(grouped_events_cte_sql(initial_values), <<-SQL)
             SELECT
               #{joined_group_names},
-              SUM(period_ratio) as aggregation
+              SUM(period_ratio) as aggregation,
+              sum(difference) as variation_with_initial,
+              count() as rows_count
             FROM (
               SELECT
                 #{joined_group_names},
-                (#{grouped_period_ratio_sql}) AS period_ratio
+                (#{grouped_period_ratio_sql}) AS period_ratio,
+                difference
               FROM events_data
             ) cumulated_ratios
             GROUP BY #{joined_group_names}
@@ -54,6 +60,7 @@ module Events
         delegate :arel_table,
           :with_ctes,
           :charges_duration,
+          :decimal_literal,
           :events_cte_queries,
           :grouped_by_columns,
           :grouped_arel_columns,
@@ -160,7 +167,7 @@ module Events
             [
               groups,
               "toDateTime64(:from_datetime, 5, 'UTC')",
-              "toDecimal128(#{initial_value[:value]}, :decimal_scale)"
+              "toDecimal128('#{decimal_literal(initial_value[:value])}', :decimal_scale)"
             ].flatten.join(", ")
           end
 

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -707,7 +707,7 @@ module Events
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
                 decimal_scale: DECIMAL_SCALE,
-                initial_value: initial_value || 0
+                initial_value: decimal_literal(initial_value || 0)
               }
             ]
           )
@@ -715,7 +715,12 @@ module Events
           connection.select_one(sql)
         end
 
-        BigDecimal(result["aggregation"].presence || 0)
+        build_weighted_aggregation_result(
+          value: BigDecimal(result["aggregation"].presence || 0),
+          variation_with_initial: BigDecimal(result["variation_with_initial"].presence || 0),
+          rows_count: result["rows_count"].to_i,
+          initial_value:
+        )
       end
 
       def grouped_weighted_sum(columns = grouped_by, initial_values: [])
@@ -753,7 +758,7 @@ module Events
             ]
           )
 
-          prepare_grouped_result(connection.select_all(sql), decimal: true, groups_key: :grouped_by, value_key: :aggregation)
+          prepare_grouped_weighted_values(connection.select_all(sql), formatted_initial_values)
         end
       end
 
@@ -770,7 +775,7 @@ module Events
                   from_datetime:,
                   to_datetime: to_datetime.ceil,
                   decimal_scale: DECIMAL_SCALE,
-                  initial_value: initial_value || 0
+                  initial_value: decimal_literal(initial_value || 0)
                 }
               ]
             )
@@ -961,6 +966,23 @@ module Events
             groups: r[:groups].transform_values(&:presence),
             value: decimal ? BigDecimal(r[:value].presence || 0) : r[:value],
             events_count: r[:events_count].presence&.to_i
+          )
+        end
+      end
+
+      # NOTE: parses the grouped weighted_sum rows. Each row carries the weighted aggregation, the
+      #       sum of the differences (including the initial value) and the rows count (including the
+      #       2 boundary rows). Correction is delegated to build_grouped_weighted_result.
+      def prepare_grouped_weighted_values(result, initial_values)
+        result.to_ary.map do |row|
+          r = row.symbolize_keys
+
+          build_grouped_weighted_result(
+            groups: r[:grouped_by].transform_values(&:presence),
+            value: BigDecimal(r[:aggregation].presence || 0),
+            variation_with_initial: BigDecimal(r[:variation_with_initial].presence || 0),
+            rows_count: r[:rows_count].to_i,
+            initial_values:
           )
         end
       end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -704,7 +704,7 @@ module Events
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
                 decimal_scale: DECIMAL_SCALE,
-                initial_value: initial_value || 0
+                initial_value: decimal_literal(initial_value || 0)
               }
             ]
           )
@@ -712,7 +712,12 @@ module Events
           connection.select_one(sql)
         end
 
-        BigDecimal(result["aggregation"].presence || 0)
+        build_weighted_aggregation_result(
+          value: BigDecimal(result["aggregation"].presence || 0),
+          variation_with_initial: BigDecimal(result["variation_with_initial"].presence || 0),
+          rows_count: result["rows_count"].to_i,
+          initial_value:
+        )
       end
 
       def grouped_weighted_sum(columns = grouped_by, initial_value: 0, initial_values: [])
@@ -744,7 +749,7 @@ module Events
             ]
           )
 
-          prepare_grouped_result(connection.select_all(sql).rows, decimal: true, columns: columns)
+          prepare_grouped_weighted_values(connection.select_all(sql).rows, formatted_initial_values, columns: columns)
         end
       end
 
@@ -761,7 +766,7 @@ module Events
                   from_datetime:,
                   to_datetime: to_datetime.ceil,
                   decimal_scale: DECIMAL_SCALE,
-                  initial_value: initial_value || 0
+                  initial_value: decimal_literal(initial_value || 0)
                 }
               ]
             )
@@ -879,10 +884,9 @@ module Events
       def prepare_grouped_result(rows, timestamp: false, decimal: false, columns: grouped_by)
         rows.map do |row|
           last_group = timestamp ? -2 : -1
-          groups = row.flatten[...last_group].map(&:presence)
 
           result = {
-            groups: columns.each_with_object({}).with_index { |(g, r), i| r.merge!(g => groups[i]) },
+            groups: build_groups(row.flatten[...last_group], columns:),
             value: decimal ? BigDecimal(row.last.presence || 0) : row.last
           }
 
@@ -897,12 +901,28 @@ module Events
       def prepare_grouped_aggregated_values(rows, columns: grouped_by)
         rows.map do |row|
           flat = row.flatten
-          groups = flat[...-2].map(&:presence)
 
           GroupedAggregationResult.new(
-            groups: columns.each_with_object({}).with_index { |(g, res), i| res.merge!(g => groups[i]) },
+            groups: build_groups(flat[...-2], columns:),
             value: flat[-2],
             events_count: flat[-1].presence&.to_i
+          )
+        end
+      end
+
+      # NOTE: parses the grouped weighted_sum rows. The last three columns of each row are the weighted
+      #       aggregation, the sum of the differences (including the initial value) and the rows count
+      #       (including the 2 boundary rows). Correction is delegated to build_grouped_weighted_result.
+      def prepare_grouped_weighted_values(rows, initial_values, columns: grouped_by)
+        rows.map do |row|
+          flat = row.flatten
+
+          build_grouped_weighted_result(
+            groups: build_groups(flat[...-3], columns:),
+            value: BigDecimal(flat[-3].presence || 0),
+            variation_with_initial: BigDecimal(flat[-2].presence || 0),
+            rows_count: flat[-1].to_i,
+            initial_values:
           )
         end
       end

--- a/app/services/events/stores/postgres/weighted_sum_query.rb
+++ b/app/services/events/stores/postgres/weighted_sum_query.rb
@@ -12,9 +12,12 @@ module Events
           <<-SQL
             #{events_cte_sql}
 
-            SELECT SUM(period_ratio) as aggregation
+            SELECT
+              SUM(period_ratio) as aggregation,
+              SUM(difference) as variation_with_initial,
+              COUNT(*) as rows_count
             FROM (
-              SELECT (#{period_ratio_sql}) AS period_ratio
+              SELECT (#{period_ratio_sql}) AS period_ratio, difference
               FROM events_data
             ) cumulated_ratios
           SQL
@@ -26,11 +29,14 @@ module Events
 
             SELECT
               #{group_names},
-              SUM(period_ratio) as aggregation
+              SUM(period_ratio) as aggregation,
+              SUM(difference) as variation_with_initial,
+              COUNT(*) as rows_count
             FROM (
               SELECT
                 #{group_names},
-                (#{grouped_period_ratio_sql}) AS period_ratio
+                (#{grouped_period_ratio_sql}) AS period_ratio,
+                difference
               FROM events_data
             ) cumulated_ratios
             GROUP BY #{group_names}
@@ -63,13 +69,13 @@ module Events
           <<-SQL
             WITH events_data AS (
               (#{initial_value_sql})
-              UNION
+              UNION ALL
               (#{
                 events(ordered: true)
                   .select("timestamp, (#{sanitized_property_name})::numeric AS difference, #{created_at_ordering_column}")
                   .to_sql
               })
-              UNION
+              UNION ALL
               (#{end_of_period_value_sql})
             )
           SQL
@@ -120,13 +126,13 @@ module Events
           <<-SQL
             WITH events_data AS (
               (#{grouped_initial_value_sql(initial_values)})
-              UNION
+              UNION ALL
               (#{
                 events(ordered: true)
                   .select("#{groups.join(", ")}, timestamp, (#{sanitized_property_name})::numeric AS difference, #{created_at_ordering_column}")
                   .to_sql
               })
-              UNION
+              UNION ALL
               (#{grouped_end_of_period_value_sql(initial_values)})
             )
           SQL
@@ -170,9 +176,9 @@ module Events
 
             [
               groups,
-              "timestamp without time zone :from_datetime",
+              "timestamp without time zone :to_datetime",
               0,
-              "timestamp without time zone :from_datetime"
+              "timestamp without time zone :to_datetime"
             ].flatten.join(", ")
           end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -364,7 +364,13 @@ module Events
         )
 
         result = select_one(sql)
-        result["aggregation"]
+
+        build_weighted_aggregation_result(
+          value: result["aggregation"] || 0,
+          variation_with_initial: result["variation_with_initial"] || 0,
+          rows_count: result["rows_count"].to_i,
+          initial_value:
+        )
       end
 
       def grouped_weighted_sum(columns = grouped_by, initial_value: 0, initial_values: [])
@@ -395,7 +401,7 @@ module Events
           ]
         )
 
-        prepare_grouped_result(select_all(sql).rows, columns: columns)
+        prepare_grouped_weighted_values(select_all(sql).rows, formatted_initial_values, columns: columns)
       end
 
       def formatted_weighted_sum_initial_values(initial_values)
@@ -536,10 +542,9 @@ module Events
       def prepare_grouped_result(rows, timestamp: false, columns: grouped_by)
         rows.map do |row|
           last_group = timestamp ? -2 : -1
-          groups = row[...last_group].map(&:presence)
 
           result = {
-            groups: columns.each_with_object({}).with_index { |(g, r), i| r.merge!(g => groups[i]) },
+            groups: build_groups(row[...last_group], columns:),
             value: row.last
           }
 
@@ -553,12 +558,25 @@ module Events
       #       the aggregated value and the events count, returned as GroupedAggregationResult.
       def prepare_grouped_aggregated_values(rows, columns: grouped_by)
         rows.map do |row|
-          groups = row[...-2].map(&:presence)
-
           GroupedAggregationResult.new(
-            groups: columns.each_with_object({}).with_index { |(g, r), i| r.merge!(g => groups[i]) },
+            groups: build_groups(row[...-2], columns:),
             value: row[-2],
             events_count: row[-1]&.to_i
+          )
+        end
+      end
+
+      # NOTE: parses the grouped weighted_sum rows. The last three columns of each row are the weighted
+      #       aggregation, the sum of the differences (including the initial value) and the rows count
+      #       (including the 2 boundary rows). Correction is delegated to build_grouped_weighted_result.
+      def prepare_grouped_weighted_values(rows, initial_values, columns: grouped_by)
+        rows.map do |row|
+          build_grouped_weighted_result(
+            groups: build_groups(row[...-3], columns:),
+            value: row[-3],
+            variation_with_initial: row[-2] || 0,
+            rows_count: row[-1].to_i,
+            initial_values:
           )
         end
       end

--- a/app/services/events/stores/utils/clickhouse_sql_helpers.rb
+++ b/app/services/events/stores/utils/clickhouse_sql_helpers.rb
@@ -33,6 +33,13 @@ module Events
           ::Clickhouse::BaseRecord.connection.quote(value)
         end
 
+        # NOTE: A numeric literal containing a decimal point (e.g. 2500.0) is parsed as a Float64 by
+        #       ClickHouse and loses precision when cast to Decimal. Rendering the value as a
+        #       fixed-point string makes toDecimalXX read an exact decimal literal instead.
+        def decimal_literal(value)
+          BigDecimal(value.to_s).to_s("F")
+        end
+
         def sql_condition(template, *values)
           ActiveRecord::Base.sanitize_sql_for_conditions([template, *values])
         end

--- a/spec/scenarios/current_usage/by_aggregation_type/weighted_sum_agg_spec.rb
+++ b/spec/scenarios/current_usage/by_aggregation_type/weighted_sum_agg_spec.rb
@@ -88,7 +88,7 @@ describe "Aggregation - Weighted Sum Scenarios", transaction: false do
           expect(json[:customer_usage][:total_amount_cents]).to eq(53_333)
 
           # TODO: make sure Clickhouse has the same precision as Postgres
-          expected_units = (store == :clickhouse) ? "533.33333333333338308117" : "533.3333333333333333"
+          expected_units = (store == :clickhouse) ? "533.33333333333333333334" : "533.3333333333333333"
           expect(json[:customer_usage][:charges_usage][0][:units]).to eq(expected_units)
         end
 

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 require_relative "shared_examples/an_event_store"
 
 RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_before: true} do
-  def create_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code, charge_filter: nil, enriched_at: nil, event_charge: nil)
+  def create_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code, charge_filter: nil, enriched_at: nil, event_charge: nil, created_at: nil)
     effective_charge = event_charge || charge
 
     grouped_values = if events_grouped_by.present?
@@ -30,7 +30,7 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
       value:,
       decimal_value: value&.to_i&.to_d,
       precise_total_amount_cents: value,
-      enriched_at:
+      enriched_at: created_at || enriched_at
     )
   end
 

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 require_relative "shared_examples/an_event_store"
 
 RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true} do
-  def create_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code, charge_filter: nil, enriched_at: nil, event_charge: nil)
+  def create_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code, charge_filter: nil, enriched_at: nil, event_charge: nil, created_at: nil)
     Clickhouse::EventsEnriched.create!(
       transaction_id: transaction_id,
       organization_id: organization.id,
@@ -16,7 +16,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       value: value,
       decimal_value: value&.to_i&.to_d,
       precise_total_amount_cents: value,
-      enriched_at: Time.current
+      enriched_at: created_at || enriched_at || Time.current
     )
   end
 

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -6,9 +6,8 @@ require_relative "shared_examples/an_event_store"
 
 RSpec.describe Events::Stores::PostgresStore do
   it_behaves_like "an event store", with_event_duplication: false do
-    def create_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code, charge_filter: nil, enriched_at: nil, event_charge: nil)
-      create(
-        :event,
+    def create_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code, charge_filter: nil, enriched_at: nil, event_charge: nil, created_at: nil)
+      attributes = {
         transaction_id: transaction_id,
         organization_id: organization.id,
         external_subscription_id: subscription.external_id,
@@ -17,7 +16,10 @@ RSpec.describe Events::Stores::PostgresStore do
         timestamp: timestamp,
         properties: properties.merge(billable_metric.field_name => value),
         precise_total_amount_cents: value
-      )
+      }
+      attributes[:created_at] = created_at if created_at
+
+      create(:event, **attributes)
     end
 
     def create_enriched_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code, charge_filter: nil, enriched_at: nil)
@@ -116,6 +118,36 @@ RSpec.describe Events::Stores::PostgresStore do
         )
 
         expect(event_store.count).to eq(3)
+      end
+    end
+  end
+
+  describe "#weighted_sum" do
+    context "when the period is zero-length and holds no event" do
+      let(:billable_metric) { create(:weighted_sum_billable_metric) }
+      let(:organization) { billable_metric.organization }
+      let(:customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, customer:, started_at: DateTime.parse("2023-03-15")) }
+      let(:datetime) { subscription.started_at.beginning_of_day }
+
+      let(:event_store) do
+        described_class.new(
+          code: billable_metric.code,
+          subscription:,
+          boundaries: {
+            from_datetime: datetime,
+            to_datetime: datetime,
+            charges_duration: 31
+          }
+        )
+      end
+
+      # NOTE: from_datetime == to_datetime makes both boundary rows identical, so the UNION in the
+      #       events CTE dedups them into one. events_count must not go negative.
+      it "returns a zero events count" do
+        result = event_store.weighted_sum
+
+        expect(result.events_count).to eq(0)
       end
     end
   end

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1975,8 +1975,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_weighted_sum(["cloud"])
 
           expect(result.size).to eq(2)
-          expect(result.map { |r| r[:groups] }).to match_array([{"cloud" => "aws"}, {"cloud" => "gcp"}])
-          result.each { |r| expect(r[:value].round(5)).to eq(0.02218) }
+          expect(result.map { |r| r.groups }).to match_array([{"cloud" => "aws"}, {"cloud" => "gcp"}])
+          result.each { |r| expect(r.value.round(5)).to eq(0.02218) }
         end
       end
 
@@ -2004,11 +2004,11 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         it "returns the weighted sum breakdown per group" do
           result = event_store.grouped_weighted_sum(["agent_name", "cloud"])
 
-          expect(result.map { |r| r[:groups] }).to match_array([
+          expect(result.map { |r| r.groups }).to match_array([
             {"agent_name" => "frodo", "cloud" => "aws"},
             {"agent_name" => "aragorn", "cloud" => "gcp"}
           ])
-          result.each { |r| expect(r[:value].round(5)).to eq(0.02218) }
+          result.each { |r| expect(r.value.round(5)).to eq(0.02218) }
         end
       end
 
@@ -2049,8 +2049,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         it "uses the initial values in the aggregation" do
           result = event_store.grouped_weighted_sum(["cloud"], initial_values:)
 
-          expect(result.map { |r| r[:groups] }).to match_array([{"cloud" => "aws"}, {"cloud" => "gcp"}])
-          result.each { |r| expect(r[:value].round(5)).to eq(1000.02218) }
+          expect(result.map { |r| r.groups }).to match_array([{"cloud" => "aws"}, {"cloud" => "gcp"}])
+          result.each { |r| expect(r.value.round(5)).to eq(1000.02218) }
         end
       end
     end
@@ -2226,7 +2226,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
             value: values[:value],
             timestamp: values[:timestamp],
             properties:,
-            charge_filter: values[:charge_filter]
+            charge_filter: values[:charge_filter],
+            created_at: values[:created_at]
           )
         end
       end
@@ -2237,7 +2238,11 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       end
 
       it "returns the weighted sum of event properties" do
-        expect(event_store.weighted_sum.round(5)).to eq(0.02218)
+        result = event_store.weighted_sum
+
+        expect(result.value.round(5)).to eq(0.02218)
+        expect(result.variation).to eq(0)
+        expect(result.events_count).to eq(7)
       end
 
       context "with a single event" do
@@ -2248,7 +2253,11 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         end
 
         it "returns the weighted sum of event properties" do
-          expect(event_store.weighted_sum.round(5)).to eq(870.96774) # 4 / 31 * 0 + 27 / 31 * 1000
+          result = event_store.weighted_sum
+
+          expect(result.value.round(5)).to eq(870.96774) # 4 / 31 * 0 + 27 / 31 * 1000
+          expect(result.variation).to eq(1000)
+          expect(result.events_count).to eq(1)
         end
       end
 
@@ -2256,20 +2265,26 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         let(:events_values) { [] }
 
         it "returns the weighted sum of event properties" do
-          expect(event_store.weighted_sum.round(5)).to eq(0.0)
+          result = event_store.weighted_sum
+
+          expect(result.value.round(5)).to eq(0.0)
+          expect(result.variation).to eq(0)
+          expect(result.events_count).to eq(0)
         end
       end
 
       context "with events with the same timestamp" do
+        # NOTE: created_at is also identical to cover batch-ingested events that share
+        #       timestamp, value and created_at. They must be summed, not deduplicated.
         let(:events_values) do
           [
-            {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 3},
-            {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 3}
+            {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 3, created_at: Time.zone.parse("2023-03-05 12:00:00.000")},
+            {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 3, created_at: Time.zone.parse("2023-03-05 12:00:00.000")}
           ]
         end
 
         it "returns the weighted sum of event properties" do
-          expect(event_store.weighted_sum.round(5)).to eq(5.22581) # 4 / 31 * 0 + 27 / 31 * 6
+          expect(event_store.weighted_sum.value.round(5)).to eq(5.22581) # 4 / 31 * 0 + 27 / 31 * 6
         end
       end
 
@@ -2277,14 +2292,22 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         let(:initial_value) { 1000 }
 
         it "uses the initial value in the aggregation" do
-          expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.02218)
+          result = event_store.weighted_sum(initial_value:)
+
+          expect(result.value.round(5)).to eq(1000.02218)
+          expect(result.variation).to eq(0)
+          expect(result.events_count).to eq(7)
         end
 
         context "without events" do
           let(:events_values) { [] }
 
           it "uses only the initial value in the aggregation" do
-            expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.0)
+            result = event_store.weighted_sum(initial_value:)
+
+            expect(result.value.round(5)).to eq(1000.0)
+            expect(result.variation).to eq(0)
+            expect(result.events_count).to eq(0)
           end
         end
       end
@@ -2302,7 +2325,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         end
 
         it "returns the weighted sum of event properties scoped to the group" do
-          expect(event_store.weighted_sum.round(5)).to eq(870.96774) # 4 / 31 * 0 + 27 / 31 * 1000
+          expect(event_store.weighted_sum.value.round(5)).to eq(870.96774) # 4 / 31 * 0 + 27 / 31 * 1000
         end
       end
 
@@ -2323,7 +2346,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
         it "includes the event in the weighted sum" do
           result = event_store.weighted_sum
-          expect(result.round(5)).to eq(5.0)
+          expect(result.value.round(5)).to eq(5.0)
         end
       end
     end
@@ -2354,7 +2377,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
             value: values[:value],
             timestamp: values[:timestamp],
             properties:,
-            charge_filter: values[:charge_filter]
+            charge_filter: values[:charge_filter],
+            created_at: values[:created_at]
           )
         end
       end
@@ -2539,15 +2563,19 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
         expect(result.count).to eq(3)
 
-        null_group = result.find { |v| v[:groups]["agent_name"].nil? }
-        expect(null_group[:groups]["agent_name"]).to be_nil
-        expect(null_group[:groups]["other"]).to be_nil
-        expect(null_group[:value].round(5)).to eq(0.02218)
+        null_group = result.find { |v| v.groups["agent_name"].nil? }
+        expect(null_group.groups["agent_name"]).to be_nil
+        expect(null_group.groups["other"]).to be_nil
+        expect(null_group.value.round(5)).to eq(0.02218)
+        expect(null_group.variation).to eq(0)
+        expect(null_group.events_count).to eq(7)
 
         (result - [null_group]).each do |row|
-          expect(row[:groups]["agent_name"]).not_to be_nil
-          expect(row[:groups]["other"]).to be_nil
-          expect(row[:value].round(5)).to eq(0.02218)
+          expect(row.groups["agent_name"]).not_to be_nil
+          expect(row.groups["other"]).to be_nil
+          expect(row.value.round(5)).to eq(0.02218)
+          expect(row.variation).to eq(0)
+          expect(row.events_count).to eq(7)
         end
       end
 
@@ -2575,15 +2603,19 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
           expect(result.count).to eq(3)
 
-          null_group = result.find { |v| v[:groups]["agent_name"].nil? }
-          expect(null_group[:groups]["agent_name"]).to be_nil
-          expect(null_group[:groups]["other"]).to be_nil
-          expect(null_group[:value].round(5)).to eq(1000.02218)
+          null_group = result.find { |v| v.groups["agent_name"].nil? }
+          expect(null_group.groups["agent_name"]).to be_nil
+          expect(null_group.groups["other"]).to be_nil
+          expect(null_group.value.round(5)).to eq(1000.02218)
+          expect(null_group.variation).to eq(0)
+          expect(null_group.events_count).to eq(7)
 
           (result - [null_group]).each do |row|
-            expect(row[:groups]["agent_name"]).not_to be_nil
-            expect(row[:groups]["other"]).to be_nil
-            expect(row[:value].round(5)).to eq(1000.02218)
+            expect(row.groups["agent_name"]).not_to be_nil
+            expect(row.groups["other"]).to be_nil
+            expect(row.value.round(5)).to eq(1000.02218)
+            expect(row.variation).to eq(0)
+            expect(row.events_count).to eq(7)
           end
         end
 
@@ -2595,15 +2627,19 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
             expect(result.count).to eq(3)
 
-            null_group = result.find { |v| v[:groups]["agent_name"].nil? }
-            expect(null_group[:groups]["agent_name"]).to be_nil
-            expect(null_group[:groups]["other"]).to be_nil
-            expect(null_group[:value].round(5)).to eq(1000)
+            null_group = result.find { |v| v.groups["agent_name"].nil? }
+            expect(null_group.groups["agent_name"]).to be_nil
+            expect(null_group.groups["other"]).to be_nil
+            expect(null_group.value.round(5)).to eq(1000)
+            expect(null_group.variation).to eq(0)
+            expect(null_group.events_count).to eq(0)
 
             (result - [null_group]).each do |row|
-              expect(row[:groups]["agent_name"]).not_to be_nil
-              expect(row[:groups]["other"]).to be_nil
-              expect(row[:value].round(5)).to eq(1000)
+              expect(row.groups["agent_name"]).not_to be_nil
+              expect(row.groups["other"]).to be_nil
+              expect(row.value.round(5)).to eq(1000)
+              expect(row.variation).to eq(0)
+              expect(row.events_count).to eq(0)
             end
           end
         end


### PR DESCRIPTION
## Description

This PR follows https://github.com/getlago/lago-api/pull/5805
It keeps updating events stores to group queries related to the same aggregation

This PR applies the single-pass approach to the `weighted_sum` and `grouped_weighted_sum` aggregation. Both now returns an `AggregatedResult` or `GroupedAggregatedResult`
