### PR TITLE
feat(products): attach rate cards to subscriptions

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -167,6 +167,7 @@ module Api
             :external_id,
             :billing_time,
             :subscription_at,
+            :billing_anchor_date,
             :ending_at,
             :progressive_billing_disabled,
             :consolidate_invoice,

--- a/app/controllers/api/v2/subscription_rate_cards/rate_phases_controller.rb
+++ b/app/controllers/api/v2/subscription_rate_cards/rate_phases_controller.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    module SubscriptionRateCards
+      class RatePhasesController < Api::BaseController
+        include Api::RequiresProductCatalog
+
+        def index
+          return not_found_error(resource: "applied_rate_card") unless subscription_rate_card
+
+          render_rate_phases(subscription_rate_card.rate_phases.order(:position))
+        end
+
+        def create
+          return not_found_error(resource: "applied_rate_card") unless subscription_rate_card
+
+          result = ::RatePhases::CreateService.call(
+            subscription_rate_card:,
+            params: create_params.to_h.deep_symbolize_keys
+          )
+
+          if result.success?
+            render_rate_phase(result.rate_phase)
+          else
+            render_error_response(result)
+          end
+        end
+
+        def update
+          rate_phase = find_rate_phase
+          return not_found_error(resource: "rate_phase") unless rate_phase
+
+          result = ::RatePhases::UpdateService.call(
+            rate_phase:,
+            params: update_params.to_h.deep_symbolize_keys
+          )
+
+          if result.success?
+            render_rate_phase(result.rate_phase)
+          else
+            render_error_response(result)
+          end
+        end
+
+        def destroy
+          rate_phase = find_rate_phase
+          return not_found_error(resource: "rate_phase") unless rate_phase
+
+          result = ::RatePhases::DestroyService.call(rate_phase:)
+
+          if result.success?
+            render_rate_phase(result.rate_phase)
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        def subscription_rate_card
+          @subscription_rate_card ||= begin
+            subscriptions = current_organization.subscriptions.where(external_id: params[:subscription_external_id])
+            subscription = subscriptions.pending.first || subscriptions.order(created_at: :desc).first
+
+            if subscription
+              entries = subscription.applied_rate_cards.joins(:rate_card).where(rate_cards: {code: params[:applied_rate_card_code]})
+              # The version in force now, or the upcoming one: a card authored
+              # on a pending subscription starts in the future and must stay
+              # addressable during its authoring window.
+              entries.active_at(Time.current).first || entries.current_and_scheduled.order(:started_at).first
+            end
+          end
+        end
+
+        def find_rate_phase
+          subscription_rate_card&.rate_phases&.find_by(code: params[:code])
+        end
+
+        def create_params
+          params.require(:rate_phase).permit(
+            :code, :position, :name, :billing_interval_cycle_count,
+            rate_override: [
+              :rate_model,
+              :min_amount_cents,
+              :billing_interval_count,
+              :billing_interval_unit,
+              :pricing_unit_conversion_rate,
+              # Structural card fields pass through so the override service can
+              # reject them explicitly instead of strong params dropping them.
+              :billing_timing,
+              :currency,
+              :proration,
+              :display_on_invoice,
+              :regroup_paid_fees,
+              :wallet_targetable,
+              :applied_pricing_unit_code,
+              {rate_properties: {}}
+            ]
+          )
+        end
+
+        # Positions are not editable on update (ordering goes through insert
+        # and delete), so update does not permit one.
+        def update_params
+          # Required before any wrapper inspection so a missing rate_phase key
+          # stays a parameter-missing 400, not a NoMethodError.
+          permitted = permitted_update_params
+
+          # permit drops an explicit null; carry it through so an override can
+          # be cleared over REST like it can over GraphQL.
+          if params[:rate_phase].include?(:rate_override) && params[:rate_phase][:rate_override].nil?
+            permitted = permitted.merge(rate_override: nil)
+          end
+
+          permitted
+        end
+
+        def permitted_update_params
+          params.require(:rate_phase).permit(
+            :code, :name, :billing_interval_cycle_count,
+            rate_override: [
+              :rate_model,
+              :min_amount_cents,
+              :billing_interval_count,
+              :billing_interval_unit,
+              :pricing_unit_conversion_rate,
+              # Structural card fields pass through so the override service can
+              # reject them explicitly instead of strong params dropping them.
+              :billing_timing,
+              :currency,
+              :proration,
+              :display_on_invoice,
+              :regroup_paid_fees,
+              :wallet_targetable,
+              :applied_pricing_unit_code,
+              {rate_properties: {}}
+            ]
+          )
+        end
+
+        def render_rate_phase(rate_phase)
+          render(json: ::V2::RatePhaseSerializer.new(rate_phase, root_name: "rate_phase"))
+        end
+
+        def render_rate_phases(rate_phases)
+          render(
+            json: ::CollectionSerializer.new(
+              rate_phases,
+              ::V2::RatePhaseSerializer,
+              collection_name: "rate_phases"
+            )
+          )
+        end
+
+        def resource_name
+          "subscription_rate_card"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/subscription_rate_cards_controller.rb
+++ b/app/controllers/api/v2/subscription_rate_cards_controller.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class SubscriptionRateCardsController < Api::BaseController
+      include Api::RequiresProductCatalog
+
+      def create
+        result = ::SubscriptionRateCards::CreateService.call(
+          subscription: find_subscription,
+          params: create_params.to_h.deep_symbolize_keys
+        )
+
+        if result.success?
+          render_subscription_rate_card(result.subscription_rate_card)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        subscription_rate_card = find_subscription_rate_card
+
+        return not_found_error(resource: "applied_rate_card") unless subscription_rate_card
+
+        render_subscription_rate_card(subscription_rate_card)
+      end
+
+      def update
+        subscription_rate_card = find_subscription_rate_card
+        result = ::SubscriptionRateCards::UpdateService.call(
+          subscription_rate_card:,
+          params: update_params.to_h.deep_symbolize_keys
+        )
+
+        if result.success?
+          render_subscription_rate_card(result.subscription_rate_card)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def destroy
+        subscription_rate_card = find_subscription_rate_card
+        result = ::SubscriptionRateCards::DestroyService.call(subscription_rate_card:)
+
+        if result.success?
+          render_subscription_rate_card(result.subscription_rate_card)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def index
+        subscription = find_subscription
+        return not_found_error(resource: "subscription") unless subscription
+
+        # Scope by id, not external_id: several subscriptions can share an
+        # external_id over time and the list must match the version the nested
+        # routes address.
+        result = ::SubscriptionRateCardsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters: {subscription_id: subscription.id}
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.subscription_rate_cards,
+              ::V1::SubscriptionRateCardSerializer,
+              collection_name: "applied_rate_cards",
+              meta: pagination_metadata(result.subscription_rate_cards)
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      private
+
+      # All routes are nested under the subscription: an entry is addressed by
+      # its natural key — the subscription external id and the rate card code
+      # (unique together thanks to the one-card-per-slice rule) — so consumers
+      # never persist Lago ids.
+      def find_subscription_rate_card
+        subscription = find_subscription
+        return nil unless subscription
+
+        entries = subscription.applied_rate_cards.joins(:rate_card).where(rate_cards: {code: params[:code]})
+        # The version in force now, or the upcoming one: a card authored on a
+        # pending subscription starts in the future and must stay addressable
+        # during its authoring window.
+        entries.active_at(Time.current).first || entries.current_and_scheduled.order(:started_at).first
+      end
+
+      # A pending subscription can share its external_id with a past one;
+      # prefer the pending one (the only editable state), then the latest.
+      def find_subscription
+        subscriptions = current_organization.subscriptions.where(external_id: params[:subscription_external_id])
+        subscriptions.pending.first || subscriptions.order(created_at: :desc).first
+      end
+
+      def create_params
+        params.require(:applied_rate_card).permit(
+          :rate_card_code, :units, :started_at, :billing_anchor_date,
+          rate_phases: [
+            :code,
+            :position,
+            :name,
+            :billing_interval_cycle_count,
+            {rate_override: [
+              :rate_model,
+              :min_amount_cents,
+              :billing_interval_count,
+              :billing_interval_unit,
+              :pricing_unit_conversion_rate,
+              # Structural card fields pass through so the override service can
+              # reject them explicitly instead of strong params dropping them.
+              :billing_timing,
+              :currency,
+              :proration,
+              :display_on_invoice,
+              :regroup_paid_fees,
+              :wallet_targetable,
+              :applied_pricing_unit_code,
+              {rate_properties: {}}
+            ]}
+          ]
+        )
+      end
+
+      def update_params
+        params.require(:applied_rate_card).permit(:units, :apply_units, :started_at, :billing_anchor_date)
+      end
+
+      def render_subscription_rate_card(subscription_rate_card)
+        render(json: ::V1::SubscriptionRateCardSerializer.new(subscription_rate_card, root_name: "applied_rate_card"))
+      end
+
+      def resource_name
+        "subscription_rate_card"
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/subscriptions_controller.rb
+++ b/app/controllers/api/v2/subscriptions_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class SubscriptionsController < Api::BaseController
+      include Api::RequiresProductCatalog
+
+      def index
+        filters = params.permit(:plan_code, :external_customer_id, :external_id, status: [])
+        filters[:status] = ["active"] if filters[:status].blank?
+
+        result = ::SubscriptionsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters:
+        )
+
+        if result.success?
+          subscriptions = result.subscriptions.includes(:plan, customer: :billing_entity)
+
+          # One grouped query instead of one COUNT per row in the serializer.
+          applied_rate_cards_counts = SubscriptionRateCard.current_and_scheduled
+            .where(subscription_id: subscriptions.map(&:id))
+            .group(:subscription_id)
+            .count
+
+          render(
+            json: ::CollectionSerializer.new(
+              subscriptions,
+              ::V2::SubscriptionSerializer,
+              collection_name: "subscriptions",
+              meta: pagination_metadata(subscriptions),
+              applied_rate_cards_counts:
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        subscription = current_organization.subscriptions
+          .order("terminated_at DESC NULLS FIRST, started_at DESC")
+          .find_by(
+            external_id: params[:external_id],
+            status: params[:status] || :active
+          )
+        return not_found_error(resource: "subscription") unless subscription
+
+        render(
+          json: ::V2::SubscriptionSerializer.new(
+            subscription,
+            root_name: "subscription",
+            includes: %i[applied_rate_cards]
+          )
+        )
+      end
+
+      private
+
+      def resource_name
+        "subscription"
+      end
+    end
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -8,6 +8,7 @@ class ApiKey < ApplicationRecord
     customer event fee invoice organization order order_form payment payment_receipt payment_request payment_method plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
     billing_entity alert feature security_log quote product_category product rate_card plan_rate_card
+    subscription_rate_card
   ].freeze
 
   MODES = %w[read write].freeze

--- a/app/models/concerns/rate_phaseable.rb
+++ b/app/models/concerns/rate_phaseable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Shared by the two rate-phase parents (plan_rate_card and
+# subscription_rate_card): walking the ordered phase sequence to find the
+# one covering a billing cycle.
+module RatePhaseable
+  extend ActiveSupport::Concern
+
+  # Returns the rate phase covering the given zero-based billing cycle index.
+  # Phases (ordered by position) partition the timeline by their cumulative
+  # billing_interval_cycle_count; the final phase may carry a nil count,
+  # meaning it runs indefinitely. Returns nil when no phase covers the cycle.
+  def rate_phase_for_cycle(cycle_index)
+    cursor = 0
+
+    rate_phases.order(:position).each do |phase|
+      count = phase.billing_interval_cycle_count
+      return phase if count.nil?
+
+      cursor += count
+      return phase if cycle_index < cursor
+    end
+
+    nil
+  end
+end

--- a/app/models/plan_rate_card.rb
+++ b/app/models/plan_rate_card.rb
@@ -3,6 +3,7 @@
 class PlanRateCard < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
+  include RatePhaseable
 
   self.discard_column = :deleted_at
 

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -100,6 +100,14 @@ class RateCard < ApplicationRecord
   def active_rate
     rates.effective.order(effective_from: :desc).first
   end
+
+  # The rate that was active at a given time — how billing resolves the rate
+  # for a period (the rate effective at the period start). Rates are
+  # append-only and locked once the card has subscriptions, so only rates
+  # scheduled before signing can change a subscriber's price.
+  def rate_active_at(datetime)
+    rates.where(effective_from: ..datetime).order(effective_from: :desc).first
+  end
 end
 
 # == Schema Information

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -69,6 +69,17 @@ class RateCardRate < ApplicationRecord
     rate_properties
   end
 
+  # The charge-model calculators (ChargeModels::*) read the pricing model from
+  # a `charge_model` attribute and check `prorated?`; expose both so a rate can
+  # be priced through the same calculators as charges.
+  def charge_model
+    rate_model
+  end
+
+  def prorated?
+    rate_card.proration?
+  end
+
   # Status is derived from the card's append-only timeline rather than stored:
   # the latest effective rate is active, future rates are pending, and earlier
   # effective rates have been superseded and are terminated.

--- a/app/models/rate_override.rb
+++ b/app/models/rate_override.rb
@@ -38,6 +38,21 @@ class RateOverride < ApplicationRecord
     rate_properties
   end
 
+  # The charge-model calculators (ChargeModels::*) read the pricing model from
+  # a `charge_model` attribute and check `prorated?`; expose both so an
+  # override can be priced through the same calculators as charges.
+  def charge_model
+    rate_model
+  end
+
+  # Proration is structural and never overridable: it is always inherited from
+  # the card the override's phase prices. An override not yet attached to a
+  # phase cannot be priced, so false is only the safe default there.
+  def prorated?
+    card_entry = rate_phase&.plan_rate_card || rate_phase&.subscription_rate_card
+    card_entry&.rate_card&.proration? || false
+  end
+
   private
 
   def validate_properties

--- a/app/models/subscription_rate_card.rb
+++ b/app/models/subscription_rate_card.rb
@@ -3,6 +3,7 @@
 class SubscriptionRateCard < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
+  include RatePhaseable
 
   self.discard_column = :deleted_at
 
@@ -21,7 +22,16 @@ class SubscriptionRateCard < ApplicationRecord
 
   validate :validate_started_before_ended
 
+  validates :units, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
+
   default_scope -> { kept }
+
+  # An entry is versioned on units changes: rows are time-bounded by
+  # [started_at, ended_at). active_at picks the version in force at a given
+  # time; current_and_scheduled hides superseded history but keeps upcoming
+  # versions visible.
+  scope :active_at, ->(time) { where(started_at: ..time).where("ended_at IS NULL OR ended_at > ?", time) }
+  scope :current_and_scheduled, -> { where("ended_at IS NULL OR ended_at > ?", Time.current) }
 
   private
 

--- a/app/queries/subscription_rate_cards_query.rb
+++ b/app/queries/subscription_rate_cards_query.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class SubscriptionRateCardsQuery < BaseQuery
+  Result = BaseResult[:subscription_rate_cards]
+  Filters = BaseFilters[:subscription_id, :external_subscription_id]
+
+  def call
+    subscription_rate_cards = base_scope
+    subscription_rate_cards = with_subscription(subscription_rate_cards) if filters.subscription_id.present?
+    subscription_rate_cards = with_external_subscription(subscription_rate_cards) if filters.external_subscription_id.present?
+    subscription_rate_cards = paginate(subscription_rate_cards)
+    subscription_rate_cards = apply_consistent_ordering(subscription_rate_cards)
+
+    result.subscription_rate_cards = subscription_rate_cards
+    result
+  end
+
+  private
+
+  def base_scope
+    SubscriptionRateCard.current_and_scheduled.where(organization:)
+  end
+
+  def with_subscription(scope)
+    scope.where(subscription_id: filters.subscription_id)
+  end
+
+  def with_external_subscription(scope)
+    scope.joins(:subscription).where(subscriptions: {external_id: filters.external_subscription_id})
+  end
+end

--- a/app/serializers/v1/subscription_rate_card_serializer.rb
+++ b/app/serializers/v1/subscription_rate_card_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  class SubscriptionRateCardSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        external_subscription_id: model.subscription.external_id,
+        rate_card_code: model.rate_card.code,
+        units: model.units,
+        started_at: model.started_at.iso8601,
+        ended_at: model.ended_at&.iso8601,
+        billing_anchor_date: model.billing_anchor_date.iso8601,
+        next_billing_at: model.next_billing_at.iso8601,
+        # size counts the loaded collection when the caller preloaded it.
+        rate_phases_count: model.rate_phases.size,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+    end
+  end
+end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -15,6 +15,7 @@ module V1
         status: model.status,
         billing_time: model.billing_time,
         subscription_at: model.subscription_at&.iso8601,
+        billing_anchor_date: model.effective_billing_anchor_date&.iso8601,
         started_at: model.started_at&.iso8601(3),
         trial_ended_at: model.trial_ended_at&.iso8601,
         ending_at: model.ending_at&.iso8601,

--- a/app/serializers/v2/subscription_serializer.rb
+++ b/app/serializers/v2/subscription_serializer.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module V2
+  # The v2 shape drops the plan-interval fields (amounts, billing periods,
+  # trial): a product-catalog subscription prices through its rate card
+  # entries, each carrying its own billing cycle.
+  class SubscriptionSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        external_id: model.external_id,
+        lago_customer_id: model.customer_id,
+        external_customer_id: model.customer.external_id,
+        name: model.name,
+        plan_code: model.plan.code,
+        status: model.status,
+        billing_time: model.billing_time,
+        subscription_at: model.subscription_at&.iso8601,
+        started_at: model.started_at&.iso8601,
+        ending_at: model.ending_at&.iso8601,
+        terminated_at: model.terminated_at&.iso8601,
+        canceled_at: model.canceled_at&.iso8601,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601,
+        # Ended versions (closed by units changes) are history, not cards the
+        # subscription currently carries.
+        applied_rate_cards_count: applied_rate_cards_count
+      }
+
+      payload[:applied_rate_cards] = applied_rate_cards if include?(:applied_rate_cards)
+
+      payload
+    end
+
+    private
+
+    # The index passes one grouped count for the whole page; show falls back
+    # to the scoped count on the single record.
+    def applied_rate_cards_count
+      counts = options[:applied_rate_cards_counts]
+      return counts.fetch(model.id, 0) if counts
+
+      model.applied_rate_cards.current_and_scheduled.count
+    end
+
+    def applied_rate_cards
+      ::CollectionSerializer.new(
+        model.applied_rate_cards.current_and_scheduled.includes(:rate_phases, :rate_card, :subscription),
+        ::V1::SubscriptionRateCardSerializer,
+        collection_name: "applied_rate_cards"
+      ).serialize[:applied_rate_cards]
+    end
+  end
+end

--- a/app/services/organizations/create_service.rb
+++ b/app/services/organizations/create_service.rb
@@ -14,6 +14,9 @@ module Organizations
         params.slice(:name, :document_numbering, :premium_integrations)
       )
 
