### PR TITLE
fix: discard Idempotency::IdempotencyError for RecalculateAndCheckJob

### DIFF
--- a/app/jobs/lifetime_usages/recalculate_and_check_job.rb
+++ b/app/jobs/lifetime_usages/recalculate_and_check_job.rb
@@ -12,6 +12,15 @@ module LifetimeUsages
 
     retry_on Customers::FailedToAcquireLock, ActiveRecord::StaleObjectError, attempts: MAX_LOCK_RETRY_ATTEMPTS, wait: random_lock_retry_delay
 
+    # This job can run concurrently for the same lifetime usage (the clock's async
+    # sweep and the inline perform_now from subscription activity processing don't
+    # share the uniqueness lock). When they race on the same passed threshold, the
+    # losing run raises an IdempotencyError because the progressive billing invoice
+    # was already created by the winning run. That is a benign no-op, not a failure
+    # to retry, so we discard it instead of letting it exhaust retries and pile up
+    # in the dead set.
+    discard_on Idempotency::IdempotencyError
+
     unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
 
     # NOTE: do not pass current usage with perform_later as it will be a huge JSON

--- a/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
+++ b/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
@@ -64,4 +64,22 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckJob do
       end
     end
   end
+
+  describe "discard_on" do
+    context "when an Idempotency::IdempotencyError is raised", :premium do
+      before do
+        allow(LifetimeUsages::CalculateService).to receive(:call!)
+        allow(LifetimeUsages::CheckThresholdsService).to receive(:call!)
+          .and_raise(Idempotency::IdempotencyError.new("already exists"))
+      end
+
+      it "discards the job without raising or retrying" do
+        assert_performed_jobs(1, only: [described_class]) do
+          expect do
+            described_class.perform_later(lifetime_usage)
+          end.not_to raise_error
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
 ## Context

`LifetimeUsages::RecalculateAndCheckJob` runs from two paths that don't share the Sidekiq uniqueness lock (the clock's perform_later and the inline perform_now from subscription activity), so two runs can execute concurrently for the same lifetime usage. When they do, both attempt the same progressive billing invoice; the loser raises `Idempotency::IdempotencyError` at the invoice-level idempotency guard because the winner already created it.

## Description

Add `discard_on Idempotency::IdempotencyError` to the job so the losing run is dropped instead of retried, stopping the dead-job accumulation.