### PR TITLE
[ING-328] misc(clickhouse): Apply AggregationResult to prorated sum

### DIFF
--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -3,6 +3,11 @@
 module BillableMetrics
   module Aggregations
     class SumService < BillableMetrics::Aggregations::BaseService
+      # NOTE: when set, the aggregation reuses these precomputed results instead of
+      #       querying the event store. Used by the prorated aggregation service which
+      #       already sums the (non-prorated) value and count while computing proration.
+      attr_accessor :injected_sum_result, :injected_grouped_sum_result
+
       def initialize(...)
         super
 
@@ -14,7 +19,7 @@ module BillableMetrics
       def compute_aggregation(options: {})
         return empty_result if should_bypass_aggregation?
 
-        sum_result = event_store.sum
+        sum_result = injected_sum_result || event_store.sum
 
         if options[:is_pay_in_advance] && options[:is_current_usage]
           handle_in_advance_current_usage(sum_result.value)
@@ -47,7 +52,7 @@ module BillableMetrics
       def compute_grouped_by_aggregation(options: {})
         return empty_results if should_bypass_aggregation?
 
-        aggregations = event_store.grouped_sum
+        aggregations = injected_grouped_sum_result || event_store.grouped_sum
         return empty_results if aggregations.blank?
 
         if presentation_by.present?

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -3,6 +3,8 @@
 module BillableMetrics
   module ProratedAggregations
     class SumService < BillableMetrics::ProratedAggregations::BaseService
+      PERSISTED_TOP_BOUNDARY_DELAY = 0.000001.seconds
+
       def initialize(**args)
         super
         @base_aggregator = BillableMetrics::Aggregations::SumService.new(**args)
@@ -13,10 +15,11 @@ module BillableMetrics
       end
 
       def compute_aggregation(options: {})
-        aggregation_without_proration = base_aggregator.aggregate(options:)
+        return base_aggregator.aggregate(options:) if bill_full_amount?(options)
 
-        # For charges that are pay in advance on billing date we always bill full amount
-        return aggregation_without_proration if event.nil? && options[:is_pay_in_advance] && !options[:is_current_usage]
+        # NOTE: Inject the result in the non-prorated aggregator to avoid duplicated queries
+        base_aggregator.injected_sum_result = non_prorated_sum_result
+        aggregation_without_proration = base_aggregator.aggregate(options:)
 
         aggregation = compute_event_aggregation.ceil(5)
         result.full_units_number = aggregation_without_proration.aggregation if event.nil?
@@ -55,10 +58,11 @@ module BillableMetrics
       #       as pay in advance aggregation will be computed on a single group
       #       with the grouped_by_values filter
       def compute_grouped_by_aggregation(options: {})
-        aggregation_without_proration = base_aggregator.aggregate(options:)
+        return base_aggregator.aggregate(options:) if bill_full_amount?(options)
 
-        # For charges that are pay in advance on billing date we always bill full amount
-        return aggregation_without_proration if event.nil? && options[:is_pay_in_advance] && !options[:is_current_usage]
+        # NOTE: Inject the result in the non-prorated aggregator to avoid duplicated queries
+        base_aggregator.injected_grouped_sum_result = non_prorated_grouped_sum_result
+        aggregation_without_proration = base_aggregator.aggregate(options:)
 
         aggregations = compute_grouped_event_aggregation
         return empty_results if aggregations.blank?
@@ -127,40 +131,74 @@ module BillableMetrics
 
       protected
 
-      def persisted_event_store_instance
-        event_store = event_store_class.new(
-          code: billable_metric.code,
-          subscription:,
-          boundaries: {to_datetime: from_datetime},
-          filters:
-        )
+      # NOTE: pay in advance charges billed on the billing date (no event, not current usage)
+      #       always bill the full amount, so proration is not applied.
+      def bill_full_amount?(options)
+        event.nil? && options[:is_pay_in_advance] && !options[:is_current_usage]
+      end
 
-        event_store.use_from_boundary = false
-        event_store.aggregation_property = billable_metric.field_name
-        event_store.numeric_property = true
-        event_store
+      def persisted_event_store_instance
+        @persisted_event_store_instance ||= begin
+          event_store = event_store_class.new(
+            code: billable_metric.code,
+            subscription:,
+            boundaries: {to_datetime: from_datetime - PERSISTED_TOP_BOUNDARY_DELAY}, # Note: Avoid counting events exactly on `from_datetime` twice
+            filters:,
+            deduplicate: deduplicate?
+          )
+
+          event_store.use_from_boundary = false
+          event_store.aggregation_property = billable_metric.field_name
+          event_store.numeric_property = true
+          event_store
+        end
       end
 
       def compute_event_aggregation