+      # New organizations default to the product catalog (billing v2).
+      organization.feature_flags = organization.feature_flags.to_a | ["product_catalog"]
+
       if ActiveModel::Type::Boolean.new.cast(ENV["LAGO_CLICKHOUSE_ENABLED"]) && ENV["LAGO_DEFAULT_EVENT_STORE"] == "clickhouse"
         organization.clickhouse_events_store = true
         organization.clickhouse_deduplication_enabled = true

--- a/app/services/rate_phases/create_service.rb
+++ b/app/services/rate_phases/create_service.rb
@@ -31,6 +31,10 @@ module RatePhases
           return result.single_validation_failure!(field: :rate_phase, error_code: "plan_locked")
         end
 
+        if subscription_locked?
+          return result.single_validation_failure!(field: :rate_phase, error_code: "subscription_locked")
+        end
+
         existing = parent.rate_phases.order(:position).to_a
         position = (params[:position].presence || default_position(existing)).to_i
 
@@ -89,6 +93,10 @@ module RatePhases
 
     def plan_locked?
       plan_rate_card.present? && plan_rate_card.plan.attached_to_subscriptions?
+    end
+
+    def subscription_locked?
+      subscription_rate_card.present? && !subscription_rate_card.subscription.pending?
     end
 
     # Omitted position appends at the end — except a definite phase lands just

--- a/app/services/rate_phases/destroy_service.rb
+++ b/app/services/rate_phases/destroy_service.rb
@@ -22,6 +22,10 @@ module RatePhases
           return result.single_validation_failure!(field: :rate_phase, error_code: "plan_locked")
         end
 
+        if subscription_locked?
+          return result.single_validation_failure!(field: :rate_phase, error_code: "subscription_locked")
+        end
+
         siblings = parent.rate_phases.order(:position).to_a
         if siblings.size == 1
           return result.single_validation_failure!(field: :rate_phase, error_code: "cannot_delete_last_phase")
@@ -56,6 +60,10 @@ module RatePhases
 
     def plan_locked?
       rate_phase.plan_rate_card.present? && rate_phase.plan_rate_card.plan.attached_to_subscriptions?
+    end
+
+    def subscription_locked?
+      rate_phase.subscription_rate_card.present? && !rate_phase.subscription_rate_card.subscription.pending?
     end
   end
 end

--- a/app/services/rate_phases/replace_service.rb
+++ b/app/services/rate_phases/replace_service.rb
@@ -4,29 +4,34 @@ module RatePhases
   class ReplaceService < BaseService
     Result = BaseResult[:rate_phases]
 
-    def initialize(plan_rate_card:, phases_params:)
+    def initialize(plan_rate_card: nil, subscription_rate_card: nil, phases_params: [])
       @plan_rate_card = plan_rate_card
+      @subscription_rate_card = subscription_rate_card
       @phases_params = Array.wrap(phases_params).map { |phase| phase.to_h.with_indifferent_access }
       super
     end
 
     def call
-      return result.not_found_failure!(resource: "applied_rate_card") unless plan_rate_card
+      return result.not_found_failure!(resource: "rate_phaseable") unless parent
 
       sequence_failure = validate_sequence
       return sequence_failure if sequence_failure
 
-      # The lock covers the plan_locked? read too, so a subscription attaching
-      # concurrently cannot slip past the guard mid-replace.
-      plan_rate_card.with_lock do
+      # The lock covers the guards too, so a subscription attaching or
+      # activating concurrently cannot slip past them mid-replace.
+      parent.with_lock do
         if plan_locked?
           return result.single_validation_failure!(field: :rate_phases, error_code: "plan_locked")
+        end
+
+        if subscription_locked?
+          return result.single_validation_failure!(field: :rate_phases, error_code: "subscription_locked")
         end
 
         discard_existing_phases
 
         result.rate_phases = ordered_params.map do |phase|
