### PR TITLE
[ING-112] Cascade ongoing usage across wallets

### DIFF
--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -18,12 +18,13 @@ module Customers
     retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
 
     def perform(customer, wallet_ids: nil)
-      # When targeting specific wallets, the refresh is explicitly requested (e.g. balance increase)
-      # so we don't rely on the customer-wide awaiting_wallet_refresh flag.
+      # wallet_ids marks an explicitly requested refresh (e.g. balance increase) that must run
+      # even when the customer-wide awaiting_wallet_refresh flag is not set. The refresh itself
+      # always covers every wallet: the cascade makes allocations interdependent.
       return if wallet_ids.nil? && !customer.awaiting_wallet_refresh?
       return if customer.error_details.tax_error.exists?
 
-      Customers::RefreshWalletsService.call!(customer:, target_wallet_ids: wallet_ids)
+      Customers::RefreshWalletsService.call!(customer:)
     rescue BaseService::ValidationFailure => e
       tax_error = Array(e.messages[:tax_error])
 

--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -31,8 +31,7 @@ module Customers
         )
       end
 
-      now = Time.current
-      Wallet.where(id: all_wallets.map(&:id)).update_all(updated_at: now, last_ongoing_balance_sync_at: now) # rubocop:disable Rails/SkipsModelValidations
+      Wallet.where(id: all_wallets.map(&:id)).touch_all(:last_ongoing_balance_sync_at) # rubocop:disable Rails/SkipsModelValidations
 
       customer.update!(awaiting_wallet_refresh: false)
 

--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -31,7 +31,8 @@ module Customers
         )
       end
 
