### PR TITLE
[ING-323][ING-331]misc(clickhouse): Apply AggregationResult to count queries

### DIFF
--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -6,13 +6,14 @@ module BillableMetrics
       def compute_aggregation(options: {})
         return empty_result if should_bypass_aggregation?
 
-        result.aggregation = event_store.count
-        result.current_usage_units = result.aggregation
-        result.count = result.aggregation
+        count_result = event_store.count
+        result.aggregation = count_result.value
+        result.current_usage_units = count_result.value
+        result.count = count_result.events_count
         result.pay_in_advance_aggregation = BigDecimal(1)
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_count(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_count(uniq_grouped_by_and_presentation_by).map(&:to_grouped_hash)
           result.pay_in_advance_breakdowns = build_pay_in_advance_breakdowns(value: 1)
         end
 
@@ -36,16 +37,16 @@ module BillableMetrics
 
         result.aggregations = aggregations.map do |aggregation|
           group_result = BaseService::Result.new
-          group_result.grouped_by = aggregation[:groups]
-          group_result.aggregation = aggregation[:value]
-          group_result.count = aggregation[:value]
-          group_result.current_usage_units = aggregation[:value]
+          group_result.grouped_by = aggregation.groups
+          group_result.aggregation = aggregation.value
+          group_result.count = aggregation.events_count
+          group_result.current_usage_units = aggregation.value
           group_result.options = {running_total: running_total(options, aggregation: group_result.aggregation)}
           group_result
         end
 
         if presentation_by.present?
-          result.breakdowns = event_store.grouped_count(uniq_grouped_by_and_presentation_by)
+          result.breakdowns = event_store.grouped_count(uniq_grouped_by_and_presentation_by).map(&:to_grouped_hash)
         end
 
         result
@@ -63,7 +64,7 @@ module BillableMetrics
       end
 
       def compute_per_event_aggregation(exclude_event:, include_event_value:)
-        values = (0...event_store.count).map { |_| 1 }
+        values = (0...event_store.count.value).map { |_| 1 }
         values << 1 if include_event_value
         values
       end

--- a/app/services/billable_metrics/aggregations/custom_service.rb
+++ b/app/services/billable_metrics/aggregations/custom_service.rb
@@ -11,7 +11,7 @@ module BillableMetrics
       def compute_aggregation(options: {})
         return empty_result if should_bypass_aggregation?
 
-        result.count = event_store.count
+        result.count = event_store.count.value
 
         aggregation_result = perform_custom_aggregation(grouped_by_values:)
         in_advance_aggregation_result = compute_pay_in_advance_aggregation
@@ -47,12 +47,12 @@ module BillableMetrics
 
         result.aggregations = counts.map do |aggregation|
           group_result = BaseService::Result.new
-          group_result.grouped_by = aggregation[:groups]
-          group_result.count = aggregation[:value]
+          group_result.grouped_by = aggregation.groups
+          group_result.count = aggregation.events_count
 
           aggregation_result = perform_custom_aggregation(
             target_result: group_result,
-            grouped_by_values: aggregation[:groups]
+            grouped_by_values: aggregation.groups
           )
 
           group_result.aggregation = aggregation_result[:total_units]
@@ -61,7 +61,7 @@ module BillableMetrics
           group_result.options = options
 
           if billable_metric.recurring?
-            last_event = last_events.find { |c| c[:groups] == aggregation[:groups] }
+            last_event = last_events.find { |c| c[:groups] == aggregation.groups }
 
             group_result.recurring_updated_at = last_event&.[](:timestamp) || from_datetime
           end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -95,7 +95,9 @@ module Events
         raise NotImplementedError
       end
 
-      delegate :count, to: :events
+      def count
+        raise NotImplementedError
+      end
 
       def grouped_count
         raise NotImplementedError

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -259,7 +259,7 @@ module Events
       end
 
       def count
-        Utils::ClickhouseConnection.connection_with_retry do |connection|
+        value = Utils::ClickhouseConnection.connection_with_retry do |connection|
           sql = with_ctes(events_cte_queries(deduplicated_columns: %w[value]), <<-SQL)
             SELECT count()
             FROM events
@@ -267,6 +267,8 @@ module Events
 
           connection.select_value(sql).to_i
         end
+
+        build_aggregation_result_from_value(value)
       end
 
       def grouped_count(columns = grouped_by)
@@ -291,7 +293,7 @@ module Events
             SQL
           end
 
-          prepare_grouped_result(connection.select_all(sql))
+          grouped_results_with_value_as_count(prepare_grouped_result(connection.select_all(sql)))
         end
       end
 
@@ -734,9 +736,9 @@ module Events
           #       from the events in the period
           formatted_initial_values = grouped_count(columns).map do |group|
             value = 0
-            previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
+            previous_group = initial_values.find { |g| g[:groups] == group.groups }
             value = previous_group[:value] if previous_group
-            {groups: group[:groups], value:}
+            {groups: group.groups, value:}
           end
 
           # NOTE: add the initial values for groups that are not in the events

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -253,9 +253,11 @@ module Events
       end
 
       def count
-        Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
+        value = Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           connection.select_value(count_query).to_i
         end
+
+        build_aggregation_result_from_value(value)
       end
 
       # Counting deduplicated events only needs the number of distinct dedup keys,
@@ -308,7 +310,7 @@ module Events
             GROUP BY #{column_names}
           SQL
 
-          prepare_grouped_result(connection.select_all(sql).rows, columns: columns)
+          grouped_results_with_value_as_count(prepare_grouped_result(connection.select_all(sql).rows, columns: columns))
         end
       end
 
@@ -952,9 +954,9 @@ module Events
       def formatted_weighted_sum_initial_values(initial_values)
         formatted_initial_values = grouped_count.map do |group|
           value = 0
-          previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
+          previous_group = initial_values.find { |g| g[:groups] == group.groups }
           value = previous_group[:value] if previous_group
-          {groups: group[:groups], value:}
+          {groups: group.groups, value:}
         end
 
         initial_values.each do |initial_value|

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -105,13 +105,17 @@ module Events
         events(ordered: true).pluck(Arel.sql("(#{sanitized_property_name})::numeric * (#{ratio_sql})::numeric"))
       end
 
+      def count
+        build_aggregation_result_from_value(events.count)
+      end
+
       def grouped_count(columns = grouped_by)
         results = events
           .group(columns.map { sanitized_property_name(it) })
           .count
           .map { |group, value| [group, value].flatten }
 
-        prepare_grouped_result(results, columns: columns)
+        grouped_results_with_value_as_count(prepare_grouped_result(results, columns: columns))
       end
 
       # NOTE: check if an event created before the current on belongs to an active (as in present and not removed)
@@ -409,9 +413,9 @@ module Events
         #       from the events in the period
         formatted_initial_values = grouped_count.map do |group|
           value = 0
-          previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
+          previous_group = initial_values.find { |g| g[:groups] == group.groups }
           value = previous_group[:value] if previous_group
-          {groups: group[:groups], value:}
+          {groups: group.groups, value:}
         end
 
         # NOTE: add the initial values for groups that are not in the events

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
         let(:matching_filters) { {"region" => ["europe"]} }
 
         it "does not count the event (latest enrichment is asia, filter excludes it)" do
-          expect(event_store.count).to eq(0)
+          expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 0, events_count: 0))
         end
       end
 