-          plan_rate_card.rate_phases.create!(
+          parent.rate_phases.create!(
             organization:,
             code: phase[:code],
             position: phase[:position],
@@ -46,29 +51,40 @@ module RatePhases
 
     private
 
-    attr_reader :plan_rate_card, :phases_params
+    attr_reader :plan_rate_card, :subscription_rate_card, :phases_params
+
+    def parent
+      plan_rate_card || subscription_rate_card
+    end
 
     def organization
-      plan_rate_card.organization
+      parent.organization
     end
 
     def discard_existing_phases
-      existing_phases = plan_rate_card.rate_phases.to_a
+      existing_phases = parent.rate_phases.to_a
       RateOverride.where(id: existing_phases.filter_map(&:rate_override_id)).discard_all!
-      plan_rate_card.rate_phases.discard_all!
+      parent.rate_phases.discard_all!
     end
 
     def build_override(phase)
       return if phase[:rate_override].nil?
 
       RateOverrides::CreateService.call(
-        rate_card: plan_rate_card.rate_card,
+        rate_card: parent.rate_card,
         params: phase[:rate_override]
       ).raise_if_error!.rate_override
     end
 
+    # Plan-level phases freeze once the plan has subscriptions; a
+    # subscription's own phases are editable only while the subscription is
+    # pending — once active, its pricing is signed.
     def plan_locked?
-      plan_rate_card.plan.attached_to_subscriptions?
+      plan_rate_card.present? && plan_rate_card.plan.attached_to_subscriptions?
+    end
+
+    def subscription_locked?
+      subscription_rate_card.present? && !subscription_rate_card.subscription.pending?
     end
 
     def ordered_params

--- a/app/services/rate_phases/update_service.rb
+++ b/app/services/rate_phases/update_service.rb
@@ -26,6 +26,10 @@ module RatePhases
           return result.single_validation_failure!(field: :rate_phase, error_code: "plan_locked")
         end
 
+        if subscription_locked?
+          return result.single_validation_failure!(field: :rate_phase, error_code: "subscription_locked")
+        end
+
         if params.key?(:billing_interval_cycle_count) && params[:billing_interval_cycle_count].nil? && !last_phase?
           return result.single_validation_failure!(field: :billing_interval_cycle_count, error_code: "indefinite_phase_must_be_last")
         end
@@ -77,6 +81,10 @@ module RatePhases
 
     def plan_locked?
       rate_phase.plan_rate_card.present? && rate_phase.plan_rate_card.plan.attached_to_subscriptions?
+    end
+
+    def subscription_locked?
+      rate_phase.subscription_rate_card.present? && !rate_phase.subscription_rate_card.subscription.pending?
     end
 
     def last_phase?

--- a/app/services/subscription_rate_cards/create_service.rb
+++ b/app/services/subscription_rate_cards/create_service.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module SubscriptionRateCards
+  # Attaches a rate card directly to a subscription (sales-led flow). The
+  # entry is authored on the subscription itself and is only editable while
+  # the subscription is pending: once active, its pricing is signed.
+  class CreateService < BaseService
+    Result = BaseResult[:subscription_rate_card]
+
+    def initialize(subscription:, params:)
+      @subscription = subscription
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "subscription") unless subscription
+
+      unless subscription.pending?
+        return result.single_validation_failure!(field: :subscription, error_code: "subscription_locked")
+      end
+
+      rate_card = organization.rate_cards.find_by(code: params[:rate_card_code])
+      return result.not_found_failure!(resource: "rate_card") unless rate_card
+
+      # One card per pricing slice, mirroring the plan-side rule: a second card
+      # on the same (item, filter) pair would price the same events twice.
+      if slice_already_priced?(rate_card)
+        return result.single_validation_failure!(field: :rate_card, error_code: slice_error_code(rate_card))
+      end
+
+      # Same rule as on plans: the invoice is issued in the subscription's
+      # plan currency, so a directly-attached card must match it. A mismatch
+      # fails at configuration time, not on the first invoice.
+      if rate_card.currency != subscription.plan.amount_currency
+        return result.single_validation_failure!(field: :currency, error_code: "currency_does_not_match")
+      end
+
+      # The column is a date: a malformed value would cast to nil, fall
+      # through the NOT NULL constraint and crash instead of failing cleanly.
+      if params[:billing_anchor_date].present? && !Utils::Datetime.valid_format?(params[:billing_anchor_date])
+        return result.single_validation_failure!(field: :billing_anchor_date, error_code: "value_is_invalid")
+      end
+
+      # Same default as plan materialization: the card starts with the
+      # subscription, not on the day it was authored — a pending subscription
+      # starts in the future.
+      started_at = params[:started_at].presence || subscription.started_at || subscription.subscription_at
+
+      ActiveRecord::Base.transaction do
+        subscription_rate_card = subscription.applied_rate_cards.create!(
+          organization:,
+          rate_card:,
+          units: params[:units],
+          started_at:,
+          # A card added mid-subscription follows the subscription's anchor, not
+          # the day it was added, so it invoices alongside the existing cards.
+          billing_anchor_date: params[:billing_anchor_date].presence || subscription.effective_billing_anchor_date,
+          next_billing_at: started_at
+        )
+
+        # Phases can be authored atomically with the entry: a provided sequence
+        # goes through the same validations as the PUT (contiguous positions,
+        # indefinite phase last) and a failure rolls the whole create back.
+        # Omitted, the entry starts on a single default terminal phase.
+        # Same gate as on plans: an explicit empty array is a meaningful input
+        # and must be rejected by the replace validations, not silently swapped
+        # for the default phase.
+        if params.key?(:rate_phases) && !params[:rate_phases].nil?
+          RatePhases::ReplaceService.call!(subscription_rate_card:, phases_params: params[:rate_phases])
+        else
+          RatePhases::CreateService.call!(subscription_rate_card:, params: {code: "default", position: 1})
+        end
+
+        result.subscription_rate_card = subscription_rate_card
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :subscription, :params
+
+    def slice_error_code(rate_card)
+      if rate_card.product_filter_id
+        "product_filter_already_priced"
+      else
+        "product_already_priced"
+      end
+    end
+
+    def slice_already_priced?(rate_card)
+      subscription.applied_rate_cards.joins(:rate_card).exists?(
+        rate_cards: {
+          product_id: rate_card.product_id,
+          product_filter_id: rate_card.product_filter_id
+        }
+      )
+    end
+
+    def organization
+      subscription.organization
+    end
+  end
+end

--- a/app/services/subscription_rate_cards/destroy_service.rb
+++ b/app/services/subscription_rate_cards/destroy_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SubscriptionRateCards
+  # Detaches a rate card from a subscription during the authoring window: only
+  # while the subscription is pending — once active, its pricing is signed.
+  class DestroyService < BaseService
+    Result = BaseResult[:subscription_rate_card]
+
+    def initialize(subscription_rate_card:)
+      @subscription_rate_card = subscription_rate_card
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "applied_rate_card") unless subscription_rate_card
+
+      unless subscription_rate_card.subscription.pending?
+        return result.single_validation_failure!(field: :subscription, error_code: "subscription_locked")
+      end
+
+      ActiveRecord::Base.transaction do
+        phases = subscription_rate_card.rate_phases.to_a
+        RateOverride.where(id: phases.filter_map(&:rate_override_id)).discard_all!
+        subscription_rate_card.rate_phases.discard_all!
+        subscription_rate_card.discard!
+      end
+
+      result.subscription_rate_card = subscription_rate_card
+      result
+    end
+
+    private
+
+    attr_reader :subscription_rate_card
+  end
+end

--- a/app/services/subscription_rate_cards/update_service.rb
+++ b/app/services/subscription_rate_cards/update_service.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+module SubscriptionRateCards
+  # Edits a subscription entry. While the subscription is pending the entry is
+  # freely editable (authoring window). Once active, only the units can change
+  # — as a quantity, not a price — and every change is recorded by versioning
+  # the entry: the current row is closed (ended_at) and a successor row opens
+  # at the effective time, carrying the phases and overrides. The timeline of
+  # rows is the units history the billing engine prices per period.
+  class UpdateService < BaseService
+    Result = BaseResult[:subscription_rate_card]
+
+    APPLY_UNITS = %w[now next_billing_period].freeze
+
+    def initialize(subscription_rate_card:, params:)
+      @subscription_rate_card = subscription_rate_card
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "applied_rate_card") unless subscription_rate_card
+
+      # The column is a date and NOT NULL: a malformed or null value would
+      # cast to nil and crash on save instead of failing cleanly.
+      if params.key?(:billing_anchor_date) && Utils::Datetime.parse_iso8601_date(params[:billing_anchor_date]).nil?
+        return result.single_validation_failure!(field: :billing_anchor_date, error_code: "value_is_invalid")
+      end
+
+      # A malformed quantity must fail cleanly on both branches; an explicit
+      # null stays a valid clear (the column allows it).
+      if params.key?(:units) && !params[:units].nil? && BigDecimal(params[:units].to_s, exception: false).nil?
+        return result.single_validation_failure!(field: :units, error_code: "value_is_invalid")
+      end
+
+      if subscription_rate_card.subscription.pending?
+        return update_pending_entry
+      end
+
+      if locked_field_changed
+        return result.single_validation_failure!(field: locked_field_changed, error_code: "subscription_locked")
+      end
+
+      return result_with_current unless units_changed?
+
+      unless params.key?(:apply_units)
+        return result.single_validation_failure!(field: :apply_units, error_code: "value_is_mandatory")
+      end
+
+      unless APPLY_UNITS.include?(params[:apply_units])
+        return result.single_validation_failure!(field: :apply_units, error_code: "value_is_invalid")
+      end
+
+      version_units!
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :subscription_rate_card, :params
+
+    def update_pending_entry
+      subscription_rate_card.units = params[:units] if params.key?(:units)
+      subscription_rate_card.billing_anchor_date = params[:billing_anchor_date] if params.key?(:billing_anchor_date)
+
+      # The billing clock is seeded from the start date, so it follows it.
+      if params.key?(:started_at)
+        subscription_rate_card.started_at = params[:started_at]
+        subscription_rate_card.next_billing_at = params[:started_at]
+      end
+
+      subscription_rate_card.save!
+
+      result.subscription_rate_card = subscription_rate_card
+      result
+    end
+
+    # On an active subscription only the quantity may move; the clock and
+    # start date stay signed. Resending unchanged values is always allowed.
+    def locked_field_changed
+      %i[started_at billing_anchor_date].find do |field|
+        next false unless params.key?(field)
+
+        submitted = params[field].to_s
+        current = subscription_rate_card.public_send(field)
+        submitted != current.to_s && submitted != current&.iso8601.to_s
+      end
+    end
+
+    def units_changed?
+      return false unless params.key?(:units)
+      return !subscription_rate_card.units.nil? if params[:units].nil?
+
+      BigDecimal(params[:units].to_s) != subscription_rate_card.units
+    end
+
+    def result_with_current
+      result.subscription_rate_card = subscription_rate_card
+      result
+    end
+
+    def effective_at
+      return Time.current if params[:apply_units] == "now"
+
+      # The per-entry clock normally points at the upcoming period boundary.
+      # If it lags (engine mid-run or not yet processing), the next boundary
+      # is effectively now.
+      [subscription_rate_card.next_billing_at, Time.current].max
+    end
+
+    def version_units!
+      at = effective_at
+
+      ActiveRecord::Base.transaction do
+        # A newer change supersedes any still-scheduled one.
+        subscription_rate_card.subscription.applied_rate_cards
+          .where(rate_card_id: subscription_rate_card.rate_card_id)
+          .where("started_at > ?", Time.current)
+          .find_each { |scheduled| discard_version(scheduled) }
+
+        successor = subscription_rate_card.dup
+        successor.units = params[:units]
+        successor.started_at = at
+        successor.ended_at = nil
+
+        subscription_rate_card.update!(ended_at: at)
+        successor.save!
+
+        subscription_rate_card.rate_phases.order(:position).each do |phase|
+          copied_override = phase.rate_override&.dup
+          copied_override&.save!
+
+          copied_phase = phase.dup
+          copied_phase.subscription_rate_card = successor
+          copied_phase.rate_override = copied_override
+          copied_phase.save!
+        end
+
+        result.subscription_rate_card = successor
+      end
+    end
+
+    def discard_version(entry)
+      phases = entry.rate_phases.to_a
+      RateOverride.where(id: phases.filter_map(&:rate_override_id)).discard_all!
+      entry.rate_phases.discard_all!
+      entry.discard!
+    end
+  end
+end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -27,6 +27,7 @@ module Subscriptions
         plan:,
         subscription_at:,
         ending_at: params[:ending_at],
