### PR TITLE
chore(db): Guard against unvalidated constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ To create a webhook:
 - Never use hardcoded or fake timestamps in migration filenames. Migration timestamps should be generated using `date +"%Y%m%d%H%M%S"` command to ensure proper chronological ordering.
 - For enums, use `create_enum` to define the PostgreSQL enum type before adding the column
   - Enum type names should be descriptive and include the table/model context (e.g., `subscription_on_termination_credit_note`)
-- When adding a constraint with `validate: false` (`NOT VALID`), register it in `db/not_valid_constraints.yml` with a `validate_by` deadline and the ticket tracking the validation follow-up. Remove the entry once the constraint is validated. `spec/db/not_valid_constraints_spec.rb` enforces this.
+- When adding a constraint with `validate: false` (`NOT VALID`), add a second migration right after it that validates the constraint (`validate_foreign_key` or `validate_check_constraint`), within the same PR. If validation is not possible yet (e.g. existing rows must be backfilled or fixed first), register the constraint in `db/not_valid_constraints.yml` with a `validate_by` deadline, and remove the entry once the constraint is validated. `spec/db/not_valid_constraints_spec.rb` enforces this.
 - When validating a foreign key on a table that has several foreign keys to the same target table, pass the `column:` option to `validate_foreign_key`, otherwise the wrong constraint may be validated silently.
 
 # Backward Compatibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,8 @@ To create a webhook:
 - Never use hardcoded or fake timestamps in migration filenames. Migration timestamps should be generated using `date +"%Y%m%d%H%M%S"` command to ensure proper chronological ordering.
 - For enums, use `create_enum` to define the PostgreSQL enum type before adding the column
   - Enum type names should be descriptive and include the table/model context (e.g., `subscription_on_termination_credit_note`)
+- When adding a constraint with `validate: false` (`NOT VALID`), register it in `db/not_valid_constraints.yml` with a `validate_by` deadline and the ticket tracking the validation follow-up. Remove the entry once the constraint is validated. `spec/db/not_valid_constraints_spec.rb` enforces this.
+- When validating a foreign key on a table that has several foreign keys to the same target table, pass the `column:` option to `validate_foreign_key`, otherwise the wrong constraint may be validated silently.
 
 # Backward Compatibility
 

--- a/db/not_valid_constraints.yml
+++ b/db/not_valid_constraints.yml
@@ -14,4 +14,4 @@
 #
 # - table: payments
 #   constraint: payments_customer_id_null
-#   validate_by: 2026-08-09  # usually ~1 month after the constraint is added
+#   validate_by: 2026-08-09  # deadline for the validation follow-up

--- a/db/not_valid_constraints.yml
+++ b/db/not_valid_constraints.yml
@@ -1,0 +1,16 @@
+# Registry of constraints created with `NOT VALID` (via `validate: false`)
+# that still await validation.
+#
+# Adding a `NOT VALID` constraint is the right zero-downtime move, but it must
+# be followed by a validation migration. This file makes that follow-up
+# explicit: `spec/db/not_valid_constraints_spec.rb` fails when a `NOT VALID`
+# constraint in db/structure.sql is missing from this list, when an entry here
+# is no longer `NOT VALID` (validated: remove the entry), or when an entry is
+# past its `validate_by` date.
+#
+# Entry format:
+#
+# - table: payments
+#   constraint: payments_customer_id_null
+#   validate_by: 2026-08-09  # usually ~1 month after the constraint is added
+#   ticket: ING-427          # ticket tracking the validation follow-up

--- a/db/not_valid_constraints.yml
+++ b/db/not_valid_constraints.yml
@@ -2,15 +2,16 @@
 # that still await validation.
 #
 # Adding a `NOT VALID` constraint is the right zero-downtime move, but it must
-# be followed by a validation migration. This file makes that follow-up
-# explicit: `spec/db/not_valid_constraints_spec.rb` fails when a `NOT VALID`
-# constraint in db/structure.sql is missing from this list, when an entry here
-# is no longer `NOT VALID` (validated: remove the entry), or when an entry is
-# past its `validate_by` date.
+# be followed by a validation migration, normally right after it in the same
+# PR. This file is only for constraints that cannot be validated right away
+# (e.g. existing rows must be backfilled or fixed first). It makes the
+# follow-up explicit: `spec/db/not_valid_constraints_spec.rb` fails when a
+# `NOT VALID` constraint in db/structure.sql is missing from this list, when
+# an entry here is no longer `NOT VALID` (validated: remove the entry), or
+# when an entry is past its `validate_by` date.
 #
 # Entry format:
 #
 # - table: payments
 #   constraint: payments_customer_id_null
 #   validate_by: 2026-08-09  # usually ~1 month after the constraint is added
