### PR TITLE
fix: add small changes in pdf templates used for historical invoices

### DIFF
--- a/app/views/helpers/date_helper.rb
+++ b/app/views/helpers/date_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DateHelper
+  def self.format(date, format: :default)
+    return if date.nil?
+
+    I18n.l(date, format:)
+  end
+end

--- a/app/views/templates/invoices/v1.slim
+++ b/app/views/templates/invoices/v1.slim
@@ -490,7 +490,7 @@ html
           h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.invoice_name)
           .body-1 = I18n.t('invoice.subscription')
           .mb-24.body-3
-            | #{I18n.t('invoice.date_from')} #{I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default)} #{I18n.t('invoice.date_to')} #{I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default)}
+            | #{I18n.t('invoice.date_from')} #{DateHelper.format(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date)} #{I18n.t('invoice.date_to')} #{DateHelper.format(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date)}
 
           .invoice-resume.mb-24.overflow-auto
             table.invoice-resume-table width="100%"
@@ -508,7 +508,7 @@ html
           - if subscription? && subscription_fees(subscription.id).charge.any?
             .body-1 = I18n.t('invoice.usage_based_fees')
             .mb-24.body-3
-              = I18n.t('invoice.list_of_charges', from: I18n.l(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date, format: :default), to: I18n.l(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date, format: :default))
+              = I18n.t('invoice.list_of_charges', from: DateHelper.format(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date), to: DateHelper.format(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date))
             .charge-details.mb-24
               table.charge-details-table width="100%"
                 - subscription_fees(subscription.id).charge.group_by(&:charge_id).each do |_charge_id, fees|
@@ -570,11 +570,11 @@ html
                             td.body-3 width="15%" = I18n.l(breakdown.date, format: :default)
                             td.body-1 width="65%"
                               - if breakdown.action.to_sym == :add
-                                | +#{breakdown.count} #{fee.invoice_name}
+                                | +#{breakdown.amount} #{fee.invoice_name}
                               - elsif breakdown.action.to_sym == :remove
-                                | -#{breakdown.count} #{fee.invoice_name}
+                                | -#{breakdown.amount} #{fee.invoice_name}
                               - else
-                                | +/-#{breakdown.count} #{fee.invoice_name}
+                                | +/-#{breakdown.amount} #{fee.invoice_name}
                             td.body-3 width="20%"
                               = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
                 - else
@@ -588,11 +588,11 @@ html
                             td.body-3 width="15%" = breakdown.date.strftime('%b %d, %Y')
                             td.body-1 width="65%"
                               - if breakdown.action.to_sym == :add
-                                | +#{breakdown.count} #{fee.invoice_name}
+                                | +#{breakdown.amount} #{fee.invoice_name}
                               - elsif breakdown.action.to_sym == :remove
-                                | -#{breakdown.count} #{fee.invoice_name}
+                                | -#{breakdown.amount} #{fee.invoice_name}
                               - else
-                                | +/-#{breakdown.count} #{fee.invoice_name}
+                                | +/-#{breakdown.amount} #{fee.invoice_name}
                             td.body-3 width="20%"
                               = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
 

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -499,7 +499,7 @@ html
           h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.invoice_name)
           .body-1 = I18n.t('invoice.subscription')
           .mb-24.body-3
-            | #{I18n.t('invoice.date_from')} #{I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default)} #{I18n.t('invoice.date_to')} #{I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default)}
+            | #{I18n.t('invoice.date_from')} #{DateHelper.format(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date)} #{I18n.t('invoice.date_to')} #{DateHelper.format(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date)}
 
           .invoice-resume.mb-24.overflow-auto
             table.invoice-resume-table width="100%"
@@ -517,7 +517,7 @@ html
           - if subscription? && subscription_fees(subscription.id).charge.any?
             .body-1 = I18n.t('invoice.usage_based_fees')
             .mb-24.body-3
-              = I18n.t('invoice.list_of_charges', from: I18n.l(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date, format: :default), to: I18n.l(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date, format: :default))
+              = I18n.t('invoice.list_of_charges', from: DateHelper.format(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date), to: DateHelper.format(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date))
             .charge-details.mb-24
               table.charge-details-table width="100%"
                 - subscription_fees(subscription.id).charge.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
@@ -591,11 +591,11 @@ html
                             td.body-3 width="15%" = I18n.l(breakdown.date, format: :default)
                             td.body-1 width="65%"
                               - if breakdown.action.to_sym == :add
-                                | +#{breakdown.count} #{fee.invoice_name}
+                                | +#{breakdown.amount} #{fee.invoice_name}
                               - elsif breakdown.action.to_sym == :remove
-                                | -#{breakdown.count} #{fee.invoice_name}
+                                | -#{breakdown.amount} #{fee.invoice_name}
                               - else
-                                | +/-#{breakdown.count} #{fee.invoice_name}
+                                | +/-#{breakdown.amount} #{fee.invoice_name}
                             td.body-3 width="20%"
                               = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
                 - else
