### PR TITLE
[ING-311] fix(data-api): Improve HTTP client retry on transient errors

### DIFF
--- a/app/services/data_api/base_service.rb
+++ b/app/services/data_api/base_service.rb
@@ -16,7 +16,7 @@ module DataApi
     attr_reader :organization, :params
 
     def http_client
-      @http_client ||= LagoHttpClient::Client.new(endpoint_url)
+      @http_client ||= LagoHttpClient::Client.new(endpoint_url, retry_on_transient_errors: true)
     end
 
     def headers

--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -147,36 +147,38 @@ module LagoHttpClient
     def request(req, params = nil)
       attempt = 0
 
-      loop do
+      begin
         attempt += 1
-
-        begin
-          response = http_client.request(req, params)
-        rescue => e
-          raise unless retry_on_error?(e) && attempt < MAX_RETRIES_ATTEMPTS
-
-          backoff
-          next
-        end
-
-        if retry_on_status?(response.code.to_i) && attempt < MAX_RETRIES_ATTEMPTS
-          backoff
-          next
-        end
-
+        response = http_client.request(req, params)
         raise_error(response) unless RESPONSE_SUCCESS_CODES.include?(response.code.to_i)
+        response
+      rescue => e
+        if retryable?(e) && attempt < MAX_RETRIES_ATTEMPTS
+          backoff
+          retry
+        end
 
-        return response
+        raise
       end
     end
 
-    def retry_on_error?(error)
-      retries_on.include?(error.class) ||
-        (retry_on_transient_errors && TRANSIENT_ERROR_CLASSES.any? { |klass| error.is_a?(klass) })
+    # An error is retryable when its class was explicitly opted in through
+    # `retries_on:`, or when `retry_on_transient_errors` is enabled and the error
+    # is a known transient failure (a connection-level exception or a transient
+    # HTTP status such as 502/503).
+    def retryable?(error)
+      return true if retries_on.include?(error.class)
+      return false unless retry_on_transient_errors
+
+      transient_exception?(error) || transient_http_error?(error)
     end
 
-    def retry_on_status?(code)
-      retry_on_transient_errors && RETRYABLE_HTTP_STATUSES.include?(code)
+    def transient_exception?(error)
+      TRANSIENT_ERROR_CLASSES.any? { |klass| error.is_a?(klass) }
+    end
+
+    def transient_http_error?(error)
+      error.is_a?(::LagoHttpClient::HttpError) && RETRYABLE_HTTP_STATUSES.include?(error.error_code.to_i)
     end
 
     def backoff

--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -2,15 +2,28 @@
 
 require "net/http/post/multipart"
 require "event_stream_parser"
+require "openssl"
 
 module LagoHttpClient
   class Client
     RESPONSE_SUCCESS_CODES = [200, 201, 202, 204].freeze
     MAX_RETRIES_ATTEMPTS = 3
+    RETRYABLE_HTTP_STATUSES = [500, 502, 503, 504].freeze
+    TRANSIENT_ERROR_CLASSES = [
+      OpenSSL::SSL::SSLError,
+      Net::OpenTimeout,
+      Net::ReadTimeout,
+      EOFError,
+      Errno::ECONNRESET,
+      Errno::ECONNREFUSED,
+      Errno::ETIMEDOUT,
+      Errno::EHOSTUNREACH
+    ].freeze
+    RETRY_BACKOFF_RANGE = (0.25..0.5)
 
-    attr_reader :uri, :retries_on
+    attr_reader :uri, :retries_on, :retry_on_transient_errors
 
-    def initialize(url, open_timeout: nil, read_timeout: nil, write_timeout: nil, retries_on: [])
+    def initialize(url, open_timeout: nil, read_timeout: nil, write_timeout: nil, retries_on: [], retry_on_transient_errors: false)
       @uri = URI(url)
       @http_client = Net::HTTP.new(uri.host, uri.port)
       @http_client.open_timeout = open_timeout if open_timeout.present?
@@ -18,6 +31,7 @@ module LagoHttpClient
       @http_client.write_timeout = write_timeout if write_timeout.present?
       @http_client.use_ssl = true if uri.scheme == "https"
       @retries_on = retries_on
+      @retry_on_transient_errors = retry_on_transient_errors
     end
 
     def post(body, headers)
@@ -133,19 +147,40 @@ module LagoHttpClient
     def request(req, params = nil)
       attempt = 0
 
-      response = begin
+      loop do
         attempt += 1
-        http_client.request(req, params)
-      rescue => e
-        if retries_on.include?(e.class)
-          retry if attempt < MAX_RETRIES_ATTEMPTS
-        else
-          raise
-        end
-      end
 
