### PR TITLE
feat(purchase_order_number): Change Wallets services to persist purchase_order_number

### DIFF
--- a/app/graphql/types/subscriptions/create_subscription_input.rb
+++ b/app/graphql/types/subscriptions/create_subscription_input.rb
@@ -22,6 +22,7 @@ module Types
       argument :consolidate_invoice, Boolean, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       argument :progressive_billing_disabled, Boolean, required: false
+      argument :purchase_order_number, String, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
     end
   end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -55,6 +55,7 @@ module Types
       field :payment_method, Types::PaymentMethods::Object
       field :payment_method_type, Types::PaymentMethods::MethodTypeEnum
       field :progressive_billing_disabled, Boolean
+      field :purchase_order_number, String, null: true
 
       field :activated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :activation_rules, [Types::Subscriptions::ActivationRuleType], null: false

--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -16,6 +16,7 @@ module Types
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       argument :plan_overrides, Types::Subscriptions::PlanOverridesInput, required: false
       argument :progressive_billing_disabled, Boolean, required: false
+      argument :purchase_order_number, String, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
     end

--- a/app/graphql/types/wallet_transactions/create_input.rb
+++ b/app/graphql/types/wallet_transactions/create_input.rb
@@ -16,6 +16,7 @@ module Types
       argument :paid_credits, String, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       argument :priority, Integer, required: false
+      argument :purchase_order_number, String, required: false
       argument :voided_credits, String, required: false
     end
   end

--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -13,6 +13,7 @@ module Types
       field :invoice_requires_successful_payment, Boolean, null: false
       field :name, String, null: true
       field :priority, Integer, null: false
+      field :purchase_order_number, String, null: true
       field :source, Types::WalletTransactions::SourceEnum, null: false
       field :status, Types::WalletTransactions::StatusEnum, null: false
       field :transaction_status, Types::WalletTransactions::TransactionStatusEnum, null: false

--- a/app/graphql/types/wallets/create_input.rb
+++ b/app/graphql/types/wallets/create_input.rb
@@ -15,6 +15,7 @@ module Types
       argument :name, String, required: false
       argument :paid_credits, String, required: true
       argument :priority, Integer, required: true
+      argument :purchase_order_number, String, required: false
       argument :rate_amount, String, required: true
 
       argument :ignore_paid_top_up_limits_on_creation, Boolean, required: false

--- a/app/graphql/types/wallets/object.rb
+++ b/app/graphql/types/wallets/object.rb
@@ -15,6 +15,7 @@ module Types
       field :currency, Types::CurrencyEnum, null: false
       field :name, String, null: true
       field :priority, Integer, null: false
+      field :purchase_order_number, String, null: true
       field :status, Types::Wallets::StatusEnum, null: false
 
       field :rate_amount, GraphQL::Types::Float, null: false

--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -15,6 +15,7 @@ module Types
         argument :invoice_requires_successful_payment, Boolean, required: false
         argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: false
         argument :paid_credits, String, required: false
+        argument :purchase_order_number, String, required: false
         argument :started_at, GraphQL::Types::ISO8601DateTime, required: false
         argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false

--- a/app/graphql/types/wallets/recurring_transaction_rules/object.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/object.rb
@@ -19,6 +19,7 @@ module Types
         field :paid_credits, String, null: false
         field :payment_method, Types::PaymentMethods::Object
         field :payment_method_type, Types::PaymentMethods::MethodTypeEnum
+        field :purchase_order_number, String, null: true
         field :selected_invoice_custom_sections, [Types::InvoiceCustomSections::Object], null: true
         field :skip_invoice_custom_sections, Boolean
         field :started_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
@@ -16,6 +16,7 @@ module Types
         argument :lago_id, ID, required: false
         argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: false
         argument :paid_credits, String, required: false
+        argument :purchase_order_number, String, required: false
         argument :started_at, GraphQL::Types::ISO8601DateTime, required: false
         argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false

--- a/app/graphql/types/wallets/update_input.rb
+++ b/app/graphql/types/wallets/update_input.rb
@@ -12,6 +12,7 @@ module Types
       argument :invoice_requires_successful_payment, Boolean, required: false
       argument :name, String, required: false
       argument :priority, Integer, required: true
+      argument :purchase_order_number, String, required: false
 
       argument :paid_top_up_max_amount_cents, GraphQL::Types::BigInt, required: false
       argument :paid_top_up_min_amount_cents, GraphQL::Types::BigInt, required: false

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class RecurringTransactionRule < ApplicationRecord
+  include HasPurchaseOrderNumber
   include PaperTrailTraceable
 
   belongs_to :wallet
@@ -140,6 +141,7 @@ end
 #  method                              :integer          default("fixed"), not null
 #  paid_credits                        :decimal(30, 5)   default(0.0), not null
 #  payment_method_type                 :enum             default("provider"), not null
+#  purchase_order_number               :string
 #  skip_invoice_custom_sections        :boolean          default(FALSE), not null
 #  started_at                          :datetime
 #  status                              :integer          default("active")

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Subscription < ApplicationRecord
+  include HasPurchaseOrderNumber
   include PaperTrailTraceable
   include RansackUuidSearch
 
@@ -346,6 +347,7 @@ end
 #  on_termination_invoice       :enum             default("generate"), not null
 #  payment_method_type          :enum             default("provider"), not null
 #  progressive_billing_disabled :boolean          default(FALSE), not null
+#  purchase_order_number        :string
 #  skip_daily_usage             :boolean          default(FALSE), not null
 #  skip_invoice_custom_sections :boolean          default(FALSE), not null
 #  started_at                   :datetime

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Wallet < ApplicationRecord
+  include HasPurchaseOrderNumber
   include PaperTrailTraceable
   include Currencies
 
@@ -156,6 +157,7 @@ end
 #  paid_top_up_min_amount_cents        :bigint
 #  payment_method_type                 :enum             default("provider"), not null
 #  priority                            :integer          default(50), not null