-        result = 0.0
-
-        # NOTE: Billed on the full period
-        result += persisted_sum || 0
-
-        # NOTE: Added during the period
-        result + (event_store.prorated_sum(period_duration:) || 0)
+        # NOTE: persisted value is billed on the full period, current value is added during the period
+        (persisted_prorated_result.prorated_value || 0) + (current_prorated_result.prorated_value || 0)
       end
 
-      def persisted_sum
-        persisted_event_store_instance.prorated_sum(
+      # NOTE: prorated sum of the events added during the current period.
+      def current_prorated_result
+        @current_prorated_result ||= event_store.prorated_sum(period_duration:)
+      end
+
+      # NOTE: prorated sum of the events persisted before the current period.
+      def persisted_prorated_result
+        @persisted_prorated_result ||= persisted_event_store_instance.prorated_sum(
           period_duration:,
           persisted_duration: subscription.date_diff_with_timezone(from_datetime, to_datetime)
         )
       end
 
+      # NOTE: rebuilds the non-prorated AggregationResult for the base aggregator
+      def non_prorated_sum_result
+        current = current_prorated_result
+
+        unless billable_metric.recurring
+          return Events::Stores::BaseStore::AggregationResult.new(
+            value: current.value || 0,
+            events_count: current.events_count
+          )
+        end
+
+        persisted = persisted_prorated_result
+        Events::Stores::BaseStore::AggregationResult.new(
+          value: (persisted.value || 0) + (current.value || 0), # TODO: Refactor to inject persisted value
+          events_count: (persisted.events_count || 0) + (current.events_count || 0)
+        )
+      end
+
       def recurring_value(grouped_by_values: nil)
-        store = persisted_event_store_instance
-        raw_sum = store.with_grouped_by_values(grouped_by_values) { store.sum(with_count: false).value }
+        # NOTE: for the ungrouped case the persisted non-prorated sum is already computed
+        #       by persisted_prorated_result, so we reuse it instead of querying again.
+        raw_sum = if grouped_by_values.present?
+          store = persisted_event_store_instance
+          store.with_grouped_by_values(grouped_by_values) { store.sum(with_count: false).value }
+        else
+          persisted_prorated_result.value
+        end
 
         return nil if raw_sum.nil? || raw_sum.zero?
 
@@ -168,28 +206,34 @@ module BillableMetrics
       end
 
       def compute_grouped_event_aggregation
-        result = grouped_persisted_sums
-        current_results = event_store.grouped_prorated_sum(period_duration:)
+        # NOTE: persisted values are billed on the full period, current values are added during the period
+        results = persisted_grouped_prorated_results + current_grouped_prorated_results
 
-        current_results.each do |group_result|
-          group = group_result[:groups]
-
-          if (persisted_group = result.find { |r| r[:groups] == group })
-            # NOTE: A persisted value already exists for this group
-            #       We just append the value to the persisted one
-            persisted_group[:value] += group_result[:value]
-            next
-          end
-
-          # NOTE: Add the new group to the result
-          result << group_result
+        results.group_by(&:groups).map do |groups, group_results|
+          {groups:, value: group_results.sum { |r| r.prorated_value || 0 }}
         end
-
-        result
       end
 
-      def grouped_persisted_sums
-        persisted_event_store_instance.grouped_prorated_sum(
+      # NOTE: rebuilds the per-group non-prorated AggregationResult for the base aggregator
+      def non_prorated_grouped_sum_result
+        results = current_grouped_prorated_results
+        results += persisted_grouped_prorated_results if billable_metric.recurring
+
+        results.group_by(&:groups).map do |groups, group_results|
+          Events::Stores::BaseStore::GroupedAggregationResult.new(
+            groups:,
+            value: group_results.sum { |r| r.value || 0 },
+            events_count: group_results.sum { |r| r.events_count || 0 }
+          )
+        end
+      end
+
+      def current_grouped_prorated_results
+        @current_grouped_prorated_results ||= event_store.grouped_prorated_sum(period_duration:)
+      end
+
+      def persisted_grouped_prorated_results
+        @persisted_grouped_prorated_results ||= persisted_event_store_instance.grouped_prorated_sum(
           period_duration:,
           persisted_duration: subscription.date_diff_with_timezone(from_datetime, to_datetime)
         )

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -40,6 +40,22 @@ module Events
         end
       end
 
+      # NOTE: result of a prorated_sum aggregation. Unlike AggregationResult it also
+      #       carries the raw, non-prorated value alongside the events count
+      ProratedAggregationResult = Data.define(
+        :value,           # non-prorated sum
+        :prorated_value,  # prorated sum (value * ratio)
+        :events_count
+      )
+
+      # NOTE: grouped variant of ProratedAggregationResult.
+      GroupedProratedAggregationResult = Data.define(
+        :groups,
+        :value,
+        :prorated_value,
+        :events_count
+      )
+
       def initialize(subscription:, boundaries:, code: nil, filters: {}, deduplicate: false)
         @code = code
         @subscription = subscription
@@ -226,6 +242,26 @@ module Events
         AggregationResult.new(
           value: row && row["value"],
           events_count: with_count ? (row && row["events_count"]).to_i : nil
+        )
+      end
+
+      # NOTE: Build a ProratedAggregationResult from the raw query columns. Mirrors
+      #       build_aggregation_result but also carries the prorated value.
+      def build_prorated_aggregation_result(row)
+        ProratedAggregationResult.new(
+          value: row["value"] || 0,
+          prorated_value: row["prorated_value"] || 0,
+          events_count: row["events_count"].presence&.to_i
+        )
+      end
+
+      # NOTE: grouped variant of build_prorated_aggregation_result.
+      def build_grouped_prorated_aggregation_result(groups:, value:, prorated_value:, events_count:)
+        GroupedProratedAggregationResult.new(
+          groups:,
+          value: value || 0,
+          prorated_value: prorated_value || 0,
+          events_count: events_count.presence&.to_i
         )
       end
 

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -617,6 +617,7 @@ module Events
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
             select: [
+              arel_table[:decimal_value],
               Arel::Nodes::InfixOperation.new(
                 "*",
                 arel_table[:decimal_value],
@@ -627,11 +628,14 @@ module Events
           )
 
           sql = with_ctes(ctes_sql, <<-SQL)
-            SELECT sum(events.prorated_value)
+            SELECT
+              sum(events.prorated_value) as prorated_value,
+              sum(events.decimal_value) as value,
+              count() as events_count
             FROM events
           SQL
 
-          connection.select_value(sql)
+          build_prorated_aggregation_result(connection.select_one(sql))
         end
       end
 
@@ -647,6 +651,7 @@ module Events
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
             select: [arel_table[:sorted_grouped_by]] + [
+              arel_table[:decimal_value],
               Arel::Nodes::InfixOperation.new(
                 "*",
                 arel_table[:decimal_value],
@@ -659,12 +664,14 @@ module Events
           sql = with_ctes(ctes_sql, <<-SQL)
             SELECT
               sorted_grouped_by as groups,
-              sum(events.prorated_value) as value
+              sum(events.prorated_value) as prorated_value,
+              sum(events.decimal_value) as value,
+              count() as events_count
             FROM events
             GROUP BY sorted_grouped_by
           SQL
 
-          prepare_grouped_result(connection.select_all(sql))
+          prepare_grouped_prorated_values(connection.select_all(sql))
         end
       end
 
@@ -968,6 +975,21 @@ module Events
             groups: r[:groups].transform_values(&:presence),
             value: decimal ? BigDecimal(r[:value].presence || 0) : r[:value],
             events_count: r[:events_count].presence&.to_i
+          )
+        end
+      end
+
+      # NOTE: like prepare_grouped_aggregated_values but each row also carries a prorated
+      #       value column, returned as GroupedProratedAggregationResult.
+      def prepare_grouped_prorated_values(result)
+        result.to_ary.map do |row|
+          r = row.symbolize_keys
+
+          build_grouped_prorated_aggregation_result(
+            groups: r[:groups].transform_values(&:presence),
+            prorated_value: r[:prorated_value],
+            value: r[:value],
+            events_count: r[:events_count]
           )
         end
       end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -614,6 +614,7 @@ module Events
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
             select: [
+              arel_table[:decimal_value],
               Arel::Nodes::InfixOperation.new(
                 "*",
                 arel_table[:decimal_value],
@@ -624,11 +625,14 @@ module Events
           )
 
           sql = with_ctes(ctes_sql, <<-SQL)
-            SELECT sum(events.prorated_value)
+            SELECT
+              sum(events.prorated_value) as prorated_value,
+              sum(events.decimal_value) as value,
+              count() as events_count
             FROM events
           SQL
 
-          connection.select_value(sql)
+          build_prorated_aggregation_result(connection.select_one(sql))
         end
       end
 
@@ -644,6 +648,7 @@ module Events
         Events::Stores::Utils::ClickhouseConnection.connection_with_retry do |connection|
           ctes_sql = events_cte_queries(
             select: groups + [
+              arel_table[:decimal_value],
               Arel::Nodes::InfixOperation.new(
                 "*",
                 arel_table[:decimal_value],
@@ -656,12 +661,14 @@ module Events
           sql = with_ctes(ctes_sql, <<-SQL)
             SELECT
               #{group_names},
-              sum(events.prorated_value)
+              sum(events.prorated_value) as prorated_value,
+              sum(events.decimal_value) as value,
+              count() as events_count
             FROM events
             GROUP BY #{group_names}
           SQL
 
-          prepare_grouped_result(connection.select_all(sql).rows)
+          prepare_grouped_prorated_result(connection.select_all(sql).rows)
         end
       end
 
@@ -908,6 +915,22 @@ module Events
             groups: build_groups(flat[...-2], columns:),
             value: flat[-2],
             events_count: flat[-1].presence&.to_i
+          )
+        end
+      end
+
+      # NOTE: Same as prepare_grouped_aggregated_values but the last three columns of each
+      #       row are the prorated value, the non-prorated value and the events count,
+      #       returned as GroupedProratedAggregationResult.
+      def prepare_grouped_prorated_result(rows, columns: grouped_by)
+        rows.map do |row|
+          flat = row.flatten
+
+          build_grouped_prorated_aggregation_result(
+            groups: build_groups(flat[...-3], columns:),
+            prorated_value: flat[-3],
+            value: flat[-2],
+            events_count: flat[-1]
           )
         end
       end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -312,12 +312,12 @@ module Events
         end
 
         sql = <<-SQL
-          SUM(
-            (#{sanitized_property_name})::numeric * (#{ratio})::numeric
-          ) AS sum_result
+          SUM((#{sanitized_property_name})::numeric * (#{ratio})::numeric) AS prorated_value,
+          SUM((#{sanitized_property_name})::numeric) AS value,
+          COUNT(*) AS events_count
         SQL
 
-        connection.execute(Arel.sql(events.select(sql).to_sql)).first["sum_result"]
+        build_prorated_aggregation_result(select_one(events.select(sql).to_sql))
       end
 
       def grouped_prorated_sum(period_duration:, persisted_duration: nil)
@@ -329,9 +329,9 @@ module Events
 
         sum_sql = <<-SQL
           #{sanitized_grouped_by.join(", ")},
-          SUM(
-            (#{sanitized_property_name})::numeric * (#{ratio})::numeric
-          ) AS sum_result
+          SUM((#{sanitized_property_name})::numeric * (#{ratio})::numeric) AS prorated_value,
+          SUM((#{sanitized_property_name})::numeric) AS value,
+          COUNT(*) AS events_count
         SQL
 
         sql = events
@@ -339,7 +339,7 @@ module Events
           .select(sum_sql)
           .to_sql
 
-        prepare_grouped_result(select_all(sql).rows)
+        prepare_grouped_prorated_result(select_all(sql).rows)
       end
 
       def sum_date_breakdown
@@ -566,6 +566,20 @@ module Events
             groups: build_groups(row[...-2], columns:),
             value: row[-2],
             events_count: row[-1]&.to_i
+          )
+        end
+      end
+
+      # NOTE: Same as prepare_grouped_aggregated_values but the last three columns of each
+      #       row are the prorated value, the non-prorated value and the events count,
+      #       returned as GroupedProratedAggregationResult.
+      def prepare_grouped_prorated_result(rows, columns: grouped_by)
+        rows.map do |row|
+          build_grouped_prorated_aggregation_result(
+            groups: build_groups(row[...-3], columns:),
+            prorated_value: row[-3],
+            value: row[-2],
+            events_count: row[-1]
           )
         end
       end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -112,6 +112,52 @@ RSpec.describe BillableMetrics::Aggregations::SumService, transaction: false do
     end
   end
 
+  context "when a sum result is injected" do
+    let(:injected_sum_result) { Events::Stores::BaseStore::AggregationResult.new(value: 999, events_count: 7) }
+
+    before { sum_service.injected_sum_result = injected_sum_result }
+
+    it "uses the injected result instead of querying the event store" do
+      result = sum_service.aggregate(options: {})
+
+      expect(result.aggregation).to eq(999)
+      expect(result.count).to eq(7)
+    end
+  end
+
+  context "when a grouped sum result is injected" do
+    let(:grouped_by) { %w[region] }
+    let(:injected_grouped_sum_result) do
+      [
+        Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "us"}, value: 100, events_count: 3),
+        Events::Stores::BaseStore::GroupedAggregationResult.new(groups: {"region" => "eu"}, value: 50, events_count: 2)
+      ]
+    end
+
+    before { sum_service.injected_grouped_sum_result = injected_grouped_sum_result }
+
+    it "builds the group results from the injected values" do
+      result = sum_service.aggregate(options: {})
+
+      expect(result.aggregations.map { |agg| [agg.grouped_by, agg.aggregation, agg.count] }).to match_array(
+        [
+          [{"region" => "us"}, 100, 3],
+          [{"region" => "eu"}, 50, 2]
+        ]
+      )
+    end
+
+    context "when the injected grouped result is blank" do
+      let(:injected_grouped_sum_result) { [] }
+
+      it "returns empty results" do
+        result = sum_service.aggregate(options: {})
+
+        expect(result.aggregations.map(&:aggregation)).to eq([0])
+      end
+    end
+  end
+
   context "when options are not present" do
     let(:options) { {} }
 

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -92,6 +92,30 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
     expect(result.count).to eq(4)
   end
 
+  context "with an event exactly on the period boundary" do
+    let(:boundary_event) do
+      create(
+        :event,
+        organization_id: organization.id,
+        code: billable_metric.code,
+        customer:,
+        subscription:,
+        timestamp: from_datetime,
+        properties: {total_count: 10}
+      )
+    end
+
+    before { boundary_event }
+
+    it "counts the boundary event once, not in both the persisted and current windows" do
+      result = sum_service.aggregate(options:)
+
+      # The event sits on `from_datetime`: it belongs to the current period only.
+      # 4 base events + 1 boundary event, counted once (a double-count would report 6).
+      expect(result.count).to eq(5)
+    end
+  end
+
   context "with presentation group keys" do
     let(:presentation_by) { ["cloud"] }
 
@@ -205,6 +229,15 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
       expect(result.aggregation).to eq(29)
       expect(result.pay_in_advance_aggregation).to be_zero
       expect(result.count).to eq(4)
+    end
+
+    it "does not run the prorated queries" do
+      event_store = sum_service.send(:event_store)
+      allow(event_store).to receive(:prorated_sum).and_call_original
+
+      sum_service.aggregate(options:)
+
+      expect(event_store).not_to have_received(:prorated_sum)
     end
   end
 
@@ -682,6 +715,17 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
 
       expect(result.event_aggregation).to eq([5, 12, 12])
       expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([5, 2.32258, 2.32258])
+    end
+
+    it "reuses the persisted prorated result instead of running a sum query" do
+      persisted_store = sum_service.send(:persisted_event_store_instance)
+      allow(persisted_store).to receive(:sum).and_call_original
+
+      sum_service.options = {}
+      result = sum_service.per_event_aggregation
+
+      expect(result.event_aggregation).to eq([5, 12, 12])
+      expect(persisted_store).not_to have_received(:sum)
     end
 
     context "with grouped_by_values" do

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -105,6 +105,12 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
     events
   end
 
+  def grouped_prorated_to_h(results)
+    results.map do |r|
+      {groups: r.groups, prorated_value: r.prorated_value.to_f, value: r.value.to_f, events_count: r.events_count}
+    end
+  end
+
   def create_european_event(country:, city:, value:, timestamp:, charge_filter: nil)
     create_event(
       timestamp:,
@@ -2126,19 +2132,27 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
   if include_feature?(:prorated_sum)
     describe "#prorated_sum" do
-      it "returns the prorated sum of event properties" do
+      it "returns the prorated sum alongside the non-prorated value and events count" do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
-        expect(event_store.prorated_sum(period_duration: 31).round(5)).to eq(6.45161)
+        result = event_store.prorated_sum(period_duration: 31)
+
+        expect(result.prorated_value.round(5)).to eq(6.45161)
+        expect(result.value.to_f).to eq(15)
+        expect(result.events_count).to eq(5)
       end
 
       context "with persisted_duration" do
-        it "returns the prorated sum of event properties" do
+        it "returns the prorated sum alongside the non-prorated value and events count" do
           event_store.aggregation_property = billable_metric.field_name
           event_store.numeric_property = true
 
-          expect(event_store.prorated_sum(period_duration: 31, persisted_duration: 10).round(5)).to eq(4.83871)
+          result = event_store.prorated_sum(period_duration: 31, persisted_duration: 10)
+
+          expect(result.prorated_value.round(5)).to eq(4.83871)
+          expect(result.value.to_f).to eq(15)
+          expect(result.events_count).to eq(5)
         end
       end
     end
@@ -2148,28 +2162,28 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
     describe "#grouped_prorated_sum" do
       let(:grouped_by) { %w[region] }
 
-      it "returns the prorated sum of event properties" do
+      it "returns the prorated sum alongside the non-prorated value and events count" do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
         result = event_store.grouped_prorated_sum(period_duration: 31)
 
-        expect(result).to match_array([
-          {groups: {"region" => nil}, value: within(0.00001).of(2.64516)},
-          {groups: {"region" => "europe"}, value: within(0.00001).of(3.80645)}
+        expect(grouped_prorated_to_h(result)).to match_array([
+          {groups: {"region" => nil}, prorated_value: within(0.00001).of(2.64516), value: 6, events_count: 2},
+          {groups: {"region" => "europe"}, prorated_value: within(0.00001).of(3.80645), value: 9, events_count: 3}
         ])
       end
 
       context "with persisted_duration" do
-        it "returns the prorated sum of event properties" do
+        it "returns the prorated sum alongside the non-prorated value and events count" do
           event_store.aggregation_property = billable_metric.field_name
           event_store.numeric_property = true
 
           result = event_store.grouped_prorated_sum(period_duration: 31, persisted_duration: 10)
 
-          expect(result).to match_array([
-            {groups: {"region" => nil}, value: within(0.00001).of(1.93548)},
-            {groups: {"region" => "europe"}, value: within(0.00001).of(2.90322)}
+          expect(grouped_prorated_to_h(result)).to match_array([
+            {groups: {"region" => nil}, prorated_value: within(0.00001).of(1.93548), value: 6, events_count: 2},
+            {groups: {"region" => "europe"}, prorated_value: within(0.00001).of(2.90322), value: 9, events_count: 3}
           ])
         end
       end
@@ -2183,19 +2197,19 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
 
           result = event_store.grouped_prorated_sum(period_duration: 31)
 
-          expect(result).to match_array(
+          expect(grouped_prorated_to_h(result)).to match_array(
             [
               {
                 groups: {"country" => "united kingdom", "region" => "europe"},
-                value: within(0.00001).of(1.93548)
+                prorated_value: within(0.00001).of(1.93548), value: 5, events_count: 1
               },
               {
                 groups: {"country" => nil, "region" => nil},
-                value: within(0.00001).of(2.64516)
+                prorated_value: within(0.00001).of(2.64516), value: 6, events_count: 2
               },
               {
                 groups: {"country" => "france", "region" => "europe"},
-                value: within(0.00001).of(1.87096)
+                prorated_value: within(0.00001).of(1.87096), value: 4, events_count: 2
               }
             ]
           )


### PR DESCRIPTION
## Description

This PR follows https://github.com/getlago/lago-api/pull/5805
It keeps updating events stores to group queries related to the same aggregation

This PR applies the single-pass approach to the `prorated_sum` and `grouped_prorated_sum` aggregations.
Both now returns an `ProratedAggregationResult` or `GroupedProratedAggregationResult`.

The PR also refactors the interconnection of the `BillableMetrics::ProratedAggregations::SumService` with the BillableMetrics::Aggregations::SumService
