### PR TITLE
refactor(analytics): Resolve billing entity code in resolvers

### DIFF
--- a/app/graphql/concerns/billing_entity_args_resolvable.rb
+++ b/app/graphql/concerns/billing_entity_args_resolvable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module BillingEntityArgsResolvable
+  extend ActiveSupport::Concern
+
+  private
+
+  # Replaces the `billing_entity_code` argument with the matching `billing_entity_id`
+  # so analytics models only deal with ids.
+  # Mutates `args` and returns an execution error when the arguments are invalid, nil otherwise.
+  def resolve_billing_entity!(args)
+    if args[:billing_entity_code].present? && args[:billing_entity_id].present?
+      return validation_error(messages: {billing_entity_id: ["can't be present when billing_entity_code is provided"]})
+    end
+
+    code = args.delete(:billing_entity_code)
+    return nil if code.blank?
+
+    billing_entity = current_organization.billing_entities.find_by(code:)
+    if billing_entity.nil?
+      return not_found_error(resource: "billing_entity")
+    end
+
+    args[:billing_entity_id] = billing_entity.id
+    nil
+  end
+end

--- a/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
+++ b/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
@@ -5,11 +5,13 @@ module Resolvers
     class GrossRevenuesResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
+      include BillingEntityArgsResolvable
 
       REQUIRED_PERMISSION = "analytics:view"
 
       description "Query gross revenue of an organization"
 
+      argument :billing_entity_code, String, required: false
       argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
       argument :external_customer_id, String, required: false
@@ -20,6 +22,9 @@ module Resolvers
       type Types::Analytics::GrossRevenues::Object.collection_type, null: false
 
       def resolve(**args)
+        error = resolve_billing_entity!(args)
+        return error if error
+
         ::Analytics::GrossRevenue.find_all_by(current_organization.id, **args)
       end
     end

--- a/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
@@ -5,6 +5,7 @@ module Resolvers
     class InvoiceCollectionsResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
+      include BillingEntityArgsResolvable
 
       REQUIRED_PERMISSION = "analytics:view"
 
@@ -19,6 +20,9 @@ module Resolvers
 
       def resolve(**args)
         raise unauthorized_error unless License.premium?
+
+        error = resolve_billing_entity!(args)
+        return error if error
 
         ::Analytics::InvoiceCollection.find_all_by(current_organization.id, **args.merge(months: 12))
       end

--- a/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
@@ -5,11 +5,13 @@ module Resolvers
     class InvoicedUsagesResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
+      include BillingEntityArgsResolvable
 
       REQUIRED_PERMISSION = "analytics:view"
 
       description "Query invoiced usage of an organization"
 
+      argument :billing_entity_code, String, required: false
       argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
 
@@ -17,6 +19,9 @@ module Resolvers
 
       def resolve(**args)
         raise unauthorized_error unless License.premium?
+
+        error = resolve_billing_entity!(args)
+        return error if error
 
         ::Analytics::InvoicedUsage.find_all_by(current_organization.id, **args.merge({months: 12}))
       end

--- a/app/graphql/resolvers/analytics/mrrs_resolver.rb
+++ b/app/graphql/resolvers/analytics/mrrs_resolver.rb
@@ -5,11 +5,13 @@ module Resolvers
     class MrrsResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
+      include BillingEntityArgsResolvable
 
       REQUIRED_PERMISSION = "analytics:view"
 
       description "Query MRR of an organization"
 
+      argument :billing_entity_code, String, required: false
       argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
 
@@ -17,6 +19,9 @@ module Resolvers
 
       def resolve(**args)
         raise unauthorized_error unless License.premium?
+
+        error = resolve_billing_entity!(args)
+        return error if error
 
         ::Analytics::Mrr.find_all_by(current_organization.id, **args.merge({months: 12}))
       end

--- a/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
+++ b/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
@@ -5,6 +5,7 @@ module Resolvers
     class OverdueBalancesResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
+      include BillingEntityArgsResolvable
 
       REQUIRED_PERMISSION = "analytics:view"
 
@@ -22,6 +23,9 @@ module Resolvers
       type Types::Analytics::OverdueBalances::Object.collection_type, null: false
 
       def resolve(**args)