-      Wallet.where(id: all_wallets.map(&:id)).update_all(last_ongoing_balance_sync_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      now = Time.current
+      Wallet.where(id: all_wallets.map(&:id)).update_all(updated_at: now, last_ongoing_balance_sync_at: now) # rubocop:disable Rails/SkipsModelValidations
 
       customer.update!(awaiting_wallet_refresh: false)
 

--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -2,68 +2,39 @@
 
 module Customers
   class RefreshWalletsService < BaseService
-    Result = BaseResult[:usage_amount_cents, :wallets, :allocation_rules]
+    Result = BaseResult[:wallets]
 
-    def initialize(customer:, include_generating_invoices: false, target_wallet_ids: nil)
+    def initialize(customer:, include_generating_invoices: false)
       @customer = customer
       @include_generating_invoices = include_generating_invoices
-      @target_wallet_ids = target_wallet_ids
 
       super
     end
 
     def call
-      usage_amount_cents = customer.active_subscriptions.map do |subscription|
-        invoice = ::Invoices::CustomerUsageService.call!(customer:, subscription:, usage_filters: UsageFilters::WITHOUT_PRESENTATION_FILTER).invoice
+      wallet_allocations = Wallets::Balance::AllocateOngoingUsageByWalletsService.call!(
+        customer:,
+        wallets: all_wallets,
+        current_usage_fees:,
+        draft_invoices_fees:,
+        progressive_billing_fees:,
+        pay_in_advance_fees:
+      ).wallet_allocations
 
-        billed_progressive_invoice_subscriptions = ::Subscriptions::ProgressiveBilledAmount
-          .call(subscription:, include_generating_invoices:)
-          .invoice_subscriptions
-
-        {
-          billed_progressive_invoice_subscriptions:,
-          invoice:,
-          subscription:
-        }
+      # The cascade makes every wallet's allocation depend on the others' balances, so all
+      # wallets must be persisted together; refreshing a subset would leave the rest stale.
+      all_wallets.each do |wallet|
+        Wallets::Balance::RefreshOngoingUsageService.call!(
+          wallet:,
+          ongoing_usage_amount_cents: wallet_allocations[wallet],
+          skip_single_wallet_update: true
+        )
       end
 
-      @allocation_rules = Wallets::BuildAllocationRulesService.call!(customer:).allocation_rules
-
-      # we need to get both: ALL fees and wallets_applicable_on_fees ({ fee_key => wallet_id, ... }) per each fee type
-      # to not rebuild wallet assigning per each fee when going per each separate wallet
-      usage_fees = usage_amount_cents.flat_map { |usage| usage[:invoice].fees }
-      wallets_applicable_on_usage_fees = assign_wallet_per_fee(usage_fees) # { usage_fee_key => wallet_id }
-
-      draft_invoice_fees = customer.invoices.draft.where.not(total_amount_cents: 0).includes(fees: :charge).flat_map(&:fees)
-      wallets_applicable_on_draft_fees = assign_wallet_per_fee(draft_invoice_fees) # { draft_fee_key => wallet_id }
-
-      progressive_billing_fees = usage_amount_cents.flat_map { |usage| usage[:billed_progressive_invoice_subscriptions].flat_map { it.invoice.fees } }
-      wallets_applicable_on_pb_fees = assign_wallet_per_fee(progressive_billing_fees) # { pb_fee_key => wallet_id }
-
-      pay_in_advance_fees = usage_amount_cents.flat_map { |usage| usage[:invoice].fees.select { |f| f.charge.pay_in_advance? } }
-      wallets_applicable_on_adv_fees = assign_wallet_per_fee(pay_in_advance_fees) # { adv_fee_key => wallet_id }
-
-      wallets_to_process = customer.wallets.active.includes(:recurring_transaction_rules)
-      wallets_to_process = wallets_to_process.where(id: target_wallet_ids) if target_wallet_ids
-      wallets_to_process.find_in_batches(batch_size: 100) do |wallets|
-        wallets.each do |wallet|
-          Wallets::Balance::RefreshOngoingUsageService.call!(
-            wallet:,
-            usage_amount_cents:,
-            skip_single_wallet_update: true,
-            current_usage_fees: applicable_fees(usage_fees, wallets_applicable_on_usage_fees, wallet),
-            draft_invoices_fees: applicable_fees(draft_invoice_fees, wallets_applicable_on_draft_fees, wallet),
-            progressive_billing_fees: applicable_fees(progressive_billing_fees, wallets_applicable_on_pb_fees, wallet),
-            pay_in_advance_fees: applicable_fees(pay_in_advance_fees, wallets_applicable_on_adv_fees, wallet)
-          )
-        end
-      end
-      wallets_to_process.update_all(last_ongoing_balance_sync_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      Wallet.where(id: all_wallets.map(&:id)).update_all(last_ongoing_balance_sync_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
 
       customer.update!(awaiting_wallet_refresh: false)
 
-      result.usage_amount_cents = usage_amount_cents
-      result.allocation_rules = allocation_rules
       result.wallets = customer.wallets.active.reload
       result
     rescue BaseService::FailedResult => e
@@ -72,32 +43,41 @@ module Customers
 
     private
 
-    attr_reader :customer, :include_generating_invoices, :allocation_rules, :target_wallet_ids
+    attr_reader :customer, :include_generating_invoices
 
-    def assign_wallet_per_fee(fees)
-      fee_wallet = {}
-      fee_targeting_wallets_enabled = customer.organization.events_targeting_wallets_enabled?
-
-      fees.each do |fee|
-        key = fee.item_key
-
-        if fee_targeting_wallets_enabled && fee.charge&.accepts_target_wallet && fee&.grouped_by&.dig("target_wallet_code").present?
-          targeted_wallet = customer.wallets.active.where(code: fee.grouped_by["target_wallet_code"]).ids.first
-          fee_wallet[key] = targeted_wallet
-          next if targeted_wallet
-        end
-
-        applicable_wallets = Wallets::FindApplicableOnFeesService
-          .call!(allocation_rules: allocation_rules, fee:, customer_id: customer.id, fee_targeting_wallets_enabled:)
-          .top_priority_wallet
-        fee_wallet[key] = applicable_wallets.presence
-      end
-
-      fee_wallet
+    def all_wallets
+      @all_wallets ||= customer.wallets.active.includes(:recurring_transaction_rules, :wallet_targets).in_application_order.to_a
     end
 
-    def applicable_fees(fees, fee_map, wallet)
-      fees.select { |fee| fee_map[fee.item_key] == wallet.id && fee.amount_currency == wallet.balance_currency }
+    def current_usage_fees
+      @current_usage_fees ||= subscription_usages.flat_map { |usage| usage[:invoice].fees }
+    end
+
+    # Must be a subset of current_usage_fees so both buckets share fee keys and net out.
+    def pay_in_advance_fees
+      current_usage_fees.select { |fee| fee.charge.pay_in_advance? }
+    end
+
+    def draft_invoices_fees
+      customer.invoices.draft.where.not(total_amount_cents: 0).includes(fees: :charge).flat_map(&:fees)
+    end
+
+    def progressive_billing_fees
+      subscription_usages.flat_map { |usage| usage[:billed_progressive_invoice_subscriptions].flat_map { it.invoice.fees.includes(:charge) } }
+    end
+
+    # One entry per active subscription: its current-usage invoice and the progressively
+    # billed invoice subscriptions used to net already-billed amounts out of ongoing usage.
+    def subscription_usages
+      @subscription_usages ||= customer.active_subscriptions.map do |subscription|
+        invoice = ::Invoices::CustomerUsageService.call!(customer:, subscription:, usage_filters: UsageFilters::WITHOUT_PRESENTATION_FILTER).invoice
+
+        billed_progressive_invoice_subscriptions = ::Subscriptions::ProgressiveBilledAmount
+          .call(subscription:, include_generating_invoices:)
+          .invoice_subscriptions
+
+        {billed_progressive_invoice_subscriptions:, invoice:, subscription:}
+      end
     end
   end
 end

--- a/app/services/wallets/balance/allocate_ongoing_usage_by_wallets_service.rb
+++ b/app/services/wallets/balance/allocate_ongoing_usage_by_wallets_service.rb
@@ -33,7 +33,8 @@ module Wallets
       def calculate_wallet_allocations
         net_amounts = net_usage_by_fee_key
         budgets = currency_budgets(net_amounts)
-        metas = wallets.map { |wallet| wallet_meta(wallet) }
+        balances = fresh_balances
+        metas = wallets.map { |wallet| wallet_meta(wallet, balances) }
         allocations = wallets.index_with(0)
 
         allocatable_pool(net_amounts).each do |fee_key, key_amount|
@@ -63,17 +64,21 @@ module Wallets
         allocations
       end
 
-      def wallet_meta(wallet)
+      def wallet_meta(wallet, balances)
         threshold = threshold_wallet?(wallet)
         {
           wallet:,
           targets: wallet.wallet_targets.filter_map { |wt| ["charge", wt.billable_metric_id] if wt.billable_metric_id },
           types: wallet.allowed_fee_types,
           threshold:,
-          # Re-read the balance so a concurrent pay-in-advance DecreaseService can't make us cap
-          # against a stale value. Balance only, to keep the eager-loaded associations.
-          balance: threshold ? 0 : Wallet.where(id: wallet.id).pick(:balance_cents)
+          balance: threshold ? 0 : balances.fetch(wallet.id, 0)
         }
+      end
+
+      # Re-read balances so a concurrent pay-in-advance DecreaseService can't make us cap
+      # against stale in-memory values: one query for all wallets, one consistent snapshot.
+      def fresh_balances
+        Wallet.where(id: wallets.map(&:id)).pluck(:id, :balance_cents).to_h
       end
 
       # Net the fee buckets into a signed amount per fee key. Keys whose net is <= 0

--- a/app/services/wallets/balance/allocate_ongoing_usage_by_wallets_service.rb
+++ b/app/services/wallets/balance/allocate_ongoing_usage_by_wallets_service.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module Wallets
+  module Balance
+    # Distributes ongoing (unbilled) usage across the customer's wallets in priority order,
+    # mirroring Credits::AllocatePrepaidCreditsByWalletsService. A wallet with an active
+    # threshold-based recurring rule is the exception: it absorbs everything and may go
+    # negative (no cascade) so the rule can fire and refill it.
+    class AllocateOngoingUsageByWalletsService < BaseService
+      Result = BaseResult[:wallet_allocations]
+
+      def initialize(customer:, wallets:, current_usage_fees:, draft_invoices_fees:, progressive_billing_fees:, pay_in_advance_fees:)
+        @customer = customer
+        @wallets = wallets
+        @current_usage_fees = current_usage_fees
+        @draft_invoices_fees = draft_invoices_fees
+        @progressive_billing_fees = progressive_billing_fees
+        @pay_in_advance_fees = pay_in_advance_fees
+
+        super
+      end
+
+      def call
+        result.wallet_allocations = calculate_wallet_allocations
+        result
+      end
+
+      private
+
+      attr_reader :customer, :wallets, :current_usage_fees, :draft_invoices_fees,
+        :progressive_billing_fees, :pay_in_advance_fees
+
+      def calculate_wallet_allocations
+        net_amounts = net_usage_by_fee_key
+        budgets = currency_budgets(net_amounts)
+        metas = wallets.map { |wallet| wallet_meta(wallet) }
+        allocations = wallets.index_with(0)
+
+        allocatable_pool(net_amounts).each do |fee_key, key_amount|
+          currency = fee_key.last
+          remaining = [key_amount, budgets[currency]].min
+          applicable = metas.select { |meta| applicable_fee?(fee_key:, wallet: meta[:wallet], targets: meta[:targets], types: meta[:types]) }
+
+          applicable.each_with_index do |meta, index|
+            break if remaining <= 0
+
+            if meta[:threshold] || index == applicable.length - 1
+              # A threshold wallet absorbs everything so its rule can refill it; the last
+              # applicable wallet absorbs the overflow. Both are allowed to go negative.
+              take = remaining
+            else
+              room = meta[:balance] - allocations[meta[:wallet]]
+              next if room <= 0
+              take = [remaining, room].min
+            end
+
+            allocations[meta[:wallet]] += take
+            remaining -= take
+            budgets[currency] -= take
+          end
+        end
+
+        allocations
+      end
+
+      def wallet_meta(wallet)
+        threshold = threshold_wallet?(wallet)
+        {
+          wallet:,
+          targets: wallet.wallet_targets.filter_map { |wt| ["charge", wt.billable_metric_id] if wt.billable_metric_id },
+          types: wallet.allowed_fee_types,
+          threshold:,
+          # Re-read the balance so a concurrent pay-in-advance DecreaseService can't make us cap
+          # against a stale value. Balance only, to keep the eager-loaded associations.
+          balance: threshold ? 0 : Wallet.where(id: wallet.id).pick(:balance_cents)
+        }
+      end
+
+      # Net the fee buckets into a signed amount per fee key. Keys whose net is <= 0
+      # (already fully billed) cannot receive allocations, but their negative nets still
+      # reduce the per-currency budget the same way billing credits reduce the invoice total.
+      def net_usage_by_fee_key
+        net_amounts = Hash.new(0)
+
+        add_to_pool(net_amounts, current_usage_fees) { |fee| fee.amount_cents + fee.taxes_amount_cents }
+        add_to_pool(net_amounts, draft_invoices_fees) { |fee| fee.amount_cents + fee.taxes_amount_cents - fee.precise_coupons_amount_cents }
+        add_to_pool(net_amounts, progressive_billing_fees) { |fee| -(fee.sub_total_excluding_taxes_amount_cents + fee.taxes_amount_cents) }
+        add_to_pool(net_amounts, pay_in_advance_fees) { |fee| -(fee.amount_cents + fee.taxes_amount_cents) }
+
+        net_amounts
+      end
+
+      def allocatable_pool(net_amounts)
+        net_amounts
+          .select { |_, amount| amount.positive? }
+          # Ties broken by fee key so the allocation order is stable across refreshes.
+          .sort_by { |fee_key, amount| [-amount, fee_key.map(&:to_s)] }
+          .to_h
+      end
+
+      # Mirrors billing's remaining_invoice_amount: an over-billed key's negative net offsets
+      # the other keys in its currency, the same way credits offset the invoice at billing.
+      def currency_budgets(net_amounts)
+        budgets = Hash.new(0)
+        net_amounts.each { |fee_key, amount| budgets[fee_key.last] += amount }
+        budgets.transform_values! { |amount| [amount, 0].max }
+      end
+
+      def add_to_pool(remaining, fees)
+        fees.each { |fee| remaining[fee_key(fee)] += yield(fee) }
+      end
+
+      def fee_key(fee)
+        target_wallet_code = if fee_targeting_wallets_enabled? && fee.charge&.accepts_target_wallet
+          fee.grouped_by&.dig("target_wallet_code")
+        end
+
+        [fee.fee_type, fee.charge&.billable_metric_id, target_wallet_code, fee.amount_currency]
+      end
+
+      def applicable_fee?(fee_key:, wallet:, targets:, types:)
+        fee_type, _billable_metric_id, target_wallet_code, currency = fee_key
+
+        return false unless wallet.balance_currency == currency
+        return wallet.code == target_wallet_code if target_wallet_code.present?
+
+        target_match = targets.include?(fee_key.first(2))
+        type_match = types.include?(fee_type)
+        unrestricted_wallet = targets.empty? && types.empty?
+
+        target_match || type_match || unrestricted_wallet
+      end
+
+      def threshold_wallet?(wallet)
+        wallet.recurring_transaction_rules.any? { |rule| rule.currently_active? && rule.threshold? }
+      end
+
+      def fee_targeting_wallets_enabled?
+        return @fee_targeting_wallets_enabled if defined?(@fee_targeting_wallets_enabled)
+
+        @fee_targeting_wallets_enabled = customer.organization.events_targeting_wallets_enabled?
+      end
+    end
+  end
+end

--- a/app/services/wallets/balance/refresh_ongoing_usage_service.rb
+++ b/app/services/wallets/balance/refresh_ongoing_usage_service.rb
@@ -5,22 +5,15 @@ module Wallets
     class RefreshOngoingUsageService < BaseService
       Result = BaseResult[:wallet]
 
-      def initialize(wallet:, usage_amount_cents:, current_usage_fees:, draft_invoices_fees:, progressive_billing_fees:, pay_in_advance_fees:, skip_single_wallet_update: false)
+      def initialize(wallet:, ongoing_usage_amount_cents:, skip_single_wallet_update: false)
         @wallet = wallet
-        @usage_amount_cents = usage_amount_cents
+        @ongoing_usage_amount_cents = ongoing_usage_amount_cents
         @skip_single_wallet_update = skip_single_wallet_update
-        @current_usage_fees = current_usage_fees
-        @draft_invoices_fees = draft_invoices_fees
-        @progressive_billing_fees = progressive_billing_fees
-        @pay_in_advance_fees = pay_in_advance_fees
 
         super
       end
 
       def call
-        @total_usage_amount_cents = calculate_total_usage_with_limitation
-        @total_billed_usage_amount_cents = calculate_total_billed_usage_amount_cents
-
         # Before this service is called, the wallet is already loaded in the memory. If while calculating current usage we received
         # a pay_in_advance_fee, wallet will be updated by Wallets::Balance::DecreaseService and current wallet version will throw an
         # `Attempted to update a stale object` error. To avoid this, we reload the wallet before updating it.
@@ -35,37 +28,7 @@ module Wallets
 
       private
 
-      attr_reader :wallet, :total_usage_amount_cents, :total_billed_usage_amount_cents, :usage_amount_cents, :skip_single_wallet_update,
-        :current_usage_fees, :draft_invoices_fees, :progressive_billing_fees, :pay_in_advance_fees
-
-      delegate :customer, to: :wallet
-
-      def calculate_total_billed_usage_amount_cents
-        billed_progressive_invoices_amount_cents +
-          billed_pay_in_advance_amount_cents
-      end
-
-      def billed_progressive_invoices_amount_cents
-        progressive_billing_fees.sum do |fee|
-          fee.taxes_amount_cents + fee.sub_total_excluding_taxes_amount_cents
-        end
-      end
-
-      def draft_invoices_total_amount_cents
-        draft_invoices_fees.sum do |fee|
-          fee.amount_cents + fee.taxes_amount_cents - fee.precise_coupons_amount_cents
-        end
-      end
-
-      def billed_pay_in_advance_amount_cents
-        # Invoice that is returned from CustomerUsageService includes the taxes in total_usage
-        # so if the fees ae already paid, we should exclude fees AND their taxes
-        pay_in_advance_fees.sum { |fee| fee.amount_cents + fee.taxes_amount_cents }
-      end
-
-      def calculate_total_usage_with_limitation
-        current_usage_fees.sum { |fee| fee.amount_cents + fee.taxes_amount_cents }
-      end
+      attr_reader :wallet, :ongoing_usage_amount_cents, :skip_single_wallet_update
 
       def wallet_update_params
         params = {
@@ -89,9 +52,7 @@ module Wallets
       end
 
       def ongoing_usage_balance_cents
-        @ongoing_usage_balance_cents ||= total_usage_amount_cents +
-          draft_invoices_total_amount_cents -
-          total_billed_usage_amount_cents
+        ongoing_usage_amount_cents
       end
 
       def credits_ongoing_usage_balance

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Customers::RefreshWalletJob do
     let(:wallet_ids) { nil }
 
     before do
-      allow(Customers::RefreshWalletsService).to receive(:call).with(customer:, target_wallet_ids: wallet_ids).and_return(result)
+      allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_return(result)
     end
 
     context "when customer is not awaiting wallet refresh" do
@@ -54,9 +54,9 @@ RSpec.describe Customers::RefreshWalletJob do
       context "when wallet_ids are provided" do
         let(:wallet_ids) { create_list(:wallet, 2, customer:).map(&:id) }
 
-        it "calls the Customers::RefreshWalletsService service scoped to the given wallets" do
+        it "still refreshes the whole customer" do
           subject
-          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:, target_wallet_ids: wallet_ids)
+          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:)
         end
       end
     end
@@ -67,16 +67,16 @@ RSpec.describe Customers::RefreshWalletJob do
       context "when refresh customer's wallets succeeds" do
         it "calls the Customers::RefreshWalletsService service" do
           subject
-          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:, target_wallet_ids: nil)
+          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:)
         end
       end
 
       context "when wallet_ids are provided" do
         let(:wallet_ids) { create_list(:wallet, 2, customer:).map(&:id) }
 
