### PR TITLE
Fix migration script for existing databases

### DIFF
--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -5,8 +5,7 @@ if [ "$RAILS_ENV" == "staging" ]
 then
   bundle exec rake db:prepare
 else
-  bundle exec rake db:create
-  bundle exec rails db:migrate
+  bundle exec rails db:prepare
   bundle exec rails roles:seed_predefined
 
   if [ -v LAGO_CREATE_ORG ] && [ "$LAGO_CREATE_ORG" == "true" ]


### PR DESCRIPTION
## Summary
- Replace the unconditional `db:create` + `db:migrate` sequence in `scripts/migrate.sh` with `rails db:prepare`.
- Keep the existing role seeding and optional organization seeding behavior unchanged.

## Why
`scripts/migrate.sh` currently always runs `db:create` before migrations outside staging. That fails for deployments where the Lago database already exists but the Lago database user does not have permission to create databases.

`db:prepare` is the Rails task intended for this case: it migrates an existing database and only attempts setup/create behavior when the database is missing.

Fixes getlago/lago-api#5481.


