### PR TITLE
fix(subscriptions): Skip pay-in-advance event for terminated subscription

### DIFF
--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -50,6 +50,8 @@ module Fees
     private
 
     def skip_missing_subscription
+      # NOTE: `event.subscription` is nil when the subscription was terminated before the
+      # event's timestamp (e.g. enqueued while active, terminated before the job ran).
       message = "Fees::CreatePayInAdvanceService skipped: no active subscription for event"
       context = {
         organization_id: event.organization_id,

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -16,6 +16,8 @@ module Fees
     end
 
     def call
+      return skip_missing_subscription if subscription.nil?
+
       fees = []
 
       ActiveRecord::Base.transaction(**isolation_mode) do
@@ -46,6 +48,22 @@ module Fees
     end
 
     private
+
+    def skip_missing_subscription
+      message = "Fees::CreatePayInAdvanceService skipped: no active subscription for event"
+      context = {
+        organization_id: event.organization_id,
+        external_subscription_id: event.external_subscription_id,
+        charge_id: charge.id,
+        event_transaction_id: event.transaction_id,
+        event_timestamp: billing_at.iso8601
+      }
+
+      Rails.logger.warn("#{message} #{context.map { |k, v| "#{k}=#{v}" }.join(" ")}")
+
+      result.fees = []
+      result
+    end
 
     attr_reader :charge, :event, :billing_at, :estimate
 

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -62,6 +62,30 @@ RSpec.describe Fees::CreatePayInAdvanceService do
         .and_return(charge_result)
     end
 
+    context "when the event has no matching subscription" do
+      let(:event) do
+        source = create(
+          :event,
+          external_subscription_id: "unknown-#{SecureRandom.uuid}",
+          external_customer_id: customer.external_id,
+          organization_id: organization.id,
+          properties: event_properties
+        )
+        Events::CommonFactory.new_instance(source:)
+      end
+
+      it "skips without creating a fee and logs a warning" do
+        allow(Rails.logger).to receive(:warn)
+
+        result = fee_service.call
+
+        expect(result).to be_success
+        expect(result.fees).to eq([])
+        expect(Fee.count).to eq(0)
+        expect(Rails.logger).to have_received(:warn).with(/no active subscription for event/)
+      end
+    end
+
     it "creates a fee" do
       result = fee_service.call
 


### PR DESCRIPTION
## Context

Pay-in-advance fee creation runs asynchronously from a job. Between enqueue and execution a subscription can be terminated, so by the time `Fees::CreatePayInAdvanceService` runs, the event no longer maps to an active subscription. The service assumed a subscription was always present and raised when it was `nil`, leaving the job to fail and retry indefinitely.

## Description

Skip event processing if there is no related active subscription