### PR TITLE
fix: refactor query for removing billable metric events

### DIFF
--- a/app/services/events/delete_for_metric_service.rb
+++ b/app/services/events/delete_for_metric_service.rb
@@ -15,18 +15,22 @@ module Events
 
       clickhouse_enabled = ENV["LAGO_CLICKHOUSE_ENABLED"].present?
 
-      # The subscription is queried in batches to avoid memory pressure
-      # and cross-database subqueries: events is built to live on a dedicated
-      # database (so is clickhouse) while subscriptions/charges live on the primary database.
-      subscriptions_relation.in_batches(of: BATCH_SIZE) do |batch|
-        rows = batch.pluck(:id, :external_id)
-        next if rows.empty?
+      billable_metric.charges.with_discarded.in_batches(of: CHARGE_BATCH_SIZE) do |charges|
+        plan_ids = charges.pluck(:plan_id).uniq
 
-        subscription_ids, external_subscription_ids = rows.transpose
+        # The subscription is queried in batches to avoid memory pressure
+        # and cross-database subqueries: events is built to live on a dedicated
+        # database (so is clickhouse) while subscriptions/charges live on the primary database.
+        Subscription.where(plan_id: plan_ids).in_batches(of: BATCH_SIZE) do |batch|
+          rows = batch.pluck(:id, :external_id)
+          next if rows.empty?
 
-        delete_postgres_events(subscription_ids, external_subscription_ids)
-        delete_clickhouse_events(external_subscription_ids) if clickhouse_enabled
-        expire_charge_caches(subscription_ids)
+          subscription_ids, external_subscription_ids = rows.transpose
+
+          delete_postgres_events(subscription_ids, external_subscription_ids)
+          delete_clickhouse_events(external_subscription_ids) if clickhouse_enabled
+          expire_charge_caches(subscription_ids)
+        end
       end
 
       result
@@ -35,6 +39,7 @@ module Events
     private
 
     BATCH_SIZE = 10_000
