### PR TITLE
[STA-9] misc: Define more service Results

### DIFF
--- a/app/services/api_keys/track_usage_service.rb
+++ b/app/services/api_keys/track_usage_service.rb
@@ -2,6 +2,8 @@
 
 module ApiKeys
   class TrackUsageService < BaseService
+    Result = BaseResult
+
     def call
       ApiKey.find_each do |api_key|
         cache_key = "api_key_last_used_#{api_key.id}"

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -2,6 +2,8 @@
 
 module Charges
   class ApplyPayInAdvanceChargeModelService < BaseService
+    Result = BaseResult[:aggregation, :aggregator, :amount, :amount_details, :count, :options, :pay_in_advance_event, :precise_amount, :precise_total_amount_cents, :unit_amount, :units]
+
     def initialize(charge:, aggregation_result:, properties:)
       @charge = charge
       @aggregation_result = aggregation_result

--- a/app/services/charges/pay_in_advance/amount_details_calculator.rb
+++ b/app/services/charges/pay_in_advance/amount_details_calculator.rb
@@ -3,6 +3,8 @@
 module Charges
   module PayInAdvance
     class AmountDetailsCalculator < BaseService
+      Result = BaseResult
+
       AMOUNT_DETAILS_FOR_SINGLE_EVENT_ENABLED = %w[percentage graduated_percentage].freeze
       PERCENTAGE_CHARGE_AMOUNT_DETAILS_KEYS = %i[units free_units paid_units free_events paid_events fixed_fee_total_amount
         min_max_adjustment_total_amount per_unit_total_amount].freeze

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -2,6 +2,8 @@
 
 module Charges
   class PayInAdvanceAggregationService < BaseService
+    Result = BaseResult
+
     def initialize(charge:, boundaries:, properties:, event:, charge_filter: nil)
       @charge = charge
       @boundaries = boundaries

--- a/app/services/commitments/calculate_amount_service.rb
+++ b/app/services/commitments/calculate_amount_service.rb
@@ -2,6 +2,8 @@
 
 module Commitments
   class CalculateAmountService < BaseService
+    Result = BaseResult[:commitment_amount_cents]
+
     def initialize(commitment:, invoice_subscription:)
       @commitment = commitment
       @invoice_subscription = invoice_subscription

--- a/app/services/commitments/calculate_prorated_coefficient_service.rb
+++ b/app/services/commitments/calculate_prorated_coefficient_service.rb
@@ -2,6 +2,8 @@
 
 module Commitments
   class CalculateProratedCoefficientService < BaseService
+    Result = BaseResult[:proration_coefficient]
+
     def initialize(commitment:, invoice_subscription:)
       @commitment = commitment
       @invoice_subscription = invoice_subscription

--- a/app/services/credit_notes/generate_pdf_service.rb
+++ b/app/services/credit_notes/generate_pdf_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class GeneratePdfService < BaseService
+    Result = BaseResult[:credit_note]
+
     def initialize(credit_note:, context: nil)
       @credit_note = credit_note
       @context = context

--- a/app/services/credit_notes/generate_xml_service.rb
+++ b/app/services/credit_notes/generate_xml_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class GenerateXmlService < BaseService
+    Result = BaseResult[:credit_note]
+
     def initialize(credit_note:, context: nil)
       @credit_note = credit_note
       @context = context

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -3,6 +3,8 @@
 module CreditNotes
   module Refunds
     class AdyenService < BaseService
+      Result = BaseResult[:credit_note, :refund]
+
       include Customers::PaymentProviderFinder
 
       def initialize(credit_note = nil)

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -3,6 +3,8 @@
 module CreditNotes
   module Refunds
     class GocardlessService < BaseService
+      Result = BaseResult[:credit_note, :refund]
+
       include Customers::PaymentProviderFinder
 
       PENDING_STATUSES = %w[created pending_submission submitted refund_settled].freeze

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -3,6 +3,8 @@
 module CreditNotes
   module Refunds
     class StripeService < BaseService
