### PR TITLE
fix(payment-providers): soft delete provider customers on destroy

### DIFF
--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -24,7 +24,7 @@ module CreditNotes
           reason: :credit_note,
           payment:,
           payment_provider: payment.payment_provider,
-          payment_provider_customer: payment_provider_customer(customer),
+          payment_provider_customer: payment_provider_customer(payment),
           amount_cents: adyen_result.response.dig("amount", "value"),
           amount_currency: adyen_result.response.dig("amount", "currency"),
           status: "pending",
@@ -118,7 +118,7 @@ module CreditNotes
         SendWebhookJob.perform_later(
           "credit_note.provider_refund_failure",
           credit_note,
-          provider_customer_id: payment_provider_customer(customer)&.provider_customer_id,
+          provider_customer_id: payment_provider_customer(payment)&.provider_customer_id,
           provider_error: {
             message:,
             error_code: code

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -28,7 +28,7 @@ module CreditNotes
           reason: :credit_note,
           payment:,
           payment_provider: payment.payment_provider,
-          payment_provider_customer: payment_provider_customer(customer),
+          payment_provider_customer: payment_provider_customer(payment),
           amount_cents: gocardless_result.amount,
           amount_currency: gocardless_result.currency&.upcase,
           status: gocardless_result.status,
@@ -130,7 +130,7 @@ module CreditNotes
         SendWebhookJob.perform_later(
           "credit_note.provider_refund_failure",
           credit_note,
-          provider_customer_id: payment_provider_customer(customer)&.provider_customer_id,
+          provider_customer_id: payment_provider_customer(payment)&.provider_customer_id,
           provider_error: {
             message:,
             error_code: code

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -26,7 +26,7 @@ module CreditNotes
           reason: :credit_note,
           payment:,
           payment_provider: payment.payment_provider,
-          payment_provider_customer: payment_provider_customer(customer),
+          payment_provider_customer: payment_provider_customer(payment),
           amount_cents: stripe_result.amount,
           amount_currency: stripe_result.currency&.upcase,
           status: stripe_result.status,
@@ -145,7 +145,7 @@ module CreditNotes
         SendWebhookJob.perform_later(
           "credit_note.provider_refund_failure",
           credit_note,
-          provider_customer_id: payment_provider_customer(customer)&.provider_customer_id,
+          provider_customer_id: payment_provider_customer(payment)&.provider_customer_id,
           provider_error: {
             message:,
             error_code: code

--- a/app/services/customers/payment_provider_finder.rb
+++ b/app/services/customers/payment_provider_finder.rb
@@ -18,10 +18,10 @@ module Customers
         payment_provider_result.payment_provider
       end
 
-      def payment_provider_customer(customer)
-        return nil unless customer
+      def payment_provider_customer(payment)
+        return nil unless payment
 
-        PaymentProviderCustomers::BaseCustomer.with_discarded.find_by(customer_id: customer.id)
+        PaymentProviderCustomers::BaseCustomer.with_discarded.find_by(id: payment.payment_provider_customer_id)
       end
     end
   end

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -14,7 +14,8 @@ module PaymentProviders
       customer_ids = payment_provider.customer_ids
 
       ActiveRecord::Base.transaction do
-        payment_provider.payment_provider_customers.update_all(payment_provider_id: nil, deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+        now = Time.current
+        payment_provider.payment_provider_customers.update_all(updated_at: now, deleted_at: now) # rubocop:disable Rails/SkipsModelValidations
         payment_provider.discard!
 
         Customer.where(id: customer_ids).update_all(payment_provider: nil, payment_provider_code: nil) # rubocop:disable Rails/SkipsModelValidations

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -14,7 +14,7 @@ module PaymentProviders
       customer_ids = payment_provider.customer_ids
 
       ActiveRecord::Base.transaction do
-        payment_provider.payment_provider_customers.update_all(payment_provider_id: nil) # rubocop:disable Rails/SkipsModelValidations
+        payment_provider.payment_provider_customers.update_all(payment_provider_id: nil, deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
         payment_provider.discard!
 
         Customer.where(id: customer_ids).update_all(payment_provider: nil, payment_provider_code: nil) # rubocop:disable Rails/SkipsModelValidations

--- a/spec/scenarios/payment_providers/destroy_and_reconnect_spec.rb
+++ b/spec/scenarios/payment_providers/destroy_and_reconnect_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Payment Provider Destroy And Reconnect Scenarios" do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+
+  it "soft deletes provider customers on destroy and recreates them on reconnect" do
+    provider = create(:stripe_provider, organization:)
+    create_or_update_customer({
+      external_id: customer.external_id,
+      billing_configuration: {
+        payment_provider: "stripe",
+        payment_provider_code: provider.code,
+        provider_customer_id: "cus_old"
+      }
+    })
+    provider_customer = customer.stripe_customer
+    expect(provider_customer.payment_provider_id).to eq(provider.id)
+
+    PaymentProviders::DestroyService.call(provider)
+
+    expect(provider.reload).to be_discarded
+    expect(provider_customer.reload).to be_discarded
+    expect(provider_customer.payment_provider_id).to eq(provider.id)
+
+    new_provider = create(:stripe_provider, organization:, code: "stripe_reconnected")
+    create_or_update_customer({
+      external_id: customer.external_id,
+      billing_configuration: {
+        payment_provider: "stripe",
+        payment_provider_code: new_provider.code,
+        provider_customer_id: "cus_new"
+      }
+    })
+
+    new_provider_customer = customer.reload.stripe_customer
+    expect(new_provider_customer).not_to eq(provider_customer)
+    expect(new_provider_customer.payment_provider_id).to eq(new_provider.id)
+    expect(new_provider_customer.provider_customer_id).to eq("cus_new")
+
+    expect(PaymentProviderCustomers::StripeCustomer.where(customer_id: customer.id)).to eq([new_provider_customer])
+    expect(PaymentProviderCustomers::StripeCustomer.with_discarded.where(customer_id: customer.id))
+      .to match_array([provider_customer, new_provider_customer])
+  end
+end

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -193,6 +193,23 @@ RSpec.describe CreditNotes::Refunds::AdyenService do
         expect(result.credit_note.refunded_at).not_to be_present
       end
     end
+
+    context "when the provider was disconnected and reconnected" do
+      let(:reconnected_provider) { create(:adyen_provider, organization:, code: "adyen_reconnected") }
+      let(:reconnected_customer) { create(:adyen_customer, customer:, payment_provider: reconnected_provider) }
+
+      before do
+        adyen_customer.discard!
+        reconnected_customer
+      end
+
+      it "attaches the refund to the provider customer that holds the payment" do
+        result = adyen_service.create
+
+        expect(result).to be_success
+        expect(result.refund.payment_provider_customer_id).to eq(adyen_customer.id)
+      end
+    end
   end
 
   describe "#update_status" do
@@ -294,7 +311,7 @@ RSpec.describe CreditNotes::Refunds::AdyenService do
 
     context "when status is failed" do
       before do
-        adyen_customer
+        payment
       end
 
       it "delivers an error webhook" do

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -214,6 +214,23 @@ RSpec.describe CreditNotes::Refunds::GocardlessService do
         expect(result.credit_note).to be_succeeded
       end
     end
+
+    context "when the provider was disconnected and reconnected" do
+      let(:reconnected_provider) { create(:gocardless_provider, organization:, code: "gocardless_reconnected") }
+      let(:reconnected_customer) { create(:gocardless_customer, customer:, payment_provider: reconnected_provider) }
+
+      before do
+        gocardless_customer.discard!
+        reconnected_customer
+      end
+
+      it "attaches the refund to the provider customer that holds the payment" do
+        result = gocardless_service.create
+
+        expect(result).to be_success
+        expect(result.refund.payment_provider_customer_id).to eq(gocardless_customer.id)
+      end
+    end
   end
 
   describe "#update_status" do

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -124,6 +124,23 @@ RSpec.describe CreditNotes::Refunds::StripeService do
       end
     end
 
+    context "when the provider was disconnected and reconnected" do
+      let(:reconnected_provider) { create(:stripe_provider, organization:, code: "stripe_reconnected") }
+      let(:reconnected_customer) { create(:stripe_customer, customer:, payment_provider: reconnected_provider) }
+
+      before do
+        stripe_customer.discard!
+        reconnected_customer
+      end
+
+      it "attaches the refund to the provider customer that holds the payment" do
+        result = stripe_service.create
+
+        expect(result).to be_success
+        expect(result.refund.payment_provider_customer_id).to eq(stripe_customer.id)
+      end
+    end
+
     context "with an error on stripe" do
       let(:error_message) { "error" }
 
@@ -358,7 +375,7 @@ RSpec.describe CreditNotes::Refunds::StripeService do
 
     context "when status is failed" do
       before do
-        stripe_customer
+        payment
       end
 
       it "delivers an error webhook" do

--- a/spec/services/payment_providers/destroy_service_spec.rb
+++ b/spec/services/payment_providers/destroy_service_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe PaymentProviders::DestroyService do
       before { destroy_service.call }
     end
 
+    context "with attached payment provider customers" do
+      let(:customer) { create(:customer, organization:) }
+      let(:payment_provider_customer) { create(:stripe_customer, customer:, organization:, payment_provider:) }
+
+      before { payment_provider_customer }
+
+      it "soft deletes the payment provider customers" do
+        expect { destroy_service.call }
+          .to change { payment_provider_customer.reload.discarded? }.from(false).to(true)
+      end
+
+      it "detaches the payment provider customers from the payment provider" do
+        destroy_service.call
+
+        expect(payment_provider_customer.reload.payment_provider_id).to be_nil
+      end
+    end
+
     context "when payment provider is not found" do
       let(:payment_provider) { nil }
 

--- a/spec/services/payment_providers/destroy_service_spec.rb
+++ b/spec/services/payment_providers/destroy_service_spec.rb
@@ -35,10 +35,15 @@ RSpec.describe PaymentProviders::DestroyService do
           .to change { payment_provider_customer.reload.discarded? }.from(false).to(true)
       end
 
-      it "detaches the payment provider customers from the payment provider" do
+      it "keeps the payment provider association on the customers" do
         destroy_service.call
 
-        expect(payment_provider_customer.reload.payment_provider_id).to be_nil
+        expect(payment_provider_customer.reload.payment_provider_id).to eq(payment_provider.id)
+      end
+
+      it "bumps updated_at on the payment provider customers" do
+        expect { destroy_service.call }
+          .to change { payment_provider_customer.reload.updated_at }
       end
     end
 


### PR DESCRIPTION
## Context

When a payment provider is destroyed, its associated payment provider customers were only detached by nullifying their payment_provider_id. The records were left active, even though they no longer point to any provider and the provider itself is discarded.

## Description

Set deleted_at on the payment provider customers so they are soft deleted alongside the provider, in addition to clearing their payment_provider_id. This keeps the discarded provider and its customer records consistent.