-      raise_error(response) unless RESPONSE_SUCCESS_CODES.include?(response.code.to_i)
-      response
+        begin
+          response = http_client.request(req, params)
+        rescue => e
+          raise unless retry_on_error?(e) && attempt < MAX_RETRIES_ATTEMPTS
+
+          backoff
+          next
+        end
+
+        if retry_on_status?(response.code.to_i) && attempt < MAX_RETRIES_ATTEMPTS
+          backoff
+          next
+        end
+
+        raise_error(response) unless RESPONSE_SUCCESS_CODES.include?(response.code.to_i)
+
+        return response
+      end
+    end
+
+    def retry_on_error?(error)
+      retries_on.include?(error.class) ||
+        (retry_on_transient_errors && TRANSIENT_ERROR_CLASSES.any? { |klass| error.is_a?(klass) })
+    end
+
+    def retry_on_status?(code)
+      retry_on_transient_errors && RETRYABLE_HTTP_STATUSES.include?(code)
+    end
+
+    def backoff
+      sleep(rand(RETRY_BACKOFF_RANGE))
     end
   end
 end

--- a/spec/lib/lago_http_client/client_spec.rb
+++ b/spec/lib/lago_http_client/client_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe LagoHttpClient::Client do
   let(:url) { "http://example.com/api/v1/example" }
   let(:client_options) { {} }
 
+  before { stub_const("#{described_class}::RETRY_BACKOFF_RANGE", 0.0..0.0) }
+
   describe "#initialize" do
     it "parses the URL into a URI" do
       expect(client.uri).to eq URI("http://example.com/api/v1/example")
@@ -523,8 +525,8 @@ RSpec.describe LagoHttpClient::Client do
         stub_request(:post, url).to_raise(Net::OpenTimeout)
       end
 
-      it "raises NoMethodError due to nil response" do
-        expect { client.post({}, []) }.to raise_error(NoMethodError)
+      it "re-raises the original error after exhausting retries" do
+        expect { client.post({}, []) }.to raise_error(Net::OpenTimeout)
       end
     end
 
@@ -547,6 +549,142 @@ RSpec.describe LagoHttpClient::Client do
 
       it "raises the error immediately" do
         expect { client.post({}, []) }.to raise_error(Net::OpenTimeout)
+      end
+    end
+
+    context "with retry_on_transient_errors enabled" do
+      let(:client_options) { {retry_on_transient_errors: true} }
+
+      context "when the response is a 500 then succeeds" do
+        before do
+          call_count = 0
+          stub_request(:post, url).to_return do
+            call_count += 1
+            if call_count == 1
+              {body: "transient error", status: 500}
+            else
+              {body: "{}", status: 200}
+            end
+          end
+        end
+
+        it "retries and returns the parsed body" do
+          expect(client.post({}, [])).to eq({})
+        end
+      end
+
+      context "when the response is a 503 on every call" do
+        before do
+          stub_request(:post, url).to_return(body: "unavailable", status: 503)
+        end
+
+        it "raises an HttpError after exhausting retries" do
+          expect { client.post({}, []) }.to raise_error(LagoHttpClient::HttpError) do |error|
+            expect(error.error_code).to eq "503"
+          end
+        end
+      end
+
+      context "when a transient exception occurs then succeeds" do
+        before do
+          call_count = 0
+          stub_request(:post, url).to_return do
+            call_count += 1
+            if call_count == 1
+              raise Net::OpenTimeout
+            else
+              {body: "{}", status: 200}
+            end
+          end
+        end
+
+        it "retries and returns the parsed body" do
+          expect(client.post({}, [])).to eq({})
+        end
+      end
+
+      context "when an SSL error occurs then succeeds" do
+        before do
+          call_count = 0
+          stub_request(:post, url).to_return do
+            call_count += 1
+            if call_count == 1
+              raise OpenSSL::SSL::SSLError
+            else
+              {body: "{}", status: 200}
+            end
+          end
+        end
+
+        it "retries and returns the parsed body" do
+          expect(client.post({}, [])).to eq({})
+        end
+      end
+
+      context "when the response is a 4xx" do
+        it "raises an HttpError without retrying" do
+          stub = stub_request(:post, url).to_return(body: "Error", status: 422)
+
+          expect { client.post({}, []) }.to raise_error(LagoHttpClient::HttpError) do |error|
+            expect(error.error_code).to eq "422"
+          end
+          expect(stub).to have_been_requested.once
+        end
+      end
+
+      context "when a transient exception occurs on every call" do
+        let(:call_count) { {value: 0} }
+
+        before do
+          counter = call_count
+          stub_request(:post, url).to_return do
+            counter[:value] += 1
+            raise Errno::ECONNRESET
+          end
+        end
+
+        # Exception-path exhaustion goes through the `is_a?` branch of
+        # `retry_on_error?`, distinct from the `retries_on.include?` branch.
+        it "re-raises the original error after exhausting retries" do
+          expect { client.post({}, []) }.to raise_error(Errno::ECONNRESET)
+        end
+
+        it "attempts exactly MAX_RETRIES_ATTEMPTS times" do
+          expect { client.post({}, []) }.to raise_error(Errno::ECONNRESET)
+          expect(call_count[:value]).to eq(described_class::MAX_RETRIES_ATTEMPTS)
+        end
+      end
+
+      context "when a retryable status is returned on every call" do
+        it "attempts exactly MAX_RETRIES_ATTEMPTS times" do
+          stub = stub_request(:post, url).to_return(body: "unavailable", status: 503)
+
+          expect { client.post({}, []) }.to raise_error(LagoHttpClient::HttpError)
+          expect(stub).to have_been_requested.times(described_class::MAX_RETRIES_ATTEMPTS)
+        end
+      end
+
+      context "when a non-transient exception occurs" do
+        before do
+          stub_request(:post, url).to_raise(ArgumentError)
+        end
+
+        # ArgumentError is neither in retries_on nor TRANSIENT_ERROR_CLASSES,
+        # so it must propagate immediately even with the flag enabled.
+        it "raises the error immediately without retrying" do
+          expect { client.post({}, []) }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context "with retry_on_transient_errors disabled (default)" do
+      let(:client_options) { {} }
+
+      it "raises an HttpError without retrying on a 500" do
+        stub = stub_request(:post, url).to_return(body: "Error", status: 500)
+
+        expect { client.post({}, []) }.to raise_error(LagoHttpClient::HttpError)
+        expect(stub).to have_been_requested.once
       end
     end
   end

