### PR TITLE
imp(agg): Bypass event agg when no filters are applied

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -112,8 +112,12 @@ module BillableMetrics
       #   Used only for in advance billing
       def per_event_aggregation(exclude_event: false, include_event_value: false, grouped_by_values: nil)
         PerEventAggregationResult.new.tap do |result|
-          result.event_aggregation = event_store.with_grouped_by_values(grouped_by_values) do
-            compute_per_event_aggregation(exclude_event:, include_event_value:)
+          result.event_aggregation = if should_bypass_aggregation?
+            []
+          else
+            event_store.with_grouped_by_values(grouped_by_values) do
+              compute_per_event_aggregation(exclude_event:, include_event_value:)
+            end
           end
         end
       end

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -114,6 +114,13 @@ module BillableMetrics
       end
 
       def per_event_aggregation(exclude_event: false, include_event_value: false, grouped_by_values: nil)
+        if should_bypass_aggregation?
+          return ProratedPerEventAggregationResult.new.tap do |result|
+            result.event_aggregation = []
+            result.event_prorated_aggregation = []
+          end
+        end
+
         recurring_result = recurring_value
         recurring_aggregation = recurring_result ? [BigDecimal(recurring_result)] : []
         recurring_prorated_aggregation = recurring_result ? [BigDecimal(recurring_result) * persisted_pro_rata] : []

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -102,6 +102,13 @@ module BillableMetrics
       end
 
       def per_event_aggregation(grouped_by_values: nil, include_event_value: false)
+        if should_bypass_aggregation?
+          return ProratedPerEventAggregationResult.new.tap do |result|
+            result.event_aggregation = []
+            result.event_prorated_aggregation = []
+          end
+        end
+
         event_aggregation_array = []
         period_aggregation = event_store.with_grouped_by_values(grouped_by_values) do
           event_store.prorated_unique_count_breakdown(with_remove: true).map do |row|

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -457,7 +457,7 @@ module Fees
           charges_duration: boundaries.charges_duration,
           max_timestamp: boundaries.max_timestamp
         },
-        filters: aggregation_filters(charge_filter:),
+        filters: aggregation_filters(charge_filter:, bypass_aggregation: !aggregate),
         bypass_aggregation: !aggregate
       )
     end
@@ -499,7 +499,7 @@ module Fees
       grouped_by_keys if grouped_by_keys.present? && !usage_filters.skip_grouping
     end
 
-    def aggregation_filters(charge_filter: nil)
+    def aggregation_filters(charge_filter: nil, bypass_aggregation: false)
       filters = {charge_id: charge.id}
 
       grouped_by_keys = grouped_by_keys(charge_filter:)
@@ -511,10 +511,16 @@ module Fees
       end
 
       if charge_filter.present?
-        result = ChargeFilters::MatchingAndIgnoredService.call(charge:, filter: charge_filter)
         filters[:charge_filter] = charge_filter
-        filters[:matching_filters] = result.matching_filters
-        filters[:ignored_filters] = result.ignored_filters
+
+        # NOTE: Matching and ignored filters are only used to filter events when querying the store.
+        #       When the aggregation is bypassed, no event is queried, so computing them is a waste
+        #       (see BillableMetrics::Aggregations::BaseService#should_bypass_aggregation?).
+        if !bypass_aggregation || billable_metric.recurring?
+          result = ChargeFilters::MatchingAndIgnoredService.call(charge:, filter: charge_filter)
+          filters[:matching_filters] = result.matching_filters
+          filters[:ignored_filters] = result.ignored_filters
+        end
       end
 
       if usage_filters.filter_by_group.present?

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -300,6 +300,19 @@ RSpec.describe BillableMetrics::Aggregations::CountService do
         expect(result.event_aggregation).to eq([1, 1, 1, 1, 1])
       end
     end
+
+    context "when aggregation is bypassed" do
+      let(:bypass_aggregation) { true }
+
+      it "returns an empty aggregation without querying the event store" do
+        allow(Events::Stores::PostgresStore).to receive(:new).and_call_original
+
+        result = count_service.per_event_aggregation
+
+        expect(result.event_aggregation).to eq([])
+        expect(Events::Stores::PostgresStore).not_to have_received(:new)
+      end
+    end
   end
 
   describe ".grouped_by_aggregation" do

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -604,6 +604,15 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
         expect(result.options).to eq({running_total: []})
       end
     end
