### PR TITLE
[STA-9] misc: Define more service Results

### DIFF
--- a/app/services/api_keys/create_service.rb
+++ b/app/services/api_keys/create_service.rb
@@ -2,6 +2,8 @@
 
 module ApiKeys
   class CreateService < BaseService
+    Result = BaseResult[:api_key]
+
     def initialize(params)
       @params = params
       super

--- a/app/services/applied_coupons/lock_service.rb
+++ b/app/services/applied_coupons/lock_service.rb
@@ -2,6 +2,8 @@
 
 module AppliedCoupons
   class LockService < BaseService
+    Result = BaseResult
+
     def initialize(customer:)
       @customer = customer
 

--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -2,6 +2,8 @@
 
 module BillableMetricFilters
   class CreateOrUpdateBatchService < BaseService
+    Result = BaseResult[:filters]
+
     BATCH_SIZE = 1_000
 
     def initialize(billable_metric:, filters_params:)

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -2,6 +2,8 @@
 
 module BillableMetrics
   class CreateService < BaseService
+    Result = BaseResult[:billable_metric]
+
     def initialize(args = {})
       @args = args
       super

--- a/app/services/billable_metrics/evaluate_expression_service.rb
+++ b/app/services/billable_metrics/evaluate_expression_service.rb
@@ -2,6 +2,8 @@
 
 module BillableMetrics
   class EvaluateExpressionService < BaseService
+    Result = BaseResult[:evaluation_result]
+
     def initialize(expression:, event:)
       @expression = expression
       @event = event || {}

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -2,6 +2,8 @@
 
 module BillableMetrics
   class UpdateService < BaseService
+    Result = BaseResult[:billable_metric]
+
     def initialize(billable_metric:, params:)
       @billable_metric = billable_metric
       @params = params

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -2,6 +2,8 @@
 
 module ChargeFilters
   class CreateOrUpdateBatchService < BaseService
+    Result = BaseResult[:filters]
+
     def initialize(charge:, filters_params:)
       @charge = charge
       @filters_params = filters_params

--- a/app/services/charge_filters/event_matching_service.rb
+++ b/app/services/charge_filters/event_matching_service.rb
@@ -2,6 +2,8 @@
 
 module ChargeFilters
   class EventMatchingService < BaseService
+    Result = BaseResult[:matching_charge_filters, :charge_filter]
+
     def initialize(charge:, event:)
       @charge = charge
       @event = event

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -2,6 +2,8 @@
 
 module ChargeFilters
   class MatchingAndIgnoredService < BaseService
+    Result = BaseResult[:matching_filters, :ignored_filters]
+
     def initialize(charge:, filter:)
       @charge = charge
       @filter = filter

--- a/app/services/charges/apply_taxes_service.rb
+++ b/app/services/charges/apply_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module Charges
   class ApplyTaxesService < BaseService
+    Result = BaseResult[:applied_taxes]
+
     def initialize(charge:, tax_codes:)
       @charge = charge
       @tax_codes = tax_codes

--- a/app/services/charges/create_service.rb
+++ b/app/services/charges/create_service.rb
@@ -2,6 +2,8 @@
 
 module Charges
   class CreateService < BaseService
+    Result = BaseResult[:charge]
+
     def initialize(plan:, params:, cascade_updates: false)
       @plan = plan
       @params = params

--- a/app/services/charges/estimate_instant/percentage_service.rb
+++ b/app/services/charges/estimate_instant/percentage_service.rb
@@ -3,6 +3,8 @@
 module Charges
   module EstimateInstant
     class PercentageService < BaseService
+      Result = BaseResult[:units, :amount]
+
       def initialize(properties:, units:)
         @properties = properties
         @units = units

--- a/app/services/charges/estimate_instant/standard_service.rb
+++ b/app/services/charges/estimate_instant/standard_service.rb
@@ -3,6 +3,8 @@
 module Charges
   module EstimateInstant
     class StandardService < BaseService
+      Result = BaseResult[:units, :amount]
+
       def initialize(properties:, units:)
         @properties = properties
         @units = units

--- a/app/services/charges/override_service.rb
+++ b/app/services/charges/override_service.rb
@@ -2,6 +2,8 @@
 
 module Charges
   class OverrideService < BaseService
+    Result = BaseResult[:charge]
+
     def initialize(charge:, params:)
       @charge = charge
       @params = params

--- a/app/services/charges/update_service.rb
+++ b/app/services/charges/update_service.rb
@@ -4,6 +4,8 @@ module Charges
   class UpdateService < BaseService
     include CascadeUpdatable
 
+    Result = BaseResult[:charge]
+
     def initialize(charge:, params:, cascade_options: {}, cascade_updates: false)
       @charge = charge
       @params = params.to_h.deep_symbolize_keys

--- a/app/services/commitments/apply_taxes_service.rb
+++ b/app/services/commitments/apply_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module Commitments
   class ApplyTaxesService < BaseService
+    Result = BaseResult[:applied_taxes]
+
     def initialize(commitment:, tax_codes:)
       @commitment = commitment
       @tax_codes = tax_codes

--- a/app/services/commitments/dates_service.rb
+++ b/app/services/commitments/dates_service.rb
@@ -2,6 +2,8 @@
 
 module Commitments
   class DatesService < BaseService
+    Result = BaseResult
+
     def self.new_instance(commitment:, invoice_subscription:)
       klass = if invoice_subscription.subscription.plan.pay_in_advance?
         Commitments::Minimum::InAdvance::DatesService

--- a/app/services/commitments/minimum/calculate_true_up_fee_service.rb
+++ b/app/services/commitments/minimum/calculate_true_up_fee_service.rb
@@ -3,6 +3,8 @@
 module Commitments
   module Minimum
     class CalculateTrueUpFeeService < BaseService
