### PR TITLE
perf(analytics): version customer cache to avoid keyspace scan

### DIFF
--- a/app/models/analytics/base.rb
+++ b/app/models/analytics/base.rb
@@ -4,12 +4,14 @@ module Analytics
   class Base < ApplicationRecord
     self.abstract_class = true
 
+    VERSION_CACHE_EXPIRATION = 1.day
+
     def self.find_all_by(organization_id, **args)
       if args[:expire_cache] == true && args[:external_customer_id].present?
         expire_cache_for_customer(organization_id, args[:external_customer_id])
       end
 
-      Rails.cache.fetch(cache_key(organization_id, **args), expires_in: cache_expiration) do
+      Rails.cache.fetch(versioned_cache_key(organization_id, **args), expires_in: cache_expiration) do
         sql = query(organization_id, **args)
 
         result = ActiveRecord::Base.connection.exec_query(sql)
@@ -21,8 +23,42 @@ module Analytics
       4.hours
     end
 
+    # Appends a per-customer version token to the cache key so that all the
+    # cached variants of a customer (every billing entity / currency / months
+    # combination) can be invalidated at once by bumping a single token.
+    # Org-level keys (no external_customer_id) are left untouched.
+    def self.versioned_cache_key(organization_id, **args)
+      key = cache_key(organization_id, **args)
+      return key if args[:external_customer_id].blank?
+
+      [key, cache_version(organization_id, args[:external_customer_id])].join("/")
+    end
+
+    # Reads the current version token, seeding it with the current timestamp
+    # when absent. Using a wall-clock token (instead of a 0-based counter)
+    # makes eviction/expiry of the token safe: a regenerated token is always
+    # greater than any token a still-cached data key was written with, so a
+    # lost token can only ever cause a cold recompute (a miss), never a stale
+    # hit.
+    def self.cache_version(organization_id, external_customer_id)
+      Rails.cache.fetch(
+        cache_version_key(organization_id, external_customer_id),
+        raw: true,
+        expires_in: VERSION_CACHE_EXPIRATION
+      ) { Time.current.to_i.to_s }
+    end
+
     def self.expire_cache_for_customer(organization_id, external_customer_id)
-      raise NotImplementedError
+      Rails.cache.write(
+        cache_version_key(organization_id, external_customer_id),
+        Time.current.to_i.to_s,
+        raw: true,
+        expires_in: VERSION_CACHE_EXPIRATION
+      )
+    end
+
+    def self.cache_version_key(organization_id, external_customer_id)
+      "#{name}/cache-version/#{organization_id}/#{external_customer_id}"
     end
   end
 end

--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -134,12 +134,6 @@ module Analytics
           args[:months]
         ].join("/")
       end
-
-      def expire_cache_for_customer(organization_id, external_customer_id)
-        Rails.cache.delete_matched(
-          "gross-revenue/#{Date.current.strftime("%Y-%m-%d")}/#{organization_id}*#{external_customer_id}*"
-        )
-      end
     end
   end
 end

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -113,12 +113,6 @@ module Analytics
           args[:months]
         ].join("/")
       end
-
-      def expire_cache_for_customer(organization_id, external_customer_id)
-        Rails.cache.delete_matched(
-          "invoice-collection/#{Date.current.strftime("%Y-%m-%d")}/#{organization_id}*#{external_customer_id}*"
-        )
-      end
     end
   end
 end

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -114,12 +114,6 @@ module Analytics
           args[:months]
         ].join("/")
       end
-
-      def expire_cache_for_customer(organization_id, external_customer_id)
-        Rails.cache.delete_matched(
-          "overdue-balance/#{Date.current.strftime("%Y-%m-%d")}/#{organization_id}*#{external_customer_id}*"
-        )
-      end
     end
   end
 end

--- a/spec/models/analytics/gross_revenue_spec.rb
+++ b/spec/models/analytics/gross_revenue_spec.rb
@@ -231,4 +231,30 @@ RSpec.describe Analytics::GrossRevenue do
       end
     end
   end