-        it "calls the Customers::RefreshWalletsService service scoped to the given wallets" do
+        it "refreshes the whole customer" do
           subject
-          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:, target_wallet_ids: wallet_ids)
+          expect(Customers::RefreshWalletsService).to have_received(:call).with(customer:)
         end
       end
 
@@ -114,7 +114,7 @@ RSpec.describe Customers::RefreshWalletJob do
         ].each do |error_class|
           context "when the error is #{error_class.name.demodulize.underscore.humanize.downcase}" do
             before do
-              allow(Customers::RefreshWalletsService).to receive(:call).with(customer:, target_wallet_ids: nil).and_raise(error_class)
+              allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(error_class)
             end
 
             it "raises the error and retries the job" do

--- a/spec/scenarios/events_targeting_wallets_spec.rb
+++ b/spec/scenarios/events_targeting_wallets_spec.rb
@@ -480,10 +480,10 @@ describe "Events Targeting Wallets Scenarios", transaction: false do
         # Refresh wallets
         recalculate_wallet_balances
 
-        # Without wallet targeting, all usage should be attributed to oldest wallet (wallet1)
-        # Total: 35 units * $10 = $350
-        expect(wallet1.reload.ongoing_usage_balance_cents).to eq(35_000)
-        expect(wallet2.reload.ongoing_usage_balance_cents).to eq(0)
+        # Without wallet targeting, ongoing usage cascades in priority order like billing:
+        # wallet1 fills ($200), the remaining $150 spills onto wallet2.
+        expect(wallet1.reload.ongoing_usage_balance_cents).to eq(20_000)
+        expect(wallet2.reload.ongoing_usage_balance_cents).to eq(15_000)
       end
 
       # Bill at end of month

--- a/spec/scenarios/wallets/balance_spec.rb
+++ b/spec/scenarios/wallets/balance_spec.rb
@@ -641,7 +641,7 @@ describe "Use wallet's credits and recalculate balances", :premium, transaction:
     end
 
     context "when each wallet limited to 2 billable metrics" do
-      it "applies usage once per metric following wallets priority" do
+      it "cascades each metric across its applicable wallets by priority" do
         time_0 = DateTime.new(2022, 12, 1)
         w1 = w2 = w3 = w4 = nil
         travel_to time_0 do
@@ -707,20 +707,18 @@ describe "Use wallet's credits and recalculate balances", :premium, transaction:
 
           recalculate_wallet_balances
 
-          # W1: storage+seats -> applies 10 + 20 = 30 -> 10 - 30 = -20
-          expect_wallet(w1, balance: 1000, balance_usage: 3000, ongoing_balance: -2000, credits: 10, credits_usage: 30, ongoing_credits: -20)
-          # W2: seats already applied, applies API 30 -> 20 - 30 = -10
+          # Each metric fills its highest-priority applicable wallet, then spills to the next;
+          # the last applicable wallet absorbs the overflow and may go negative.
+          expect_wallet(w1, balance: 1000, balance_usage: 1000, ongoing_balance: 0, credits: 10, credits_usage: 10, ongoing_credits: 0)
           expect_wallet(w2, balance: 2000, balance_usage: 3000, ongoing_balance: -1000, credits: 20, credits_usage: 30, ongoing_credits: -10)
-          # W3: api already applied, applies SMS 40 -> 30 - 40 = -10
           expect_wallet(w3, balance: 3000, balance_usage: 4000, ongoing_balance: -1000, credits: 30, credits_usage: 40, ongoing_credits: -10)
-          # W4: sms and storage already applied -> nothing -> stays 40
-          expect_wallet(w4, balance: 4000, balance_usage: 0, ongoing_balance: 4000, credits: 40, credits_usage: 0, ongoing_credits: 40)
+          expect_wallet(w4, balance: 4000, balance_usage: 2000, ongoing_balance: 2000, credits: 40, credits_usage: 20, ongoing_credits: 20)
         end
       end
     end
 
     context "when each wallet limited to 2 billable metrics with filtered events" do
-      it "applies usage once per metric even when events include filters" do
+      it "cascades each metric across its applicable wallets even when events include filters" do
         time_0 = DateTime.new(2022, 12, 1)
         w1 = w2 = w3 = w4 = nil
         travel_to time_0 do
@@ -796,20 +794,18 @@ describe "Use wallet's credits and recalculate balances", :premium, transaction:
 
           recalculate_wallet_balances
 
-          # W1: storage+seats -> applies 10 + 20 = 30 -> 10 - 30 = -20
-          expect_wallet(w1, balance: 1000, balance_usage: 3000, ongoing_balance: -2000, credits: 10, credits_usage: 30, ongoing_credits: -20)
-          # W2: seats already applied, applies API 30 -> 20 - 30 = -10
+          # Each metric fills its highest-priority applicable wallet, then spills to the next;
+          # the last applicable wallet absorbs the overflow and may go negative.
+          expect_wallet(w1, balance: 1000, balance_usage: 1000, ongoing_balance: 0, credits: 10, credits_usage: 10, ongoing_credits: 0)
           expect_wallet(w2, balance: 2000, balance_usage: 3000, ongoing_balance: -1000, credits: 20, credits_usage: 30, ongoing_credits: -10)
-          # W3: api already applied, applies SMS 40 -> 30 - 40 = -10
           expect_wallet(w3, balance: 3000, balance_usage: 4000, ongoing_balance: -1000, credits: 30, credits_usage: 40, ongoing_credits: -10)
-          # W4: sms and storage already applied -> nothing -> stays 40
-          expect_wallet(w4, balance: 4000, balance_usage: 0, ongoing_balance: 4000, credits: 40, credits_usage: 0, ongoing_credits: 40)
+          expect_wallet(w4, balance: 4000, balance_usage: 2000, ongoing_balance: 2000, credits: 40, credits_usage: 20, ongoing_credits: 20)
         end
       end
     end
 
     context "when wallets are limited to charges (fee type)" do
