### PR TITLE
fix(analytics): Add TIN filter arg to invoice collections cache key

### DIFF
--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -110,7 +110,8 @@ module Analytics
           args[:billing_entity_id],
           args[:external_customer_id],
           args[:currency],
-          args[:months]
+          args[:months],
+          args[:is_customer_tin_empty]
         ].join("/")
       end
     end

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Analytics::InvoiceCollection do
 
     context "with no arguments" do
       let(:args) { {} }
-      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}////" }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}/////" }
 
       it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)
@@ -26,7 +26,7 @@ RSpec.describe Analytics::InvoiceCollection do
       let(:args) { {external_customer_id:, currency:, months:} }
 
       let(:cache_key) do
-        "invoice-collection/#{date}/#{organization_id}//#{external_customer_id}/#{currency}/#{months}"
+        "invoice-collection/#{date}/#{organization_id}//#{external_customer_id}/#{currency}/#{months}/"
       end
 
       it "returns the cache key" do
@@ -36,7 +36,7 @@ RSpec.describe Analytics::InvoiceCollection do
       context "with billing entity id" do
         let(:args) { {external_customer_id:, currency:, months:, billing_entity_id:} }
         let(:cache_key) do
-          "invoice-collection/#{date}/#{organization_id}/#{billing_entity_id}/#{external_customer_id}/#{currency}/#{months}"
+          "invoice-collection/#{date}/#{organization_id}/#{billing_entity_id}/#{external_customer_id}/#{currency}/#{months}/"
         end
 
         it "returns the cache key" do
@@ -49,7 +49,7 @@ RSpec.describe Analytics::InvoiceCollection do
       let(:args) { {months:} }
 
       let(:cache_key) do
-        "invoice-collection/#{date}/#{organization_id}////#{months}"
+        "invoice-collection/#{date}/#{organization_id}////#{months}/"
       end
 
       it "returns the cache key" do
@@ -59,7 +59,7 @@ RSpec.describe Analytics::InvoiceCollection do
 
     context "with currency" do
       let(:args) { {currency:} }
-      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}///#{currency}/" }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}///#{currency}//" }
 
       it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)
@@ -68,9 +68,18 @@ RSpec.describe Analytics::InvoiceCollection do
 
     context "with billing_entity_id" do
       let(:args) { {billing_entity_id:} }
-      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}/#{billing_entity_id}///" }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}/#{billing_entity_id}////" }
 
       it "returns the cache key" do
+        expect(invoice_collection_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with is_customer_tin_empty" do
+      let(:args) { {is_customer_tin_empty: true} }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}/////true" }
+
+      it "includes is_customer_tin_empty so filtered and unfiltered requests do not share a cache entry" do
         expect(invoice_collection_cache_key).to eq(cache_key)
       end
     end


### PR DESCRIPTION
## Context

The `Analytics::InvoiceCollection` query filters on `is_customer_tin_empty` in SQL, but its cache key omitted that argument. Two requests differing only by that filter shared one cache entry for up to 4 hours and the second request got the first one's numbers.

## Description

The `is_customer_tin_empty` argument is appended to the `Analytics::InvoiceCollection` cache key so each filter variant gets its own entry.

Split out of #5828. This PR is independent and targets main directly.