@@ -609,11 +609,11 @@ html
                             td.body-3 width="15%" = breakdown.date.strftime('%b %d, %Y')
                             td.body-1 width="65%"
                               - if breakdown.action.to_sym == :add
-                                | +#{breakdown.count} #{fee.invoice_name}
+                                | +#{breakdown.amount} #{fee.invoice_name}
                               - elsif breakdown.action.to_sym == :remove
-                                | -#{breakdown.count} #{fee.invoice_name}
+                                | -#{breakdown.amount} #{fee.invoice_name}
                               - else
-                                | +/-#{breakdown.count} #{fee.invoice_name}
+                                | +/-#{breakdown.amount} #{fee.invoice_name}
                             td.body-3 width="20%"
                               = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
 

--- a/app/views/templates/invoices/v3/_subscription_details.slim
+++ b/app/views/templates/invoices/v3/_subscription_details.slim
@@ -7,7 +7,7 @@
     .invoice-resume.overflow-auto class="#{'mb-24' if subscription_fees(subscription.id).charge.any?}"
       table.invoice-resume-table width="100%"
         tr
-          td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default))
+          td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: DateHelper.format(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date), to_date: DateHelper.format(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date))
           td.body-2 = I18n.t('invoice.unit')
           td.body-2 = I18n.t('invoice.tax_rate')
           td.body-2 = I18n.t('invoice.amount_without_tax')
@@ -25,7 +25,7 @@
         .invoice-resume.overflow-auto
           table.invoice-resume-table width="100%"
             tr
