### PR TITLE
fix(jobs): Add missing `unique` guard to jobs

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -19,6 +19,15 @@ jobs:
           POSTGRES_DB: lago
           POSTGRES_USER: lago
           POSTGRES_PASSWORD: lago
+      redis:
+        image: redis
+        ports:
+          - "6379:6379"
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       RAILS_ENV: test
       DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"

--- a/app/jobs/clock/create_interval_wallet_transactions_job.rb
+++ b/app/jobs/clock/create_interval_wallet_transactions_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class CreateIntervalWalletTransactionsJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       Wallets::CreateIntervalWalletTransactionsService.call
     end

--- a/app/jobs/clock/create_interval_wallet_transactions_job.rb
+++ b/app/jobs/clock/create_interval_wallet_transactions_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class CreateIntervalWalletTransactionsJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       Wallets::CreateIntervalWalletTransactionsService.call

--- a/app/jobs/clock/expire_incomplete_subscriptions_job.rb
+++ b/app/jobs/clock/expire_incomplete_subscriptions_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class ExpireIncompleteSubscriptionsJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       Subscription.expirable.find_each do |subscription|

--- a/app/jobs/clock/expire_incomplete_subscriptions_job.rb
+++ b/app/jobs/clock/expire_incomplete_subscriptions_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class ExpireIncompleteSubscriptionsJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       Subscription.expirable.find_each do |subscription|
         Subscriptions::ActivationRules::ExpireIncompleteJob.perform_later(subscription)

--- a/app/jobs/clock/free_trial_subscriptions_biller_job.rb
+++ b/app/jobs/clock/free_trial_subscriptions_biller_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class FreeTrialSubscriptionsBillerJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       Subscriptions::FreeTrialBillingService.call
     end

--- a/app/jobs/clock/free_trial_subscriptions_biller_job.rb
+++ b/app/jobs/clock/free_trial_subscriptions_biller_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class FreeTrialSubscriptionsBillerJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       Subscriptions::FreeTrialBillingService.call

--- a/app/jobs/clock/inbound_webhooks_cleanup_job.rb
+++ b/app/jobs/clock/inbound_webhooks_cleanup_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class InboundWebhooksCleanupJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       InboundWebhook.where("updated_at < ?", 90.days.ago).in_batches.delete_all
     end

--- a/app/jobs/clock/inbound_webhooks_retry_job.rb
+++ b/app/jobs/clock/inbound_webhooks_retry_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class InboundWebhooksRetryJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       InboundWebhook.retriable.find_each do |inbound_webhook|
         InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)

--- a/app/jobs/clock/inbound_webhooks_retry_job.rb
+++ b/app/jobs/clock/inbound_webhooks_retry_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class InboundWebhooksRetryJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       InboundWebhook.retriable.find_each do |inbound_webhook|

--- a/app/jobs/clock/retry_failed_invoices_job.rb
+++ b/app/jobs/clock/retry_failed_invoices_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class RetryFailedInvoicesJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       Invoice
         .failed

--- a/app/jobs/clock/retry_failed_invoices_job.rb
+++ b/app/jobs/clock/retry_failed_invoices_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class RetryFailedInvoicesJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       Invoice

--- a/app/jobs/clock/retry_generating_subscription_invoices_job.rb
+++ b/app/jobs/clock/retry_generating_subscription_invoices_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class RetryGeneratingSubscriptionInvoicesJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     THRESHOLD = -> { 1.day.ago }
 

--- a/app/jobs/clock/retry_generating_subscription_invoices_job.rb
+++ b/app/jobs/clock/retry_generating_subscription_invoices_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class RetryGeneratingSubscriptionInvoicesJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     THRESHOLD = -> { 1.day.ago }
 
     def perform

--- a/app/jobs/clock/subscriptions_biller_job.rb
+++ b/app/jobs/clock/subscriptions_biller_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class SubscriptionsBillerJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       Organization.find_each do |organization|