@@ -133,7 +133,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
         let(:matching_filters) { {"region" => ["asia"]} }
 
         it "counts the deduplicated event exactly once" do
-          expect(event_store.count).to eq(1)
+          expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 1, events_count: 1))
         end
       end
     end
@@ -282,8 +282,8 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       insert_event(transaction_id: txn, timestamp: ts, enriched_at: Time.current)
       insert_event(transaction_id: SecureRandom.uuid, timestamp: ts + 1.day, enriched_at: Time.current)
 
-      expect(event_store.count).to eq(2)
-      expect(event_store.count).to eq(join_based_count)
+      expect(event_store.count.value).to eq(2)
+      expect(event_store.count.value).to eq(join_based_count)
     end
 
     it "treats the same transaction_id at different timestamps as distinct events" do
@@ -291,21 +291,21 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       insert_event(transaction_id: txn, timestamp: ts, enriched_at: Time.current)
       insert_event(transaction_id: txn, timestamp: ts + 1.hour, enriched_at: Time.current)
 
-      expect(event_store.count).to eq(2)
-      expect(event_store.count).to eq(join_based_count)
+      expect(event_store.count.value).to eq(2)
+      expect(event_store.count.value).to eq(join_based_count)
     end
 
     it "excludes events outside the boundaries" do
       insert_event(transaction_id: SecureRandom.uuid, timestamp: ts, enriched_at: Time.current)
       insert_event(transaction_id: SecureRandom.uuid, timestamp: boundaries[:to_datetime] + 2.days, enriched_at: Time.current)
 
-      expect(event_store.count).to eq(1)
-      expect(event_store.count).to eq(join_based_count)
+      expect(event_store.count.value).to eq(1)
+      expect(event_store.count.value).to eq(join_based_count)
     end
 
     it "returns zero when there are no events" do
-      expect(event_store.count).to eq(0)
-      expect(event_store.count).to eq(join_based_count)
+      expect(event_store.count.value).to eq(0)
+      expect(event_store.count.value).to eq(join_based_count)
     end
   end
 end

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -93,13 +93,13 @@ RSpec.describe Events::Stores::PostgresStore do
       it "assigns a distinct position to each event sharing the boundary timestamp" do
         tied_events = (1..3).map { |i| create_event(timestamp:, created_at: timestamp + i.seconds) }
 