-              td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date, format: :default))
+              td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: DateHelper.format(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date), to_date: DateHelper.format(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date))
               td.body-2 = I18n.t('invoice.unit')
               td.body-2 = I18n.t('invoice.tax_rate')
               td.body-2 = I18n.t('invoice.amount_without_tax')

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v1.slim/when_a_recurring_metric_produces_a_usage_breakdown/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v1.slim/when_a_recurring_metric_produces_a_usage_breakdown/renders_correctly.html.snap
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-8">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All Subscriptions
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All usage based fees
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-2" width="30%">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Tax
+            </td>
+            <td class="body-2">
+              $0.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-1">
+              Total due
+            </td>
+            <td class="body-1">
+              $50.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+      <h2 class="invoice-details-title title-2 mb-24">
+        Basic Plan details
+      </h2>
+      <div class="body-1">
+        Subscription
+      </div>
+      <div class="mb-24 body-3">
+        From Aug 01, 2023 to Aug 31, 2023
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                Monthly subscription - Basic Plan
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-1" width="30%">
+              €20.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="body-1">
+        Usage based fees
+      </div>
+      <div class="mb-24 body-3">
+        List of charges used from Jul 01, 2023 to Jul 31, 2023
+      </div>
+      <div class="charge-details mb-24">
+        <table class="charge-details-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                Storage
+              </div>
+              <div class="body-3">Total unit: 30.0
+              </div>
+            </td>
+            <td class="body-1" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <div class="charge-details-resume">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Subtotal
+              </td>
+              <td class="body-1" width="30%">
+                €30.00
+              </td>
+            </tr>
+          </table>
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Total
+              </td>
+              <td class="body-1" width="30%">
+                €50.00
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+      <h2 class="invoice-details-title title-2 mb-24">
+        Basic Plan details
+      </h2>
+      <div class="body-3">
+        Storage
+      </div>
+      <div class="body-1 mb-24">
+        Breakdown
+      </div>
+      <div class="breakdown-details mb-24">
+        <table class="breakdown-details-table" width="100%">
+          <tr>
+            <td class="body-3" width="15%">
+              Jul 01, 2023
+            </td>
+            <td class="body-1" width="65%">
+              +10 Storage
+            </td>
+            <td class="body-3" width="20%">
+              Used 31 out of 31 days
+            </td>
+          </tr>
+          <tr>
+            <td class="body-3" width="15%">
+              Jul 15, 2023
+            </td>
+            <td class="body-1" width="65%">-4 Storage
+            </td>
+            <td class="body-3" width="20%">
+              Used 17 out of 31 days
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="alert body-3">
+        Translation missing: en.invoice.notice
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v1.slim/when_invoice_type_is_subscription_with_usage_charges/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v1.slim/when_invoice_type_is_subscription_with_usage_charges/renders_correctly.html.snap
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-8">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All Subscriptions
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All usage based fees
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-2" width="30%">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Tax
+            </td>
+            <td class="body-2">
+              $0.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-1">
+              Total due
+            </td>
+            <td class="body-1">
+              $50.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+      <h2 class="invoice-details-title title-2 mb-24">
+        Basic Plan details
+      </h2>
+      <div class="body-1">
+        Subscription
+      </div>
+      <div class="mb-24 body-3">
+        From Aug 01, 2023 to Aug 31, 2023
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                Monthly subscription - Basic Plan
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-1" width="30%">
+              €20.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="body-1">
+        Usage based fees
+      </div>
+      <div class="mb-24 body-3">
+        List of charges used from Jul 01, 2023 to Jul 31, 2023
+      </div>
+      <div class="charge-details mb-24">
+        <table class="charge-details-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                API calls
+              </div>
+              <div class="body-3">Total unit: 30.0
+              </div>
+            </td>
+            <td class="body-1" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <div class="charge-details-resume">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Subtotal
+              </td>
+              <td class="body-1" width="30%">
+                €30.00
+              </td>
+            </tr>
+          </table>
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Total
+              </td>
+              <td class="body-1" width="30%">
+                €50.00
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v1.slim/when_subscription_and_charge_boundaries_are_missing_(legacy_data)/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v1.slim/when_subscription_and_charge_boundaries_are_missing_(legacy_data)/renders_correctly.html.snap
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-8">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All Subscriptions
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All usage based fees
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-2" width="30%">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Tax
+            </td>
+            <td class="body-2">
+              $0.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-1">
+              Total due
+            </td>
+            <td class="body-1">
+              $50.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+      <h2 class="invoice-details-title title-2 mb-24">
+        Basic Plan details
+      </h2>
+      <div class="body-1">
+        Subscription
+      </div>
+      <div class="mb-24 body-3">
+        From  to 
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                Monthly subscription - Basic Plan
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-1" width="30%">
+              €20.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="body-1">
+        Usage based fees
+      </div>
+      <div class="mb-24 body-3">
+        List of charges used from  to 
+      </div>
+      <div class="charge-details mb-24">
+        <table class="charge-details-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                API calls
+              </div>
+              <div class="body-3">Total unit: 30.0
+              </div>
+            </td>
+            <td class="body-1" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <div class="charge-details-resume">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Subtotal
+              </td>
+              <td class="body-1" width="30%">
+                €30.00
+              </td>
+            </tr>
+          </table>
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Total
+              </td>
+              <td class="body-1" width="30%">
+                €50.00
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v2.slim/when_a_recurring_metric_produces_a_usage_breakdown/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v2.slim/when_a_recurring_metric_produces_a_usage_breakdown/renders_correctly.html.snap
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-8">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All Subscriptions
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All usage based fees
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal (excl. tax)
+            </td>
+            <td class="body-2" width="30%">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Tax (0.0%)
+            </td>
+            <td class="body-2">
+              $0.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Subtotal (incl. tax)
+            </td>
+            <td class="body-2">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-1" width="70%">
+              Total due
+            </td>
+            <td class="body-1" width="30%">
+              $50.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+      <h2 class="invoice-details-title title-2 mb-24">
+        Basic Plan details
+      </h2>
+      <div class="body-1">
+        Subscription
+      </div>
+      <div class="mb-24 body-3">
+        From Aug 01, 2023 to Aug 31, 2023
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                Monthly subscription - Basic Plan
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-1" width="30%">
+              €20.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="body-1">
+        Usage based fees
+      </div>
+      <div class="mb-24 body-3">
+        List of charges used from Jul 01, 2023 to Jul 31, 2023
+      </div>
+      <div class="charge-details mb-24">
+        <table class="charge-details-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                Storage
+              </div>
+              <div class="body-3">Total unit: 30.0
+              </div>
+            </td>
+            <td class="body-1" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <div class="charge-details-resume">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Subtotal
+              </td>
+              <td class="body-1" width="30%">
+                €30.00
+              </td>
+            </tr>
+          </table>
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Total
+              </td>
+              <td class="body-1" width="30%">
+                €50.00
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+      <h2 class="invoice-details-title title-2 mb-24">
+        Basic Plan details
+      </h2>
+      <div class="body-3">
+        Storage
+      </div>
+      <div class="body-1 mb-24">
+        Breakdown
+      </div>
+      <div class="breakdown-details mb-24">
+        <table class="breakdown-details-table" width="100%">
+          <tr>
+            <td class="body-3" width="15%">
+              Jul 01, 2023
+            </td>
+            <td class="body-1" width="65%">
+              +10 Storage
+            </td>
+            <td class="body-3" width="20%">
+              Used 31 out of 31 days
+            </td>
+          </tr>
+          <tr>
+            <td class="body-3" width="15%">
+              Jul 15, 2023
+            </td>
+            <td class="body-1" width="65%">-4 Storage
+            </td>
+            <td class="body-3" width="20%">
+              Used 17 out of 31 days
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="alert body-3">
+        Translation missing: en.invoice.notice
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v2.slim/when_invoice_type_is_subscription_with_usage_charges/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v2.slim/when_invoice_type_is_subscription_with_usage_charges/renders_correctly.html.snap
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-8">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All Subscriptions
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All usage based fees
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal (excl. tax)
+            </td>
+            <td class="body-2" width="30%">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Tax (0.0%)
+            </td>
+            <td class="body-2">
+              $0.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Subtotal (incl. tax)
+            </td>
+            <td class="body-2">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-1" width="70%">
+              Total due
+            </td>
+            <td class="body-1" width="30%">
+              $50.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+      <h2 class="invoice-details-title title-2 mb-24">
+        Basic Plan details
+      </h2>
+      <div class="body-1">
+        Subscription
+      </div>
+      <div class="mb-24 body-3">
+        From Aug 01, 2023 to Aug 31, 2023
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                Monthly subscription - Basic Plan
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-1" width="30%">
+              €20.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="body-1">
+        Usage based fees
+      </div>
+      <div class="mb-24 body-3">
+        List of charges used from Jul 01, 2023 to Jul 31, 2023
+      </div>
+      <div class="charge-details mb-24">
+        <table class="charge-details-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                API calls
+              </div>
+              <div class="body-3">Total unit: 30.0
+              </div>
+            </td>
+            <td class="body-1" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <div class="charge-details-resume">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Subtotal
+              </td>
+              <td class="body-1" width="30%">
+                €30.00
+              </td>
+            </tr>
+          </table>
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Total
+              </td>
+              <td class="body-1" width="30%">
+                €50.00
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v2.slim/when_subscription_and_charge_boundaries_are_missing_(legacy_data)/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v2.slim/when_subscription_and_charge_boundaries_are_missing_(legacy_data)/renders_correctly.html.snap
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-8">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All Subscriptions
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                All usage based fees
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal (excl. tax)
+            </td>
+            <td class="body-2" width="30%">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Tax (0.0%)
+            </td>
+            <td class="body-2">
+              $0.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-2">
+              Subtotal (incl. tax)
+            </td>
+            <td class="body-2">
+              $50.00
+            </td>
+          </tr>
+          <tr>
+            <td class="body-1" width="70%">
+              Total due
+            </td>
+            <td class="body-1" width="30%">
+              $50.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+      <h2 class="invoice-details-title title-2 mb-24">
+        Basic Plan details
+      </h2>
+      <div class="body-1">
+        Subscription
+      </div>
+      <div class="mb-24 body-3">
+        From  to 
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                Monthly subscription - Basic Plan
+              </div>
+            </td>
+            <td class="body-1" style="text-align: right;" width="30%">
+              $20.00
+            </td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2" width="70%">
+              Subtotal
+            </td>
+            <td class="body-1" width="30%">
+              €20.00
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="body-1">
+        Usage based fees
+      </div>
+      <div class="mb-24 body-3">
+        List of charges used from  to 
+      </div>
+      <div class="charge-details mb-24">
+        <table class="charge-details-table" width="100%">
+          <tr>
+            <td width="70%">
+              <div class="body-1">
+                API calls
+              </div>
+              <div class="body-3">Total unit: 30.0
+              </div>
+            </td>
+            <td class="body-1" width="30%">
+              $30.00
+            </td>
+          </tr>
+        </table>
+        <div class="charge-details-resume">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Subtotal
+              </td>
+              <td class="body-1" width="30%">
+                €30.00
+              </td>
+            </tr>
+          </table>
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2" width="70%">
+                Total
+              </td>
+              <td class="body-1" width="30%">
+                €50.00
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v3.slim/when_a_recurring_metric_produces_a_usage_breakdown/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v3.slim/when_a_recurring_metric_produces_a_usage_breakdown/renders_correctly.html.snap
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Payment term
+              </td>
+              <td class="body-2">
+                0 days
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            1234567890
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <div class="invoice-resume overflow-auto mb-24">
+          <table class="invoice-resume-table" width="100%">
+            <tr>
+              <td class="body-2">Fees from Aug 01, 2023 to Aug 31, 2023</td>
+              <td class="body-2">Unit</td>
+              <td class="body-2">Tax rate</td>
+              <td class="body-2">Amount (excl. tax)</td>
+            </tr>
+            <tr>
+              <td class="body-1">Monthly subscription - Basic Plan</td>
+              <td class="body-2">1</td>
+              <td class="body-2">
+                <div>0.0%</div>
+              </td>
+              <td class="body-2">€20.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume overflow-auto">
+          <table class="invoice-resume-table" width="100%">
+            <tr>
+              <td class="body-2">Fees from Jul 01, 2023 to Jul 31, 2023</td>
+              <td class="body-2">Unit</td>
+              <td class="body-2">Tax rate</td>
+              <td class="body-2">Amount (excl. tax)</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="body-1">Storage</div>
+              </td>
+              <td>
+                <div class="body-2">30.0</div>
+              </td>
+              <td class="body-2">
+                <div>0.0%</div>
+              </td>
+              <td class="body-2">$30.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume overflow-auto">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Subtotal (excl. tax)</td>
+              <td class="body-2">$50.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Tax (0%)</td>
+              <td class="body-2">$0.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Subtotal (incl. tax)</td>
+              <td class="body-2">$50.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-1">Total due</td>
+              <td class="body-1">$50.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume mb-24 overflow-auto">
+          <h2 class="invoice-details-title title-2 mb-24">Basic Plan details</h2>
+          <div class="body-3">Storage</div>
+          <div class="body-1 mb-24">Breakdown</div>
+          <div class="breakdown-details mb-24">
+            <table class="breakdown-details-table" width="100%">
+              <tr>
+                <td width="20%">
+                  <div class="body-1">Jul 01, 2023</div>
+                  <div class="body-3">Used 31 out of 31 days</div>
+                </td>
+                <td class="body-1" width="80%">+10 Storage</td>
+              </tr>
+              <tr>
+                <td width="20%">
+                  <div class="body-1">Jul 15, 2023</div>
+                  <div class="body-3">Used 17 out of 31 days</div>
+                </td>
+                <td class="body-1" width="80%">-4 Storage</td>
+              </tr>
+            </table>
+          </div>
+          <div class="alert body-3">Regardless of when an event is received, the unit is not prorated, we charge the full price.</div>
+        </div>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v3.slim/when_invoice_type_is_subscription_with_usage_charges/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v3.slim/when_invoice_type_is_subscription_with_usage_charges/renders_correctly.html.snap
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Payment term
+              </td>
+              <td class="body-2">
+                0 days
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            1234567890
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <div class="invoice-resume overflow-auto mb-24">
+          <table class="invoice-resume-table" width="100%">
+            <tr>
+              <td class="body-2">Fees from Aug 01, 2023 to Aug 31, 2023</td>
+              <td class="body-2">Unit</td>
+              <td class="body-2">Tax rate</td>
+              <td class="body-2">Amount (excl. tax)</td>
+            </tr>
+            <tr>
+              <td class="body-1">Monthly subscription - Basic Plan</td>
+              <td class="body-2">1</td>
+              <td class="body-2">
+                <div>0.0%</div>
+              </td>
+              <td class="body-2">€20.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume overflow-auto">
+          <table class="invoice-resume-table" width="100%">
+            <tr>
+              <td class="body-2">Fees from Jul 01, 2023 to Jul 31, 2023</td>
+              <td class="body-2">Unit</td>
+              <td class="body-2">Tax rate</td>
+              <td class="body-2">Amount (excl. tax)</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="body-1">API calls</div>
+              </td>
+              <td>
+                <div class="body-2">30.0</div>
+              </td>
+              <td class="body-2">
+                <div>0.0%</div>
+              </td>
+              <td class="body-2">$30.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume overflow-auto">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Subtotal (excl. tax)</td>
+              <td class="body-2">$50.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Tax (0%)</td>
+              <td class="body-2">$0.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Subtotal (incl. tax)</td>
+              <td class="body-2">$50.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-1">Total due</td>
+              <td class="body-1">$50.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume mb-24 overflow-auto"></div>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v3.slim/when_subscription_and_charge_boundaries_are_missing_(legacy_data)/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v3.slim/when_subscription_and_charge_boundaries_are_missing_(legacy_data)/renders_correctly.html.snap
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202308-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Aug 18, 2023
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Payment term
+              </td>
+              <td class="body-2">
+                0 days
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            Doe Corp - John Doe
+          </div>
+          <div class="body-2">
+            1234567890
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">
+          $50.00
+        </h2>
+        <div class="body-1">
+          Due Aug 18, 2023
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <div class="invoice-resume overflow-auto mb-24">
+          <table class="invoice-resume-table" width="100%">
+            <tr>
+              <td class="body-2">Fees from  to </td>
+              <td class="body-2">Unit</td>
+              <td class="body-2">Tax rate</td>
+              <td class="body-2">Amount (excl. tax)</td>
+            </tr>
+            <tr>
+              <td class="body-1">Monthly subscription - Basic Plan</td>
+              <td class="body-2">1</td>
+              <td class="body-2">
+                <div>0.0%</div>
+              </td>
+              <td class="body-2">€20.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume overflow-auto">
+          <table class="invoice-resume-table" width="100%">
+            <tr>
+              <td class="body-2">Fees from  to </td>
+              <td class="body-2">Unit</td>
+              <td class="body-2">Tax rate</td>
+              <td class="body-2">Amount (excl. tax)</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="body-1">API calls</div>
+              </td>
+              <td>
+                <div class="body-2">30.0</div>
+              </td>
+              <td class="body-2">
+                <div>0.0%</div>
+              </td>
+              <td class="body-2">$30.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume overflow-auto">
+          <table class="total-table" width="100%">
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Subtotal (excl. tax)</td>
+              <td class="body-2">$50.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Tax (0%)</td>
+              <td class="body-2">$0.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-2">Subtotal (incl. tax)</td>
+              <td class="body-2">$50.00</td>
+            </tr>
+            <tr>
+              <td class="body-2"></td>
+              <td class="body-1">Total due</td>
+              <td class="body-1">$50.00</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-resume mb-24 overflow-auto"></div>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/v1.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v1.slim_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "templates/invoices/v1.slim" do
+  subject(:rendered_template) do
+    Slim::Template.new(template, 1, pretty: true).render(invoice)
+  end
+
+  let(:template) { Rails.root.join("app/views/templates/invoices/v1.slim") }
+
+  let(:organization) { create(:organization, :with_static_values) }
+  let(:billing_entity) { create(:billing_entity, :with_static_values, organization:) }
+  let(:customer) { create(:customer, :with_static_values, organization:, billing_entity:) }
+
+  let(:plan) do
+    create(:plan, organization:, interval: "monthly", pay_in_advance: false, invoice_display_name: "Basic Plan")
+  end
+  let(:subscription) { create(:subscription, customer:, plan:, status: "active") }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      organization:,
+      billing_entity:,
+      customer:,
+      version_number: 1,
+      number: "LAGO-202308-001",
+      payment_due_date: Date.parse("2023-08-18"),
+      issuing_date: Date.parse("2023-08-18"),
+      invoice_type: :subscription,
+      currency: "USD",
+      total_amount_cents: 5000,
+      fees_amount_cents: 5000,
+      sub_total_excluding_taxes_amount_cents: 5000,
+      sub_total_including_taxes_amount_cents: 5000
+    )
+  end
+
+  let(:charges_from_datetime) { Time.zone.parse("2023-07-01 00:00:00") }
+  let(:charges_to_datetime) { Time.zone.parse("2023-07-31 23:59:59") }
+
+  let(:invoice_subscription) do
+    create(
+      :invoice_subscription,
+      invoice:,
+      subscription:,
+      from_datetime: Time.zone.parse("2023-08-01 00:00:00"),
+      to_datetime: Time.zone.parse("2023-08-31 23:59:59"),
+      charges_from_datetime:,
+      charges_to_datetime:,
+      timestamp: Time.zone.parse("2023-07-31 23:59:59")
+    )
+  end
+
+  let(:subscription_fee) do
+    create(
+      :fee,
+      invoice:,
+      subscription:,
+      fee_type: :subscription,
+      amount_cents: 2000,
+      amount_currency: "USD",
+      units: 1,
+      unit_amount_cents: 2000,
+      precise_unit_amount: 20.00,
+      invoice_display_name: "Basic Plan - Monthly"
+    )
+  end
+
+  before do
+    I18n.locale = :en
+    invoice_subscription
+    subscription_fee
+  end
+
+  context "when invoice_type is subscription with usage charges" do
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, invoice_display_name: "API calls") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        events_count: 30,
+        invoice_display_name: "API calls",
+        properties: {
+          "charges_from_datetime" => "2023-07-01 00:00:00",
+          "charges_to_datetime" => "2023-07-31 23:59:59"
+        }
+      )
+    end
+
+    before { charge_fee }
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+
+  context "when subscription and charge boundaries are missing (legacy data)" do
+    let(:invoice_subscription) do
+      create(
+        :invoice_subscription,
+        invoice:,
+        subscription:,
+        from_datetime: nil,
+        to_datetime: nil,
+        charges_from_datetime: nil,
+        charges_to_datetime: nil,
+        timestamp: Time.zone.parse("2023-07-31 23:59:59")
+      )
+    end
+
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, invoice_display_name: "API calls") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        events_count: 30,
+        invoice_display_name: "API calls"
+      )
+    end
+
+    before { charge_fee }
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+
+  context "when a recurring metric produces a usage breakdown" do
+    let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, pay_in_advance: false, invoice_display_name: "Storage") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        invoice_display_name: "Storage"
+      )
+    end
+
+    let(:breakdown) do
+      [
+        BillableMetrics::Breakdown::Item.new(
+          date: Date.parse("2023-07-01"),
+          action: "add",
+          amount: 10,
+          duration: 31,
+          total_duration: 31
+        ),
+        BillableMetrics::Breakdown::Item.new(
+          date: Date.parse("2023-07-15"),
+          action: "remove",
+          amount: 4,
+          duration: 17,
+          total_duration: 31
+        )
+      ]
+    end
+
+    before do
+      charge_fee
+      # The breakdown is computed from the event store (covered by
+      # BillableMetrics::Breakdown::SumService specs); here we stub it so the
+      # template rendering is deterministic and independent of event data.
+      allow(invoice).to receive(:recurring_breakdown).and_return(breakdown)
+    end
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+end

