### PR TITLE
perf(charges): Do not compute charge model for unused filters

### DIFF
--- a/app/services/charge_filters/event_matching_service.rb
+++ b/app/services/charge_filters/event_matching_service.rb
@@ -14,9 +14,8 @@ module ChargeFilters
     def call
       # NOTE: Find all filters matching event properties
       matching_filters = filters.select do |filter|
-        filter.to_h.all? do |key, values|
-          applicable_event_properties.key?(key) &&
-            (applicable_event_properties[key].to_s.in?(values) || values == [ChargeFilterValue::ALL_FILTER_VALUES])
+        filter.to_h_with_all_values.all? do |key, values|
+          applicable_event_properties.key?(key) && applicable_event_properties[key].to_s.in?(values.map(&:to_s))
         end
       end
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -110,18 +110,55 @@ module Fees
     end
 
     def init_charge_fees(properties:, charge_filter: nil)
-      fees = cache_middleware.call(charge_filter:) do
+      if skip_unused_filter?(charge_filter)
+        fees = []
+      else
+        fees = compute_fees_with_cache(properties:, charge_filter:)
+        # NOTE: nil means the aggregation or the charge model failed, result carries the error
+        return if fees.nil?
+      end
+
+      if fees.empty? && skip_caching_of_non_persistable_fee?
+        fees = hydrate_non_persistable_fees(properties:, charge_filter:)
+      end
+
+      # Preserve preloaded associations on all fees (including cached ones) to avoid N+1 queries
+      fees.each do |fee|
+        fee.association(:billable_metric).target = billable_metric
+        fee.association(:charge_filter).target = charge_filter if charge_filter&.id
+        fee.association(:charge).target = charge
+      end
+
+      result.fees.concat(fees.compact)
+    end
+
+    # NOTE: When the billing period pre-filtering (Events::BillingPeriodFilterService) reports
+    #       that no event matches this filter in the period, the fee can only have zero units.
+    #       The cache round-trip and the bypassed aggregation are skipped and the zero-units fee
+    #       is hydrated in memory instead. Scoped to current usage: on invoicing, adjusted fees
+    #       on draft invoices can target filters without any usage.
+    #       Recurring metrics always aggregate as usage carries over from previous periods.
+    def skip_unused_filter?(charge_filter)
+      return false unless current_usage
+      return false if filtered_aggregations.nil?
+      return false if billable_metric.recurring?
+
+      !filtered_aggregations.include?(charge_filter&.id)
+    end
+
+    def compute_fees_with_cache(properties:, charge_filter:)
+      cache_middleware.call(charge_filter:) do
         aggregation_result = aggregator(charge_filter:).aggregate(options: options(properties))
 
         unless aggregation_result.success?
           result.fail_with_error!(aggregation_result.error)
-          return []
+          return
         end
 
         charge_model_result = apply_charge_model(aggregation_result:, properties:)
         unless charge_model_result.success?
           result.fail_with_error!(charge_model_result.error)
-          return []
+          return
         end
 
         breakdowns_by_group = breakdowns_by_grouped_by(aggregation_result.breakdowns, charge_model_result)
@@ -139,19 +176,6 @@ module Fees
 
         filter_non_persistable_fees_for_caching(charge_fees)
       end
-
-      if fees.empty? && skip_caching_of_non_persistable_fee?
-        fees = hydrate_non_persistable_fees(properties:, charge_filter:)
-      end
-
-      # Preserve preloaded associations on all fees (including cached ones) to avoid N+1 queries
-      fees.each do |fee|
-        fee.association(:billable_metric).target = billable_metric
-        fee.association(:charge_filter).target = charge_filter if charge_filter&.id
-        fee.association(:charge).target = charge
-      end
-
-      result.fees.concat(fees.compact)
     end
 
     def skip_caching_of_non_persistable_fee?

--- a/spec/scenarios/current_usage/zero_fees_spec.rb
+++ b/spec/scenarios/current_usage/zero_fees_spec.rb
@@ -471,6 +471,129 @@ describe "Current usage zero fees Scenarios" do
     end
   end
 
