### PR TITLE
fix(events): Correct pay-in-advance fees for events with same timestamp ClickHouse

### DIFF
--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -860,7 +860,7 @@ module Events
         ]
 
         conditions << sql_condition("#{prefix}timestamp >= ?", from_datetime) if from_datetime
-        conditions << sql_condition("#{prefix}timestamp <= ?", to_datetime) if to_datetime
+        conditions << upper_timestamp_boundary_sql(to_datetime, prefix:) if to_datetime
         conditions << grouped_by_values_sql_condition(prefix) if include_grouped_by_values && grouped_by_values?
 
         conditions.join(" AND ")

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -35,7 +35,7 @@ module Events
               .where(code:)
 
             query = query.where("events_enriched.timestamp >= ?", from_datetime) if force_from || use_from_boundary
-            query = query.where("events_enriched.timestamp <= ?", applicable_to_datetime) if applicable_to_datetime
+            query = query.where(upper_timestamp_boundary_sql(applicable_to_datetime, prefix: "events_enriched.")) if applicable_to_datetime
             query
           end
 
@@ -144,7 +144,7 @@ module Events
         ]
 
         conditions << ActiveRecord::Base.sanitize_sql_for_conditions(["#{prefix}timestamp >= ?", from_datetime]) if from_datetime
-        conditions << ActiveRecord::Base.sanitize_sql_for_conditions(["#{prefix}timestamp <= ?", to_datetime]) if to_datetime
+        conditions << upper_timestamp_boundary_sql(to_datetime, prefix:) if to_datetime
         conditions.join(" AND ")
       end
 
@@ -784,7 +784,7 @@ module Events
 
       def with_timestamp_boundaries(query, from_datetime, to_datetime)
         query = query.where(arel_table[:timestamp].gteq(from_datetime)) if from_datetime
-        query = query.where(arel_table[:timestamp].lteq(to_datetime)) if to_datetime
+        query = query.where(Arel.sql(upper_timestamp_boundary_sql(to_datetime, prefix: "events_enriched."))) if to_datetime
         query
       end
 

--- a/app/services/events/stores/utils/clickhouse_sql_helpers.rb
+++ b/app/services/events/stores/utils/clickhouse_sql_helpers.rb
@@ -43,6 +43,25 @@ module Events
         def sql_condition(template, *values)
           ActiveRecord::Base.sanitize_sql_for_conditions([template, *values])
         end
+
+        # When the boundary is the pay-in-advance event's own timestamp, tie-break events
+        # sharing it by transaction_id so each gets a distinct position instead of all being
+        # priced as the batch's last unit. transaction_id trails every events sort key, so
+        # the comparison stays index-aligned. Any other boundary keeps the plain <=.
+        def upper_timestamp_boundary_sql(to_datetime, prefix: "")
+          boundary_transaction_id = (filters[:event]&.transaction_id if to_datetime == boundaries[:max_timestamp])
+
+          if boundary_transaction_id
+            sql_condition(
+              "(#{prefix}timestamp < ? OR (#{prefix}timestamp = ? AND #{prefix}transaction_id <= ?))",
+              to_datetime,
+              to_datetime,
+              boundary_transaction_id
+            )
+          else
+            sql_condition("#{prefix}timestamp <= ?", to_datetime)
+          end
+        end
       end
     end
   end