+        billing_anchor_date: params[:billing_anchor_date],
         payment_method: params[:payment_method],
         activation_rules: params[:activation_rules],
         subscription_type:
@@ -112,7 +113,21 @@ module Subscriptions
       Subscriptions::ValidateService.new(result, **args).valid?
     end
 
+    def product_catalog_plan_change?
+      return false unless current_subscription
+      return false if plan.id == current_subscription.plan.id
+
+      plan.product_catalog? || current_subscription.plan.product_catalog?
+    end
+
     def handle_subscription
+      # Product-catalog plan changes go through the dedicated upgrade and
+      # downgrade flows once they exist; the legacy amount comparison cannot
+      # price catalog plans, so the change is rejected instead of crashing.
+      if product_catalog_plan_change?
+        result.single_validation_failure!(field: :plan, error_code: "plan_change_not_available").raise_if_error!
+      end
+
       return upgrade_subscription if upgrade?
       return downgrade_subscription if downgrade?
 
@@ -143,6 +158,7 @@ module Subscriptions
         external_id:,
         billing_time: billing_time || :calendar,
         ending_at: params[:ending_at],
+        billing_anchor_date: params[:billing_anchor_date],
         purchase_order_number: params[:purchase_order_number],
         progressive_billing_disabled: params[:progressive_billing_disabled] || false,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : true,
@@ -172,7 +188,15 @@ module Subscriptions
         handle_future_subscription(new_subscription)
       end
 
+      materialize_product_catalog_rate_cards(new_subscription)
+
       new_subscription
+    end
+
+    def materialize_product_catalog_rate_cards(new_subscription)
+      return unless new_subscription.plan.product_catalog?
+
+      Subscriptions::ProductCatalog::MaterializeService.call!(subscription: new_subscription)
     end
 
     def handle_today_subscription(new_subscription)

--- a/app/services/subscriptions/product_catalog/materialize_service.rb
+++ b/app/services/subscriptions/product_catalog/materialize_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module ProductCatalog
+    # Materializes the plan's rate cards onto the subscription: one
+    # subscription_rate_card per plan_rate_card, carrying the billing
+    # lifecycle (anchor, clock, units). Pricing is not copied — a plan is
+    # immutable once it has subscriptions, so phases and rates resolve by
+    # reference through the plan entry.
+    class MaterializeService < BaseService
+      Result = BaseResult[:subscription_rate_cards]
+
+      def initialize(subscription:)
+        @subscription = subscription
+        super
+      end
+
+      def call
+        return result unless subscription.plan.product_catalog?
+
+        materialized = []
+        ActiveRecord::Base.transaction do
+          subscription.plan.applied_rate_cards.find_each do |plan_rate_card|
+            materialized << SubscriptionRateCard.create!(
+              organization: subscription.organization,
+              subscription:,
+              rate_card: plan_rate_card.rate_card,
+              units: plan_rate_card.units,
+              billing_anchor_date: subscription.effective_billing_anchor_date,
+              next_billing_at: started_at,
+              started_at:
+            )
+          end
+        end
+
+        result.subscription_rate_cards = materialized
+        result
+      end
+
+      private
+
+      attr_reader :subscription
+
+      def started_at
+        @started_at ||= subscription.started_at || subscription.subscription_at
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -101,8 +101,10 @@ module Subscriptions
         end
 
         if subscription.starting_in_the_future? && params.key?(:subscription_at)
+          previous_subscription_at = subscription.subscription_at
           subscription.subscription_at = params[:subscription_at]
 
+          resync_product_catalog_rate_cards(subscription, previous_subscription_at)
           process_subscription_at_change(subscription)
         else
           subscription.save!
@@ -150,6 +152,22 @@ module Subscriptions
       return false unless params.key?(:subscription_at)
 
       DateTime.parse(params[:subscription_at]).to_date < Date.current
+    end
+
+    # Materialized and default-dated entries follow the subscription's new
+    # start; entries authored with their own explicit dates keep them.
+    def resync_product_catalog_rate_cards(subscription, previous_subscription_at)
+      return unless subscription.plan&.product_catalog?
+
+      new_start = subscription.subscription_at
+      subscription.applied_rate_cards.where(started_at: previous_subscription_at).find_each do |card|
+        card.started_at = new_start
+        card.next_billing_at = new_start
+        if subscription.billing_anchor_date.nil? && card.billing_anchor_date == previous_subscription_at.to_date
+          card.billing_anchor_date = new_start.to_date
+        end
+        card.save!
+      end
     end
 
     def process_subscription_at_change(subscription)

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -8,6 +8,7 @@ module Subscriptions
 
       valid_subscription_at?
       valid_ending_at?
+      valid_billing_anchor_date?
       valid_on_termination_credit_note?
       valid_on_termination_invoice?
       valid_payment_method?
@@ -58,6 +59,17 @@ module Subscriptions
       end
 
       add_error(field: :ending_at, error_code: "invalid_date")
+      false
+    end
+
+    # The column is a date, so a malformed value would silently cast to nil
+    # and the subscription would anchor on its start date instead of failing.
+    def valid_billing_anchor_date?
+      return true if args[:billing_anchor_date].blank?
+      return true if Utils::Datetime.valid_format?(args[:billing_anchor_date])
+
+      add_error(field: :billing_anchor_date, error_code: "value_is_invalid")
+
       false
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,8 @@ Rails.application.routes.draw do
       draw(:shared_api)
     end
 
-    # Drawn first so catalog routes win recognition; everything else on /api/v2
-    # falls through to v1.
+    # Catalog-specific v2 routes are drawn before the v1 fallback: for the
+    # paths defined here (e.g. GET /api/v2/subscriptions) the first match wins.
     namespace :v2 do
       resources :products, param: :code, code: /.*/, only: %i[index show create update destroy] do
         resources :filters, param: :code, code: /.*/, only: %i[index show create update destroy], controller: "products/filters"
@@ -48,6 +48,9 @@ Rails.application.routes.draw do
         end
         draw(:plan_nested_api)
       end
+      # The constraint mirrors v1: without it, an external id containing a
+      # dot is truncated at the format separator.
+      resources :subscriptions, only: %i[index show], param: :external_id, constraints: {external_id: /[^\/]+/}
     end
 
     namespace :v2, module: :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,13 @@ Rails.application.routes.draw do
       end
       # The constraint mirrors v1: without it, an external id containing a
       # dot is truncated at the format separator.
+      resources :subscriptions, param: :external_id, constraints: {external_id: /[^\/]+/}, only: [] do
+        resources :applied_rate_cards, param: :code, code: /.*/, only: %i[index create show update destroy], controller: "subscription_rate_cards" do
+          scope module: :subscription_rate_cards do
+            resources :rate_phases, param: :code, code: /.*/, only: %i[index create update destroy]
+          end
+        end
+      end
       resources :subscriptions, only: %i[index show], param: :external_id, constraints: {external_id: /[^\/]+/}
     end
 

--- a/db/seeds/30_product_catalog.rb
+++ b/db/seeds/30_product_catalog.rb
@@ -98,7 +98,27 @@ unless ProductCategory.exists?(organization:, code: "cloud_platform")
     }
   )
 
-  # Assign the rate card to a plan so the catalog is wired into an offer.
+  platform_fee_card = RateCards::CreateService.call!(
+    product: Product.find_by!(organization:, code: "platform_fee"),
+    params: {
+      name: "Platform fee USD",
+      code: "platform_fee_usd",
+      currency: "USD"
+    }
+  ).rate_card
+
+  RateCardRates::CreateService.call!(
+    rate_card: platform_fee_card,
+    params: {
+      code: "rate_1",
+      effective_from: 1.month.ago.beginning_of_day,
+      rate_model: "standard",
+      rate_properties: {amount: "99"},
+      billing_interval_unit: "month"
+    }
+  )
+
+  # Assign the rate cards to a plan so the catalog is wired into an offer.
   plan = Plans::CreateService.call!({
     organization_id: organization.id,
     name: "Growth",
@@ -106,8 +126,83 @@ unless ProductCategory.exists?(organization:, code: "cloud_platform")
     amount_currency: "USD"
   }).plan
 