-      it "applies all charges to the first wallet limited to charge type" do
+      it "cascades charges across the charge-type wallets by priority" do
         time_0 = DateTime.new(2022, 12, 1)
         w1 = w2 = w3 = w4 = nil
         travel_to time_0 do
@@ -875,12 +871,12 @@ describe "Use wallet's credits and recalculate balances", :premium, transaction:
 
           recalculate_wallet_balances
 
-          # Total usage = 100
-          # Second wallet takes it all, cause 1st limited to subscription fee only
+          # Total charge usage = 100. W1 (subscription only) takes nothing; the charge cascades
+          # W2 -> W3 -> W4, and the last charge-type wallet (W4) absorbs the overflow (negative).
           expect_wallet(w1, balance: 1000, balance_usage: 0, ongoing_balance: 1000, credits: 10, credits_usage: 0, ongoing_credits: 10)
-          expect_wallet(w2, balance: 2000, balance_usage: 100_00, ongoing_balance: -8000, credits: 20, credits_usage: 100, ongoing_credits: -80)
-          expect_wallet(w3, balance: 3000, balance_usage: 0, ongoing_balance: 3000, credits: 30, credits_usage: 0, ongoing_credits: 30)
-          expect_wallet(w4, balance: 4000, balance_usage: 0, ongoing_balance: 4000, credits: 40, credits_usage: 0, ongoing_credits: 40)
+          expect_wallet(w2, balance: 2000, balance_usage: 2000, ongoing_balance: 0, credits: 20, credits_usage: 20, ongoing_credits: 0)
+          expect_wallet(w3, balance: 3000, balance_usage: 3000, ongoing_balance: 0, credits: 30, credits_usage: 30, ongoing_credits: 0)
+          expect_wallet(w4, balance: 4000, balance_usage: 5000, ongoing_balance: -1000, credits: 40, credits_usage: 50, ongoing_credits: -10)
         end
       end
     end
@@ -892,7 +888,7 @@ describe "Use wallet's credits and recalculate balances", :premium, transaction:
         usage_threshold
       end
 
-      it "apply unrestricted rule to first wallet only" do
+      it "cascades unrestricted usage across wallets by priority" do
         time_0 = DateTime.new(2022, 12, 1)
         w1 = w2 = w3 = w4 = nil
         travel_to time_0 do
@@ -954,12 +950,12 @@ describe "Use wallet's credits and recalculate balances", :premium, transaction:
 
           recalculate_wallet_balances
 
-          # Total usage = 100 - 10(progressive billing already billed) = 90
-          # First (unrestricted) wallet takes it all
-          expect_wallet(w1, balance: 0, balance_usage: 9000, ongoing_balance: -9000, credits: 0, credits_usage: 90, ongoing_credits: -90)
-          expect_wallet(w2, balance: 2000, balance_usage: 0, ongoing_balance: 2000, credits: 20, credits_usage: 0, ongoing_credits: 20)
-          expect_wallet(w3, balance: 3000, balance_usage: 0, ongoing_balance: 3000, credits: 30, credits_usage: 0, ongoing_credits: 30)
-          expect_wallet(w4, balance: 4000, balance_usage: 0, ongoing_balance: 4000, credits: 40, credits_usage: 0, ongoing_credits: 40)
+          # Net usage = 100 - 10 (already progressively billed) = 90. W1's balance was consumed
+          # to 0 by the progressive-billing invoice, so the 90 cascades across W2 -> W3 -> W4.
+          expect_wallet(w1, balance: 0, balance_usage: 0, ongoing_balance: 0, credits: 0, credits_usage: 0, ongoing_credits: 0)
+          expect_wallet(w2, balance: 2000, balance_usage: 2000, ongoing_balance: 0, credits: 20, credits_usage: 20, ongoing_credits: 0)
+          expect_wallet(w3, balance: 3000, balance_usage: 3000, ongoing_balance: 0, credits: 30, credits_usage: 30, ongoing_credits: 0)
+          expect_wallet(w4, balance: 4000, balance_usage: 4000, ongoing_balance: 0, credits: 40, credits_usage: 40, ongoing_credits: 0)
         end
       end
     end

--- a/spec/scenarios/wallets/customer_wallets_balance_refresh_spec.rb
+++ b/spec/scenarios/wallets/customer_wallets_balance_refresh_spec.rb
@@ -92,13 +92,11 @@ describe "Use wallet's credits and recalculate balances", transaction: false do
     end
 
     ##
-    # wallet 1
-    # 1000 - 3000(from events) = -2000
-    # wallet 2
-    # 1000 - 500(from event) = 500
+    # bm1 usage (3000) fills wallet 1 to 0, then spills onto the unrestricted wallet 3.
+    # wallet 2 covers bm2 usage (500) -> 500 remaining.
     ##
     it "updates the correct ongoing balances for each wallet" do
-      expect_wallet(wallet, ongoing_usage: 3000, credits_usage: 30, ongoing: -2000, credits: -20)
+      expect_wallet(wallet, ongoing_usage: 1000, credits_usage: 10, ongoing: 0, credits: 0)
       expect_wallet(wallet2, ongoing_usage: 500, credits_usage: 5, ongoing: 500, credits: 5)
     end
 
@@ -116,9 +114,9 @@ describe "Use wallet's credits and recalculate balances", transaction: false do
       end
 
       it "updates the correct ongoing balances for each wallet" do
-        expect_wallet(wallet, ongoing_usage: 3000, credits_usage: 30, ongoing: -2000, credits: -20)
+        expect_wallet(wallet, ongoing_usage: 1000, credits_usage: 10, ongoing: 0, credits: 0)
         expect_wallet(wallet2, ongoing_usage: 500, credits_usage: 5, ongoing: 500, credits: 5)
-        expect_wallet(wallet3, ongoing_usage: 0, credits_usage: 0, ongoing: 1000, credits: 10)
+        expect_wallet(wallet3, ongoing_usage: 2000, credits_usage: 20, ongoing: -1000, credits: -10)
       end
     end
 
@@ -171,15 +169,14 @@ describe "Use wallet's credits and recalculate balances", transaction: false do
       end
 
       ##
-      # wallet 1
-      # 1000 - 3000(from events) = -2000 #untouched
+      # bm1 usage (3000) fills wallet 1 to 0, spilling onto the unrestricted wallet 3.
       # wallet 2
       # fee 2 is not taken into account because of the wallet restrictions
       # 1000 - 500(from event) - 100(from invoice) ( 100 + 10(tax) - 10(already paid) )
       # = 400 # progressive billing invoice
       ##
       it "updates wallet ongoing balances including progressive billing invoice" do
-        expect_wallet(wallet, ongoing_usage: 3000, credits_usage: 30, ongoing: -2000, credits: -20)
+        expect_wallet(wallet, ongoing_usage: 1000, credits_usage: 10, ongoing: 0, credits: 0)
         expect_wallet(wallet2, ongoing_usage: 400, credits_usage: 4, ongoing: 600, credits: 6)
       end
     end
@@ -213,14 +210,13 @@ describe "Use wallet's credits and recalculate balances", transaction: false do
       end
 
       ##
-      # wallet 1
-      # 1000 - 3000(from events) = -2000 #untouched
+      # bm1 usage (3000) fills wallet 1 to 0, spilling onto the unrestricted wallet 3.
       # wallet 2
       # 1000 - 500(from event) - 110(from draft invoice) + 70 (already paid)
       # = 540 # progressive billing invoice
       ##
       it "updates wallet ongoing balances including progressive billing invoice" do
-        expect_wallet(wallet, ongoing_usage: 3000, credits_usage: 30, ongoing: -2000, credits: -20)
+        expect_wallet(wallet, ongoing_usage: 1000, credits_usage: 10, ongoing: 0, credits: 0)
         expect_wallet(wallet2, ongoing_usage: 540, credits_usage: 5.4, ongoing: 460, credits: 4.6)
       end
     end

--- a/spec/scenarios/wallets/customer_wallets_balance_refresh_spec.rb
+++ b/spec/scenarios/wallets/customer_wallets_balance_refresh_spec.rb
@@ -92,12 +92,22 @@ describe "Use wallet's credits and recalculate balances", transaction: false do
     end
 
     ##
-    # bm1 usage (3000) fills wallet 1 to 0, then spills onto the unrestricted wallet 3.
-    # wallet 2 covers bm2 usage (500) -> 500 remaining.
+    # USAGE                        WALLETS (priority order)
+    #
+    # bm1: $30 ────$10───────────▶ ┌─────────────────────────┐
+    #           │                  │ wallet ($10, bm1 only)  │ ongoing: $0
+    #           │                  └─────────────────────────┘
+    # bm2: $5 ─────$5───────┐      ┌─────────────────────────┐
+    #           │           └────▶ │ wallet2 ($10, bm2 only) │ ongoing: $5
+    #           │                  └─────────────────────────┘
+    #           └─$20 overflow───▶ ┌─────────────────────────┐
+    #                              │ wallet3 ($10, catch-all)│ ongoing: -$10
+    #                              └─────────────────────────┘
     ##
     it "updates the correct ongoing balances for each wallet" do
       expect_wallet(wallet, ongoing_usage: 1000, credits_usage: 10, ongoing: 0, credits: 0)
       expect_wallet(wallet2, ongoing_usage: 500, credits_usage: 5, ongoing: 500, credits: 5)