+
+  describe ".expire_cache_for_customer", cache: :redis do
+    subject(:expire_cache) { described_class.expire_cache_for_customer(organization_id, external_customer_id) }
+
+    let(:organization_id) { SecureRandom.uuid }
+    let(:external_customer_id) { "customer_01" }
+    let(:version_key) { described_class.cache_version_key(organization_id, external_customer_id) }
+
+    before { allow(Rails.cache).to receive(:delete_matched).and_call_original }
+
+    it "bumps the stored version token" do
+      initial_version = described_class.cache_version(organization_id, external_customer_id)
+
+      travel 1.second do
+        expire_cache
+      end
+
+      expect(Rails.cache.read(version_key, raw: true)).not_to eq(initial_version)
+    end
+
+    it "does not scan the keyspace" do
+      expire_cache
+
+      expect(Rails.cache).not_to have_received(:delete_matched)
+    end
+  end
 end

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -181,4 +181,30 @@ RSpec.describe Analytics::InvoiceCollection do
       end
     end
   end
+
+  describe ".expire_cache_for_customer", cache: :redis do
+    subject(:expire_cache) { described_class.expire_cache_for_customer(organization_id, external_customer_id) }
+
+    let(:organization_id) { SecureRandom.uuid }
+    let(:external_customer_id) { "customer_01" }
+    let(:version_key) { described_class.cache_version_key(organization_id, external_customer_id) }
+
+    before { allow(Rails.cache).to receive(:delete_matched).and_call_original }
+
+    it "bumps the stored version token" do
+      initial_version = described_class.cache_version(organization_id, external_customer_id)
+
+      travel 1.second do
+        expire_cache
+      end
+
+      expect(Rails.cache.read(version_key, raw: true)).not_to eq(initial_version)
+    end
+
+    it "does not scan the keyspace" do
+      expire_cache
+
+      expect(Rails.cache).not_to have_received(:delete_matched)
+    end
+  end
 end

--- a/spec/models/analytics/overdue_balance_spec.rb
+++ b/spec/models/analytics/overdue_balance_spec.rb
@@ -357,6 +357,19 @@ RSpec.describe Analytics::OverdueBalance do
     end
   end
 
+  describe ".cache_version", cache: :redis do
+    let(:organization_id) { SecureRandom.uuid }
+    let(:external_customer_id) { "customer_01" }
+
+    it "seeds the token once and keeps it stable across reads" do
+      first = described_class.cache_version(organization_id, external_customer_id)
+
+      travel 1.second do
+        expect(described_class.cache_version(organization_id, external_customer_id)).to eq(first)
+      end
+    end
+  end
+
   describe "cache invalidation through .find_all_by", cache: :redis do
     let(:organization) { create(:organization, created_at: 3.months.ago) }
     let(:customer) { create(:customer, organization:) }
@@ -383,6 +396,11 @@ RSpec.describe Analytics::OverdueBalance do
 
       travel 1.second do
         expect(overdue_amounts(expire_cache: true)).to eq(350)
+
+        # The expiring read seeded a fresh token and recomputed. A subsequent
+        # plain read must neither reseed the token nor bust the cache: it still
+        # hits the cache written against the new token and returns 350.
+        expect(overdue_amounts).to eq(350)
       end
     end
   end

--- a/spec/models/analytics/overdue_balance_spec.rb
+++ b/spec/models/analytics/overdue_balance_spec.rb
@@ -314,4 +314,76 @@ RSpec.describe Analytics::OverdueBalance do
       end
     end
   end