+      Result = BaseResult[:amount_cents, :commitment_amount_cents, :precise_amount_cents]
+
       def self.new_instance(invoice_subscription:)
         klass = if invoice_subscription.subscription.plan.pay_in_advance?
           Commitments::Minimum::InAdvance::CalculateTrueUpFeeService

--- a/app/services/commitments/override_service.rb
+++ b/app/services/commitments/override_service.rb
@@ -2,6 +2,8 @@
 
 module Commitments
   class OverrideService < BaseService
+    Result = BaseResult[:commitment]
+
     def initialize(commitment:, params:)
       @commitment = commitment
       @params = params

--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -2,6 +2,8 @@
 
 module Coupons
   class CreateService < BaseService
+    Result = BaseResult[:coupon]
+
     def initialize(args)
       @args = args
       super

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module Coupons
   class DestroyService < BaseService
+    Result = BaseResult[:coupon]
+
     def initialize(coupon:)
       @coupon = coupon
       super

--- a/app/services/coupons/preview_service.rb
+++ b/app/services/coupons/preview_service.rb
@@ -2,6 +2,8 @@
 
 module Coupons
   class PreviewService < BaseService
+    Result = BaseResult[:credits, :invoice]
+
     def initialize(invoice:, applied_coupons:)
       @invoice = invoice
       @applied_coupons = applied_coupons

--- a/app/services/coupons/terminate_service.rb
+++ b/app/services/coupons/terminate_service.rb
@@ -2,6 +2,8 @@
 
 module Coupons
   class TerminateService < BaseService
+    Result = BaseResult[:coupon]
+
     def self.terminate_all_expired
       Coupon
         .active

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -2,6 +2,8 @@
 
 module Coupons
   class UpdateService < BaseService
+    Result = BaseResult[:coupon]
+
     def initialize(coupon:, params:)
       @coupon = coupon
       @params = params

--- a/app/services/credit_notes/apply_taxes_service.rb
+++ b/app/services/credit_notes/apply_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class ApplyTaxesService < BaseService
+    Result = BaseResult[:applied_taxes, :coupons_adjustment_amount_cents, :precise_taxes_amount_cents, :taxes_amount_cents, :taxes_rate]
+
     def initialize(invoice:, items:)
       @invoice = invoice
       @items = items

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class EstimateService < BaseService
+    Result = BaseResult[:credit_note]
+
     def initialize(invoice:, items:)
       @invoice = invoice
       @items = items

--- a/app/services/credit_notes/provider_taxes/report_service.rb
+++ b/app/services/credit_notes/provider_taxes/report_service.rb
@@ -3,6 +3,8 @@
 module CreditNotes
   module ProviderTaxes
     class ReportService < BaseService
+      Result = BaseResult[:credit_note]
+
       def initialize(credit_note:)
         @credit_note = credit_note
 

--- a/app/services/credit_notes/recredit_service.rb
+++ b/app/services/credit_notes/recredit_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class RecreditService < BaseService
+    Result = BaseResult[:credit_note]
+
     def initialize(credit:)
       @credit = credit
       @credit_note = credit.credit_note

--- a/app/services/credit_notes/refresh_draft_service.rb
+++ b/app/services/credit_notes/refresh_draft_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class RefreshDraftService < BaseService
+    Result = BaseResult[:credit_note]
+
     def initialize(credit_note:, fee:, old_fee_values:)
       @credit_note = credit_note
       @fee = fee

--- a/app/services/credit_notes/update_service.rb
+++ b/app/services/credit_notes/update_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class UpdateService < BaseService
+    Result = BaseResult[:credit_note]
+
     def initialize(credit_note:, partial_metadata: false, **params)
       @params = params&.with_indifferent_access
       @credit_note = credit_note

--- a/app/services/credit_notes/void_service.rb
+++ b/app/services/credit_notes/void_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class VoidService < BaseService
+    Result = BaseResult[:credit_note]
+
     def initialize(credit_note:)
       @credit_note = credit_note
 

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -2,6 +2,8 @@
 
 module Credits
   class AppliedCouponService < BaseService
+    Result = BaseResult[:credit]
+
     def initialize(invoice:, applied_coupon:)
       @invoice = invoice
       @applied_coupon = applied_coupon

--- a/app/services/credits/applied_coupons_service.rb
+++ b/app/services/credits/applied_coupons_service.rb
@@ -2,6 +2,8 @@
 
 module Credits
   class AppliedCouponsService < BaseService
+    Result = BaseResult[:credits, :invoice]
+
     def initialize(invoice:)
       @invoice = invoice
       super

--- a/app/services/credits/credit_note_service.rb
+++ b/app/services/credits/credit_note_service.rb
@@ -2,6 +2,8 @@
 
 module Credits
   class CreditNoteService < BaseService
+    Result = BaseResult[:credits]
+
     def initialize(invoice:, context: nil)
       @invoice = invoice
       @context = context

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -2,6 +2,8 @@
 
 module Credits
   class ProgressiveBillingService < BaseService
+    Result = BaseResult[:credits]
+
     def initialize(invoice:)
       @invoice = invoice
       super

--- a/app/services/customer_portal/customer_update_service.rb
+++ b/app/services/customer_portal/customer_update_service.rb
@@ -2,6 +2,8 @@
 
 module CustomerPortal
   class CustomerUpdateService < BaseService
+    Result = BaseResult[:customer]
+
     def initialize(customer:, args:)
       @customer = customer
       @args = args

--- a/app/services/customer_portal/generate_url_service.rb
+++ b/app/services/customer_portal/generate_url_service.rb
@@ -2,6 +2,8 @@
 
 module CustomerPortal
   class GenerateUrlService < BaseService
+    Result = BaseResult[:url]
+
     def initialize(customer:)
       @customer = customer
 

--- a/app/services/customers/apply_taxes_service.rb
+++ b/app/services/customers/apply_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module Customers
   class ApplyTaxesService < BaseService
