### PR TITLE
[STA-7] misc: Add TypedResult concern for legacy services

### DIFF
--- a/app/graphql/mutations/auth/google/accept_invite.rb
+++ b/app/graphql/mutations/auth/google/accept_invite.rb
@@ -13,7 +13,7 @@ module Mutations
         type Types::Payloads::RegisterUserType
 
         def resolve(code:, invite_token:)
-          result = ::Auth::GoogleService.new.accept_invite(code, invite_token)
+          result = ::Auth::GoogleService.call(:accept_invite, code, invite_token)
 
           result.success? ? result : result_error(result)
         end

--- a/app/graphql/mutations/auth/google/login_user.rb
+++ b/app/graphql/mutations/auth/google/login_user.rb
@@ -13,7 +13,7 @@ module Mutations
         type Types::Payloads::LoginUserType
 
         def resolve(code:)
-          result = ::Auth::GoogleService.new.login(code)
+          result = ::Auth::GoogleService.call(:login, code)
           result.success? ? result : result_error(result)
         end
       end

--- a/app/graphql/mutations/auth/google/register_user.rb
+++ b/app/graphql/mutations/auth/google/register_user.rb
@@ -13,7 +13,7 @@ module Mutations
         type Types::Payloads::RegisterUserType
 
         def resolve(code:, organization_name:)
-          result = ::Auth::GoogleService.new.register_user(code, organization_name)
+          result = ::Auth::GoogleService.call(:register_user, code, organization_name)
           result.success? ? result : result_error(result)
         end
       end

--- a/app/graphql/resolvers/auth/google/auth_url_resolver.rb
+++ b/app/graphql/resolvers/auth/google/auth_url_resolver.rb
@@ -10,9 +10,7 @@ module Resolvers
         type Types::Auth::Google::AuthUrl, null: false
 
         def resolve(**_args)
-          result = ::Auth::GoogleService
-            .new
-            .authorize_url(context[:request])
+          result = ::Auth::GoogleService.call(:authorize_url, context[:request])
 
           result.success? ? result : result_error(result)
         end

--- a/app/services/auth/google_service.rb
+++ b/app/services/auth/google_service.rb
@@ -2,7 +2,16 @@
 
 module Auth
   class GoogleService < BaseService
+    include TypedResults
+
     BASE_SCOPE = %w[profile email openid].freeze
+
+    RESULTS = {
+      authorize_url: BaseResult[:url],
+      login: BaseResult[:user, :token],
+      register_user: BaseResult[:user, :organization, :membership, :token],
+      accept_invite: Invites::AcceptService::Result
+    }.freeze
 
     def authorize_url(request)
       ensure_google_auth_setup

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -210,14 +210,19 @@ class BaseService
   end
 
   def call_with_middlewares(&block)
-    chain = init_middlewares
-
-    chain.call { call(&block) }
+    with_middlewares { call(&block) }
   end
 
   protected
 
   attr_writer :result
+
+  # Runs an arbitrary block through the service middleware chain.
+  # Used by `call_with_middlewares` and by the TypedResults bridge to wrap
+  # legacy named methods with the same instrumentation as a regular `call`.
+  def with_middlewares(&block)
+    init_middlewares.call(&block)
+  end
 
   private
 

--- a/app/services/typed_results.rb
+++ b/app/services/typed_results.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# TEMPORARY bridge for legacy multi-method services not yet migrated to the single
+# `call` + typed `Result` pattern.
+#
+# Include the concern and declare a `RESULTS` constant mapping each public
+# method to the typed Result it should return:
+#
+#   class Auth::GoogleService < BaseService
+#     include TypedResults
+#
+#     RESULTS = {
+#       authorize_url: BaseResult[:url],
+#       login: BaseResult[:user, :token],
+#       register_user: BaseResult[:user, :organization, :membership, :token],
+#       accept_invite: Invites::AcceptService::Result
+#     }.freeze
+#
+#     def login(code) = ...
+#   end
+#
+# The class-level `call` returns a typed Result instead of the
+# deprecated LegacyResult (OpenStruct):
+#
+#   Auth::GoogleService.call(:login, code)
+#   Auth::GoogleService.call(:register_user, code, organization_name)
+#
+# The service is built without constructor arguments; all arguments are
+# forwarded to the target method.
+module TypedResults
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def call(method_name, *args, **kwargs, &block)
+      result_class = self::RESULTS.fetch(method_name) do
+        raise ArgumentError, "#{name}: #{method_name.inspect} is not declared in RESULTS"
+      end
+
+      instance = new
+      instance.send(:result=, result_class.new)
+      instance.send(:with_middlewares) do
+        instance.public_send(method_name, *args, **kwargs, &block)
+      end
+    end
+
+    def call!(method_name, *args, **kwargs, &block)
+      call(method_name, *args, **kwargs, &block).raise_if_error!
+    end
+  end
+end