+      Result = BaseResult[:credit_note, :refund]
+
       include Customers::PaymentProviderFinder
 
       INVALID_PAYMENT_METHOD_ERROR = "charge_not_refundable"

--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -2,6 +2,8 @@
 
 module DunningCampaigns
   class BulkProcessService < BaseService
+    Result = BaseResult
+
     def call
       return result unless License.premium?
 
@@ -26,6 +28,8 @@ module DunningCampaigns
     end
 
     class CustomerDunningEvaluator < BaseService
+      Result = BaseResult
+
       def initialize(customer)
         @customer = customer
         @billing_entity = customer.billing_entity

--- a/app/services/fees/paid_credit_service.rb
+++ b/app/services/fees/paid_credit_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class PaidCreditService < BaseService
+    Result = BaseResult[:fee]
+
     def initialize(invoice:, wallet_transaction:, customer:)
       @invoice = invoice
       @customer = customer

--- a/app/services/integration_collection_mappings/create_service.rb
+++ b/app/services/integration_collection_mappings/create_service.rb
@@ -2,6 +2,8 @@
 
 module IntegrationCollectionMappings
   class CreateService < BaseService
+    Result = BaseResult[:integration_collection_mapping]
+
     attr_reader :params
 
     def initialize(params:)

--- a/app/services/integration_collection_mappings/destroy_service.rb
+++ b/app/services/integration_collection_mappings/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module IntegrationCollectionMappings
   class DestroyService < BaseService
+    Result = BaseResult[:integration_collection_mapping]
+
     def initialize(integration_collection_mapping:)
       @integration_collection_mapping = integration_collection_mapping
 

--- a/app/services/integration_collection_mappings/update_service.rb
+++ b/app/services/integration_collection_mappings/update_service.rb
@@ -2,6 +2,8 @@
 
 module IntegrationCollectionMappings
   class UpdateService < BaseService
+    Result = BaseResult[:integration_collection_mapping]
+
     def initialize(integration_collection_mapping:, params:)
       @integration_collection_mapping = integration_collection_mapping
       @params = params

--- a/app/services/integration_mappings/create_service.rb
+++ b/app/services/integration_mappings/create_service.rb
@@ -2,6 +2,8 @@
 
 module IntegrationMappings
   class CreateService < BaseService
+    Result = BaseResult[:integration_mapping]
+
     def call(**args)
       integration = Integrations::BaseIntegration.find_by(id: args[:integration_id])
 

--- a/app/services/integration_mappings/destroy_service.rb
+++ b/app/services/integration_mappings/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module IntegrationMappings
   class DestroyService < BaseService
+    Result = BaseResult[:integration_mapping]
+
     def initialize(integration_mapping:)
       @integration_mapping = integration_mapping
 

--- a/app/services/integration_mappings/update_service.rb
+++ b/app/services/integration_mappings/update_service.rb
@@ -2,6 +2,8 @@
 
 module IntegrationMappings
   class UpdateService < BaseService
+    Result = BaseResult[:integration_mapping]
+
     def initialize(integration_mapping:, params:)
       @integration_mapping = integration_mapping
       @params = params

--- a/app/services/invoices/generate_xml_service.rb
+++ b/app/services/invoices/generate_xml_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class GenerateXmlService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(invoice:, context: nil)
       @invoice = invoice
       @context = context

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class PaidCreditService < BaseService
+    Result = BaseResult[:invoice]
+
     def initialize(wallet_transaction:, timestamp:, invoice: nil)
       @customer = wallet_transaction.wallet.customer
       @wallet_transaction = wallet_transaction

--- a/app/services/invoices/payments/deliver_error_webhook_service.rb
+++ b/app/services/invoices/payments/deliver_error_webhook_service.rb
@@ -3,6 +3,8 @@
 module Invoices
   module Payments
     class DeliverErrorWebhookService < BaseService
+      Result = BaseResult
+
       def initialize(invoice, params)
         @invoice = invoice
         @params = params