-  PlanRateCards::CreateService.call!(
+  usage_entry = PlanRateCards::CreateService.call!(
     plan:,
     params: {rate_card_code: rate_card.code}
+  ).plan_rate_card
+
+  PlanRateCards::CreateService.call!(
+    plan:,
+    params: {rate_card_code: platform_fee_card.code, units: 1}
+  )
+
+  # Phases must be authored before the first subscription: a subscribed plan
+  # is immutable (cards, phases and rates all lock).
+  RatePhases::ReplaceService.call!(
+    plan_rate_card: usage_entry,
+    phases_params: [
+      {
+        code: "launch_offer",
+        position: 1,
+        name: "Launch offer",
+        billing_interval_cycle_count: 3,
+        rate_override: {rate_model: "standard", rate_properties: {amount: "0.005"}}
+      },
+      {code: "standard", position: 2, name: "Standard", billing_interval_cycle_count: nil}
+    ]
+  )
+
+  billing_entity = organization.billing_entities.find_by!(code: "hooli_v2")
+
+  # An active subscription: materialization gives each plan card its own
+  # billing lifecycle on the subscription, pricing stays on the plan.
+  richard = Customer.create_with(
+    name: "Richard Hendricks",
+    currency: "USD",
+    email: "richard@piedpiper.com"
+  ).find_or_create_by!(organization:, billing_entity:, external_id: "cust_hooli_v2_1")
+
+  active_subscription = Subscription.create_with(
+    organization:,
+    started_at: 1.month.ago,
+    subscription_at: 1.month.ago,
+    status: :active,
+    billing_time: :anniversary
+  ).find_or_create_by!(customer: richard, plan:, external_id: "sub_hooli_v2_1")
+
+  Subscriptions::ProductCatalog::MaterializeService.call!(subscription: active_subscription)
+
+  # A pending subscription still in its authoring window: rate cards and
+  # phases can be added, edited or removed until activation.
+  monica = Customer.create_with(
+    name: "Monica Hall",
+    currency: "USD",
+    email: "monica@raviga.com"
+  ).find_or_create_by!(organization:, billing_entity:, external_id: "cust_hooli_v2_2")
+
+  pending_subscription = Subscription.create_with(
+    organization:,
+    subscription_at: 1.month.from_now,
+    status: :pending,
+    billing_time: :anniversary
+  ).find_or_create_by!(customer: monica, plan:, external_id: "sub_hooli_v2_2")
+
+  negotiated_entry = SubscriptionRateCards::CreateService.call!(
+    subscription: pending_subscription,
+    params: {rate_card_code: platform_fee_card.code, units: 1, started_at: 1.month.from_now.iso8601}
+  ).subscription_rate_card
+
+  RatePhases::ReplaceService.call!(
+    subscription_rate_card: negotiated_entry,
+    phases_params: [
+      {
+        code: "negotiated_intro",
+        position: 1,
+        name: "Negotiated intro",
+        billing_interval_cycle_count: 3,
+        rate_override: {rate_model: "standard", rate_properties: {amount: "49"}}
+      },
+      {code: "standard", position: 2, name: "Standard", billing_interval_cycle_count: nil}
+    ]
   )
 end

--- a/spec/models/plan_rate_card_spec.rb
+++ b/spec/models/plan_rate_card_spec.rb
@@ -55,4 +55,11 @@ RSpec.describe PlanRateCard do
       end
     end
   end
+
+  it_behaves_like "a rate phase parent" do
+    let(:item) { create(:plan_rate_card) }
+    let(:create_rate_phase) do
+      ->(attributes) { create(:rate_phase, plan_rate_card: item, **attributes) }
+    end
+  end
 end

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -300,4 +300,17 @@ RSpec.describe RateCardRate do
       end
     end
   end
+
+  describe "#charge_model" do
+    it "exposes the rate model under the calculators' expected name" do
+      expect(build(:rate_card_rate).charge_model).to eq("standard")
+    end
+  end
+
+  describe "#prorated?" do
+    it "reflects the card's proration mode" do
+      expect(build(:rate_card_rate, rate_card: build(:rate_card, proration: true)).prorated?).to be(true)
+      expect(build(:rate_card_rate, rate_card: build(:rate_card, proration: false)).prorated?).to be(false)
+    end
+  end
 end

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -204,4 +204,20 @@ RSpec.describe RateCard do
       expect(rate_card.attached_to_subscriptions?).to be(true)
     end
   end
+
+  describe "#rate_active_at" do
+    subject(:rate_card) { create(:rate_card) }
+
+    let!(:old_rate) { create(:rate_card_rate, rate_card:, effective_from: 10.days.ago.beginning_of_day) }
+    let!(:new_rate) { create(:rate_card_rate, rate_card:, effective_from: 2.days.ago.beginning_of_day) }
+
+    it "returns the rate that was active at the given time" do
+      expect(rate_card.rate_active_at(5.days.ago)).to eq(old_rate)
+      expect(rate_card.rate_active_at(1.day.ago)).to eq(new_rate)
+    end
+
+    it "returns nil before the first rate" do
+      expect(rate_card.rate_active_at(11.days.ago)).to be_nil
+    end
+  end
 end

--- a/spec/models/rate_override_spec.rb
+++ b/spec/models/rate_override_spec.rb
@@ -60,4 +60,27 @@ RSpec.describe RateOverride do
       end
     end
   end
+
+  describe "#charge_model" do
+    it "exposes the rate model under the calculators' expected name" do
+      expect(build(:rate_override).charge_model).to eq("standard")
+    end
+  end
+
+  describe "#prorated?" do
+    it "inherits the structural proration of the card its phase prices" do
+      organization = create(:organization)
+      product = create(:product, :fixed, organization:)
+      rate_card = create(:rate_card, organization:, product:, proration: true)
+      plan_rate_card = create(:plan_rate_card, organization:, rate_card:)
+      override = create(:rate_override, organization:)
+      create(:rate_phase, organization:, plan_rate_card:, position: 1, rate_override: override)
+
+      expect(override.prorated?).to be(true)
+    end
+
+    it "defaults to false when not attached to a phase yet" do
+      expect(build(:rate_override).prorated?).to be(false)
+    end
+  end
 end

--- a/spec/models/subscription_rate_card_spec.rb
+++ b/spec/models/subscription_rate_card_spec.rb
@@ -61,4 +61,11 @@ RSpec.describe SubscriptionRateCard do
       end
     end
   end
+
+  it_behaves_like "a rate phase parent" do
+    let(:item) { create(:subscription_rate_card) }
+    let(:create_rate_phase) do
+      ->(attributes) { create(:rate_phase, :subscription_level, subscription_rate_card: item, **attributes) }
+    end
+  end
 end

--- a/spec/queries/subscription_rate_cards_query_spec.rb
+++ b/spec/queries/subscription_rate_cards_query_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubscriptionRateCardsQuery, type: :query do
+  subject(:result) { described_class.call(organization:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:pagination) { nil }
+  let(:filters) { {} }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, organization:) }
+  let!(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
+  let!(:other_subscription_rate_card) { create(:subscription_rate_card, organization:) }
+
+  it "returns all subscription products of the organization" do
+    expect(result).to be_success
+    expect(result.subscription_rate_cards).to match_array([subscription_rate_card, other_subscription_rate_card])
+  end
+
+  context "when filtering by subscription_id" do
+    let(:filters) { {subscription_id: subscription.id} }
+
+    it "returns only the subscription's products" do
+      expect(result.subscription_rate_cards).to eq([subscription_rate_card])
+    end
+  end
+
+  context "when filtering by external_subscription_id" do
+    let(:filters) { {external_subscription_id: subscription.external_id} }
+
+    it "returns only the subscription's products" do
+      expect(result.subscription_rate_cards).to eq([subscription_rate_card])
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -63,6 +63,71 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
 
     include_examples "requires API permission", "subscription", "write"
 
+    context "when changing the plan of a product-catalog subscription" do
+      let(:plan) { create(:plan, :product_catalog, organization:) }
+      let(:other_plan) { create(:plan, :product_catalog, organization:) }
+
+      it "rejects the change instead of crashing on the legacy comparison" do
+        post_with_token(organization, "/api/v1/subscriptions", {subscription: {
+          external_customer_id: customer.external_id, plan_code: plan.code, external_id: "cat-sub-1"
+        }})
+        expect(response).to have_http_status(:ok)
+
+        post_with_token(organization, "/api/v1/subscriptions", {subscription: {
+          external_customer_id: customer.external_id, plan_code: other_plan.code, external_id: "cat-sub-1"
+        }})
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :plan)).to eq(["plan_change_not_available"])
+      end
+    end
+
+    context "with a billing_anchor_date" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          billing_anchor_date: "2026-01-01"
+        }
+      end
+
+      it "stores and returns it" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:subscription][:billing_anchor_date]).to eq("2026-01-01")
+      end
+    end
+
+    context "without a billing_anchor_date" do
+      it "returns the effective anchor instead of null" do
+        freeze_time do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          expect(json[:subscription][:billing_anchor_date]).to eq(Time.current.to_date.iso8601)
+        end
+      end
+    end
+
+    context "with a malformed billing_anchor_date" do
+      let(:params) do
+        {
+          external_customer_id: customer.external_id,
+          plan_code:,
+          external_id: SecureRandom.uuid,
+          billing_anchor_date: "hello"
+        }
+      end
+
+      it "returns a validation error instead of silently dropping it" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :billing_anchor_date)).to eq(["value_is_invalid"])
+      end
+    end
+
     it "returns a success" do
       create(:plan, code: plan.code, parent_id: plan.id, organization:, description: "foo")
       create(:entitlement, organization:, plan:)

--- a/spec/requests/api/v2/subscription_rate_cards/rate_phases_controller_spec.rb
+++ b/spec/requests/api/v2/subscription_rate_cards/rate_phases_controller_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::SubscriptionRateCards::RatePhasesController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, :pending, customer:, organization:) }
+  let(:rate_card) { create(:rate_card, organization:) }
+  let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:, rate_card:) }
+
+  describe "GET /api/v2/subscriptions/:external_id/applied_rate_cards/:rate_card_code/rate_phases" do
+    subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases") }
+
+    let!(:rate_phase) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1) }
+
+    include_examples "requires API permission", "subscription_rate_card", "read"
+
+    it "returns the entry's rate phases with their codes" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_phases].map { |phase| phase[:lago_id] }).to eq([rate_phase.id])
+      expect(json[:rate_phases].map { |phase| phase[:code] }).to eq([rate_phase.code])
+    end
+
+    context "when the entry does not exist" do
+      subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/unknown/rate_phases") }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("applied_rate_card")
+      end
+    end
+  end
+
+  describe "POST /api/v2/subscriptions/:external_id/applied_rate_cards/:rate_card_code/rate_phases" do
+    subject do
+      post_with_token(
+        organization,
+        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases",
+        {rate_phase: phase_params}
+      )
+    end
+
+    let!(:terminal) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1, billing_interval_cycle_count: nil) }
+    let(:phase_params) do
+      {
+        code: "negotiated",
+        billing_interval_cycle_count: 3,
+        rate_override: {rate_model: "standard", rate_properties: {amount: "0.01"}}
+      }
+    end
+
+    include_examples "requires API permission", "subscription_rate_card", "write"
+
+    it "inserts the phase with its override before the indefinite tail" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_phase][:code]).to eq("negotiated")
+      expect(json[:rate_phase][:position]).to eq(1)
+      expect(json.dig(:rate_phase, :rate_override, :rate_model)).to eq("standard")
+      expect(terminal.reload.position).to eq(2)
+    end
+
+    context "when the subscription is active" do
+      let(:subscription) { create(:subscription, customer:, organization:) }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :rate_phase)).to eq(["subscription_locked"])
+      end
+    end
+  end
+
+  context "when the card starts in the future on a pending subscription" do
+    let(:subscription) { create(:subscription, :pending, customer:, organization:, subscription_at: 1.month.from_now) }
+    let(:subscription_rate_card) do
+      create(:subscription_rate_card, organization:, subscription:, rate_card:, started_at: 1.month.from_now)
+    end
+
+    let!(:terminal) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1, billing_interval_cycle_count: nil) }
+
+    it "keeps the phases addressable during the authoring window" do
+      get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}/rate_phases")
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_phases].map { |phase| phase[:lago_id] }).to eq([terminal.id])
+
+      post_with_token(
+        organization,
+        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}/rate_phases",
+        {rate_phase: {code: "intro", billing_interval_cycle_count: 3}}
+      )
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_phase][:position]).to eq(1)
+    end
+  end
+
+  describe "PUT /api/v2/subscriptions/:external_id/applied_rate_cards/:rate_card_code/rate_phases/:code" do
+    subject do
+      put_with_token(
+        organization,
+        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
+        {rate_phase: {name: "Renamed"}}
+      )
+    end
+
+    let!(:rate_phase) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1, code: "negotiated") }
+
+    include_examples "requires API permission", "subscription_rate_card", "write"
+
+    it "updates the phase" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:rate_phase][:name]).to eq("Renamed")
+    end
+
+    context "when a position is provided" do
+      subject do
+        put_with_token(
+          organization,
+          "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
+          {rate_phase: {name: "Renamed", position: 4}}
+        )
+      end
+
+      it "does not permit it" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(rate_phase.reload.position).to eq(1)
+      end
+    end
+
+    context "when the override is an explicit null" do
+      subject do
+        put_with_token(
+          organization,
+          "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
+          {rate_phase: {rate_override: nil}}
+        )
+      end
+
+      let(:override) { create(:rate_override, organization:) }
+
+      before { rate_phase.update!(rate_override_id: override.id) }
+
+      it "clears the override" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:rate_phase][:rate_override]).to be_nil
+        expect(rate_phase.reload.rate_override).to be_nil
+        expect(override.reload).to be_discarded
+      end
+    end
+
+    context "when the override names a structural card field" do
+      subject do
+        put_with_token(
+          organization,
+          "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{rate_phase.code}",
+          {rate_phase: {rate_override: {rate_model: "standard", rate_properties: {amount: "0.02"}, currency: "EUR"}}}
+        )
+      end
+
+      it "rejects it instead of silently dropping the field" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :currency)).to eq(["not_overridable"])
+        expect(rate_phase.reload.rate_override).to be_nil
+      end
+    end
+
+    context "when the subscription is active" do
+      let(:subscription) { create(:subscription, customer:, organization:) }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json.dig(:error_details, :rate_phase)).to eq(["subscription_locked"])
+      end
+    end
+  end
+
+  describe "DELETE /api/v2/subscriptions/:external_id/applied_rate_cards/:rate_card_code/rate_phases/:code" do
+    subject do
+      delete_with_token(
+        organization,
+        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}/rate_phases/#{terminal.code}"
+      )
+    end
+
+    let!(:launch) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1, billing_interval_cycle_count: 3) }
+    let!(:terminal) { create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 2, billing_interval_cycle_count: nil) }
+
+    include_examples "requires API permission", "subscription_rate_card", "write"
+
+    it "deletes the phase and promotes the new last phase to indefinite" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(terminal.reload).to be_discarded
+      expect(launch.reload.billing_interval_cycle_count).to be_nil
+    end
+  end
+end