--- a/app/jobs/clock/subscriptions_biller_job.rb
+++ b/app/jobs/clock/subscriptions_biller_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class SubscriptionsBillerJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       Organization.find_each do |organization|
         Subscriptions::OrganizationBillingJob.perform_later(organization:)

--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class SubscriptionsToBeTerminatedJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       now = Time.current

--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class SubscriptionsToBeTerminatedJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       now = Time.current
       today = now.to_date

--- a/app/jobs/clock/terminate_coupons_job.rb
+++ b/app/jobs/clock/terminate_coupons_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class TerminateCouponsJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       Coupons::TerminateService.terminate_all_expired
     end

--- a/app/jobs/clock/terminate_coupons_job.rb
+++ b/app/jobs/clock/terminate_coupons_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class TerminateCouponsJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       Coupons::TerminateService.terminate_all_expired

--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class TerminateEndedSubscriptionsJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       Subscription

--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class TerminateEndedSubscriptionsJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       Subscription
         .joins(customer: :billing_entity)

--- a/app/jobs/clock/terminate_recurring_transaction_rules_job.rb
+++ b/app/jobs/clock/terminate_recurring_transaction_rules_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class TerminateRecurringTransactionRulesJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       RecurringTransactionRule.eligible_for_termination.find_each do |recurring_transaction_rule|
         Wallets::RecurringTransactionRules::TerminateService.call(recurring_transaction_rule:)

--- a/app/jobs/clock/terminate_recurring_transaction_rules_job.rb
+++ b/app/jobs/clock/terminate_recurring_transaction_rules_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class TerminateRecurringTransactionRulesJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       RecurringTransactionRule.eligible_for_termination.find_each do |recurring_transaction_rule|

--- a/app/jobs/clock/terminate_wallets_job.rb
+++ b/app/jobs/clock/terminate_wallets_job.rb
@@ -2,7 +2,7 @@
 
 module Clock
   class TerminateWalletsJob < ClockJob
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
       Wallet.active.expired.find_each do |wallet|

--- a/app/jobs/clock/terminate_wallets_job.rb
+++ b/app/jobs/clock/terminate_wallets_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class TerminateWalletsJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     def perform
       Wallet.active.expired.find_each do |wallet|
         Wallets::TerminateService.call(wallet:)

--- a/app/jobs/clock/webhooks_cleanup_job.rb
+++ b/app/jobs/clock/webhooks_cleanup_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class WebhooksCleanupJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
     class_attribute :batch_size, default: 1_000 # rubocop:disable ThreadSafety/ClassAndModuleAttributes
     class_attribute :retention_period, default: 90.days # rubocop:disable ThreadSafety/ClassAndModuleAttributes
 

--- a/app/jobs/customers/vies_check_job.rb
+++ b/app/jobs/customers/vies_check_job.rb
@@ -12,6 +12,9 @@ module Customers
     # perform runs and holds a separate runtime lock during execution. Releasing the
     # enqueue lock before perform is what lets schedule_retry re-enqueue this job for
     # the same customer from inside perform without being dropped.
+    # The retry is scheduled with a delay (RETRY_DELAYS starts at 5 minutes), so by
+    # the time it runs the current job has finished and released the runtime lock,
+    # and the retry is not dropped by the runtime guard either.
     unique :until_and_while_executing, on_conflict: :log
 
     def perform(customer)

--- a/app/jobs/customers/vies_check_job.rb
+++ b/app/jobs/customers/vies_check_job.rb
@@ -7,6 +7,13 @@ module Customers
 
     queue_as :default
 
+    # until_and_while_executing takes the enqueue lock (keyed on the customer) so
+    # duplicate enqueues while one is pending are deduped, then releases it before
+    # perform runs and holds a separate runtime lock during execution. Releasing the
+    # enqueue lock before perform is what lets schedule_retry re-enqueue this job for
+    # the same customer from inside perform without being dropped.
+    unique :until_and_while_executing, on_conflict: :log
+
     def perform(customer)
       vies_check_result = Customers::ViesCheckService.call(customer:)
 

