### PR TITLE
perf(events): add org_id + timestamp partial index

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -91,6 +91,7 @@ end
 #  index_events_on_organization_id                     (organization_id)
 #  index_events_on_organization_id_and_code            (organization_id,code)
 #  index_events_on_organization_id_and_created_at      (organization_id,created_at DESC) WHERE (deleted_at IS NULL)
+#  index_events_on_organization_id_and_timestamp       (organization_id,timestamp DESC) WHERE (deleted_at IS NULL)
 #  index_events_on_organization_id_and_transaction_id  (organization_id,transaction_id) WHERE (deleted_at IS NULL)
 #  index_unique_transaction_id                         (organization_id,external_subscription_id,transaction_id) UNIQUE
 #

--- a/db/migrate/20260706173746_add_events_organization_timestamp_index.rb
+++ b/db/migrate/20260706173746_add_events_organization_timestamp_index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddEventsOrganizationTimestampIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :events,
+      [:organization_id, :timestamp],
+      order: {timestamp: :desc},
+      where: "deleted_at IS NULL",
+      name: "index_events_on_organization_id_and_timestamp",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -643,6 +643,7 @@ DROP INDEX IF EXISTS public.index_fees_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_fees_on_applied_add_on_id;
 DROP INDEX IF EXISTS public.index_fees_on_add_on_id;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_transaction_id;
+DROP INDEX IF EXISTS public.index_events_on_organization_id_and_timestamp;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_created_at;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_events_on_organization_id;
@@ -8188,6 +8189,13 @@ CREATE INDEX index_events_on_organization_id_and_created_at ON public.events USI
 
 
 --
+-- Name: index_events_on_organization_id_and_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_on_organization_id_and_timestamp ON public.events USING btree (organization_id, "timestamp" DESC) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: index_events_on_organization_id_and_transaction_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12843,6 +12851,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260706173746'),
 ('20260703164249'),
 ('20260702074504'),
 ('20260701083110'),


### PR DESCRIPTION
## Context

`GET /api/v1/events` lists events through `EventsQuery`, which runs `organization_id = ? ORDER BY timestamp DESC, transaction_id ASC` on the `events` table. No index covers this pattern: the `organization_id`-leading indexes are on other columns (`created_at`, `transaction_id`, `code`) and the remaining composite indexes are led by `external_subscription_id`. Postgres falls back to a sequential scan and an in-memory sort over all of an organization's events, and on high-volume organizations the query exceeds the 60s statement timeout with `ActiveRecord::QueryCanceled`.

## Description

This adds a partial index on `events`, built with `CREATE INDEX CONCURRENTLY`:

```sql
(organization_id, timestamp DESC) WHERE deleted_at IS NULL
```

The predicate matches the model's `default_scope` (Discard's `kept`), so all reads through `EventsQuery` qualify for the index.

The `transaction_id ASC` tiebreaker is intentionally not part of the index: ties on identical timestamps are resolved with an incremental sort on top of the presorted index scan, which is negligible (verified with `EXPLAIN`, the plan shows `Presorted Key: timestamp`).

Fixes ING-398.