--- a/spec/requests/api/v2/subscription_rate_cards_controller_spec.rb
+++ b/spec/requests/api/v2/subscription_rate_cards_controller_spec.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::SubscriptionRateCardsController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, :pending, customer:, organization:) }
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  describe "POST /api/v2/subscriptions/:external_id/applied_rate_cards" do
+    subject { post_with_token(organization, "/api/v2/subscriptions/#{external_id}/applied_rate_cards", {applied_rate_card: create_params}) }
+
+    let(:external_id) { subscription.external_id }
+    let(:create_params) do
+      {rate_card_code: rate_card.code, units: "10"}
+    end
+
+    include_examples "requires API permission", "subscription_rate_card", "write"
+
+    it "attaches the rate card to the subscription with a default rate phase" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:applied_rate_card][:lago_id]).to be_present
+      expect(json[:applied_rate_card][:external_subscription_id]).to eq(subscription.external_id)
+      expect(json[:applied_rate_card][:rate_card_code]).to eq(rate_card.code)
+      expect(json[:applied_rate_card][:external_subscription_id]).to eq(subscription.external_id)
+      expect(json[:applied_rate_card][:rate_card_code]).to eq(rate_card.code)
+      expect(json[:applied_rate_card][:rate_phases_count]).to eq(1)
+    end
+
+    context "with a nested rate_phases sequence" do
+      let(:create_params) do
+        {
+          rate_card_code: rate_card.code,
+          units: "1",
+          rate_phases: [
+            {code: "launch", position: 1, name: "Launch", billing_interval_cycle_count: 3, rate_override: {rate_model: "standard", rate_properties: {amount: "0.02"}}},
+            {code: "standard", position: 2, name: "Standard", billing_interval_cycle_count: nil}
+          ]
+        }
+      end
+
+      it "creates the entry with the provided phases and overrides in one call" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:applied_rate_card][:rate_phases_count]).to eq(2)
+        expect(RateOverride.count).to eq(1)
+      end
+    end
+
+    context "when the subscription does not exist" do
+      let(:external_id) { "unknown" }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("subscription")
+      end
+    end
+
+    context "when the rate card does not exist" do
+      let(:create_params) { {rate_card_code: "unknown"} }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("rate_card")
+      end
+    end
+
+    context "when the subscription is active" do
+      let(:subscription) { create(:subscription, customer:, organization:) }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  context "when the card starts in the future on a pending subscription" do
+    let(:subscription) { create(:subscription, :pending, customer:, organization:, subscription_at: 1.month.from_now) }
+    let!(:subscription_rate_card) do
+      create(:subscription_rate_card, organization:, subscription:, rate_card:, started_at: 1.month.from_now)
+    end
+
+    it "stays addressable during the authoring window" do
+      get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}")
+      expect(response).to have_http_status(:success)
+
+      put_with_token(
+        organization,
+        "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}",
+        {applied_rate_card: {units: "3"}}
+      )
+      expect(response).to have_http_status(:success)
+      expect(subscription_rate_card.reload.units).to eq(3)
+
+      delete_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{rate_card.code}")
+      expect(response).to have_http_status(:success)
+      expect(subscription_rate_card.reload).to be_discarded
+    end
+  end
+
+  describe "GET /api/v2/subscriptions/:external_id/applied_rate_cards" do
+    subject { get_with_token(organization, "/api/v2/subscriptions/#{external_id}/applied_rate_cards") }
+
+    let(:external_id) { subscription.external_id }
+    let!(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
+
+    before { create(:subscription_rate_card, organization:) }
+
+    include_examples "requires API permission", "subscription_rate_card", "read"
+
+    it "returns the subscription's entries only" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:applied_rate_cards].map { |i| i[:lago_id] }).to eq([subscription_rate_card.id])
+    end
+
+    context "when a past subscription shares the external_id" do
+      before do
+        past = create(:subscription, :terminated, customer:, organization:, external_id: subscription.external_id)
+        create(:subscription_rate_card, organization:, subscription: past)
+      end
+
+      it "lists only the addressed subscription's entries" do
+        subject
+
+        expect(json[:applied_rate_cards].map { |i| i[:lago_id] }).to eq([subscription_rate_card.id])
+      end
+    end
+
+    context "when the subscription does not exist" do
+      let(:external_id) { "unknown" }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("subscription")
+      end
+    end
+  end
+
+  describe "GET /api/v2/subscriptions/:external_id/applied_rate_cards/:code" do
+    subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}") }
+
+    let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
+
+    include_examples "requires API permission", "subscription_rate_card", "read"
+
+    it "returns the subscription product" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:applied_rate_card][:lago_id]).to eq(subscription_rate_card.id)
+    end
+
+    context "when it does not exist" do
+      subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/unknown") }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("applied_rate_card")
+      end
+    end
+  end
+
+  describe "PUT /api/v2/subscriptions/:external_id/applied_rate_cards/:code" do
+    subject { put_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}", {applied_rate_card: {units: "12"}}) }
+
+    let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:, units: 5) }
+
+    include_examples "requires API permission", "subscription_rate_card", "write"
+
+    it "updates the entry" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:applied_rate_card][:units]).to eq("12.0")
+    end
+
+    context "when the subscription is active" do
+      let(:subscription) { create(:subscription, customer:, organization:) }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when it does not exist" do
+      subject { put_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/unknown", {applied_rate_card: {units: "12"}}) }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("applied_rate_card")
+      end
+    end
+  end
+
+  describe "DELETE /api/v2/subscriptions/:external_id/applied_rate_cards/:code" do
+    subject { delete_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}/applied_rate_cards/#{subscription_rate_card.rate_card.code}") }
+
+    let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
+
+    include_examples "requires API permission", "subscription_rate_card", "write"
+
+    it "soft deletes the entry" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(subscription.reload.applied_rate_cards).to be_empty
+    end
+
+    context "when the subscription is active" do
+      let(:subscription) { create(:subscription, customer:, organization:) }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v2/subscriptions_controller_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::SubscriptionsController do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
+  let(:subscription) { create(:subscription, customer:, plan:, organization:) }
+
+  describe "GET /api/v2/subscriptions" do
+    subject { get_with_token(organization, "/api/v2/subscriptions") }
+
+    before do
+      create(:subscription_rate_card, organization:, subscription:)
+      # An ended version must not inflate the grouped count.
+      create(:subscription_rate_card, organization:, subscription:, started_at: 10.days.ago, ended_at: 1.day.ago)
+    end
+
+    include_examples "requires API permission", "subscription", "read"
+
+    it "returns subscriptions in the v2 shape" do
+      subject
+
+      expect(response).to have_http_status(:success)
+
+      result = json[:subscriptions].sole
+      expect(result[:lago_id]).to eq(subscription.id)
+      expect(result[:plan_code]).to eq(plan.code)
+      expect(result[:applied_rate_cards_count]).to eq(1)
+      expect(result).not_to have_key(:current_billing_period_started_at)
+      expect(result).not_to have_key(:plan_amount_cents)
+    end
+
+    context "with a pending subscription" do
+      let!(:pending_subscription) { create(:subscription, :pending, customer:, plan:, organization:) }
+
+      it "lists only active subscriptions by default" do
+        subject
+
+        expect(json[:subscriptions].map { |s| s[:lago_id] }).to eq([subscription.id])
+      end
+
+      it "lists pending subscriptions when the status filter asks for them" do
+        get_with_token(organization, "/api/v2/subscriptions?status[]=pending")
+
+        expect(json[:subscriptions].map { |s| s[:lago_id] }).to eq([pending_subscription.id])
+      end
+    end
+  end
+
+  describe "GET /api/v2/subscriptions/:external_id" do
+    subject { get_with_token(organization, "/api/v2/subscriptions/#{subscription.external_id}") }
+
+    let!(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
+
+    include_examples "requires API permission", "subscription", "read"
+
+    it "returns the subscription with its rate card entries" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:subscription][:lago_id]).to eq(subscription.id)
+      expect(json[:subscription][:applied_rate_cards].sole[:lago_id]).to eq(subscription_rate_card.id)
+    end
+
+    context "with an ended version of an entry" do
+      before do
+        create(:subscription_rate_card, organization:, subscription:, started_at: 10.days.ago, ended_at: 1.day.ago)
+      end
+
+      it "excludes it from the count and the list" do
+        subject
+
+        expect(json[:subscription][:applied_rate_cards_count]).to eq(1)
+        expect(json[:subscription][:applied_rate_cards].sole[:lago_id]).to eq(subscription_rate_card.id)
+      end
+    end
+
+    context "when the external id contains a dot" do
+      let(:subscription) { create(:subscription, customer:, plan:, organization:, external_id: "sub.2026-01") }
+
+      it "matches the full id instead of truncating at the format separator" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:external_id]).to eq("sub.2026-01")
+      end
+    end
+
+    context "when it does not exist" do
+      subject { get_with_token(organization, "/api/v2/subscriptions/unknown") }
+
+      it "returns a not found error" do
+        subject
+
+        expect(response).to be_not_found_error("subscription")
+      end
+    end
+  end
+end

--- a/spec/services/organizations/create_service_spec.rb
+++ b/spec/services/organizations/create_service_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Organizations::CreateService do
           )
       end
 
+      it "enables the product catalog for the new organization" do
+        expect(service_result.organization).to be_product_catalog_enabled
+      end
+
       it "creates an API key for created organization" do
         expect { service_result }.to change(ApiKey, :count).by(1)
 

--- a/spec/services/rate_phases/replace_service_spec.rb
+++ b/spec/services/rate_phases/replace_service_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe RatePhases::ReplaceService do
 
     it "returns a not found failure" do
       expect(result).not_to be_success
-      expect(result.error.resource).to eq("applied_rate_card")
+      expect(result.error.resource).to eq("rate_phaseable")
     end
   end
 
@@ -147,6 +147,31 @@ RSpec.describe RatePhases::ReplaceService do
     it "returns a plan_locked failure" do
       expect(result).not_to be_success
       expect(result.error.messages[:rate_phases]).to include("plan_locked")