+
+    context "when bypass_aggregation is set to true and metric is recurring" do
+      let(:bypass_aggregation) { true }
+
+      it "ignores the bypass and aggregates the events" do
+        expect(result.aggregation).to eq(1)
+        expect(result.count).to eq(1)
+      end
+    end
   end
 
   describe ".grouped_by_aggregation" do
@@ -773,6 +782,33 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: f
         expect(aggregation.aggregation).to eq(0)
         expect(aggregation.count).to eq(0)
         expect(aggregation.grouped_by).to eq({"agent_name" => nil})
+      end
+    end
+
+    context "when bypass_aggregation is set to true and metric is recurring" do
+      let(:bypass_aggregation) { true }
+
+      let(:unique_count_event) do
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
+          timestamp: added_at,
+          properties: {unique_id: SecureRandom.uuid, agent_name: "aragorn"}
+        )
+      end
+
+      it "ignores the bypass and aggregates the events" do
+        result = count_service.aggregate
+
+        expect(result.aggregations.count).to eq(1)
+
+        aggregation = result.aggregations.first
+        expect(aggregation.aggregation).to eq(1)
+        expect(aggregation.count).to eq(1)
+        expect(aggregation.grouped_by).to eq({"agent_name" => "aragorn"})
       end
     end
 

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -825,6 +825,46 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
         expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([5, 2.32258])
       end
     end
+
+    context "when aggregation is bypassed" do
+      subject(:sum_service) do
+        described_class.new(
+          event_store_class:,
+          charge:,
+          subscription:,
+          boundaries: {
+            from_datetime:,
+            to_datetime:,
+            charges_duration: 31
+          },
+          filters:,
+          bypass_aggregation: true
+        )
+      end
+
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          organization:,
+          aggregation_type: "sum_agg",
+          field_name: "total_count",
+          recurring: false
+        )
+      end
+
+      it "returns empty aggregations without querying the event store" do
+        event_store = sum_service.__send__(:event_store)
+        allow(event_store).to receive(:prorated_events_values).and_call_original
+        allow(event_store).to receive(:events_values).and_call_original
+
+        result = sum_service.per_event_aggregation
+
+        expect(result.event_aggregation).to eq([])
+        expect(result.event_prorated_aggregation).to eq([])
+        expect(event_store).not_to have_received(:prorated_events_values)
+        expect(event_store).not_to have_received(:events_values)
+      end
+    end
   end
 
   describe ".grouped_by aggregation" do

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -865,6 +865,31 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
         expect(event_store).not_to have_received(:events_values)
       end
     end
+
+    context "when aggregation is bypassed and metric is recurring" do
+      subject(:sum_service) do
+        described_class.new(
+          event_store_class:,
+          charge:,
+          subscription:,
+          boundaries: {
+            from_datetime:,
+            to_datetime:,
+            charges_duration: 31
+          },
+          filters:,
+          bypass_aggregation: true
+        )
+      end
+
+      it "ignores the bypass and aggregates per events" do
+        sum_service.options = {}
+        result = sum_service.per_event_aggregation
+
+        expect(result.event_aggregation).to eq([5, 12, 12])
+        expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([5, 2.32258, 2.32258])
+      end
+    end
   end
 
   describe ".grouped_by aggregation" do

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -1082,6 +1082,32 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
       end
     end
 
+    context "when aggregation is bypassed and metric is recurring" do
+      subject(:unique_count_service) do
+        described_class.new(
+          event_store_class:,
+          charge:,
+          subscription:,
+          boundaries: {
+            from_datetime:,
+            to_datetime:,
+            charges_duration: 31
+          },
+          filters:,
+          bypass_aggregation: true
+        )
+      end
+
+      let(:added_at) { from_datetime + 10.days }
+
+      it "ignores the bypass and aggregates per events" do
+        result = unique_count_service.per_event_aggregation
+
+        expect(result.event_aggregation).to eq([1])
+        expect(result.event_prorated_aggregation.map { |el| el.ceil(5) }).to eq([21.fdiv(31).ceil(5)])
+      end
+    end
+
     context "with event added in the period" do
       let(:added_at) { from_datetime + 10.days }
 

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -1044,6 +1044,44 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
   describe ".per_event_aggregation" do
     before { unique_count_service.options = {} }
 
