### PR TITLE
test(payment-gated-subs): drop flag from specs

### DIFF
--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -753,44 +753,40 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         }
       end
 
-      context "when feature flag is enabled" do
-        before { organization.enable_feature_flag!(:payment_gated_subscriptions) }
+      it "creates subscription with activation rules and returns them" do
+        subject
 
-        it "creates subscription with activation rules and returns them" do
+        expect(response).to have_http_status(:ok)
+        expect(json[:subscription][:status]).to eq("pending")
+        expect(json[:subscription][:cancellation_reason]).to be_nil
+        expect(json[:subscription][:activated_at]).to be_nil
+        expect(json[:subscription][:activation_rules].size).to eq(1)
+        expect(json[:subscription][:activation_rules].first).to include(
+          lago_id: String,
+          type: "payment",
+          timeout_hours: 48,
+          status: "inactive",
+          expires_at: nil
+        )
+      end
+
+      context "when timeout_hours is omitted" do
+        let(:params) do
+          {
+            external_customer_id: customer.external_id,
+            plan_code: plan.code,
+            external_id: SecureRandom.uuid,
+            billing_time: "anniversary",
+            subscription_at:,
+            activation_rules: [{type: "payment"}]
+          }
+        end
+
+        it "persists rule with default timeout_hours of 0" do
           subject
 
           expect(response).to have_http_status(:ok)
-          expect(json[:subscription][:status]).to eq("pending")
-          expect(json[:subscription][:cancellation_reason]).to be_nil
-          expect(json[:subscription][:activated_at]).to be_nil
-          expect(json[:subscription][:activation_rules].size).to eq(1)
-          expect(json[:subscription][:activation_rules].first).to include(
-            lago_id: String,
-            type: "payment",
-            timeout_hours: 48,
-            status: "inactive",
-            expires_at: nil
-          )
-        end
-
-        context "when timeout_hours is omitted" do
-          let(:params) do
-            {
-              external_customer_id: customer.external_id,
-              plan_code: plan.code,
-              external_id: SecureRandom.uuid,
-              billing_time: "anniversary",
-              subscription_at:,
-              activation_rules: [{type: "payment"}]
-            }
-          end
-
-          it "persists rule with default timeout_hours of 0" do
-            subject
-
-            expect(response).to have_http_status(:ok)
-            expect(json[:subscription][:activation_rules].first[:timeout_hours]).to eq(0)
-          end
+          expect(json[:subscription][:activation_rules].first[:timeout_hours]).to eq(0)
         end
       end
 
@@ -1760,31 +1756,27 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
 
       before { create(:payment_method, customer:, organization:) }
 
-      context "when feature flag is enabled" do
-        before { organization.enable_feature_flag!(:payment_gated_subscriptions) }
+      it "persists and returns activation rules" do
+        subject
 
-        it "persists and returns activation rules" do
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:activation_rules].size).to eq(1)
+        expect(json[:subscription][:activation_rules].first).to include(
+          lago_id: String,
+          type: "payment",
+          timeout_hours: 24,
+          status: "inactive"
+        )
+      end
+
+      context "when timeout_hours is omitted" do
+        let(:update_params) { {activation_rules: [{type: "payment"}]} }
+
+        it "persists rule with default timeout_hours of 0" do
           subject
 
           expect(response).to have_http_status(:success)
-          expect(json[:subscription][:activation_rules].size).to eq(1)
-          expect(json[:subscription][:activation_rules].first).to include(
-            lago_id: String,
-            type: "payment",
-            timeout_hours: 24,
-            status: "inactive"
-          )
-        end
-
-        context "when timeout_hours is omitted" do
-          let(:update_params) { {activation_rules: [{type: "payment"}]} }
-
-          it "persists rule with default timeout_hours of 0" do
-            subject
-
-            expect(response).to have_http_status(:success)
-            expect(json[:subscription][:activation_rules].first[:timeout_hours]).to eq(0)
-          end
+          expect(json[:subscription][:activation_rules].first[:timeout_hours]).to eq(0)
         end
       end
 

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -98,7 +98,9 @@ RSpec.describe ::V1::SubscriptionSerializer do
           "current_billing_period_started_at" => "2024-05-01T00:00:00Z",
           "current_billing_period_ending_at" => "2024-05-31T23:59:59Z",
           "progressive_billing_disabled" => false,
