### PR TITLE
[STA-7] misc: Result for all remaining Auth services

### DIFF
--- a/app/controllers/concerns/authenticable_user.rb
+++ b/app/controllers/concerns/authenticable_user.rb
@@ -39,7 +39,7 @@ module AuthenticableUser
   end
 
   def decoded_token
-    @decoded_token ||= Auth::TokenService.decode(token:)
+    @decoded_token ||= Utils::AuthToken.decode(token:)
   rescue JWT::DecodeError => e
     raise e if e.is_a?(JWT::ExpiredSignature) || Rails.env.development?
   end
@@ -54,8 +54,8 @@ module AuthenticableUser
   def renew_token
     return unless current_user
 
-    renewed = Auth::TokenService.renew(token:)
-    response.set_header(Auth::TokenService::LAGO_TOKEN_HEADER, renewed) if renewed.present?
+    renewed = Utils::AuthToken.renew(token:)
+    response.set_header(Utils::AuthToken::LAGO_TOKEN_HEADER, renewed) if renewed.present?
   rescue => e
     Rails.logger.warn("Error renewing token: #{e.message}")
   end

--- a/app/graphql/mutations/login_user.rb
+++ b/app/graphql/mutations/login_user.rb
@@ -11,7 +11,7 @@ module Mutations
     type Types::Payloads::LoginUserType
 
     def resolve(email:, password:)
-      result = UsersService.new.login(email, password)
+      result = UsersService.call(:login, email, password)
       result.success? ? result : result_error(result)
     end
   end

--- a/app/graphql/mutations/register_user.rb
+++ b/app/graphql/mutations/register_user.rb
@@ -11,7 +11,8 @@ module Mutations
     type Types::Payloads::RegisterUserType
 
     def resolve(email:, password:, organization_name:)
-      result = UsersService.new.register(
+      result = UsersService.call(
+        :register,
         email,
         password,
         organization_name

--- a/app/services/auth/google_service.rb
+++ b/app/services/auth/google_service.rb
@@ -13,6 +13,8 @@ module Auth
       accept_invite: Invites::AcceptService::Result
     }.freeze
 
+    private
+
     def authorize_url(request)
       ensure_google_auth_setup
       return result unless result.success?
@@ -95,10 +97,8 @@ module Auth
       result.single_validation_failure!(error_code: "invalid_google_code")
     end
 
-    private
-
     def generate_token
-      result.token = Auth::TokenService.encode(user: result.user, login_method: Organizations::AuthenticationMethods::GOOGLE_OAUTH)
+      result.token = Utils::AuthToken.encode(user: result.user, login_method: Organizations::AuthenticationMethods::GOOGLE_OAUTH)
       result
     rescue => e
       result.service_failure!(code: "token_encoding_error", message: e.message)

--- a/app/services/auth/okta/login_service.rb
+++ b/app/services/auth/okta/login_service.rb
@@ -40,7 +40,7 @@ module Auth
       attr_reader :code, :state
 
       def generate_token
-        result.token = Auth::TokenService.encode(user: result.user, login_method: Organizations::AuthenticationMethods::OKTA)
+        result.token = Utils::AuthToken.encode(user: result.user, login_method: Organizations::AuthenticationMethods::OKTA)
         result
       rescue => e
         result.service_failure!(code: "token_encoding_error", message: e.message)

--- a/app/services/invites/accept_service.rb
+++ b/app/services/invites/accept_service.rb
@@ -12,7 +12,7 @@ module Invites
       end
 
       result = ActiveRecord::Base.transaction do
-        result = UsersService.new.register_from_invite(invite, args[:password])
+        result = UsersService.call(:register_from_invite, invite, args[:password])
         result.token = generate_token(result.user, login_method: args[:login_method])
         invite.recipient = result.membership
         invite.mark_as_accepted!
@@ -27,7 +27,7 @@ module Invites
     private
 
     def generate_token(user, **extra_auth)
-      Auth::TokenService.encode(user:, **extra_auth)
+      Utils::AuthToken.encode(user:, **extra_auth)
     rescue => e
       result.service_failure!(code: "token_encoding_error", message: e.message)
     end

--- a/app/services/password_resets/reset_service.rb
+++ b/app/services/password_resets/reset_service.rb
@@ -27,8 +27,7 @@ module PasswordResets
         user.save!
 
         UsersService
-          .new
-          .login(user.email, new_password)
+          .call(:login, user.email, new_password)
           .tap { password_reset.destroy! }
       end
 

--- a/app/services/typed_results.rb
+++ b/app/services/typed_results.rb
@@ -16,8 +16,13 @@
 #       accept_invite: Invites::AcceptService::Result
 #     }.freeze
 #
+#     private
+#
 #     def login(code) = ...
 #   end
+#
+# The target methods should be declared `private` to discourage direct
+# invocation; `call` reaches them via `send`, so routing still works.
 #
 # The class-level `call` returns a typed Result instead of the
 # deprecated LegacyResult (OpenStruct):
@@ -39,7 +44,7 @@ module TypedResults
       instance = new
       instance.send(:result=, result_class.new)
       instance.send(:with_middlewares) do
-        instance.public_send(method_name, *args, **kwargs, &block)
+        instance.send(method_name, *args, **kwargs, &block)
       end
     end
 

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class UsersService < BaseService
+  include TypedResults
+
+  RESULTS = {
+    login: BaseResult[:user, :token],
+    register: BaseResult[:user, :organization, :membership, :token],
+    register_from_invite: BaseResult[:user, :organization, :membership, :token]
+  }.freeze
+
+  private
+
   def login(email, password)
     # NOTE: Null byte injection. Prevent 500 errors.
     if email.include?("\u0000") || password.include?("\u0000")
@@ -112,10 +122,8 @@ class UsersService < BaseService
     result
   end
 
-  private
-
   def generate_token
-    Auth::TokenService.encode(user: result.user, login_method: Organizations::AuthenticationMethods::EMAIL_PASSWORD)
+    Utils::AuthToken.encode(user: result.user, login_method: Organizations::AuthenticationMethods::EMAIL_PASSWORD)
   rescue => e
     result.service_failure!(code: "token_encoding_error", message: e.message)
   end

--- a/app/services/utils/auth_token.rb
+++ b/app/services/utils/auth_token.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Auth
-  class TokenService < BaseService
+module Utils
+  class AuthToken
     THREE_HOURS = 10800
     ALGORITHM = "HS256"
     LAGO_TOKEN_HEADER = "x-lago-token"
@@ -28,8 +28,6 @@ module Auth
       encode(user_id:, **extra)
     end
 
-    private_class_method
-
     def self.non_extra_attributes
       ["sub", "exp", "alg"]
     end
@@ -40,5 +38,7 @@ module Auth
         exp: Time.current.to_i + THREE_HOURS
       }.merge(extra)
     end
