### PR TITLE
feat(purchase_order_number) Add PO number to Xero and Hubspot payload

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/hubspot.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/hubspot.rb
@@ -28,7 +28,8 @@ module Integrations
                   "lago_invoice_total_amount" => total_amount,
                   "lago_invoice_total_due_amount" => total_due_amount,
                   "lago_invoice_subtotal_excluding_taxes" => subtotal_excluding_taxes,
-                  "lago_invoice_file_url" => invoice.file_url
+                  "lago_invoice_file_url" => invoice.file_url,
+                  "lago_invoice_url" => invoice_url
                 }
               }
             }
@@ -57,7 +58,8 @@ module Integrations
                   "lago_invoice_total_amount" => total_amount,
                   "lago_invoice_total_due_amount" => total_due_amount,
                   "lago_invoice_subtotal_excluding_taxes" => subtotal_excluding_taxes,
-                  "lago_invoice_file_url" => invoice.file_url
+                  "lago_invoice_file_url" => invoice.file_url,
+                  "lago_invoice_url" => invoice_url
                 }
               }
             }

--- a/app/services/integrations/aggregator/invoices/payloads/hubspot.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/hubspot.rb
@@ -17,6 +17,7 @@ module Integrations
                 "properties" => {
                   "lago_invoice_id" => invoice.id,
                   "lago_invoice_number" => invoice.number,
+                  "lago_invoice_purchase_order_number" => invoice.purchase_order_number,
                   "lago_invoice_issuing_date" => formatted_date(invoice.issuing_date),
                   "lago_invoice_payment_due_date" => formatted_date(invoice.payment_due_date),
                   "lago_invoice_payment_overdue" => invoice.payment_overdue,
@@ -45,6 +46,7 @@ module Integrations
                 "properties" => {
                   "lago_invoice_id" => invoice.id,
                   "lago_invoice_number" => invoice.number,
+                  "lago_invoice_purchase_order_number" => invoice.purchase_order_number,
                   "lago_invoice_issuing_date" => formatted_date(invoice.issuing_date),
                   "lago_invoice_payment_due_date" => formatted_date(invoice.payment_due_date),
                   "lago_invoice_payment_overdue" => invoice.payment_overdue,

--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -11,7 +11,7 @@ module Integrations
 
           def body
             super.map do |invoice_payload|
-              invoice_payload.merge("purchase_order_number" => invoice.purchase_order_number)
+              invoice_payload.merge("reference" => invoice.purchase_order_number)
             end
           end
 

--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -9,6 +9,12 @@ module Integrations
             super
           end
 
+          def body
+            super.map do |invoice_payload|
+              invoice_payload.merge("purchase_order_number" => invoice.purchase_order_number)
+            end
+          end
+
           def item(fee)
             base_item = super
             base_item["item_code"] = base_item.delete("external_id")

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
   let(:invoice_file_url) { invoice.file_url }
   let(:file_url) { Faker::Internet.url }
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
+  let(:purchase_order_number) { "PO-123" }
 
   let(:invoice) do
     create(
@@ -25,7 +26,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
       coupons_amount_cents: 2000,
       prepaid_credit_amount_cents: 4000,
       credit_notes_amount_cents: 6000,
-      taxes_amount_cents: 8000
+      taxes_amount_cents: 8000,
+      purchase_order_number:
     )
   end
 
@@ -155,6 +157,19 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
               expect(integration_resource.syncable_id).to eq(invoice.id)
               expect(integration_resource.syncable_type).to eq("Invoice")
               expect(integration_resource.resource_type).to eq("invoice")
+            end
+
+            it "sends the purchase order number" do
+              service_call
+
+              expect(lago_client).to have_received(:post_with_response).with(
+                hash_including(
+                  "input" => hash_including(
+                    "properties" => hash_including("lago_invoice_purchase_order_number" => purchase_order_number)
+                  )
+                ),
+                headers
+              )
             end
 
             it_behaves_like "throttles!", :hubspot

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
   let(:file_url) { Faker::Internet.url }
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
   let(:purchase_order_number) { "PO-123" }
+  let(:invoice_url_path) { "/#{organization.slug}/customer/#{customer.id}/invoice/#{invoice.id}/overview" }
 
   let(:invoice) do
     create(
@@ -159,13 +160,16 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
               expect(integration_resource.resource_type).to eq("invoice")
             end
 
-            it "sends the purchase order number" do
+            it "sends the invoice properties" do
               service_call
 
               expect(lago_client).to have_received(:post_with_response).with(
                 hash_including(
                   "input" => hash_including(
-                    "properties" => hash_including("lago_invoice_purchase_order_number" => purchase_order_number)
+                    "properties" => hash_including(
+                      "lago_invoice_purchase_order_number" => purchase_order_number,
+                      "lago_invoice_url" => a_string_ending_with(invoice_url_path)
+                    )
                   )
                 ),
                 headers

--- a/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
   let(:file_url) { Faker::Internet.url }
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
   let(:purchase_order_number) { "PO-123" }
+  let(:invoice_url_path) { "/#{organization.slug}/customer/#{customer.id}/invoice/#{invoice.id}/overview" }
 
   let(:invoice) do
     create(
@@ -115,13 +116,16 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
             expect(result.external_id).to eq("123456789")
           end
 
-          it "sends the purchase order number" do
+          it "sends the invoice properties" do
             service_call
 
             expect(lago_client).to have_received(:put_with_response).with(
               hash_including(
                 "input" => hash_including(
-                  "properties" => hash_including("lago_invoice_purchase_order_number" => purchase_order_number)
+                  "properties" => hash_including(
+                    "lago_invoice_purchase_order_number" => purchase_order_number,
+                    "lago_invoice_url" => a_string_ending_with(invoice_url_path)
+                  )
                 )
               ),
               headers

--- a/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
   let(:invoice_file_url) { invoice.file_url }
   let(:file_url) { Faker::Internet.url }
   let(:due_date) { invoice.payment_due_date.strftime("%Y-%m-%d") }
+  let(:purchase_order_number) { "PO-123" }
 
   let(:invoice) do
     create(
@@ -25,7 +26,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
       coupons_amount_cents: 2000,
       prepaid_credit_amount_cents: 4000,
       credit_notes_amount_cents: 6000,
-      taxes_amount_cents: 8000
+      taxes_amount_cents: 8000,
+      purchase_order_number:
     )
   end
 
@@ -111,6 +113,19 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
 
             expect(result).to be_success
             expect(result.external_id).to eq("123456789")
+          end
+
+          it "sends the purchase order number" do
+            service_call
+
+            expect(lago_client).to have_received(:put_with_response).with(
+              hash_including(
+                "input" => hash_including(
+                  "properties" => hash_including("lago_invoice_purchase_order_number" => purchase_order_number)
+                )
+              ),
+              headers
+            )
           end
 
           it_behaves_like "throttles!", :hubspot

--- a/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
           "properties" => {
             "lago_invoice_id" => invoice.id,
             "lago_invoice_number" => invoice.number,
+            "lago_invoice_purchase_order_number" => invoice.purchase_order_number,
             "lago_invoice_issuing_date" => invoice.issuing_date.strftime("%Y-%m-%d"),
             "lago_invoice_payment_due_date" => invoice.payment_due_date.strftime("%Y-%m-%d"),
             "lago_invoice_payment_overdue" => invoice.payment_overdue,
@@ -58,7 +59,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
             "lago_invoice_total_amount" => invoice.total_amount_cents / 100.0,
             "lago_invoice_total_due_amount" => invoice.total_due_amount_cents / 100.0,
             "lago_invoice_subtotal_excluding_taxes" => invoice.sub_total_including_taxes_amount_cents / 100.0,
-            "lago_invoice_file_url" => invoice.file_url
+            "lago_invoice_file_url" => invoice.file_url,
+            "lago_invoice_url" => invoice_url
           }
         }
       }
@@ -88,6 +90,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
           "properties" => {
             "lago_invoice_id" => invoice.id,
             "lago_invoice_number" => invoice.number,
+            "lago_invoice_purchase_order_number" => invoice.purchase_order_number,
             "lago_invoice_issuing_date" => invoice.issuing_date.strftime("%Y-%m-%d"),
             "lago_invoice_payment_due_date" => invoice.payment_due_date.strftime("%Y-%m-%d"),
             "lago_invoice_payment_overdue" => invoice.payment_overdue,
@@ -98,7 +101,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
             "lago_invoice_total_amount" => invoice.total_amount_cents / 100.0,
             "lago_invoice_total_due_amount" => invoice.total_due_amount_cents / 100.0,
             "lago_invoice_subtotal_excluding_taxes" => invoice.sub_total_including_taxes_amount_cents / 100.0,
-            "lago_invoice_file_url" => invoice.file_url
+            "lago_invoice_file_url" => invoice.file_url,
+            "lago_invoice_url" => invoice_url
           }
         }
       }

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -7,6 +7,24 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
     subject(:payload) { described_class.new(integration_customer:, invoice:).body }
 
     it_behaves_like "an integration payload", :xero do
+      let(:invoice) do
+        invoice = create(
+          :invoice,
+          customer:,
+          organization:,
+          billing_entity:,
+          coupons_amount_cents: 200,
+          prepaid_credit_amount_cents: 300,
+          progressive_billing_credit_amount_cents: 100,
+          credit_notes_amount_cents: 500,
+          taxes_amount_cents: 300,
+          purchase_order_number: "PO-123",
+          issuing_date: DateTime.new(2024, 7, 8)
+        )
+        create(:invoice_subscription, invoice:, subscription:)
+        invoice
+      end
+
       def build_expected_payload(mapping_codes)
         [
           {
@@ -15,6 +33,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
             "issuing_date" => "2024-07-08T00:00:00Z",
             "payment_due_date" => "2024-07-08T00:00:00Z",
             "number" => invoice.number,
+            "purchase_order_number" => "PO-123",
             "currency" => "EUR",
             "type" => "ACCREC",
             "fees" => [

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
             "issuing_date" => "2024-07-08T00:00:00Z",
             "payment_due_date" => "2024-07-08T00:00:00Z",
             "number" => invoice.number,
-            "purchase_order_number" => "PO-123",
+            "reference" => "PO-123",
             "currency" => "EUR",
             "type" => "ACCREC",
             "fees" => [


### PR DESCRIPTION
This commit updates the connections of Xero and Hubspot

Continuing the PO number epic and considering the new custom object is already in place
[in this PR](https://github.com/getlago/lago-api/pull/5844)
We're updating the payload of Hubspot to include `lago_purchase_order_number` and `lago_invoice_url`.

Also, we're adding the `reference` to Xero payload. Since Xero doesn't support specific column for PO number,
we're using the `reference` which is a text field with a limit of 255 chars that matches exactly what we
need for the invoice purchase_order_number.