### PR TITLE
feat(orders): add executeOrder mutation shell

### DIFF
--- a/app/graphql/mutations/orders/execute.rb
+++ b/app/graphql/mutations/orders/execute.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Orders
+    class Execute < BaseMutation
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "orders:execute"
+
+      graphql_name "ExecuteOrder"
+      description "Execute an order"
+
+      input_object_class Types::Orders::ExecuteInput
+
+      type Types::Orders::Object
+
+      def resolve(**args)
+        order = current_organization.orders.find_by(id: args[:id])
+        result = ::Orders::ExecuteService.call(order:)
+
+        result.success? ? result.order : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -152,6 +152,7 @@ module Types
 
     field :void_order_form, mutation: Mutations::OrderForms::Void
 
+    field :execute_order, mutation: Mutations::Orders::Execute
     field :update_order, mutation: Mutations::Orders::Update
 
     field :download_payment_receipt, mutation: Mutations::PaymentReceipts::Download

--- a/app/graphql/types/orders/execute_input.rb
+++ b/app/graphql/types/orders/execute_input.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class ExecuteInput < Types::BaseInputObject
+      description "Execute Order input arguments"
+
+      argument :id, ID, required: true
+    end
+  end
+end

--- a/app/services/orders/execute_service.rb
+++ b/app/services/orders/execute_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Orders
+  class ExecuteService < BaseService
+    include OrderForms::Premium
+
+    Result = BaseResult[:order]
+
+    def initialize(order:)
+      @order = order
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "order") unless order
+      return result.forbidden_failure! unless order_forms_enabled?(order.organization)
+
+      Order.transaction do
+        Quotes::LockService.call(quote: order.quote) do
+          order.reload
+          next result.single_validation_failure!(field: :status, error_code: "not_executable") unless order.created?
+          next result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory") if order.execution_mode.blank?
+
+          # TODO: delegate to the order_type execution service (billing, execution_record, webhook)
+          order.update!(status: :executed, executed_at: Time.current)
+
+          result.order = order
+        end
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :order
+  end
+end

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -156,6 +156,8 @@ orders:
     - manager
   update:
     - manager
+  execute:
+    - manager
 organization:
   view:
     - finance