--- a/spec/graphql/mutations/auth/google/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/google/accept_invite_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::Google::AcceptInvite do
-  let(:google_service) { instance_double(Auth::GoogleService) }
   let(:user) { create(:user) }
   let(:invite) { create(:invite) }
 
@@ -29,8 +28,7 @@ RSpec.describe Mutations::Auth::Google::AcceptInvite do
   end
 
   before do
-    allow(Auth::GoogleService).to receive(:new).and_return(google_service)
-    allow(google_service).to receive(:accept_invite).and_return(accept_invite_result)
+    allow(Auth::GoogleService).to receive(:call).with(:accept_invite, "code", invite.token).and_return(accept_invite_result)
   end
 
   it "returns token and user" do

--- a/spec/graphql/mutations/auth/google/login_user_spec.rb
+++ b/spec/graphql/mutations/auth/google/login_user_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe Mutations::Auth::Google::LoginUser do
   let(:membership) { create(:membership) }
   let(:user) { membership.user }
-  let(:google_service) { instance_double(Auth::GoogleService) }
 
   let(:login_result) do
     result = BaseService::Result.new
@@ -29,8 +28,7 @@ RSpec.describe Mutations::Auth::Google::LoginUser do
   end
 
   before do
-    allow(Auth::GoogleService).to receive(:new).and_return(google_service)
-    allow(google_service).to receive(:login).and_return(login_result)
+    allow(Auth::GoogleService).to receive(:call).with(:login, "code").and_return(login_result)
   end
 
   it "returns token and user" do

--- a/spec/graphql/mutations/auth/google/register_user_spec.rb
+++ b/spec/graphql/mutations/auth/google/register_user_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Mutations::Auth::Google::RegisterUser do
-  let(:google_service) { instance_double(Auth::GoogleService) }
   let(:user) { create(:user) }
 
   let(:register_user_result) do
@@ -28,8 +27,7 @@ RSpec.describe Mutations::Auth::Google::RegisterUser do
   end
 
   before do
-    allow(Auth::GoogleService).to receive(:new).and_return(google_service)
-    allow(google_service).to receive(:register_user).and_return(register_user_result)
+    allow(Auth::GoogleService).to receive(:call).with(:register_user, "code", "FooBar").and_return(register_user_result)
   end
 
   it "returns token and user" do

--- a/spec/services/auth/google_service_spec.rb
+++ b/spec/services/auth/google_service_spec.rb
@@ -10,6 +10,77 @@ RSpec.describe Auth::GoogleService do
     ENV["GOOGLE_AUTH_CLIENT_SECRET"] = "client_secret"
   end
 
+  describe ".call (typed routing)" do
+    it "routes :authorize_url to a typed Result" do
+      request = Rack::Request.new(Rack::MockRequest.env_for("http://example.com"))
+      result = described_class.call(:authorize_url, request)
+
+      expect(result).to be_a(BaseResult)
+      expect(result).not_to be_a(BaseService::LegacyResult)
+      expect(result).to be_success
+      expect(result.url).to include("https://accounts.google.com/o/oauth2/auth")
+    end
+
+    it "raises when the method is not declared in RESULTS" do
+      expect { described_class.call(:unknown) }
+        .to raise_error(ArgumentError, /not declared in RESULTS/)
+    end
+
+    context "with google oauth mocked" do
+      let(:authorizer) { instance_double(Google::Auth::UserAuthorizer) }
+      let(:authorizer_response) { instance_double(Google::Auth::UserRefreshCredentials, id_token: "id_token") }
+      let(:email) { "foo@bar.com" }
+
+      before do
+        allow(Google::Auth::UserAuthorizer).to receive(:new).and_return(authorizer)
+        allow(authorizer).to receive(:get_credentials_from_code).and_return(authorizer_response)
+        allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return({"email" => email})
+        allow(UserDevices::RegisterService).to receive(:call!)
+      end
+
+      it "routes :login to a typed Result" do
+        user = create(:user, email:, password: "foobar")
+        create(:membership, :active, user:)
+
+        result = described_class.call(:login, "code")
+
+        expect(result).to be_a(BaseResult)
+        expect(result).not_to be_a(BaseService::LegacyResult)
+        expect(result).to be_success
+        expect(result.user).to eq(user)
+        expect(result.token).to be_present
+      end
+
+      it "routes :register_user to a typed Result" do
+        create(:role, :admin)
+
+        result = described_class.call(:register_user, "code", "Foobar")
+
+        expect(result).to be_a(BaseResult)
+        expect(result).not_to be_a(BaseService::LegacyResult)
+        expect(result).to be_success
+        expect(result.user).to be_a(User)
+        expect(result.organization).to be_present
+        expect(result.membership).to be_present
+        expect(result.token).to be_present
+      end
+
+      # NOTE: accept_invite delegates to Invites::AcceptService and returns its
+      # result, so the TypedResults-injected result is discarded. The returned
+      # type follows the delegate (still LegacyResult until it migrates), hence
+      # no BaseResult assertion here.
+      it "routes :accept_invite and returns the delegate result" do
+        invite = create(:invite, email:)
+
+        result = described_class.call(:accept_invite, "code", invite.token)
+
+        expect(result).to be_success
+        expect(result.user.email).to eq(invite.email)
+        expect(result.token).to be_present
+      end
+    end
+  end
+
   describe "#authorize_url" do
     it "returns the authorize url" do
       request = Rack::Request.new(Rack::MockRequest.env_for("http://example.com"))

