### PR TITLE
fix(invoices): Skip provider taxes without data

### DIFF
--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -12,7 +12,7 @@ module Invoices
     def call
       if should_apply_fee_taxes?
         invoice.fees.each do |fee|
-          if provider_taxes && customer_provider_taxation? && invoice.should_apply_provider_tax?
+          if should_apply_provider_taxes?
             Fees::ApplyProviderTaxesService.call!(fee:, fee_taxes: fee_taxes(fee))
           else
             Fees::ApplyTaxesService.call!(fee:)
@@ -29,7 +29,7 @@ module Invoices
         invoice.fees_amount_cents - invoice.progressive_billing_credit_amount_cents - invoice.coupons_amount_cents
       )
 
-      if customer_provider_taxation? && invoice.should_apply_provider_tax?
+      if should_apply_provider_taxes?
         Invoices::ApplyProviderTaxesService.call!(invoice:, provider_taxes:)
       else
         Invoices::ApplyTaxesService.call!(invoice:)
@@ -49,6 +49,10 @@ module Invoices
     private
 
     attr_reader :invoice, :provider_taxes
+
+    def should_apply_provider_taxes?
+      provider_taxes && customer_provider_taxation? && invoice.should_apply_provider_tax?
+    end
 
     def customer_provider_taxation?
       @customer_provider_taxation ||= invoice.customer.tax_customer

--- a/spec/services/invoices/build_regeneration_preview_service_spec.rb
+++ b/spec/services/invoices/build_regeneration_preview_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Invoices::BuildRegenerationPreviewService do
 
     before do
       allow(Fees::ApplyTaxesService).to receive(:call!).and_call_original
+      allow(Invoices::ComputeAmountsFromFees).to receive(:call).and_call_original
 
       invoice_subscription
       fee
@@ -47,6 +48,30 @@ RSpec.describe Invoices::BuildRegenerationPreviewService do
       preview_service.call
 
       expect(Fees::ApplyTaxesService).to have_received(:call!).at_least(:once).with(fee:)
+    end
+
+    it "does not apply provider taxes" do
+      preview_service.call
+
+      expect(Invoices::ComputeAmountsFromFees).to have_received(:call).with(
+        invoice: be_a(Invoice),
+        provider_taxes: nil
+      )
+    end
+
+    context "when the customer has a tax customer" do
+      let(:integration) { create(:anrok_integration, organization:) }
+
+      before do
+        create(:anrok_customer, integration:, customer:)
+        allow(Invoices::ApplyProviderTaxesService).to receive(:call!)
+      end
+
+      it "does not apply provider taxes" do
+        preview_service.call
+
+        expect(Invoices::ApplyProviderTaxesService).not_to have_received(:call!)
+      end
     end
 
     context "with multiple fees" do

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -160,5 +160,22 @@ RSpec.describe Invoices::ComputeAmountsFromFees do
       expect(invoice.taxes_rate).to eq(80)
       expect(invoice.total_amount_cents).to eq(272)
     end
+
+    context "when provider taxes are not provided" do
+      subject(:compute_amounts) { described_class.new(invoice:, provider_taxes: nil) }
+
+      before do
+        allow(invoice).to receive(:should_apply_provider_tax?).and_return(true)
+        allow(Invoices::ApplyProviderTaxesService).to receive(:call!)
+        allow(Invoices::ApplyTaxesService).to receive(:call!).and_call_original
+      end
+
+      it "applies regular taxes without fetching provider taxes" do
+        compute_amounts.call
+
+        expect(Invoices::ApplyProviderTaxesService).not_to have_received(:call!)
+        expect(Invoices::ApplyTaxesService).to have_received(:call!).with(invoice:)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Regeneration previews should avoid external provider tax calls because they operate on duplicated, non-provider-backed invoices. The previous computation path still reached provider tax application for tax-provider customers and could fail when the provider invoice id was absent.

## Description

Use the presence of provider tax data as the condition for applying provider taxes in invoice amount computation. This lets preview regeneration pass nil provider taxes and fall back to regular tax computation while preserving the provider tax path when data is supplied.

Fixes API-2JD