-          "consolidate_invoice" => true
+          "consolidate_invoice" => true,
+          "activated_at" => subscription.activated_at.iso8601,
+          "activation_rules" => []
         )
 
         expect(result["subscription"]["customer"]["lago_id"]).to be_present
@@ -248,52 +250,39 @@ RSpec.describe ::V1::SubscriptionSerializer do
     end
   end
 
-  context "when payment_gated_subscriptions feature flag is enabled" do
-    let(:organization) { create(:organization, feature_flags: ["payment_gated_subscriptions"]) }
-    let(:activated_at) { Time.zone.parse("2026-04-13T10:00:00Z") }
+  context "with a canceled subscription" do
     let(:subscription) do
       create(
         :subscription,
-        organization:,
-        cancellation_reason: Subscription::CANCELLATION_REASONS[:payment_failed],
-        activated_at:
+        :canceled,
+        cancellation_reason: Subscription::CANCELLATION_REASONS[:payment_failed]
       )
     end
 
-    it "serializes cancellation_reason and activated_at" do
+    it "serializes the cancellation reason" do
       result = JSON.parse(serializer.to_json)
 
-      expect(result["subscription"]).to include(
-        "cancellation_reason" => Subscription::CANCELLATION_REASONS[:payment_failed],
-        "activated_at" => activated_at.iso8601
-      )
+      expect(result["subscription"]["cancellation_reason"])
+        .to eq(Subscription::CANCELLATION_REASONS[:payment_failed])
     end
+  end
 
-    context "when subscription does not have activation_rules" do
-      it "serializes activation_rules as an empty array" do
-        result = JSON.parse(serializer.to_json)
+  context "with activation rules" do
+    let(:activation_rule) { create(:subscription_activation_rule, subscription:) }
 
-        expect(result["subscription"]["activation_rules"]).to eq([])
-      end
-    end
+    before { activation_rule }
 
-    context "when subscription has activation_rules" do
-      let(:activation_rule) { create(:subscription_activation_rule, subscription:, organization:) }
+    it "serializes the activation rules" do
+      result = JSON.parse(serializer.to_json)
 
-      before { activation_rule }
-
-      it "serializes activation_rules" do
-        result = JSON.parse(serializer.to_json)
-
-        expect(result["subscription"]["activation_rules"]).to contain_exactly(
-          include(
-            "lago_id" => activation_rule.id,
-            "type" => Subscription::ActivationRule::TYPES[:payment],
-            "timeout_hours" => activation_rule.timeout_hours,
-            "status" => activation_rule.status
-          )
+      expect(result["subscription"]["activation_rules"]).to contain_exactly(
+        include(
+          "lago_id" => activation_rule.id,
+          "type" => Subscription::ActivationRule::TYPES[:payment],
+          "timeout_hours" => activation_rule.timeout_hours,
+          "status" => activation_rule.status
         )
-      end
+      )
     end
   end
 end


### PR DESCRIPTION
## Context

Payment-gated subscriptions no longer rely on the payment_gated_subscriptions feature flag in application code — activation-rules behavior is driven entirely by the request payload. The specs were the only remaining place enabling the flag, so they had drifted out of date.

## Description

Remove the feature-flag setup from the subscriptions controller and subscription serializer specs: drop the "when feature flag is enabled" wrappers and the enable_feature_flag! / feature_flags setup, keeping the existing assertions. Restructure the serializer specs so each context reflects the subscription state it exercises — a canceled subscription for cancellation_reason and a subscription with activation rules for the rules array — and assert the always-present activated_at and empty activation_rules fields in the standard payload test.