+    end
+  end
+
+  context "with a subscription product parent" do
+    subject(:result) { described_class.call(subscription_rate_card:, phases_params:) }
+
+    let(:subscription) { create(:subscription, :pending, organization:) }
+    let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:, rate_card:) }
+
+    it "replaces the phase sequence on the subscription entry" do
+      create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1)
+
+      expect { result }.to change { subscription_rate_card.rate_phases.reload.pluck(:name) }
+        .to(%w[trial standard])
+
+      expect(result.rate_phases.map(&:subscription_rate_card_id).uniq).to eq([subscription_rate_card.id])
+    end
+
+    context "when the subscription is active" do
+      let(:subscription) { create(:subscription, organization:) }
+
+      it "forbids editing the phases" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:rate_phases]).to eq(["subscription_locked"])
+      end
     end
   end
 end

--- a/spec/services/subscription_rate_cards/create_service_spec.rb
+++ b/spec/services/subscription_rate_cards/create_service_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubscriptionRateCards::CreateService do
+  subject(:result) { described_class.call(subscription:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, :pending, customer:, organization:) }
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  let(:params) { {rate_card_code: rate_card.code, units: "10"} }
+
+  it "attaches the rate card to the subscription" do
+    expect { result }.to change(SubscriptionRateCard, :count).by(1)
+
+    subscription_rate_card = result.subscription_rate_card
+    expect(subscription_rate_card.subscription).to eq(subscription)
+    expect(subscription_rate_card.rate_card).to eq(rate_card)
+    expect(subscription_rate_card.units).to eq(10)
+    expect(subscription_rate_card.billing_anchor_date).to eq(subscription.effective_billing_anchor_date)
+  end
+
+  context "when the card is added after the subscription started" do
+    let(:subscription) do
+      create(:subscription, :pending, customer:, organization:, billing_anchor_date: Date.new(2026, 1, 1))
+    end
+
+    let(:params) { {rate_card_code: rate_card.code, started_at: "2026-03-12T00:00:00Z"} }
+
+    it "anchors on the subscription rather than the day it was added" do
+      subscription_rate_card = result.subscription_rate_card
+
+      expect(subscription_rate_card.started_at).to eq(Time.zone.parse("2026-03-12"))
+      expect(subscription_rate_card.billing_anchor_date).to eq(Date.new(2026, 1, 1))
+    end
+  end
+
+  context "when started_at is omitted" do
+    let(:subscription) do
+      create(:subscription, :pending, customer:, organization:, subscription_at: Time.zone.parse("2026-10-01"))
+    end
+
+    it "defaults to the subscription start, not the authoring day" do
+      subscription_rate_card = result.subscription_rate_card
+
+      expect(subscription_rate_card.started_at).to eq(subscription.subscription_at)
+      expect(subscription_rate_card.next_billing_at).to eq(subscription.subscription_at)
+    end
+  end
+
+  it "creates a default rate phase" do
+    expect { result }.to change(RatePhase, :count).by(1)
+
+    rate_phase = result.subscription_rate_card.rate_phases.first
+    expect(rate_phase.position).to eq(1)
+    expect(rate_phase.billing_interval_cycle_count).to be_nil
+    expect(rate_phase.plan_rate_card_id).to be_nil
+  end
+
+  context "with explicit dates" do
+    let(:params) do
+      {
+        rate_card_code: rate_card.code,
+        started_at: "2026-08-01T00:00:00Z",
+        billing_anchor_date: "2026-08-15"
+      }
+    end
+
+    it "uses them" do
+      subscription_rate_card = result.subscription_rate_card
+      expect(subscription_rate_card.started_at).to eq(Time.zone.parse("2026-08-01"))
+      expect(subscription_rate_card.billing_anchor_date).to eq(Date.parse("2026-08-15"))
+      expect(subscription_rate_card.next_billing_at).to eq(Time.zone.parse("2026-08-01"))
+    end
+  end
+
+  context "with a malformed billing_anchor_date" do
+    let(:params) { {rate_card_code: rate_card.code, billing_anchor_date: "hello"} }
+
+    it "returns a validation failure instead of crashing on the date cast" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:billing_anchor_date]).to eq(["value_is_invalid"])
+    end
+  end
+
+  context "with a nested rate_phases sequence" do
+    let(:params) do
+      {
+        rate_card_code: rate_card.code,
+        units: "1",
+        rate_phases: [
+          {code: "launch", position: 1, name: "Launch", billing_interval_cycle_count: 3},
+          {code: "standard", position: 2, name: "Standard", billing_interval_cycle_count: nil}
+        ]
+      }
+    end
+
+    it "creates the entry with the provided phases instead of the default" do
+      expect(result).to be_success
+      expect(result.subscription_rate_card.rate_phases.order(:position).pluck(:name)).to eq(%w[Launch Standard])
+    end
+  end
+
+  context "with an invalid nested rate_phases sequence" do
+    let(:params) do
+      {
+        rate_card_code: rate_card.code,
+        rate_phases: [
+          {code: "launch", position: 1, billing_interval_cycle_count: 3},
+          {code: "standard", position: 3, billing_interval_cycle_count: nil}
+        ]
+      }
+    end
+
+    it "fails and rolls the whole create back" do
+      expect { result }.not_to change(SubscriptionRateCard, :count)
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_phases]).to eq(["positions_must_be_contiguous"])
+    end
+  end
+
+  context "with an explicit empty rate_phases sequence" do
+    let(:params) { {rate_card_code: rate_card.code, rate_phases: []} }
+
+    it "rejects it instead of falling back to the default phase" do
+      expect { result }.not_to change(SubscriptionRateCard, :count)
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_phases]).to eq(["value_is_mandatory"])
+    end
+  end
+
+  context "when the rate card currency does not match the plan currency" do
+    let(:rate_card) { create(:rate_card, organization:, currency: "USD") }
+
+    it "rejects the attachment at configuration time" do
+      expect { result }.not_to change(SubscriptionRateCard, :count)
+
+      expect(result).not_to be_success
+      expect(result.error.messages[:currency]).to eq(["currency_does_not_match"])
+    end
+  end
+
+  context "when the subscription is missing" do
+    let(:subscription) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+    end
+  end
+
+  context "when the rate card does not exist" do
+    let(:params) { {rate_card_code: "unknown"} }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("rate_card")
+    end
+  end
+
+  context "when the rate card is already attached and live" do
+    before { create(:subscription_rate_card, organization:, subscription:, rate_card:) }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_card]).to eq(["product_already_priced"])
+    end
+  end
+
+  context "when the subscription is active" do
+    let(:subscription) { create(:subscription, customer:, organization:) }
+
+    it "forbids attaching a rate card" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:subscription]).to eq(["subscription_locked"])
+    end
+  end
+
+  context "when the subscription already prices the same slice" do
+    before do
+      other_card = create(:rate_card, organization:, product: rate_card.product)
+      create(:subscription_rate_card, organization:, subscription:, rate_card: other_card)
+    end
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_card]).to eq(["product_already_priced"])
+    end
+  end
+
+  context "when the subscription already prices the same filter slice" do
+    let(:product) { create(:product, organization:) }
+    let(:filter) { create(:product_filter, organization:, product:) }
+    let(:rate_card) { create(:rate_card, organization:, product:, product_filter: filter) }
+
+    before do
+      other_card = create(:rate_card, organization:, product:, product_filter: filter)
+      create(:subscription_rate_card, organization:, subscription:, rate_card: other_card)
+    end
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_card]).to eq(["product_filter_already_priced"])
+    end
+  end
+end

--- a/spec/services/subscription_rate_cards/destroy_service_spec.rb
+++ b/spec/services/subscription_rate_cards/destroy_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubscriptionRateCards::DestroyService do
+  subject(:result) { described_class.call(subscription_rate_card:) }
+
+  let(:organization) { create(:organization) }
+  let(:subscription) { create(:subscription, :pending, organization:) }
+  let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:) }
+
+  it "soft deletes the entry" do
+    expect(result).to be_success
+    expect(result.subscription_rate_card).to be_discarded
+    expect(subscription.reload.applied_rate_cards).to be_empty
+  end
+
+  it "discards the entry's phases and their overrides" do
+    rate_override = create(:rate_override, organization:)
+    phase = create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1, rate_override:)
+
+    result
+
+    expect(phase.reload).to be_discarded
+    expect(rate_override.reload).to be_discarded
+  end
+
+  context "when the subscription is active" do
+    let(:subscription) { create(:subscription, organization:) }
+
+    it "forbids the deletion" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:subscription]).to eq(["subscription_locked"])
+      expect(subscription_rate_card.reload).not_to be_discarded
+    end
+  end
+
+  context "when the entry is missing" do
+    let(:subscription_rate_card) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("applied_rate_card")
+    end
+  end
+end