+
+    private_class_method :non_extra_attributes, :payload
   end
 end

--- a/spec/graphql/mutations/invites/accept_spec.rb
+++ b/spec/graphql/mutations/invites/accept_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Mutations::Invites::Accept do
         expect(data["user"]["email"]).to eq(invite.email)
         expect(data["token"]).to be_present
 
-        expect(Auth::TokenService.decode(token: data["token"])).to include("login_method" => "email_password")
+        expect(Utils::AuthToken.decode(token: data["token"])).to include("login_method" => "email_password")
       end
     end
 

--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe GraphqlController do
       end
 
       let(:token) do
-        Auth::TokenService.encode(user:)
+        Utils::AuthToken.encode(user:)
       end
 
       it "retrieves the current user" do
@@ -211,7 +211,7 @@ RSpec.describe GraphqlController do
     context "with query length validation" do
       let(:user) { create(:user) }
       let(:token) do
-        Auth::TokenService.encode(user:)
+        Utils::AuthToken.encode(user:)
       end
 
       it "rejects queries that exceed maximum length" do

--- a/spec/services/auth/google_service_spec.rb
+++ b/spec/services/auth/google_service_spec.rb
@@ -3,89 +3,17 @@
 require "rails_helper"
 
 RSpec.describe Auth::GoogleService do
-  subject(:service) { described_class.new }
-
   before do
     ENV["GOOGLE_AUTH_CLIENT_ID"] = "client_id"
     ENV["GOOGLE_AUTH_CLIENT_SECRET"] = "client_secret"
   end
 
-  describe ".call (typed routing)" do
-    it "routes :authorize_url to a typed Result" do
+  describe ".call(:authorize_url)" do
+    it "returns the authorize url" do
       request = Rack::Request.new(Rack::MockRequest.env_for("http://example.com"))
       result = described_class.call(:authorize_url, request)
 
       expect(result).to be_a(BaseResult)