+#  purchase_order_number               :string
 #  rate_amount                         :decimal(30, 5)   default(0.0), not null
 #  ready_to_be_refreshed               :boolean          default(FALSE), not null
 #  skip_invoice_custom_sections        :boolean          default(FALSE), not null

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class WalletTransaction < ApplicationRecord
+  include HasPurchaseOrderNumber
   include PaperTrailTraceable
 
   belongs_to :wallet
@@ -138,6 +139,7 @@ end
 #  name                                :string(255)
 #  payment_method_type                 :enum             default("provider"), not null
 #  priority                            :integer          default(50), not null
+#  purchase_order_number               :string
 #  remaining_amount_cents              :bigint
 #  settled_at                          :datetime
 #  skip_invoice_custom_sections        :boolean          default(FALSE), not null

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -32,6 +32,7 @@ module Invoices
 
       old_payment_status = invoice.payment_status
       invoice.payment_status = params[:payment_status] if params.key?(:payment_status)
+      invoice.purchase_order_number = params[:purchase_order_number] if params.key?(:purchase_order_number)
 
       if invoice.draft? && (old_payment_status != invoice.payment_status)
         return result.not_allowed_failure!(code: "payment_status_update_on_draft_invoice")

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -32,7 +32,6 @@ module Invoices
 
       old_payment_status = invoice.payment_status
       invoice.payment_status = params[:payment_status] if params.key?(:payment_status)
-      invoice.purchase_order_number = params[:purchase_order_number] if params.key?(:purchase_order_number)
 
       if invoice.draft? && (old_payment_status != invoice.payment_status)
         return result.not_allowed_failure!(code: "payment_status_update_on_draft_invoice")

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -138,6 +138,7 @@ module Subscriptions
         external_id:,
         billing_time: billing_time || :calendar,
         ending_at: params[:ending_at],
+        purchase_order_number: params[:purchase_order_number],
         progressive_billing_disabled: params[:progressive_billing_disabled] || false,
         consolidate_invoice: params.key?(:consolidate_invoice) ? params[:consolidate_invoice] : true,
         billing_entity: resolve_billing_entity(organization: customer.organization, params:)

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -53,6 +53,7 @@ module Subscriptions
       ActiveRecord::Base.transaction do
         subscription.name = params[:name] if params.key?(:name)
         subscription.ending_at = params[:ending_at] if params.key?(:ending_at)
+        subscription.purchase_order_number = params[:purchase_order_number] if params.key?(:purchase_order_number)
         subscription.progressive_billing_disabled = params[:progressive_billing_disabled] if params.key?(:progressive_billing_disabled)
         subscription.consolidate_invoice = params[:consolidate_invoice] if params.key?(:consolidate_invoice)
 

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -20,6 +20,7 @@ module WalletTransactions
           :invoice_requires_successful_payment,
           :name,
           :priority,
+          :purchase_order_number,
           :settled_at,
           :source,
           :status,

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -40,6 +40,7 @@ module Wallets
         status: :active,
         paid_top_up_min_amount_cents: params[:paid_top_up_min_amount_cents],
         paid_top_up_max_amount_cents: params[:paid_top_up_max_amount_cents],
+        purchase_order_number: params[:purchase_order_number],
         traceable: traceable?
       }
 
@@ -65,6 +66,7 @@ module Wallets
       end
 
       wallet = Wallet.new(attributes)
+      recurring_transaction_rule = nil
 
       ActiveRecord::Base.transaction do
         if currency.present? && (!organization_flag_enabled?(:multi_currency) || customer.currency.blank?)
@@ -77,7 +79,9 @@ module Wallets
         validate_wallet_initial_amount! wallet
 
         if params[:recurring_transaction_rules].present?
-          Wallets::RecurringTransactionRules::CreateService.call!(wallet:, wallet_params: params)
+          recurring_transaction_rule = Wallets::RecurringTransactionRules::CreateService
+            .call!(wallet:, wallet_params: params)
+            .recurring_transaction_rule
         end
 
         if params[:invoice_custom_section].present?
@@ -97,7 +101,7 @@ module Wallets
 
       SendWebhookJob.perform_after_commit("wallet.created", wallet)
 
-      schedule_top_up(wallet)
+      schedule_top_up(wallet, recurring_transaction_rule)
 
       result
     rescue ActiveRecord::RecordInvalid => e
@@ -110,21 +114,24 @@ module Wallets
 
     attr_reader :params
 
-    def schedule_top_up(wallet)
+    def schedule_top_up(wallet, recurring_transaction_rule)
       return unless positive_amount?(paid_credits) || positive_amount?(granted_credits)
+
+      transaction_params = {
+        wallet_id: wallet.id,
+        paid_credits: paid_credits,
+        granted_credits: granted_credits,
+        source: :manual,
+        metadata: params[:transaction_metadata],
+        name: params[:transaction_name],
+        priority: params[:transaction_priority],
+        ignore_paid_top_up_limits: params[:ignore_paid_top_up_limits_on_creation],
+        purchase_order_number: recurring_transaction_rule&.purchase_order_number.presence || wallet.purchase_order_number
+      }
 
       WalletTransactions::CreateJob.perform_after_commit(
         organization_id:,
-        params: {
-          wallet_id: wallet.id,
-          paid_credits: paid_credits,
-          granted_credits: granted_credits,
-          source: :manual,
-          metadata: params[:transaction_metadata],
-          name: params[:transaction_name],
-          priority: params[:transaction_priority],
-          ignore_paid_top_up_limits: params[:ignore_paid_top_up_limits_on_creation]
-        }
+        params: transaction_params
       )
     end
 

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -33,7 +33,8 @@ module Wallets
           target_ongoing_balance: rule_params[:target_ongoing_balance],
           trigger: rule_params[:trigger].to_s,
           transaction_metadata: rule_params[:transaction_metadata] || [],
-          transaction_name: rule_params[:transaction_name].presence
+          transaction_name: rule_params[:transaction_name].presence,
+          purchase_order_number: rule_params[:purchase_order_number]
         }
 
         if rule_params.key? :ignore_paid_top_up_limits

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -69,6 +69,8 @@ module Wallets
 
         result.recurring_transaction_rule = rule
         result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
       rescue BaseService::FailedResult
         result
       end