+    Result = BaseResult[:applied_taxes]
+
     def initialize(customer:, tax_codes:)
       @customer = customer
       @tax_codes = tax_codes

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module Customers
   class DestroyService < BaseService
+    Result = BaseResult[:customer]
+
     def initialize(customer:)
       @customer = customer
 

--- a/app/services/customers/generate_checkout_url_service.rb
+++ b/app/services/customers/generate_checkout_url_service.rb
@@ -2,6 +2,8 @@
 
 module Customers
   class GenerateCheckoutUrlService < BaseService
+    Result = BaseResult
+
     def initialize(customer:)
       @customer = customer
       @provider_customer = customer&.provider_customer

--- a/app/services/customers/lock_service.rb
+++ b/app/services/customers/lock_service.rb
@@ -16,6 +16,8 @@ module Customers
     ACQUIRE_LOCK_TIMEOUT = 5.seconds
     VALID_SCOPES = %i[prepaid_credit].freeze
 
+    Result = BaseResult
+
     def initialize(customer:, scope:, timeout_seconds: ACQUIRE_LOCK_TIMEOUT, transaction: true)
       @customer = customer
       @scope = scope

--- a/app/services/customers/metadata/update_service.rb
+++ b/app/services/customers/metadata/update_service.rb
@@ -3,6 +3,8 @@
 module Customers
   module Metadata
     class UpdateService < BaseService
+      Result = BaseResult[:customer]
+
       def initialize(customer:, params:)
         @customer = customer
         @params = params

--- a/app/services/customers/terminate_relations_service.rb
+++ b/app/services/customers/terminate_relations_service.rb
@@ -2,6 +2,8 @@
 
 module Customers
   class TerminateRelationsService < BaseService
+    Result = BaseResult[:customer]
+
     def initialize(customer:)
       @customer = customer
       super

--- a/app/services/customers/update_currency_service.rb
+++ b/app/services/customers/update_currency_service.rb
@@ -2,6 +2,8 @@
 
 module Customers
   class UpdateCurrencyService < BaseService
+    Result = BaseResult
+
     def initialize(customer:, currency:, customer_update: false)
       @customer = customer
       @currency = currency

--- a/app/services/customers/update_invoice_issuing_date_settings_service.rb
+++ b/app/services/customers/update_invoice_issuing_date_settings_service.rb
@@ -2,6 +2,8 @@
 
 module Customers
   class UpdateInvoiceIssuingDateSettingsService < BaseService
+    Result = BaseResult[:customer]
+
     def initialize(customer:, params:)
       @customer = customer
       @params = params

--- a/app/services/customers/update_invoice_payment_due_date_service.rb
+++ b/app/services/customers/update_invoice_payment_due_date_service.rb
@@ -2,6 +2,8 @@
 
 module Customers
   class UpdateInvoicePaymentDueDateService < BaseService
+    Result = BaseResult[:customer]
+
     def initialize(customer:, net_payment_term:)
       @customer = customer
       @net_payment_term = net_payment_term

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -5,6 +5,8 @@ module Customers
     extend Forwardable
     include Customers::PaymentProviderFinder
 
+    Result = BaseResult[:customer]
+
     def initialize(customer:, args:)
       @customer = customer
       @args = args

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -4,6 +4,8 @@ module DailyUsages
   class ComputeAllService < BaseService
     ENQUEUE_BATCH_SIZE = 1_000
 
+    Result = BaseResult
+
     def initialize(timestamp: Time.current)
       @timestamp = timestamp
 

--- a/app/services/daily_usages/compute_diff_service.rb
+++ b/app/services/daily_usages/compute_diff_service.rb
@@ -2,6 +2,8 @@
 
 module DailyUsages
   class ComputeDiffService < BaseService
+    Result = BaseResult[:usage_diff]
+
     def initialize(daily_usage:, previous_daily_usage: nil)
       @daily_usage = daily_usage
       @previous_daily_usage = previous_daily_usage

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -2,6 +2,8 @@
 
 module DailyUsages
   class ComputeService < BaseService
+    Result = BaseResult[:daily_usage]
+
     def initialize(subscription:, timestamp:)
       @subscription = subscription
       @timestamp = timestamp

--- a/app/services/daily_usages/fill_from_invoice_service.rb
+++ b/app/services/daily_usages/fill_from_invoice_service.rb
@@ -4,6 +4,8 @@ module DailyUsages
   class FillFromInvoiceService < BaseService
     Usage = Struct.new(:from_datetime, :to_datetime, :issuing_date, :currency, :amount_cents, :total_amount_cents, :taxes_amount_cents, :fees)
 
+    Result = BaseResult[:daily_usages]
+
     def initialize(invoice:, subscriptions:)
       @invoice = invoice
       @subscriptions = subscriptions

--- a/app/services/data_exports/combine_parts_service.rb
+++ b/app/services/data_exports/combine_parts_service.rb
@@ -2,6 +2,8 @@
 
 module DataExports
   class CombinePartsService < BaseService
+    Result = BaseResult[:data_export]
+
     def initialize(data_export:)
       @data_export = data_export
       super

--- a/app/services/data_exports/create_part_service.rb
+++ b/app/services/data_exports/create_part_service.rb
@@ -2,6 +2,8 @@
 
 module DataExports
   class CreatePartService < BaseService
+    Result = BaseResult[:data_export_part]
+
     def initialize(data_export:, object_ids:, index:)
       @data_export = data_export
       @object_ids = object_ids

--- a/app/services/data_exports/create_service.rb
+++ b/app/services/data_exports/create_service.rb
@@ -2,6 +2,8 @@
 
 module DataExports
   class CreateService < BaseService
+    Result = BaseResult[:data_export]
+
     def initialize(organization:, user:, format:, resource_type:, resource_query:)
       @organization = organization
       @user = user