-      expect(result).not_to be_a(BaseService::LegacyResult)
-      expect(result).to be_success
-      expect(result.url).to include("https://accounts.google.com/o/oauth2/auth")
-    end
-
-    it "raises when the method is not declared in RESULTS" do
-      expect { described_class.call(:unknown) }
-        .to raise_error(ArgumentError, /not declared in RESULTS/)
-    end
-
-    context "with google oauth mocked" do
-      let(:authorizer) { instance_double(Google::Auth::UserAuthorizer) }
-      let(:authorizer_response) { instance_double(Google::Auth::UserRefreshCredentials, id_token: "id_token") }
-      let(:email) { "foo@bar.com" }
-
-      before do
-        allow(Google::Auth::UserAuthorizer).to receive(:new).and_return(authorizer)
-        allow(authorizer).to receive(:get_credentials_from_code).and_return(authorizer_response)
-        allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return({"email" => email})
-        allow(UserDevices::RegisterService).to receive(:call!)
-      end
-
-      it "routes :login to a typed Result" do
-        user = create(:user, email:, password: "foobar")
-        create(:membership, :active, user:)
-
-        result = described_class.call(:login, "code")
-
-        expect(result).to be_a(BaseResult)
-        expect(result).not_to be_a(BaseService::LegacyResult)
-        expect(result).to be_success
-        expect(result.user).to eq(user)
-        expect(result.token).to be_present
-      end
-
-      it "routes :register_user to a typed Result" do
-        create(:role, :admin)
-
-        result = described_class.call(:register_user, "code", "Foobar")
-
-        expect(result).to be_a(BaseResult)
-        expect(result).not_to be_a(BaseService::LegacyResult)
-        expect(result).to be_success
-        expect(result.user).to be_a(User)
-        expect(result.organization).to be_present
-        expect(result.membership).to be_present
-        expect(result.token).to be_present
-      end
-
-      # NOTE: accept_invite delegates to Invites::AcceptService and returns its
-      # result, so the TypedResults-injected result is discarded. The returned
-      # type follows the delegate (still LegacyResult until it migrates), hence
-      # no BaseResult assertion here.
-      it "routes :accept_invite and returns the delegate result" do
-        invite = create(:invite, email:)
-
-        result = described_class.call(:accept_invite, "code", invite.token)
-
-        expect(result).to be_success
-        expect(result.user.email).to eq(invite.email)
-        expect(result.token).to be_present
-      end
-    end
-  end
-
-  describe "#authorize_url" do
-    it "returns the authorize url" do
-      request = Rack::Request.new(Rack::MockRequest.env_for("http://example.com"))
-      result = service.authorize_url(request)
-
       expect(result).to be_success
       expect(result.url).to include("https://accounts.google.com/o/oauth2/auth")
     end
@@ -98,7 +26,7 @@ RSpec.describe Auth::GoogleService do
 
       it "returns a service failure" do
         request = Rack::Request.new(Rack::MockRequest.env_for("http://example.com"))
-        result = service.authorize_url(request)
+        result = described_class.call(:authorize_url, request)
 
         expect(result).not_to be_success
         expect(result.error.code).to eq("google_auth_missing_setup")
@@ -106,7 +34,7 @@ RSpec.describe Auth::GoogleService do
     end
   end
 
-  describe "#login" do
+  describe ".call(:login)" do
     let(:authorizer) { instance_double(Google::Auth::UserAuthorizer) }
     let(:oidc_verifier) { instance_double(Google::Auth::IDTokens) }
     let(:authorizer_response) { instance_double(Google::Auth::UserRefreshCredentials, id_token: "id_token") }
@@ -128,26 +56,27 @@ RSpec.describe Auth::GoogleService do
       end
 
       it "registers the user device" do
-        result = service.login("code")
+        result = described_class.call(:login, "code")
 
         expect(UserDevices::RegisterService).to have_received(:call!).with(user: result.user)
       end
 
       it "logins the user" do
-        result = service.login("code")
+        result = described_class.call(:login, "code")
 
+        expect(result).to be_a(BaseResult)
         expect(result).to be_success
         expect(result.user).to be_a(User)
         expect(result.token).to be_present
 
-        decoded = Auth::TokenService.decode(token: result.token)
+        decoded = Utils::AuthToken.decode(token: result.token)
         expect(decoded["login_method"]).to eq(Organizations::AuthenticationMethods::GOOGLE_OAUTH)
       end
     end
 
     context "when user does not exist" do
       it "returns a validation failure" do
-        result = service.login("code")
+        result = described_class.call(:login, "code")
 
         expect(result).not_to be_success
         expect(result.error.messages.values.flatten).to include("user_does_not_exist")