--- a/app/services/wallets/recurring_transaction_rules/update_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/update_service.rb
@@ -77,6 +77,8 @@ module Wallets
 
         result.wallet = wallet
         result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
       rescue BaseService::FailedResult => e
         e.result
       end

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -22,6 +22,7 @@ module Wallets
         invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
         metadata: rule.transaction_metadata,
         name: rule.transaction_name,
+        purchase_order_number: rule.purchase_order_number,
         ignore_paid_top_up_limits: rule.ignore_paid_top_up_limits?
       }
 

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -37,6 +37,7 @@ module Wallets
         wallet.code = params[:code] if params[:code]
         wallet.priority = params[:priority] if params[:priority]
         wallet.expiration_at = params[:expiration_at] if params.key?(:expiration_at)
+        wallet.purchase_order_number = params[:purchase_order_number] if params.key?(:purchase_order_number)
         unless params[:invoice_requires_successful_payment].nil?
           wallet.invoice_requires_successful_payment = ActiveModel::Type::Boolean.new.cast(params[:invoice_requires_successful_payment])
         end

--- a/db/migrate/20260706131152_add_purchase_order_number.rb
+++ b/db/migrate/20260706131152_add_purchase_order_number.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddPurchaseOrderNumber < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recurring_transaction_rules, :purchase_order_number, :string
+    add_column :subscriptions, :purchase_order_number, :string
+    add_column :wallet_transactions, :purchase_order_number, :string
+    add_column :wallets, :purchase_order_number, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3385,7 +3385,8 @@ CREATE TABLE public.subscriptions (
     billing_entity_id uuid,
     consolidate_invoice boolean DEFAULT true NOT NULL,
     skip_daily_usage boolean DEFAULT false NOT NULL,
-    cancellation_reason public.subscription_cancellation_reasons
+    cancellation_reason public.subscription_cancellation_reasons,
+    purchase_order_number character varying
 );
 
 
@@ -4264,6 +4265,7 @@ CREATE TABLE public.wallet_transactions (
     remaining_amount_cents bigint,
     voided_invoice_id uuid,
     billing_entity_id uuid,
+    purchase_order_number character varying,
     CONSTRAINT remaining_amount_cents_non_negative CHECK (((remaining_amount_cents >= 0) OR (remaining_amount_cents IS NULL)))
 );
 
@@ -4353,7 +4355,8 @@ CREATE TABLE public.wallets (
     skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
     traceable boolean DEFAULT false NOT NULL,
     code character varying,
-    billing_entity_id uuid
+    billing_entity_id uuid,
+    purchase_order_number character varying
 );
 
 
@@ -5061,7 +5064,8 @@ CREATE TABLE public.recurring_transaction_rules (
     payment_method_id uuid,
     payment_method_type public.payment_method_types DEFAULT 'provider'::public.payment_method_types NOT NULL,
     skip_invoice_custom_sections boolean DEFAULT false NOT NULL,
-    grants_target_top_up boolean
+    grants_target_top_up boolean,
+    purchase_order_number character varying
 );
 
 