--- a/app/services/payment_methods/create_from_provider_service.rb
+++ b/app/services/payment_methods/create_from_provider_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentMethods
   class CreateFromProviderService < BaseService
+    Result = BaseResult[:payment_method]
+
     def initialize(customer:, params:, provider_method_id:, payment_provider_id: nil, payment_provider_customer: nil, details: nil)
       @customer = customer
       @params = params || {}

--- a/app/services/payment_methods/destroy_service.rb
+++ b/app/services/payment_methods/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentMethods
   class DestroyService < BaseService
+    Result = BaseResult[:payment_method]
+
     def initialize(payment_method:)
       @payment_method = payment_method
 

--- a/app/services/payment_methods/update_details_service.rb
+++ b/app/services/payment_methods/update_details_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentMethods
   class UpdateDetailsService < BaseService
+    Result = BaseResult[:payment_method]
+
     def initialize(payment_method:, insert: {}, delete: {})
       @payment_method = payment_method
       @insert = insert.with_indifferent_access

--- a/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
@@ -3,6 +3,8 @@
 module PaymentProviderCustomers
   module Stripe
     class UpdatePaymentMethodService < BaseService
+      Result = BaseResult[:payment_method, :stripe_customer]
+
       def initialize(stripe_customer:, payment_method_id:, payment_method_details: {})
         @stripe_customer = stripe_customer
         @payment_method_id = payment_method_id

--- a/app/services/payment_provider_customers/update_service.rb
+++ b/app/services/payment_provider_customers/update_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentProviderCustomers
   class UpdateService < BaseService
+    Result = BaseResult
+
     attr_reader :customer
 
     def initialize(customer)

--- a/app/services/payment_receipts/generate_pdf_service.rb
+++ b/app/services/payment_receipts/generate_pdf_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentReceipts
   class GeneratePdfService < BaseService
+    Result = BaseResult[:payment_receipt]
+
     def initialize(payment_receipt:, context: nil)
       @payment_receipt = payment_receipt
       @context = context

--- a/app/services/payment_requests/payments/deliver_error_webhook_service.rb
+++ b/app/services/payment_requests/payments/deliver_error_webhook_service.rb
@@ -3,6 +3,8 @@
 module PaymentRequests
   module Payments
     class DeliverErrorWebhookService < BaseService
+      Result = BaseResult
+
       def initialize(payment_request, params)
         @payment_request = payment_request
         @params = params

--- a/app/services/payment_requests/payments/flutterwave_service.rb
+++ b/app/services/payment_requests/payments/flutterwave_service.rb
@@ -6,8 +6,6 @@ module PaymentRequests
       include Customers::PaymentProviderFinder
       include Updatable
 
-      Result = BaseResult[:payable, :payment, :payment_url]
-
       def initialize(payable = nil)
         @payable = payable
 

--- a/app/services/payment_requests/payments/generate_payment_url_service.rb
+++ b/app/services/payment_requests/payments/generate_payment_url_service.rb
@@ -3,6 +3,8 @@
 module PaymentRequests
   module Payments
     class GeneratePaymentUrlService < BaseService
+      Result = BaseResult
+
       include Customers::PaymentProviderFinder
 
       PROVIDER_GOCARDLESS = "gocardless"

--- a/app/services/utils/pdf_attachment_service.rb
+++ b/app/services/utils/pdf_attachment_service.rb
@@ -2,6 +2,8 @@
 
 module Utils
   class PdfAttachmentService < BaseService
+    Result = BaseResult[:file]
+
     def initialize(file:, attachment:)
       @file = file
       @attachment = attachment

--- a/app/services/utils/pdf_generator.rb
+++ b/app/services/utils/pdf_generator.rb
@@ -2,6 +2,8 @@
 
 module Utils
   class PdfGenerator < BaseService
+    Result = BaseResult[:io]
+
     include ActiveSupport::NumberHelper
 
     def initialize(template:, context:)

