### PR TITLE
perf(features): Introduce materialized view for Features#subscriptions_count

### DIFF
--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -27,8 +27,12 @@ module Entitlement
     def subscriptions_count
       return @subscriptions_count if defined?(@subscriptions_count)
 
-      base_scope = Subscription.joins(:plan).where(status: [:active, :pending])
-      base_scope.where(plan: plans).or(base_scope.where(plan: {parent: plans})).count
+      subscriptions_count = SubscriptionsCountQuery.call(
+        organization:,
+        filters: {feature_ids: [id]}
+      )
+
+      subscriptions_count[id]
     end
 
     def self.preload_subscriptions_count(organization, features)

--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -32,7 +32,7 @@ module Entitlement
         filters: {feature_ids: [id]}
       )
 
-      subscriptions_count[id]
+      subscriptions_count[id] || 0
     end
 
     def self.preload_subscriptions_count(organization, features)

--- a/app/queries/entitlement/feature/subscriptions_count_query.rb
+++ b/app/queries/entitlement/feature/subscriptions_count_query.rb
@@ -12,7 +12,7 @@ module Entitlement
         )
 
         result.each_with_object({}) do |row, hash|
-          hash[row["feature_id"]] = row["count"]
+          hash[row["entitlement_feature_id"]] = row["count"]
         end
       end
 
@@ -21,46 +21,18 @@ module Entitlement
       def subscriptions_count_query
         ActiveRecord::Base.sanitize_sql_array([
           subscriptions_count_sql,
-          filters.feature_ids,
-          organization.id
+          filters.feature_ids
         ])
       end
 
       def subscriptions_count_sql
         <<~SQL
-          WITH
-            plan_features AS (
-              SELECT
-                plan_id,
-                entitlement_feature_id
-              FROM
-                entitlement_entitlements
-              WHERE
-                plan_id IS NOT NULL
-                AND entitlement_feature_id IN (?)
-            ),
-            plan_subscriptions AS (
-              SELECT
-                coalesce(plans.parent_id, plan_id) AS plan_id,
-                count(*)
-              FROM
-                subscriptions
-                INNER JOIN plans ON plans.id = subscriptions.plan_id
-              WHERE
-                plans.deleted_at IS NULL
-                AND plans.organization_id = ?
-                AND subscriptions.status IN (0, 1)
-              GROUP BY
-                coalesce(plans.parent_id, plan_id)
-            )
           SELECT
-            plan_features.entitlement_feature_id AS feature_id,
-            SUM(plan_subscriptions.count) AS count
+            *
           FROM
-            plan_features
-            INNER JOIN plan_subscriptions ON plan_features.plan_id = plan_subscriptions.plan_id
-          GROUP BY
-            plan_features.entitlement_feature_id
+            entitlement_features_subscriptions_count
+          WHERE
+            entitlement_feature_id IN (?)
         SQL
       end
     end

--- a/clock.rb
+++ b/clock.rb
@@ -206,6 +206,10 @@ module Clockwork
       .perform_later
   end
 
+  every(10.minutes, "schedule:refresh_entitlement_features_subscription_count") do
+    Scenic.database.refresh_materialized_view(:entitlement_features_subscriptions_count, concurrently: true)
+  end
+
   # NOTE: Enable wallets and lifetime usage refresh from the events-processor
   if ENV["LAGO_REDIS_STORE_URL"].present? && ENV["LAGO_CLICKHOUSE_ENABLED"].present?
     every(10.seconds, "schedule:refresh_flagged_subscriptions") do

--- a/clock.rb
+++ b/clock.rb
@@ -206,10 +206,6 @@ module Clockwork
       .perform_later
   end
 
-  every(10.minutes, "schedule:refresh_entitlement_features_subscription_count") do
-    Scenic.database.refresh_materialized_view(:entitlement_features_subscriptions_count, concurrently: true)
-  end
-
   # NOTE: Enable wallets and lifetime usage refresh from the events-processor
   if ENV["LAGO_REDIS_STORE_URL"].present? && ENV["LAGO_CLICKHOUSE_ENABLED"].present?
     every(10.seconds, "schedule:refresh_flagged_subscriptions") do
@@ -217,5 +213,9 @@ module Clockwork
         .set(sentry: {"slug" => "lago_refresh_flagged_subscriptions"})
         .perform_later
     end
+  end
+
+  every(10.minutes, "refresh:entitlement_features_subscription_count") do
+    Scenic.database.refresh_materialized_view(:entitlement_features_subscriptions_count, concurrently: true)
   end
 end

--- a/db/migrate/20260702103547_create_entitlement_features_subscriptions_count.rb
+++ b/db/migrate/20260702103547_create_entitlement_features_subscriptions_count.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateEntitlementFeaturesSubscriptionsCount < ActiveRecord::Migration[8.0]
   def change
     create_view :entitlement_features_subscriptions_count, materialized: true

--- a/db/migrate/20260702103547_create_entitlement_features_subscriptions_count.rb
+++ b/db/migrate/20260702103547_create_entitlement_features_subscriptions_count.rb
@@ -1,0 +1,5 @@
+class CreateEntitlementFeaturesSubscriptionsCount < ActiveRecord::Migration[8.0]
+  def change
+    create_view :entitlement_features_subscriptions_count, materialized: true
+  end
+end

--- a/db/migrate/20260706095722_add_unique_index_on_entitlement_features_subscription_count.rb
+++ b/db/migrate/20260706095722_add_unique_index_on_entitlement_features_subscription_count.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnEntitlementFeaturesSubscriptionCount < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :entitlement_features_subscriptions_count, :entitlement_feature_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -881,6 +881,7 @@ DROP INDEX IF EXISTS public.idx_on_fixed_charge_id_06503ae1a5;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_entitlement_entitle_9d0542eb1a;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_9946ccf514;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_6a228dc433;
+DROP INDEX IF EXISTS public.idx_on_entitlement_feature_id_f4c7f65817;
 DROP INDEX IF EXISTS public.idx_on_entitlement_feature_id_821ae72311;
 DROP INDEX IF EXISTS public.idx_on_entitlement_entitlement_id_48c0b3356a;
 DROP INDEX IF EXISTS public.idx_on_enriched_store_migration_id_e409c5dc43;