--- a/app/services/data_exports/export_resources_service.rb
+++ b/app/services/data_exports/export_resources_service.rb
@@ -2,6 +2,8 @@
 
 module DataExports
   class ExportResourcesService < BaseService
+    Result = BaseResult[:data_export, :data_export_parts]
+
     EXPIRED_FAILURE_MESSAGE = "Data Export already expired"
     PROCESSED_FAILURE_MESSAGE = "Data Export already processed"
     DEFAULT_BATCH_SIZE = 20

--- a/app/services/data_exports/process_part_service.rb
+++ b/app/services/data_exports/process_part_service.rb
@@ -2,6 +2,8 @@
 
 module DataExports
   class ProcessPartService < BaseService
+    Result = BaseResult[:data_export_part]
+
     def initialize(data_export_part:)
       @data_export_part = data_export_part
       @data_export = data_export_part.data_export

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -2,6 +2,8 @@
 
 module DunningCampaigns
   class CreateService < BaseService
+    Result = BaseResult[:dunning_campaign]
+
     def initialize(organization:, params:)
       @organization = organization
       @params = params

--- a/app/services/dunning_campaigns/destroy_service.rb
+++ b/app/services/dunning_campaigns/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module DunningCampaigns
   class DestroyService < BaseService
+    Result = BaseResult[:dunning_campaign]
+
     def initialize(dunning_campaign:)
       @dunning_campaign = dunning_campaign
 

--- a/app/services/dunning_campaigns/process_attempt_service.rb
+++ b/app/services/dunning_campaigns/process_attempt_service.rb
@@ -2,6 +2,8 @@
 
 module DunningCampaigns
   class ProcessAttemptService < BaseService
+    Result = BaseResult[:customer, :payment_request]
+
     def initialize(customer:, dunning_campaign_threshold:, billing_entity:)
       @customer = customer
       @dunning_campaign_threshold = dunning_campaign_threshold

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -2,6 +2,8 @@
 
 module DunningCampaigns
   class UpdateService < BaseService
+    Result = BaseResult[:dunning_campaign]
+
     def initialize(organization:, dunning_campaign:, params:)
       @dunning_campaign = dunning_campaign
       @organization = organization

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -2,6 +2,8 @@
 
 module Events
   class ValidateCreationService < BaseService
+    Result = BaseResult
+
     def initialize(organization:, event_params:, customer:, subscriptions: [])
       @organization = organization
       @event_params = event_params

--- a/app/services/fees/apply_provider_taxes_service.rb
+++ b/app/services/fees/apply_provider_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class ApplyProviderTaxesService < BaseService
+    Result = BaseResult[:applied_taxes]
+
     def initialize(fee:, fee_taxes:)
       @fee = fee
       @fee_taxes = fee_taxes

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class ApplyTaxesService < BaseService
+    Result = BaseResult[:applied_taxes]
+
     def initialize(fee:, tax_codes: nil, customer: nil, plan: nil)
       @fee = fee
       @tax_codes = tax_codes

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class ChargeService < BaseService
+    Result = BaseResult[:fees, :cached_aggregations]
+
     # optional params:
     # | usage_filters - UsageFilters
     #  - context (:current_usage, :invoice_preview, :recurring) - to be moved in usage_filters

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class CreateTrueUpService < BaseService
+    Result = BaseResult[:true_up_fee]
+
     def initialize(fee:, used_amount_cents:, used_precise_amount_cents:)
       @fee = fee
       @used_amount_cents = used_amount_cents

--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class EstimatePayInAdvanceService < BaseService
+    Result = BaseResult[:fees]
+
     def initialize(organization:, params:)
       @organization = organization
       # NOTE: validation is shared with event creation and is expecting a transaction_id
@@ -12,7 +14,10 @@ module Fees
 
     def call
       validation_result = Events::ValidateCreationService.call(organization:, event_params:, customer:, subscriptions:)
-      return validation_result unless validation_result.success?
+      unless validation_result.success?
+        result.fail_with_error!(validation_result.error)
+        return result
+      end
 
       if charges.none?
         return result.single_validation_failure!(field: :code, error_code: "does_not_match_an_instant_charge")

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class OneOffService < BaseService
+    Result = BaseResult[:fees]
+
     def initialize(invoice:, fees:)
       @invoice = invoice
       @fees = fees

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class SubscriptionService < BaseService
+    Result = BaseResult[:fee]
+
     def initialize(invoice:, subscription:, boundaries:, context: nil)
       @invoice = invoice
       @subscription = subscription

--- a/app/services/fees/update_service.rb
+++ b/app/services/fees/update_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class UpdateService < BaseService
+    Result = BaseResult[:fee]
+
     def initialize(fee:, params:)
       @fee = fee
       @params = params

--- a/app/services/inbound_webhooks/create_service.rb
+++ b/app/services/inbound_webhooks/create_service.rb
@@ -2,6 +2,8 @@
 
 module InboundWebhooks
   class CreateService < BaseService
+    Result = BaseResult[:inbound_webhook]
+
     def initialize(organization_id:, webhook_source:, payload:, event_type:, code: nil, signature: nil)
       @organization_id = organization_id
       @webhook_source = webhook_source

--- a/app/services/inbound_webhooks/process_service.rb
+++ b/app/services/inbound_webhooks/process_service.rb
@@ -7,6 +7,8 @@ module InboundWebhooks
       moneyhash: PaymentProviders::Moneyhash::HandleIncomingWebhookService
     }
 
+    Result = BaseResult[:inbound_webhook]
+
     def initialize(inbound_webhook:)
       @inbound_webhook = inbound_webhook
 

--- a/app/services/inbound_webhooks/validate_payload_service.rb
+++ b/app/services/inbound_webhooks/validate_payload_service.rb
@@ -7,6 +7,8 @@ module InboundWebhooks
       moneyhash: PaymentProviders::Moneyhash::ValidateIncomingWebhookService
     }
 