--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -3,6 +3,8 @@
 module Wallets
   module RecurringTransactionRules
     class ValidateService < BaseService
+      Result = BaseResult
+
       def initialize(params:)
         @params = params
         super

--- a/spec/services/credit_notes/generate_pdf_service_spec.rb
+++ b/spec/services/credit_notes/generate_pdf_service_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe CreditNotes::GeneratePdfService do
       it "returns a result with error" do
         result = credit_note_generate_service.call
 
-        expect(result.success).to be_falsey
+        expect(result).not_to be_success
         expect(result.error.error_code).to eq("credit_note_not_found")
       end
     end
@@ -141,7 +141,7 @@ RSpec.describe CreditNotes::GeneratePdfService do
       it "returns a not found error" do
         result = credit_note_generate_service.call
 
-        expect(result.success).to be_falsey
+        expect(result).not_to be_success
         expect(result.error.error_code).to eq("credit_note_not_found")
       end
     end

--- a/spec/services/credit_notes/generate_xml_service_spec.rb
+++ b/spec/services/credit_notes/generate_xml_service_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe CreditNotes::GenerateXmlService, type: :service do
         it "results in error" do
           result = described_class.call(credit_note:, context:)
 
-          expect(result.success).to be_falsey
+          expect(result).not_to be_success
           expect(result.error.error_code).to eq("credit_note_not_found")
         end
       end
@@ -89,7 +89,7 @@ RSpec.describe CreditNotes::GenerateXmlService, type: :service do
         it "results in error" do
           result = described_class.call(credit_note:, context:)
 
-          expect(result.success).to be_falsey
+          expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
           expect(result.error.code).to eq("is_draft")
         end

--- a/spec/services/invoices/generate_xml_service_spec.rb
+++ b/spec/services/invoices/generate_xml_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Invoices::GenerateXmlService do
         it "results in error" do
           result = described_class.call(invoice:, context:)
 
-          expect(result.success).to be_falsey
+          expect(result).not_to be_success
           expect(result.error.error_code).to eq("invoice_not_found")
         end
       end
@@ -87,7 +87,7 @@ RSpec.describe Invoices::GenerateXmlService do
         it "results in error" do
           result = described_class.call(invoice:, context:)
 
-          expect(result.success).to be_falsey
+          expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
           expect(result.error.code).to eq("is_draft")
         end

--- a/spec/services/payment_receipts/generate_pdf_service_spec.rb
+++ b/spec/services/payment_receipts/generate_pdf_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe PaymentReceipts::GeneratePdfService do
       it "returns a result with error" do
         result = payment_receipt_generate_service.call
 
-        expect(result.success).to be_falsey
+        expect(result).not_to be_success
         expect(result.error.error_code).to eq("payment_receipt_not_found")
       end
     end

--- a/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
@@ -113,6 +113,8 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
     end
 
     before do
+      provider_customer
+
       allow(PaymentRequests::Payments::CashfreeService)
         .to receive(:new)
         .and_return(payment_provider_service)
@@ -143,7 +145,7 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
   end
 
   context "when provider service return an error" do
-    let(:payment_provider_service) { instance_double(Invoices::Payments::StripeService) }
+    let(:payment_provider_service) { instance_double(PaymentRequests::Payments::StripeService) }
 
     let(:error_result) do
       BaseService::Result.new.tap do |result|
@@ -158,7 +160,9 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
     end
 
     before do
-      allow(Invoices::Payments::StripeService)
+      provider_customer
+
+      allow(PaymentRequests::Payments::StripeService)
         .to receive(:new)
         .and_return(payment_provider_service)
 


### PR DESCRIPTION
## Context

Following https://github.com/getlago/lago-api/pull/5859, this PR is part of the long standing epic required to enable YJIT on Lago by removing all remaining usage of `OpenStruct`

## Description

The goal of this changes is to define the `Result` for a lot of new service class to avoid using the `LegacyResult` (an `OpenStruct`) that will be definitely removed when all services will be migrated to the new approach.