+
+  describe ".expire_cache_for_customer", cache: :redis do
+    subject(:expire_cache) { described_class.expire_cache_for_customer(organization_id, external_customer_id) }
+
+    let(:organization_id) { SecureRandom.uuid }
+    let(:external_customer_id) { "customer_01" }
+    let(:version_key) { described_class.cache_version_key(organization_id, external_customer_id) }
+
+    before { allow(Rails.cache).to receive(:delete_matched).and_call_original }
+
+    it "bumps the stored version token" do
+      initial_version = described_class.cache_version(organization_id, external_customer_id)
+
+      travel 1.second do
+        expire_cache
+      end
+
+      expect(Rails.cache.read(version_key, raw: true)).not_to eq(initial_version)
+    end
+
+    it "does not scan the keyspace" do
+      expire_cache
+
+      expect(Rails.cache).not_to have_received(:delete_matched)
+    end
+
+    it "uses an independent version namespace per model" do
+      expect(described_class.cache_version_key(organization_id, external_customer_id))
+        .not_to eq(Analytics::GrossRevenue.cache_version_key(organization_id, external_customer_id))
+    end
+  end
+
+  describe ".versioned_cache_key" do
+    let(:organization_id) { SecureRandom.uuid }
+
+    context "without external_customer_id" do
+      it "returns the cache key without a version suffix" do
+        expect(described_class.versioned_cache_key(organization_id))
+          .to eq(described_class.cache_key(organization_id))
+      end
+    end
+  end
+
+  describe "cache invalidation through .find_all_by", cache: :redis do
+    let(:organization) { create(:organization, created_at: 3.months.ago) }
+    let(:customer) { create(:customer, organization:) }
+    let(:billing_entity) { organization.default_billing_entity }
+
+    before do
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        total_amount_cents: 100, billing_entity:, issuing_date: 1.month.ago)
+    end
+
+    def overdue_amounts(expire_cache: false)
+      args = {external_customer_id: customer.external_id}
+      args[:expire_cache] = true if expire_cache
+      described_class.find_all_by(organization.id, **args).sum { |row| row["amount_cents"] }
+    end
+
+    it "serves stale results until expired, then recomputes" do
+      expect(overdue_amounts).to eq(100)
+
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        total_amount_cents: 250, billing_entity:, issuing_date: 1.month.ago)
+
+      expect(overdue_amounts).to eq(100)
+
+      travel 1.second do
+        expect(overdue_amounts(expire_cache: true)).to eq(350)
+      end
+    end
+  end
 end

