### PR TITLE
feat(purchase_order_number): Add the new field to Subscriptions REST API

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -176,6 +176,7 @@ module Api
             :ending_at,
             :progressive_billing_disabled,
             :consolidate_invoice,
+            :purchase_order_number,
             invoice_custom_section: [
               :skip_invoice_custom_sections,
               {invoice_custom_section_codes: []}
@@ -201,6 +202,7 @@ module Api
           :billing_entity_id,
           :billing_entity_code,
           :consolidate_invoice,
+          :purchase_order_number,
           activation_rules: [:type, :timeout_hours],
           invoice_custom_section: [
             :skip_invoice_custom_sections,

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -30,6 +30,7 @@ module V1
         on_termination_invoice: model.on_termination_invoice,
         progressive_billing_disabled: model.progressive_billing_disabled,
         consolidate_invoice: model.consolidate_invoice,
+        purchase_order_number: model.purchase_order_number,
         cancellation_reason: model.cancellation_reason,
         activated_at: model.activated_at&.iso8601
       }

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         billing_time: "anniversary",
         subscription_at:,
         ending_at:,
+        purchase_order_number: "PO-123",
         invoice_custom_section: {
           invoice_custom_section_codes: [section_1.code]
         },
@@ -84,6 +85,7 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
           billing_time: "anniversary",
           subscription_at: Time.current.iso8601,
           ending_at: (Time.current + 1.year).iso8601,
+          purchase_order_number: "PO-123",
           previous_plan_code: nil,
           next_plan_code: nil,
           downgrade_plan_date: nil
@@ -1698,6 +1700,21 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
 
         subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
         expect(subscription.consolidate_invoice).to be(false)
+      end
+    end
+
+    context "when updating purchase_order_number" do
+      let(:update_params) { {purchase_order_number: "PO-123"} }
+      let(:subscription) { create(:subscription, customer:, plan:) }
+
+      it "updates purchase_order_number" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription][:purchase_order_number]).to eq("PO-123")
+
+        subscription = Subscription.find_by(external_id: json[:subscription][:external_id])
+        expect(subscription.purchase_order_number).to eq("PO-123")
       end
     end
 

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ::V1::SubscriptionSerializer do
   let(:started_at) { Time.zone.parse("2024-04-23 10:02:03") }
   let(:ending_at) { Time.zone.parse("2024-06-30") }
   let(:subscription) do
-    create(:subscription, created_at: started_at, started_at:, ending_at:)
+    create(:subscription, created_at: started_at, started_at:, ending_at:, purchase_order_number: "PO-123")
   end
 
   let(:includes) { %i[customer plan entitlements] }
@@ -34,6 +34,7 @@ RSpec.describe ::V1::SubscriptionSerializer do
           "status" => subscription.status,
           "billing_time" => subscription.billing_time,
           "created_at" => "2024-04-23T10:02:03Z",
+          "purchase_order_number" => "PO-123",
           "ending_at" => ending_at.iso8601,
           "trial_ended_at" => nil,
           "started_at" => "2024-04-23T10:02:03.000Z",


### PR DESCRIPTION
## Context
This commit changes the subscriptions API endpoints to add a new field `purchase_order_number`.

## Description
This includes API serializers and webhooks