--- a/app/jobs/invoices/create_all_pay_in_advance_fixed_charges_job.rb
+++ b/app/jobs/invoices/create_all_pay_in_advance_fixed_charges_job.rb
@@ -13,6 +13,8 @@ module Invoices
       end
     end
 
+    unique :until_executed, on_conflict: :log
+
     def perform(plan, timestamp, fixed_charge = nil)
       subscriptions = plan.subscriptions.active
       if fixed_charge

--- a/app/jobs/payment_providers/gocardless/handle_event_job.rb
+++ b/app/jobs/payment_providers/gocardless/handle_event_job.rb
@@ -11,6 +11,8 @@ module PaymentProviders
         end
       end
 
+      unique :until_executed, on_conflict: :log
+
       def perform(organization: nil, payment_provider: nil, events_json: nil, event_json: nil)
         # NOTE: temporary keeps both events_json and event_json to avoid errors during the deployment
         if events_json.present?

--- a/app/jobs/taxes/update_all_eu_taxes_job.rb
+++ b/app/jobs/taxes/update_all_eu_taxes_job.rb
@@ -4,6 +4,8 @@ module Taxes
   class UpdateAllEuTaxesJob < ApplicationJob
     queue_as "default"
 
+    unique :until_executed, on_conflict: :log
+
     def perform
       Organization.where(eu_tax_management: true).find_each do |org|
         ::Taxes::UpdateOrganizationEuTaxesJob.perform_later(org)

--- a/spec/jobs/clock/create_interval_wallet_transactions_job_spec.rb
+++ b/spec/jobs/clock/create_interval_wallet_transactions_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 describe Clock::CreateIntervalWalletTransactionsJob, job: true do
   subject(:interval_wallet_transactions_job) { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/create_interval_wallet_transactions_job_spec.rb
+++ b/spec/jobs/clock/create_interval_wallet_transactions_job_spec.rb
@@ -5,6 +5,21 @@ require "rails_helper"
 describe Clock::CreateIntervalWalletTransactionsJob, job: true do
   subject(:interval_wallet_transactions_job) { described_class }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     before { allow(Wallets::CreateIntervalWalletTransactionsService).to receive(:call) }
 

--- a/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
@@ -7,19 +7,8 @@ describe Clock::ExpireIncompleteSubscriptionsJob, job: true do
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:, pay_in_advance: true) }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/expire_incomplete_subscriptions_job_spec.rb
@@ -7,6 +7,21 @@ describe Clock::ExpireIncompleteSubscriptionsJob, job: true do
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:, pay_in_advance: true) }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     let(:expirable_subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }
     let(:non_expirable_pending_subscription) { create(:subscription, :incomplete, customer:, organization:, plan:) }

