### PR TITLE
[ING-244] fix(current-usage): stop negative-state inflation

### DIFF
--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -73,13 +73,13 @@ module BillableMetrics
           target_result.current_usage_units = aggregation_without_proration.current_usage_units
 
           persisted_units_without_proration = aggregation_without_proration.current_usage_units -
-            BigDecimal(cached_aggregation.current_aggregation)
+            [BigDecimal(cached_aggregation.current_aggregation), BigDecimal(0)].max
           target_result.aggregation = (persisted_units_without_proration * persisted_pro_rata).ceil(5) +
             BigDecimal(cached_aggregation.max_aggregation_with_proration)
         elsif cached_aggregation
           target_result.current_usage_units = aggregation_without_proration.current_usage_units
           target_result.aggregation = aggregation_without_proration.current_usage_units -
-            BigDecimal(cached_aggregation.current_aggregation) +
+            [BigDecimal(cached_aggregation.current_aggregation), BigDecimal(0)].max +
             BigDecimal(cached_aggregation.max_aggregation_with_proration)
         elsif persisted_pro_rata < 1
           target_result.aggregation = result_with_proration.negative? ? 0 : result_with_proration
@@ -88,6 +88,9 @@ module BillableMetrics
           target_result.aggregation = value_without_proration
           target_result.current_usage_units = aggregation_without_proration.current_usage_units
         end
+
+        target_result.aggregation = 0 if target_result.aggregation.negative?
+        target_result.current_usage_units = 0 if target_result.current_usage_units.negative?
       end
 
       def period_duration

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -414,6 +414,86 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: f
         expect(result.current_usage_units).to eq(5)
       end
     end
+
+    context "when the aggregated state turned negative after an upfront payment" do
+      let(:old_events) { nil }
+      let(:latest_events) do
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: to_datetime - 3.days,
+          properties: {
+            total_count: -5
+          }
+        )
+      end
+
+      let(:cached_aggregation) do
+        create(
+          :cached_aggregation,
+          organization: billable_metric.organization,
+          charge:,
+          external_subscription_id: subscription.external_id,
+          event_transaction_id: latest_events.transaction_id,
+          timestamp: latest_events.timestamp,
+          current_aggregation: "-5",
+          max_aggregation: "20",
+          max_aggregation_with_proration: "8.5"
+        )
+      end
+
+      before { cached_aggregation }
+
+      it "does not inflate the aggregation with the negative units" do
+        result = sum_service.aggregate(options:)
+
+        expect(result.aggregation).to eq(8.5)
+        expect(result.current_usage_units).to eq(0)
+      end
+    end
+
+    context "when the aggregated state is negative from the start with nothing invoiced" do
+      let(:old_events) { nil }
+      let(:latest_events) do
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          customer:,
+          subscription:,
+          timestamp: to_datetime - 3.days,
+          properties: {
+            total_count: -10
+          }
+        )
+      end
+
+      let(:cached_aggregation) do
+        create(
+          :cached_aggregation,
+          organization: billable_metric.organization,
+          charge:,
+          external_subscription_id: subscription.external_id,
+          event_transaction_id: latest_events.transaction_id,
+          timestamp: latest_events.timestamp,
+          current_aggregation: "-10",
+          max_aggregation: "-10",
+          max_aggregation_with_proration: "0"
+        )
+      end
+
+      before { cached_aggregation }
+
+      it "returns zero" do
+        result = sum_service.aggregate(options:)
+
+        expect(result.aggregation).to eq(0)
+        expect(result.current_usage_units).to eq(0)
+      end
+    end
   end
 
   context "when current usage context and charge is pay in advance and just upgraded" do

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -551,6 +551,29 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
           expect(result.current_usage_units).to eq(1)
         end
       end
+
+      context "when cached aggregation is negative" do
+        let(:previous_event) { nil }
+
+        let(:cached_aggregation) do
+          create(
+            :cached_aggregation,
+            organization:,
+            charge:,
+            event_transaction_id: event.transaction_id,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 5.days,
+            current_aggregation: "-1",
+            max_aggregation: "1",
+            max_aggregation_with_proration: "0.8"
+          )
+        end
+
+        it "does not inflate the aggregation with the negative units" do
+          expect(result.aggregation).to eq(1.8)
+          expect(result.current_usage_units).to eq(1)
+        end
+      end
     end
 
     context "when event is given" do


### PR DESCRIPTION
## Summary

For recurring + sum_agg + pay-in-advance + prorated charges, the current usage endpoint returned an inflated amount once the aggregated state went negative. After paying upfront for 20 units and then sending an event that dropped the state to -5, the negative cached aggregation was subtracted — turning the subtraction into an addition — and phantom units were billed on top of what was actually invoiced. A subscription starting in a negative state was billed for units that were never invoiced at all.

## Changes

- Clamp the cached `current_aggregation` to zero in both pay-in-advance branches of `handle_current_usage`, so a negative cached value can no longer flip the subtraction into an addition and inflate the amount.
- Guard the final aggregation and unit count against negative results, mirroring the non-prorated `handle_in_advance_current_usage`.
- Add specs for a state that turns negative after an upfront payment and one that is negative from the start, for both sum and unique_count prorated aggregations.