+    Result = BaseResult
+
     def initialize(organization_id:, code:, payload:, webhook_source:, signature:)
       @organization_id = organization_id
       @code = code

--- a/app/services/integrations/avalara/fetch_company_id_service.rb
+++ b/app/services/integrations/avalara/fetch_company_id_service.rb
@@ -3,6 +3,8 @@
 module Integrations
   module Avalara
     class FetchCompanyIdService < BaseService
+      Result = BaseResult
+
       def initialize(integration:)
         @integration = integration
         super

--- a/app/services/integrations/create_service.rb
+++ b/app/services/integrations/create_service.rb
@@ -2,6 +2,8 @@
 
 module Integrations
   class CreateService < BaseService
+    Result = BaseResult[:integration]
+
     # Guarantees security logging for integration creation.
     # Subclasses are unaware of the logging — the only requirement
     # is that `result.integration` is set upon the successful `call`.

--- a/app/services/integrations/destroy_service.rb
+++ b/app/services/integrations/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module Integrations
   class DestroyService < BaseService
+    Result = BaseResult[:integration]
+
     def initialize(integration:)
       @integration = integration
 

--- a/app/services/integrations/hubspot/save_portal_id_service.rb
+++ b/app/services/integrations/hubspot/save_portal_id_service.rb
@@ -3,6 +3,8 @@
 module Integrations
   module Hubspot
     class SavePortalIdService < BaseService
+      Result = BaseResult
+
       def initialize(integration:)
         @integration = integration
         super

--- a/app/services/integrations/update_service.rb
+++ b/app/services/integrations/update_service.rb
@@ -2,6 +2,8 @@
 
 module Integrations
   class UpdateService < BaseService
+    Result = BaseResult[:integration]
+
     # Guarantees security logging for integration updates.
     # Subclasses are unaware of the logging — the only requirement
     # is that `result.integration` is set upon the successful `call`.

--- a/app/services/invites/accept_service.rb
+++ b/app/services/invites/accept_service.rb
@@ -2,6 +2,8 @@
 
 module Invites
   class AcceptService < BaseService
+    Result = BaseResult[:membership, :token, :user]
+
     def call(**args)
       invite = args[:invite] || Invite.find_by(token: args[:token], status: :pending)
       return result.not_found_failure!(resource: "invite") unless invite

--- a/app/services/invites/create_service.rb
+++ b/app/services/invites/create_service.rb
@@ -2,6 +2,8 @@
 
 module Invites
   class CreateService < BaseService
+    Result = BaseResult[:invite, :invite_url]
+
     def initialize(args)
       @args = args
       super

--- a/app/services/invites/revoke_service.rb
+++ b/app/services/invites/revoke_service.rb
@@ -2,6 +2,8 @@
 
 module Invites
   class RevokeService < BaseService
+    Result = BaseResult[:invite]
+
     def initialize(invite)
       @invite = invite
       super

--- a/app/services/invites/update_service.rb
+++ b/app/services/invites/update_service.rb
@@ -2,6 +2,8 @@
 
 module Invites
   class UpdateService < BaseService
+    Result = BaseResult[:invite]
+
     def initialize(user:, invite:, params:)
       @user = user
       @invite = invite

--- a/app/services/invoice_custom_sections/attach_to_resource_service.rb
+++ b/app/services/invoice_custom_sections/attach_to_resource_service.rb
@@ -2,6 +2,8 @@
 
 module InvoiceCustomSections
   class AttachToResourceService < BaseService
+    Result = BaseResult
+
     def initialize(resource:, params:)
       super
 

--- a/app/services/invoice_custom_sections/funding_instructions_formatter_service.rb
+++ b/app/services/invoice_custom_sections/funding_instructions_formatter_service.rb
@@ -2,6 +2,8 @@
 
 module InvoiceCustomSections
   class FundingInstructionsFormatterService < BaseService
+    Result = BaseResult[:details]
+
     def initialize(funding_data:, locale:)
       @funding_data = funding_data
       @locale = locale

--- a/app/services/invoices/apply_invoice_custom_sections_service.rb
+++ b/app/services/invoices/apply_invoice_custom_sections_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class ApplyInvoiceCustomSectionsService < BaseService
+    Result = BaseResult[:applied_sections]
+
     def initialize(invoice:, resources: [], custom_section_ids: [])
       @invoice = invoice
       @customer = invoice.customer

--- a/app/services/invoices/apply_provider_taxes_service.rb
+++ b/app/services/invoices/apply_provider_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class ApplyProviderTaxesService < BaseService
+    Result = BaseResult[:applied_taxes, :invoice]
+
     def initialize(invoice:, provider_taxes: nil)
       @invoice = invoice
       @provider_taxes = provider_taxes || fetch_provider_taxes_result.fees

--- a/app/services/invoices/apply_taxes_service.rb
+++ b/app/services/invoices/apply_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class ApplyTaxesService < BaseService
+    Result = BaseResult[:applied_taxes, :invoice]
+
     def initialize(invoice:)
       @invoice = invoice
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class CalculateFeesService < BaseService
+    Result = BaseResult[:invoice, :non_invoiceable_fees]
+
     def initialize(invoice:, recurring: false, context: nil)
       @invoice = invoice
       @timestamp = invoice.invoice_subscriptions.first&.timestamp

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class ComputeAmountsFromFees < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:, provider_taxes: nil)
       @invoice = invoice
       @provider_taxes = provider_taxes

