### PR TITLE
perf(events): drop redundant organization_id index

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -88,7 +88,6 @@ end
 #  idx_events_billing_lookup                           (external_subscription_id,organization_id,code,timestamp) WHERE (deleted_at IS NULL)
 #  idx_events_for_distinct_codes                       (external_subscription_id,organization_id,timestamp) WHERE (deleted_at IS NULL)
 #  index_events_on_created_at                          (created_at) WHERE (deleted_at IS NULL)
-#  index_events_on_organization_id                     (organization_id)
 #  index_events_on_organization_id_and_code            (organization_id,code)
 #  index_events_on_organization_id_and_created_at      (organization_id,created_at DESC) WHERE (deleted_at IS NULL)
 #  index_events_on_organization_id_and_timestamp       (organization_id,timestamp DESC) WHERE (deleted_at IS NULL)

--- a/db/migrate/20260708095857_drop_index_events_on_organization_id.rb
+++ b/db/migrate/20260708095857_drop_index_events_on_organization_id.rb
@@ -6,4 +6,8 @@ class DropIndexEventsOnOrganizationId < ActiveRecord::Migration[8.0]
   def up
     remove_index :events, name: :index_events_on_organization_id, algorithm: :concurrently, if_exists: true
   end
+
+  def down
+    add_index :events, :organization_id, name: :index_events_on_organization_id, algorithm: :concurrently, if_not_exists: true
+  end
 end

--- a/db/migrate/20260708095857_drop_index_events_on_organization_id.rb
+++ b/db/migrate/20260708095857_drop_index_events_on_organization_id.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DropIndexEventsOnOrganizationId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :events, name: :index_events_on_organization_id, algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -646,7 +646,6 @@ DROP INDEX IF EXISTS public.index_events_on_organization_id_and_transaction_id;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_timestamp;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_created_at;
 DROP INDEX IF EXISTS public.index_events_on_organization_id_and_code;
-DROP INDEX IF EXISTS public.index_events_on_organization_id;
 DROP INDEX IF EXISTS public.index_events_on_created_at;
 DROP INDEX IF EXISTS public.index_error_details_on_owner;
 DROP INDEX IF EXISTS public.index_error_details_on_organization_id;
@@ -8168,13 +8167,6 @@ CREATE INDEX index_events_on_created_at ON public.events USING btree (created_at
 
 
 --
--- Name: index_events_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_events_on_organization_id ON public.events USING btree (organization_id);
-
-
---
 -- Name: index_events_on_organization_id_and_code; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12851,6 +12843,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260708095857'),
 ('20260706173746'),
 ('20260703164249'),
 ('20260702074504'),


### PR DESCRIPTION
## Context

The `events` table has a single-column index on `organization_id`. That column is also the leading column of several composite indexes on the table (`index_events_on_organization_id_and_code`, `index_events_on_organization_id_and_created_at`, `index_events_on_organization_id_and_timestamp`, `index_events_on_organization_id_and_transaction_id`, and the unique `index_unique_transaction_id`), so lookups on `organization_id` alone stay covered without it. On a high-volume table, the extra index only adds write amplification and storage.

## Description

This adds an up-only migration dropping `index_events_on_organization_id` with `DROP INDEX CONCURRENTLY` (via `disable_ddl_transaction!`) to avoid locking the table. The `Event` model schema annotation was refreshed accordingly.

Note that `index_events_on_organization_id_and_code` is non-partial, so queries touching soft-deleted events by organization (for example `with_discarded` reads in rake tasks) keep index support after this drop. Dropping that index is a separate follow-up and will need its own coverage check.

Fixes ING-399