### PR TITLE
feat(products): support product-catalog plans

### DIFF
--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -8,18 +8,20 @@ module Types
       field :id, ID, null: false
       field :organization, Types::Organizations::OrganizationType
 
-      field :amount_cents, GraphQL::Types::BigInt, null: false
+      # Nullable: product-catalog plans price through their rate cards, so they
+      # carry no plan-level amount, interval or billing timing.
+      field :amount_cents, GraphQL::Types::BigInt
       field :amount_currency, Types::CurrencyEnum, null: false
       field :bill_charges_monthly, Boolean
       field :bill_fixed_charges_monthly, Boolean
       field :code, String, null: false
       field :description, String
-      field :interval, Types::Plans::IntervalEnum, null: false
+      field :interval, Types::Plans::IntervalEnum
       field :invoice_display_name, String
       field :minimum_commitment, Types::Commitments::Object, null: true
       field :name, String, null: false
       field :parent, Types::Plans::Object, null: true
-      field :pay_in_advance, Boolean, null: false
+      field :pay_in_advance, Boolean
       field :trial_period, Float
 
       field :applicable_usage_thresholds, [Types::UsageThresholds::Object]

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -86,6 +86,8 @@ module Types
       end
 
       def period_end_date
+        return if object.plan.product_catalog?
+
         ::Subscriptions::DatesService.new_instance(object, object.billing_reference_time)
           .next_end_of_period
       end
@@ -97,11 +99,11 @@ module Types
       end
 
       def current_billing_period_started_at
-        dates_service.charges_from_datetime
+        dates_service&.charges_from_datetime
       end
 
       def current_billing_period_ending_at
-        dates_service.charges_to_datetime
+        dates_service&.charges_to_datetime
       end
 
       def charges
@@ -125,7 +127,11 @@ module Types
         end
       end
 
+      # Billing periods derive from the plan interval, which product-catalog
+      # plans don't have: their rate cards each carry their own billing cycle.
       def dates_service
+        return if object.plan.product_catalog?
+
         @dates_service ||= ::Subscriptions::DatesService.new_instance(object, object.billing_reference_time, current_usage: true)
       end
     end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -49,13 +49,22 @@ class Plan < ApplicationRecord
     semiannual
   ].freeze
 
-  enum :interval, INTERVALS, validate: true
+  PRICING_TYPES = {legacy: "legacy", product_catalog: "product_catalog"}.freeze
 
-  monetize :amount_cents
+  enum :pricing_type, PRICING_TYPES, validate: true
+  enum :interval, INTERVALS, validate: {allow_nil: true}
+
+  monetize :amount_cents, allow_nil: true
 
   validates :name, :code, presence: true
   validates :amount_currency, inclusion: {in: currency_list}
-  validates :pay_in_advance, inclusion: {in: [true, false]}
+  # Legacy plans price at the plan level; product-catalog plans price through
+  # their products, so the plan-level billing fields are optional for them.
+  # A blank interval keeps the historical "value_is_invalid" error (the enum used
+  # to reject nil as an out-of-range value) rather than a "value_is_mandatory" one.
+  validates :interval, presence: {message: "value_is_invalid"}, unless: :product_catalog?
+  validates :amount_cents, presence: true, unless: :product_catalog?
+  validates :pay_in_advance, inclusion: {in: [true, false]}, unless: :product_catalog?
   validate :validate_code_unique
 
   default_scope -> { kept }
@@ -155,18 +164,19 @@ end
 # Database name: primary
 #
 #  id                         :uuid             not null, primary key
-#  amount_cents               :bigint           not null
+#  amount_cents               :bigint
 #  amount_currency            :string           not null
 #  bill_charges_monthly       :boolean
 #  bill_fixed_charges_monthly :boolean          default(FALSE)
 #  code                       :string           not null
 #  deleted_at                 :datetime
 #  description                :string
-#  interval                   :integer          not null
+#  interval                   :integer
 #  invoice_display_name       :string
 #  name                       :string           not null
-#  pay_in_advance             :boolean          default(FALSE), not null
+#  pay_in_advance             :boolean          default(FALSE)
 #  pending_deletion           :boolean          default(FALSE), not null
+#  pricing_type               :enum             default("legacy"), not null
 #  trial_period               :float
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -230,6 +230,11 @@ class Subscription < ApplicationRecord
 
   def downgrade_plan_date
     return unless next_subscription
+    # Downgrades compare plan-level amounts and land at the end of the current
+    # period, neither of which product-catalog plans have: their price and their
+    # billing cycles live on the rate cards.
+    return if plan.product_catalog?
+
     if next_subscription.active? && downgraded?
       return next_subscription.started_at&.to_date
     end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -24,8 +24,8 @@ module V1
         previous_plan_code: model.previous_subscription&.plan&.code,
         next_plan_code: model.next_subscription&.plan&.code,
         downgrade_plan_date: model.downgrade_plan_date&.iso8601,