+      expect_wallet(wallet3, ongoing_usage: 2000, credits_usage: 20, ongoing: -1000, credits: -10)
     end
 
     context "when there is paid in advance charges" do
@@ -113,6 +123,15 @@ describe "Use wallet's credits and recalculate balances", transaction: false do
         third_charge
       end
 
+      ##
+      # Same cascade as the parent scenario; bm3 usage is pay-in-advance, so it is
+      # already billed and nets to 0 -- it reaches no wallet.
+      #
+      # bm1: $30 ── $10 ▶ wallet ($10, bm1 only)    ongoing: $0
+      #          └─ $20 ▶ wallet3 ($10, catch-all)  ongoing: -$10
+      # bm2: $5 ──── $5 ▶ wallet2 ($10, bm2 only)   ongoing: $5
+      # bm3: paid in advance ──▶ nets to $0
+      ##
       it "updates the correct ongoing balances for each wallet" do
         expect_wallet(wallet, ongoing_usage: 1000, credits_usage: 10, ongoing: 0, credits: 0)
         expect_wallet(wallet2, ongoing_usage: 500, credits_usage: 5, ongoing: 500, credits: 5)
@@ -169,15 +188,20 @@ describe "Use wallet's credits and recalculate balances", transaction: false do
       end
 
       ##
-      # bm1 usage (3000) fills wallet 1 to 0, spilling onto the unrestricted wallet 3.
-      # wallet 2
-      # fee 2 is not taken into account because of the wallet restrictions
-      # 1000 - 500(from event) - 100(from invoice) ( 100 + 10(tax) - 10(already paid) )
-      # = 400 # progressive billing invoice
+      # The progressive billing invoice nets $1 out of bm2 ($1 + $0.10 tax - $0.10 coupon)
+      # and $1 out of bm3, before the cascade runs.
+      #
+      # bm1: $30 ──────── $10 ▶ wallet ($10, bm1 only)    ongoing: $0
+      #                └─ $20 ▶ wallet3 (overflow)
+      # bm2: $5 - $1 ────── $4 ▶ wallet2 ($10, bm2 only)  ongoing: $6
+      # bm3: $33 - $1 ──── $32 ▶ wallet3 (only match)
+      #
+      # wallet3 ($10, catch-all): $20 + $32 = $52 consumed, ongoing: -$42
       ##
       it "updates wallet ongoing balances including progressive billing invoice" do
         expect_wallet(wallet, ongoing_usage: 1000, credits_usage: 10, ongoing: 0, credits: 0)
         expect_wallet(wallet2, ongoing_usage: 400, credits_usage: 4, ongoing: 600, credits: 6)
+        expect_wallet(wallet3, ongoing_usage: 5200, credits_usage: 52, ongoing: -4200, credits: -42)
       end
     end
 
@@ -210,14 +234,17 @@ describe "Use wallet's credits and recalculate balances", transaction: false do
       end
 
       ##
-      # bm1 usage (3000) fills wallet 1 to 0, spilling onto the unrestricted wallet 3.
-      # wallet 2
-      # 1000 - 500(from event) - 110(from draft invoice) + 70 (already paid)
-      # = 540 # progressive billing invoice
+      # The draft invoice adds $0.40 to bm2 ($1 + $0.10 tax - $0.70 already paid)
+      # before the cascade runs. bm3 has no charge here, so its event prices nothing.
+      #
+      # bm1: $30 ────────── $10 ▶ wallet ($10, bm1 only)    ongoing: $0
+      #                  └─ $20 ▶ wallet3 ($10, catch-all)  ongoing: -$10
+      # bm2: $5 + $0.40 ── $5.40 ▶ wallet2 ($10, bm2 only)  ongoing: $4.60
       ##
       it "updates wallet ongoing balances including progressive billing invoice" do
         expect_wallet(wallet, ongoing_usage: 1000, credits_usage: 10, ongoing: 0, credits: 0)
         expect_wallet(wallet2, ongoing_usage: 540, credits_usage: 5.4, ongoing: 460, credits: 4.6)
+        expect_wallet(wallet3, ongoing_usage: 2000, credits_usage: 20, ongoing: -1000, credits: -10)
       end
     end
   end

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -137,6 +137,9 @@ RSpec.describe Customers::RefreshWalletsService do
           create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) do |invoice_subscription|
             create(
               :charge_fee,
+              # Progressively-billed usage must net against the same metric it bills,
+              # so reuse the in-arrears charge that produces the ongoing usage.
+              charge: subscription.plan.charges.find { |c| c.billable_metric_id == billable_metric.id },
               subscription:,
               precise_coupons_amount_cents: 0,
               invoice: invoice_subscription.invoice,
@@ -204,10 +207,8 @@ RSpec.describe Customers::RefreshWalletsService do
       end
     end
 
-    context "when target_wallet_ids is provided" do
-      subject(:result) { described_class.call(customer:, include_generating_invoices:, target_wallet_ids: [target_wallet.id]) }
-
-      let!(:target_wallet) do
+    context "when the customer has multiple wallets" do
+      let!(:first_wallet) do
         create(
           :wallet,
           customer:,
@@ -220,7 +221,7 @@ RSpec.describe Customers::RefreshWalletsService do
         )
       end
 
-      let!(:other_wallet) do
+      let!(:second_wallet) do
         create(
           :wallet,
           customer:,
@@ -233,22 +234,22 @@ RSpec.describe Customers::RefreshWalletsService do
         )
       end
 
-      it "only calls RefreshOngoingUsageService for targeted wallets" do
+      it "refreshes every wallet together" do
         allow(Wallets::Balance::RefreshOngoingUsageService).to receive(:call!).and_call_original
 
         subject
 
         expect(Wallets::Balance::RefreshOngoingUsageService)
-          .to have_received(:call!).once
+          .to have_received(:call!).with(hash_including(wallet: first_wallet))
         expect(Wallets::Balance::RefreshOngoingUsageService)
-          .to have_received(:call!).with(hash_including(wallet: target_wallet))
+          .to have_received(:call!).with(hash_including(wallet: second_wallet))
       end
 
-      it "only updates last_ongoing_balance_sync_at for targeted wallets" do
+      it "updates last_ongoing_balance_sync_at on every wallet" do
         subject
 
-        expect(target_wallet.reload.last_ongoing_balance_sync_at).not_to be_nil
-        expect(other_wallet.reload.last_ongoing_balance_sync_at).to be_nil
+        expect(first_wallet.reload.last_ongoing_balance_sync_at).not_to be_nil
+        expect(second_wallet.reload.last_ongoing_balance_sync_at).not_to be_nil
       end
 
       it "returns all active wallets in the result" do
@@ -442,6 +443,55 @@ RSpec.describe Customers::RefreshWalletsService do
         # EUR: in-arrears 1500 + PIA 400 = 1900 total usage, minus 400 PIA billed = 1500 ongoing usage
         expect(eur_wallet.reload.ongoing_usage_balance_cents).to eq(1500)
         expect(eur_wallet.ongoing_balance_cents).to eq(8500)
+      end
+    end
+
+    context "when ongoing usage cascades across multiple wallets" do
+      subject(:result) { described_class.call(customer: cascade_customer, include_generating_invoices: false) }
+
+      let(:cascade_org) { create(:organization) }
+      let(:cascade_customer) { create(:customer, organization: cascade_org, awaiting_wallet_refresh: true) }
+      let(:cascade_bm) { create(:billable_metric, organization: cascade_org, aggregation_type: "count_agg") }
+      let(:cascade_subscription) { create(:subscription, organization: cascade_org, customer: cascade_customer, started_at: Time.zone.now - 1.year) }
+
+      # Wallet B (free, consumed first) and Wallet A (paid), as in the ticket worked example.
+      let(:wallet_b) do
+        create(:wallet, customer: cascade_customer, organization: cascade_org, balance_cents: 50, priority: 1,
+          ongoing_balance_cents: 50, credits_balance: 0.5, credits_ongoing_balance: 0.5)
+      end
+      let(:wallet_a) do
+        create(:wallet, customer: cascade_customer, organization: cascade_org, balance_cents: 150, priority: 2,
+          ongoing_balance_cents: 150, credits_balance: 1.5, credits_ongoing_balance: 1.5)
+      end
+
+      before do
+        create(:standard_charge, plan: cascade_subscription.plan, billable_metric: cascade_bm, properties: {amount: "0.8"})
+        wallet_b
+        wallet_a
+        # 1 event * $0.80 = 80 cents of ongoing usage
+        create(:event, organization: cascade_org, subscription: cascade_subscription, customer: cascade_customer, code: cascade_bm.code)
+      end
+
+      it "fills the priority wallet then spills the overflow onto the next" do
+        expect(result).to be_success
+
+        expect(wallet_b.reload.ongoing_balance_cents).to eq(0)
+        expect(wallet_b.ongoing_usage_balance_cents).to eq(50)
+        expect(wallet_a.reload.ongoing_balance_cents).to eq(120)
+        expect(wallet_a.ongoing_usage_balance_cents).to eq(30)
+      end
+
+      context "when the priority wallet has an active threshold-based recurring rule" do
+        before { create(:recurring_transaction_rule, wallet: wallet_b, organization: cascade_org, trigger: :threshold) }
+
+        it "keeps the legacy behavior: the threshold wallet goes negative and does not cascade" do
+          expect(result).to be_success
+
+          expect(wallet_b.reload.ongoing_balance_cents).to eq(-30)
+          expect(wallet_b.ongoing_usage_balance_cents).to eq(80)
+          expect(wallet_a.reload.ongoing_balance_cents).to eq(150)
+          expect(wallet_a.ongoing_usage_balance_cents).to eq(0)
+        end
       end
     end
   end

--- a/spec/services/wallets/balance/allocate_ongoing_usage_by_wallets_service_spec.rb
+++ b/spec/services/wallets/balance/allocate_ongoing_usage_by_wallets_service_spec.rb
@@ -300,6 +300,23 @@ RSpec.describe Wallets::Balance::AllocateOngoingUsageByWalletsService do
       end
     end
 
+    context "when a fee targets a wallet whose balance is smaller than the fee" do
+      around { |test| lago_premium! { test.run } }
+
+      let(:organization) { create(:organization, premium_integrations: ["events_targeting_wallets"]) }
+      let(:charge) { create(:standard_charge, organization:, accepts_target_wallet: true) }
+      let(:wallet_b) { create(:wallet, customer:, organization:, code: "wallet-b", balance_cents: 50, priority: 1) }
+      let(:current_usage_fees) do
+        [create(:charge_fee, charge:, subscription:, organization:, invoice:, amount_cents: 80,
+          taxes_amount_cents: 0, amount_currency: "EUR", grouped_by: {"target_wallet_code" => "wallet-b"})]
+      end
+
+      it "lets the targeted wallet absorb the full amount and go negative, never spilling onto other wallets" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 80, wallet_a => 0})
+      end
+    end
+
     context "when a wallet's in-memory balance is stale" do
       let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
 