+  context "with charge filters and event_property_combinations pre-filtering" do
+    let(:region) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[europe usa]) }
+
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"}) }
+    let(:europe_filter) { create(:charge_filter, charge:, properties: {amount: "20"}) }
+    let(:usa_filter) { create(:charge_filter, charge:, properties: {amount: "50"}) }
+
+    before do
+      organization.enable_feature_flag!(:event_property_combinations)
+
+      create(:charge_filter_value, charge_filter: europe_filter, billable_metric_filter: region, values: ["europe"])
+      create(:charge_filter_value, charge_filter: usa_filter, billable_metric_filter: region, values: ["usa"])
+    end
+
+    context "with zero events" do
+      it "returns zero fees for all filters and catch-all" do
+        fetch_current_usage(customer:)
+
+        customer_usage = json[:customer_usage]
+        expect_zero_customer_usage(customer_usage)
+        expect(customer_usage[:charges_usage].count).to eq(1)
+
+        charge_usage = customer_usage[:charges_usage].first
+        expect_zero_charge_usage(charge_usage, charge_model: "standard")
+
+        filters = charge_usage[:filters]
+        expect(filters.count).to eq(3)
+        filters.each { |filter| expect_zero_filter(filter) }
+
+        filter_values = filters.map { |f| f[:values] }
+        expect(filter_values).to match_array([{region: ["europe"]}, {region: ["usa"]}, nil])
+      end
+    end
+
+    context "when some filters have usage" do
+      it "returns non-zero fees for matching filters and zero fees for the others" do
+        create_event(
+          {
+            code: billable_metric.code,
+            external_subscription_id: customer.external_id,
+            properties: {region: "europe"}
+          }
+        )
+        # Event not matching any filter falls into the catch-all bucket
+        create_event(
+          {
+            code: billable_metric.code,
+            external_subscription_id: customer.external_id,
+            properties: {region: "unknown"}
+          }
+        )
+
+        fetch_current_usage(customer:)
+
+        customer_usage = json[:customer_usage]
+        expect(customer_usage[:amount_cents]).to eq(3000)
+        expect(customer_usage[:charges_usage].count).to eq(1)
+
+        charge_usage = customer_usage[:charges_usage].first
+        expect(charge_usage[:units]).to eq("2.0")
+        expect(charge_usage[:events_count]).to eq(2)
+        expect(charge_usage[:amount_cents]).to eq(3000)
+
+        filters = charge_usage[:filters]
+        expect(filters.count).to eq(3)
+
+        europe = filters.find { |f| f[:values] == {region: ["europe"]} }
+        expect(europe[:units]).to eq("1.0")
+        expect(europe[:total_aggregated_units]).to eq("1.0")
+        expect(europe[:events_count]).to eq(1)
+        expect(europe[:amount_cents]).to eq(2000)
+
+        usa = filters.find { |f| f[:values] == {region: ["usa"]} }
+        expect_zero_filter(usa)
+
+        catch_all = filters.find { |f| f[:values].nil? }
+        expect(catch_all[:units]).to eq("1.0")
+        expect(catch_all[:events_count]).to eq(1)
+        expect(catch_all[:amount_cents]).to eq(1000)
+      end
+    end
+
+    context "with recurring billable metric" do
+      let(:billable_metric) { create(:unique_count_billable_metric, :recurring, organization:) }
+
+      it "keeps computing all filters even without events in the current period" do
+        create_event(
+          {
+            code: billable_metric.code,
+            external_subscription_id: customer.external_id,
+            properties: {region: "europe", item_id: "item_1"}
+          }
+        )
+
+        # Usage carries over to the next period even though it has no events
+        travel_to(DateTime.new(2024, 4, 10))
+
+        fetch_current_usage(customer:)
+
+        customer_usage = json[:customer_usage]
+        expect(customer_usage[:amount_cents]).to eq(2000)
+        expect(customer_usage[:charges_usage].count).to eq(1)
+
+        charge_usage = customer_usage[:charges_usage].first
+        expect(charge_usage[:units]).to eq("1.0")
+        expect(charge_usage[:amount_cents]).to eq(2000)
+
+        filters = charge_usage[:filters]
+        expect(filters.count).to eq(3)
+
+        europe = filters.find { |f| f[:values] == {region: ["europe"]} }
+        expect(europe[:units]).to eq("1.0")
+        expect(europe[:amount_cents]).to eq(2000)
+
+        usa = filters.find { |f| f[:values] == {region: ["usa"]} }
+        expect_zero_filter(usa)
+
+        catch_all = filters.find { |f| f[:values].nil? }
+        expect_zero_filter(catch_all)
+      end
+    end
+  end
+
   context "with events but zero amount (standard charge with amount 0)" do
     before do
       create(:standard_charge, plan:, billable_metric:, properties: {amount: "0"})

