### PR TITLE
fix(clickhouse): Retry total_count failure on GET /events

### DIFF
--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -10,7 +10,14 @@ module Pagination
 
   def pagination_metadata(records, **count_params)
     current_page = prev_page = next_page = total_pages = nil
-    total_count = _count_total(**count_params) { records.total_count }
+    total_count = _count_total(**count_params) do
+      if clickhouse_relation?(records)
+        # Handle Clickhouse intermittent errors
+        Events::Stores::Utils::ClickhouseConnection.with_retry { records.total_count }
+      else
+        records.total_count
+      end
+    end
 
     if total_count.positive?
       current_page = records.current_page
@@ -29,6 +36,10 @@ module Pagination
   end
 
   private
+
+  def clickhouse_relation?(records)
+    records.respond_to?(:klass) && records.klass < Clickhouse::BaseRecord
+  end
 
   # Computes total pages from the record count.
   # For kaminari collections, derives it from limit_value to avoid an extra COUNT(*) query.

--- a/spec/controllers/concerns/pagination_spec.rb
+++ b/spec/controllers/concerns/pagination_spec.rb
@@ -121,6 +121,41 @@ RSpec.describe Pagination do
     end
   end
 
+  context "when records are backed by a ClickHouse relation" do
+    let(:records) do
+      double("records", klass: Clickhouse::EventsRaw, current_page: 2, limit_value: 10)
+    end
+
+    context "when the count query drops the connection once" do
+      before do
+        call_count = 0
+        allow(records).to receive(:total_count) do
+          call_count += 1
+          raise ActiveRecord::ActiveRecordError, "Response: end of file reached" if call_count == 1
+
+          25
+        end
+      end
+
+      it "retries the count and returns correct metadata" do
+        expect(result["total_count"]).to eq(25)
+        expect(records).to have_received(:total_count).twice
+      end
+    end
+
+    context "when the count query keeps failing" do
+      before do
+        allow(records).to receive(:total_count)
+          .and_raise(ActiveRecord::ActiveRecordError, "Response: end of file reached")
+      end
+
+      it "raises after exhausting retries" do
+        expect { result }.to raise_error(ActiveRecord::ActiveRecordError)
+        expect(records).to have_received(:total_count).exactly(3).times
+      end
+    end
+  end
+
   context "with different filter params" do
     let(:organization_id) { SecureRandom.uuid }
 


### PR DESCRIPTION
## Description

This PR adds the auto retry management from `Events::Stores::Utils::ClickhouseConnection` to the `total_count` used for pagination on the `GET /events endpoint`

This should reduce the number of occurrence of:
```
ActiveRecord::ActiveRecordError 
Response: end of file reached (ActiveRecord::ActiveRecordError)
```