--- a/spec/services/subscription_rate_cards/update_service_spec.rb
+++ b/spec/services/subscription_rate_cards/update_service_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubscriptionRateCards::UpdateService do
+  subject(:result) { described_class.call(subscription_rate_card:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:subscription) { create(:subscription, :pending, organization:) }
+  let(:subscription_rate_card) { create(:subscription_rate_card, organization:, subscription:, units: 5) }
+
+  let(:params) { {units: "12"} }
+
+  it "updates the entry" do
+    expect(result).to be_success
+    expect(result.subscription_rate_card.units).to eq(12)
+  end
+
+  context "when moving the start date" do
+    let(:params) { {started_at: Time.zone.parse("2026-09-01")} }
+
+    it "moves the billing clock along with it" do
+      item = result.subscription_rate_card
+      expect(item.started_at).to eq(Time.zone.parse("2026-09-01"))
+      expect(item.next_billing_at).to eq(Time.zone.parse("2026-09-01"))
+    end
+  end
+
+  context "when updating the billing anchor" do
+    let(:params) { {billing_anchor_date: "2026-09-15"} }
+
+    it "updates it" do
+      expect(result.subscription_rate_card.billing_anchor_date).to eq(Date.parse("2026-09-15"))
+    end
+  end
+
+  context "when updating the billing anchor with a malformed value" do
+    let(:params) { {billing_anchor_date: "hello"} }
+
+    it "returns a validation failure instead of crashing on the date cast" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:billing_anchor_date]).to eq(["value_is_invalid"])
+    end
+  end
+
+  context "when the subscription is active" do
+    let(:subscription) { create(:subscription, organization:) }
+    let(:subscription_rate_card) do
+      create(:subscription_rate_card, organization:, subscription:, units: 5, next_billing_at: 10.days.from_now)
+    end
+
+    context "when changing a locked field" do
+      let(:params) { {started_at: Time.zone.parse("2026-09-01")} }
+
+      it "forbids the update" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:started_at]).to eq(["subscription_locked"])
+      end
+    end
+
+    context "when resending unchanged values" do
+      let(:params) { {units: "5", billing_anchor_date: subscription_rate_card.billing_anchor_date.to_s} }
+
+      it "is a no-op success" do
+        subscription_rate_card
+        expect { result }.not_to change(SubscriptionRateCard, :count)
+        expect(result).to be_success
+        expect(result.subscription_rate_card).to eq(subscription_rate_card)
+      end
+    end
+
+    context "when changing units without apply_units" do
+      let(:params) { {units: "8"} }
+
+      it "requires apply_units" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:apply_units]).to eq(["value_is_mandatory"])
+      end
+    end
+
+    context "when apply_units is unknown" do
+      let(:params) { {units: "8", apply_units: "someday"} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:apply_units]).to eq(["value_is_invalid"])
+      end
+    end
+
+    context "when applying units now" do
+      let(:params) { {units: "8", apply_units: "now"} }
+
+      before do
+        create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1,
+          billing_interval_cycle_count: nil, code: "default")
+      end
+
+      it "closes the current version and opens a successor carrying the phases" do
+        successor = result.subscription_rate_card
+
+        expect(result).to be_success
+        expect(successor.id).not_to eq(subscription_rate_card.id)
+        expect(successor.units).to eq(8)
+        expect(successor.ended_at).to be_nil
+        expect(successor.started_at).to be_within(5.seconds).of(Time.current)
+        expect(successor.rate_phases.sole.code).to eq("default")
+
+        expect(subscription_rate_card.reload.ended_at).to be_within(5.seconds).of(Time.current)
+        expect(subscription_rate_card.units).to eq(5)
+      end
+    end
+
+    context "when applying units at the next billing period" do
+      let(:params) { {units: "8", apply_units: "next_billing_period"} }
+
+      it "schedules the successor at the entry's next billing time" do
+        successor = result.subscription_rate_card
+
+        expect(result).to be_success
+        expect(successor.reload.started_at).to eq(subscription_rate_card.reload.next_billing_at)
+        expect(subscription_rate_card.ended_at).to eq(subscription_rate_card.next_billing_at)
+      end
+
+      it "supersedes a previously scheduled change" do
+        described_class.call(subscription_rate_card:, params: {units: "7", apply_units: "next_billing_period"})
+        first_scheduled = subscription.applied_rate_cards.where("started_at > ?", Time.current).sole
+
+        current = subscription.applied_rate_cards.active_at(Time.current).sole
+        second = described_class.call(subscription_rate_card: current, params: {units: "9", apply_units: "next_billing_period"})
+
+        expect(second).to be_success
+        expect(first_scheduled.reload).to be_discarded
+        expect(subscription.applied_rate_cards.where("started_at > ?", Time.current).sole.units).to eq(9)
+      end
+
+      it "discards the superseded version's phases and overrides" do
+        override = create(:rate_override, organization:)
+        phase = create(:rate_phase, :subscription_level, organization:, subscription_rate_card:, position: 1,
+          billing_interval_cycle_count: nil, code: "default")
+        phase.update!(rate_override_id: override.id)
+
+        described_class.call(subscription_rate_card:, params: {units: "7", apply_units: "next_billing_period"})
+        scheduled = subscription.applied_rate_cards.where("started_at > ?", Time.current).sole
+        scheduled_phase = scheduled.rate_phases.sole
+        scheduled_override = scheduled_phase.rate_override
+
+        current = subscription.applied_rate_cards.active_at(Time.current).sole
+        described_class.call(subscription_rate_card: current, params: {units: "9", apply_units: "next_billing_period"})
+
+        expect(scheduled_phase.reload).to be_discarded
+        expect(scheduled_override.reload).to be_discarded
+      end
+    end
+  end
+
+  context "when the entry is missing" do
+    let(:subscription_rate_card) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("applied_rate_card")
+    end
+  end
+
+  describe "units input validation" do
+    context "when units are malformed" do
+      let(:params) { {units: "abc"} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:units]).to eq(["value_is_invalid"])
+      end
+    end
+
+    context "when units are negative on a pending subscription" do
+      let(:subscription) { create(:subscription, :pending, organization:) }
+      let(:params) { {units: "-2"} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:units]).to be_present
+      end
+    end
+
+    context "when units are explicitly null on a pending subscription" do
+      let(:subscription) { create(:subscription, :pending, organization:) }
+      let(:params) { {units: nil} }
+
+      it "clears the units" do
+        expect(result).to be_success
+        expect(result.subscription_rate_card.reload.units).to be_nil
+      end
+    end
+
+    context "when units are negative on an active subscription" do
+      let(:subscription) { create(:subscription, organization:) }
+      let(:params) { {units: "-2", apply_units: "now"} }
+
+      it "returns a validation failure without versioning" do
+        subscription_rate_card
+
+        expect { result }.not_to change(SubscriptionRateCard.with_discarded, :count)
+        expect(result).not_to be_success
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -2198,4 +2198,28 @@ RSpec.describe Subscriptions::CreateService do
       end
     end
   end
+
+  describe "product catalog materialization" do
+    before do
+      allow(Subscriptions::ProductCatalog::MaterializeService).to receive(:call!).and_call_original
+    end
+
+    context "when the plan uses the product catalog" do
+      let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
+
+      it "materializes the plan's rate cards onto the subscription" do
+        create_service.call
+
+        expect(Subscriptions::ProductCatalog::MaterializeService).to have_received(:call!)
+      end
+    end
+
+    context "when the plan is legacy" do
+      it "does not materialize rate cards" do
+        create_service.call
+
+        expect(Subscriptions::ProductCatalog::MaterializeService).not_to have_received(:call!)
+      end
+    end
+  end
 end

--- a/spec/services/subscriptions/product_catalog/materialize_service_spec.rb
+++ b/spec/services/subscriptions/product_catalog/materialize_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ProductCatalog::MaterializeService do
+  subject(:result) { described_class.call(subscription:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, pricing_type: "product_catalog") }
+  let(:subscription) { create(:subscription, customer:, plan:, started_at: Time.current) }
+
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  before do
+    create(:plan_rate_card, organization:, plan:, rate_card:, units: 5)
+  end
+
+  it "materializes the plan's rate cards onto the subscription" do
+    expect { result }.to change(SubscriptionRateCard, :count).by(1)
+
+    item = subscription.reload.applied_rate_cards.sole
+    expect(item.rate_card).to eq(rate_card)
+    expect(item.units).to eq(5)
+    expect(item.started_at).to eq(subscription.started_at)
+    expect(item.billing_anchor_date).to eq(subscription.started_at.to_date)
+    expect(item.next_billing_at).to eq(subscription.started_at)
+    expect(result.subscription_rate_cards).to eq([item])
+  end
+
+  context "when the subscription carries its own billing anchor" do
+    let(:subscription) do
+      create(:subscription, customer:, plan:, started_at: Time.zone.parse("2026-01-15"), billing_anchor_date: Date.new(2026, 1, 1))
+    end
+
+    it "materializes cards on the subscription's anchor, not its start date" do
+      result
+
+      expect(subscription.reload.applied_rate_cards.sole.billing_anchor_date).to eq(Date.new(2026, 1, 1))
+    end
+  end
+
+  it "does not copy the plan entry's phases: pricing resolves by reference" do
+    plan_rate_card = plan.applied_rate_cards.sole
+    create(:rate_phase, organization:, plan_rate_card:, position: 1)
+
+    expect { result }.not_to change(RatePhase, :count)
+    expect(subscription.reload.applied_rate_cards.sole.rate_phases).to be_empty
+  end
+
+  context "when the plan is not a product catalog plan" do
+    let(:plan) { create(:plan, organization:, pricing_type: "legacy") }
+
+    it "does not materialize anything" do
+      expect { result }.not_to change(SubscriptionRateCard, :count)
+      expect(result.subscription_rate_cards).to be_nil
+    end
+  end
+end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1668,4 +1668,40 @@ RSpec.describe Subscriptions::UpdateService do
       end
     end
   end
+
+  context "when moving a pending product-catalog subscription's date" do
+    let(:organization) { membership.organization }
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, :product_catalog, organization:) }
+    let(:subscription) do
+      create(:subscription, :pending, organization:, customer:, plan:, subscription_at: 1.month.from_now, started_at: nil)
+    end
+
+    let!(:materialized_card) do
+      create(
+        :subscription_rate_card,
+        organization:,
+        subscription:,
+        started_at: subscription.subscription_at,
+        next_billing_at: subscription.subscription_at,
+        billing_anchor_date: subscription.subscription_at.to_date
+      )
+    end
+
+    let!(:custom_card) do
+      create(:subscription_rate_card, organization:, subscription:, started_at: 2.months.from_now)
+    end
+
+    it "resyncs the cards that followed the subscription date" do
+      new_date = 6.weeks.from_now.change(usec: 0)
+
+      result = described_class.call(subscription:, params: {subscription_at: new_date.iso8601})
+
+      expect(result).to be_success
+      expect(materialized_card.reload.started_at).to eq(new_date)
+      expect(materialized_card.next_billing_at).to eq(new_date)
+      expect(materialized_card.billing_anchor_date).to eq(new_date.to_date)
+      expect(custom_card.reload.started_at).to be_within(1.second).of(2.months.from_now)
+    end
+  end
 end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -98,6 +98,43 @@ RSpec.describe Subscriptions::ValidateService do
       end
     end
 
+    context "with invalid billing_anchor_date" do
+      let(:args) do
+        {
+          customer:,
+          plan:,
+          subscription_at:,
+          ending_at:,
+          billing_anchor_date: "hello",
+          subscription:,
+          subscription_type:
+        }
+      end
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:billing_anchor_date]).to eq(["value_is_invalid"])
+      end
+    end
+
+    context "with a valid billing_anchor_date" do
+      let(:args) do
+        {
+          customer:,
+          plan:,
+          subscription_at:,
+          ending_at:,
+          billing_anchor_date: "2026-01-01",
+          subscription:,
+          subscription_type:
+        }
+      end
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
+    end
+
     context "with invalid subscription_at" do
       context "when string is not a valid iso8601 datetime" do
         let(:subscription_at) { "2022-12-13 12:00:00Z" }

--- a/spec/support/shared_examples/rate_phaseable.rb
+++ b/spec/support/shared_examples/rate_phaseable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Expects the including spec to define:
+#   let(:item) { ... }              - the rate-phase parent
+#   let(:create_rate_phase) { ... } - ->(attributes) { create(:rate_phase, ...) }
+RSpec.shared_examples "a rate phase parent" do
+  describe "#rate_phase_for_cycle" do
+    context "with a terminal (indefinite) phase" do
+      let!(:first) { create_rate_phase.call(position: 1, billing_interval_cycle_count: 2) }
+      let!(:terminal) { create_rate_phase.call(position: 2, billing_interval_cycle_count: nil) }
+
+      it "returns the phase covering each cycle" do
+        expect(item.rate_phase_for_cycle(0)).to eq(first)
+        expect(item.rate_phase_for_cycle(1)).to eq(first)
+        expect(item.rate_phase_for_cycle(2)).to eq(terminal)
+        expect(item.rate_phase_for_cycle(99)).to eq(terminal)
+      end
+    end
+
+    context "when all phases are finite" do
+      before do
+        create_rate_phase.call(position: 1, billing_interval_cycle_count: 2)
+        create_rate_phase.call(position: 2, billing_interval_cycle_count: 3)
+      end
+
+      it "returns nil for cycles past the defined window" do
+        expect(item.rate_phase_for_cycle(5)).to be_nil
+      end
+    end
+
+    context "without any phase" do
+      it "returns nil" do
+        expect(item.rate_phase_for_cycle(0)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Runtime counterpart of the plan-side attachments: when a customer subscribes, the plan's rate cards are materialized onto the subscription so the billing engine has per-subscriber rows to scan, with their own anchor and clock.

## Description

- Materialize a plan's rate cards onto the subscription at creation, copying phases and overrides.
- Support attaching rate cards directly to a subscription for sales-led (plan-less) deals.
- Version `units` on an active subscription: the change requires `apply_units` (`now` | `next_billing_period`), closes the current row and opens a successor, so historical periods keep the units they billed with.
- Add phase-aware rate resolution helpers.
- Serve subscriptions on the v2 API with a catalog-shaped payload; period information lives on each attachment rather than on the plan.
- Seed subscriptions on the example catalog.