--- a/spec/scenarios/current_usage/zero_fees_spec.rb
+++ b/spec/scenarios/current_usage/zero_fees_spec.rb
@@ -471,7 +471,7 @@ describe "Current usage zero fees Scenarios" do
     end
   end
 
-  context "with charge filters and event_property_combinations pre-filtering" do
+  context "with charge filters pre-filtering" do
     let(:region) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[europe usa]) }
 
     let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"}) }
@@ -479,8 +479,6 @@ describe "Current usage zero fees Scenarios" do
     let(:usa_filter) { create(:charge_filter, charge:, properties: {amount: "50"}) }
 
     before do
-      organization.enable_feature_flag!(:event_property_combinations)
-
       create(:charge_filter_value, charge_filter: europe_filter, billable_metric_filter: region, values: ["europe"])
       create(:charge_filter_value, charge_filter: usa_filter, billable_metric_filter: region, values: ["usa"])
     end
@@ -514,7 +512,6 @@ describe "Current usage zero fees Scenarios" do
             properties: {region: "europe"}
           }
         )
-        # Event not matching any filter falls into the catch-all bucket
         create_event(
           {
             code: billable_metric.code,
@@ -565,7 +562,6 @@ describe "Current usage zero fees Scenarios" do
           }
         )
 
-        # Usage carries over to the next period even though it has no events
         travel_to(DateTime.new(2024, 4, 10))
 
         fetch_current_usage(customer:)

--- a/spec/services/charge_filters/event_matching_service_spec.rb
+++ b/spec/services/charge_filters/event_matching_service_spec.rb
@@ -104,5 +104,22 @@ RSpec.describe ChargeFilters::EventMatchingService do
     it "returns the filter matching the most properties" do
       expect(service_result.charge_filter).to eq(filter2)
     end
+
+    context "when the event value is outside the billable metric filter defined values" do
+      let(:event_properties) do
+        {
+          payment_method: "card",
+          card_location: "domestic",
+          scheme: "amex", # not part of the scheme defined values (visa, mastercard)
+          card_type: "credit",
+          card_number: 2
+        }
+      end
+
+      it "does not match the ALL_FILTER_VALUES filter" do
+        expect(service_result.charge_filter).to be_nil
+        expect(service_result.matching_charge_filters).to be_empty
+      end
+    end
   end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -3966,6 +3966,86 @@ RSpec.describe Fees::ChargeService, :premium do
           expect(aggregated_fees).not_to be_empty
         end
       end
