### PR TITLE
misc(event): Disable event_property_combinations feature flag

### DIFF
--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -35,10 +35,6 @@ module Events
       )
     end
 
-    def distinct_event_codes
-      event_store.distinct_codes(codes: plan_codes)
-    end
-
     def plan_codes
       @plan_codes ||= plan.billable_metrics.distinct.pluck(:code)
     end
@@ -58,16 +54,10 @@ module Events
     # property combinations actually present in the events against the charge filters, so
     # only the filters that received usage are returned.
     def charges_and_filters_from_events
-      return all_charges_and_filters_from_event_codes unless organization.feature_flag_enabled?(:event_property_combinations)
-
       combinations = event_store.distinct_codes_and_property_combinations(
         codes: plan_codes,
         filter_keys: billable_metric_filter_keys
       )
-
-      # Stores that cannot extract property combinations (e.g. Clickhouse) fall back to
-      # including every filter of each charge that received events in the period.
-      return all_charges_and_filters_from_event_codes if combinations.nil?
 
       combinations_by_code = combinations
         .group_by(&:first)
@@ -95,17 +85,6 @@ module Events
       end
 
       result
-    end
-
-    # Return all charges and filters for codes that matches events plus all recurring charges.
-    def all_charges_and_filters_from_event_codes
-      plan.charges.joins(:billable_metric).left_joins(:filters)
-        .where(billable_metrics: {code: distinct_event_codes})
-        .or(plan.charges.joins(:billable_metric).where(billable_metrics: {recurring: true}))
-        .group("charges.id, charge_filters.id")
-        .pluck("charges.id", "charge_filters.id")
-        .then { group_by_charge_id(it) }
-        .then { add_default_filter(it) }
     end
 
     # Recurring charges and all their filters (including the default bucket).

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -150,21 +150,6 @@ module Events
         SQL
       end
 
-      # DEPRECATED: This method will be replaced by distinct_charges_and_filters
-      #             to filter the charge and filters in a billing period.
-      #             See app/services/events/billing_period_filter_service.rb:42
-      def distinct_codes(codes: nil)
-        Events::Stores::Utils::ClickhouseConnection.with_retry do
-          scope = ::Clickhouse::EventsEnrichedExpanded
-            .where(external_subscription_id: subscription.external_id)
-            .where(organization_id: subscription.organization_id)
-            .where(timestamp: from_datetime..applicable_to_datetime)
-
-          scope = scope.where(code: codes) unless codes.nil?
-          scope.pluck("DISTINCT(code)")
-        end
-      end
-
       def distinct_charges_and_filters(codes: nil)
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = ::Clickhouse::EventsEnrichedExpanded

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -148,19 +148,6 @@ module Events
         conditions.join(" AND ")
       end
 
-      def distinct_codes(codes: nil)
-        Events::Stores::Utils::ClickhouseConnection.with_retry do
-          scope = ::Clickhouse::EventsEnriched
-            .where(external_subscription_id: subscription.external_id)
-            .where(organization_id: subscription.organization.id)
-            .where("events_enriched.timestamp >= ?", from_datetime)
-            .where("events_enriched.timestamp <= ?", applicable_to_datetime)
-
-          scope = scope.where(code: codes) unless codes.nil?
-          scope.pluck("DISTINCT(code)")
-        end
-      end
-
       def distinct_charges_and_filters(codes: nil)
         # Implementation relies directly on the events_enriched_expanded table,
         # so we delegate the implementation to the ClickhouseEnrichedStore

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -22,19 +22,6 @@ module Events
         filters_scope(scope)
       end
 
-      def distinct_codes(codes: nil)
-        scope = Event.where(external_subscription_id: subscription.external_id)
-          .where(organization_id: subscription.organization.id)
-          .from_datetime(from_datetime)
-          .to_datetime(applicable_to_datetime)
-
-        if codes.nil?
-          scope.pluck("DISTINCT(code)")
-        else
-          codes.select { |code| scope.where(code:).exists? }
-        end
-      end
-
       def distinct_charges_and_filters(codes: nil)
         scope = EnrichedEvent.where(organization_id: subscription.organization_id)
           .where(subscription_id: subscription.id)

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -397,8 +397,6 @@ RSpec.describe Events::BillingPeriodFilterService do
 
   describe "#call" do
     context "when relying on event codes" do
-      before { organization.enable_feature_flag!(:event_property_combinations) }
-
       it "returns the filtered charge_ids" do
         result = filter_service.call
 
@@ -615,44 +613,6 @@ RSpec.describe Events::BillingPeriodFilterService do
 
         expect(event_store).to have_received(:distinct_codes_and_property_combinations)
           .with(codes: [billable_metric.code], filter_keys: [])
-      end
-
-      context "when the event_property_combinations feature flag is disabled" do
-        let(:charge_filter) { create(:charge_filter, charge:) }
-        let(:billable_metric_filter) do
-          create(:billable_metric_filter, billable_metric:, key: "region", values: %w[eu us])
-        end
-        let(:charge_filter_value) do
-          create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["eu"])
-        end
-
-        let(:charge_filter_us) { create(:charge_filter, charge:) }
-        let(:charge_filter_us_value) do
-          create(:charge_filter_value, charge_filter: charge_filter_us, billable_metric_filter:, values: ["us"])
-        end
-
-        before do
-          organization.disable_feature_flag!(:event_property_combinations)
-
-          charge_filter_value
-          charge_filter_us_value
-
-          create(
-            :event,
-            organization_id: organization.id,
-            external_subscription_id: subscription.external_id,
-            timestamp: boundaries.charges_from_datetime + 5.days,
-            code: billable_metric.code,
-            properties: {"region" => "eu"}
-          )
-        end
-
-        it "falls back to every filter of the charges that received events" do
-          result = filter_service.call
-
-          expect(result).to be_success
-          expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id, charge_filter_us.id, nil)})
-        end
       end
     end
 

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -422,44 +422,6 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
     end
   end
 
-  if include_feature?(:distinct_codes)
-    describe "#distinct_codes" do
-      before do
-        create_event(
-          timestamp: subscription_started_at + (1..10).to_a.sample.days,
-          value: "value",
-          transaction_id: SecureRandom.uuid,
-          code: "other_code"
-        )
-      end
-
-      it "returns the distinct event codes" do
-        expect(event_store.distinct_codes).to match_array([code, "other_code"])
-      end
-
-      context "when codes are provided" do
-        it "returns only the distinct event codes matching the provided codes" do
-          expect(event_store.distinct_codes(codes: [code, "unknown_code"])).to eq([code])
-        end
-
-        context "when an event with a provided code exists outside the period" do
-          before do
-            create_event(
-              timestamp: boundaries[:to_datetime] + 1.day,
-              value: "value",
-              transaction_id: SecureRandom.uuid,
-              code: "out_of_period_code"
-            )
-          end
-
-          it "does not return the code" do
-            expect(event_store.distinct_codes(codes: [code, "out_of_period_code"])).to eq([code])
-          end
-        end
-      end
-    end
-  end
-
   if include_feature?(:grouped_count)
     describe "#grouped_count" do
       let(:grouped_by) { %w[region] }


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/5759 and https://github.com/getlago/lago-api/pull/5767

## Description

The goal is to enable the aggregation pre-filtering for all organization and remove the need for the `event_property_combinations` feature flag.

This PR removes the old code related to the events filtering at code level only that was used before the improvement

The feature flag itself will be removed in a future PR.
