### PR TITLE
refactor(analytics): Drop unused billingEntityId arguments

### DIFF
--- a/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
@@ -12,7 +12,6 @@ module Resolvers
       description "Query invoice collections of an organization"
 
       argument :billing_entity_code, String, required: false
-      argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
       argument :is_customer_tin_empty, Boolean, required: false
 

--- a/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
@@ -12,7 +12,6 @@ module Resolvers
       description "Query invoiced usage of an organization"
 
       argument :billing_entity_code, String, required: false
-      argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
 
       type Types::Analytics::InvoicedUsages::Object.collection_type, null: false

--- a/app/graphql/resolvers/analytics/mrrs_resolver.rb
+++ b/app/graphql/resolvers/analytics/mrrs_resolver.rb
@@ -12,7 +12,6 @@ module Resolvers
       description "Query MRR of an organization"
 
       argument :billing_entity_code, String, required: false
-      argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
 
       type Types::Analytics::Mrrs::Object.collection_type, null: false

--- a/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
+++ b/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
@@ -12,7 +12,6 @@ module Resolvers
       description "Query overdue balances of an organization"
 
       argument :billing_entity_code, String, required: false
-      argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
       argument :external_customer_id, String, required: false
       argument :is_customer_tin_empty, Boolean, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -10567,7 +10567,7 @@ type Query {
   """
   Query invoice collections of an organization
   """
-  invoiceCollections(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum, isCustomerTinEmpty: Boolean): FinalizedInvoiceCollectionCollection!
+  invoiceCollections(billingEntityCode: String, currency: CurrencyEnum, isCustomerTinEmpty: Boolean): FinalizedInvoiceCollectionCollection!
 
   """
   Query invoice's credit note
@@ -10599,7 +10599,7 @@ type Query {
   """
   Query invoiced usage of an organization
   """
-  invoicedUsages(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum): InvoicedUsageCollection!
+  invoicedUsages(billingEntityCode: String, currency: CurrencyEnum): InvoicedUsageCollection!
 
   """
   Query invoices
@@ -10640,7 +10640,7 @@ type Query {
   """
   Query MRR of an organization
   """
-  mrrs(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum): MrrCollection!
+  mrrs(billingEntityCode: String, currency: CurrencyEnum): MrrCollection!
 
   """
   Query a single order
@@ -10680,7 +10680,7 @@ type Query {
   """
   Query overdue balances of an organization
   """
-  overdueBalances(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String, isCustomerTinEmpty: Boolean, months: Int): OverdueBalanceCollection!
+  overdueBalances(billingEntityCode: String, currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String, isCustomerTinEmpty: Boolean, months: Int): OverdueBalanceCollection!
 
   """
   Query a password reset by token

--- a/schema.json
+++ b/schema.json
@@ -56738,18 +56738,6 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "billingEntityId",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
                   "name": "currency",
                   "description": null,
                   "type": {
@@ -56919,18 +56907,6 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "billingEntityId",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -57322,18 +57298,6 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "billingEntityId",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -57883,18 +57847,6 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "billingEntityId",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $billingEntityCode: String, $billingEntityId: ID) {
-        invoiceCollections(currency: $currency, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
+      query($currency: CurrencyEnum, $billingEntityCode: String) {
+        invoiceCollections(currency: $currency, billingEntityCode: $billingEntityCode) {
           collection {
             month
             amountCents
@@ -98,26 +98,6 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
         )
 
         expect_graphql_error(result:, message: "not_found")
-      end
-    end
-
-    context "when both billing entity code and id are provided" do
-      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
-
-      it "returns a validation error" do
-        result = execute_graphql(
-          current_user: membership.user,
-          current_organization: organization,
-          permissions: required_permission,
-          query:,
-          variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
-        )
-
-        expect_graphql_error(
-          result:,
-          message: "unprocessable_entity",
-          details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
-        )
       end
     end
   end

--- a/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $billingEntityCode: String, $billingEntityId: ID) {
-        invoicedUsages(currency: $currency, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
+      query($currency: CurrencyEnum, $billingEntityCode: String) {
+        invoicedUsages(currency: $currency, billingEntityCode: $billingEntityCode) {
           collection {
             month
             amountCents
@@ -96,26 +96,6 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
         )
 
         expect_graphql_error(result:, message: "not_found")
-      end
-    end
-
-    context "when both billing entity code and id are provided" do
-      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
-
-      it "returns a validation error" do
-        result = execute_graphql(
-          current_user: membership.user,
-          current_organization: organization,
-          permissions: required_permission,
-          query:,
-          variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
-        )
-
-        expect_graphql_error(
-          result:,
-          message: "unprocessable_entity",
-          details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
-        )
       end
     end
   end

--- a/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::MrrsResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $billingEntityCode: String, $billingEntityId: ID) {
-        mrrs(currency: $currency, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
+      query($currency: CurrencyEnum, $billingEntityCode: String) {
+        mrrs(currency: $currency, billingEntityCode: $billingEntityCode) {
           collection {
             month
             amountCents
@@ -102,26 +102,6 @@ RSpec.describe Resolvers::Analytics::MrrsResolver do
         )
 
         expect_graphql_error(result:, message: "not_found")
-      end
-    end
-
-    context "when both billing entity code and id are provided" do
-      let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
-
-      it "returns a validation error" do
-        result = execute_graphql(
-          current_user: membership.user,
-          current_organization: organization,
-          permissions: required_permission,
-          query:,
-          variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
-        )
-
-        expect_graphql_error(
-          result:,
-          message: "unprocessable_entity",
-          details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
-        )
       end
     end
   end

--- a/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::OverdueBalancesResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean, $billingEntityCode: String, $billingEntityId: ID) {
-        overdueBalances(currency: $currency, externalCustomerId: $externalCustomerId, months: $months, expireCache: $expireCache, billingEntityCode: $billingEntityCode, billingEntityId: $billingEntityId) {
+      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean, $billingEntityCode: String) {
+        overdueBalances(currency: $currency, externalCustomerId: $externalCustomerId, months: $months, expireCache: $expireCache, billingEntityCode: $billingEntityCode) {
           collection {
             amountCents
             currency
@@ -105,26 +105,6 @@ RSpec.describe Resolvers::Analytics::OverdueBalancesResolver do
       )
 
       expect(result["data"]["overdueBalances"]["collection"]).to eq([])
-    end
-  end
-
-  context "when both billing entity code and id are provided" do
-    let(:billing_entity) { create(:billing_entity, organization:, code: "entity_01") }
-
-    it "returns a validation error" do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query:,
-        variables: {billingEntityCode: billing_entity.code, billingEntityId: billing_entity.id}
-      )
-
-      expect_graphql_error(
-        result:,
-        message: "unprocessable_entity",
-        details: {billingEntityId: ["can't be present when billing_entity_code is provided"]}
-      )
     end
   end
 end


### PR DESCRIPTION
## Context

Now that all five analytics resolvers accept `billingEntityCode`, the `billingEntityId` argument is redundant on most of them: the dashboard never sends it to `overdueBalances`, `invoiceCollections`, `mrrs` and `invoicedUsages`.

## Description

The `billingEntityId` argument is removed from `overdueBalances`, `invoiceCollections`, `mrrs` and `invoicedUsages`. Only `grossRevenues` keeps both arguments because the customer Usage tab still filters it by id; the id argument can be dropped once the front sends the code instead. The schema dumps were regenerated accordingly.

Split out of #5828, stacked on top of #5909.