+
+      context "when context is current_usage", cache: :memory do
+        subject(:charge_subscription_service) do
+          described_class.new(
+            invoice:,
+            charge:,
+            subscription:,
+            boundaries:,
+            context: :current_usage,
+            apply_taxes: false,
+            filtered_aggregations:,
+            with_zero_units_filters:,
+            cache_middleware:
+          )
+        end
+
+        let(:with_zero_units_filters) { true }
+        let(:filtered_aggregations) { [eu_charge_filter.id, nil] }
+
+        let(:cache_middleware) do
+          Subscriptions::ChargeCacheMiddleware.new(
+            subscription:,
+            charge:,
+            to_datetime: boundaries.charges_to_datetime,
+            cache: true
+          )
+        end
+
+        around { |test| travel_to(Time.zone.parse("2022-03-16")) { test.run } }
+
+        before do
+          Rails.cache.clear
+          allow(Subscriptions::ChargeCacheService).to receive(:call).and_call_original
+        end
+
+        it "skips the cache and aggregation for filters without any usage" do
+          result = charge_subscription_service.call
+          expect(result).to be_success
+
+          eu_fee = result.fees.find { |f| f.charge_filter_id == eu_charge_filter.id }
+          us_fee = result.fees.find { |f| f.charge_filter_id == us_charge_filter.id }
+          asia_fee = result.fees.find { |f| f.charge_filter_id == asia_charge_filter.id }
+          default_fee = result.fees.find { |f| f.charge_filter_id.nil? }
+
+          expect(eu_fee).to have_attributes(units: 1, amount_cents: 2_000)
+          expect(us_fee).to have_attributes(units: 0, amount_cents: 0)
+          expect(asia_fee).to have_attributes(units: 0, amount_cents: 0)
+          expect(default_fee).to have_attributes(units: 1, amount_cents: 2_000)
+
+          expect(Subscriptions::ChargeCacheService).to have_received(:call)
+            .with(hash_including(charge_filter: eu_charge_filter)).once
+          expect(Subscriptions::ChargeCacheService).not_to have_received(:call)
+            .with(hash_including(charge_filter: us_charge_filter))
+          expect(Subscriptions::ChargeCacheService).not_to have_received(:call)
+            .with(hash_including(charge_filter: asia_charge_filter))
+        end
+
+        context "when with_zero_units_filters is false" do
+          let(:with_zero_units_filters) { false }
+
+          it "does not return zero-units fees for filters without any usage" do
+            result = charge_subscription_service.call
+            expect(result).to be_success
+
+            expect(result.fees.map(&:charge_filter_id)).to match_array([eu_charge_filter.id, nil])
+          end
+        end
+
+        context "with recurring billable metric" do
+          let(:billable_metric) { create(:weighted_sum_billable_metric, :recurring, organization:) }
+          let(:filtered_aggregations) { [] }
+
+          it "computes fees for all filters regardless of filtered_aggregations" do
+            result = charge_subscription_service.call
+            expect(result).to be_success
+
+            expect(Subscriptions::ChargeCacheService).to have_received(:call).exactly(4).times
+          end
+        end
+      end
     end
 
     context "with filter_by_group" do


### PR DESCRIPTION
## Context

  On subscriptions with a large number of charge filters, computing current usage is slow even when the
  billing-period pre-filtering (`Events::BillingPeriodFilterService`) works correctly. A production trace showed a
  `LifetimeUsages::RecalculateAndCheckJob` taking ~27s for a subscription with **zero events in the period**:
  `Fees::ChargeService` still iterates every filter (~1,550 here), paying one sequential Redis cache lookup (~9ms
  each, ~15.6s total) plus a bypassed aggregation per filter, only to end up hydrating the same zero-units fee in
  memory.

  ## Description

  - In `Fees::ChargeService`, skip the cache round-trip and the bypassed aggregation for filters that
  `filtered_aggregations` reports as having no usage, and hydrate the zero-units fee directly (same code path and
  output as before).
  - The skip is scoped to `current_usage` only:
    - Invoicing keeps the full path, as adjusted fees on draft invoices can target filters without usage, and
  true-up fees are unaffected.
    - Recurring metrics never skip, mirroring `should_bypass_aggregation?`, as usage carries over from previous
  periods.
  - All charge models return a zero amount for zero units (flat/fixed amounts only apply with usage), so no fee
  amount can change.

  Added scenario specs covering the pre-filtering end to end: zero events, partial filter usage with a catch-all
  bucket, and a recurring metric with usage carried over from a previous period.