--- a/spec/scenarios/analytics/customer_cache_invalidation_spec.rb
+++ b/spec/scenarios/analytics/customer_cache_invalidation_spec.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Analytics customer cache invalidation" do
+  include GraphQLHelper
+
+  let(:membership) { create(:membership, organization:) }
+  let(:organization) { create(:organization, created_at: 3.months.ago, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:billing_entity) { organization.default_billing_entity }
+
+  # Freeze the clock to midday of the current day so the wall-clock version
+  # token and the Date.current embedded in the cache key stay stable: the
+  # nested `travel 1.second` around expiring reads can no longer cross a day
+  # boundary. Midday of today (not a hardcoded date) is used on purpose: the
+  # analytics SQL groups on Postgres CURRENT_DATE, which travel_to does not
+  # freeze, so the frozen Ruby clock must remain in the real current month.
+  # A non-block travel_to is used so the per-example `travel 1.second do` blocks
+  # don't trip ActiveSupport's nested-block guard.
+  before { travel_to(Time.current.midday) }
+  after { travel_back }
+
+  let(:overdue_balances_query) do
+    <<~GQL
+      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean) {
+        overdueBalances(currency: $currency, externalCustomerId: $externalCustomerId, months: $months, expireCache: $expireCache) {
+          collection {
+            amountCents
+            currency
+            lagoInvoiceIds
+            month
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:gross_revenues_query) do
+    <<~GQL
+      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean) {
+        grossRevenues(currency: $currency, externalCustomerId: $externalCustomerId, months: $months, expireCache: $expireCache) {
+          collection {
+            month
+            amountCents
+            currency
+            invoicesCount
+          }
+        }
+      }
+    GQL
+  end
+
+  def overdue_amounts(**variables)
+    collection = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: "analytics:view",
+      query: overdue_balances_query,
+      variables:
+    )["data"]["overdueBalances"]["collection"]
+    collection.sum { |row| row["amountCents"].to_i }
+  end
+
+  def gross_amounts(**variables)
+    collection = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: "analytics:view",
+      query: gross_revenues_query,
+      variables:
+    )["data"]["grossRevenues"]["collection"]
+    collection.sum { |row| row["amountCents"].to_i }
+  end
+
+  describe "overdue balances family invalidation", cache: :redis do
+    before do
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 100, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: Time.current,
+        issuing_date: Time.current, total_amount_cents: 50, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 70, currency: "USD", billing_entity:)
+    end
+
+    it "invalidates every cached variant of the customer when one variant expires" do
+      # Each read populates an independent cache entry under the current token.
+      # months: 1 keeps only the current month, so it differs from the unfiltered read.
+      expect(overdue_amounts(externalCustomerId: customer.external_id)).to eq(220)
+      expect(overdue_amounts(externalCustomerId: customer.external_id, currency: "EUR")).to eq(150)
+      expect(overdue_amounts(externalCustomerId: customer.external_id, currency: "USD")).to eq(70)
+      expect(overdue_amounts(externalCustomerId: customer.external_id, months: 1)).to eq(50)
+
+      # The mutation moves every variant: EUR (past + current month), USD, and
+      # the current-month-only window, so each post-expiry sibling read changes
+      # value and a cache hit is distinguishable from a recompute.
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 300, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 130, currency: "USD", billing_entity:)
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: Time.current,
+        issuing_date: Time.current, total_amount_cents: 50, currency: "EUR", billing_entity:)
+
+      # Without expireCache every variant still serves the original cached value.
+      expect(overdue_amounts(externalCustomerId: customer.external_id)).to eq(220)
+      expect(overdue_amounts(externalCustomerId: customer.external_id, currency: "EUR")).to eq(150)
+      expect(overdue_amounts(externalCustomerId: customer.external_id, currency: "USD")).to eq(70)
+      expect(overdue_amounts(externalCustomerId: customer.external_id, months: 1)).to eq(50)
+
+      travel 1.second do
+        # A single expiring read on one variant bumps the per-customer token.
+        expect(overdue_amounts(externalCustomerId: customer.external_id, expireCache: true)).to eq(700)
+
+        # Every other variant now recomputes too, proving the whole family was invalidated.
+        expect(overdue_amounts(externalCustomerId: customer.external_id, currency: "EUR")).to eq(500)
+        expect(overdue_amounts(externalCustomerId: customer.external_id, currency: "USD")).to eq(200)
+        expect(overdue_amounts(externalCustomerId: customer.external_id, months: 1)).to eq(100)
+      end
+    end
+
+    it "leaves org-level cached entries untouched after a customer expiry" do
+      # The org-level read (no externalCustomerId) uses the unversioned cache key.
+      expect(overdue_amounts(externalCustomerId: customer.external_id)).to eq(220)
+      expect(overdue_amounts).to eq(220)
+
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 300, currency: "EUR", billing_entity:)
+
+      travel 1.second do
+        expect(overdue_amounts(externalCustomerId: customer.external_id, expireCache: true)).to eq(520)
+
+        # The org-level entry was not versioned, so it still serves the stale value.
+        expect(overdue_amounts).to eq(220)
+      end
+    end
+  end
+
+  describe "gross revenues family invalidation", cache: :redis do
+    before do
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 100, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: Time.current,
+        issuing_date: Time.current, total_amount_cents: 50, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 70, currency: "USD", billing_entity:)
+    end
+
+    it "invalidates every cached variant of the customer when one variant expires" do
+      expect(gross_amounts(externalCustomerId: customer.external_id)).to eq(220)
+      expect(gross_amounts(externalCustomerId: customer.external_id, currency: "EUR")).to eq(150)
+      expect(gross_amounts(externalCustomerId: customer.external_id, currency: "USD")).to eq(70)
+      expect(gross_amounts(externalCustomerId: customer.external_id, months: 1)).to eq(50)
+
+      # Mutation moves EUR, USD and the current-month window so every sibling
+      # variant changes and a cache hit is distinguishable from a recompute.
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 300, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 130, currency: "USD", billing_entity:)
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: Time.current,
+        issuing_date: Time.current, total_amount_cents: 50, currency: "EUR", billing_entity:)
+
+      expect(gross_amounts(externalCustomerId: customer.external_id)).to eq(220)
+      expect(gross_amounts(externalCustomerId: customer.external_id, currency: "EUR")).to eq(150)
+      expect(gross_amounts(externalCustomerId: customer.external_id, currency: "USD")).to eq(70)
+      expect(gross_amounts(externalCustomerId: customer.external_id, months: 1)).to eq(50)
+
+      travel 1.second do
+        expect(gross_amounts(externalCustomerId: customer.external_id, expireCache: true)).to eq(700)
+
+        expect(gross_amounts(externalCustomerId: customer.external_id, currency: "EUR")).to eq(500)
+        expect(gross_amounts(externalCustomerId: customer.external_id, currency: "USD")).to eq(200)
+        expect(gross_amounts(externalCustomerId: customer.external_id, months: 1)).to eq(100)
+      end
+    end
+
+    it "leaves org-level cached entries untouched after a customer expiry" do
+      expect(gross_amounts(externalCustomerId: customer.external_id)).to eq(220)
+      expect(gross_amounts).to eq(220)
+
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 300, currency: "EUR", billing_entity:)
+
+      travel 1.second do
+        expect(gross_amounts(externalCustomerId: customer.external_id, expireCache: true)).to eq(520)
+
+        expect(gross_amounts).to eq(220)
+      end
+    end
+  end
+
+  describe "per-customer isolation", cache: :redis do
+    let(:other_customer) { create(:customer, organization:) }
+
+    before do
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 100, currency: "EUR", billing_entity:)
+      create(:invoice, customer: other_customer, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 70, currency: "EUR", billing_entity:)
+    end
+
+    it "does not invalidate another customer's cached entry when one customer expires" do
+      # Each customer's read populates an entry under its own per-customer token.
+      expect(overdue_amounts(externalCustomerId: customer.external_id)).to eq(100)
+      expect(overdue_amounts(externalCustomerId: other_customer.external_id)).to eq(70)
+
+      # Both customers get new overdue invoices, so a recompute is distinguishable
+      # from a cache hit for either of them.
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 300, currency: "EUR", billing_entity:)
+      create(:invoice, customer: other_customer, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 130, currency: "EUR", billing_entity:)
+
+      travel 1.second do
+        # Expiring customer A bumps only customer A's token.
+        expect(overdue_amounts(externalCustomerId: customer.external_id, expireCache: true)).to eq(400)
+
+        # Customer B's token is untouched, so its entry still serves the stale value.
+        expect(overdue_amounts(externalCustomerId: other_customer.external_id)).to eq(70)
+      end
+    end
+  end
+
+  describe "org-level expireCache is a no-op", cache: :redis do
+    before do
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 100, currency: "EUR", billing_entity:)
+    end
+
+    it "leaves a customer-scoped cached entry untouched when expireCache runs without externalCustomerId" do
+      # Cache the customer-scoped entry under its per-customer token.
+      expect(overdue_amounts(externalCustomerId: customer.external_id)).to eq(100)
+
+      create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 300, currency: "EUR", billing_entity:)
+
+      travel 1.second do
+        # The Base guard only expires when external_customer_id is present, so an
+        # org-level expireCache read cannot bump any per-customer token.
+        expect(overdue_amounts(expireCache: true)).to eq(400)
+
+        # The customer-scoped entry still serves its stale value.
+        expect(overdue_amounts(externalCustomerId: customer.external_id)).to eq(100)
+      end
+    end
+  end
+
+  describe "cross-model isolation", cache: :redis do
+    before do
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 100, currency: "EUR", billing_entity:)
+      # Draft so it counts toward overdue balance but not gross revenue (status = 1).
+      create(:invoice, customer:, organization:, status: :draft, payment_overdue: true, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 100, currency: "EUR", billing_entity:)
+    end
+
+    it "does not invalidate gross revenue when overdue balance is expired for the same customer" do
+      expect(gross_amounts(externalCustomerId: customer.external_id)).to eq(100)
+
+      create(:invoice, customer:, organization:, status: :finalized, payment_due_date: 1.month.ago,
+        issuing_date: 1.month.ago, total_amount_cents: 300, currency: "EUR", billing_entity:)
+
+      travel 1.second do
+        # Expiring the overdue balance token must not touch the gross revenue token.
+        Analytics::OverdueBalance.find_all_by(organization.id, external_customer_id: customer.external_id, expire_cache: true)
+
+        expect(gross_amounts(externalCustomerId: customer.external_id)).to eq(100)
+      end
+    end
+  end
+
+  # InvoiceCollectionsResolver does not expose externalCustomerId or expireCache
+  # (and is premium-gated), so the per-customer versioning is unreachable through
+  # GraphQL. This model is exercised at the model level via .find_all_by instead.
+  describe "invoice collections family invalidation", cache: :redis do
+    def collection_amounts(**args)
+      Analytics::InvoiceCollection
+        .find_all_by(organization.id, **args)
+        .sum { |row| row["amount_cents"] }
+    end
+
+    before do
+      create(:invoice, customer:, organization:, status: :finalized, payment_status: :succeeded,
+        payment_due_date: 1.month.ago, issuing_date: 1.month.ago, total_amount_cents: 100, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, status: :finalized, payment_status: :pending,
+        payment_due_date: 1.month.ago, issuing_date: 1.month.ago, total_amount_cents: 50, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, status: :finalized, payment_status: :failed,
+        payment_due_date: 1.month.ago, issuing_date: 1.month.ago, total_amount_cents: 70, currency: "USD", billing_entity:)
+    end
+
+    it "invalidates every cached variant of the customer when one variant expires" do
+      expect(collection_amounts(external_customer_id: customer.external_id)).to eq(220)
+      expect(collection_amounts(external_customer_id: customer.external_id, currency: "EUR")).to eq(150)
+      expect(collection_amounts(external_customer_id: customer.external_id, currency: "USD")).to eq(70)
+
+      # Mutation moves both EUR and USD so each sibling variant changes and a
+      # cache hit is distinguishable from a recompute.
+      create(:invoice, customer:, organization:, status: :finalized, payment_status: :succeeded,
+        payment_due_date: 1.month.ago, issuing_date: 1.month.ago, total_amount_cents: 300, currency: "EUR", billing_entity:)
+      create(:invoice, customer:, organization:, status: :finalized, payment_status: :failed,
+        payment_due_date: 1.month.ago, issuing_date: 1.month.ago, total_amount_cents: 130, currency: "USD", billing_entity:)
+
+      expect(collection_amounts(external_customer_id: customer.external_id)).to eq(220)
+      expect(collection_amounts(external_customer_id: customer.external_id, currency: "EUR")).to eq(150)
+      expect(collection_amounts(external_customer_id: customer.external_id, currency: "USD")).to eq(70)
+
+      travel 1.second do
+        expect(collection_amounts(external_customer_id: customer.external_id, expire_cache: true)).to eq(650)
+
+        expect(collection_amounts(external_customer_id: customer.external_id, currency: "EUR")).to eq(450)
+        expect(collection_amounts(external_customer_id: customer.external_id, currency: "USD")).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/scenarios/analytics/customer_cache_invalidation_spec.rb
+++ b/spec/scenarios/analytics/customer_cache_invalidation_spec.rb
@@ -10,17 +10,6 @@ describe "Analytics customer cache invalidation" do
   let(:customer) { create(:customer, organization:) }
   let(:billing_entity) { organization.default_billing_entity }
 