@@ -12835,6 +12839,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260706131152'),
 ('20260702074504'),
 ('20260701083110'),
 ('20260701083109'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -2954,6 +2954,7 @@ input CreateCustomerWalletInput {
   paidTopUpMinAmountCents: BigInt
   paymentMethod: PaymentMethodReferenceInput
   priority: Int!
+  purchaseOrderNumber: String
   rateAmount: String!
   recurringTransactionRules: [CreateRecurringTransactionRuleInput!]
   transactionName: String
@@ -2976,6 +2977,7 @@ input CreateCustomerWalletTransactionInput {
   paidCredits: String
   paymentMethod: PaymentMethodReferenceInput
   priority: Int
+  purchaseOrderNumber: String
   voidedCredits: String
   walletId: ID!
 }
@@ -3318,6 +3320,7 @@ input CreateRecurringTransactionRuleInput {
   method: RecurringTransactionMethodEnum
   paidCredits: String
   paymentMethod: PaymentMethodReferenceInput
+  purchaseOrderNumber: String
   startedAt: ISO8601DateTime
   targetOngoingBalance: String
   thresholdCredits: String
@@ -3409,6 +3412,7 @@ input CreateSubscriptionInput {
   planId: ID!
   planOverrides: PlanOverridesInput
   progressiveBillingDisabled: Boolean
+  purchaseOrderNumber: String
   subscriptionAt: ISO8601DateTime
   subscriptionId: ID
   usageThresholds: [UsageThresholdInput!]
@@ -11110,6 +11114,7 @@ type RecurringTransactionRule {
   paidCredits: String!
   paymentMethod: PaymentMethod
   paymentMethodType: PaymentMethodTypeEnum
+  purchaseOrderNumber: String
   selectedInvoiceCustomSections: [InvoiceCustomSection!]
   skipInvoiceCustomSections: Boolean
   startedAt: ISO8601DateTime
@@ -11664,6 +11669,7 @@ type Subscription {
   previousPlan: Plan
   previousSubscription: Subscription
   progressiveBillingDisabled: Boolean
+  purchaseOrderNumber: String
   selectedInvoiceCustomSections: [InvoiceCustomSection!]
   skipInvoiceCustomSections: Boolean
   startedAt: ISO8601DateTime
@@ -13034,6 +13040,7 @@ input UpdateCustomerWalletInput {
   paidTopUpMinAmountCents: BigInt
   paymentMethod: PaymentMethodReferenceInput
   priority: Int!
+  purchaseOrderNumber: String
   recurringTransactionRules: [UpdateRecurringTransactionRuleInput!]
 }
 
@@ -13426,6 +13433,7 @@ input UpdateRecurringTransactionRuleInput {
   method: RecurringTransactionMethodEnum
   paidCredits: String
   paymentMethod: PaymentMethodReferenceInput
+  purchaseOrderNumber: String
   startedAt: ISO8601DateTime
   targetOngoingBalance: String
   thresholdCredits: String
@@ -13566,6 +13574,7 @@ input UpdateSubscriptionInput {
   paymentMethod: PaymentMethodReferenceInput
   planOverrides: PlanOverridesInput
   progressiveBillingDisabled: Boolean
+  purchaseOrderNumber: String
   subscriptionAt: ISO8601DateTime
   usageThresholds: [UsageThresholdInput!]
 }
@@ -13728,6 +13737,7 @@ type Wallet {
   paymentMethod: PaymentMethod
   paymentMethodType: PaymentMethodTypeEnum
   priority: Int!
+  purchaseOrderNumber: String
   rateAmount: Float!
   recurringTransactionRules: [RecurringTransactionRule!]
   selectedInvoiceCustomSections: [InvoiceCustomSection!]
@@ -13800,6 +13810,7 @@ type WalletTransaction {
   metadata: [WalletTransactionMetadataObject!]
   name: String
   priority: Int!
+  purchaseOrderNumber: String
   remainingAmountCents: BigInt
   remainingCreditAmount: String
   selectedInvoiceCustomSections: [InvoiceCustomSection!]

--- a/schema.json
+++ b/schema.json
@@ -12708,6 +12708,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rateAmount",
               "description": null,
               "type": {
@@ -12996,6 +13008,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,
@@ -15283,6 +15307,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "startedAt",
               "description": null,
               "type": {
@@ -15983,6 +16019,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,
@@ -60912,6 +60960,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "selectedInvoiceCustomSections",
               "description": null,
               "args": [],
@@ -63813,6 +63873,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -69122,6 +69194,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "paidTopUpMaxAmountCents",
               "description": null,
               "type": {
@@ -71856,6 +71940,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "startedAt",
               "description": null,
               "type": {
@@ -72793,6 +72889,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,
@@ -74146,6 +74254,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rateAmount",
               "description": null,
               "args": [],
@@ -74648,6 +74768,18 @@
                   "name": "Int",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
       end
     end
 
+    trait :with_purchase_order_number do
+      purchase_order_number { "PO-123" }
+    end
+
     trait :failed do
       status { :failed }
     end

--- a/spec/factories/recurring_transaction_rules.rb
+++ b/spec/factories/recurring_transaction_rules.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
     after(:build) do |rule|
       rule.grants_target_top_up = false if rule.method.to_s == "target" && rule.grants_target_top_up.nil?
     end
+
+    trait :with_purchase_order_number do
+      purchase_order_number { "PO-123" }
+    end
   end
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -47,6 +47,10 @@ FactoryBot.define do
       previous_subscription { association(:subscription, customer:, plan:, organization:) }
     end
 
+    trait :with_purchase_order_number do
+      purchase_order_number { "PO-123" }
+    end
+
     trait :with_activation_rules do
       transient do
         activation_rules_config { [{type: "payment", timeout_hours: 48}] }

--- a/spec/factories/wallet_transactions.rb
+++ b/spec/factories/wallet_transactions.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
       failed_at { Time.current }
     end
 
+    trait :with_purchase_order_number do
+      purchase_order_number { "PO-123" }
+    end
+
     trait :with_invoice do
       transient do
         customer { association(:customer) }

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -28,6 +28,10 @@ FactoryBot.define do
       paid_top_up_max_amount_cents { rand(2000..5000) }
     end
 
+    trait :with_purchase_order_number do
+      purchase_order_number { "PO-123" }
+    end
+
     trait :with_inbound_transaction do
       after(:create) do |wallet|
         create(:wallet_transaction,

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
           subscriptionAt
           endingAt
           progressiveBillingDisabled
+          purchaseOrderNumber
           customer {
             id
           },
@@ -74,6 +75,7 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
           billingTime: "anniversary",
           endingAt: ending_at.iso8601,
           progressiveBillingDisabled: true,
+          purchaseOrderNumber: "PO-123",
           usageThresholds: [
             amountCents: 100,
             thresholdDisplayName: "threshold display name"
@@ -107,7 +109,8 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
       "startedAt" => String,
       "billingTime" => "anniversary",
       "endingAt" => ending_at.iso8601,
-      "progressiveBillingDisabled" => true
+      "progressiveBillingDisabled" => true,
+      "purchaseOrderNumber" => "PO-123"
     )
     expect(result_data["customer"]).to include(
       "id" => customer.id

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
           name
           subscriptionAt
           progressiveBillingDisabled
+          purchaseOrderNumber
           plan {
             fixedCharges {
               invoiceDisplayName
@@ -43,6 +44,7 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
       id: subscription.id,
       name: "New name",
       progressiveBillingDisabled: true,
+      purchaseOrderNumber: "PO-456",
       planOverrides: {
         fixedCharges: [
           {
@@ -72,6 +74,7 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
 
     expect(result_data["name"]).to eq("New name")
     expect(result_data["progressiveBillingDisabled"]).to be(true)
+    expect(result_data["purchaseOrderNumber"]).to eq("PO-456")
 
     expect(result_data["plan"]["fixedCharges"].first).to include(
       "invoiceDisplayName" => "NEW fixed charge display name",

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Mutations::WalletTransactions::Create do
           priority
           source
           name
+          purchaseOrderNumber
           invoiceRequiresSuccessfulPayment
           transactionStatus
           transactionType
@@ -45,6 +46,7 @@ RSpec.describe Mutations::WalletTransactions::Create do
       grantedCredits: "15.00",
       invoiceRequiresSuccessfulPayment: true,
       priority: 25,
+      purchaseOrderNumber: "PO-123",
       metadata: [
         {
           key: "fixed",

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Mutations::Wallets::Create, :premium do
     expect(result_data["code"]).to eq("first_wallet")
     expect(result_data["name"]).to eq("First Wallet")
     expect(result_data["priority"]).to eq(9)
+    expect(result_data["purchaseOrderNumber"]).to eq("PO-123")
     expect(result_data["invoiceRequiresSuccessfulPayment"]).to eq(true)
     expect(result_data["expirationAt"]).to eq(expiration_at.iso8601)
     expect(result_data["paidTopUpMinAmountCents"]).to eq("100")
@@ -136,6 +137,7 @@ RSpec.describe Mutations::Wallets::Create, :premium do
       {"key" => "another_key", "value" => "another_value"}
     )
     expect(result_data["recurringTransactionRules"][0]["transactionName"]).to eq("Monthly AI Credits Top-up")
+    expect(result_data["recurringTransactionRules"][0]["purchaseOrderNumber"]).to eq("PO-456")
     expect(result_data["appliesTo"]["feeTypes"]).to eq(["subscription"])
     expect(result_data["appliesTo"]["billableMetrics"].first["id"]).to eq(billable_metric.id)
 
@@ -149,10 +151,95 @@ RSpec.describe Mutations::Wallets::Create, :premium do
         metadata: nil,
         priority: nil,
         name: "Initial Credits Purchase",
-        ignore_paid_top_up_limits: nil
+        ignore_paid_top_up_limits: nil,
+        purchase_order_number: "PO-456"
       }
     )
     expect(SendWebhookJob).to have_been_enqueued.with("wallet.created", Wallet)
+  end
+
+  context "when wallet purchase order number is present and recurring rule purchase order number is nil" do
+    it "enqueues the initial top-up with the wallet purchase order number" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            name: "Wallet PO Fallback",
+            priority: 9,
+            purchaseOrderNumber: "PO-WALLET-123",
+            rateAmount: "1",
+            paidCredits: "10.00",
+            grantedCredits: "0.00",
+            expirationAt: expiration_at.iso8601,
+            currency: "EUR",
+            recurringTransactionRules: [
+              {
+                method: "target",
+                trigger: "interval",
+                interval: "monthly",
+                targetOngoingBalance: "0.0",
+                purchaseOrderNumber: nil
+              }
+            ]
+          }
+        }
+      )
+
+      result_data = result["data"]["createCustomerWallet"]
+      expect(result_data["purchaseOrderNumber"]).to eq("PO-WALLET-123")
+      expect(result_data["recurringTransactionRules"][0]["purchaseOrderNumber"]).to be_nil
+
+      expect(WalletTransactions::CreateJob).to have_been_enqueued.with(
+        organization_id: membership.organization.id,
+        params: hash_including(purchase_order_number: "PO-WALLET-123")
+      )
+    end
+  end
+
+  context "when wallet purchase order number is nil and recurring rule purchase order number is present" do
+    it "enqueues the initial top-up with the recurring rule purchase order number" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            name: "Rule PO Fallback",
+            priority: 9,
+            purchaseOrderNumber: nil,
+            rateAmount: "1",
+            paidCredits: "10.00",
+            grantedCredits: "0.00",
+            expirationAt: expiration_at.iso8601,
+            currency: "EUR",
+            recurringTransactionRules: [
+              {
+                method: "target",
+                trigger: "interval",
+                interval: "monthly",
+                targetOngoingBalance: "0.0",
+                purchaseOrderNumber: "PO-RULE-456"
+              }
+            ]
+          }
+        }
+      )
+
+      result_data = result["data"]["createCustomerWallet"]
+      expect(result_data["purchaseOrderNumber"]).to be_nil
+      expect(result_data["recurringTransactionRules"][0]["purchaseOrderNumber"]).to eq("PO-RULE-456")
+
+      expect(WalletTransactions::CreateJob).to have_been_enqueued.with(
+        organization_id: membership.organization.id,
+        params: hash_including(purchase_order_number: "PO-RULE-456")
+      )
+    end
   end
 
   context "when grants_target_top_up is omitted on a target rule" do
@@ -326,7 +413,8 @@ RSpec.describe Mutations::Wallets::Create, :premium do
           metadata: nil,
           priority: nil,
           name: nil,
-          ignore_paid_top_up_limits: nil
+          ignore_paid_top_up_limits: nil,
+          purchase_order_number: nil
         }
       )
     end

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Mutations::Wallets::Create, :premium do
           code
           name
           priority
+          purchaseOrderNumber
           rateAmount
           status
           currency
@@ -46,6 +47,7 @@ RSpec.describe Mutations::Wallets::Create, :premium do
               value
             }
             transactionName
+            purchaseOrderNumber
           }
           appliesTo {
             feeTypes
@@ -73,6 +75,7 @@ RSpec.describe Mutations::Wallets::Create, :premium do
           customerId: customer.id,
           name: "First Wallet",
           priority: 9,
+          purchaseOrderNumber: "PO-123",
           rateAmount: "1",
           paidCredits: "10.00",
           grantedCredits: "0.00",
@@ -96,7 +99,8 @@ RSpec.describe Mutations::Wallets::Create, :premium do
                 {key: "example_key", value: "example_value"},
                 {key: "another_key", value: "another_value"}
               ],
-              transactionName: "Monthly AI Credits Top-up"
+              transactionName: "Monthly AI Credits Top-up",
+              purchaseOrderNumber: "PO-456"
             }
           ],
           appliesTo: {

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Mutations::Wallets::Update, :premium do
           code
           name
           priority
+          purchaseOrderNumber
           status
           expirationAt
           invoiceRequiresSuccessfulPayment
@@ -48,6 +49,7 @@ RSpec.describe Mutations::Wallets::Update, :premium do
               value
             }
             transactionName
+            purchaseOrderNumber
           }
           appliesTo {
             feeTypes
@@ -80,6 +82,7 @@ RSpec.describe Mutations::Wallets::Update, :premium do
           id: wallet.id,
           name: "New name",
           priority: 22,
+          purchaseOrderNumber: "PO-123",
           expirationAt: expiration_at.iso8601,
           invoiceRequiresSuccessfulPayment: true,
           paidTopUpMinAmountCents: 1_00,
@@ -101,7 +104,8 @@ RSpec.describe Mutations::Wallets::Update, :premium do
                 {key: "example_key", value: "example_value"},
                 {key: "another_key", value: "another_value"}
               ],
-              transactionName: "Updated Credits Transaction"
+              transactionName: "Updated Credits Transaction",
+              purchaseOrderNumber: "PO-456"
             }
           ],
           appliesTo: {
@@ -119,6 +123,7 @@ RSpec.describe Mutations::Wallets::Update, :premium do
       "code" => wallet.code,
       "name" => "New name",
       "priority" => 22,
+      "purchaseOrderNumber" => "PO-123",
       "status" => "active",
       "invoiceRequiresSuccessfulPayment" => true,
       "expirationAt" => expiration_at.iso8601,
@@ -132,6 +137,7 @@ RSpec.describe Mutations::Wallets::Update, :premium do
       {"key" => "another_key", "value" => "another_value"}
     )
     expect(result_data["recurringTransactionRules"][0]["transactionName"]).to eq("Updated Credits Transaction")
+    expect(result_data["recurringTransactionRules"][0]["purchaseOrderNumber"]).to eq("PO-456")
     expect(result_data["recurringTransactionRules"][0]).to include(
       "lagoId" => recurring_transaction_rule.id,
       "method" => "target",

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -9,9 +9,13 @@ RSpec.describe Mutations::Wallets::Update, :premium do
   let(:customer) { create(:customer, organization:) }
   let(:billable_metric) { create(:billable_metric, organization: membership.organization) }
   let(:subscription) { create(:subscription, customer:) }
-  let(:wallet) { create(:wallet, customer:) }
+  let(:wallet) { create(:wallet, customer:, purchase_order_number: wallet_purchase_order_number) }
+  let(:wallet_purchase_order_number) { nil }
   let(:expiration_at) { (Time.zone.now + 1.year) }
-  let(:recurring_transaction_rule) { create(:recurring_transaction_rule, wallet:) }
+  let(:recurring_transaction_rule) do
+    create(:recurring_transaction_rule, wallet:, purchase_order_number: recurring_transaction_rule_purchase_order_number)
+  end
+  let(:recurring_transaction_rule_purchase_order_number) { nil }
 
   let(:mutation) do
     <<-GQL
@@ -154,6 +158,80 @@ RSpec.describe Mutations::Wallets::Update, :premium do
     expect(result_data["appliesTo"]["billableMetrics"].first["id"]).to eq(billable_metric.id)
 
     expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
+  end
+
+  context "when wallet purchase order number is present and recurring rule purchase order number is nil" do
+    let(:recurring_transaction_rule_purchase_order_number) { "PO-OLD-RULE" }
+
+    it "updates the wallet purchase order number and clears the recurring rule purchase order number" do
+      result = execute_graphql(
+        current_organization: organization,
+        current_user: membership.user,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: wallet.id,
+            priority: 22,
+            purchaseOrderNumber: "PO-WALLET-123",
+            recurringTransactionRules: [
+              {
+                lagoId: recurring_transaction_rule.id,
+                trigger: "interval",
+                interval: "weekly",
+                paidCredits: "22.2",
+                grantedCredits: "22.2",
+                purchaseOrderNumber: nil
+              }
+            ]
+          }
+        }
+      )
+
+      result_data = result["data"]["updateCustomerWallet"]
+
+      expect(result_data["purchaseOrderNumber"]).to eq("PO-WALLET-123")
+      expect(result_data["recurringTransactionRules"][0]["purchaseOrderNumber"]).to be_nil
+      expect(wallet.reload.purchase_order_number).to eq("PO-WALLET-123")
+      expect(recurring_transaction_rule.reload.purchase_order_number).to be_nil
+    end
+  end
+
+  context "when wallet purchase order number is nil and recurring rule purchase order number is present" do
+    let(:wallet_purchase_order_number) { "PO-OLD-WALLET" }
+
+    it "clears the wallet purchase order number and updates the recurring rule purchase order number" do
+      result = execute_graphql(
+        current_organization: organization,
+        current_user: membership.user,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: wallet.id,
+            priority: 22,
+            purchaseOrderNumber: nil,
+            recurringTransactionRules: [
+              {
+                lagoId: recurring_transaction_rule.id,
+                trigger: "interval",
+                interval: "weekly",
+                paidCredits: "22.2",
+                grantedCredits: "22.2",
+                purchaseOrderNumber: "PO-RULE-456"
+              }
+            ]
+          }
+        }
+      )
+
+      result_data = result["data"]["updateCustomerWallet"]
+
+      expect(result_data["purchaseOrderNumber"]).to be_nil
+      expect(result_data["recurringTransactionRules"][0]["purchaseOrderNumber"]).to eq("PO-RULE-456")
+      expect(wallet.reload.purchase_order_number).to be_nil
+      expect(recurring_transaction_rule.reload.purchase_order_number).to eq("PO-RULE-456")
+    end
   end
 
   context "with metadata" do

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Types::Invoices::Object do
     expect(subject).to have_field(:payment_dispute_losable).of_type("Boolean!")
     expect(subject).to have_field(:payment_dispute_lost_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:payment_status).of_type("InvoicePaymentStatusTypeEnum!")
+    expect(subject).to have_field(:purchase_order_number).of_type("String")
     expect(subject).to have_field(:status).of_type("InvoiceStatusTypeEnum!")
     expect(subject).to have_field(:voidable).of_type("Boolean!")
 

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Types::Subscriptions::Object do
     expect(subject).to have_field(:payment_method).of_type("PaymentMethod")
     expect(subject).to have_field(:payment_method_type).of_type("PaymentMethodTypeEnum")
     expect(subject).to have_field(:consolidate_invoice).of_type("Boolean!")
+    expect(subject).to have_field(:purchase_order_number).of_type("String")
 
     expect(subject).to have_field(:activated_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:activation_rules).of_type("[SubscriptionActivationRule!]!")

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Types::WalletTransactions::Object do
     expect(subject).to have_field(:invoice_requires_successful_payment).of_type("Boolean!")
     expect(subject).to have_field(:name).of_type("String")
     expect(subject).to have_field(:priority).of_type("Int!")
+    expect(subject).to have_field(:purchase_order_number).of_type("String")
     expect(subject).to have_field(:source).of_type("WalletTransactionSourceEnum!")
     expect(subject).to have_field(:status).of_type("WalletTransactionStatusEnum!")
     expect(subject).to have_field(:transaction_status).of_type("WalletTransactionTransactionStatusEnum!")

--- a/spec/graphql/types/wallets/object_spec.rb
+++ b/spec/graphql/types/wallets/object_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Types::Wallets::Object do
     expect(subject).to have_field(:currency).of_type("CurrencyEnum!")
     expect(subject).to have_field(:name).of_type("String")
     expect(subject).to have_field(:priority).of_type("Int!")
+    expect(subject).to have_field(:purchase_order_number).of_type("String")
     expect(subject).to have_field(:status).of_type("WalletStatusEnum!")
 
     expect(subject).to have_field(:rate_amount).of_type("Float!")

--- a/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
@@ -25,5 +25,6 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::Object do
     expect(subject).to have_field(:skip_invoice_custom_sections).of_type("Boolean")
     expect(subject).to have_field(:payment_method).of_type("PaymentMethod")
     expect(subject).to have_field(:payment_method_type).of_type("PaymentMethodTypeEnum")
+    expect(subject).to have_field(:purchase_order_number).of_type("String")
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Invoice do
   let(:organization) { create(:organization) }
 
   it_behaves_like "paper_trail traceable"
+  it_behaves_like "a model with a purchase order number"
 
   it { is_expected.to have_many(:integration_resources) }
   it { is_expected.to have_many(:error_details) }

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RecurringTransactionRule do
+  it_behaves_like "a model with a purchase order number"
+
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }
     it { is_expected.to belong_to(:organization) }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Subscription do
   let(:plan) { create(:plan) }
 
   it_behaves_like "paper_trail traceable"
+  it_behaves_like "a model with a purchase order number"
 
   describe "enums" do
     it do

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Wallet do
   subject(:wallet) { build(:wallet) }
 
   it_behaves_like "paper_trail traceable"
+  it_behaves_like "a model with a purchase order number"
 
   describe "associations" do
     it do

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -292,6 +292,7 @@ RSpec.describe Wallet do
       customer_id
       organization_id
       payment_method_id
+      purchase_order_number
     ].freeze
 
     it "covers every column that does not need to trigger a refresh" do

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe WalletTransaction do
+  it_behaves_like "a model with a purchase order number"
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:priority) }
     it { is_expected.to validate_inclusion_of(:priority).in_range(1..50) }

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -165,6 +165,19 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
+    context "when purchase_order_number is too long" do
+      let(:params) do
+        super().merge(purchase_order_number: "a" * 256)
+      end
+
+      it "returns a validation error" do
+        expect { service_result }.not_to change(Wallet, :count)
+
+        expect(service_result).not_to be_success
+        expect(service_result.error.messages[:purchase_order_number]).to eq(["value_is_too_long"])
+      end
+    end
+
     context "when the initial credits round to zero monetary value" do
       let(:params) do
         {

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe Wallets::CreateService do
           metadata: nil,
           name: nil,
           priority: nil,
-          ignore_paid_top_up_limits: ignore_paid_top_up_limits_on_creation
+          ignore_paid_top_up_limits: ignore_paid_top_up_limits_on_creation,
+          purchase_order_number: nil
         }
       })
     end