--- a/spec/services/wallets/balance/allocate_ongoing_usage_by_wallets_service_spec.rb
+++ b/spec/services/wallets/balance/allocate_ongoing_usage_by_wallets_service_spec.rb
@@ -1,0 +1,324 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Wallets::Balance::AllocateOngoingUsageByWalletsService do
+  subject(:result) do
+    described_class.call(
+      customer:,
+      wallets:,
+      current_usage_fees:,
+      draft_invoices_fees:,
+      progressive_billing_fees:,
+      pay_in_advance_fees:
+    )
+  end
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+
+  let(:draft_invoices_fees) { [] }
+  let(:progressive_billing_fees) { [] }
+  let(:pay_in_advance_fees) { [] }
+
+  # Wallet B (free, consumed first) and Wallet A (paid), as in the ticket worked example.
+  let(:wallet_b) { create(:wallet, customer:, organization:, balance_cents: 50, priority: 1) }
+  let(:wallet_a) { create(:wallet, customer:, organization:, balance_cents: 150, priority: 2) }
+  let(:wallets) { [wallet_b, wallet_a] }
+
+  def usage_fee(amount_cents:, charge: create(:standard_charge, organization:), currency: "EUR")
+    create(:charge_fee, charge:, subscription:, organization:, invoice:,
+      amount_cents:, taxes_amount_cents: 0, amount_currency: currency)
+  end
+
+  describe "#call" do
+    context "with a single fee that overflows the first wallet" do
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      it "cascades the overflow onto the next wallet in priority order" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 30})
+      end
+    end
+
+    context "when the first wallet has an active threshold-based recurring rule" do
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      before { create(:recurring_transaction_rule, wallet: wallet_b, organization:, trigger: :threshold) }
+
+      it "absorbs everything on the threshold wallet and does not cascade" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 80, wallet_a => 0})
+      end
+    end
+
+    context "when both wallets have an active threshold-based recurring rule" do
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      before do
+        create(:recurring_transaction_rule, wallet: wallet_b, organization:, trigger: :threshold)
+        create(:recurring_transaction_rule, wallet: wallet_a, organization:, trigger: :threshold)
+      end
+
+      it "lets the highest-priority threshold wallet absorb everything and does not cascade" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 80, wallet_a => 0})
+      end
+    end
+
+    context "when the threshold rule is not active" do
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      before { create(:recurring_transaction_rule, wallet: wallet_b, organization:, trigger: :threshold, status: :terminated) }
+
+      it "cascades as if there were no threshold rule" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 30})
+      end
+    end
+
+    context "when a wallet has an active non-threshold (interval) recurring rule" do
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      before { create(:recurring_transaction_rule, wallet: wallet_b, organization:, trigger: :interval) }
+
+      it "cascades like a normal wallet instead of absorbing everything" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 30})
+      end
+    end
+
+    context "when a middle-priority wallet has an active threshold-based recurring rule" do
+      let(:w1) { create(:wallet, customer:, organization:, balance_cents: 50, priority: 1) }
+      let(:w2) { create(:wallet, customer:, organization:, balance_cents: 50, priority: 2) }
+      let(:w3) { create(:wallet, customer:, organization:, balance_cents: 50, priority: 3) }
+      let(:wallets) { [w1, w2, w3] }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 200)] }
+
+      before { create(:recurring_transaction_rule, wallet: w2, organization:, trigger: :threshold) }
+
+      it "fills the higher-priority wallet, then the threshold wallet absorbs the rest and stops the cascade" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({w1 => 50, w2 => 150, w3 => 0})
+      end
+    end
+
+    context "with a single wallet" do
+      let(:wallets) { [wallet_a] }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      it "allocates the full usage to that wallet" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_a => 80})
+      end
+    end
+
+    context "with a single non-threshold wallet whose usage exceeds its balance" do
+      let(:wallets) { [wallet_b] }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      it "lets the lone wallet absorb the overflow and go negative" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 80})
+      end
+    end
+
+    context "when usage exceeds the sum of all wallet balances and no threshold rule exists" do
+      let(:current_usage_fees) { [usage_fee(amount_cents: 250)] }
+
+      it "fills each wallet then lets the last one absorb the overflow and go negative" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 200})
+      end
+    end
+
+    context "with a pay-in-advance offset reducing the net usage" do
+      let(:charge) { create(:standard_charge, organization:, pay_in_advance: true) }
+      let(:usage) { usage_fee(amount_cents: 80, charge:) }
+      let(:billed) { usage_fee(amount_cents: 30, charge:) }
+      let(:current_usage_fees) { [usage] }
+      let(:pay_in_advance_fees) { [billed] }
+
+      it "nets the already-billed amount before cascading" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 0})
+      end
+    end
+
+    context "with a progressive-billing offset reducing the net usage" do
+      let(:charge) { create(:standard_charge, organization:) }
+      let(:usage) { usage_fee(amount_cents: 80, charge:) }
+      # Already progressively billed for the same charge, so it nets against the usage key.
+      let(:billed) do
+        create(:charge_fee, charge:, subscription:, organization:, invoice:,
+          amount_cents: 30, taxes_amount_cents: 0, precise_coupons_amount_cents: 0, amount_currency: "EUR")
+      end
+      let(:current_usage_fees) { [usage] }
+      let(:progressive_billing_fees) { [billed] }
+
+      it "nets the progressively-billed amount before cascading" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 0})
+      end
+    end
+
+    context "with a draft invoice fee adding to the net usage" do
+      let(:charge) { create(:standard_charge, organization:) }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 40, charge:)] }
+      let(:draft_invoices_fees) { [usage_fee(amount_cents: 40, charge:)] }
+
+      it "sums usage and draft amounts before cascading" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 30})
+      end
+    end
+
+    context "with wallet billable-metric targeting" do
+      let(:billable_metric1) { create(:billable_metric, organization:) }
+      let(:billable_metric2) { create(:billable_metric, organization:) }
+      let(:charge1) { create(:standard_charge, organization:, billable_metric: billable_metric1) }
+      let(:charge2) { create(:standard_charge, organization:, billable_metric: billable_metric2) }
+
+      let(:wallet_b) { create(:wallet, customer:, organization:, balance_cents: 1000, priority: 1) }
+      let(:wallet_a) { create(:wallet, customer:, organization:, balance_cents: 2000, priority: 2) }
+
+      let(:current_usage_fees) { [usage_fee(amount_cents: 600, charge: charge1), usage_fee(amount_cents: 500, charge: charge2)] }
+
+      before { create(:wallet_target, wallet: wallet_b, billable_metric: billable_metric1, organization:) }
+
+      it "routes targeted fees to the targeting wallet and the rest to the unrestricted wallet" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 600, wallet_a => 500})
+      end
+    end
+
+    context "with wallet fee-type restriction (allowed_fee_types)" do
+      # wallet_b only accepts subscription fees, so the charge usage cascades past it to wallet_a.
+      let(:wallet_b) { create(:wallet, customer:, organization:, balance_cents: 1000, priority: 1, allowed_fee_types: %w[subscription]) }
+      let(:wallet_a) { create(:wallet, customer:, organization:, balance_cents: 2000, priority: 2, allowed_fee_types: %w[charge]) }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      it "only allocates a fee to wallets whose allowed_fee_types include its type" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 0, wallet_a => 80})
+      end
+    end
+
+    context "when a wallet currency does not match the fee currency" do
+      let(:wallet_b) { create(:wallet, customer:, organization:, currency: "USD", balance_cents: 1000, priority: 1) }
+      let(:wallet_a) { create(:wallet, customer:, organization:, currency: "EUR", balance_cents: 1000, priority: 2) }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80, currency: "EUR")] }
+
+      it "only allocates to wallets matching the fee currency" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 0, wallet_a => 80})
+      end
+    end
+
+    context "with a zero-balance non-threshold wallet in the middle of the cascade" do
+      let(:w1) { create(:wallet, customer:, organization:, balance_cents: 0, priority: 1) }
+      let(:w2) { create(:wallet, customer:, organization:, balance_cents: 50, priority: 2) }
+      let(:w3) { create(:wallet, customer:, organization:, balance_cents: 50, priority: 3) }
+      let(:wallets) { [w1, w2, w3] }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      it "skips the depleted wallet instead of forcing it negative" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({w1 => 0, w2 => 50, w3 => 30})
+      end
+    end
+
+    context "with two fees on different metrics competing for the same wallets" do
+      let(:current_usage_fees) do
+        [usage_fee(amount_cents: 40, charge: create(:standard_charge, organization:)),
+          usage_fee(amount_cents: 40, charge: create(:standard_charge, organization:))]
+      end
+
+      it "accounts for the first fee's allocation when the second fee reuses a wallet" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 30})
+      end
+    end
+
+    context "with a subscription fee that has no charge" do
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:current_usage_fees) { [create(:fee, subscription:, organization:, invoice:, amount_cents: 80, taxes_amount_cents: 0, amount_currency: "EUR")] }
+
+      before { create(:wallet_target, wallet: wallet_b, billable_metric:, organization:) }
+
+      it "bypasses the metric-targeted wallet and lands on the unrestricted one" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 0, wallet_a => 80})
+      end
+    end
+
+    context "when a fee is already fully covered by progressive billing (net usage of zero)" do
+      let(:charge) { create(:standard_charge, organization:) }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80, charge:)] }
+      let(:progressive_billing_fees) do
+        [create(:charge_fee, charge:, subscription:, organization:, invoice:,
+          amount_cents: 80, taxes_amount_cents: 0, precise_coupons_amount_cents: 0, amount_currency: "EUR")]
+      end
+
+      it "drops the fully-billed fee key and allocates nothing" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 0, wallet_a => 0})
+      end
+    end
+
+    context "when progressive billing exceeds one metric's usage" do
+      let(:charge1) { create(:standard_charge, organization:) }
+      let(:charge2) { create(:standard_charge, organization:) }
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80, charge: charge1), usage_fee(amount_cents: 100, charge: charge2)] }
+      let(:progressive_billing_fees) do
+        [create(:charge_fee, charge: charge2, subscription:, organization:, invoice:,
+          amount_cents: 150, taxes_amount_cents: 0, precise_coupons_amount_cents: 0, amount_currency: "EUR")]
+      end
+
+      it "lets the over-billed key offset the other keys, like billing credits offset the invoice" do
+        # net = 80 + (100 - 150) = 30, matching what billing would deduct from wallets
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 30, wallet_a => 0})
+      end
+    end
+
+    context "when a fee targets a wallet code that matches no wallet" do
+      around { |test| lago_premium! { test.run } }
+
+      let(:organization) { create(:organization, premium_integrations: ["events_targeting_wallets"]) }
+      let(:charge) { create(:standard_charge, organization:, accepts_target_wallet: true) }
+      let(:current_usage_fees) do
+        [create(:charge_fee, charge:, subscription:, organization:, invoice:, amount_cents: 80,
+          taxes_amount_cents: 0, amount_currency: "EUR", grouped_by: {"target_wallet_code" => "missing-wallet"})]
+      end
+
+      it "allocates the fee to no wallet, matching billing where no wallet covers it" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 0, wallet_a => 0})
+      end
+    end
+
+    context "when a wallet's in-memory balance is stale" do
+      let(:current_usage_fees) { [usage_fee(amount_cents: 80)] }
+
+      # Simulate a concurrent DecreaseService: the in-memory object is stale, the DB is authoritative.
+      before { wallet_b.balance_cents = 999_99 }
+
+      it "caps against the balance re-read from the database, not the stale value" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 50, wallet_a => 30})
+      end
+    end
+
+    context "when there is no usage" do
+      let(:current_usage_fees) { [] }
+
+      it "allocates zero to every wallet" do
+        expect(result).to be_success
+        expect(result.wallet_allocations).to eq({wallet_b => 0, wallet_a => 0})
+      end
+    end
+  end
+end