@@ -1128,8 +1129,6 @@ DROP TABLE IF EXISTS public.integration_customers;
 DROP VIEW IF EXISTS public.exports_fees_taxes;
 DROP TABLE IF EXISTS public.fees_taxes;
 DROP VIEW IF EXISTS public.exports_fees;
-DROP TABLE IF EXISTS public.subscriptions;
-DROP TABLE IF EXISTS public.plans;
 DROP TABLE IF EXISTS public.invoices;
 DROP TABLE IF EXISTS public.fees;
 DROP VIEW IF EXISTS public.exports_entitlement_features;
@@ -1149,8 +1148,11 @@ DROP VIEW IF EXISTS public.exports_billable_metrics;
 DROP VIEW IF EXISTS public.exports_applied_coupons;
 DROP TABLE IF EXISTS public.events;
 DROP TABLE IF EXISTS public.error_details;
-DROP TABLE IF EXISTS public.entitlement_subscription_feature_removals;
 DROP TABLE IF EXISTS public.entitlement_privileges;
+DROP MATERIALIZED VIEW IF EXISTS public.entitlement_features_subscriptions_count;
+DROP TABLE IF EXISTS public.subscriptions;
+DROP TABLE IF EXISTS public.plans;
+DROP TABLE IF EXISTS public.entitlement_subscription_feature_removals;
 DROP TABLE IF EXISTS public.entitlement_features;
 DROP TABLE IF EXISTS public.entitlement_entitlements;
 DROP TABLE IF EXISTS public.entitlement_entitlement_values;