+        error = resolve_billing_entity!(args)
+        return error if error
+
         ::Analytics::OverdueBalance.find_all_by(current_organization.id, **args)
       end
     end

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -10,12 +10,6 @@ module Analytics
           and_billing_entity_id_sql = sanitize_sql(["AND i.billing_entity_id = :billing_entity_id", args[:billing_entity_id]])
         end
 
-        if args[:billing_entity_code].present?
-          and_billing_entity_code_sql = sanitize_sql(
-            ["AND be.code = :billing_entity_code", args[:billing_entity_code]]
-          )
-        end
-
         if args[:external_customer_id].present?
           and_external_customer_id_sql = sanitize_sql(
             ["AND c.external_id = :external_customer_id AND c.deleted_at IS NULL", args[:external_customer_id]]
@@ -74,7 +68,6 @@ module Analytics
                 COALESCE(SUM(i.total_amount_cents::float), 0) AS amount_cents
             FROM invoices i
             LEFT JOIN customers c ON i.customer_id = c.id
-            LEFT JOIN billing_entities be ON i.billing_entity_id = be.id
             WHERE i.organization_id = :organization_id
             AND i.self_billed IS FALSE
             AND i.status = 1
@@ -82,7 +75,6 @@ module Analytics
             #{and_external_customer_id_sql}
             #{and_is_customer_tin_empty_sql}
             #{and_billing_entity_id_sql}
-            #{and_billing_entity_code_sql}
             GROUP BY payment_status, month, i.currency
           )
           SELECT

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -10,12 +10,6 @@ module Analytics
           and_billing_entity_id_sql = sanitize_sql(["AND i.billing_entity_id = :billing_entity_id", args[:billing_entity_id]])
         end
 
