### PR TITLE
feat(purchase_order_number) Change hubspot object to include PO number and invoice url

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
@@ -149,6 +149,12 @@ module Integrations
 
             output
           end
+
+          def invoice_url
+            url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+
+            URI.join(url, "/#{invoice.customer.organization.slug}/customer/#{invoice.customer.id}/", "invoice/#{invoice.id}/overview").to_s
+          end
         end
       end
     end

--- a/app/services/integrations/aggregator/invoices/payloads/hubspot.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/hubspot.rb
@@ -17,6 +17,7 @@ module Integrations
                 "properties" => {
                   "lago_invoice_id" => invoice.id,
                   "lago_invoice_number" => invoice.number,
+                  "lago_invoice_purchase_order_number" => invoice.purchase_order_number,
                   "lago_invoice_issuing_date" => formatted_date(invoice.issuing_date),
                   "lago_invoice_payment_due_date" => formatted_date(invoice.payment_due_date),
                   "lago_invoice_payment_overdue" => invoice.payment_overdue,
@@ -27,7 +28,8 @@ module Integrations
                   "lago_invoice_total_amount" => total_amount,
                   "lago_invoice_total_due_amount" => total_due_amount,
                   "lago_invoice_subtotal_excluding_taxes" => subtotal_excluding_taxes,
-                  "lago_invoice_file_url" => invoice.file_url
+                  "lago_invoice_file_url" => invoice.file_url,
+                  "lago_invoice_url" => invoice_url
                 }
               }
             }
@@ -45,6 +47,7 @@ module Integrations
                 "properties" => {
                   "lago_invoice_id" => invoice.id,
                   "lago_invoice_number" => invoice.number,
+                  "lago_invoice_purchase_order_number" => invoice.purchase_order_number,
                   "lago_invoice_issuing_date" => formatted_date(invoice.issuing_date),
                   "lago_invoice_payment_due_date" => formatted_date(invoice.payment_due_date),
                   "lago_invoice_payment_overdue" => invoice.payment_overdue,
@@ -55,7 +58,8 @@ module Integrations
                   "lago_invoice_total_amount" => total_amount,
                   "lago_invoice_total_due_amount" => total_due_amount,
                   "lago_invoice_subtotal_excluding_taxes" => subtotal_excluding_taxes,
-                  "lago_invoice_file_url" => invoice.file_url
+                  "lago_invoice_file_url" => invoice.file_url,
+                  "lago_invoice_url" => invoice_url
                 }
               }
             }

--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -87,12 +87,6 @@ module Integrations
             }
           end
 
-          def invoice_url
-            url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
-
-            URI.join(url, "/#{invoice.customer.organization.slug}/customer/#{invoice.customer.id}/", "invoice/#{invoice.id}/overview").to_s
-          end
-
           def due_date
             invoice.payment_due_date&.strftime("%-m/%-d/%Y")
           end

--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -9,6 +9,12 @@ module Integrations
             super
           end
 
+          def body
+            super.map do |invoice_payload|
+              invoice_payload.merge("reference" => invoice.purchase_order_number)
+            end
+          end
+
           def item(fee)
             base_item = super
             base_item["item_code"] = base_item.delete("external_id")

--- a/app/services/integrations/hubspot/invoices/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/invoices/deploy_object_service.rb
@@ -4,7 +4,7 @@ module Integrations
   module Hubspot
     module Invoices
       class DeployObjectService < Integrations::Aggregator::BaseService
-        VERSION = 1
+        VERSION = 2
 
         def action_path
           "v1/hubspot/object"

