### PR TITLE
fix(stripe): Retry FetchDefaultPaymentMethodJob on rate limit

### DIFF
--- a/app/jobs/payment_providers/stripe/customers/fetch_default_payment_method_job.rb
+++ b/app/jobs/payment_providers/stripe/customers/fetch_default_payment_method_job.rb
@@ -6,6 +6,8 @@ module PaymentProviders
       class FetchDefaultPaymentMethodJob < ApplicationJob
         queue_as :default
 
+        retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 5
+
         def perform(provider_customer)
           PaymentProviders::Stripe::Customers::FetchDefaultPaymentMethodService.call!(provider_customer:)
         end


### PR DESCRIPTION
## Context

Fixes API-230

Stripe raises RateLimitError when the same object is accessed concurrently by multiple requests. FetchDefaultPaymentMethodJob had no retry handling, so this transient error caused unhandled job failures in production.

## Description

Add retry_on for Stripe::RateLimitError with polynomial backoff, matching the pattern already used in
Payments::SetPaymentMethodAndCreateReceiptJob.
