### PR TITLE
fix(charges): add unscoped index on billable_metric_id

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -224,6 +224,7 @@ end
 #  idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb   (plan_id,billable_metric_id,pay_in_advance) WHERE (deleted_at IS NULL)
 #  index_charges_on_accepts_target_wallet                        (accepts_target_wallet) WHERE (accepts_target_wallet = true)
 #  index_charges_on_billable_metric_id                           (billable_metric_id) WHERE (deleted_at IS NULL)
+#  index_charges_on_billable_metric_id_all                       (billable_metric_id)
 #  index_charges_on_deleted_at                                   (deleted_at)
 #  index_charges_on_organization_id                              (organization_id)
 #  index_charges_on_parent_id                                    (parent_id)

--- a/db/migrate/20260703164249_add_unscoped_index_on_charges_billable_metric_id.rb
+++ b/db/migrate/20260703164249_add_unscoped_index_on_charges_billable_metric_id.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddUnscopedIndexOnChargesBillableMetricId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :charges,
+      :billable_metric_id,
+      name: :index_charges_on_billable_metric_id_all,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -743,6 +743,7 @@ DROP INDEX IF EXISTS public.index_charges_on_plan_id;
 DROP INDEX IF EXISTS public.index_charges_on_parent_id;
 DROP INDEX IF EXISTS public.index_charges_on_organization_id;
 DROP INDEX IF EXISTS public.index_charges_on_deleted_at;
+DROP INDEX IF EXISTS public.index_charges_on_billable_metric_id_all;
 DROP INDEX IF EXISTS public.index_charges_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_charges_on_accepts_target_wallet;
 DROP INDEX IF EXISTS public.index_charge_filters_on_organization_id;
@@ -7448,6 +7449,13 @@ CREATE INDEX index_charges_on_billable_metric_id ON public.charges USING btree (
 
 
 --
+-- Name: index_charges_on_billable_metric_id_all; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_charges_on_billable_metric_id_all ON public.charges USING btree (billable_metric_id);
+
+
+--
 -- Name: index_charges_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12803,6 +12811,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260703164249'),
 ('20260702074504'),
 ('20260625095837'),
 ('20260622113747'),


### PR DESCRIPTION
## Context

`index_charges_on_billable_metric_id` is a partial index (`WHERE deleted_at IS NULL`) since #2872. `BillableMetrics::DestroyService` soft deletes the metric's charges before enqueuing `BillableMetrics::DeleteEventsJob`, and `Events::DeleteForMetricService` then looks up charges by `billable_metric_id` without the `deleted_at IS NULL` predicate (the join intentionally bypasses `Charge`'s default scope, since the charges are already discarded at that point). The partial index cannot serve that query, so Postgres falls back to a sequential scan on `charges`. On large tables the statement exceeds the statement timeout and the job dies, as it runs with `retry: 0`.

## Description

A new full index `index_charges_on_billable_metric_id_all` is added on `charges (billable_metric_id)`, built with `algorithm: :concurrently`. The existing partial index is kept: it serves the queries going through `Charge`'s default scope, which #2872 optimized for.

Fixes ING-374.