-        if args[:billing_entity_code].present?
-          and_billing_entity_code_sql = sanitize_sql(
-            ["AND be.code = :billing_entity_code", args[:billing_entity_code]]
-          )
-        end
-
         if args[:external_customer_id].present?
           and_external_customer_id_sql = sanitize_sql(
             ["AND c.external_id = :external_customer_id AND c.deleted_at IS NULL", args[:external_customer_id]]
@@ -68,7 +62,6 @@ module Analytics
               array_agg(DISTINCT i.id) AS ids
             FROM invoices i
             LEFT JOIN customers c ON i.customer_id = c.id
-            LEFT JOIN billing_entities be ON i.billing_entity_id = be.id
             LEFT JOIN (
               SELECT invoice_id, SUM(offset_amount_cents) AS offset_amount_cents_sum
               FROM credit_notes
@@ -80,7 +73,6 @@ module Analytics
             AND i.payment_overdue IS TRUE
             #{and_external_customer_id_sql}
             #{and_billing_entity_id_sql}
-            #{and_billing_entity_code_sql}
             GROUP BY month, i.currency, i.billing_entity_id, total_amount_cents
             ORDER BY month ASC
           )

--- a/schema.graphql
+++ b/schema.graphql
@@ -10497,7 +10497,7 @@ type Query {
   """
   Query gross revenue of an organization
   """
-  grossRevenues(billingEntityId: ID, currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String, months: Int): GrossRevenueCollection!
+  grossRevenues(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String, months: Int): GrossRevenueCollection!
 
   """
   Query a single integration
@@ -10599,7 +10599,7 @@ type Query {
   """
   Query invoiced usage of an organization
   """
-  invoicedUsages(billingEntityId: ID, currency: CurrencyEnum): InvoicedUsageCollection!
+  invoicedUsages(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum): InvoicedUsageCollection!
 
   """
   Query invoices
@@ -10640,7 +10640,7 @@ type Query {
   """
   Query MRR of an organization
   """
-  mrrs(billingEntityId: ID, currency: CurrencyEnum): MrrCollection!
+  mrrs(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum): MrrCollection!
 
   """
   Query a single order

--- a/schema.json
+++ b/schema.json
@@ -56292,6 +56292,18 @@
               "description": "Query gross revenue of an organization",
               "args": [
                 {
+                  "name": "billingEntityCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "billingEntityId",
                   "description": null,
                   "type": {
@@ -56902,6 +56914,18 @@
               "description": "Query invoiced usage of an organization",
               "args": [
                 {
+                  "name": "billingEntityCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "billingEntityId",
                   "description": null,
                   "type": {
@@ -57292,6 +57316,18 @@
               "name": "mrrs",
               "description": "Query MRR of an organization",
               "args": [
+                {
+                  "name": "billingEntityCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
                 {
                   "name": "billingEntityId",
                   "description": null,

--- a/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::GrossRevenuesResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $externalCustomerId: String, $expireCache: Boolean) {
-        grossRevenues(currency: $currency, externalCustomerId: $externalCustomerId, expireCache: $expireCache) {
+      query($currency: CurrencyEnum, $externalCustomerId: String, $expireCache: Boolean, $billingEntityCode: String, $billingEntityId: ID) {
+        grossRevenues(currency: $currency, externalCustomerId: $externalCustomerId, expireCache: $expireCache, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
           collection {
             month
             amountCents
@@ -35,5 +35,55 @@ RSpec.describe Resolvers::Analytics::GrossRevenuesResolver do
     )
 
     expect(result["data"]["grossRevenues"]["collection"]).to eq([])
+  end
+
+  context "when filtering by billing entity code" do
+    let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+    it "returns a list of gross revenues for the billing entity" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityCode: billing_entity.code}
+      )
+
+      expect(result["data"]["grossRevenues"]["collection"]).to eq([])
+    end
+  end
+
+  context "when billing entity code does not match any entity of the organization" do
+    it "returns a not found error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityCode: "unknown"}
+      )
+
+      expect_graphql_error(result:, message: "not_found")
+    end
+  end
+
+  context "when both billing entity code and id are provided" do
+    let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+    it "returns a validation error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
+      )
+
+      expect_graphql_error(
+        result:,
+        message: "unprocessable_entity",
+        details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
+      )
+    end
   end
 end

--- a/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
@@ -39,8 +39,16 @@ RSpec.describe Resolvers::Analytics::GrossRevenuesResolver do
 
   context "when filtering by billing entity code" do
     let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+    let(:customer) { create(:customer, organization:) }
 
-    it "returns a list of gross revenues for the billing entity" do
+    before do
+      create(:invoice, organization:, customer:, billing_entity:,
+        issuing_date: Time.current.beginning_of_month, total_amount_cents: 100)
+      create(:invoice, organization:, customer:, billing_entity: organization.default_billing_entity,
+        issuing_date: Time.current.beginning_of_month, total_amount_cents: 200)
+    end
+
+    it "returns gross revenues scoped to the billing entity" do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
@@ -49,7 +57,11 @@ RSpec.describe Resolvers::Analytics::GrossRevenuesResolver do
         variables: {billingEntityCode: billing_entity.code}
       )
 
-      expect(result["data"]["grossRevenues"]["collection"]).to eq([])
+      collection = result["data"]["grossRevenues"]["collection"]
+
+      expect(collection.count).to eq(1)
+      expect(collection.first["amountCents"]).to eq("100")
+      expect(collection.first["invoicesCount"]).to eq("1")
     end
   end
 

--- a/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
@@ -61,8 +61,16 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
 
     context "when filtering by billing entity code" do
       let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+      let(:customer) { create(:customer, organization:) }
 
-      it "returns a list of invoice collections for the billing entity" do
+      before do
+        create(:invoice, organization:, customer:, billing_entity:,
+          issuing_date: Time.current.beginning_of_month, total_amount_cents: 100)
+        create(:invoice, organization:, customer:, billing_entity: organization.default_billing_entity,
+          issuing_date: Time.current.beginning_of_month, total_amount_cents: 200)
+      end
+
+      it "returns invoice collections scoped to the billing entity" do
         result = execute_graphql(
           current_user: membership.user,
           current_organization: organization,
@@ -71,10 +79,11 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
           variables: {billingEntityCode: billing_entity.code}
         )
 
-        invoice_collections_response = result["data"]["invoiceCollections"]
+        collection = result["data"]["invoiceCollections"]["collection"]
 
-        expect(invoice_collections_response["collection"].first["amountCents"]).to eq("0")
-        expect(invoice_collections_response["collection"].first["invoicesCount"]).to eq("0")
+        expect(collection.count).to eq(1)
+        expect(collection.first["amountCents"]).to eq("100")
+        expect(collection.first["invoicesCount"]).to eq("1")
       end
     end
 

--- a/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum) {
-        invoiceCollections(currency: $currency) {
+      query($currency: CurrencyEnum, $billingEntityCode: String, $billingEntityId: ID) {
+        invoiceCollections(currency: $currency, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
           collection {
             month
             amountCents
@@ -57,6 +57,59 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
       expect(month).to eq(DateTime.current.beginning_of_month)
       expect(invoice_collections_response["collection"].first["amountCents"]).to eq("0")
       expect(invoice_collections_response["collection"].first["invoicesCount"]).to eq("0")
+    end
+
+    context "when filtering by billing entity code" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+      it "returns a list of invoice collections for the billing entity" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: billing_entity.code}
+        )
+
+        invoice_collections_response = result["data"]["invoiceCollections"]
+
+        expect(invoice_collections_response["collection"].first["amountCents"]).to eq("0")
+        expect(invoice_collections_response["collection"].first["invoicesCount"]).to eq("0")
+      end
+    end
+
+    context "when billing entity code does not match any entity of the organization" do
+      it "returns a not found error" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: "unknown"}
+        )
+
+        expect_graphql_error(result:, message: "not_found")
+      end
+    end
+
+    context "when both billing entity code and id are provided" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+      it "returns a validation error" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
+        )
+
+        expect_graphql_error(
+          result:,
+          message: "unprocessable_entity",
+          details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
+        )
+      end
     end
   end
 end

--- a/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
@@ -55,8 +55,20 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
 
     context "when filtering by billing entity code" do
       let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+      let(:customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, customer:) }
+      let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+      let(:charge) { create(:standard_charge, billable_metric:) }
+      let(:fee1) { create(:charge_fee, charge:, subscription:, amount_cents: 100, amount_currency: "EUR") }
+      let(:fee2) { create(:charge_fee, charge:, subscription:, amount_cents: 200, amount_currency: "EUR") }
 
-      it "returns a list of invoiced usages for the billing entity" do
+      before do
+        create(:invoice, organization:, customer:, billing_entity:, status: :finalized, fees: [fee1])
+        create(:invoice, organization:, customer:, billing_entity: organization.default_billing_entity,
+          status: :finalized, fees: [fee2])
+      end
+
+      it "returns invoiced usages scoped to the billing entity" do
         result = execute_graphql(
           current_user: membership.user,
           current_organization: organization,
@@ -65,7 +77,11 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
           variables: {billingEntityCode: billing_entity.code}
         )
 
-        expect(result["data"]["invoicedUsages"]["collection"]).to eq([])
+        collection = result["data"]["invoicedUsages"]["collection"]
+
+        expect(collection.count).to eq(1)
+        expect(collection.first["amountCents"]).to eq("100")
+        expect(collection.first["currency"]).to eq("EUR")
       end
     end
 

--- a/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum) {
-        invoicedUsages(currency: $currency) {
+      query($currency: CurrencyEnum, $billingEntityCode: String, $billingEntityId: ID) {
+        invoicedUsages(currency: $currency, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
           collection {
             month
             amountCents
@@ -51,6 +51,56 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
       )
 
       expect(result["data"]["invoicedUsages"]["collection"]).to eq([])
+    end
+
+    context "when filtering by billing entity code" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+      it "returns a list of invoiced usages for the billing entity" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: billing_entity.code}
+        )
+
+        expect(result["data"]["invoicedUsages"]["collection"]).to eq([])
+      end
+    end
+
+    context "when billing entity code does not match any entity of the organization" do
+      it "returns a not found error" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: "unknown"}
+        )
+
+        expect_graphql_error(result:, message: "not_found")
+      end
+    end
+
+    context "when both billing entity code and id are provided" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+      it "returns a validation error" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
+        )
+
+        expect_graphql_error(
+          result:,
+          message: "unprocessable_entity",
+          details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
+        )
+      end
     end
   end
 end

--- a/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
@@ -60,8 +60,19 @@ RSpec.describe Resolvers::Analytics::MrrsResolver do
 
     context "when filtering by billing entity code" do
       let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+      let(:customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, customer:) }
+      let(:fee1) { create(:fee, subscription:, amount_cents: 100, amount_currency: "EUR", taxes_amount_cents: 0) }
+      let(:fee2) { create(:fee, subscription:, amount_cents: 200, amount_currency: "EUR", taxes_amount_cents: 0) }
 
-      it "returns a list of mrrs for the billing entity" do
+      before do
+        create(:invoice, organization:, customer:, billing_entity:, status: :finalized,
+          issuing_date: Time.current.beginning_of_month, fees: [fee1])
+        create(:invoice, organization:, customer:, billing_entity: organization.default_billing_entity,
+          status: :finalized, issuing_date: Time.current.beginning_of_month, fees: [fee2])
+      end
+
+      it "returns mrrs scoped to the billing entity" do
         result = execute_graphql(
           current_user: membership.user,
           current_organization: organization,
@@ -70,11 +81,13 @@ RSpec.describe Resolvers::Analytics::MrrsResolver do
           variables: {billingEntityCode: billing_entity.code}
         )
 
-        mrrs_response = result["data"]["mrrs"]
-        month = DateTime.parse mrrs_response["collection"].first["month"]
+        collection = result["data"]["mrrs"]["collection"]
+        month = DateTime.parse collection.first["month"]
 
+        expect(collection.count).to eq(1)
         expect(month).to eq(DateTime.current.beginning_of_month)
-        expect(mrrs_response["collection"].first["amountCents"]).to eq(nil)
+        expect(collection.first["amountCents"]).to eq("100")
+        expect(collection.first["currency"]).to eq("EUR")
       end
     end
 

--- a/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::MrrsResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum) {
-        mrrs(currency: $currency) {
+      query($currency: CurrencyEnum, $billingEntityCode: String, $billingEntityId: ID) {
+        mrrs(currency: $currency, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
           collection {
             month
             amountCents
@@ -56,6 +56,60 @@ RSpec.describe Resolvers::Analytics::MrrsResolver do
       expect(month).to eq(DateTime.current.beginning_of_month)
       expect(mrrs_response["collection"].first["amountCents"]).to eq(nil)
       expect(mrrs_response["collection"].first["currency"]).to eq(nil)
+    end
+
+    context "when filtering by billing entity code" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+      it "returns a list of mrrs for the billing entity" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: billing_entity.code}
+        )
+
+        mrrs_response = result["data"]["mrrs"]
+        month = DateTime.parse mrrs_response["collection"].first["month"]
+
+        expect(month).to eq(DateTime.current.beginning_of_month)
+        expect(mrrs_response["collection"].first["amountCents"]).to eq(nil)
+      end
+    end
+
+    context "when billing entity code does not match any entity of the organization" do
+      it "returns a not found error" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: "unknown"}
+        )
+
+        expect_graphql_error(result:, message: "not_found")
+      end
+    end
+
+    context "when both billing entity code and id are provided" do
+      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+      it "returns a validation error" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
+        )
+
+        expect_graphql_error(
+          result:,
+          message: "unprocessable_entity",
+          details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
+        )
+      end
     end
   end
 end

--- a/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::OverdueBalancesResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean) {
-        overdueBalances(currency: $currency, externalCustomerId: $externalCustomerId, months: $months, expireCache: $expireCache) {
+      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean, $billingEntityCode: String, $billingEntityId: ID) {
+        overdueBalances(currency: $currency, externalCustomerId: $externalCustomerId, months: $months, expireCache: $expireCache, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
           collection {
             amountCents
             currency
@@ -35,5 +35,66 @@ RSpec.describe Resolvers::Analytics::OverdueBalancesResolver do
     )
 
     expect(result["data"]["overdueBalances"]["collection"]).to eq([])
+  end
+
+  context "when filtering by billing entity code" do
+    let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+    let(:customer) { create(:customer, organization:) }
+
+    before do
+      create(:invoice, organization:, customer:, billing_entity:, payment_overdue: true,
+        payment_due_date: Time.current.beginning_of_month, total_amount_cents: 100)
+      create(:invoice, organization:, customer:, billing_entity: organization.default_billing_entity,
+        payment_overdue: true, payment_due_date: Time.current.beginning_of_month, total_amount_cents: 200)
+    end
+
+    it "returns overdue balances scoped to the billing entity" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityCode: billing_entity.code}
+      )
+
+      collection = result["data"]["overdueBalances"]["collection"]
+
+      expect(collection.count).to eq(1)
+      expect(collection.first["amountCents"]).to eq("100")
+    end
+  end
+
+  context "when billing entity code does not match any entity of the organization" do
+    it "returns a not found error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityCode: "unknown"}
+      )
+
+      expect_graphql_error(result:, message: "not_found")
+    end
+  end
+
+  context "when both billing entity code and id are provided" do
+    let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
+
+    it "returns a validation error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
+      )
+
+      expect_graphql_error(
+        result:,
+        message: "unprocessable_entity",
+        details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
+      )
+    end
   end
 end

--- a/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
@@ -78,6 +78,36 @@ RSpec.describe Resolvers::Analytics::OverdueBalancesResolver do
     end
   end
 
+  context "when billing entity code belongs to another organization" do
+    before { create(:billing_entity, code: "entity_01") }
+
+    it "returns a not found error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityCode: "entity_01"}
+      )
+
+      expect_graphql_error(result:, message: "not_found")
+    end
+  end
+
+  context "when billing entity code is blank" do
+    it "does not filter by billing entity" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityCode: ""}
+      )
+
+      expect(result["data"]["overdueBalances"]["collection"]).to eq([])
+    end
+  end
+
   context "when both billing entity code and id are provided" do
     let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
 

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -130,23 +130,6 @@ RSpec.describe Analytics::InvoiceCollection do
       end
     end
 
-    context "when billing entity code is provided" do
-      let(:args) { {billing_entity_code: billing_entity2.code} }
-
-      it "returns the finalized invoices collections filtered by billing_entity_code" do
-        expect(invoice_collections).to match_array([
-          hash_including({"month" => Time.current.beginning_of_month - 3.months,
-                         "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0}),
-          hash_including({"month" => Time.current.beginning_of_month - 2.months,
-                         "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0}),
-          hash_including({"month" => Time.current.beginning_of_month - 1.month,
-                         "payment_status" => "pending", "currency" => "EUR", "invoices_count" => 1, "amount_cents" => 400.0}),
-          hash_including({"month" => Time.current.beginning_of_month,
-                         "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0})
-        ])
-      end
-    end
-
     context "when is_customer_tin_empty is true" do
       let(:args) { {is_customer_tin_empty: true} }
 

--- a/spec/models/analytics/overdue_balance_spec.rb
+++ b/spec/models/analytics/overdue_balance_spec.rb
@@ -174,22 +174,6 @@ RSpec.describe Analytics::OverdueBalance do
       end
     end
 
-    context "with billing entity code" do
-      let(:args) { {billing_entity_code: billing_entity2.code} }
-
-      it "returns the overdue balances for provided billing_entity only" do
-        expect(overdue_balances).to match_array([
-          hash_including({
-            "month" => Time.current.beginning_of_month - 2.months,
-            "currency" => "EUR",
-            "billing_entity_id" => billing_entity2.id,
-            "amount_cents" => 400,
-            "lago_invoice_ids" => "[[\"#{invoice4.id}\"]]"
-          })
-        ])
-      end
-    end
-
     context "with special invoice scenarios" do
       let(:args) { {} }
 


### PR DESCRIPTION
## Context

Two analytics GraphQL requests that differ only by `billingEntityCode` could return each other's figures. `Analytics::OverdueBalance` and `Analytics::InvoiceCollection` filtered their SQL on that argument through a dedicated `billing_entities` join, but their cache keys only included `billing_entity_id`, so both requests shared one cache entry for up to 4 hours and the second request got the first one's numbers.

The analytics resolvers were also inconsistent: only `overdueBalances` and `invoiceCollections` accepted `billingEntityCode`, while `grossRevenues`, `mrrs` and `invoicedUsages` only accepted `billingEntityId`. The REST analytics controllers already resolve the code to an id before calling the models, so the GraphQL layer was the only caller pushing codes into the SQL.

## Description

Instead of patching the cache keys with the missing code argument, the GraphQL layer now resolves `billingEntityCode` to a `billing_entity_id` before calling the models, the same way the REST controllers do. A shared `BillingEntityArgsResolvable` concern is included in all five analytics resolvers. The lookup is scoped to the current organization's billing entities, returns a not-found error when the code matches no entity (previously an unknown code silently returned empty results), and rejects requests carrying both `billingEntityCode` and `billingEntityId` with a validation error. `grossRevenues`, `mrrs` and `invoicedUsages` gain the `billingEntityCode` argument that only `overdueBalances` and `invoiceCollections` had before.

The models are id-only again: the `billing_entity_code` SQL branch and its `billing_entities` join were removed from `Analytics::OverdueBalance` and `Analytics::InvoiceCollection`. Since `billing_entity_id` was already part of every cache key, the collision is gone by construction. Resolver specs now assert the entity scoping for all five queries.

This is the first PR of a stack split out of #5828.

Fixes ING-368