--- a/app/services/integrations/hubspot/invoices/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/invoices/deploy_object_service.rb
@@ -84,6 +84,13 @@ module Integrations
                 searchableInGlobalSearch: true
               },
               {
+                name: "lago_invoice_purchase_order_number",
+                label: "Lago Purchase Order Number",
+                type: "string",
+                fieldType: "text",
+                searchableInGlobalSearch: true
+              },
+              {
                 name: "lago_invoice_issuing_date",
                 label: "Lago Invoice Issuing Date",
                 type: "date",

--- a/app/services/integrations/hubspot/invoices/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/invoices/deploy_object_service.rb
@@ -4,7 +4,7 @@ module Integrations
   module Hubspot
     module Invoices
       class DeployObjectService < Integrations::Aggregator::BaseService
-        VERSION = 2
+        VERSION = 3
 
         def action_path
           "v1/hubspot/object"

--- a/app/services/integrations/hubspot/invoices/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/invoices/deploy_object_service.rb
@@ -160,6 +160,12 @@ module Integrations
                 label: "Lago Invoice File URL",
                 type: "string",
                 fieldType: "file"
+              },
+              {
+                name: "lago_invoice_url",
+                label: "Lago Invoice URL",
+                type: "string",
+                fieldType: "text"
               }
             ],
             associatedObjects: %w[COMPANY CONTACT]

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
   let(:invoice_file_url) { invoice.file_url }
   let(:file_url) { Faker::Internet.url }
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
+  let(:purchase_order_number) { "PO-123" }
+  let(:invoice_url_path) { "/#{organization.slug}/customer/#{customer.id}/invoice/#{invoice.id}/overview" }
 
   let(:invoice) do
     create(
@@ -25,7 +27,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
       coupons_amount_cents: 2000,
       prepaid_credit_amount_cents: 4000,
       credit_notes_amount_cents: 6000,
-      taxes_amount_cents: 8000
+      taxes_amount_cents: 8000,
+      purchase_order_number:
     )
   end
 
@@ -155,6 +158,22 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
               expect(integration_resource.syncable_id).to eq(invoice.id)
               expect(integration_resource.syncable_type).to eq("Invoice")
               expect(integration_resource.resource_type).to eq("invoice")
+            end
+
+            it "sends the invoice properties" do
+              service_call
+
+              expect(lago_client).to have_received(:post_with_response).with(
+                hash_including(
+                  "input" => hash_including(
+                    "properties" => hash_including(
+                      "lago_invoice_purchase_order_number" => purchase_order_number,
+                      "lago_invoice_url" => a_string_ending_with(invoice_url_path)
+                    )
+                  )
+                ),
+                headers
+              )
             end
 
             it_behaves_like "throttles!", :hubspot

--- a/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
   let(:invoice_file_url) { invoice.file_url }
   let(:file_url) { Faker::Internet.url }
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
+  let(:purchase_order_number) { "PO-123" }
+  let(:invoice_url_path) { "/#{organization.slug}/customer/#{customer.id}/invoice/#{invoice.id}/overview" }
 
   let(:invoice) do
     create(
@@ -25,7 +27,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
       coupons_amount_cents: 2000,
       prepaid_credit_amount_cents: 4000,
       credit_notes_amount_cents: 6000,
-      taxes_amount_cents: 8000
+      taxes_amount_cents: 8000,
+      purchase_order_number:
     )
   end
 
@@ -111,6 +114,22 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
 
             expect(result).to be_success
             expect(result.external_id).to eq("123456789")
+          end
+
+          it "sends the invoice properties" do
+            service_call
+
+            expect(lago_client).to have_received(:put_with_response).with(
+              hash_including(
+                "input" => hash_including(
+                  "properties" => hash_including(
+                    "lago_invoice_purchase_order_number" => purchase_order_number,
+                    "lago_invoice_url" => a_string_ending_with(invoice_url_path)
+                  )
+                )
+              ),
+              headers
+            )
           end
 
           it_behaves_like "throttles!", :hubspot

--- a/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
           "properties" => {
             "lago_invoice_id" => invoice.id,
             "lago_invoice_number" => invoice.number,
+            "lago_invoice_purchase_order_number" => invoice.purchase_order_number,
             "lago_invoice_issuing_date" => invoice.issuing_date.strftime("%Y-%m-%d"),
             "lago_invoice_payment_due_date" => invoice.payment_due_date.strftime("%Y-%m-%d"),
             "lago_invoice_payment_overdue" => invoice.payment_overdue,
@@ -58,7 +59,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
             "lago_invoice_total_amount" => invoice.total_amount_cents / 100.0,
             "lago_invoice_total_due_amount" => invoice.total_due_amount_cents / 100.0,
             "lago_invoice_subtotal_excluding_taxes" => invoice.sub_total_including_taxes_amount_cents / 100.0,
-            "lago_invoice_file_url" => invoice.file_url
+            "lago_invoice_file_url" => invoice.file_url,
+            "lago_invoice_url" => invoice_url
           }
         }
       }