--- a/spec/services/wallets/balance/refresh_ongoing_usage_service_spec.rb
+++ b/spec/services/wallets/balance/refresh_ongoing_usage_service_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Wallets::Balance::RefreshOngoingUsageService do
+  subject(:result) do
+    described_class.call(wallet:, ongoing_usage_amount_cents:, skip_single_wallet_update:)
+  end
+
   let(:wallet) do
     create(
       :wallet,
@@ -16,164 +20,42 @@ RSpec.describe Wallets::Balance::RefreshOngoingUsageService do
   end
 
   let(:depleted_ongoing_balance) { false }
+  let(:skip_single_wallet_update) { false }
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:first_subscription) do
-    create(:subscription, organization:, customer:, started_at: Time.zone.now - 2.years)
-  end
-  let(:second_subscription) do
-    create(:subscription, organization:, customer:, started_at: Time.zone.now - 1.year)
-  end
-  let(:timestamp) { Time.current }
-  let(:billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
-
-  let(:first_charge) do
-    create(
-      :standard_charge,
-      plan: first_subscription.plan,
-      billable_metric:,
-      properties: {amount: "3"}
-    )
-  end
-  let(:second_charge) do
-    create(
-      :standard_charge,
-      plan: second_subscription.plan,
-      billable_metric:,
-      properties: {amount: "5"}
-    )
-  end
-
-  let(:usage_amount_cents) { 1100 }
-  let(:current_usage_fees) { [] }
-  let(:draft_invoices_fees) { [] }
-  let(:progressive_billing_fees) { [] }
-  let(:pay_in_advance_fees) { [] }
-
-  before do
-    first_charge
-    second_charge
-    wallet
-  end
+  let(:ongoing_usage_amount_cents) { 1100 }
 
   describe ".call" do
-    subject(:result) do
-      described_class.call(
-        wallet:,
-        usage_amount_cents:,
-        current_usage_fees:,
-        draft_invoices_fees:,
-        progressive_billing_fees:,
-        pay_in_advance_fees:
-      )
+    it "writes the precomputed ongoing usage onto the wallet" do
+      expect { subject }
+        .to change(wallet.reload, :ongoing_usage_balance_cents).from(200).to(1100)
+        .and change(wallet, :credits_ongoing_usage_balance).from(2.0).to(11.0)
+        .and change(wallet, :ongoing_balance_cents).from(800).to(-100)
+        .and change(wallet, :credits_ongoing_balance).from(8.0).to(-1.0)
     end
 
-    context "when there are current usage fees" do
-      let(:invoice) { create(:invoice, customer:, organization:) }
-      let(:first_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 600, taxes_amount_cents: 0)
-      end
-      let(:second_fee) do
-        create(:charge_fee, charge: second_charge, subscription: second_subscription,
-          organization:, invoice:, amount_cents: 500, taxes_amount_cents: 0)
-      end
-      let(:current_usage_fees) { [first_fee, second_fee] }
+    it "returns the wallet" do
+      expect(result.wallet).to eq(wallet)
+    end
 
-      it "updates wallet ongoing balance" do
+    context "when the wallet rate differs from 1" do
+      let(:wallet) do
+        create(:wallet, customer:, balance_cents: 1000, rate_amount: "2",
+          ongoing_balance_cents: 800, ongoing_usage_balance_cents: 200,
+          credits_balance: 5.0, credits_ongoing_balance: 4.0, credits_ongoing_usage_balance: 1.0)
+      end
+
+      it "converts cents to credits using the wallet rate" do
         expect { subject }
           .to change(wallet.reload, :ongoing_usage_balance_cents).from(200).to(1100)
-          .and change(wallet, :credits_ongoing_usage_balance).from(2.0).to(11.0)
+          .and change(wallet, :credits_ongoing_usage_balance).from(1.0).to(5.5)
           .and change(wallet, :ongoing_balance_cents).from(800).to(-100)
-          .and change(wallet, :credits_ongoing_balance).from(8.0).to(-1.0)
-      end
-
-      it "returns the wallet" do
-        expect(result.wallet).to eq(wallet)
-      end
-    end
-
-    context "when there are paid in advance fees" do
-      let(:invoice) { create(:invoice, customer:, organization:) }
-      let(:current_usage_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 1100, taxes_amount_cents: 0)
-      end
-      let(:pay_in_advance_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 700, taxes_amount_cents: 0)
-      end
-      let(:current_usage_fees) { [current_usage_fee] }
-      let(:pay_in_advance_fees) { [pay_in_advance_fee] }
-
-      it "updates wallet ongoing balance by deducting pay in advance fees" do
-        # total_usage = 1100, billed_pay_in_advance = 700
-        # ongoing_usage = 1100 - 700 = 400
-        expect { subject }
-          .to change(wallet.reload, :ongoing_usage_balance_cents).from(200).to(400)
-          .and change(wallet, :credits_ongoing_usage_balance).from(2.0).to(4.0)
-          .and change(wallet, :ongoing_balance_cents).from(800).to(600)
-          .and change(wallet, :credits_ongoing_balance).from(8.0).to(6.0)
-      end
-    end
-
-    context "when there is a progressive billing invoice" do
-      let(:invoice) { create(:invoice, customer:, organization:) }
-      let(:current_usage_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 1100, taxes_amount_cents: 0)
-      end
-      let(:progressive_billing_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 100, taxes_amount_cents: 10,
-          precise_coupons_amount_cents: 0)
-      end
-      let(:current_usage_fees) { [current_usage_fee] }
-      let(:progressive_billing_fees) { [progressive_billing_fee] }
-
-      it "deducts progressively_billed amount from the ongoing usage" do
-        # total_usage = 1100, billed_progressive = 110 (100 + 10 taxes)
-        # ongoing_usage = 1100 - 110 = 990
-        expect { subject }
-          .to change(wallet.reload, :ongoing_usage_balance_cents).from(200).to(990)
-          .and change(wallet, :credits_ongoing_usage_balance).from(2.0).to(9.9)
-          .and change(wallet, :ongoing_balance_cents).from(800).to(10)
-          .and change(wallet, :credits_ongoing_balance).from(8.0).to(0.1)
-      end
-    end
-
-    context "when there are draft invoices fees" do
-      let(:invoice) { create(:invoice, customer:, organization:) }
-      let(:current_usage_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 1000, taxes_amount_cents: 0)
-      end
-      let(:draft_invoice_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 100, taxes_amount_cents: 10,
-          precise_coupons_amount_cents: 10)
-      end
-      let(:current_usage_fees) { [current_usage_fee] }
-      let(:draft_invoices_fees) { [draft_invoice_fee] }
-
-      it "adds draft invoices amount to the ongoing usage" do
-        # total_usage = 1000, draft_invoices = 100 (amount) + 10 (taxes) - 10 (coupons) = 100
-        # ongoing_usage = 1000 + 100 = 1100
-        expect { subject }
-          .to change(wallet.reload, :ongoing_usage_balance_cents).from(200).to(1100)
-          .and change(wallet, :credits_ongoing_usage_balance).from(2.0).to(11.0)
-          .and change(wallet, :ongoing_balance_cents).from(800).to(-100)
-          .and change(wallet, :credits_ongoing_balance).from(8.0).to(-1.0)
+          .and change(wallet, :credits_ongoing_balance).from(4.0).to(-0.5)
       end
     end
 
     context "when recalculated ongoing balance is less than 0" do
-      let(:invoice) { create(:invoice, customer:, organization:) }
-      let(:current_usage_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 1100, taxes_amount_cents: 0)
-      end
-      let(:current_usage_fees) { [current_usage_fee] }
+      let(:ongoing_usage_amount_cents) { 1100 }
 
       before do
         allow(Wallets::Balance::UpdateOngoingService).to receive(:call).and_call_original
@@ -202,12 +84,7 @@ RSpec.describe Wallets::Balance::RefreshOngoingUsageService do
 
     context "when ongoing balance becomes positive after being depleted" do
       let(:depleted_ongoing_balance) { true }
-      let(:invoice) { create(:invoice, customer:, organization:) }
-      let(:current_usage_fee) do
-        create(:charge_fee, charge: first_charge, subscription: first_subscription,
-          organization:, invoice:, amount_cents: 500, taxes_amount_cents: 0)
-      end
-      let(:current_usage_fees) { [current_usage_fee] }
+      let(:ongoing_usage_amount_cents) { 500 }
 
       before do
         allow(Wallets::Balance::UpdateOngoingService).to receive(:call).and_call_original
@@ -218,6 +95,21 @@ RSpec.describe Wallets::Balance::RefreshOngoingUsageService do
 
         expect(Wallets::Balance::UpdateOngoingService).to have_received(:call)
           .with(wallet: wallet, update_params: hash_including(depleted_ongoing_balance: false), skip_single_wallet_update: false)
+      end
+    end
+
+    context "when skip_single_wallet_update is true" do
+      let(:skip_single_wallet_update) { true }
+
+      before do
+        allow(Wallets::Balance::UpdateOngoingService).to receive(:call).and_call_original
+      end
+
+      it "forwards the flag to the update service" do
+        subject
+
+        expect(Wallets::Balance::UpdateOngoingService).to have_received(:call)
+          .with(wallet: wallet, update_params: anything, skip_single_wallet_update: true)
       end
     end
   end


### PR DESCRIPTION
## Context

Lago consumes wallet credits through two paths that diverge for multi-wallet customers. Billing already cascades across wallets in priority order, but ongoing usage stopped at the first wallet, taking it negative instead of spilling onto the next. The negative ongoing balance is customer-visible (UI, API, threshold rules) and breaks the two-wallet (paid + free) setup.

Linear: https://linear.app/getlago/issue/ING-112

## Behavior

`Wallet B` = priority 1 (consumed first), `Wallet A` = priority 2. Ongoing balance per wallet after the given usage:

| Wallets (priority order)        | Usage | Before        | After                    |
|---------------------------------|-------|---------------|--------------------------|
| Single wallet, balance 50       | 30    | 20            | 20 (unchanged)           |
| Single wallet, balance 50       | 80    | −30           | −30 (unchanged)          |
| B 50 + A 150                    | 80    | B −30, A 150  | **B 0, A 120**           |
| B 50 + A 150                    | 250   | B −200, A 150 | B 0, **A −50**           |
| B 50 (threshold rule) + A 150   | 80    | B −30, A 150  | B −30, A 150 (unchanged) |

- **Single wallet** is unchanged: it still absorbs everything and may go negative.
- **Multiple wallets** now cascade in priority order -- a wallet fills to 0 before the next is touched (row 3, the headline case: matches what billing produces).
- When usage exceeds every wallet, the **last** wallet absorbs the overflow and goes negative (row 4) instead of the first -- nothing is silently dropped.
- A wallet with an **active threshold recurring rule** keeps today's behavior: it absorbs everything and goes negative so the rule can fire and refill it (row 5).

## Changes

- Add `Wallets::Balance::AllocateOngoingUsageByWalletsService`, mirroring the billing cascade (`Credits::AllocatePrepaidCreditsByWalletsService`): net usage per fee, distribute across active wallets in priority order, fill each to its balance, spill the overflow, and let the last applicable wallet go negative. An over-billed fee key reduces a per-currency budget the same way billing credits reduce the invoice total.
- A wallet with an active threshold-based recurring rule keeps the previous behavior (absorbs everything, may go negative) so the rule can fire and refill it.
- `RefreshWalletsService` runs the allocator once and feeds each wallet its precomputed amount. Because the cascade makes allocations interdependent, every refresh persists all wallets; the previous `target_wallet_ids` narrowing would leave non-target wallets stale.
- The old single-wallet assignment is replaced, which leaves `FindApplicableOnFeesService` and `BuildAllocationRulesService` without callers. They are deleted in https://github.com/getlago/lago-api/pull/5884 (~600 lines of pure deletion) to keep this one focused on the behavior change.

## Validation

The specs from this branch (they encode the expected cascade behavior) were run against `main` and against this branch -- same 46 examples:

| Codebase | Result |
|---|---|
| `main` (old allocation) | 46 examples, **10 failures** -- every multi-wallet cascade scenario |
| this branch | 46 examples, **0 failures** |

Per-scenario ongoing balances (each row is one failing-then-fixed spec):

| Scenario | On `main` | On this branch |
|---|---|---|
| B (50, priority 1) + A (150), usage 80 -- the ticket example | B **-30**, A 150 | B 0, A **120** |
| 4 wallets (10/20/30/40), each limited to 2 metrics, overlapping; usage 100 | W1 **-20**, W2 -10, W3 -10, W4 idle at 40 | W1 0, W2 -10, W3 -10, W4 **20** |
| 4 wallets, three limited to charge fees; charge usage 100 | W2 absorbs all: **-80**; W3, W4 idle | W2 0, W3 0, W4 **-10** |
| 4 unrestricted wallets; net usage 90 (10 already progressively billed) | W1 **-90**; W2, W3, W4 idle | cascades W2, W3, W4 -- all land at 0 |
| Wallet targeted to metric 1 (1000) + catch-all wallet; metric-1 usage 3000 | targeted **-2000**; catch-all untouched | targeted 0; catch-all absorbs the overflow (**-1000**) |
| Two wallets (20000 + 25000), usage 35000; billing deducts 20000 + 15000 | ongoing shows **35000 on wallet 1, 0 on wallet 2** -- diverges from billing | ongoing shows 20000 + 15000 -- **identical to what billing deducts** |

Preserved behavior passes on both codebases: single wallet going negative, threshold-rule wallets absorbing and refilling, and ongoing-balance alerts firing as the balance crosses into negative.

Edge cases pinned by the new allocator unit suite (the service does not exist on `main`, so no old-code column):

| Edge case | Behavior |
|---|---|
| Wallet with an active interval (non-threshold) recurring rule | cascades like a normal wallet -- only threshold rules absorb and refill |
| Threshold wallet that is not first in priority | higher-priority wallets fill first, then it absorbs the remainder and stops the cascade |
| Zero-balance wallet in the middle of the cascade | skipped, never forced negative |
| One metric over-billed by progressive billing (usage corrected down) | its excess offsets the other metrics, like billing credits offset the invoice |
| Fee already fully covered by progressive billing | nothing is allocated |
| Mixed-currency wallets | a fee is only absorbed by wallets in its currency |
| Fee targeting a wallet code that matches no wallet | allocated to no wallet, matching billing where no wallet covers it |
| Balance changed concurrently (stale in-memory value) | the cascade caps against the balance re-read from the database |