--- a/app/services/invoices/compute_taxes_and_totals_service.rb
+++ b/app/services/invoices/compute_taxes_and_totals_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class ComputeTaxesAndTotalsService < BaseService
+    Result = BaseResult[:invoice, :non_invoiceable_fees]
+
     def initialize(invoice:, finalizing: true)
       @invoice = invoice
       @finalizing = finalizing

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class CreateGeneratingService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false, skip_charges: false, invoice_id: nil, invoicing_reason: nil, subscription_gated: false, billing_entity: nil) # rubocop:disable Metrics/ParameterLists
       @customer = customer
       @invoice_type = invoice_type

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class CreateInvoiceSubscriptionService < BaseService
+    Result = BaseResult[:invoice_subscriptions]
+
     def initialize(invoice:, subscriptions:, timestamp:, invoicing_reason:, refresh: false)
       @invoice = invoice
       @subscriptions = subscriptions

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class CreateOneOffService < BaseService
+    Result = BaseResult[:invoice, :payment_method]
+
     def initialize(customer:, currency:, fees:, timestamp:, skip_psp: false, voided_invoice_id: nil, payment_method_params: nil, invoice_custom_section: {}, billing_entity_id: nil, billing_entity_code: nil, purchase_order_number: nil)
       @customer = customer
       @currency = currency || customer&.currency

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class CustomerUsageService < BaseService
+    Result = BaseResult[:invoice, :usage, :fees_taxes]
+
     def initialize(
       customer:,
       subscription:,

--- a/app/services/invoices/ensure_completed_vies_check_service.rb
+++ b/app/services/invoices/ensure_completed_vies_check_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class EnsureCompletedViesCheckService < BaseService
+    Result = BaseResult[:non_invoiceable_fees]
+
     def initialize(invoice:, finalizing: true)
       @invoice = invoice
       @customer = invoice&.customer

--- a/app/services/invoices/finalize_batch_service.rb
+++ b/app/services/invoices/finalize_batch_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class FinalizeBatchService < BaseService
+    Result = BaseResult[:invoice, :invoices]
+
     def initialize(organization:)
       @organization = organization
 

--- a/app/services/invoices/finalize_open_credit_service.rb
+++ b/app/services/invoices/finalize_open_credit_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class FinalizeOpenCreditService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:)
       @invoice = invoice
       super

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class FinalizeService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:)
       @invoice = invoice
       super

--- a/app/services/invoices/generate_pdf_service.rb
+++ b/app/services/invoices/generate_pdf_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class GeneratePdfService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:, context: nil)
       @invoice = invoice
       @context = context

--- a/app/services/invoices/lose_dispute_service.rb
+++ b/app/services/invoices/lose_dispute_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class LoseDisputeService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:, payment_dispute_lost_at: nil, reason: nil)
       @invoice = invoice
       @payment_dispute_lost_at = payment_dispute_lost_at.presence || DateTime.current

--- a/app/services/invoices/metadata/update_service.rb
+++ b/app/services/invoices/metadata/update_service.rb
@@ -3,6 +3,8 @@
 module Invoices
   module Metadata
     class UpdateService < BaseService
+      Result = BaseResult[:invoice]
+
       def initialize(invoice:, params:)
         @invoice = invoice
         @params = params

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -3,6 +3,8 @@
 module Invoices
   module Payments
     class CreateService < BaseService
+      Result = BaseResult[:invoice, :payment, :payment_provider]
+
       include Customers::PaymentProviderFinder
 
       def initialize(invoice:, payment_provider: nil, payment_method_params: {})

--- a/app/services/invoices/payments/mark_overdue_service.rb
+++ b/app/services/invoices/payments/mark_overdue_service.rb
@@ -3,6 +3,8 @@
 module Invoices
   module Payments
     class MarkOverdueService < BaseService
+      Result = BaseResult[:invoice]
+
       def initialize(invoice:)
         @invoice = invoice
 

--- a/app/services/invoices/payments/retry_batch_service.rb
+++ b/app/services/invoices/payments/retry_batch_service.rb
@@ -3,6 +3,8 @@
 module Invoices
   module Payments
     class RetryBatchService < BaseService
+      Result = BaseResult[:invoice, :invoices]
+
       def initialize(organization_id:)
         @organization_id = organization_id
 

--- a/app/services/invoices/payments/retry_service.rb
+++ b/app/services/invoices/payments/retry_service.rb
@@ -3,6 +3,8 @@
 module Invoices
   module Payments
     class RetryService < BaseService
+      Result = BaseResult[:invoice]
+
       def initialize(invoice:, payment_method_params: {})
         @invoice = invoice
         @payment_method_params = payment_method_params

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -3,6 +3,8 @@
 module Invoices
   module ProviderTaxes
     class PullTaxesAndApplyService < BaseService
+      Result = BaseResult[:invoice]
+
       def initialize(invoice:)
         @invoice = invoice
 

--- a/app/services/invoices/provider_taxes/void_service.rb
+++ b/app/services/invoices/provider_taxes/void_service.rb
@@ -3,6 +3,8 @@
 module Invoices
   module ProviderTaxes
     class VoidService < BaseService
+      Result = BaseResult[:invoice]
+
       def initialize(invoice:)
         @invoice = invoice
 

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class RefreshDraftAndFinalizeService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:)
       @invoice = invoice
       super

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class RefreshDraftService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:, context: :refresh)
       @invoice = invoice
       @subscription_ids = invoice.subscriptions.pluck(:id)

--- a/app/services/invoices/retry_batch_service.rb
+++ b/app/services/invoices/retry_batch_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class RetryBatchService < BaseService
+    Result = BaseResult[:invoice, :invoices]
+
     def initialize(organization:)
       @organization = organization
 

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class RetryService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:)
       @invoice = invoice
 

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class SubscriptionService < BaseService
+    Result = BaseResult[:invoice, :non_invoiceable_fees]
+
     def initialize(subscriptions:, timestamp:, invoicing_reason:, invoice: nil, skip_charges: false)
       @subscriptions = subscriptions
       @timestamp = timestamp

--- a/app/services/invoices/sync_salesforce_id_service.rb
+++ b/app/services/invoices/sync_salesforce_id_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class SyncSalesforceIdService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:, params:)
       @invoice = invoice
       @params = params

