### PR TITLE
fix(payment_request): PaymentRequestMailer empty payment_url

### DIFF
--- a/app/services/payment_requests/payments/generate_payment_url_service.rb
+++ b/app/services/payment_requests/payments/generate_payment_url_service.rb
@@ -3,7 +3,7 @@
 module PaymentRequests
   module Payments
     class GeneratePaymentUrlService < BaseService
-      Result = BaseResult
+      Result = BaseResult[:payment_url]
 
       include Customers::PaymentProviderFinder
 
@@ -35,7 +35,8 @@ module PaymentRequests
 
         return result.single_validation_failure!(error_code: "payment_provider_error") if payment_url_result.payment_url.blank?
 
-        payment_url_result
+        result.payment_url = payment_url_result.payment_url
+        result
       rescue BaseService::ThirdPartyFailure => e
         deliver_error_webhook(e)
 

--- a/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
         expect(result.error.messages[:base]).to eq(["invalid_payment_status"])
+        expect(result.payment_url).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Context

This PR fixes a regression introduced by https://github.com/getlago/lago-api/pull/5873. When an error happen when we want to generate a `payment_url` from the `PaymentRequestMailer` the email must be sent without including the missing url.

The definition of the Result in `PaymentRequests::Payments::GeneratePaymentUrlService` changed this behavior as it was not returning a `LegacyResult` anymore in case of error but a `PaymentRequests::Payments::GeneratePaymentUrlService::Result` on which no `payment_url` was defined, leading to this error.

## Description

The fix is simple: 
- Add the `payment_url` attribute to the Result definition so that the behavior in the mailer remain consistent with what it was
- Avoid returning a result from one of the `PaymentRequests::Payments::XxxService` in `PaymentRequests::Payments::GeneratePaymentUrlService`, but the service's `Result` instance