+    context "when aggregation is bypassed" do
+      subject(:unique_count_service) do
+        described_class.new(
+          event_store_class:,
+          charge:,
+          subscription:,
+          boundaries: {
+            from_datetime:,
+            to_datetime:,
+            charges_duration: 31
+          },
+          filters:,
+          bypass_aggregation: true
+        )
+      end
+
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          organization:,
+          aggregation_type: "unique_count_agg",
+          field_name: "unique_id",
+          recurring: false
+        )
+      end
+
+      it "returns empty aggregations without querying the event store" do
+        event_store = unique_count_service.__send__(:event_store)
+        allow(event_store).to receive(:prorated_unique_count_breakdown).and_call_original
+
+        result = unique_count_service.per_event_aggregation
+
+        expect(result.event_aggregation).to eq([])
+        expect(result.event_prorated_aggregation).to eq([])
+        expect(event_store).not_to have_received(:prorated_unique_count_breakdown)
+      end
+    end
+
     context "with event added in the period" do
       let(:added_at) { from_datetime + 10.days }
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -4088,6 +4088,24 @@ RSpec.describe Fees::ChargeService, :premium do
           aggregated_fees = result.fees.select { |f| f.units != 0 || f.events_count != 0 }
           expect(aggregated_fees).not_to be_empty
         end
+
+        context "when some filters are excluded from filtered_aggregations" do
+          let(:filtered_aggregations) { [eu_charge_filter.id] }
+
+          it "computes matching and ignored filters for all filters" do
+            allow(ChargeFilters::MatchingAndIgnoredService).to receive(:call).and_call_original
+
+            result = charge_subscription_service.call
+            expect(result).to be_success
+
+            expect(ChargeFilters::MatchingAndIgnoredService).to have_received(:call)
+              .with(charge:, filter: eu_charge_filter)
+            expect(ChargeFilters::MatchingAndIgnoredService).to have_received(:call)
+              .with(charge:, filter: us_charge_filter)
+            expect(ChargeFilters::MatchingAndIgnoredService).to have_received(:call)
+              .with(charge:, filter: asia_charge_filter)
+          end
+        end
       end
 
       context "when context is current_usage", cache: :memory do

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -4017,6 +4017,24 @@ RSpec.describe Fees::ChargeService, :premium do
         end
       end
 
+      context "when some filters are excluded from filtered_aggregations" do
+        let(:filtered_aggregations) { [eu_charge_filter.id] }
+
+        it "does not compute matching and ignored filters for bypassed aggregations" do
+          allow(ChargeFilters::MatchingAndIgnoredService).to receive(:call).and_call_original
+
+          result = charge_subscription_service.call
+          expect(result).to be_success
+
+          expect(ChargeFilters::MatchingAndIgnoredService).to have_received(:call)
+            .with(charge:, filter: eu_charge_filter)
+          expect(ChargeFilters::MatchingAndIgnoredService).not_to have_received(:call)
+            .with(charge:, filter: us_charge_filter)
+          expect(ChargeFilters::MatchingAndIgnoredService).not_to have_received(:call)
+            .with(charge:, filter: asia_charge_filter)
+        end
+      end
+
       context "when filtered_aggregations includes nil for default bucket" do
         let(:filtered_aggregations) { [nil] }
 


### PR DESCRIPTION
## Context

  While profiling customer usage computation (`Customers::RefreshWalletsService` → `Invoices::CustomerUsageService`), traces showed `ChargeFilters::MatchingAndIgnoredService` being called once per charge filter — over 1,500 times (~2.5s) per usage refresh on plans with many filters.

 Since #5846, aggregations for filters without usage in the period are bypassed (`bypass_aggregation`). The matching and ignored filters are only consumed by the event stores when building an events query, so computing them for bypassed aggregations is wasted work.

  ## Description

  Skip the computation of matching and ignored filters when the aggregation is bypassed:

  - `Fees::ChargeService#aggregation_filters` no longer calls `ChargeFilters::MatchingAndIgnoredService` when the aggregation is bypassed. Recurring metrics are excluded from the
  skip, as they always aggregate (matching `should_bypass_aggregation?` semantics).

  To make this safe, `per_event_aggregation` now returns an empty result when the aggregation is bypassed, instead of querying the event store:

  - `BillableMetrics::Aggregations::BaseService`
  - `BillableMetrics::ProratedAggregations::SumService`
  - `BillableMetrics::ProratedAggregations::UniqueCountService`

  Without this guard, some charge models (prorated graduated, percentage with per-transaction min/max) could still query the event store on a bypassed aggregator and would then miss the matching filters. This is also a small perf win on its own: those queries were guaranteed to return no events, since the billing period pre-filtering already established the filter had no usage.