### PR TITLE
Support terminating recurring grouped usage

### DIFF
--- a/app/controllers/api/v1/subscriptions/base_controller.rb
+++ b/app/controllers/api/v1/subscriptions/base_controller.rb
@@ -14,7 +14,7 @@ module Api
           @subscription = current_organization.subscriptions
             .order("terminated_at DESC NULLS FIRST, started_at DESC") # TODO: Confirm
             .find_by!(
-              external_id: params[:subscription_external_id],
+              external_id: params[:subscription_external_id] || params[:external_id],
               # we're keeping both `subscription_status` and `status` for backward compatibility,
               # but we should rely more on the `subscription_status`
               status: params[:subscription_status] || params[:status] || :active

--- a/app/controllers/api/v1/subscriptions/recurring_usage_controller.rb
+++ b/app/controllers/api/v1/subscriptions/recurring_usage_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Subscriptions
+      class RecurringUsageController < BaseController
+        def terminate
+          result = ::Subscriptions::TerminateRecurringUsageService.call(
+            subscription:,
+            params: input_params,
+            metadata: event_metadata
+          )
+
+          if result.success?
+            render(
+              json: ::V1::EventSerializer.new(
+                result.event,
+                root_name: "event"
+              )
+            )
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        def resource_name
+          "subscription"
+        end
+
+        def input_params
+          params
+            .require(:recurring_usage)
+            .permit(
+              :billable_metric_code,
+              :charge_code,
+              :transaction_id,
+              :timestamp,
+              group: {}
+            )
+        end
+
+        def event_metadata
+          {
+            user_agent: request.user_agent,
+            ip_address: request.remote_ip
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/terminate_recurring_usage_service.rb
+++ b/app/services/subscriptions/terminate_recurring_usage_service.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class TerminateRecurringUsageService < BaseService
+    Result = BaseResult[:event]
+
+    def initialize(subscription:, params:, metadata: {})
+      @subscription = subscription
+      @params = params.to_h.deep_symbolize_keys
+      @metadata = metadata
+
+      super
+    end
+
+    def call
+      if billable_metric_code.blank?
+        return result.single_validation_failure!(field: :billable_metric_code, error_code: "value_is_mandatory")
+      end
+      return result.single_validation_failure!(field: :group, error_code: "value_is_mandatory") if group.blank?
+      return result.not_found_failure!(resource: "charge") unless charge
+      unless billable_metric.recurring?
+        return result.single_validation_failure!(field: :billable_metric_code, error_code: "not_recurring")
+      end
+      unless supported_aggregation?
+        return result.single_validation_failure!(
+          field: :billable_metric_code,
+          error_code: "unsupported_aggregation_type"
+        )
+      end
+      if missing_group_keys.any?
+        return result.validation_failure!(
+          errors: {group: missing_group_keys.index_with { ["value_is_mandatory"] }}
+        )
+      end
+      if current_units <= 0
+        return result.single_validation_failure!(field: :group, error_code: "no_active_recurring_usage")
+      end
+
+      event_result = Events::CreateService.call(
+        organization: subscription.organization,
+        params: event_params,
+        timestamp: event_timestamp.to_f,
+        metadata:
+      )
+
+      return result.fail_with_error!(event_result.error) unless event_result.success?
+
+      result.event = event_result.event
+      result
+    rescue ArgumentError
+      result.single_validation_failure!(field: :timestamp, error_code: "invalid_format")
+    rescue JSON::ParserError
+      result.single_validation_failure!(field: :group, error_code: "invalid_format")
+    end
+
+    private
+
+    attr_reader :subscription, :params, :metadata
+
+    delegate :billable_metric, to: :charge
+
+    def charge
+      return @charge if defined?(@charge)
+
+      scope = subscription.plan.charges
+        .joins(:billable_metric)
+        .includes(:billable_metric)
+        .where(billable_metrics: {code: billable_metric_code})
+      scope = scope.where(code: charge_code) if charge_code.present?
+
+      @charge = scope.first
+    end
+
+    def supported_aggregation?
+      billable_metric.sum_agg?
+    end
+
+    def current_units
+      @current_units ||= begin
+        usage_result = Invoices::CustomerUsageService.call(
+          customer: subscription.customer,
+          subscription:,
+          timestamp: event_timestamp,
+          apply_taxes: false,
+          with_cache: false,
+          usage_filters:
+        )
+        usage_result.raise_if_error!
+
+        usage_result.usage.fees
+          .select { |fee| fee.charge_id == charge.id }
+          .sum { |fee| BigDecimal(fee.units.to_s) }
+      end
+    end
+
+    def usage_filters
+      UsageFilters.new(
+        filter_by_charge_code: charge.code,
+        filter_by_group: group
+      )
+    end
+
+    def event_params
+      {
+        transaction_id: transaction_id,
+        code: billable_metric.code,
+        external_subscription_id: subscription.external_id,
+        timestamp: event_timestamp.to_f,
+        properties: group.merge(billable_metric.field_name => (-current_units).to_s)
+      }
+    end
+
+    def transaction_id
+      params[:transaction_id].presence || "terminate_recurring_usage-#{SecureRandom.uuid}"
+    end
+
+    def event_timestamp
+      @event_timestamp ||= if params[:timestamp].present?
+        Time.zone.at(BigDecimal(params[:timestamp].to_s))
+      else
+        Time.current
+      end
+    end
+
+    def billable_metric_code
+      params[:billable_metric_code].to_s.presence
+    end
+
+    def charge_code
+      params[:charge_code].to_s.presence
+    end
+
+    def group
+      @group ||= begin
+        value = params[:group] || {}
+        value = JSON.parse(value) if value.is_a?(String)
+        value = value.to_unsafe_h if value.respond_to?(:to_unsafe_h)
+        value.to_h.stringify_keys
+      end
+    end
+
+    def missing_group_keys
+      Array(charge.pricing_group_keys) - group.keys
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
 
       resources :subscriptions, only: %i[create update show index], param: :external_id do
         resource :lifetime_usage, only: %i[show update], controller: "subscriptions/lifetime_usages"
+        post :terminate_recurring_usage, to: "subscriptions/recurring_usage#terminate"
         resources :alerts, only: %i[create index update show destroy], param: :code, controller: "subscriptions/alerts" do
           collection do
             delete "/", action: :destroy_all

--- a/spec/requests/api/v1/subscriptions/recurring_usage_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/recurring_usage_controller_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Subscriptions::RecurringUsageController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+  let(:billable_metric) do
+    create(
+      :sum_billable_metric,
+      :recurring,
+      organization:,
+      code: "twilio_device",
+      field_name: "amount"
+    )
+  end
+  let(:charge) do
+    create(
+      :standard_charge,
+      organization:,
+      plan:,
+      billable_metric:,
+      code: "twilio_device_monthly",
+      properties: {
+        amount: "1",
+        pricing_group_keys: ["device_id"]
+      }
+    )
+  end
+  let(:body) do
+    {
+      recurring_usage: {
+        billable_metric_code: billable_metric.code,
+        charge_code: charge.code,
+        transaction_id: "remove-device-1",
+        group: {
+          device_id: "device-1"
+        }
+      }
+    }
+  end
+
+  before do
+    charge
+    create(
+      :event,
+      organization_id: organization.id,
+      subscription:,
+      code: billable_metric.code,
+      timestamp: 2.days.ago,
+      properties: {
+        "device_id" => "device-1",
+        "amount" => "1.15"
+      }
+    )
+    create(
+      :event,
+      organization_id: organization.id,
+      subscription:,
+      code: billable_metric.code,
+      timestamp: 2.days.ago,
+      properties: {
+        "device_id" => "device-2",
+        "amount" => "2.00"
+      }
+    )
+  end
+
+  describe "POST /api/v1/subscriptions/:external_id/terminate_recurring_usage" do
+    subject do
+      post_with_token(
+        organization,
+        "/api/v1/subscriptions/#{subscription.external_id}/terminate_recurring_usage",
+        body
+      )
+    end
+
+    include_examples "requires API permission", "subscription", "write"
+
+    it "creates a compensating event for the targeted recurring group" do
+      expect { subject }.to change(Event, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:event]).to include(
+        transaction_id: "remove-device-1",
+        code: billable_metric.code,
+        external_subscription_id: subscription.external_id
+      )
+
+      event = Event.find_by!(transaction_id: "remove-device-1")
+      expect(event.properties).to include(
+        "device_id" => "device-1",
+        "amount" => "-1.15"
+      )
+    end
+
+    context "when the group is already inactive" do
+      let(:body) do
+        {
+          recurring_usage: {
+            billable_metric_code: billable_metric.code,
+            group: {
+              device_id: "unknown-device"
+            }
+          }
+        }
+      end
+
+      it "returns a validation error" do
+        expect { subject }.not_to change(Event, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details][:group]).to eq(["no_active_recurring_usage"])
+      end
+    end
+
+    context "when the billable metric is not recurring" do
+      before { billable_metric.update!(recurring: false) }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details][:billable_metric_code]).to eq(["not_recurring"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add a subscription-scoped API endpoint to terminate a recurring grouped usage value.
- Compute the currently active units for the targeted recurring group and emit a compensating event through the existing event pipeline.
- Cover successful termination, inactive groups, and non-recurring metric validation with request specs.

## Why
Issue getlago/lago#552 describes recurring per-device charges, such as Twilio phone numbers, that should keep billing each cycle until a specific device is removed.

Lago already supports recurring grouped usage through recurring billable metrics, but there was no first-class API action to stop one grouped value. This endpoint lets callers target a group, for example `{ device_id: "device-1" }`, and stops future recurring billing for that group by recording the inverse usage event.