--- a/spec/jobs/clock/free_trial_subscriptions_biller_job_spec.rb
+++ b/spec/jobs/clock/free_trial_subscriptions_biller_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 RSpec.describe Clock::FreeTrialSubscriptionsBillerJob do
   subject { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/free_trial_subscriptions_biller_job_spec.rb
+++ b/spec/jobs/clock/free_trial_subscriptions_biller_job_spec.rb
@@ -2,10 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe Taxes::UpdateAllEuTaxesJob do
-  subject { described_class.perform_now }
-
-  let(:organization) { create(:organization, eu_tax_management: true) }
+RSpec.describe Clock::FreeTrialSubscriptionsBillerJob do
+  subject { described_class }
 
   describe "unique job behavior" do
     around do |example|
@@ -23,10 +21,12 @@ RSpec.describe Taxes::UpdateAllEuTaxesJob do
   end
 
   describe ".perform" do
-    it "enqueues a job for organization with EU Tax Management" do
-      create(:organization, eu_tax_management: false)
+    before { allow(Subscriptions::FreeTrialBillingService).to receive(:call) }
 
-      expect { subject }.to have_enqueued_job(::Taxes::UpdateOrganizationEuTaxesJob).with(organization).exactly(:once)
+    it "calls Subscriptions::FreeTrialBillingService" do
+      described_class.perform_now
+
+      expect(Subscriptions::FreeTrialBillingService).to have_received(:call)
     end
   end
 end

--- a/spec/jobs/clock/inbound_webhooks_cleanup_job_spec.rb
+++ b/spec/jobs/clock/inbound_webhooks_cleanup_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 describe Clock::InboundWebhooksCleanupJob, job: true do
   subject(:inbound_webhooks_cleanup_job) { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/inbound_webhooks_cleanup_job_spec.rb
+++ b/spec/jobs/clock/inbound_webhooks_cleanup_job_spec.rb
@@ -5,6 +5,21 @@ require "rails_helper"
 describe Clock::InboundWebhooksCleanupJob, job: true do
   subject(:inbound_webhooks_cleanup_job) { described_class }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     it "removes all old inbound webhooks" do
       create(:inbound_webhook, updated_at: 90.days.ago)

--- a/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
+++ b/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 describe Clock::InboundWebhooksRetryJob, job: true do
   subject(:inbound_webhooks_retry_job) { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
+++ b/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
@@ -5,6 +5,21 @@ require "rails_helper"
 describe Clock::InboundWebhooksRetryJob, job: true do
   subject(:inbound_webhooks_retry_job) { described_class }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     before { inbound_webhook }
 

--- a/spec/jobs/clock/retry_failed_invoices_job_spec.rb
+++ b/spec/jobs/clock/retry_failed_invoices_job_spec.rb
@@ -5,6 +5,21 @@ require "rails_helper"
 describe Clock::RetryFailedInvoicesJob, job: true do
   subject { described_class }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     let(:customer) { create(:customer) }
     let(:failed_invoice) do

--- a/spec/jobs/clock/retry_failed_invoices_job_spec.rb
+++ b/spec/jobs/clock/retry_failed_invoices_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 describe Clock::RetryFailedInvoicesJob, job: true do
   subject { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
+++ b/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 describe Clock::RetryGeneratingSubscriptionInvoicesJob, job: true do
   subject { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
+++ b/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
@@ -5,6 +5,21 @@ require "rails_helper"
 describe Clock::RetryGeneratingSubscriptionInvoicesJob, job: true do
   subject { described_class }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     let(:old_generating_invoice) { create(:invoice, :generating, created_at: 5.days.ago) }
 

--- a/spec/jobs/clock/subscriptions_biller_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_biller_job_spec.rb
@@ -5,6 +5,21 @@ require "rails_helper"
 RSpec.describe Clock::SubscriptionsBillerJob do
   subject { described_class }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     let(:organization1) { create(:organization, api_keys: []) }
     let(:organization2) { create(:organization, api_keys: []) }

--- a/spec/jobs/clock/subscriptions_biller_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_biller_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 RSpec.describe Clock::SubscriptionsBillerJob do
   subject { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 describe Clock::SubscriptionsToBeTerminatedJob, job: true do
   subject { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -5,6 +5,21 @@ require "rails_helper"
 describe Clock::SubscriptionsToBeTerminatedJob, job: true do
   subject { described_class }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     let(:organization) { create(:organization) }
     let(:customer) { create(:customer, organization:) }

--- a/spec/jobs/clock/terminate_coupons_job_spec.rb
+++ b/spec/jobs/clock/terminate_coupons_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 RSpec.describe Clock::TerminateCouponsJob do
   subject { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/terminate_coupons_job_spec.rb
+++ b/spec/jobs/clock/terminate_coupons_job_spec.rb
@@ -2,10 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe Taxes::UpdateAllEuTaxesJob do
-  subject { described_class.perform_now }
-
-  let(:organization) { create(:organization, eu_tax_management: true) }
+RSpec.describe Clock::TerminateCouponsJob do
+  subject { described_class }
 
   describe "unique job behavior" do
     around do |example|
@@ -23,10 +21,12 @@ RSpec.describe Taxes::UpdateAllEuTaxesJob do
   end
 
   describe ".perform" do
-    it "enqueues a job for organization with EU Tax Management" do
-      create(:organization, eu_tax_management: false)
+    before { allow(Coupons::TerminateService).to receive(:terminate_all_expired) }
 
-      expect { subject }.to have_enqueued_job(::Taxes::UpdateOrganizationEuTaxesJob).with(organization).exactly(:once)
+    it "calls Coupons::TerminateService.terminate_all_expired" do
+      described_class.perform_now
+
+      expect(Coupons::TerminateService).to have_received(:terminate_all_expired)
     end
   end
 end

--- a/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
@@ -10,6 +10,21 @@ describe Clock::TerminateEndedSubscriptionsJob, job: true do
   let!(:subscription2) { create(:subscription, ending_at: ending_at + 1.year) }
   let!(:subscription3) { create(:subscription, ending_at: nil) }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe ".perform" do
     it "enqueues a TerminateEndedSubscriptionJob for matching subscriptions" do
       current_date = Time.current + 2.months

--- a/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
@@ -10,19 +10,8 @@ describe Clock::TerminateEndedSubscriptionsJob, job: true do
   let!(:subscription2) { create(:subscription, ending_at: ending_at + 1.year) }
   let!(:subscription3) { create(:subscription, ending_at: nil) }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do

--- a/spec/jobs/clock/terminate_recurring_transaction_rules_job_spec.rb
+++ b/spec/jobs/clock/terminate_recurring_transaction_rules_job_spec.rb
@@ -3,6 +3,21 @@
 require "rails_helper"
 
 describe Clock::TerminateRecurringTransactionRulesJob, job: true do
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   let(:wallet) { create(:wallet) }
   let(:to_expire_rule) do
     create(

--- a/spec/jobs/clock/terminate_recurring_transaction_rules_job_spec.rb
+++ b/spec/jobs/clock/terminate_recurring_transaction_rules_job_spec.rb
@@ -3,19 +3,8 @@
 require "rails_helper"
 
 describe Clock::TerminateRecurringTransactionRulesJob, job: true do
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   let(:wallet) { create(:wallet) }

--- a/spec/jobs/clock/terminate_wallets_job_spec.rb
+++ b/spec/jobs/clock/terminate_wallets_job_spec.rb
@@ -3,6 +3,21 @@
 require "rails_helper"
 
 describe Clock::TerminateWalletsJob, job: true do
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   let(:to_expire_wallet) do
     create(
       :wallet,

--- a/spec/jobs/clock/terminate_wallets_job_spec.rb
+++ b/spec/jobs/clock/terminate_wallets_job_spec.rb
@@ -3,19 +3,8 @@
 require "rails_helper"
 
 describe Clock::TerminateWalletsJob, job: true do
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   let(:to_expire_wallet) do

--- a/spec/jobs/clock/webhooks_cleanup_job_spec.rb
+++ b/spec/jobs/clock/webhooks_cleanup_job_spec.rb
@@ -5,6 +5,21 @@ require "rails_helper"
 describe Clock::WebhooksCleanupJob do
   subject(:webhooks_cleanup_job) { described_class }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later
+        described_class.perform_later
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   def with_batch_size(size)
     previous = described_class.batch_size
     described_class.batch_size = size

--- a/spec/jobs/clock/webhooks_cleanup_job_spec.rb
+++ b/spec/jobs/clock/webhooks_cleanup_job_spec.rb
@@ -5,19 +5,8 @@ require "rails_helper"
 describe Clock::WebhooksCleanupJob do
   subject(:webhooks_cleanup_job) { described_class }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   def with_batch_size(size)

--- a/spec/jobs/customers/vies_check_job_spec.rb
+++ b/spec/jobs/customers/vies_check_job_spec.rb
@@ -18,19 +18,8 @@ RSpec.describe Customers::ViesCheckJob do
     allow_any_instance_of(Valvat).to receive(:exists?).and_return(vies_response) # rubocop:disable RSpec/AnyInstance
   end
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later(customer)
-        described_class.perform_later(customer)
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [customer] }
   end
 
   it "calls the ViesCheckService" do

--- a/spec/jobs/customers/vies_check_job_spec.rb
+++ b/spec/jobs/customers/vies_check_job_spec.rb
@@ -116,4 +116,40 @@ RSpec.describe Customers::ViesCheckJob do
         .not_to have_enqueued_job(Invoices::FinalizePendingViesInvoiceJob)
     end
   end
+
+  # Regression guard for the uniqueness strategy. The job re-enqueues itself for
+  # the same customer from inside perform (schedule_retry). With
+  # `until_and_while_executing` the enqueue lock is released before perform runs,
+  # so the self-reschedule is allowed. If the strategy is switched to
+  # `until_executed`, the enqueue lock is still held during perform and the retry
+  # is dropped, which this test detects.
+  describe "self-reschedule under the real uniqueness lock" do
+    let(:customer) { create(:customer, tax_identification_number: "IE6388047V") }
+
+    around do |example|
+      # Run against the real lock manager (the suite defaults to test_mode! where
+      # locks are no-ops) so the enqueue lock is actually taken and released.
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    before do
+      # Force the VIES check to fail so schedule_retry fires with a delayed retry.
+      allow_any_instance_of(Valvat).to receive(:exists?).and_raise(Valvat::Timeout.new("Timeout", "dummy")) # rubocop:disable RSpec/AnyInstance
+    end
+
+    it "re-enqueues the retry for the same customer from inside perform" do
+      # Running only the ViesCheckJob due now executes the initial job (releasing
+      # the enqueue lock in before_perform) while leaving the delayed retry
+      # enqueued. `only:` also skips the customer.vies_check webhook job the
+      # service enqueues, and `at:` avoids running (and recursing on) the retry,
+      # which is scheduled with a wait of at least 5 minutes.
+      expect do
+        perform_enqueued_jobs(only: described_class, at: Time.current) do
+          described_class.perform_later(customer)
+        end
+      end.to have_enqueued_job(described_class).with(customer)
+    end
+  end
 end

--- a/spec/jobs/customers/vies_check_job_spec.rb
+++ b/spec/jobs/customers/vies_check_job_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe Customers::ViesCheckJob do
     allow_any_instance_of(Valvat).to receive(:exists?).and_return(vies_response) # rubocop:disable RSpec/AnyInstance
   end
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later(customer)
+        described_class.perform_later(customer)
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   it "calls the ViesCheckService" do
     allow(Customers::ViesCheckService).to receive(:call).and_call_original
 

--- a/spec/jobs/invoices/create_all_pay_in_advance_fixed_charges_job_spec.rb
+++ b/spec/jobs/invoices/create_all_pay_in_advance_fixed_charges_job_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe Invoices::CreateAllPayInAdvanceFixedChargesJob do
   let(:timestamp) { Time.current.to_i }
   let(:fixed_charge) { nil }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later(plan, timestamp)
+        described_class.perform_later(plan, timestamp)
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   describe "#perform" do
     let(:subscription) { create(:subscription, :active, plan:) }
     let(:pending_subscription) { create(:subscription, :pending, plan:) }

--- a/spec/jobs/invoices/create_all_pay_in_advance_fixed_charges_job_spec.rb
+++ b/spec/jobs/invoices/create_all_pay_in_advance_fixed_charges_job_spec.rb
@@ -10,19 +10,8 @@ RSpec.describe Invoices::CreateAllPayInAdvanceFixedChargesJob do
   let(:timestamp) { Time.current.to_i }
   let(:fixed_charge) { nil }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later(plan, timestamp)
-        described_class.perform_later(plan, timestamp)
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [plan, timestamp] }
   end
 
   describe "#perform" do

--- a/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
@@ -17,19 +17,8 @@ RSpec.describe PaymentProviders::Gocardless::HandleEventJob do
 
   let(:service_result) { BaseService::Result.new }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later(payment_provider:, event_json:)
-        described_class.perform_later(payment_provider:, event_json:)
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [{payment_provider:, event_json:}] }
   end
 
   it "delegate to the event service" do

--- a/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe PaymentProviders::Gocardless::HandleEventJob do
 
   let(:service_result) { BaseService::Result.new }
 
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later(payment_provider:, event_json:)
+        described_class.perform_later(payment_provider:, event_json:)
+      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+    end
+  end
+
   it "delegate to the event service" do
     allow(PaymentProviders::Gocardless::HandleEventService).to receive(:call)
       .with(payment_provider:, event_json:)

--- a/spec/jobs/taxes/update_all_eu_taxes_job_spec.rb
+++ b/spec/jobs/taxes/update_all_eu_taxes_job_spec.rb
@@ -7,19 +7,8 @@ RSpec.describe Taxes::UpdateAllEuTaxesJob do
 
   let(:organization) { create(:organization, eu_tax_management: true) }
 
-  describe "unique job behavior" do
-    around do |example|
-      ActiveJob::Uniqueness.reset_manager!
-      example.run
-      ActiveJob::Uniqueness.test_mode!
-    end
-
-    it "does not enqueue duplicate jobs" do
-      expect do
-        described_class.perform_later
-        described_class.perform_later
-      end.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
-    end
+  it_behaves_like "a unique job" do
+    let(:job_args) { [] }
   end
 
   describe ".perform" do


### PR DESCRIPTION
## Context

Clock jobs are scheduled by Clockwork on a fixed cadence and enqueued with `perform_later`. When the worker fleet is saturated, the clock queue drains slower than Clockwork enqueues, so copies of the same clock job stack up. Each copy of a fan-out job re-runs its full scan and enqueues one child job per record, so N stacked copies over M records produce up to N×M child enqueues. This can grow the Sidekiq queue by a very large factor. 14 of the 28 clock jobs already guarded against this with the `activejob-uniqueness` macro; the rest did not.

## Description

This adds `unique :until_executed, on_conflict: :log` to the 14 clock jobs and 3 event-triggered fan-out jobs that were missing it, matching the pattern already used across the codebase (for example `Clock::ActivateSubscriptionsJob`). The macro holds a Redis lock from enqueue until the job finishes, so a duplicate enqueue for the same key is dropped (and logged) while a copy is still pending or running.

The 12 clock fan-out drivers set `lock_ttl: 4.hours`. The default TTL (1 hour) is close to the hourly cadence of these jobs, so during a multi-hour worker backlog the enqueue lock can expire right as the next Clockwork tick fires, and a second copy still stacks up. A 4-hour TTL caps accumulation to one pending copy across a typical backlog window, and stays well under the 12 hours used by the heavy child jobs. The 2 daily cleanup jobs (`Clock::WebhooksCleanupJob`, `Clock::InboundWebhooksCleanupJob`) and the 3 event-triggered jobs keep the 1-hour default.

`Customers::ViesCheckJob` is the exception. It re-enqueues itself for the same customer from inside `perform` (the VIES retry backoff), so `until_executed` would keep the enqueue lock held during `perform` and drop the retry. It uses `until_and_while_executing` instead: the enqueue lock is released before `perform` runs (so the reschedule is allowed), while a separate runtime lock prevents two checks for the same customer from running at once. Because the retry is scheduled with a delay (at least 5 minutes), the original job has released the runtime lock by the time the retry runs.

Each job gets a duplicate-enqueue test through the existing `shared_examples "a unique job"`, and `ViesCheckJob` gets a regression test that exercises the full enqueue-to-perform lifecycle and fails if the strategy is switched back to `until_executed`.

Fixes LAGO-1673.
