### PR TITLE
misc(event): delete event_property_combinations flag

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -10,10 +10,6 @@ enriched_events_aggregation:
   description: "Use the enriched events store for aggregation queries in ClickHouse"
   owners: ["@vincent-pochet"]
 
-event_property_combinations:
-  description: "Resolve exact charge filters from distinct event property combinations during billing period filtering"
-  owners: ["@vincent-pochet"]
-
 wallet_traceability:
   description: "Enable wallet traceability on newly created wallets"
   owners: ["@groyoh", "@D1353L"]

--- a/schema.graphql
+++ b/schema.graphql
@@ -5864,7 +5864,6 @@ Organization Feature Flag Values
 """
 enum FeatureFlagEnum {
   enriched_events_aggregation
-  event_property_combinations
   multi_currency
   multi_entity_billing
   multiple_payment_methods

--- a/schema.json
+++ b/schema.json
@@ -28536,12 +28536,6 @@
               "deprecationReason": null
             },
             {
-              "name": "event_property_combinations",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "wallet_traceability",
               "description": null,
               "isDeprecated": false,


### PR DESCRIPTION
## Description

This PR removes the `event_property_combinations` feature flag that was used to gate the aggregation pre-filtering for a subset of organization. 
The feature was made fully available to all organization with https://github.com/getlago/lago-api/pull/5849