-        current_billing_period_started_at: dates_service.charges_from_datetime&.iso8601,
-        current_billing_period_ending_at: dates_service.charges_to_datetime&.iso8601,
+        current_billing_period_started_at: dates_service&.charges_from_datetime&.iso8601,
+        current_billing_period_ending_at: dates_service&.charges_to_datetime&.iso8601,
         on_termination_credit_note: model.on_termination_credit_note,
         on_termination_invoice: model.on_termination_invoice,
         progressive_billing_disabled: model.progressive_billing_disabled,
@@ -87,7 +87,11 @@ module V1
       ::V1::UsageThresholdSerializer.new(options[:usage_threshold]).serialize
     end
 
+    # Billing periods derive from the plan interval, which product-catalog
+    # plans don't have: their rate cards each carry their own billing cycle.
     def dates_service
+      return if model.plan.product_catalog?
+
       @dates_service ||= ::Subscriptions::DatesService.new_instance(model, model.billing_reference_time, current_usage: true)
     end
 

--- a/db/migrate/20260630161816_add_pricing_type_to_plans.rb
+++ b/db/migrate/20260630161816_add_pricing_type_to_plans.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddPricingTypeToPlans < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :plan_pricing_type, %w[legacy product_catalog]
+    add_column :plans, :pricing_type, :enum, enum_type: :plan_pricing_type, default: "legacy", null: false
+
+    safety_assured do
+      change_column_null :plans, :interval, true
+      change_column_null :plans, :amount_cents, true
+      change_column_null :plans, :pay_in_advance, true
+    end
+  end
+end

--- a/db/migrate/20260817175012_add_legacy_billing_fields_check_to_plans.rb
+++ b/db/migrate/20260817175012_add_legacy_billing_fields_check_to_plans.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddLegacyBillingFieldsCheckToPlans < ActiveRecord::Migration[8.0]
+  def change
+    # interval, amount_cents and pay_in_advance are only optional for
+    # product-catalog plans: legacy plans keep the guarantee the NOT NULL
+    # constraints used to give the v1 billing code.
+    add_check_constraint :plans,
+      %(pricing_type <> 'legacy' OR ("interval" IS NOT NULL AND amount_cents IS NOT NULL AND pay_in_advance IS NOT NULL)),
+      name: "check_plans_on_legacy_billing_fields",
+      validate: false
+  end
+end

--- a/db/migrate/20260817175013_validate_legacy_billing_fields_check_on_plans.rb
+++ b/db/migrate/20260817175013_validate_legacy_billing_fields_check_on_plans.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateLegacyBillingFieldsCheckOnPlans < ActiveRecord::Migration[8.0]
+  def change
+    validate_check_constraint :plans, name: "check_plans_on_legacy_billing_fields"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3669,7 +3669,8 @@ CREATE TABLE public.plans (
     pending_deletion boolean DEFAULT false NOT NULL,
     invoice_display_name character varying,
     bill_fixed_charges_monthly boolean DEFAULT false,
-    pricing_type public.plan_pricing_type DEFAULT 'legacy'::public.plan_pricing_type NOT NULL
+    pricing_type public.plan_pricing_type DEFAULT 'legacy'::public.plan_pricing_type NOT NULL,
+    CONSTRAINT check_plans_on_legacy_billing_fields CHECK (((pricing_type <> 'legacy'::public.plan_pricing_type) OR (("interval" IS NOT NULL) AND (amount_cents IS NOT NULL) AND (pay_in_advance IS NOT NULL))))
 );
 
 