+    CHARGE_BATCH_SIZE = 1_000
     CLICKHOUSE_BATCH_SIZE = BATCH_SIZE / 2
     CLICKHOUSE_TABLES = {
       events_raw: :ingested_at,
@@ -46,16 +51,6 @@ module Events
     attr_reader :billable_metric, :deleted_at
 
     delegate :code, :organization_id, to: :billable_metric
-
-    def subscriptions_relation
-      # Explicit SQL join bypasses Charge's `default_scope -> { kept }` so
-      # discarded charges are still considered when collecting subscriptions.
-      Subscription
-        .joins(:plan)
-        .joins("INNER JOIN charges ON charges.plan_id = plans.id")
-        .where("charges.billable_metric_id = ?", billable_metric.id)
-        .distinct
-    end
 
     def delete_postgres_events(subscription_ids, external_subscription_ids)
       # Delete events having an old-style `subscription_id`

--- a/spec/services/events/delete_for_metric_service_spec.rb
+++ b/spec/services/events/delete_for_metric_service_spec.rb
@@ -69,6 +69,50 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
       end
     end
 
+    context "when a plan's charges span several charge batches" do
+      let(:second_charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
+
+      before do
+        stub_const("#{described_class}::CHARGE_BATCH_SIZE", 1)
+        second_charge
+        allow(Subscriptions::ChargeCacheService).to receive(:expire_for_subscriptions).and_call_original
+      end
+
+      it "processes the subscription twice but deletes its events idempotently" do
+        expect { service.call }
+          .to change { event.reload.deleted_at }.from(nil).to(billable_metric.deleted_at)
+
+        expect(Subscriptions::ChargeCacheService).to have_received(:expire_for_subscriptions).twice
+        expect(not_impacted_event.reload.deleted_at).to be_nil
+      end
+    end
+
+    context "with unrelated events" do
+      let(:other_metric) { create(:billable_metric, organization: billable_metric.organization) }
+      let(:other_metric_charge) { create(:standard_charge, plan: subscription.plan, billable_metric: other_metric) }
+      let(:other_metric_event) do
+        create(:event, code: other_metric.code, subscription_id: subscription.id, organization_id: billable_metric.organization_id, timestamp: event_timestamp, created_at: event_timestamp)
+      end
+      let(:other_organization) { create(:organization) }
+      let(:other_org_event) do
+        create(:event, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: other_organization.id, timestamp: event_timestamp, created_at: event_timestamp)
+      end
+
+      before do
+        other_metric_charge
+        other_metric_event
+        other_org_event
+      end
+
+      it "only deletes events matching the metric code and organization" do
+        service.call
+
+        expect(event.reload.deleted_at).to eq(billable_metric.deleted_at)
+        expect(other_metric_event.reload.deleted_at).to be_nil
+        expect(other_org_event.reload.deleted_at).to be_nil
+      end
+    end
+
     context "when event is received after billable_metric deletion" do
       let(:event) do
         create(
@@ -152,6 +196,26 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
         )
       end
 
+      let(:other_code_ch_event) do
+        create(
+          :clickhouse_events_raw,
+          organization_id: billable_metric.organization_id,
+          code: "#{billable_metric.code}_other",
+          external_subscription_id: subscription.external_id,
+          ingested_at: event_timestamp
+        )
+      end
+
+      let(:other_org_ch_event) do
+        create(
+          :clickhouse_events_raw,
+          organization_id: SecureRandom.uuid,
+          code: billable_metric.code,
+          external_subscription_id: subscription.external_id,
+          ingested_at: event_timestamp
+        )
+      end
+
       let(:ch_enriched_event) do
         create(
           :clickhouse_events_enriched,
@@ -197,6 +261,8 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
 
         ch_event
         not_impacted_ch_event
+        other_code_ch_event
+        other_org_ch_event
         ch_enriched_event
         not_impacted_ch_enriched_event
         ch_enriched_expanded_event
@@ -209,6 +275,10 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
         expect(Clickhouse::EventsRaw.where(transaction_id: ch_event.transaction_id).count)
           .to eq(0)
         expect(Clickhouse::EventsRaw.where(transaction_id: not_impacted_ch_event.transaction_id).count)
+          .to eq(1)
+        expect(Clickhouse::EventsRaw.where(transaction_id: other_code_ch_event.transaction_id).count)
+          .to eq(1)
+        expect(Clickhouse::EventsRaw.where(transaction_id: other_org_ch_event.transaction_id).count)
           .to eq(1)
       end
 

--- a/spec/services/events/delete_for_metric_service_spec.rb
+++ b/spec/services/events/delete_for_metric_service_spec.rb
@@ -48,6 +48,27 @@ RSpec.describe Events::DeleteForMetricService, clickhouse: true, transaction: fa
       end
     end
 
+    context "when the charges span several charge batches" do
+      let(:other_subscription) { create(:subscription) }
+      let(:other_charge) { create(:standard_charge, plan: other_subscription.plan, billable_metric:) }
+      let(:other_event) do
+        create(:event, code: billable_metric.code, subscription_id: other_subscription.id, organization_id: billable_metric.organization_id, timestamp: event_timestamp, created_at: event_timestamp)
+      end
+
+      before do
+        stub_const("#{described_class}::CHARGE_BATCH_SIZE", 1)
+        other_charge
+        other_event
+      end
+
+      it "deletes events for subscriptions across every charge batch" do
+        service.call
+
+        expect(event.reload.deleted_at).to eq(billable_metric.deleted_at)
+        expect(other_event.reload.deleted_at).to eq(billable_metric.deleted_at)
+      end
+    end
+
     context "when event is received after billable_metric deletion" do
       let(:event) do
         create(


### PR DESCRIPTION
## Context

`BillableMetrics::DeleteEventsJob` keeps timing out on EU production with `ActiveRecord::QueryCanceled`, even after the `index_charges_on_billable_metric_id_all` index. With retry: 0, every failure lands in the dead set and the deleted metric's events are never cleaned up.

The cursor query in `Events::DeleteForMetricService` joined subscriptions → plans → charges with a `DISTINCT ... ORDER BY subscriptions.id LIMIT n` shape, letting the planner walk subscriptions_pkey across all 19.4M rows on an unreliable cross-join estimate. The join only existed to bypass Charge's kept default scope.

## Description

Removed the join and split the query to rely on single-column stats and existing indexes:

- Walk billable_metric.charges.with_discarded in batches — discarded charges are found via `index_charges_on_billable_metric_id_all`, no join needed.
- Query Subscription.where(plan_id: ...) in batches — cursor is now `WHERE plan_id IN (...) AND id > ? ORDER BY id LIMIT n`, served by `index_subscriptions_on_plan_id`.

Plans spanning two charge batches get processed twice; this is idempotent.