--- a/spec/lib/lago_http_client/client_spec.rb
+++ b/spec/lib/lago_http_client/client_spec.rb
@@ -644,7 +644,7 @@ RSpec.describe LagoHttpClient::Client do
         end
 
         # Exception-path exhaustion goes through the `is_a?` branch of
-        # `retry_on_error?`, distinct from the `retries_on.include?` branch.
+        # `transient_exception?`, distinct from the `retries_on.include?` branch.
         it "re-raises the original error after exhausting retries" do
           expect { client.post({}, []) }.to raise_error(Errno::ECONNRESET)
         end

--- a/spec/services/data_api/usages_service_spec.rb
+++ b/spec/services/data_api/usages_service_spec.rb
@@ -87,6 +87,29 @@ RSpec.describe DataApi::UsagesService do
         end
       end
     end
+
+    context "when the data api returns a transient error before succeeding" do
+      let(:query) { {time_granularity: "daily", start_of_period_dt: Date.current - 30.days} }
+
+      before do
+        call_count = 0
+        stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/")
+          .with(query:)
+          .to_return do
+            call_count += 1
+            if call_count == 1
+              {status: 500, body: "transient error", headers: {}}
+            else
+              {status: 200, body: body_response, headers: {}}
+            end
+          end
+      end
+
+      it "retries and returns usages" do
+        expect(service_call).to be_success
+        expect(service_call.usages.count).to eq(3)
+      end
+    end
   end
 
   describe "#filtered_params" do


### PR DESCRIPTION
## Context

`Api::V1::DataApi::UsagesController#index` calls `DataApi::UsagesService` synchronously, which fetches usage data from the Lago Data API over HTTP. When the Data API hits a transient database error (a closed connection), it returns a 5xx. `LagoHttpClient::Client` turns that into a `LagoHttpClient::HttpError`, which surfaces as a failed request to the caller. These errors are transient and succeed when the call is retried.

## Description

This adds an opt-in retry capability to `LagoHttpClient::Client`. A new `retry_on_transient_errors:` flag (default `false`, so existing callers are unaffected) makes the client retry a curated set of transient failures: connection-level exceptions (SSL, open and read timeouts, EOF, connection reset/refused) and transient 5xx responses (500, 502, 503, 504). Retries reuse the existing `MAX_RETRIES_ATTEMPTS` limit, with a short jittered pause between attempts. 4xx responses are never retried.

The flag is enabled for the DataApi client in `DataApi::BaseService`, so all DataApi services (usages, MRRs, prepaid credits, revenue streams) gain the retry, since they share the same backend and the same transient failure.

Rewriting the request loop also fixes a pre-existing issue: once an exception-based retry exhausted its attempts, the client raised a `NoMethodError` on a nil response instead of re-raising the original error. It now re-raises the original error.