@@ -14184,6 +14185,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260817175013'),
+('20260817175012'),
 ('20260805201143'),
 ('20260805110509'),
 ('20260805110508'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1332,6 +1332,7 @@ DROP TYPE IF EXISTS public.quote_void_reason;
 DROP TYPE IF EXISTS public.quote_status;
 DROP TYPE IF EXISTS public.quote_order_type;
 DROP TYPE IF EXISTS public.product_type;
+DROP TYPE IF EXISTS public.plan_pricing_type;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
 DROP TYPE IF EXISTS public.payment_method_types;
@@ -1632,6 +1633,16 @@ CREATE TYPE public.payment_payable_payment_status AS ENUM (
 CREATE TYPE public.payment_type AS ENUM (
     'provider',
     'manual'
+);
+
+
+--
+-- Name: plan_pricing_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.plan_pricing_type AS ENUM (
+    'legacy',
+    'product_catalog'
 );
 
 
@@ -3646,18 +3657,19 @@ CREATE TABLE public.plans (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     code character varying NOT NULL,
-    "interval" integer NOT NULL,
+    "interval" integer,
     description character varying,
-    amount_cents bigint NOT NULL,
+    amount_cents bigint,
     amount_currency character varying NOT NULL,
     trial_period double precision,
-    pay_in_advance boolean DEFAULT false NOT NULL,
+    pay_in_advance boolean DEFAULT false,
     bill_charges_monthly boolean,
     parent_id uuid,
     deleted_at timestamp(6) without time zone,
     pending_deletion boolean DEFAULT false NOT NULL,
     invoice_display_name character varying,
-    bill_fixed_charges_monthly boolean DEFAULT false
+    bill_fixed_charges_monthly boolean DEFAULT false,
+    pricing_type public.plan_pricing_type DEFAULT 'legacy'::public.plan_pricing_type NOT NULL
 );
 
 
@@ -14220,6 +14232,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260701083109'),
 ('20260701083108'),
 ('20260701083107'),
+('20260630161816'),
 ('20260630122927'),
 ('20260625095837'),
 ('20260622113747'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -10665,7 +10665,7 @@ type Permissions {
 type Plan {
   activeSubscriptionsCount: Int!
   activityLogs: [ActivityLog!]
-  amountCents: BigInt!
+  amountCents: BigInt
   amountCurrency: CurrencyEnum!
   applicableUsageThresholds: [UsageThreshold!]
   billChargesMonthly: Boolean
@@ -10701,7 +10701,7 @@ type Plan {
   hasOverriddenPlans: Boolean
   hasSubscriptions: Boolean!
   id: ID!
-  interval: PlanInterval!
+  interval: PlanInterval
   invoiceDisplayName: String
   isOverridden: Boolean!
   metadata: [ItemMetadata!]
@@ -10709,7 +10709,7 @@ type Plan {
   name: String!
   organization: Organization
   parent: Plan
-  payInAdvance: Boolean!
+  payInAdvance: Boolean
   subscriptionsCount: Int!
   taxes: [Tax!]
   trialPeriod: Float

--- a/schema.json
+++ b/schema.json
@@ -53131,13 +53131,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -53511,13 +53507,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "PlanInterval",
-                  "ofType": null
-                }
+                "kind": "ENUM",
+                "name": "PlanInterval",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -53627,13 +53619,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -340,6 +340,29 @@ RSpec.describe Resolvers::PlanResolver do
     end
   end
 
+  context "when the plan uses the product catalog" do
+    let(:query) do
+      <<~GQL
+        query($planId: ID!) {
+          plan(id: $planId) { id amountCents interval payInAdvance }
+        }
+      GQL
+    end
+
+    let(:plan) do
+      create(:plan, organization:, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
+    end
+
+    it "returns the plan with null plan-level billing fields" do
+      expect(result["data"]["plan"]).to eq(
+        "id" => plan.id,
+        "amountCents" => nil,
+        "interval" => nil,
+        "payInAdvance" => nil
+      )
+    end
+  end
+
   context "when plan is not found" do
     it "returns an error" do
       result = execute_graphql(

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -7,19 +7,19 @@ RSpec.describe Types::Plans::Object do
 
   it { is_expected.to have_field(:id).of_type("ID!") }
   it { is_expected.to have_field(:organization).of_type("Organization") }
-  it { is_expected.to have_field(:amount_cents).of_type("BigInt!") }
+  it { is_expected.to have_field(:amount_cents).of_type("BigInt") }
   it { is_expected.to have_field(:amount_currency).of_type("CurrencyEnum!") }
   it { is_expected.to have_field(:bill_charges_monthly).of_type("Boolean") }
   it { is_expected.to have_field(:bill_fixed_charges_monthly).of_type("Boolean") }
   it { is_expected.to have_field(:code).of_type("String!") }
   it { is_expected.to have_field(:description).of_type("String") }
   it { is_expected.to have_field(:has_overridden_plans).of_type("Boolean") }
-  it { is_expected.to have_field(:interval).of_type("PlanInterval!") }
+  it { is_expected.to have_field(:interval).of_type("PlanInterval") }
   it { is_expected.to have_field(:invoice_display_name).of_type("String") }
   it { is_expected.to have_field(:minimum_commitment).of_type("Commitment") }
   it { is_expected.to have_field(:name).of_type("String!") }
   it { is_expected.to have_field(:parent).of_type("Plan") }
-  it { is_expected.to have_field(:pay_in_advance).of_type("Boolean!") }
+  it { is_expected.to have_field(:pay_in_advance).of_type("Boolean") }
   it { is_expected.to have_field(:trial_period).of_type("Float") }
   it { is_expected.to have_field(:activity_logs).of_type("[ActivityLog!]") }
   it { is_expected.to have_field(:charges).of_type("[Charge!]") }

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe Plan do
     expect(subject).to have_many(:entitlements).class_name("Entitlement::Entitlement").dependent(:destroy)
     expect(subject).to have_many(:entitlement_values).through(:entitlements).source(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
 
-    expect(subject).to define_enum_for(:interval).with_values(Plan::INTERVALS).validating
+    expect(subject).to define_enum_for(:interval).with_values(Plan::INTERVALS).validating(allowing_nil: true)
+    expect(subject).to define_enum_for(:pricing_type)
+      .with_values(Plan::PRICING_TYPES)
+      .backed_by_column_of_type(:enum)
+      .validating
   end
 
   describe "Clickhouse associations", clickhouse: true do
@@ -45,6 +49,26 @@ RSpec.describe Plan do
 
       plan.pay_in_advance = true
       expect(plan).to be_valid
+    end
+
+    context "with a product_catalog plan" do
+      subject(:plan) do
+        build(:plan, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
+      end
+
+      it "does not require the plan-level billing fields" do
+        expect(plan).to be_valid
+      end
+    end
+
+    context "with a legacy plan" do
+      it "requires interval and amount_cents" do
+        plan.interval = nil
+        plan.amount_cents = nil
+        expect(plan).not_to be_valid
+        expect(plan.errors).to be_added(:interval, :blank)
+        expect(plan.errors).to be_added(:amount_cents, :blank)
+      end
     end
   end
 

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Plan do
         plan.interval = nil
         plan.amount_cents = nil
         expect(plan).not_to be_valid
-        expect(plan.errors).to be_added(:interval, :blank)
-        expect(plan.errors).to be_added(:amount_cents, :blank)
+        expect(plan.errors.messages[:interval]).to eq(["value_is_invalid"])
+        expect(plan.errors.messages[:amount_cents]).to eq(["value_is_mandatory"])
       end
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -830,6 +830,25 @@ RSpec.describe Subscription do
       end
     end
 
+    context "with a product-catalog plan" do
+      let(:plan) do
+        create(:plan, pricing_type: "product_catalog", interval: nil, amount_cents: nil, pay_in_advance: nil)
+      end
+      let(:subscription) { create(:subscription, plan:) }
+
+      it "returns nil rather than deriving a plan-level period" do
+        create(:subscription, previous_subscription: subscription, status: :pending)
+
+        expect(subscription.downgrade_plan_date).to be_nil
+      end
+
+      it "returns nil without comparing plan amounts when the next subscription is active" do
+        create(:subscription, previous_subscription: subscription, status: :active)
+
+        expect(subscription.downgrade_plan_date).to be_nil
+      end
+    end
+
     it "returns the date when the plan will be downgraded" do
       current_date = DateTime.parse("20 Jun 2022")
       create(:subscription, previous_subscription: subscription, status: :pending)

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -286,4 +286,19 @@ RSpec.describe ::V1::SubscriptionSerializer do
       )
     end
   end
+
+  context "when the plan uses the product catalog" do
+    let(:plan) { create(:plan, pricing_type: "product_catalog") }
+    let(:subscription) { create(:subscription, plan:, created_at: started_at, started_at:, ending_at:) }
+
+    it "serializes without plan-level billing period dates" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["subscription"]).to include(
+        "plan_code" => plan.code,
+        "current_billing_period_started_at" => nil,
+        "current_billing_period_ending_at" => nil
+      )
+    end
+  end
 end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -959,4 +959,5 @@ RSpec.describe Plans::CreateService do
       end
     end
   end
+
 end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -959,5 +959,4 @@ RSpec.describe Plans::CreateService do
       end
     end
   end
-
 end


### PR DESCRIPTION
## Context

A plan on the product catalog prices through its rate cards, so the plan-level billing fields (interval, amount, pay-in-advance) no longer apply to it.

## Description

- Add `Plan#pricing_type` (`legacy` | `product_catalog`), defaulting to `legacy`. It is **not** accepted in any payload: the pricing engine is an organization-level choice, so the value is derived from the organization's `product_catalog` feature flag at plan creation (the derivation ships with the flag in a follow-up PR of this stack).
- Make `interval`, `amount_cents` and `pay_in_advance` optional for catalog plans, keeping them required for legacy ones.
- Return no billing period dates and no downgrade date for catalog subscriptions, instead of deriving them from a plan-level period.

### Acceptable breaking change on v1

A legacy plan created without `amount_cents` now returns `amount_cents: ["value_is_mandatory"]` instead of `["is not a number"]`
