### PR TITLE
fix(factory): Build organization child records

### DIFF
--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -14,13 +14,14 @@ FactoryBot.define do
     email { Faker::Internet.email }
     email_settings { ["invoice.finalized", "credit_note.created"] }
 
-    api_keys { [association(:api_key, organization: instance)] }
+    api_keys { [association(:api_key, organization: instance, strategy: :build)] }
     billing_entities do
       [
         association(
           :billing_entity,
           *(with_static_values ? [:with_static_values] : []),
-          organization: instance
+          organization: instance,
+          strategy: :build
         )
       ]
     end


### PR DESCRIPTION
Force `strategy: :build` on `api_keys` and `billing_entities` associations so the children are built and persisted through the organization's own autosave, after its id is assigned. The `api_keys: []` override and `build(:organization)` behavior are preserved.