-#   ticket: ING-427          # ticket tracking the validation follow-up

--- a/spec/db/not_valid_constraints_spec.rb
+++ b/spec/db/not_valid_constraints_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe "NOT VALID constraints" do # rubocop:disable RSpec/DescribeClass
       #{unregistered.map { |c| "  - #{c["table"]}.#{c["constraint"]}" }.join("\n")}
 
       A NOT VALID constraint must be validated by a follow-up migration
-      (`validate_foreign_key` or `validate_check_constraint`). Until then, register
-      it in db/not_valid_constraints.yml with a `validate_by` deadline and the
-      ticket tracking the follow-up.
+      (`validate_foreign_key` or `validate_check_constraint`), normally added
+      right after it in the same PR. If validation is not possible yet (e.g.
+      existing rows must be backfilled or fixed first), register the constraint
+      in db/not_valid_constraints.yml with a `validate_by` deadline.
 
       Note: when a table has several foreign keys to the same table, pass the
       `column:` option to `validate_foreign_key`, otherwise the wrong constraint
@@ -50,10 +51,10 @@ RSpec.describe "NOT VALID constraints" do # rubocop:disable RSpec/DescribeClass
 
     expect(overdue).to be_empty, <<~MSG
       The following NOT VALID constraints are past their validation deadline.
-      Add a migration validating them (see the referenced ticket), then remove
-      them from db/not_valid_constraints.yml:
+      Add a migration validating them, then remove them from
+      db/not_valid_constraints.yml:
 
-      #{overdue.map { |c| "  - #{c["table"]}.#{c["constraint"]} (validate_by: #{c["validate_by"]}, ticket: #{c["ticket"]})" }.join("\n")}
+      #{overdue.map { |c| "  - #{c["table"]}.#{c["constraint"]} (validate_by: #{c["validate_by"]})" }.join("\n")}
     MSG
   end
 end

--- a/spec/db/not_valid_constraints_spec.rb
+++ b/spec/db/not_valid_constraints_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "NOT VALID constraints" do # rubocop:disable RSpec/DescribeClass
+  let(:structure_sql) { Rails.root.join("db/structure.sql").read }
+  let(:allowlist) { YAML.load_file(Rails.root.join("db/not_valid_constraints.yml")) || [] }
+
+  let(:not_valid_constraints) do
+    structure_sql
+      .scan(/ALTER TABLE (?:ONLY )?public\.(\w+)\n\s+ADD CONSTRAINT (\w+) [^;]+ NOT VALID;/)
+      .map { |table, constraint| {"table" => table, "constraint" => constraint} }
+  end
+
+  it "only contains NOT VALID constraints registered in db/not_valid_constraints.yml" do
+    registered = allowlist.map { |entry| entry.slice("table", "constraint") }
+    unregistered = not_valid_constraints - registered
+
+    expect(unregistered).to be_empty, <<~MSG
+      The following constraints are NOT VALID but are not registered in db/not_valid_constraints.yml:
+
+      #{unregistered.map { |c| "  - #{c["table"]}.#{c["constraint"]}" }.join("\n")}
+
+      A NOT VALID constraint must be validated by a follow-up migration
+      (`validate_foreign_key` or `validate_check_constraint`). Until then, register
+      it in db/not_valid_constraints.yml with a `validate_by` deadline and the
+      ticket tracking the follow-up.
+
+      Note: when a table has several foreign keys to the same table, pass the
+      `column:` option to `validate_foreign_key`, otherwise the wrong constraint
+      may be validated silently.
+    MSG
+  end
+
+  it "does not register constraints that are already validated" do
+    registered = allowlist.map { |entry| entry.slice("table", "constraint") }
+    stale = registered - not_valid_constraints
+
+    expect(stale).to be_empty, <<~MSG
+      The following db/not_valid_constraints.yml entries no longer match a NOT VALID
+      constraint in db/structure.sql. They were validated (or removed): delete them
+      from the registry.
+
+      #{stale.map { |c| "  - #{c["table"]}.#{c["constraint"]}" }.join("\n")}
+    MSG
+  end
+
+  it "validates registered constraints before their deadline" do
+    overdue = allowlist.select { |entry| Date.parse(entry.fetch("validate_by").to_s) < Date.current }
+
+    expect(overdue).to be_empty, <<~MSG
+      The following NOT VALID constraints are past their validation deadline.
+      Add a migration validating them (see the referenced ticket), then remove
+      them from db/not_valid_constraints.yml:
+
+      #{overdue.map { |c| "  - #{c["table"]}.#{c["constraint"]} (validate_by: #{c["validate_by"]}, ticket: #{c["ticket"]})" }.join("\n")}
+    MSG
+  end
+end