@@ -163,7 +92,7 @@ RSpec.describe Auth::GoogleService do
       end
 
       it "returns a validation failure" do
-        result = service.login("code")
+        result = described_class.call(:login, "code")
 
         expect(result).not_to be_success
         expect(result.error.messages).to match(google_oauth: ["login_method_not_authorized"])
@@ -176,7 +105,7 @@ RSpec.describe Auth::GoogleService do
       end
 
       it "returns a validation failure" do
-        result = service.login("code")
+        result = described_class.call(:login, "code")
 
         expect(result).not_to be_success
         expect(result.error.messages.values.flatten).to include("user_does_not_exist")
@@ -190,7 +119,7 @@ RSpec.describe Auth::GoogleService do
       end
 
       it "returns a service failure" do
-        result = service.login("code")
+        result = described_class.call(:login, "code")
 
         expect(result).not_to be_success
         expect(result.error.code).to eq("google_auth_missing_setup")
@@ -198,7 +127,7 @@ RSpec.describe Auth::GoogleService do
     end
   end
 
-  describe "#register_user" do
+  describe ".call(:register_user)" do
     let(:authorizer) { instance_double(Google::Auth::UserAuthorizer) }
     let(:oidc_verifier) { instance_double(Google::Auth::IDTokens) }
     let(:authorizer_response) { instance_double(Google::Auth::UserRefreshCredentials, id_token: "id_token") }
@@ -215,19 +144,20 @@ RSpec.describe Auth::GoogleService do
     end
 
     it "registers the user device" do
-      result = service.register_user("code", "Foobar")
+      result = described_class.call(:register_user, "code", "Foobar")
 
       expect(UserDevices::RegisterService).to have_received(:call!).with(user: result.user, skip_log: true)
     end
 
     it "register the user" do
-      result = service.register_user("code", "Foobar")
+      result = described_class.call(:register_user, "code", "Foobar")
 
+      expect(result).to be_a(BaseResult)
       expect(result).to be_success
       expect(result.user).to be_a(User)
       expect(result.token).to be_present
 
-      decoded = Auth::TokenService.decode(token: result.token)
+      decoded = Utils::AuthToken.decode(token: result.token)
       expect(decoded["login_method"]).to eq(Organizations::AuthenticationMethods::GOOGLE_OAUTH)
     end
 
@@ -235,7 +165,7 @@ RSpec.describe Auth::GoogleService do
       before { create(:user, email: "foo@bar.com") }
 
       it "returns a validation failure" do
-        result = service.register_user("code", "FooBar")
+        result = described_class.call(:register_user, "code", "FooBar")
 
         expect(result).not_to be_success
         expect(result.error.messages.values.flatten).to include("user_already_exists")
@@ -249,7 +179,7 @@ RSpec.describe Auth::GoogleService do
       end
 
       it "returns a service failure" do
-        result = service.register_user("code", "FooBar")
+        result = described_class.call(:register_user, "code", "FooBar")
 
         expect(result).not_to be_success
         expect(result.error.code).to eq("google_auth_missing_setup")
@@ -257,7 +187,7 @@ RSpec.describe Auth::GoogleService do
     end
   end
 
-  describe "#accept_invite" do
+  describe ".call(:accept_invite)" do
     let(:invite) { create(:invite) }
     let(:authorizer) { instance_double(Google::Auth::UserAuthorizer) }
     let(:oidc_verifier) { instance_double(Google::Auth::IDTokens) }
@@ -274,20 +204,21 @@ RSpec.describe Auth::GoogleService do
     end
 
     it "accepts the invite" do
-      result = service.accept_invite("code", invite.token)
+      result = described_class.call(:accept_invite, "code", invite.token)
 
+      expect(result).to be_a(BaseResult)
       expect(result).to be_success
       expect(result.user).to be_a(User)
       expect(result.user.email).to eq(invite.email)
       expect(result.token).to be_present
 
-      decoded = Auth::TokenService.decode(token: result.token)
+      decoded = Utils::AuthToken.decode(token: result.token)
       expect(decoded["login_method"]).to eq(Organizations::AuthenticationMethods::GOOGLE_OAUTH)
     end
 
     context "when invite does not exists" do
       it "returns a not found failure" do
-        result = service.accept_invite("code", "not_a_valid_token")
+        result = described_class.call(:accept_invite, "code", "not_a_valid_token")
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq("invite_not_found")
@@ -300,7 +231,7 @@ RSpec.describe Auth::GoogleService do
       end
 
       it "returns a validation failure" do