--- a/spec/scenarios/clickhouse/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/clickhouse/pay_in_advance_charges_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Pay in advance charges Scenarios (Clickhouse)", clickhouse: true, transaction: false do
+  let(:organization) { create(:organization, webhook_url: nil, clickhouse_events_store: true) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, amount_cents: 1000) }
+  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg", field_name: nil) }
+
+  # Mirrors the Postgres scenario from spec/scenarios/pay_in_advance_charges_spec.rb:
+  # events sharing the same timestamp must each be priced at their own position in
+  # the graduated ranges, not all as the last unit of the batch.
+  describe "with count_agg / graduated when events share the same timestamp" do
+    it "assigns each event its own marginal amount" do
+      travel_to(DateTime.new(2023, 1, 24)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code
+          }
+        )
+      end
+
+      charge = create(
+        :graduated_charge,
+        :pay_in_advance,
+        invoiceable: false,
+        plan:,
+        billable_metric:,
+        properties: {
+          graduated_ranges: [
+            {from_value: 0, to_value: 2, per_unit_amount: "0", flat_amount: "0"},
+            {from_value: 3, to_value: nil, per_unit_amount: "2", flat_amount: "0"}
+          ]
+        }
+      )
+
+      subscription = customer.subscriptions.first
+      timestamp = Time.zone.parse("2023-02-15 10:00:00.000")
+
+      events = Array.new(3) do
+        Events::Common.new(
+          organization_id: organization.id,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp:,
+          properties: {}
+        )
+      end
+
+      # All events are ingested before any fee is calculated, like a batch ingestion.
+      events.each do |event|
+        Clickhouse::EventsEnriched.create!(
+          transaction_id: event.transaction_id,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          timestamp:,
+          properties: {},
+          value: "1",
+          decimal_value: 1.to_d,
+          enriched_at: Time.current
+        )
+      end
+
+      travel_to(timestamp + 1.second) do
+        events.each { |event| Fees::CreatePayInAdvanceService.call!(charge:, event: event.as_json) }
+      end
+
+      fees = subscription.fees.where(charge:)
+      expect(fees.map(&:pay_in_advance_event_transaction_id)).to match_array(events.map(&:transaction_id))
+      expect(fees.map(&:units)).to all(eq(1))
+      expect(fees.map(&:amount_cents).sort).to eq([0, 0, 200])
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse_enriched_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_enriched_store_spec.rb
@@ -119,4 +119,55 @@ RSpec.describe Events::Stores::ClickhouseEnrichedStore, clickhouse: {clean_befor
       end
     end
   end
+
+  # SQL-shape guard: the transaction_id tie-break applies only when aggregating for a
+  # pay-in-advance event AND the boundary is that event's own timestamp.
+  describe "#charge_id_based_where_sql boundary predicate" do
+    let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
+    let(:organization) { billable_metric.organization }
+    let(:charge) { create(:standard_charge, organization:, billable_metric:) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:, started_at: DateTime.parse("2023-03-15")) }
+    let(:event_timestamp) { subscription.started_at.beginning_of_day + 1.day }
+
+    def event_store(filters)
+      described_class.new(
+        code: billable_metric.code,
+        subscription:,
+        boundaries: {
+          from_datetime: subscription.started_at.beginning_of_day,
+          to_datetime: subscription.started_at.end_of_month.end_of_day,
+          max_timestamp: event_timestamp,
+          charges_duration: 31
+        },
+        filters: {charge_id: charge.id}.merge(filters)
+      )
+    end
+
+    it "tie-breaks the boundary on transaction_id for a pay-in-advance event" do
+      store = event_store(event: Events::Common.new(transaction_id: "tx-boundary", timestamp: event_timestamp))
+
+      sql = store.charge_id_based_where_sql(from_datetime: nil, to_datetime: event_timestamp)
+
+      expect(sql).to include("transaction_id <= 'tx-boundary'")
+    end
+
+    it "keeps the plain timestamp upper bound without a pay-in-advance event" do
+      store = event_store({})
+
+      sql = store.charge_id_based_where_sql(from_datetime: nil, to_datetime: event_timestamp)
+
+      expect(sql).to include("timestamp <=")
+      expect(sql).not_to include("transaction_id <=")
+    end
+
+    it "keeps the plain timestamp upper bound when the boundary is not the event timestamp" do
+      store = event_store(event: Events::Common.new(transaction_id: "tx-boundary", timestamp: event_timestamp))
+
+      sql = store.charge_id_based_where_sql(from_datetime: nil, to_datetime: event_timestamp - 0.001.seconds)
+
+      expect(sql).to include("timestamp <=")
+      expect(sql).not_to include("transaction_id <=")
+    end
+  end
 end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -308,4 +308,69 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       expect(event_store.count.value).to eq(join_based_count)
     end
   end
+
+  # Events sharing the pay-in-advance boundary timestamp are tie-broken by
+  # transaction_id so each gets a distinct position, not the batch's last unit.
+  describe "#count with a pay-in-advance boundary" do
+    let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
+    let(:organization) { billable_metric.organization }
+    let(:charge) { create(:standard_charge, organization:, billable_metric:) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:, started_at: DateTime.parse("2023-03-15")) }
+    let(:boundary_timestamp) { subscription.started_at.beginning_of_day + 1.day }
+
+    def event_store_for(boundary_transaction_id, deduplicate:)
+      described_class.new(
+        code: billable_metric.code,
+        subscription:,
+        boundaries: {
+          from_datetime: subscription.started_at.beginning_of_day,
+          to_datetime: subscription.started_at.end_of_month.end_of_day,
+          max_timestamp: boundary_timestamp,
+          charges_duration: 31
+        },
+        filters: {
+          event: Events::Common.new(
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            transaction_id: boundary_transaction_id,
+            code: billable_metric.code,
+            timestamp: boundary_timestamp
+          )
+        },
+        deduplicate:
+      )
+    end
+
+    def insert_event(transaction_id:, timestamp:)
+      Clickhouse::EventsEnriched.create!(
+        transaction_id:,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        code: billable_metric.code,
+        timestamp:,
+        properties: {"value" => 1},
+        value: 1,
+        decimal_value: 1.to_d,
+        precise_total_amount_cents: 1,
+        enriched_at: Time.current
+      )
+    end
+
+    before do
+      insert_event(transaction_id: SecureRandom.uuid, timestamp: boundary_timestamp - 1.hour)
+      insert_event(transaction_id: SecureRandom.uuid, timestamp: boundary_timestamp - 2.hours)
+      %w[tx-1 tx-2 tx-3].each { |tx| insert_event(transaction_id: tx, timestamp: boundary_timestamp) }
+    end
+
+    [true, false].each do |dedup|
+      context "with deduplicate: #{dedup}" do
+        it "assigns each event sharing the boundary timestamp a distinct position" do
+          counts = %w[tx-1 tx-2 tx-3].map { |tx| event_store_for(tx, deduplicate: dedup).count.value }
+
+          expect(counts).to eq([3, 4, 5])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context
This is a ClickHouse version of the fix in PR #5740.

With a graduated charge (0–2 units = 0 EUR, 3+ = 2 EUR/unit) and 3 events at the same second, the expected fees are 0, 0, 200 cents; instead each fee is billed 200 cents, tripling the total. The fee amounts also feed fee.created webhooks, so customers receive incorrect amounts.

## Description

Tie-break events sharing the boundary timestamp by transaction_id, giving each event a distinct position in the aggregation.
