### PR TITLE
[ING-376] fix(events): Cache counter for GET /events

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -83,7 +83,12 @@ module Api
               result.events,
               ::V1::EventSerializer,
               collection_name: "events",
-              meta: pagination_metadata(result.events)
+              meta: pagination_metadata(
+                result.events,
+                key: "events",
+                organization_id: current_organization.id,
+                params: index_filters.merge(page: params[:page], per_page: params[:per_page])
+              )
             )
           )
         else
@@ -109,7 +114,12 @@ module Api
               result.events,
               ::V1::EventEnrichedSerializer,
               collection_name: "events",
-              meta: pagination_metadata(result.events)
+              meta: pagination_metadata(
+                result.events,
+                key: "events_enriched",
+                organization_id: current_organization.id,
+                params: index_filters.merge(page: params[:page], per_page: params[:per_page])
+              )
             )
           )
         else

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -275,6 +275,25 @@ RSpec.describe Api::V1::EventsController do
       end
     end
 
+    context "with unknown params", cache: :memory do
+      let(:params) { {page: 1, per_page: 1} }
+
+      before { create(:event, organization:) }
+
+      it "ignores unknown params for caching" do
+        # First request populates the cache
+        get_with_token(organization, "/api/v1/events", page: 1, per_page: 1)
+        expect(json[:meta][:total_count]).to eq(2)
+
+        # Add a third event
+        create(:event, organization:)
+
+        # Request with unknown param should return cached count (2), not fresh count (3)
+        get_with_token(organization, "/api/v1/events", page: 1, per_page: 1, unknown_param: "value")
+        expect(json[:meta][:total_count]).to eq(2)
+      end
+    end
+
     context "with code" do
       let(:params) { {code: event.code} }
 


### PR DESCRIPTION
## Context

The response time from `GET /events` endpoint is slow on organization with a large number of events leading to timeout in some situation.

## Description

This PR applies the count caching approach added to fees in https://github.com/getlago/lago-api/pull/5838 to the events endpoint to avoid counting records over and over when it's not necessary.

NOTE: this PR does not address the initial performance issue on the count itself, this will be addressed in a next pull request.