--- a/spec/db/not_valid_constraints_spec.rb
+++ b/spec/db/not_valid_constraints_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "NOT VALID constraints" do # rubocop:disable RSpec/DescribeClass
   let(:structure_sql) { Rails.root.join("db/structure.sql").read }
-  let(:allowlist) { YAML.load_file(Rails.root.join("db/not_valid_constraints.yml")) || [] }
+  let(:allowlist) { YAML.load_file(Rails.root.join("db/not_valid_constraints.yml"), permitted_classes: [Date]) || [] }
 
   let(:not_valid_constraints) do
     structure_sql


### PR DESCRIPTION
## Context

#5899 validates eleven constraints that were created as `NOT VALID` and then forgotten, some for up to a year. Nothing enforces the follow-up validation migration after a constraint is added with `validate: false`. One of the eleven (`fk_rails_f435d13904`) even had a validation migration, but the bare `validate_foreign_key :invoice_subscriptions, :invoices` form matched the other foreign key to `invoices` and the constraint silently stayed invalid.

## Description

This adds a guard so a `NOT VALID` constraint can no longer stay unvalidated unnoticed. The expected workflow stays the same: a constraint added with `validate: false` is normally validated by a second migration in the same PR. The registry is only for constraints that cannot be validated right away (e.g. existing rows must be backfilled or fixed first):

- `db/not_valid_constraints.yml` registers constraints awaiting validation, each with a `validate_by` deadline.
- `spec/db/not_valid_constraints_spec.rb` parses `db/structure.sql` and fails when a `NOT VALID` constraint is not registered, when a registered entry is already validated (the entry must be removed), or when a deadline is past.

Since `db/structure.sql` reflects what PostgreSQL actually validated, the wrong-foreign-key case above would have been caught too: the `NOT VALID` marker only disappears once the right constraint is validated.

The workflow is documented in the Migrations section of `AGENTS.md`.

The registry starts empty because #5899 validates all existing constraints; this PR is stacked on it.

## Failure output

Produced by simulating an unregistered `NOT VALID` constraint, a registered entry that is already validated, and an entry past its deadline:

```
1) NOT VALID constraints only contains NOT VALID constraints registered in db/not_valid_constraints.yml

   The following constraints are NOT VALID but are not registered in db/not_valid_constraints.yml:

     - payments.payments_unregistered

   A NOT VALID constraint must be validated by a follow-up migration
   (`validate_foreign_key` or `validate_check_constraint`), normally added
   right after it in the same PR. If validation is not possible yet (e.g.
   existing rows must be backfilled or fixed first), register the constraint
   in db/not_valid_constraints.yml with a `validate_by` deadline.

   Note: when a table has several foreign keys to the same table, pass the
   `column:` option to `validate_foreign_key`, otherwise the wrong constraint
   may be validated silently.

2) NOT VALID constraints does not register constraints that are already validated

   The following db/not_valid_constraints.yml entries no longer match a NOT VALID
   constraint in db/structure.sql. They were validated (or removed): delete them
   from the registry.

     - payments.payments_already_validated

3) NOT VALID constraints validates registered constraints before their deadline

   The following NOT VALID constraints are past their validation deadline.
   Add a migration validating them, then remove them from
   db/not_valid_constraints.yml:

     - payments.payments_overdue (validate_by: 2026-01-01)
```