--- a/app/services/invoices/transition_to_final_status_service.rb
+++ b/app/services/invoices/transition_to_final_status_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class TransitionToFinalStatusService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:)
       @invoice = invoice
       @customer = @invoice.customer

--- a/app/services/invoices/update_all_invoice_issuing_date_from_billing_entity_service.rb
+++ b/app/services/invoices/update_all_invoice_issuing_date_from_billing_entity_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class UpdateAllInvoiceIssuingDateFromBillingEntityService < BaseService
+    Result = BaseResult
+
     def initialize(billing_entity:, previous_issuing_date_settings:)
       @billing_entity = billing_entity
       @previous_issuing_date_settings = previous_issuing_date_settings

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class UpdateService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:, params:, webhook_notification: false)
       @invoice = invoice
       @params = params

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class VoidService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:, params: {})
       @invoice = invoice
       @params = params

--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -2,6 +2,8 @@
 
 module LifetimeUsages
   class CalculateService < BaseService
+    Result = BaseResult[:lifetime_usage]
+
     def initialize(lifetime_usage:, current_usage: nil)
       @lifetime_usage = lifetime_usage
       @current_usage = current_usage

--- a/app/services/lifetime_usages/find_last_and_next_thresholds_service.rb
+++ b/app/services/lifetime_usages/find_last_and_next_thresholds_service.rb
@@ -2,6 +2,8 @@
 
 module LifetimeUsages
   class FindLastAndNextThresholdsService < BaseService
+    Result = BaseResult[:last_threshold_amount_cents, :next_threshold_amount_cents, :next_threshold_ratio]
+
     def initialize(lifetime_usage:)
       @lifetime_usage = lifetime_usage
 

--- a/app/services/lifetime_usages/flag_refresh_from_invoice_service.rb
+++ b/app/services/lifetime_usages/flag_refresh_from_invoice_service.rb
@@ -2,6 +2,8 @@
 
 module LifetimeUsages
   class FlagRefreshFromInvoiceService < BaseService
+    Result = BaseResult[:lifetime_usages]
+
     def initialize(invoice:)
       @invoice = invoice
       super

--- a/app/services/lifetime_usages/update_service.rb
+++ b/app/services/lifetime_usages/update_service.rb
@@ -2,6 +2,8 @@
 
 module LifetimeUsages
   class UpdateService < BaseService
+    Result = BaseResult[:lifetime_usage]
+
     def initialize(lifetime_usage:, params:)
       @lifetime_usage = lifetime_usage
       @params = params

--- a/app/services/lifetime_usages/usage_thresholds_completion_service.rb
+++ b/app/services/lifetime_usages/usage_thresholds_completion_service.rb
@@ -2,6 +2,8 @@
 
 module LifetimeUsages
   class UsageThresholdsCompletionService < BaseService
+    Result = BaseResult[:usage_thresholds]
+
     def initialize(lifetime_usage:)
       @lifetime_usage = lifetime_usage
       @usage_thresholds = lifetime_usage.subscription.applicable_usage_thresholds

--- a/app/services/memberships/revoke_service.rb
+++ b/app/services/memberships/revoke_service.rb
@@ -2,6 +2,8 @@
 
 module Memberships
   class RevokeService < BaseService
+    Result = BaseResult[:membership]
+
     def initialize(user:, membership:)
       @user = user
       @membership = membership

--- a/app/services/password_resets/create_service.rb
+++ b/app/services/password_resets/create_service.rb
@@ -2,6 +2,8 @@
 
 module PasswordResets
   class CreateService < BaseService
+    Result = BaseResult[:id]
+
     def initialize(user:)
       @user = user
 

--- a/app/services/password_resets/reset_service.rb
+++ b/app/services/password_resets/reset_service.rb
@@ -2,6 +2,8 @@
 
 module PasswordResets
   class ResetService < BaseService
+    Result = BaseResult
+
     def initialize(token:, new_password:)
       @token = token
       @new_password = new_password

--- a/app/services/payment_receipts/generate_xml_service.rb
+++ b/app/services/payment_receipts/generate_xml_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentReceipts
   class GenerateXmlService < BaseService
+    Result = BaseResult[:payment_receipt]
+
     def initialize(payment_receipt:, context: nil)
       @payment_receipt = payment_receipt
       @context = context

--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentRequests
   class CreateService < BaseService
+    Result = BaseResult[:payment_request]
+
     def initialize(organization:, params:, dunning_campaign: nil)
       @organization = organization
       @params = params

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -6,6 +6,8 @@ module PaymentRequests
       include Customers::PaymentProviderFinder
       include Updatable
 
+      Result = BaseResult[:payable, :payment, :payment_provider]
+
       def initialize(payable:, payment_provider: nil, payment_method_params: {})
         @payable = payable
         @provider = payment_provider&.to_sym

--- a/app/services/payment_requests/payments/flutterwave_service.rb
+++ b/app/services/payment_requests/payments/flutterwave_service.rb
@@ -6,6 +6,8 @@ module PaymentRequests
       include Customers::PaymentProviderFinder
       include Updatable
 
+      Result = BaseResult[:payable, :payment, :payment_url]
+
       def initialize(payable = nil)
         @payable = payable
 

--- a/app/services/payment_requests/update_service.rb
+++ b/app/services/payment_requests/update_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentRequests
   class UpdateService < BaseService
+    Result = BaseResult[:payable]
+
     def initialize(payable:, params:, webhook_notification: false)
       @payable = payable
       @params = params

--- a/app/services/payments/lose_dispute_service.rb
+++ b/app/services/payments/lose_dispute_service.rb
@@ -2,6 +2,8 @@
 
 module Payments
   class LoseDisputeService < BaseService
+    Result = BaseResult[:invoices, :payment]
+
     def initialize(payment:, payment_dispute_lost_at: nil, reason: nil)
       @payment = payment
       @payable = payment&.payable

