### PR TITLE
feat(purchase_order_number): Subscriptions upgrade/downgrade

### DIFF
--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -42,6 +42,7 @@ module Subscriptions
           ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
           progressive_billing_disabled: params[:progressive_billing_disabled] || false,
           consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
+          purchase_order_number: params[:purchase_order_number],
           billing_entity_id: current_subscription.billing_entity_id
         )
 

--- a/app/services/subscriptions/plan_downgrade_service.rb
+++ b/app/services/subscriptions/plan_downgrade_service.rb
@@ -42,7 +42,7 @@ module Subscriptions
           ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
           progressive_billing_disabled: params[:progressive_billing_disabled] || false,
           consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
-          purchase_order_number: params[:purchase_order_number],
+          purchase_order_number: params.key?(:purchase_order_number) ? params[:purchase_order_number] : current_subscription.purchase_order_number,
           billing_entity_id: current_subscription.billing_entity_id
         )
 

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -62,6 +62,7 @@ module Subscriptions
         billing_time: current_subscription.billing_time,
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
+        purchase_order_number: params[:purchase_order_number],
         billing_entity_id: resolved_entity&.id || current_subscription.billing_entity_id
       )
 

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -62,7 +62,7 @@ module Subscriptions
         billing_time: current_subscription.billing_time,
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : current_subscription.consolidate_invoice,
-        purchase_order_number: params[:purchase_order_number],
+        purchase_order_number: params.key?(:purchase_order_number) ? params[:purchase_order_number] : current_subscription.purchase_order_number,
         billing_entity_id: resolved_entity&.id || current_subscription.billing_entity_id
       )
 

--- a/spec/services/subscriptions/plan_downgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_downgrade_service_spec.rb
@@ -132,6 +132,33 @@ RSpec.describe Subscriptions::PlanDowngradeService do
       end
     end
 
+    context "when the current subscription has a purchase_order_number" do
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: old_plan,
+          subscription_at: Time.current,
+          external_id: SecureRandom.uuid,
+          purchase_order_number: "PO-OLD"
+        )
+      end
+
+      it "does not carry the purchase_order_number over to the new subscription" do
+        expect(result).to be_success
+        expect(result.subscription.next_subscription.purchase_order_number).to be_nil
+      end
+
+      context "when params provide a purchase_order_number" do
+        let(:params) { {name: subscription_name, purchase_order_number: "PO-NEW"} }
+
+        it "sets it on the new subscription" do
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.purchase_order_number).to eq("PO-NEW")
+        end
+      end
+    end
+
     context "with plan overrides", :premium do
       let(:params) do
         {

--- a/spec/services/subscriptions/plan_downgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_downgrade_service_spec.rb
@@ -144,9 +144,9 @@ RSpec.describe Subscriptions::PlanDowngradeService do
         )
       end
 
-      it "does not carry the purchase_order_number over to the new subscription" do
+      it "inherits the purchase_order_number when params omit it" do
         expect(result).to be_success
-        expect(result.subscription.next_subscription.purchase_order_number).to be_nil
+        expect(result.subscription.next_subscription.purchase_order_number).to eq("PO-OLD")
       end
 
       context "when params provide a purchase_order_number" do
@@ -155,6 +155,15 @@ RSpec.describe Subscriptions::PlanDowngradeService do
         it "sets it on the new subscription" do
           expect(result).to be_success
           expect(result.subscription.next_subscription.purchase_order_number).to eq("PO-NEW")
+        end
+      end
+
+      context "when params provide an explicit nil purchase_order_number" do
+        let(:params) { {name: subscription_name, purchase_order_number: nil} }
+
+        it "clears it on the new subscription" do
+          expect(result).to be_success
+          expect(result.subscription.next_subscription.purchase_order_number).to be_nil
         end
       end
     end

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -103,6 +103,35 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       end
     end
 
+    context "when the current subscription has a purchase_order_number" do
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: old_plan,
+          status: :active,
+          subscription_at: Time.current,
+          started_at: Time.current,
+          external_id: SecureRandom.uuid,
+          purchase_order_number: "PO-OLD"
+        )
+      end
+
+      it "does not carry the purchase_order_number over to the new subscription" do
+        expect(result).to be_success
+        expect(result.subscription.purchase_order_number).to be_nil
+      end
+
+      context "when params provide a purchase_order_number" do
+        let(:params) { {name: subscription_name, purchase_order_number: "PO-NEW"} }
+
+        it "sets it on the new subscription" do
+          expect(result).to be_success
+          expect(result.subscription.purchase_order_number).to eq("PO-NEW")
+        end
+      end
+    end
+
     context "with payment method" do
       let(:payment_method) { create(:payment_method, organization: subscription.organization, customer: subscription.customer) }
       let(:params) do

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -117,9 +117,9 @@ RSpec.describe Subscriptions::PlanUpgradeService do
         )
       end
 
-      it "does not carry the purchase_order_number over to the new subscription" do
+      it "inherits the purchase_order_number when params omit it" do
         expect(result).to be_success
-        expect(result.subscription.purchase_order_number).to be_nil
+        expect(result.subscription.purchase_order_number).to eq("PO-OLD")
       end
 
       context "when params provide a purchase_order_number" do
@@ -128,6 +128,15 @@ RSpec.describe Subscriptions::PlanUpgradeService do
         it "sets it on the new subscription" do
           expect(result).to be_success
           expect(result.subscription.purchase_order_number).to eq("PO-NEW")
+        end
+      end
+
+      context "when params provide an explicit nil purchase_order_number" do
+        let(:params) { {name: subscription_name, purchase_order_number: nil} }
+
+        it "clears it on the new subscription" do
+          expect(result).to be_success
+          expect(result.subscription.purchase_order_number).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Context
During the upgrade/downgrade, it should be possible to edit, remove or keep the purchase order number.

## Description

This PR adds the new `purchase_order_number` field in subscriptions upgrade/downgrade flow.