--- a/schema.graphql
+++ b/schema.graphql
@@ -5860,6 +5860,17 @@ enum EventsStoreEnum {
 }
 
 """
+Execute Order input arguments
+"""
+input ExecuteOrderInput {
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  id: ID!
+}
+
+"""
 Organization Feature Flag Values
 """
 enum FeatureFlagEnum {
@@ -8092,6 +8103,16 @@ type Mutation {
   ): PaymentReceipt
 
   """
+  Execute an order
+  """
+  executeOrder(
+    """
+    Parameters for ExecuteOrder
+    """
+    input: ExecuteOrderInput!
+  ): Order
+
+  """
   Fetches taxes for one-off invoice
   """
   fetchDraftInvoiceTaxes(
@@ -9531,6 +9552,7 @@ enum PermissionEnum {
   order_forms_sign
   order_forms_view
   order_forms_void
+  orders_execute
   orders_update
   orders_view
   organization_emails_update
@@ -9649,6 +9671,7 @@ type Permissions {
   orderFormsSign: Boolean!
   orderFormsView: Boolean!
   orderFormsVoid: Boolean!
+  ordersExecute: Boolean!
   ordersUpdate: Boolean!
   ordersView: Boolean!
   organizationEmailsUpdate: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -28510,6 +28510,45 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ExecuteOrderInput",
+          "description": "Execute Order input arguments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "FeatureFlagEnum",
           "description": "Organization Feature Flag Values",
@@ -40324,6 +40363,35 @@
               "deprecationReason": null
             },
             {
+              "name": "executeOrder",
+              "description": "Execute an order",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for ExecuteOrder",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ExecuteOrderInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "fetchDraftInvoiceTaxes",
               "description": "Fetches taxes for one-off invoice",
               "args": [
@@ -46620,6 +46688,12 @@
               "deprecationReason": null
             },
             {
+              "name": "orders_execute",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -47847,6 +47921,22 @@
             },
             {
               "name": "orderFormsVoid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ordersExecute",
               "description": null,
               "args": [],
               "type": {

--- a/spec/graphql/mutations/orders/execute_spec.rb
+++ b/spec/graphql/mutations/orders/execute_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::Orders::Execute do
+  let(:required_permission) { "orders:execute" }
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:membership) { create(:membership, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:order) { create(:order, organization:, customer:, execution_mode: "order_only") }
+
+  let(:mutation) do
+    <<~GQL
+      mutation($input: ExecuteOrderInput!) {
+        executeOrder(input: $input) {
+          id
+          status
+          executedAt
+        }
+      }
+    GQL
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "orders:execute"
+
+  it "executes the order", :premium do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input: {id: order.id}}
+    )
+
+    data = result["data"]["executeOrder"]
+
+    expect(data["id"]).to eq(order.id)
+    expect(data["status"]).to eq("executed")
+    expect(data["executedAt"]).to be_present
+  end
+
+  context "without a premium license" do
+    it "returns a forbidden error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: order.id}}
+      )
+
+      expect_graphql_error(result:, message: "feature_unavailable")
+    end
+  end
+
+  context "when order is not executable", :premium do
+    let(:order) { create(:order, :executed_order_only, organization:, customer:) }
+
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: order.id}}
+      )
+
+      expect_graphql_error(result:, message: "Unprocessable Entity", details: {status: ["not_executable"]})
+    end
+  end
+
+  context "when order is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: SecureRandom.uuid}}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/types/orders/execute_input_spec.rb
+++ b/spec/graphql/types/orders/execute_input_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Orders::ExecuteInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:id).of_type("ID!")
+  end
+end

--- a/spec/services/orders/execute_service_spec.rb
+++ b/spec/services/orders/execute_service_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orders::ExecuteService do
+  subject(:service) { described_class.new(order:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:order) { create(:order, organization:, customer:, execution_mode: "order_only") }
+
+  describe "#call" do
+    context "without premium license" do
+      it "returns a forbidden failure" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "with premium license", :premium do
+      context "when order is nil" do
+        let(:order) { nil }
+
+        it "returns a not found failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("order")
+        end
+      end
+
+      context "when the order_forms feature flag is disabled" do
+        let(:organization) { create(:organization) }
+
+        it "returns a forbidden failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        end
+      end
+
+      context "with concurrent mutations" do
+        it "wraps the work in a per-quote lock" do
+          allow(Quotes::LockService).to receive(:call).and_call_original
+
+          service.call
+
+          expect(Quotes::LockService).to have_received(:call).with(quote: order.quote).at_least(:once)
+        end
+      end
+
+      context "when the order is already executed" do
+        let(:order) { create(:order, :executed_in_lago, organization:, customer:) }
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({status: ["not_executable"]})
+        end
+      end
+
+      context "when the order has no execution_mode" do
+        let(:order) { create(:order, organization:, customer:) }
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({execution_mode: ["value_is_mandatory"]})
+        end
+      end
+
+      context "when the order is executable" do
+        it "transitions the order to executed" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order).to be_executed
+          expect(result.order.executed_at).to be_present
+          expect(result.order.execution_mode).to eq("order_only")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [Quotes & Order forms](https://getlago.canny.io/feature-requests/p/create-quotes-order-forms)

## Context

A signed order form creates an `Order` that stays stuck in `created`: nothing can execute it yet. The real execution work (one-off validation, invoicing, `execution_record`, webhook, scheduled execution) comes in follow-up PRs, but the frontend needs the GraphQL surface now to start building against it.

## Description

- Add the `executeOrder` mutation behind a new `orders:execute` permission.
- Add a shell `Orders::ExecuteService`