@@ -2771,6 +2773,137 @@ CREATE TABLE public.entitlement_features (
 
 
 --
+-- Name: entitlement_subscription_feature_removals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.entitlement_subscription_feature_removals (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    entitlement_feature_id uuid,
+    subscription_id uuid NOT NULL,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    entitlement_privilege_id uuid,
+    CONSTRAINT check_exactly_one_feature_or_privilege_removal CHECK (((entitlement_feature_id IS NOT NULL) <> (entitlement_privilege_id IS NOT NULL)))
+);
+
+
+--
+-- Name: plans; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.plans (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    name character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    code character varying NOT NULL,
+    "interval" integer NOT NULL,
+    description character varying,
+    amount_cents bigint NOT NULL,
+    amount_currency character varying NOT NULL,
+    trial_period double precision,
+    pay_in_advance boolean DEFAULT false NOT NULL,
+    bill_charges_monthly boolean,
+    parent_id uuid,
+    deleted_at timestamp(6) without time zone,
+    pending_deletion boolean DEFAULT false NOT NULL,
+    invoice_display_name character varying,
+    bill_fixed_charges_monthly boolean DEFAULT false
+);
+
+
+--
+-- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.subscriptions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    customer_id uuid NOT NULL,
+    plan_id uuid NOT NULL,
+    status integer NOT NULL,
+    canceled_at timestamp without time zone,
+    terminated_at timestamp without time zone,
+    started_at timestamp without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    previous_subscription_id uuid,
+    name character varying,
+    external_id character varying NOT NULL,
+    billing_time integer DEFAULT 0 NOT NULL,
+    subscription_at timestamp(6) without time zone,
+    ending_at timestamp(6) without time zone,
+    trial_ended_at timestamp(6) without time zone,
+    organization_id uuid NOT NULL,
+    on_termination_credit_note public.subscription_on_termination_credit_note,
+    on_termination_invoice public.subscription_on_termination_invoice DEFAULT 'generate'::public.subscription_on_termination_invoice NOT NULL,
+    payment_method_id uuid,
+    payment_method_type public.payment_method_types DEFAULT 'provider'::public.payment_method_types NOT NULL,
+    skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
+    progressive_billing_disabled boolean DEFAULT false NOT NULL,
+    last_received_event_on date,
+    cancelation_reason public.subscription_cancelation_reasons,
+    incompleted_at timestamp(6) without time zone,
+    activated_at timestamp(6) without time zone,
+    billing_entity_id uuid,
+    consolidate_invoice boolean DEFAULT true NOT NULL,
+    skip_daily_usage boolean DEFAULT false NOT NULL,
+    cancellation_reason public.subscription_cancellation_reasons,
+    purchase_order_number character varying
+);
+
+
+--
+-- Name: entitlement_features_subscriptions_count; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.entitlement_features_subscriptions_count AS
+ WITH plan_subcriptions AS (
+         SELECT COALESCE(plans.parent_id, subscriptions.plan_id) AS plan_id,
+            count(*) AS count
+           FROM (public.subscriptions
+             JOIN public.plans ON ((plans.id = subscriptions.plan_id)))
+          WHERE ((plans.deleted_at IS NULL) AND (subscriptions.status = ANY (ARRAY[0, 1])))
+          GROUP BY COALESCE(plans.parent_id, subscriptions.plan_id)
+        ), plan_subcriptions_count AS (
+         SELECT plan_entitlements.entitlement_feature_id,
+            sum(plan_subcriptions.count) AS count
+           FROM ((public.entitlement_entitlements plan_entitlements
+             JOIN public.entitlement_features ON ((entitlement_features.id = plan_entitlements.entitlement_feature_id)))
+             JOIN plan_subcriptions ON ((plan_subcriptions.plan_id = plan_entitlements.plan_id)))
+          WHERE ((plan_entitlements.deleted_at IS NULL) AND (entitlement_features.deleted_at IS NULL) AND (plan_entitlements.plan_id IS NOT NULL))
+          GROUP BY plan_entitlements.entitlement_feature_id
+        ), direct_subscriptions_count AS (
+         SELECT subscription_entitlements.entitlement_feature_id,
+            count(*) AS count
+           FROM (((public.entitlement_entitlements subscription_entitlements
+             JOIN public.entitlement_features ON ((entitlement_features.id = subscription_entitlements.entitlement_feature_id)))
+             JOIN public.subscriptions ON ((subscriptions.id = subscription_entitlements.subscription_id)))
+             JOIN public.plans ON ((plans.id = subscriptions.plan_id)))
+          WHERE ((subscription_entitlements.deleted_at IS NULL) AND (subscription_entitlements.subscription_id IS NOT NULL) AND (entitlement_features.deleted_at IS NULL) AND (subscriptions.status = ANY (ARRAY[0, 1])) AND (plans.deleted_at IS NULL) AND (NOT (EXISTS ( SELECT 1
+                   FROM public.entitlement_entitlements plan_entitlements
+                  WHERE ((plan_entitlements.plan_id = COALESCE(plans.parent_id, plans.id)) AND (plan_entitlements.entitlement_feature_id = subscription_entitlements.entitlement_feature_id) AND (plan_entitlements.plan_id IS NOT NULL) AND (plan_entitlements.deleted_at IS NULL))))))
+          GROUP BY subscription_entitlements.entitlement_feature_id
+        ), feature_removals_count AS (
+         SELECT feature_removals.entitlement_feature_id,
+            count(*) AS count
+           FROM ((public.entitlement_subscription_feature_removals feature_removals
+             JOIN public.entitlement_features ON ((entitlement_features.id = feature_removals.entitlement_feature_id)))
+             JOIN public.subscriptions ON ((subscriptions.id = feature_removals.subscription_id)))
+          WHERE ((feature_removals.entitlement_feature_id IS NOT NULL) AND (feature_removals.deleted_at IS NULL) AND (entitlement_features.deleted_at IS NULL) AND (subscriptions.status = ANY (ARRAY[0, 1])))
+          GROUP BY feature_removals.entitlement_feature_id
+        )
+ SELECT COALESCE(plan_subcriptions_count.entitlement_feature_id, direct_subscriptions_count.entitlement_feature_id) AS entitlement_feature_id,
+    ((COALESCE(plan_subcriptions_count.count, (0)::numeric) + (COALESCE(direct_subscriptions_count.count, (0)::bigint))::numeric) - (COALESCE(feature_removals_count.count, (0)::bigint))::numeric) AS count
+   FROM ((plan_subcriptions_count
+     FULL JOIN direct_subscriptions_count ON ((plan_subcriptions_count.entitlement_feature_id = direct_subscriptions_count.entitlement_feature_id)))
+     LEFT JOIN feature_removals_count ON ((plan_subcriptions_count.entitlement_feature_id = feature_removals_count.entitlement_feature_id)))
+  WITH NO DATA;
+
+
+--
 -- Name: entitlement_privileges; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2785,23 +2918,6 @@ CREATE TABLE public.entitlement_privileges (
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: entitlement_subscription_feature_removals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.entitlement_subscription_feature_removals (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    organization_id uuid NOT NULL,
-    entitlement_feature_id uuid,
-    subscription_id uuid NOT NULL,
-    deleted_at timestamp(6) without time zone,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    entitlement_privilege_id uuid,
-    CONSTRAINT check_exactly_one_feature_or_privilege_removal CHECK (((entitlement_feature_id IS NOT NULL) <> (entitlement_privilege_id IS NOT NULL)))
 );
 
 
@@ -3447,72 +3563,6 @@ CREATE TABLE public.invoices (
     skip_automatic_payment boolean,
     purchase_order_number character varying,
     CONSTRAINT check_organizations_on_net_payment_term CHECK ((net_payment_term >= 0))
-);
-
-
---
--- Name: plans; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.plans (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    organization_id uuid NOT NULL,
-    name character varying NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    code character varying NOT NULL,
-    "interval" integer NOT NULL,
-    description character varying,
-    amount_cents bigint NOT NULL,
-    amount_currency character varying NOT NULL,
-    trial_period double precision,
-    pay_in_advance boolean DEFAULT false NOT NULL,
-    bill_charges_monthly boolean,
-    parent_id uuid,
-    deleted_at timestamp(6) without time zone,
-    pending_deletion boolean DEFAULT false NOT NULL,
-    invoice_display_name character varying,
-    bill_fixed_charges_monthly boolean DEFAULT false
-);
-
-
---
--- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.subscriptions (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    customer_id uuid NOT NULL,
-    plan_id uuid NOT NULL,
-    status integer NOT NULL,
-    canceled_at timestamp without time zone,
-    terminated_at timestamp without time zone,
-    started_at timestamp without time zone,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    previous_subscription_id uuid,
-    name character varying,
-    external_id character varying NOT NULL,
-    billing_time integer DEFAULT 0 NOT NULL,
-    subscription_at timestamp(6) without time zone,
-    ending_at timestamp(6) without time zone,
-    trial_ended_at timestamp(6) without time zone,
-    organization_id uuid NOT NULL,
-    on_termination_credit_note public.subscription_on_termination_credit_note,
-    on_termination_invoice public.subscription_on_termination_invoice DEFAULT 'generate'::public.subscription_on_termination_invoice NOT NULL,
-    payment_method_id uuid,
-    payment_method_type public.payment_method_types DEFAULT 'provider'::public.payment_method_types NOT NULL,
-    skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
-    progressive_billing_disabled boolean DEFAULT false NOT NULL,
-    last_received_event_on date,
-    cancelation_reason public.subscription_cancelation_reasons,
-    incompleted_at timestamp(6) without time zone,
-    activated_at timestamp(6) without time zone,
-    billing_entity_id uuid,
-    consolidate_invoice boolean DEFAULT true NOT NULL,
-    skip_daily_usage boolean DEFAULT false NOT NULL,
-    cancellation_reason public.subscription_cancellation_reasons,
-    purchase_order_number character varying
 );
 
 
@@ -6730,6 +6780,13 @@ CREATE INDEX idx_on_entitlement_entitlement_id_48c0b3356a ON public.entitlement_
 --
 
 CREATE INDEX idx_on_entitlement_feature_id_821ae72311 ON public.entitlement_subscription_feature_removals USING btree (entitlement_feature_id);
+
+
+--
+-- Name: idx_on_entitlement_feature_id_f4c7f65817; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_on_entitlement_feature_id_f4c7f65817 ON public.entitlement_features_subscriptions_count USING btree (entitlement_feature_id);
 
 
 --
@@ -13093,10 +13150,12 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260707182656'),
 ('20260706173746'),
 ('20260706131152'),
+('20260706095722'),
 ('20260703164249'),
 ('20260702183711'),
 ('20260702183710'),
 ('20260702183709'),
+('20260702103547'),
 ('20260702074504'),
 ('20260701083110'),
 ('20260701083109'),
@@ -14141,3 +14200,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
+

--- a/db/views/entitlement_features_subscriptions_count_v01.sql
+++ b/db/views/entitlement_features_subscriptions_count_v01.sql
@@ -1,80 +1,86 @@
 WITH
   -- Number of subscriptions per plan
-	plan_subcriptions AS (
-		SELECT
-			COALESCE(plans.parent_id, plan_id) AS plan_id,
-			COUNT(*)
-		FROM
-			subscriptions
-			INNER JOIN plans ON plans.id = subscriptions.plan_id
-		WHERE
-			plans.deleted_at IS NULL
-			AND subscriptions.status IN (0, 1)
-		GROUP BY
-			COALESCE(plans.parent_id, plan_id)
-	),
+  plan_subcriptions AS (
+    SELECT
+      COALESCE(plans.parent_id, plan_id) AS plan_id,
+      COUNT(*)
+    FROM
+      subscriptions
+      INNER JOIN plans ON plans.id = subscriptions.plan_id
+    WHERE
+      plans.deleted_at IS NULL
+      AND subscriptions.status IN (0, 1)
+    GROUP BY
+      COALESCE(plans.parent_id, plan_id)
+  ),
   -- Number of subscriptions that have the feature through a plan
-	plan_subcriptions_count AS (
-		SELECT
-			plan_features.entitlement_feature_id,
-			SUM(COUNt) AS count
-		FROM
-			entitlement_entitlements AS plan_features
-			INNER JOIN plan_subcriptions ON plan_subcriptions.plan_id = plan_features.plan_id
-		WHERE
-			plan_features.plan_id IS NOT NULL
-			AND plan_features.deleted_at IS NULL
-		GROUP BY
-			plan_features.entitlement_feature_id
-	),
+  plan_subcriptions_count AS (
+    SELECT
+      plan_features.entitlement_feature_id,
+      SUM(count) AS count
+    FROM
+      entitlement_entitlements AS plan_features
+      INNER JOIN plan_subcriptions ON plan_subcriptions.plan_id = plan_features.plan_id
+      INNER JOIN entitlement_features ON entitlement_features.id = plan_features.entitlement_feature_id
+    WHERE
+      plan_features.plan_id IS NOT NULL
+      AND plan_features.deleted_at IS NULL
+      AND entitlement_features.deleted_at IS NULL
+    GROUP BY
+      plan_features.entitlement_feature_id
+  ),
   -- Number of subscriptions that have the feature assigned directly
-	direct_subscriptions_count AS (
-		SELECT
-			subscription_features.entitlement_feature_id,
-			COUNT(*) AS count
-		FROM
-			entitlement_entitlements AS subscription_features
-			INNER JOIN subscriptions ON subscriptions.id = subscription_features.subscription_id
-			INNER JOIN plans ON plans.id = subscriptions.plan_id
-		WHERE
-			subscription_features.deleted_at IS NULL
-			AND subscription_features.subscription_id IS NOT NULL
-			AND subscriptions.status IN (0, 1)
-			AND plans.deleted_at IS NULL
+  direct_subscriptions_count AS (
+    SELECT
+      subscription_features.entitlement_feature_id,
+      COUNT(*) AS count
+    FROM
+      entitlement_entitlements AS subscription_features
+      INNER JOIN entitlement_features ON entitlement_features.id = subscription_features.entitlement_feature_id
+      INNER JOIN subscriptions ON subscriptions.id = subscription_features.subscription_id
+      INNER JOIN plans ON plans.id = subscriptions.plan_id
+    WHERE
+      subscription_features.deleted_at IS NULL
+      AND subscription_features.subscription_id IS NOT NULL
+      AND entitlement_features.deleted_at IS NULL
+      AND subscriptions.status IN (0, 1)
+      AND plans.deleted_at IS NULL
       -- Avoid counting the same subscription twice if the feature is assigned both directly and through a plan
-			AND NOT EXISTS (
-				SELECT
-					1
-				FROM
-					entitlement_entitlements AS plan_features
-				WHERE
-					plan_features.plan_id = COALESCE(plans.parent_id, plans.id)
-					AND plan_features.entitlement_feature_id = subscription_features.entitlement_feature_id
-					AND plan_features.plan_id IS NOT NULL
-					AND plan_features.deleted_at IS NULL
-			)
-		GROUP BY
-			subscription_features.entitlement_feature_id
-	),
+      AND NOT EXISTS (
+        SELECT
+          1
+        FROM
+          entitlement_entitlements AS plan_features
+        WHERE
+          plan_features.plan_id = COALESCE(plans.parent_id, plans.id)
+          AND plan_features.entitlement_feature_id = subscription_features.entitlement_feature_id
+          AND plan_features.plan_id IS NOT NULL
+          AND plan_features.deleted_at IS NULL
+       )
+    GROUP BY
+      subscription_features.entitlement_feature_id
+  ),
   -- Number of subscriptions where the feature has been manually removed
-	feature_removals_count AS (
-		SELECT
-			feature_removals.entitlement_feature_id,
-			COUNT(*) AS count
-		FROM
-			entitlement_subscription_feature_removals AS feature_removals
-			INNER JOIN subscriptions ON subscriptions.id = feature_removals.subscription_id
-		WHERE
-			feature_removals.entitlement_feature_id IS NOT NULL
-			AND subscriptions.status IN (0, 1)
-			AND feature_removals.deleted_at IS NULL
-		GROUP BY
-			feature_removals.entitlement_feature_id
-	)
+  feature_removals_count AS (
+    SELECT
+      feature_removals.entitlement_feature_id,
+      COUNT(*) AS count
+    FROM
+      entitlement_subscription_feature_removals AS feature_removals
+      INNER JOIN subscriptions ON subscriptions.id = feature_removals.subscription_id
+      INNER JOIN entitlement_features ON entitlement_features.id = feature_removals.entitlement_feature_id
+    WHERE
+      feature_removals.entitlement_feature_id IS NOT NULL
+      AND entitlement_features.deleted_at IS NULL
+      AND subscriptions.status IN (0, 1)
+      AND feature_removals.deleted_at IS NULL
+    GROUP BY
+      feature_removals.entitlement_feature_id
+  )
 SELECT
-	COALESCE(plan_subcriptions_count.entitlement_feature_id, direct_subscriptions_count.entitlement_feature_id) AS entitlement_feature_id,
-	COALESCE(plan_subcriptions_count.count, 0) + COALESCE(direct_subscriptions_count.count, 0) - COALESCE(feature_removals_count.count, 0) AS count
+  COALESCE(plan_subcriptions_count.entitlement_feature_id, direct_subscriptions_count.entitlement_feature_id) AS entitlement_feature_id,
+  COALESCE(plan_subcriptions_count.count, 0) + COALESCE(direct_subscriptions_count.count, 0) - COALESCE(feature_removals_count.count, 0) AS count
 FROM
-	plan_subcriptions_count
-	FULL JOIN direct_subscriptions_count ON plan_subcriptions_count.entitlement_feature_id = direct_subscriptions_count.entitlement_feature_id
-	LEFT JOIN feature_removals_count ON plan_subcriptions_count.entitlement_feature_id = feature_removals_count.entitlement_feature_id
+  plan_subcriptions_count
+  FULL JOIN direct_subscriptions_count ON plan_subcriptions_count.entitlement_feature_id = direct_subscriptions_count.entitlement_feature_id
+  LEFT JOIN feature_removals_count ON plan_subcriptions_count.entitlement_feature_id = feature_removals_count.entitlement_feature_id

--- a/db/views/entitlement_features_subscriptions_count_v01.sql
+++ b/db/views/entitlement_features_subscriptions_count_v01.sql
@@ -16,32 +16,32 @@ WITH
   -- Number of subscriptions that have the feature through a plan
   plan_subcriptions_count AS (
     SELECT
-      plan_features.entitlement_feature_id,
+      plan_entitlements.entitlement_feature_id,
       SUM(count) AS count
     FROM
-      entitlement_entitlements AS plan_features
-      INNER JOIN plan_subcriptions ON plan_subcriptions.plan_id = plan_features.plan_id
-      INNER JOIN entitlement_features ON entitlement_features.id = plan_features.entitlement_feature_id
+      entitlement_entitlements AS plan_entitlements
+      INNER JOIN entitlement_features ON entitlement_features.id = plan_entitlements.entitlement_feature_id
+      INNER JOIN plan_subcriptions ON plan_subcriptions.plan_id = plan_entitlements.plan_id
     WHERE
-      plan_features.plan_id IS NOT NULL
-      AND plan_features.deleted_at IS NULL
+      plan_entitlements.deleted_at IS NULL
       AND entitlement_features.deleted_at IS NULL
+      AND plan_entitlements.plan_id IS NOT NULL
     GROUP BY
-      plan_features.entitlement_feature_id
+      plan_entitlements.entitlement_feature_id
   ),
   -- Number of subscriptions that have the feature assigned directly
   direct_subscriptions_count AS (
     SELECT
-      subscription_features.entitlement_feature_id,
+      subscription_entitlements.entitlement_feature_id,
       COUNT(*) AS count
     FROM
-      entitlement_entitlements AS subscription_features
-      INNER JOIN entitlement_features ON entitlement_features.id = subscription_features.entitlement_feature_id
-      INNER JOIN subscriptions ON subscriptions.id = subscription_features.subscription_id
+      entitlement_entitlements AS subscription_entitlements
+      INNER JOIN entitlement_features ON entitlement_features.id = subscription_entitlements.entitlement_feature_id
+      INNER JOIN subscriptions ON subscriptions.id = subscription_entitlements.subscription_id
       INNER JOIN plans ON plans.id = subscriptions.plan_id
     WHERE
-      subscription_features.deleted_at IS NULL
-      AND subscription_features.subscription_id IS NOT NULL
+      subscription_entitlements.deleted_at IS NULL
+      AND subscription_entitlements.subscription_id IS NOT NULL
       AND entitlement_features.deleted_at IS NULL
       AND subscriptions.status IN (0, 1)
       AND plans.deleted_at IS NULL
@@ -50,15 +50,15 @@ WITH
         SELECT
           1
         FROM
-          entitlement_entitlements AS plan_features
+          entitlement_entitlements AS plan_entitlements
         WHERE
-          plan_features.plan_id = COALESCE(plans.parent_id, plans.id)
-          AND plan_features.entitlement_feature_id = subscription_features.entitlement_feature_id
-          AND plan_features.plan_id IS NOT NULL
-          AND plan_features.deleted_at IS NULL
+          plan_entitlements.plan_id = COALESCE(plans.parent_id, plans.id)
+          AND plan_entitlements.entitlement_feature_id = subscription_entitlements.entitlement_feature_id
+          AND plan_entitlements.plan_id IS NOT NULL
+          AND plan_entitlements.deleted_at IS NULL
        )
     GROUP BY
-      subscription_features.entitlement_feature_id
+      subscription_entitlements.entitlement_feature_id
   ),
   -- Number of subscriptions where the feature has been manually removed
   feature_removals_count AS (
@@ -67,13 +67,13 @@ WITH
       COUNT(*) AS count
     FROM
       entitlement_subscription_feature_removals AS feature_removals
-      INNER JOIN subscriptions ON subscriptions.id = feature_removals.subscription_id
       INNER JOIN entitlement_features ON entitlement_features.id = feature_removals.entitlement_feature_id
+      INNER JOIN subscriptions ON subscriptions.id = feature_removals.subscription_id
     WHERE
       feature_removals.entitlement_feature_id IS NOT NULL
+      AND feature_removals.deleted_at IS NULL
       AND entitlement_features.deleted_at IS NULL
       AND subscriptions.status IN (0, 1)
-      AND feature_removals.deleted_at IS NULL
     GROUP BY
       feature_removals.entitlement_feature_id
   )