-  # Freeze the clock to midday of the current day so the wall-clock version
-  # token and the Date.current embedded in the cache key stay stable: the
-  # nested `travel 1.second` around expiring reads can no longer cross a day
-  # boundary. Midday of today (not a hardcoded date) is used on purpose: the
-  # analytics SQL groups on Postgres CURRENT_DATE, which travel_to does not
-  # freeze, so the frozen Ruby clock must remain in the real current month.
-  # A non-block travel_to is used so the per-example `travel 1.second do` blocks
-  # don't trip ActiveSupport's nested-block guard.
-  before { travel_to(Time.current.midday) }
-  after { travel_back }
-
   let(:overdue_balances_query) do
     <<~GQL
       query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean) {
@@ -50,6 +39,17 @@ describe "Analytics customer cache invalidation" do
       }
     GQL
   end
+
+  # Freeze the clock to midday of the current day so the wall-clock version
+  # token and the Date.current embedded in the cache key stay stable: the
+  # nested `travel 1.second` around expiring reads can no longer cross a day
+  # boundary. Midday of today (not a hardcoded date) is used on purpose: the
+  # analytics SQL groups on Postgres CURRENT_DATE, which travel_to does not
+  # freeze, so the frozen Ruby clock must remain in the real current month.
+  # A non-block travel_to is used so the per-example `travel 1.second do` blocks
+  # don't trip ActiveSupport's nested-block guard.
+  before { travel_to(Time.current.midday) }
+  after { travel_back }
 
   def overdue_amounts(**variables)
     collection = execute_graphql(


### PR DESCRIPTION
## Context

Clicking the refresh button on the customer overdue-balances widget sends `getCustomerOverdueBalances` with `expire_cache: true`. That branch runs `Analytics::OverdueBalance.expire_cache_for_customer`, which called `Rails.cache.delete_matched(pattern)`.

On a `:redis_cache_store`, `delete_matched` does a `SCAN` over the entire Redis keyspace: its cost is O(total keys in Redis), independent of the customer's currencies or billing entities, and the wildcard pattern only filters the keys that come back, it does not reduce iteration. On a large, busy cache that scan runs long enough that the request times out into a 504. The cold recompute of the analytics SQL is a secondary cost; the scan is what blows past the gateway timeout. The same `delete_matched` override existed in `Analytics::GrossRevenue` and `Analytics::InvoiceCollection`. Production can also run on `:mem_cache_store`, where `delete_matched` is not supported at all.

The reason invalidation reached for a wildcard in the first place: a single customer has a whole family of cache entries, one per `(billing_entity_id × currency × months)` combination plus the no-filter variants. Refreshing has to clear the entire family, not one entry.

## Description

Cache invalidation now uses a per-customer version token folded into the cache key, implemented once in `Analytics::Base` and inherited by all analytics models. `find_all_by` fetches against a `versioned_cache_key`, which appends the customer's current token to the existing `cache_key` (only when an `external_customer_id` is present, so org-level keys are unchanged). Expiring a customer just writes a new token: the whole family of keys becomes unreachable in a single O(1) write, with no keyspace scan, and the orphaned entries fall off via the existing 4h TTL. The three `delete_matched` overrides were removed so every model shares the `Base` implementation.

Fixes ING-343.

### Alternatives considered

Three strategies were weighed against each other:

- **Targeted single `delete`** of the one key matching the request's args. O(1), but only correct if the frontend sends `expire_cache: true` on every variant it reads; otherwise the other months/currency/entity tiles in the widget keep serving stale values.
- **Enumerated `delete_multi`** that rebuilds every known `(entity × currency × months)` key and deletes them in one call. Bounded and store-agnostic, but it can only invalidate the keys it can name: any variant not enumerated (a non-default currency, or a `billing_entity_code`-filtered request, which the cache key doesn't even encode) silently goes stale. It also couples backend invalidation to the frontend's exact filter matrix.
- **Per-customer versioning** (chosen). Invalidates the entire family regardless of how many currencies/entities/months exist, and stays correct even if new filters are added later, because it doesn't enumerate anything. The cost is one extra small cache read on the customer-scoped read path, which is noise next to the analytics SQL.

Versioning won on correctness: it is the only option that cannot silently serve stale data, and it is store-agnostic.

### Token design

The token is a wall-clock timestamp (`Time.current.to_i`) rather than a 0-based counter, stored `raw: true` for portability across redis and memcache (`Rails.cache.increment` is avoided because Dalli's `incr` on a missing key returns nil and never seeds it). It is seeded on read and namespaced by class name so the analytics models don't collide.

The wall-clock choice is what makes losing the token safe. If the token key is evicted under memory pressure or expires, the next read reseeds it with the current time, which is strictly greater than any token a still-cached data key was written with. So a lost token can only ever produce a cache miss (a cold recompute), never a stale hit. That safety is also why the token carries a 1-day TTL: it bounds memory growth (one small key per model/org/customer ever viewed) without needing a sweeper job, and expiring it early costs at most one recompute.