### PR TITLE
[STA-9] misc: Add Result and specs on more services

### DIFF
--- a/app/services/commitments/fetch_invoices_service.rb
+++ b/app/services/commitments/fetch_invoices_service.rb
@@ -2,6 +2,8 @@
 
 module Commitments
   class FetchInvoicesService < BaseService
+    Result = BaseResult[:invoices]
+
     def self.new_instance(commitment:, invoice_subscription:)
       klass = if invoice_subscription.subscription.plan.pay_in_advance?
         Commitments::Minimum::InAdvance::FetchInvoicesService

--- a/app/services/fees/destroy_service.rb
+++ b/app/services/fees/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class DestroyService < BaseService
+    Result = BaseResult[:fee]
+
     def initialize(fee:)
       @fee = fee
 

--- a/app/services/integrations/salesforce/invoices/sync_service.rb
+++ b/app/services/integrations/salesforce/invoices/sync_service.rb
@@ -4,6 +4,8 @@ module Integrations
   module Salesforce
     module Invoices
       class SyncService < BaseService
+        Result = BaseResult[:invoice_id]
+
         def initialize(invoice)
           @invoice = invoice
 

--- a/spec/services/commitments/fetch_invoices_service_spec.rb
+++ b/spec/services/commitments/fetch_invoices_service_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Commitments::FetchInvoicesService do
+  let(:commitment) { create(:commitment, plan:) }
+  let(:plan) { create(:plan, pay_in_advance:) }
+  let(:subscription) { create(:subscription, plan:) }
+  let(:invoice_subscription) { create(:invoice_subscription, subscription:) }
+  let(:pay_in_advance) { false }
+
+  describe ".new_instance" do
+    subject(:instance) { described_class.new_instance(commitment:, invoice_subscription:) }
+
+    context "when the plan is paid in arrears" do
+      let(:pay_in_advance) { false }
+
+      it "returns an in arrears fetch invoices service" do
+        expect(instance).to be_a(Commitments::Minimum::InArrears::FetchInvoicesService)
+      end
+    end
+
+    context "when the plan is paid in advance" do
+      let(:pay_in_advance) { true }
+
+      it "returns an in advance fetch invoices service" do
+        expect(instance).to be_a(Commitments::Minimum::InAdvance::FetchInvoicesService)
+      end
+    end
+  end
+
+  describe "#call" do
+    subject(:result) { described_class.new_instance(commitment:, invoice_subscription:).call }
+
+    context "when the plan is paid in arrears" do
+      let(:pay_in_advance) { false }
+
+      it "returns the invoice subscription invoice" do
+        expect(result).to be_success
+        expect(result.invoices).to eq([invoice_subscription.invoice])
+      end
+    end
+
+    context "when the plan is paid in advance" do
+      let(:pay_in_advance) { true }
+
+      it "returns the invoice subscription invoice" do
+        expect(result).to be_success
+        expect(result.invoices).to eq([invoice_subscription.invoice])
+      end
+    end
+  end
+end

--- a/spec/services/fees/destroy_service_spec.rb
+++ b/spec/services/fees/destroy_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Fees::DestroyService do
+  subject(:destroy_service) { described_class.new(fee:) }
+
+  describe "#call" do
+    context "when fee is nil" do
+      let(:fee) { nil }
+
+      it "returns a not found failure" do
+        result = destroy_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("fee")
+      end
+    end
+
+    context "when fee is attached to an invoice" do
+      let(:fee) { create(:fee) }
+
+      it "returns a not allowed failure" do
+        result = destroy_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoiced_fee")
+      end
+
+      it "does not discard the fee" do
+        expect { destroy_service.call }.not_to change { fee.reload.discarded? }
+      end
+    end
+
+    context "when fee is not attached to an invoice" do
+      let(:fee) { create(:fee, invoice: nil) }
+
+      it "discards the fee" do
+        expect { destroy_service.call }.to change { fee.reload.discarded? }.from(false).to(true)
+      end
+
+      it "returns the fee in the result" do
+        result = destroy_service.call
+
+        expect(result).to be_success
+        expect(result.fee).to eq(fee)
+      end
+    end
+  end
+end

--- a/spec/services/integrations/salesforce/invoices/sync_service_spec.rb
+++ b/spec/services/integrations/salesforce/invoices/sync_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Integrations::Salesforce::Invoices::SyncService do
+  subject(:sync_service) { described_class.new(invoice) }
+
+  describe "#call" do
+    context "when invoice is nil" do
+      let(:invoice) { nil }
+
+      it "returns a not found failure" do
+        result = sync_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("invoice")
+      end
+
+      it "does not enqueue a webhook job" do
+        expect { sync_service.call }.not_to have_enqueued_job(SendWebhookJob)
+      end
+    end
+
+    context "when invoice is present" do
+      let(:invoice) { create(:invoice) }
+
+      it "enqueues an invoice.resynced webhook job" do
+        expect { sync_service.call }
+          .to have_enqueued_job(SendWebhookJob)
+          .with("invoice.resynced", invoice)
+      end
+
+      it "returns the invoice id in the result" do
+        result = sync_service.call
+
+        expect(result).to be_success
+        expect(result.invoice_id).to eq(invoice.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Following https://github.com/getlago/lago-api/pull/5873, this PR is part of the long standing epic required to enable YJIT on Lago by removing all remaining usage of `OpenStruct`

## Description

The goal of this changes is to define the `Result` for more service class to avoid using the `LegacyResult` (an `OpenStruct`) that will be definitely removed when all services will be migrated to the new approach.
The targeted services were missing specs, so the PR is also adding these.