--- a/db/views/entitlement_features_subscriptions_count_v01.sql
+++ b/db/views/entitlement_features_subscriptions_count_v01.sql
@@ -1,0 +1,80 @@
+WITH
+  -- Number of subscriptions per plan
+	plan_subcriptions AS (
+		SELECT
+			COALESCE(plans.parent_id, plan_id) AS plan_id,
+			COUNT(*)
+		FROM
+			subscriptions
+			INNER JOIN plans ON plans.id = subscriptions.plan_id
+		WHERE
+			plans.deleted_at IS NULL
+			AND subscriptions.status IN (0, 1)
+		GROUP BY
+			COALESCE(plans.parent_id, plan_id)
+	),
+  -- Number of subscriptions that have the feature through a plan
+	plan_subcriptions_count AS (
+		SELECT
+			plan_features.entitlement_feature_id,
+			SUM(COUNt) AS count
+		FROM
+			entitlement_entitlements AS plan_features
+			INNER JOIN plan_subcriptions ON plan_subcriptions.plan_id = plan_features.plan_id
+		WHERE
+			plan_features.plan_id IS NOT NULL
+			AND plan_features.deleted_at IS NULL
+		GROUP BY
+			plan_features.entitlement_feature_id
+	),
+  -- Number of subscriptions that have the feature assigned directly
+	direct_subscriptions_count AS (
+		SELECT
+			subscription_features.entitlement_feature_id,
+			COUNT(*) AS count
+		FROM
+			entitlement_entitlements AS subscription_features
+			INNER JOIN subscriptions ON subscriptions.id = subscription_features.subscription_id
+			INNER JOIN plans ON plans.id = subscriptions.plan_id
+		WHERE
+			subscription_features.deleted_at IS NULL
+			AND subscription_features.subscription_id IS NOT NULL
+			AND subscriptions.status IN (0, 1)
+			AND plans.deleted_at IS NULL
+      -- Avoid counting the same subscription twice if the feature is assigned both directly and through a plan
+			AND NOT EXISTS (
+				SELECT
+					1
+				FROM
+					entitlement_entitlements AS plan_features
+				WHERE
+					plan_features.plan_id = COALESCE(plans.parent_id, plans.id)
+					AND plan_features.entitlement_feature_id = subscription_features.entitlement_feature_id
+					AND plan_features.plan_id IS NOT NULL
+					AND plan_features.deleted_at IS NULL
+			)
+		GROUP BY
+			subscription_features.entitlement_feature_id
+	),
+  -- Number of subscriptions where the feature has been manually removed
+	feature_removals_count AS (
+		SELECT
+			feature_removals.entitlement_feature_id,
+			COUNT(*) AS count
+		FROM
+			entitlement_subscription_feature_removals AS feature_removals
+			INNER JOIN subscriptions ON subscriptions.id = feature_removals.subscription_id
+		WHERE
+			feature_removals.entitlement_feature_id IS NOT NULL
+			AND subscriptions.status IN (0, 1)
+			AND feature_removals.deleted_at IS NULL
+		GROUP BY
+			feature_removals.entitlement_feature_id
+	)
+SELECT
+	COALESCE(plan_subcriptions_count.entitlement_feature_id, direct_subscriptions_count.entitlement_feature_id) AS entitlement_feature_id,
+	COALESCE(plan_subcriptions_count.count, 0) + COALESCE(direct_subscriptions_count.count, 0) - COALESCE(feature_removals_count.count, 0) AS count
+FROM
+	plan_subcriptions_count
+	FULL JOIN direct_subscriptions_count ON plan_subcriptions_count.entitlement_feature_id = direct_subscriptions_count.entitlement_feature_id
+	LEFT JOIN feature_removals_count ON plan_subcriptions_count.entitlement_feature_id = feature_removals_count.entitlement_feature_id