@@ -88,6 +90,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
           "properties" => {
             "lago_invoice_id" => invoice.id,
             "lago_invoice_number" => invoice.number,
+            "lago_invoice_purchase_order_number" => invoice.purchase_order_number,
             "lago_invoice_issuing_date" => invoice.issuing_date.strftime("%Y-%m-%d"),
             "lago_invoice_payment_due_date" => invoice.payment_due_date.strftime("%Y-%m-%d"),
             "lago_invoice_payment_overdue" => invoice.payment_overdue,
@@ -98,7 +101,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
             "lago_invoice_total_amount" => invoice.total_amount_cents / 100.0,
             "lago_invoice_total_due_amount" => invoice.total_due_amount_cents / 100.0,
             "lago_invoice_subtotal_excluding_taxes" => invoice.sub_total_including_taxes_amount_cents / 100.0,
-            "lago_invoice_file_url" => invoice.file_url
+            "lago_invoice_file_url" => invoice.file_url,
+            "lago_invoice_url" => invoice_url
           }
         }
       }

--- a/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }
   let(:file_url) { Faker::Internet.url }
+  let(:invoice_url) do
+    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+
+    URI.join(url, "/#{customer.organization.slug}/customer/#{customer.id}/", "invoice/#{invoice.id}/overview").to_s
+  end
 
   let(:invoice) do
     create(

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -7,6 +7,24 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
     subject(:payload) { described_class.new(integration_customer:, invoice:).body }
 
     it_behaves_like "an integration payload", :xero do
+      let(:invoice) do
+        invoice = create(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity:,
+          coupons_amount_cents: 200,
+          prepaid_credit_amount_cents: 300,
+          progressive_billing_credit_amount_cents: 100,
+          credit_notes_amount_cents: 500,
+          taxes_amount_cents: 300,
+          purchase_order_number: "PO-123",
+          issuing_date: DateTime.new(2024, 7, 8)
+        )
+        create(:invoice_subscription, invoice:, subscription:)
+        invoice
+      end
+
       def build_expected_payload(mapping_codes)
         [
           {
@@ -15,6 +33,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
             "issuing_date" => "2024-07-08T00:00:00Z",
             "payment_due_date" => "2024-07-08T00:00:00Z",
             "number" => invoice.number,
+            "reference" => "PO-123",
             "currency" => "EUR",
             "type" => "ACCREC",
             "fees" => [

--- a/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployObjectService do
             type: "string",
             fieldType: "text",
             searchableInGlobalSearch: true
+          ),
+          hash_including(
+            name: "lago_invoice_url",
+            label: "Lago Invoice URL",
+            type: "string",
+            fieldType: "text"
           )
         )
         expect(headers["Authorization"]).to include("Bearer")

--- a/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployObjectService do
       expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
       expect(http_client).to have_received(:post_with_response) do |payload, headers|
         expect(payload[:name]).to eq("LagoInvoices")
+        expect(payload[:properties]).to include(
+          hash_including(
+            name: "lago_invoice_purchase_order_number",
+            label: "Lago Purchase Order Number",
+            type: "string",
+            fieldType: "text",
+            searchableInGlobalSearch: true
+          )
+        )
         expect(headers["Authorization"]).to include("Bearer")
       end
       expect(integration.reload.invoices_properties_version).to eq(described_class::VERSION)


### PR DESCRIPTION
This commit changes hubspot object to include two new fields.

Continuing the epic of purchase order number, we're sending the value to Hubspot.
In order to do that, we need to change the custom object of `LagoInvoices`. The steps are
quite simple, we're bumping the version to `2` and including the `lago_purchase_order_number`.

Also, we noticed the payload doesn't include the invoice_url. We refactored the `Netsuite` payload
to share the method and to be used in different payloads. 

The missing step, since the `DeployObjectService` it's called only when a service of Hubspot is created
and/or updated. We need to manually call via production console to push the new version.