--- a/app/services/payments/manual_create_service.rb
+++ b/app/services/payments/manual_create_service.rb
@@ -2,6 +2,8 @@
 
 module Payments
   class ManualCreateService < BaseService
+    Result = BaseResult[:payment]
+
     def initialize(organization:, params:)
       @organization = organization
       @params = params

--- a/app/services/quotes/lock_service.rb
+++ b/app/services/quotes/lock_service.rb
@@ -15,6 +15,8 @@ module Quotes
   class LockService < BaseService
     ACQUIRE_LOCK_TIMEOUT = 5.seconds
 
+    Result = BaseResult
+
     def initialize(quote:, timeout_seconds: ACQUIRE_LOCK_TIMEOUT, transaction: true)
       @quote = quote
       @timeout_seconds = timeout_seconds

--- a/app/services/taxes/create_service.rb
+++ b/app/services/taxes/create_service.rb
@@ -2,6 +2,8 @@
 
 module Taxes
   class CreateService < BaseService
+    Result = BaseResult[:tax]
+
     def initialize(organization:, params:)
       @organization = organization
       @params = params

--- a/app/services/taxes/update_service.rb
+++ b/app/services/taxes/update_service.rb
@@ -2,6 +2,8 @@
 
 module Taxes
   class UpdateService < BaseService
+    Result = BaseResult[:tax]
+
     def initialize(tax:, params:)
       @tax = tax
       @params = params

--- a/app/services/usage_thresholds/override_service.rb
+++ b/app/services/usage_thresholds/override_service.rb
@@ -2,6 +2,8 @@
 
 module UsageThresholds
   class OverrideService < BaseService
+    Result = BaseResult[:usage_thresholds]
+
     def initialize(usage_thresholds_params:, new_plan:)
       @usage_thresholds_params = usage_thresholds_params
       @new_plan = new_plan

--- a/app/services/wallet_transactions/mark_as_failed_service.rb
+++ b/app/services/wallet_transactions/mark_as_failed_service.rb
@@ -2,6 +2,8 @@
 
 module WalletTransactions
   class MarkAsFailedService < BaseService
+    Result = BaseResult[:wallet_transaction]
+
     def initialize(wallet_transaction:)
       @wallet_transaction = wallet_transaction
       super

--- a/app/services/wallet_transactions/payments/generate_payment_url_service.rb
+++ b/app/services/wallet_transactions/payments/generate_payment_url_service.rb
@@ -3,6 +3,8 @@
 module WalletTransactions
   module Payments
     class GeneratePaymentUrlService < BaseService
+      Result = BaseResult
+
       def initialize(wallet_transaction:)
         @wallet_transaction = wallet_transaction
         super

--- a/app/services/wallet_transactions/recredit_service.rb
+++ b/app/services/wallet_transactions/recredit_service.rb
@@ -2,6 +2,8 @@
 
 module WalletTransactions
   class RecreditService < BaseService
+    Result = BaseResult[:wallet_transaction]
+
     def initialize(wallet_transaction:)
       @wallet_transaction = wallet_transaction
       @wallet = wallet_transaction.wallet

--- a/app/services/wallet_transactions/settle_service.rb
+++ b/app/services/wallet_transactions/settle_service.rb
@@ -2,6 +2,8 @@
 
 module WalletTransactions
   class SettleService < BaseService
+    Result = BaseResult[:wallet_transaction]
+
     def initialize(wallet_transaction:)
       super(nil)
 

--- a/app/services/webhook_endpoints/create_service.rb
+++ b/app/services/webhook_endpoints/create_service.rb
@@ -2,6 +2,8 @@
 
 module WebhookEndpoints
   class CreateService < BaseService
+    Result = BaseResult[:webhook_endpoint]
+
     def initialize(organization:, params:)
       @organization = organization
       @params = params

--- a/app/services/webhook_endpoints/destroy_service.rb
+++ b/app/services/webhook_endpoints/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module WebhookEndpoints
   class DestroyService < BaseService
+    Result = BaseResult[:webhook_endpoint]
+
     def initialize(webhook_endpoint:)
       @webhook_endpoint = webhook_endpoint
 

--- a/app/services/webhook_endpoints/update_service.rb
+++ b/app/services/webhook_endpoints/update_service.rb
@@ -2,6 +2,8 @@
 
 module WebhookEndpoints
   class UpdateService < BaseService
+    Result = BaseResult[:webhook_endpoint]
+
     def initialize(id:, organization:, params:)
       @id = id
       @organization = organization

--- a/spec/services/invoices/generate_pdf_service_spec.rb
+++ b/spec/services/invoices/generate_pdf_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Invoices::GeneratePdfService do
       it "returns a result with error" do
         result = described_class.call(invoice:, context:)
 
-        expect(result.success).to be_falsey
+        expect(result).to be_failure
         expect(result.error.error_code).to eq("invoice_not_found")
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe Invoices::GeneratePdfService do
       it "returns a result with error" do
         result = described_class.call(invoice:, context:)
 
-        expect(result.success).to be_falsey
+        expect(result).to be_failure
         expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
         expect(result.error.code).to eq("is_draft")
       end

--- a/spec/services/payment_receipts/generate_xml_service_spec.rb
+++ b/spec/services/payment_receipts/generate_xml_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe PaymentReceipts::GenerateXmlService do
         it "results in error" do
           result = described_class.call(payment_receipt:, context:)
 
-          expect(result.success).to be_falsey
+          expect(result).to be_failure
           expect(result.error.error_code).to eq("payment_receipt_not_found")
         end
       end


### PR DESCRIPTION
## Context

This PR is part of the long standing epic required to enable YJIT on Lago by removing all remaining usage of `OpenStruct`

## Description

The goal of this changes is to define the `Result` for a lot of new service class to avoid using the `LegacyResult` (an `OpenStruct`) that will be definitely removed when all services will be migrated to the new approach.