--- a/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Resolvers::Entitlement::FeaturesResolver, :premium do
     GQL
   end
 
+  before_all do |example|
+    Scenic.database.refresh_materialized_view(
+      :entitlement_features_subscriptions_count,
+      concurrently: false
+    )
+  end
+
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "features:view"

--- a/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Resolvers::Entitlement::FeaturesResolver, :premium do
     GQL
   end
 
-  before_all do |example|
+  before do |example|
     Scenic.database.refresh_materialized_view(
       :entitlement_features_subscriptions_count,
       concurrently: false

--- a/spec/models/entitlement/feature_spec.rb
+++ b/spec/models/entitlement/feature_spec.rb
@@ -27,19 +27,14 @@ RSpec.describe Entitlement::Feature do
   end
 
   describe "#subscriptions_count" do
+    subject { build_stubbed(:feature) }
+
     context "when subscriptions_count is not preloaded" do
-      it "calculates the number of subscriptions" do
-        expect(subject.subscriptions_count).to eq(0)
-        entitlement = create(:entitlement, feature: subject)
-        create(:subscription, plan: entitlement.plan)
-        create(:subscription, :pending, plan: entitlement.plan)
-        create(:subscription, :terminated, plan: entitlement.plan)
-        create(:subscription, :canceled, plan: entitlement.plan)
-        expect(subject.subscriptions_count).to eq(2)
-        create(:subscription, plan: create(:plan, parent: entitlement.plan))
-        create(:subscription, :pending, plan: create(:plan, parent: entitlement.plan))
-        create(:subscription, :terminated, plan: create(:plan, parent: entitlement.plan))
-        create(:subscription, :canceled, plan: create(:plan, parent: entitlement.plan))
+      before do
+        allow(Entitlement::Feature::SubscriptionsCountQuery).to receive(:call).and_return(subject.id => 4)
+      end
+
+      it "queries for the subscriptions count" do
         expect(subject.subscriptions_count).to eq(4)
       end
     end

--- a/spec/models/entitlement/feature_spec.rb
+++ b/spec/models/entitlement/feature_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Entitlement::Feature do
         allow(Entitlement::Feature::SubscriptionsCountQuery).to receive(:call).and_return(subject.id => subscriptions_count)
       end
 
-      context "and the feature has subscriptions" do
+      context "when the feature has subscriptions" do
         let(:subscriptions_count) { 4 }
 
         it "queries for the subscriptions count" do
@@ -42,7 +42,7 @@ RSpec.describe Entitlement::Feature do
         end
       end
 
-      context "and the feature does not have subscriptions" do
+      context "when the feature does not have subscriptions" do
         let(:subscriptions_count) { nil }
 
         it "returns 0" do

--- a/spec/models/entitlement/feature_spec.rb
+++ b/spec/models/entitlement/feature_spec.rb
@@ -31,11 +31,23 @@ RSpec.describe Entitlement::Feature do
 
     context "when subscriptions_count is not preloaded" do
       before do
-        allow(Entitlement::Feature::SubscriptionsCountQuery).to receive(:call).and_return(subject.id => 4)
+        allow(Entitlement::Feature::SubscriptionsCountQuery).to receive(:call).and_return(subject.id => subscriptions_count)
       end
 
-      it "queries for the subscriptions count" do
-        expect(subject.subscriptions_count).to eq(4)
+      context "and the feature has subscriptions" do
+        let(:subscriptions_count) { 4 }
+
+        it "queries for the subscriptions count" do
+          expect(subject.subscriptions_count).to eq(4)
+        end
+      end
+
+      context "and the feature does not have subscriptions" do
+        let(:subscriptions_count) { nil }
+
+        it "returns 0" do
+          expect(subject.subscriptions_count).to eq(0)
+        end
       end
     end
 

--- a/spec/queries/entitlement/feature/subscriptions_count_query_spec.rb
+++ b/spec/queries/entitlement/feature/subscriptions_count_query_spec.rb
@@ -5,57 +5,237 @@ require "rails_helper"
 RSpec.describe Entitlement::Feature::SubscriptionsCountQuery do
   subject { described_class.new(organization:, filters: {feature_ids:}) }
 
-  let(:organization) { create(:organization) }
-
-  let(:empty_plan) { create(:plan, organization:) }
-  let(:plan1) { create(:plan, organization:) }
-  let(:plan2) { create(:plan, organization:) }
-  let(:plan3) { create(:plan, organization:, parent: plan2) }
-
-  let(:feature1) { create(:feature, organization:) }
-  let(:feature2) { create(:feature, organization:) }
-  let(:feature3) { create(:feature, organization:) }
-  let(:feature4) { create(:feature, organization:) }
-  let(:feature5) { create(:feature, organization:) }
-
-  let(:feature_ids) do
-    [
-      feature1.id,
-      feature2.id,
-      feature3.id,
-      feature4.id,
-      feature5.id
-    ]
-  end
-
-  before do
-    create(:subscription, organization:, plan: plan1)
-    create(:subscription, :pending, organization:, plan: plan1)
-    create(:subscription, :terminated, organization:, plan: plan1)
-
-    create(:subscription, organization:, plan: plan2)
-    create(:subscription, :pending, organization:, plan: plan2)
-    create(:subscription, :canceled, organization:, plan: plan2)
-
-    create(:subscription, organization:, plan: plan3)
-    create(:subscription, :incomplete, organization:, plan: plan3)
-
-    create(:entitlement, organization:, feature: feature2, plan: empty_plan)
-    create(:entitlement, organization:, feature: feature3, plan: plan1)
-    create(:entitlement, organization:, feature: feature4, plan: plan2)
-    create(:entitlement, organization:, feature: feature5, plan: plan1)
-    create(:entitlement, organization:, feature: feature5, plan: plan2)
+  before do |example|
+    example.example_group.before do
+      Scenic.database.refresh_materialized_view(
+        :entitlement_features_subscriptions_count,
+        concurrently: false
+      )
+    end
   end
 
   describe "#call" do
-    it "returns features subscriptions_count" do
-      result = subject.call
+    let(:organization) { create(:organization) }
+    let(:plan) { create(:plan, organization:) }
 
-      expect(result).to eq({
-        feature3.id => 2,
-        feature4.id => 3,
-        feature5.id => 5
-      })
+    let(:feature) { create(:feature, organization:) }
+    let(:feature_ids) { [feature.id] }
+
+    context "with no subscriptions at all" do
+      it "returns empty hash" do
+        result = subject.call
+
+        expect(result).to eq({})
+      end
+    end
+
+    context "with a plan with no subscriptions" do
+      before do
+        create(:entitlement, feature:, plan:)
+      end
+
+      it "returns empty hash" do
+        result = subject.call
+
+        expect(result).to eq({})
+      end
+    end
+
+    context "with only plan subscriptions" do
+      before do
+        create(:subscription, plan:)
+        create(:subscription, :pending, plan:)
+        create(:subscription, :terminated, plan:)
+        create(:subscription, :canceled, plan:)
+
+        create(:entitlement, feature:, plan:)
+      end
+
+      it "returns the number of active & pending plan subscriptions" do
+        result = subject.call
+
+        expect(result).to eq({feature.id => 2})
+      end
+    end
+
+    context "with multiple plans" do
+      let(:plan1) { create(:plan, organization:) }
+      let(:plan2) { create(:plan, organization:) }
+
+      before do
+        create(:subscription, plan: plan1)
+        create(:subscription, plan: plan2)
+        create(:subscription, :pending, plan: plan2)
+
+        create(:entitlement, feature:, plan: plan1)
+        create(:entitlement, feature:, plan: plan2)
+      end
+
+      it "returns the number of all plans subscriptions" do
+        result = subject.call
+
+        expect(result).to eq({feature.id => 3})
+      end
+    end
+
+    context "with plan overrides" do
+      let(:plan1) { create(:plan, organization:) }
+      let(:plan2) { create(:plan, organization:, parent: plan1) }
+
+      before do
+        create(:subscription, plan: plan1)
+        create(:subscription, plan: plan2)
+
+        create(:entitlement, feature:, plan: plan1)
+      end
+
+      it "includes overriden plan subscriptions to its parent plan" do
+        result = subject.call
+
+        expect(result).to eq({feature.id => 2})
+      end
+    end
+
+    context "with a deleted plan" do
+      let(:plan1) { create(:plan, organization:) }
+      let(:plan2) { create(:plan, organization:, deleted_at: Time.now) }
+
+      before do
+        create(:subscription, plan: plan1)
+        create(:subscription, plan: plan2)
+
+        create(:entitlement, feature:, plan: plan1)
+        create(:entitlement, feature:, plan: plan2)
+      end
+
+      it "does not include deleted plan subscriptions" do
+        result = subject.call
+
+        expect(result).to eq({feature.id => 1})
+      end
+    end
+
+    context "with only direct subscriptions" do
+      let(:subscription1) { create(:subscription, plan:) }
+      let(:subscription2) { create(:subscription, :pending, plan:) }
+      let(:subscription3) { create(:subscription, :terminated, plan:) }
+      let(:subscription4) { create(:subscription, :canceled, plan:) }
+
+      before do
+        create(:entitlement, :subscription, feature:, subscription: subscription1)
+        create(:entitlement, :subscription, feature:, subscription: subscription2)
+        create(:entitlement, :subscription, feature:, subscription: subscription3)
+        create(:entitlement, :subscription, feature:, subscription: subscription4)
+      end
+
+      it "returns the number of active & pending direct subscriptions" do
+        result = subject.call
+
+        expect(result).to eq({feature.id => 2})
+      end
+    end
+
+    context "with both plan and direct subscriptions" do
+      let(:subscription1) { create(:subscription, plan:) }
+      let(:subscription2) { create(:subscription, plan:) }
+      let(:subscription3) { create(:subscription, organization:) }
+
+      before do
+        create(:entitlement, feature:, plan:)
+        create(:entitlement, :subscription, feature:, subscription: subscription2)
+        create(:entitlement, :subscription, feature:, subscription: subscription3)
+      end
+
+      it "returns the total number of plan and direct subscriptions" do
+        result = subject.call
+
+        expect(result).to eq({feature.id => 2})
+      end
+    end
+
+    context "with feature removals" do
+      let(:subscription) { create(:subscription, plan:) }
+
+      before do
+        create(:subscription, plan:)
+        create(:entitlement, feature:, plan:)
+
+        create(:subscription_feature_removal, feature:, subscription:)
+      end
+
+      it "does not include subscriptions for which the feature is removed" do
+        result = subject.call
+
+        expect(result).to eq({feature.id => 1})
+      end
+    end
+
+    context "with deleted plan entitlements" do
+      before do
+        create(:subscription, plan:)
+        create(:entitlement, feature:, plan:, deleted_at: Time.now)
+      end
+
+      it "does not include deleted entitlement plan subscriptions" do
+        result = subject.call
+
+        expect(result).to eq({})
+      end
+    end
+
+    context "with deleted subscription entitlements" do
+      let(:subscription) { create(:subscription, plan:) }
+
+      before do
+        create(:entitlement, :subscription, feature:, subscription:, deleted_at: Time.now)
+      end
+
+      it "does not include deleted entitlement direct subscriptions" do
+        result = subject.call
+
+        expect(result).to eq({})
+      end
+    end
+
+    context "with deleted feature removals" do
+      let(:subscription) { create(:subscription, plan:) }
+
+      before do
+        create(:subscription_feature_removal, feature:, subscription:, deleted_at: Time.now)
+        create(:entitlement, feature:, plan:)
+      end
+
+      it "includes subscriptions with a deleted feature removal" do
+        result = subject.call
+
+        expect(result).to eq({feature.id => 1})
+      end
+    end
+
+    context "with multiple features" do
+      let(:subscription) { create(:subscription, organization:) }
+
+      let(:feature1) { create(:feature, organization:) }
+      let(:feature2) { create(:feature, organization:) }
+
+      let(:feature_ids) { [feature1.id, feature2.id] }
+
+      before do
+        create(:subscription, plan:)
+        create(:subscription, :pending, plan:)
+
+        create(:entitlement, feature: feature1, plan:)
+        create(:entitlement, :subscription, feature: feature2, subscription:)
+      end
+
+      it "returns subscriptions count for each feature" do
+        result = subject.call
+
+        expect(result).to eq({
+          feature1.id => 2,
+          feature2.id => 1
+        })
+      end
     end
   end
 end

--- a/spec/queries/entitlement/feature/subscriptions_count_query_spec.rb
+++ b/spec/queries/entitlement/feature/subscriptions_count_query_spec.rb
@@ -170,6 +170,21 @@ RSpec.describe Entitlement::Feature::SubscriptionsCountQuery do
       end
     end
 
+    context "with deleted features" do
+      let(:feature) { create(:feature, organization:, deleted_at: Time.zone.now) }
+
+      before do
+        create(:subscription, plan:)
+        create(:entitlement, feature:, plan:)
+      end
+
+      it "does not include deleted features" do
+        result = subject.call
+
+        expect(result).to eq({})
+      end
+    end
+
     context "with deleted plan entitlements" do
       before do
         create(:subscription, plan:)

--- a/spec/queries/entitlement/feature/subscriptions_count_query_spec.rb
+++ b/spec/queries/entitlement/feature/subscriptions_count_query_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Entitlement::Feature::SubscriptionsCountQuery do
 
     context "with a deleted plan" do
       let(:plan1) { create(:plan, organization:) }
-      let(:plan2) { create(:plan, organization:, deleted_at: Time.now) }
+      let(:plan2) { create(:plan, organization:, deleted_at: Time.zone.now) }
 
       before do
         create(:subscription, plan: plan1)
@@ -173,7 +173,7 @@ RSpec.describe Entitlement::Feature::SubscriptionsCountQuery do
     context "with deleted plan entitlements" do
       before do
         create(:subscription, plan:)
-        create(:entitlement, feature:, plan:, deleted_at: Time.now)
+        create(:entitlement, feature:, plan:, deleted_at: Time.zone.now)
       end
 
       it "does not include deleted entitlement plan subscriptions" do
@@ -187,7 +187,7 @@ RSpec.describe Entitlement::Feature::SubscriptionsCountQuery do
       let(:subscription) { create(:subscription, plan:) }
 
       before do
-        create(:entitlement, :subscription, feature:, subscription:, deleted_at: Time.now)
+        create(:entitlement, :subscription, feature:, subscription:, deleted_at: Time.zone.now)
       end
 
       it "does not include deleted entitlement direct subscriptions" do
@@ -201,7 +201,7 @@ RSpec.describe Entitlement::Feature::SubscriptionsCountQuery do
       let(:subscription) { create(:subscription, plan:) }
 
       before do
-        create(:subscription_feature_removal, feature:, subscription:, deleted_at: Time.now)
+        create(:subscription_feature_removal, feature:, subscription:, deleted_at: Time.zone.now)
         create(:entitlement, feature:, plan:)
       end
 


### PR DESCRIPTION
## Context

The subscription count on the Features page is currently incorrect. Right now, it only counts subscriptions that get a feature through their plan. It doesn't include subscriptions that have the feature assigned directly on their Entitlements page, and it doesn't account for subscriptions where the feature has been removed.

## Description

This PR adds a materialized view that precomputes and stores the subscription count for every non-deleted feature that has at least one associated subscription.

The count is calculated in four steps for each feature:

1. Count subscriptions that get the feature through their plan. If a subscription has an overridden plan, it's counted towards the parent plan's features, since plan overrides can't have their own entitlements.
2. Count subscriptions that have the feature assigned directly on their Entitlements page. This step also removes duplicates when a subscription gets the same feature both through its plan and via a direct assignment.
3. Count subscriptions where the feature has been manually removed.
4. Calculate the final count as:

   `plan subscriptions + direct subscriptions - feature removals`

## Refreshing the Materialized View

On a database with around **2.5M subscriptions** and **4M entitlements**, refreshing the view takes about **3 seconds**. On databases roughly **10× larger**, it may take up to **30 seconds**.

To balance performance with data freshness, the view is refreshed every **10 minutes**. This helps avoid refresh-time spikes while keeping the counts reasonably up to date.