@@ -527,6 +528,62 @@ RSpec.describe Wallets::CreateService do
         wallet = service_result.wallet
         expect(wallet.name).to eq("New Wallet")
         expect(wallet.reload.recurring_transaction_rules.count).to eq(1)
+      end
+
+      context "when wallet and recurring transaction rule have purchase order numbers" do
+        let(:params) do
+          super().merge(purchase_order_number: "PO-WALLET")
+        end
+        let(:rules) do
+          [
+            {
+              interval: "monthly",
+              method: "target",
+              paid_credits: "10.0",
+              granted_credits: "5.0",
+              target_ongoing_balance: "100.0",
+              trigger: "interval",
+              purchase_order_number: "PO-RULE"
+            }
+          ]
+        end
+
+        it "persists both purchase order numbers and enqueues the initial top-up with the rule value" do
+          expect { service_result }.to have_enqueued_job(WalletTransactions::CreateJob).with(
+            organization_id: organization.id,
+            params: hash_including(purchase_order_number: "PO-RULE")
+          )
+
+          wallet = service_result.wallet.reload
+          expect(wallet.purchase_order_number).to eq("PO-WALLET")
+          expect(wallet.recurring_transaction_rules.sole.purchase_order_number).to eq("PO-RULE")
+        end
+      end
+
+      context "when recurring transaction rule purchase order number is blank" do
+        let(:params) do
+          super().merge(purchase_order_number: "PO-WALLET")
+        end
+        let(:rules) do
+          [
+            {
+              interval: "monthly",
+              method: "target",
+              paid_credits: "10.0",
+              granted_credits: "5.0",
+              target_ongoing_balance: "100.0",
+              trigger: "interval",
+              purchase_order_number: "   "
+            }
+          ]
+        end
+
+        it "enqueues the initial top-up with the wallet purchase order number" do
+          expect { service_result }.to have_enqueued_job(WalletTransactions::CreateJob).with(
+            organization_id: organization.id,
+            params: hash_including(purchase_order_number: "PO-WALLET")
+          )
+        end
       end
 
       context "when recurring transaction rule has transaction_name" do

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
         )
       end
 