-        expect(tied_events.map { |event| store_for(event).count }).to eq([2, 3, 4])
+        expect(tied_events.map { |event| store_for(event).count.value }).to eq([2, 3, 4])
       end
 
       it "assigns distinct positions when created_at is also tied" do
         tied_events = (1..3).map { create_event(timestamp:, created_at: timestamp) }
 
-        expect(tied_events.map { |event| store_for(event).count }).to match_array([2, 3, 4])
+        expect(tied_events.map { |event| store_for(event).count.value }).to match_array([2, 3, 4])
       end
 
       it "counts all events sharing the timestamp when no event filter is given" do
@@ -117,7 +117,7 @@ RSpec.describe Events::Stores::PostgresStore do
           filters: {}
         )
 
-        expect(event_store.count).to eq(3)
+        expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 3, events_count: 3))
       end
     end
   end

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -268,7 +268,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
   if include_feature?(:count)
     describe "#count" do
       it "returns the number of unique events" do
-        expect(event_store.count).to eq(5)
+        expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 5, events_count: 5))
       end
 
       context "with grouped_by_values" do
@@ -276,14 +276,14 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         let(:events_grouped_by) { ["region"] }
 
         it "returns the number of unique events" do
-          expect(event_store.count).to eq(3)
+          expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 3, events_count: 3))
         end
 
         context "when grouped_by_values value is nil" do
           let(:grouped_by_values) { {"region" => nil} }
 
           it "returns the number of unique events" do
-            expect(event_store.count).to eq(2)
+            expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 2, events_count: 2))
           end
         end
       end
@@ -314,7 +314,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           # - europe, france, paris
           # - europe, france, cambridge
           # - europe, united kingdom, manchester
-          expect(event_store.count).to eq(4)
+          expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 4, events_count: 4))
         end
 
         # We faced an issue where Arel caused a Stack Level Too Deep error due to how the request `OR` conditons are build.
@@ -362,7 +362,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           end
 
           it "returns the number of unique events ignoring empty entries" do
-            expect(event_store.count).to eq(4)
+            expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 4, events_count: 4))
           end
         end
       end
@@ -378,7 +378,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         end
 
         it "returns the number of unique events" do
-          expect(event_store.count).to eq(2)
+          expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 2, events_count: 2))
         end
       end
 
@@ -396,7 +396,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           end
 
           it "takes the event into account" do
-            expect(event_store.count).to eq(6)
+            expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 6, events_count: 6))
           end
         end
       end
@@ -410,7 +410,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
       it "applies the grouped_by_values in the block" do
         event_store.with_grouped_by_values(with_grouped_by_values) do
-          expect(event_store.count).to eq(3)
+          expect(event_store.count).to eq(Events::Stores::BaseStore::AggregationResult.new(value: 3, events_count: 3))
         end
       end
     end
@@ -461,7 +461,10 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       it "returns the number of unique events grouped by the provided group" do
         result = event_store.grouped_count
 
-        expect(result).to match_array([{groups: {"region" => nil}, value: 2}, {groups: {"region" => "europe"}, value: 3}])
+        expect(result).to match_array([
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => nil}, value: 2, events_count: 2),
+          Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "europe"}, value: 3, events_count: 3)
+        ])
       end
 
       context "with multiple groups" do
@@ -471,9 +474,9 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_count
 
           expect(result).to match_array([
-            {groups: {"country" => "france", "region" => "europe"}, value: 2},
-            {groups: {"country" => nil, "region" => nil}, value: 2},
-            {groups: {"country" => "united kingdom", "region" => "europe"}, value: 1}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "france", "region" => "europe"}, value: 2, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => nil, "region" => nil}, value: 2, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"country" => "united kingdom", "region" => "europe"}, value: 1, events_count: 1)
           ])
         end
       end
@@ -1701,8 +1704,8 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_count(["cloud"])
 
           expect(result).to match_array([
-            {groups: {"cloud" => "aws"}, value: 3},
-            {groups: {"cloud" => "gcp"}, value: 1}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "aws"}, value: 3, events_count: 3),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"cloud" => "gcp"}, value: 1, events_count: 1)
           ])
         end
       end
@@ -1720,9 +1723,9 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           result = event_store.grouped_count(["agent_name", "cloud"])
 
           expect(result).to match_array([
-            {groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2},
-            {groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1},
-            {groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1}
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "aws"}, value: 2, events_count: 2),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "frodo", "cloud" => "gcp"}, value: 1, events_count: 1),
+            Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"agent_name" => "aragorn", "cloud" => "aws"}, value: 1, events_count: 1)
           ])
         end
       end


### PR DESCRIPTION
## Description

This PR follows https://github.com/getlago/lago-api/pull/5807
It keeps updating events stores to group queries related to the same aggregation

This PR applies the return Resullt approach to the `count` and `grouped_count` aggregation.
Both now returns an `AggregatedResult` or `GroupedAggregatedResult`. It does not change the global behavior as the result from the count aggregation was already used for both `aggregation` and `events_count` in the `CountService`. The main goal is only to unify the return type with other aggregations