--- a/spec/views/app/views/templates/invoices/v2.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v2.slim_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "templates/invoices/v2.slim" do
+  subject(:rendered_template) do
+    Slim::Template.new(template, 1, pretty: true).render(invoice)
+  end
+
+  let(:template) { Rails.root.join("app/views/templates/invoices/v2.slim") }
+
+  let(:organization) { create(:organization, :with_static_values) }
+  let(:billing_entity) { create(:billing_entity, :with_static_values, organization:) }
+  let(:customer) { create(:customer, :with_static_values, organization:, billing_entity:) }
+
+  let(:plan) do
+    create(:plan, organization:, interval: "monthly", pay_in_advance: false, invoice_display_name: "Basic Plan")
+  end
+  let(:subscription) { create(:subscription, customer:, plan:, status: "active") }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      organization:,
+      billing_entity:,
+      customer:,
+      version_number: 2,
+      number: "LAGO-202308-001",
+      payment_due_date: Date.parse("2023-08-18"),
+      issuing_date: Date.parse("2023-08-18"),
+      invoice_type: :subscription,
+      currency: "USD",
+      total_amount_cents: 5000,
+      fees_amount_cents: 5000,
+      sub_total_excluding_taxes_amount_cents: 5000,
+      sub_total_including_taxes_amount_cents: 5000
+    )
+  end
+
+  let(:charges_from_datetime) { Time.zone.parse("2023-07-01 00:00:00") }
+  let(:charges_to_datetime) { Time.zone.parse("2023-07-31 23:59:59") }
+
+  let(:invoice_subscription) do
+    create(
+      :invoice_subscription,
+      invoice:,
+      subscription:,
+      from_datetime: Time.zone.parse("2023-08-01 00:00:00"),
+      to_datetime: Time.zone.parse("2023-08-31 23:59:59"),
+      charges_from_datetime:,
+      charges_to_datetime:,
+      timestamp: Time.zone.parse("2023-07-31 23:59:59")
+    )
+  end
+
+  let(:subscription_fee) do
+    create(
+      :fee,
+      invoice:,
+      subscription:,
+      fee_type: :subscription,
+      amount_cents: 2000,
+      amount_currency: "USD",
+      units: 1,
+      unit_amount_cents: 2000,
+      precise_unit_amount: 20.00,
+      invoice_display_name: "Basic Plan - Monthly"
+    )
+  end
+
+  before do
+    I18n.locale = :en
+    invoice_subscription
+    subscription_fee
+  end
+
+  context "when invoice_type is subscription with usage charges" do
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, invoice_display_name: "API calls") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        events_count: 30,
+        invoice_display_name: "API calls",
+        properties: {
+          "charges_from_datetime" => "2023-07-01 00:00:00",
+          "charges_to_datetime" => "2023-07-31 23:59:59"
+        }
+      )
+    end
+
+    before { charge_fee }
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+
+  context "when subscription and charge boundaries are missing (legacy data)" do
+    let(:invoice_subscription) do
+      create(
+        :invoice_subscription,
+        invoice:,
+        subscription:,
+        from_datetime: nil,
+        to_datetime: nil,
+        charges_from_datetime: nil,
+        charges_to_datetime: nil,
+        timestamp: Time.zone.parse("2023-07-31 23:59:59")
+      )
+    end
+
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, invoice_display_name: "API calls") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        events_count: 30,
+        invoice_display_name: "API calls"
+      )
+    end
+
+    before { charge_fee }
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+
+  context "when a recurring metric produces a usage breakdown" do
+    let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, pay_in_advance: false, invoice_display_name: "Storage") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        invoice_display_name: "Storage"
+      )
+    end
+
+    let(:breakdown) do
+      [
+        BillableMetrics::Breakdown::Item.new(
+          date: Date.parse("2023-07-01"),
+          action: "add",
+          amount: 10,
+          duration: 31,
+          total_duration: 31
+        ),
+        BillableMetrics::Breakdown::Item.new(
+          date: Date.parse("2023-07-15"),
+          action: "remove",
+          amount: 4,
+          duration: 17,
+          total_duration: 31
+        )
+      ]
+    end
+
+    before do
+      charge_fee
+      # The breakdown is computed from the event store (covered by
+      # BillableMetrics::Breakdown::SumService specs); here we stub it so the
+      # template rendering is deterministic and independent of event data.
+      allow(invoice).to receive(:recurring_breakdown).and_return(breakdown)
+    end
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+end