-        result = service.accept_invite("code", invite.token)
+        result = described_class.call(:accept_invite, "code", invite.token)
 
         expect(result).not_to be_success
         expect(result.error.messages[:base]).to include("invite_email_mistmatch")
@@ -314,7 +245,7 @@ RSpec.describe Auth::GoogleService do
       end
 
       it "returns a service failure" do
-        result = service.accept_invite("code", "FooBar")
+        result = described_class.call(:accept_invite, "code", "FooBar")
 
         expect(result).not_to be_success
         expect(result.error.code).to eq("google_auth_missing_setup")

--- a/spec/services/auth/okta/accept_invite_service_spec.rb
+++ b/spec/services/auth/okta/accept_invite_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Auth::Okta::AcceptInviteService, :premium, cache: :memory do
       expect(result.token).to be_present
       expect(invite.reload).to be_accepted
 
-      decoded = Auth::TokenService.decode(token: result.token)
+      decoded = Utils::AuthToken.decode(token: result.token)
       expect(decoded["login_method"]).to eq(Organizations::AuthenticationMethods::OKTA)
     end
 

--- a/spec/services/auth/okta/login_service_spec.rb
+++ b/spec/services/auth/okta/login_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Auth::Okta::LoginService, cache: :memory do
       expect(result.user.email).to eq("foo@bar.com")
       expect(result.token).to be_present
 
-      decoded = Auth::TokenService.decode(token: result.token)
+      decoded = Utils::AuthToken.decode(token: result.token)
       expect(decoded["login_method"]).to eq(Organizations::AuthenticationMethods::OKTA)
     end
 

--- a/spec/services/password_resets/reset_service_spec.rb
+++ b/spec/services/password_resets/reset_service_spec.rb
@@ -30,9 +30,7 @@ RSpec.describe PasswordResets::ResetService do
     it "logs in the user" do
       result = reset_service.call(**reset_args)
 
-      data = result["user"]
-
-      expect(data).to be_present
+      expect(result.user).to be_present
       expect(SegmentIdentifyJob).to have_been_enqueued.with(
         membership_id: "membership/#{membership.id}"
       )

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -3,23 +3,21 @@
 require "rails_helper"
 
 RSpec.describe UsersService do
-  subject(:user_service) { described_class.new }
-
   before { create(:role, :admin) }
 
-  describe "#register" do
+  describe ".call(:register)" do
     include_context "with mocked security logger"
 
     before { allow(UserDevices::RegisterService).to receive(:call!) }
 
     it "registers the user device" do
-      result = user_service.register("email", "password", "organization_name")
+      result = described_class.call(:register, "email", "password", "organization_name")
 
       expect(UserDevices::RegisterService).to have_received(:call!).with(user: result.user, skip_log: true)
     end
 
     it "calls SegmentIdentifyJob" do