--- a/spec/services/typed_results_spec.rb
+++ b/spec/services/typed_results_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TypedResults do
+  let(:service_class) do
+    Class.new(BaseService) do
+      include TypedResults
+
+      const_set(:RESULTS, {
+        with_kwargs: BaseResult[:value],
+        with_positional: BaseResult[:echo],
+        failing: BaseResult,
+        bare: BaseResult
+      }.freeze)
+
+      def with_kwargs(base:, multiplier:)
+        result.value = base * multiplier
+        result
+      end
+
+      def with_positional(echo)
+        result.echo = echo
+        result
+      end
+
+      def failing
+        result.service_failure!(code: "boom", message: "nope")
+      end
+
+      def bare
+        result
+      end
+    end
+  end
+
+  describe ".call" do
+    it "routes to the target method and returns the declared typed Result" do
+      result = service_class.call(:with_kwargs, base: 3, multiplier: 4)
+
+      expect(result).to be_a(BaseResult)
+      expect(result.value).to eq(12)
+      expect(result.success?).to be(true)
+    end
+
+    it "forwards positional arguments to the method" do
+      expect(service_class.call(:with_positional, "hello").echo).to eq("hello")
+    end
+
+    it "returns a bare BaseResult when no attributes are declared" do
+      result = service_class.call(:bare)
+
+      expect(result).to be_a(BaseResult)
+      expect(result.success?).to be(true)
+    end
+
+    it "surfaces failures on the result" do
+      result = service_class.call(:failing)
+
+      expect(result).to be_failure
+      expect(result.error).to be_a(BaseService::ServiceFailure)
+    end
+
+    it "raises when the method is not declared in RESULTS" do
+      expect { service_class.call(:unknown) }
+        .to raise_error(ArgumentError, /not declared in RESULTS/)
+    end
+  end
+
+  describe ".call!" do
+    it "returns the result on success" do
+      expect(service_class.call!(:with_kwargs, base: 2, multiplier: 5).value).to eq(10)
+    end
+
+    it "raises the error on failure" do
+      expect { service_class.call!(:failing) }.to raise_error(BaseService::ServiceFailure)
+    end
+  end
+end


### PR DESCRIPTION
## Context

As we are migrating services to the standardized single-call + typed Result pattern, a number of legacy services still expose several public methods (login, register_user, authorize_url, …) instead of a single call, and return the deprecated LegacyResult (OpenStruct).
Refactoring each of these into proper single-call services is a large and dangerous effort, so we need an intermediate step that lets use typed results (in order to remove OpenStructs) before propertly refactoring these services.

## Description

The PR introduces a temporary `TypedResults` concern that gives multi-method services a class-level call entry point returning a real typed Result.

Targeted services will include the concern and declares a `RESULTS` constant mapping each public method to the `Result` it returns.
Calling `Service.call(:method_name, *args)` builds the service, initializes a typed Result for that method, and routes the call to the existing instance method, leaving the method bodies untouched. 

This new pattern is applied to `Auth::GoogleService` to validate the behavior. Other remaining services will follow