+      context "when purchase_order_number is present in rule params" do
+        let(:rule_params) do
+          super().merge(purchase_order_number: "PO-RULE-123")
+        end
+
+        it "creates rule with the purchase order number" do
+          expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
+
+          expect(wallet.recurring_transaction_rules.first.purchase_order_number).to eq("PO-RULE-123")
+        end
+      end
+
       context "when method is fixed" do
         let(:rule_params) do
           {

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -64,6 +64,20 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
         end
       end
 
+      context "when purchase_order_number is too long" do
+        let(:rule_params) do
+          super().merge(purchase_order_number: "a" * 256)
+        end
+
+        it "returns a validation error" do
+          expect { create_service.call }.not_to change { wallet.reload.recurring_transaction_rules.count }
+
+          result = create_service.call
+          expect(result).to be_failure
+          expect(result.error.messages[:purchase_order_number]).to eq(["value_is_too_long"])
+        end
+      end
+
       context "when method is fixed" do
         let(:rule_params) do
           {

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -42,6 +42,48 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
       )
     end
 
+    context "when purchase_order_number is present" do
+      let(:params) do
+        [
+          {
+            lago_id: recurring_transaction_rule.id,
+            trigger: "interval",
+            interval: "weekly",
+            paid_credits: "105",
+            granted_credits: "105",
+            purchase_order_number: "PO-RULE-123"
+          }
+        ]
+      end
+
+      it "updates the existing rule purchase order number" do
+        rule = result.wallet.reload.recurring_transaction_rules.active.sole
+
+        expect(rule.id).to eq(recurring_transaction_rule.id)
+        expect(rule.purchase_order_number).to eq("PO-RULE-123")
+      end
+    end
+
+    context "when purchase_order_number is too long" do
+      let(:params) do
+        [
+          {
+            lago_id: recurring_transaction_rule.id,
+            trigger: "interval",
+            interval: "weekly",
+            paid_credits: "105",
+            granted_credits: "105",
+            purchase_order_number: "a" * 256
+          }
+        ]
+      end
+
+      it "returns a validation error" do
+        expect(result).to be_failure
+        expect(result.error.messages[:purchase_order_number]).to eq(["value_is_too_long"])
+      end
+    end
+
     context "when updating an inactive rule" do
       let(:params) do
         [
@@ -109,6 +151,29 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
           payment_method_type: "manual"
         )
         expect(rule.id).not_to eq(recurring_transaction_rule.id)
+      end
+
+      context "when purchase_order_number is present" do
+        let(:params) do
+          [
+            {
+              granted_credits: "105",
+              interval: "weekly",
+              method: "target",
+              paid_credits: "105",
+              target_ongoing_balance: "300",
+              trigger: "interval",
+              purchase_order_number: "PO-REPLACEMENT-123"
+            }
+          ]
+        end
+
+        it "creates the replacement rule with the purchase order number" do
+          rule = result.wallet.reload.recurring_transaction_rules.active.sole
+
+          expect(rule.id).not_to eq(recurring_transaction_rule.id)
+          expect(rule.purchase_order_number).to eq("PO-REPLACEMENT-123")
+        end
       end
     end
 

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -44,6 +44,28 @@ RSpec.describe Wallets::UpdateService do
       expect(Utils::ActivityLog).to have_produced("wallet.updated").after_commit.with(wallet)
     end
 
+    context "when purchase_order_number is present" do
+      let(:params) do
+        super().merge(purchase_order_number: "PO-WALLET-123")
+      end
+
+      it "updates the wallet purchase order number" do
+        expect(result).to be_success
+        expect(result.wallet.reload.purchase_order_number).to eq("PO-WALLET-123")
+      end
+    end
+
+    context "when purchase_order_number is too long" do
+      let(:params) do
+        super().merge(purchase_order_number: "a" * 256)
+      end
+
+      it "returns a validation error" do
+        expect(result).to be_failure
+        expect(result.error.messages[:purchase_order_number]).to eq(["value_is_too_long"])
+      end
+    end
+
     it "sends a `wallet.updated` webhook" do
       expect { result }.to have_enqueued_job_after_commit(SendWebhookJob).with("wallet.updated", Wallet)
     end
@@ -311,6 +333,71 @@ RSpec.describe Wallets::UpdateService do
           expect(rule.granted_credits).to eq(105.0)
 
           expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
+        end
+      end
+
+      context "when editing existing rule purchase_order_number" do
+        let(:rules) do
+          [
+            {
+              lago_id: recurring_transaction_rule.id,
+              trigger: "interval",
+              interval: "weekly",
+              paid_credits: "105",
+              granted_credits: "105",
+              purchase_order_number: "PO-RULE-123"
+            }
+          ]
+        end
+
+        it "updates the recurring rule purchase order number" do
+          expect(result).to be_success
+
+          rule = result.wallet.reload.recurring_transaction_rules.active.sole
+          expect(rule.id).to eq(recurring_transaction_rule.id)
+          expect(rule.purchase_order_number).to eq("PO-RULE-123")
+        end
+      end
+
+      context "when replacing rule with purchase_order_number" do
+        let(:rules) do
+          [
+            {
+              trigger: "interval",
+              interval: "weekly",
+              paid_credits: "105",
+              granted_credits: "105",
+              purchase_order_number: "PO-REPLACEMENT-123"
+            }
+          ]
+        end
+
+        it "creates the replacement rule with the purchase order number" do
+          expect(result).to be_success
+
+          rule = result.wallet.reload.recurring_transaction_rules.active.sole
+          expect(rule.id).not_to eq(recurring_transaction_rule.id)
+          expect(rule.purchase_order_number).to eq("PO-REPLACEMENT-123")
+        end
+      end
+
+      context "when recurring rule purchase_order_number is too long" do
+        let(:rules) do
+          [
+            {
+              lago_id: recurring_transaction_rule.id,
+              trigger: "interval",
+              interval: "weekly",
+              paid_credits: "105",
+              granted_credits: "105",
+              purchase_order_number: "a" * 256
+            }
+          ]
+        end
+
+        it "returns a validation error" do
+          expect(result).to be_failure
+          expect(result.error.messages[:purchase_order_number]).to eq(["value_is_too_long"])
         end
       end
 


### PR DESCRIPTION
This commit introduces some changes in wallet services

We're changing the Wallets::CreateService to receive the `purchase_order_number`
in the wallet itself and also in the `recurring_transaction_rules`. When the `purchase_order_number`
is available in recurring transaction rules we publish the wallet transaction job using that value
otherwise we fallback to wallet purchase order number. 

This covers the inheritance defined by product:

```markdown
For wallet-driven invoices, the resolution chain at invoice-generation time is:
**Wallet (default)** 

**→ Wallet recurring rule (overrides wallet)** 

**→ Wallet transaction (overrides both)**
```