### PR TITLE
feat(fc-units-override): drop premium gate on units-only write paths

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -31,7 +31,7 @@ module Subscriptions
         activation_rules: params[:activation_rules],
         subscription_type:
       )
-      return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
+      return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides) && !units_only_plan_overrides_change?
       return result.validation_failure!(errors: {external_customer_id: ["value_is_mandatory"]}) if params[:external_customer_id].blank? && api_context?
 
       # TODO: Remove check we stop supporting `plan_overrides.usage_thresholds`

--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -18,9 +18,9 @@ module Subscriptions
     end
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "subscription") unless subscription
       return result.not_found_failure!(resource: "fixed_charge") unless fixed_charge
+      return result.forbidden_failure! if !License.premium? && !units_only_change?
 
       ActiveRecord::Base.transaction do
         result.fixed_charge = units_only_change? ? override_units_only : override_via_plan

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -48,7 +48,7 @@ module Subscriptions
         })
       end
 
-      return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
+      return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides) && !units_only_plan_overrides_change?
 
       ActiveRecord::Base.transaction do
         subscription.name = params[:name] if params.key?(:name)

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -432,6 +432,33 @@ RSpec.describe Subscriptions::CreateService do
           expect(override.units).to eq(25)
         end
       end
+
+      context "when plan_overrides carries a fixed_charges change beyond units" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, units: 5) }
+        let(:params) do
+          {
+            external_customer_id:,
+            plan_code:,
+            name:,
+            external_id:,
+            billing_time:,
+            subscription_at:,
+            subscription_id:,
+            plan_overrides: {
+              fixed_charges: [{id: fixed_charge.id, units: 25, invoice_display_name: "Renamed"}]
+            }
+          }
+        end
+
+        before { fixed_charge }
+
+        it "still requires premium" do
+          result = create_service.call
+
+          expect(result).not_to be_success
+          expect(result.error.code).to eq("feature_unavailable")
+        end
+      end
     end
 
     context "when License is premium and plan_overrides is passed", :premium do

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -402,6 +402,36 @@ RSpec.describe Subscriptions::CreateService do
         expect(result).not_to be_success
         expect(result.error.code).to eq("feature_unavailable")
       end
+
+      context "when plan_overrides is a units-only fixed_charges payload" do
+        let(:fixed_charge) { create(:fixed_charge, plan:, units: 5) }
+        let(:params) do
+          {
+            external_customer_id:,
+            plan_code:,
+            name:,
+            external_id:,
+            billing_time:,
+            subscription_at:,
+            subscription_id:,
+            plan_overrides: {
+              fixed_charges: [{id: fixed_charge.id, units: 25}]
+            }
+          }
+        end
+
+        before { fixed_charge }
+
+        it "writes the per-subscription units override without requiring premium" do
+          result = create_service.call
+
+          expect(result).to be_success
+          subscription = result.subscription
+          expect(subscription.plan).to eq(plan)
+          override = Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+          expect(override.units).to eq(25)
+        end
+      end
     end
 
     context "when License is premium and plan_overrides is passed", :premium do

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -26,6 +26,25 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ForbiddenFailure)
       end
+
+      context "when the payload is a units-only override" do
+        let(:params) { {units: 10} }
+
+        before do
+          fixed_charge
+          subscription
+        end
+
+        it "writes the units override without requiring premium" do
+          expect { service.call }
+            .to change { Subscription::FixedChargeUnitsOverride.where(subscription:, fixed_charge:).count }.by(1)
+            .and change(Plan, :count).by(0)
+
+          expect(service.call).to be_success
+          override = Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+          expect(override.units).to eq(10)
+        end
+      end
     end
 
     context "with premium license", :premium do

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
         it "writes the units override without requiring premium" do
           expect { service.call }
             .to change { Subscription::FixedChargeUnitsOverride.where(subscription:, fixed_charge:).count }.by(1)
-            .and change(Plan, :count).by(0)
+            .and not_change(Plan, :count)
 
           expect(service.call).to be_success
           override = Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -782,6 +782,28 @@ RSpec.describe Subscriptions::UpdateService do
             expect(override.units).to eq(25)
           end
         end
+
+        context "when plan_overrides carries a fixed_charges change beyond units" do
+          let(:plan) { create(:plan, organization: membership.organization) }
+          let(:subscription) { create(:subscription, plan:) }
+          let(:fixed_charge) { create(:fixed_charge, plan:, units: 5) }
+          let(:params) do
+            {
+              plan_overrides: {
+                fixed_charges: [{id: fixed_charge.id, units: 25, invoice_display_name: "Renamed"}]
+              }
+            }
+          end
+
+          before { fixed_charge }
+
+          it "still requires premium" do
+            result = update_service.call
+
+            expect(result).not_to be_success
+            expect(result.error.code).to eq("feature_unavailable")
+          end
+        end
       end
 
       context "with fixed charge overrides and apply_units_immediately true", :premium do

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -758,6 +758,30 @@ RSpec.describe Subscriptions::UpdateService do
           expect(result).not_to be_success
           expect(result.error.code).to eq("feature_unavailable")
         end
+
+        context "when plan_overrides is a units-only fixed_charges payload" do
+          let(:plan) { create(:plan, organization: membership.organization) }
+          let(:subscription) { create(:subscription, plan:) }
+          let(:fixed_charge) { create(:fixed_charge, plan:, units: 5) }
+          let(:params) do
+            {
+              plan_overrides: {
+                fixed_charges: [{id: fixed_charge.id, units: 25}]
+              }
+            }
+          end
+
+          before { fixed_charge }
+
+          it "writes the per-subscription units override without requiring premium" do
+            result = update_service.call
+
+            expect(result).to be_success
+            expect(subscription.reload.plan).to eq(plan)
+            override = Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
+            expect(override.units).to eq(25)
+          end
+        end
       end
 
       context "with fixed charge overrides and apply_units_immediately true", :premium do


### PR DESCRIPTION
## Context

Plan override is a premium feature. Fixed-charge units override is a separate feature that does not require premium — it isn't a plan override.

The three subscription write services premium-gated every request that carried a `plan_overrides` payload (or, on the dedicated endpoint, every request at all). The units-only write paths share those entry points, so they inherited a gate that doesn't belong to them.

## Description

Relax the premium gate so it only fires when the request actually routes to the plan-override branch. The units-only branch is reachable on any license.

- UpdateOrOverrideFixedChargeService gates premium on `!units_only_change?`. The not_found checks now come before the premium check, which is the standard 404-before-403 order.
- CreateService and UpdateService extend their existing `params.key?(:plan_overrides)` gate with `!units_only_plan_overrides_change?`.

Specs cover the new free-tier units-only success path on all three services alongside the existing premium-required plan-override failures.