### PR TITLE
fix(webhooks): Retry webhook on S3 rate limit error

### DIFF
--- a/app/jobs/send_http_webhook_job.rb
+++ b/app/jobs/send_http_webhook_job.rb
@@ -14,6 +14,9 @@ class SendHttpWebhookJob < ApplicationJob
     Rails.logger.warn("Discarding #{job.class.name} after 3 retries due to: #{error.message}")
   end
 
+  # Retry when S3 throttles queries
+  retry_on "Aws::S3::Errors::SlowDown", wait: :polynomially_longer, attempts: 6
+
   def perform(webhook)
     Webhooks::SendHttpService.call(webhook:)
   end

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -13,6 +13,9 @@ class SendWebhookJob < ApplicationJob
 
   retry_on ActiveJob::DeserializationError, wait: :polynomially_longer, attempts: 6
 
+  # Retry when S3 throttles queries.
+  retry_on "Aws::S3::Errors::SlowDown", wait: :polynomially_longer, attempts: 6
+
   WEBHOOK_SERVICES = {
     "alert.triggered" => Webhooks::UsageMonitoring::AlertTriggeredService,
     "billable_metric.created" => Webhooks::BillableMetrics::CreatedService,

--- a/spec/services/webhooks/send_http_service_spec.rb
+++ b/spec/services/webhooks/send_http_service_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "aws-sdk-s3"
 
 RSpec.describe Webhooks::SendHttpService do
   subject(:service) { described_class.new(webhook:) }
@@ -107,6 +108,28 @@ RSpec.describe Webhooks::SendHttpService do
           expect(SendHttpWebhookJob).not_to have_received(:set)
         end
       end
+    end
+  end
+
+  context "when S3 throttles reading the stored payload" do
+    let(:webhook) { create(:webhook, :retrying, retries: 1) }
+    let(:slow_down_error) { Aws::S3::Errors::SlowDown.new(nil, "Please reduce your request rate.") }
+
+    before do
+      allow(webhook).to receive(:payload).and_raise(slow_down_error)
+      allow(SendHttpWebhookJob).to receive(:set)
+    end
+
+    it "lets the error propagate for the job to retry" do
+      expect { service.call }.to raise_error(Aws::S3::Errors::SlowDown)
+    end
+
+    it "does not count the S3 error against the webhook retry counter" do
+      expect { service.call }.to raise_error(Aws::S3::Errors::SlowDown)
+
+      expect(webhook.retries).to eq(1)
+      expect(webhook).to be_retrying
+      expect(SendHttpWebhookJob).not_to have_received(:set)
     end
   end
 end


### PR DESCRIPTION
- Add an automatic retry on Webhooks because of S3 rate limit errors