-      result = user_service.register("email", "password", "organization_name")
+      result = described_class.call(:register, "email", "password", "organization_name")
 
       expect(SegmentIdentifyJob).to have_been_enqueued.with(
         membership_id: "membership/#{result.membership.id}"
@@ -27,7 +25,7 @@ RSpec.describe UsersService do
     end
 
     it "calls SegmentTrackJob" do
-      result = user_service.register("user@email.com", "password", "organization_name")
+      result = described_class.call(:register, "user@email.com", "password", "organization_name")
 
       expect(SegmentTrackJob).to have_been_enqueued.with(
         membership_id: "membership/#{result.membership.id}",
@@ -41,16 +39,18 @@ RSpec.describe UsersService do
     end
 
     it_behaves_like "produces a security log", "user.signed_up" do
-      before { user_service.register("email", "password", "organization_name") }
+      before { described_class.call(:register, "email", "password", "organization_name") }
     end
 
     it "creates an organization, user and membership" do
-      result = user_service.register("email", "password", "organization_name")
+      result = described_class.call(:register, "email", "password", "organization_name")
+
+      expect(result).to be_a(BaseResult)
       expect(result.user).to be_present
       expect(result.membership).to be_present
       expect(result.token).to be_present
 
-      decoded = Auth::TokenService.decode(token: result.token)
+      decoded = Utils::AuthToken.decode(token: result.token)
       expect(decoded["login_method"]).to eq(Organizations::AuthenticationMethods::EMAIL_PASSWORD)
 
       expect(result.organization)
@@ -62,7 +62,7 @@ RSpec.describe UsersService do
       let(:user) { create(:user) }
 
       it "fails" do
-        result = user_service.register(user.email, "password", "organization_name")
+        result = described_class.call(:register, user.email, "password", "organization_name")
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
@@ -71,7 +71,7 @@ RSpec.describe UsersService do
       end
 
       it_behaves_like "does not produce a security log" do
-        before { user_service.register(user.email, "password", "organization_name") }
+        before { described_class.call(:register, user.email, "password", "organization_name") }
       end
     end
 
@@ -85,19 +85,19 @@ RSpec.describe UsersService do
       end
 
       it "returns a not allowed error" do
-        result = user_service.register("email", "password", "organization_name")
+        result = described_class.call(:register, "email", "password", "organization_name")
 
         expect(result).not_to be_success
         expect(result.error.message).to eq("signup_disabled")
       end
 
       it_behaves_like "does not produce a security log" do
-        before { user_service.register("email", "password", "organization_name") }
+        before { described_class.call(:register, "email", "password", "organization_name") }
       end
     end
   end
 
-  describe "#register_from_invite" do
+  describe ".call(:register_from_invite)" do
     let(:email) { Faker::Internet.email }
     let(:password) { SecureRandom.hex(16) }
     let(:invite) { create(:invite, email:) }
@@ -106,7 +106,7 @@ RSpec.describe UsersService do
       let!(:user) { create(:user, email:, password: "old_password") }
 
       it "reuse user and adds membership" do
-        result = user_service.register_from_invite(invite, password)
+        result = described_class.call(:register_from_invite, invite, password)
 
         expect(result.user).to be_persisted
         expect(result.user.email).to eq email
@@ -119,7 +119,7 @@ RSpec.describe UsersService do
         before { create(:membership, user:, status: :revoked) }
 
         it "updates the password" do
-          result = user_service.register_from_invite(invite, password)
+          result = described_class.call(:register_from_invite, invite, password)
 
           expect(result.user).to eq user
           expect(result.user.authenticate(password).id).to eq(user.id)
@@ -132,7 +132,7 @@ RSpec.describe UsersService do
         before { create(:membership, user:, status: :active) }
 
         it "keeps the existing password" do
-          result = user_service.register_from_invite(invite, password)
+          result = described_class.call(:register_from_invite, invite, password)
 
           expect(result.user).to eq user
           expect(result.user.authenticate(password)).to eq false
@@ -144,8 +144,9 @@ RSpec.describe UsersService do
 
     context "when is a new user" do
       it "creates user and membership" do
-        result = user_service.register_from_invite(invite, password)
+        result = described_class.call(:register_from_invite, invite, password)
 
+        expect(result).to be_a(BaseResult)
         expect(result.user).to be_persisted
         expect(result.user.email).to eq email
         expect(result.membership).to be_present
@@ -155,8 +156,8 @@ RSpec.describe UsersService do
     end
   end
 
-  describe "#login" do
-    subject(:result) { described_class.new.login(email, password) }
+  describe ".call(:login)" do
+    subject(:result) { described_class.call(:login, email, password) }
 
     let!(:membership) { create(:membership, :revoked) }
     let(:user) { membership.user }
@@ -179,6 +180,7 @@ RSpec.describe UsersService do
           end
 
           it "returns success result" do
+            expect(result).to be_a(BaseResult)
             expect(result).to be_success
             expect(result.user).to eq user
             expect(result.token).to be_present
@@ -196,7 +198,7 @@ RSpec.describe UsersService do
             it "saves the login method in token" do
               expect(result).to be_success
 
-              decoded = Auth::TokenService.decode(token: result.token)
+              decoded = Utils::AuthToken.decode(token: result.token)
               expect(decoded["login_method"]).to eq(Organizations::AuthenticationMethods::EMAIL_PASSWORD)
             end
           end

--- a/spec/services/utils/auth_token_spec.rb
+++ b/spec/services/utils/auth_token_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Auth::TokenService do
+RSpec.describe Utils::AuthToken do
   let(:user) { create(:user) }
   let(:user_id) { user.id }
   let(:extra) { {login_method: Organizations::AuthenticationMethods::EMAIL_PASSWORD} }


### PR DESCRIPTION
## Context
This PR follows https://github.com/getlago/lago-api/pull/5903/changes

## Description

It plugs `TypedResults` into the `UsersService` and rename `Auth::TokenService` into `Utils::AuthToken` 