--- a/spec/views/app/views/templates/invoices/v3.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v3.slim_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "templates/invoices/v3.slim" do
+  subject(:rendered_template) do
+    Slim::Template.new(template, 1, pretty: true).render(invoice)
+  end
+
+  let(:template) { Rails.root.join("app/views/templates/invoices/v3.slim") }
+
+  let(:organization) { create(:organization, :with_static_values) }
+  let(:billing_entity) { create(:billing_entity, :with_static_values, organization:) }
+  let(:customer) { create(:customer, :with_static_values, organization:, billing_entity:) }
+
+  let(:plan) do
+    create(:plan, organization:, interval: "monthly", pay_in_advance: false, invoice_display_name: "Basic Plan")
+  end
+  let(:subscription) { create(:subscription, customer:, plan:, status: "active") }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      organization:,
+      billing_entity:,
+      customer:,
+      version_number: 3,
+      number: "LAGO-202308-001",
+      payment_due_date: Date.parse("2023-08-18"),
+      issuing_date: Date.parse("2023-08-18"),
+      invoice_type: :subscription,
+      currency: "USD",
+      total_amount_cents: 5000,
+      fees_amount_cents: 5000,
+      sub_total_excluding_taxes_amount_cents: 5000,
+      sub_total_including_taxes_amount_cents: 5000
+    )
+  end
+
+  let(:charges_from_datetime) { Time.zone.parse("2023-07-01 00:00:00") }
+  let(:charges_to_datetime) { Time.zone.parse("2023-07-31 23:59:59") }
+
+  let(:invoice_subscription) do
+    create(
+      :invoice_subscription,
+      invoice:,
+      subscription:,
+      from_datetime: Time.zone.parse("2023-08-01 00:00:00"),
+      to_datetime: Time.zone.parse("2023-08-31 23:59:59"),
+      charges_from_datetime:,
+      charges_to_datetime:,
+      timestamp: Time.zone.parse("2023-07-31 23:59:59")
+    )
+  end
+
+  let(:subscription_fee) do
+    create(
+      :fee,
+      invoice:,
+      subscription:,
+      fee_type: :subscription,
+      amount_cents: 2000,
+      amount_currency: "USD",
+      units: 1,
+      unit_amount_cents: 2000,
+      precise_unit_amount: 20.00,
+      invoice_display_name: "Basic Plan - Monthly"
+    )
+  end
+
+  before do
+    I18n.locale = :en
+    invoice_subscription
+    subscription_fee
+  end
+
+  context "when invoice_type is subscription with usage charges" do
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, invoice_display_name: "API calls") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        events_count: 30,
+        invoice_display_name: "API calls",
+        properties: {
+          "charges_from_datetime" => "2023-07-01 00:00:00",
+          "charges_to_datetime" => "2023-07-31 23:59:59"
+        }
+      )
+    end
+
+    before { charge_fee }
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+
+  context "when subscription and charge boundaries are missing (legacy data)" do
+    let(:invoice_subscription) do
+      create(
+        :invoice_subscription,
+        invoice:,
+        subscription:,
+        from_datetime: nil,
+        to_datetime: nil,
+        charges_from_datetime: nil,
+        charges_to_datetime: nil,
+        timestamp: Time.zone.parse("2023-07-31 23:59:59")
+      )
+    end
+
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, invoice_display_name: "API calls") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        events_count: 30,
+        invoice_display_name: "API calls"
+      )
+    end
+
+    before { charge_fee }
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+
+  context "when a recurring metric produces a usage breakdown" do
+    let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:, name: "Storage") }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, pay_in_advance: false, invoice_display_name: "Storage") }
+    let(:charge_fee) do
+      create(
+        :charge_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 3000,
+        amount_currency: "USD",
+        units: 30,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1.00,
+        invoice_display_name: "Storage"
+      )
+    end
+
+    let(:breakdown) do
+      [
+        BillableMetrics::Breakdown::Item.new(
+          date: Date.parse("2023-07-01"),
+          action: "add",
+          amount: 10,
+          duration: 31,
+          total_duration: 31
+        ),
+        BillableMetrics::Breakdown::Item.new(
+          date: Date.parse("2023-07-15"),
+          action: "remove",
+          amount: 4,
+          duration: 17,
+          total_duration: 31
+        )
+      ]
+    end
+
+    before do
+      charge_fee
+      # The breakdown is computed from the event store (covered by
+      # BillableMetrics::Breakdown::SumService specs); here we stub it so the
+      # template rendering is deterministic and independent of event data.
+      allow(invoice).to receive(:recurring_breakdown).and_return(breakdown)
+    end
+
+    it "renders correctly" do
+      expect(rendered_template).to match_html_snapshot
+    end
+  end
+end

--- a/spec/views/helpers/date_helper_spec.rb
+++ b/spec/views/helpers/date_helper_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DateHelper do
+  subject(:helper) { described_class }
+
+  describe ".format" do
+    it "localizes the date" do
+      expect(helper.format(Date.new(2024, 1, 2))).to eq(I18n.l(Date.new(2024, 1, 2), format: :default))
+    end
+
+    it "accepts a custom format" do
+      expect(helper.format(Date.new(2024, 1, 2), format: :short))
+        .to eq(I18n.l(Date.new(2024, 1, 2), format: :short))
+    end
+
+    context "when the date is nil" do
+      it "returns nil instead of raising" do
+        expect(helper.format(nil)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Old versions of PDF templates are not compatible anymore with latest code.

## Description

This PR fixs fee breakdown bug and adds some I18n guards so that historical invoice can be correctly generated.
