### PR TITLE
[STA-6] misc(payment_provider_customer): Migrate to TypedResult

### DIFF
--- a/app/jobs/payment_provider_customers/adyen_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/adyen_checkout_url_job.rb
@@ -8,8 +8,7 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(adyen_customer)
-      result = PaymentProviderCustomers::AdyenService.new(adyen_customer).generate_checkout_url
-      result.raise_if_error!
+      PaymentProviderCustomers::AdyenService.call!(:generate_checkout_url, adyen_customer)
     end
   end
 end

--- a/app/jobs/payment_provider_customers/adyen_create_job.rb
+++ b/app/jobs/payment_provider_customers/adyen_create_job.rb
@@ -8,8 +8,7 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(adyen_customer)
-      result = PaymentProviderCustomers::AdyenService.new(adyen_customer).create
-      result.raise_if_error!
+      PaymentProviderCustomers::AdyenService.call!(:create, adyen_customer)
     end
   end
 end

--- a/app/jobs/payment_provider_customers/gocardless_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/gocardless_checkout_url_job.rb
@@ -10,8 +10,7 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(gocardless_customer)
-      result = PaymentProviderCustomers::GocardlessService.new(gocardless_customer).generate_checkout_url
-      result.raise_if_error!
+      PaymentProviderCustomers::GocardlessService.call!(:generate_checkout_url, gocardless_customer)
     end
   end
 end

--- a/app/jobs/payment_provider_customers/gocardless_create_job.rb
+++ b/app/jobs/payment_provider_customers/gocardless_create_job.rb
@@ -10,8 +10,7 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(gocardless_customer)
-      result = PaymentProviderCustomers::GocardlessService.new(gocardless_customer).create
-      result.raise_if_error!
+      PaymentProviderCustomers::GocardlessService.call!(:create, gocardless_customer)
     end
   end
 end

--- a/app/jobs/payment_provider_customers/moneyhash_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/moneyhash_checkout_url_job.rb
@@ -7,8 +7,7 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(moneyhash_customer)
-      result = PaymentProviderCustomers::MoneyhashService.new(moneyhash_customer).generate_checkout_url
-      result.raise_if_error!
+      PaymentProviderCustomers::MoneyhashService.call!(:generate_checkout_url, moneyhash_customer)
     end
   end
 end

--- a/app/jobs/payment_provider_customers/moneyhash_create_job.rb
+++ b/app/jobs/payment_provider_customers/moneyhash_create_job.rb
@@ -7,9 +7,7 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(moneyhash_customer)
-      result = PaymentProviderCustomers::MoneyhashService.new(moneyhash_customer).create
-
-      result.raise_if_error!
+      PaymentProviderCustomers::MoneyhashService.call!(:create, moneyhash_customer)
     end
   end
 end

--- a/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
@@ -10,9 +10,7 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(stripe_customer)
-      PaymentProviderCustomers::StripeService.new(stripe_customer)
-        .generate_checkout_url
-        .raise_if_error!
+      PaymentProviderCustomers::StripeService.call!(:generate_checkout_url, stripe_customer)
     rescue BaseService::UnauthorizedFailure, BaseService::ThirdPartyFailure => e
       Rails.logger.warn(e.message)
     end

--- a/app/jobs/payment_provider_customers/stripe_create_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_create_job.rb
@@ -10,8 +10,7 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(stripe_customer)
-      result = PaymentProviderCustomers::StripeService.new(stripe_customer).create
-      result.raise_if_error!
+      PaymentProviderCustomers::StripeService.call!(:create, stripe_customer)
     rescue BaseService::UnauthorizedFailure => e
       Rails.logger.warn(e.message)
     end

--- a/app/services/customers/generate_checkout_url_service.rb
+++ b/app/services/customers/generate_checkout_url_service.rb
@@ -20,7 +20,8 @@ module Customers
         )
       end
 
-      PaymentProviderCustomers::Factory.new_instance(provider_customer:).generate_checkout_url(send_webhook: false)
+      PaymentProviderCustomers::Factory.for(provider_customer)
+        .call(:generate_checkout_url, provider_customer, send_webhook: false)
     end
 
     private

--- a/app/services/payment_provider_customers/adyen_service.rb
+++ b/app/services/payment_provider_customers/adyen_service.rb
@@ -4,18 +4,23 @@ module PaymentProviderCustomers
   class AdyenService < BaseService
     include Lago::Adyen::ErrorHandlable
     include Customers::PaymentProviderFinder
+    include TypedResults
 
-    def initialize(adyen_customer = nil)
+    RESULTS = {
+      create: BaseResult[:adyen_customer, :checkout_url],
+      update: BaseResult,
+      generate_checkout_url: BaseResult[:checkout_url],
+      preauthorise: BaseResult[:adyen_customer]
+    }.freeze
+
+    private
+
+    def create(adyen_customer)
       @adyen_customer = adyen_customer
-
-      super(nil)
-    end
-
-    def create
       result.adyen_customer = adyen_customer
       return result if adyen_customer.provider_customer_id?
 
-      checkout_url_result = generate_checkout_url
+      checkout_url_result = generate_checkout_url(adyen_customer)
       return result unless checkout_url_result.success?
 
       result.checkout_url = checkout_url_result.checkout_url
@@ -27,11 +32,13 @@ module PaymentProviderCustomers
       result
     end
 
-    def update
+    def update(adyen_customer)
+      @adyen_customer = adyen_customer
       result
     end
 
-    def generate_checkout_url(send_webhook: true)
+    def generate_checkout_url(adyen_customer, send_webhook: true)
+      @adyen_customer = adyen_customer
       return result.not_found_failure!(resource: "adyen_payment_provider") unless adyen_payment_provider
 
       res = client.checkout.payment_links_api.payment_links(Lago::Adyen::Params.new(payment_link_params).to_h)
@@ -80,8 +87,6 @@ module PaymentProviderCustomers
       result.adyen_customer = adyen_customer
       result
     end
-
-    private
 
     attr_accessor :adyen_customer
 

--- a/app/services/payment_provider_customers/cashfree_service.rb
+++ b/app/services/payment_provider_customers/cashfree_service.rb
@@ -3,27 +3,31 @@
 module PaymentProviderCustomers
   class CashfreeService < BaseService
     include Customers::PaymentProviderFinder
+    include TypedResults
 
-    def initialize(cashfree_customer = nil)
+    RESULTS = {
+      create: BaseResult[:cashfree_customer],
+      update: BaseResult,
+      generate_checkout_url: BaseResult
+    }.freeze
+
+    private
+
+    def create(cashfree_customer)
       @cashfree_customer = cashfree_customer
-
-      super(nil)
-    end
-
-    def create
       result.cashfree_customer = cashfree_customer
       result
     end
 
-    def update
+    def update(cashfree_customer)
+      @cashfree_customer = cashfree_customer
       result
     end
 
-    def generate_checkout_url(send_webhook: true)
+    def generate_checkout_url(cashfree_customer, send_webhook: true)
+      @cashfree_customer = cashfree_customer
       result.not_allowed_failure!(code: "feature_not_supported")
     end
-
-    private
 
     attr_accessor :cashfree_customer
 

--- a/app/services/payment_provider_customers/factory.rb
+++ b/app/services/payment_provider_customers/factory.rb
@@ -2,11 +2,7 @@
 
 module PaymentProviderCustomers
   class Factory
-    def self.new_instance(provider_customer:)
-      service_class(provider_customer).new(provider_customer)
-    end
-
-    def self.service_class(provider_customer)
+    def self.for(provider_customer)
       case provider_customer&.class.to_s
       when "PaymentProviderCustomers::StripeCustomer"
         PaymentProviderCustomers::StripeService

--- a/app/services/payment_provider_customers/flutterwave_service.rb
+++ b/app/services/payment_provider_customers/flutterwave_service.rb
@@ -3,27 +3,31 @@
 module PaymentProviderCustomers
   class FlutterwaveService < BaseService
     include Customers::PaymentProviderFinder
+    include TypedResults
 
-    def initialize(flutterwave_customer = nil)
+    RESULTS = {
+      create: BaseResult[:flutterwave_customer],
+      update: BaseResult,
+      generate_checkout_url: BaseResult
+    }.freeze
+
+    private
+
+    def create(flutterwave_customer)
       @flutterwave_customer = flutterwave_customer
-
-      super(nil)
-    end
-
-    def create
       result.flutterwave_customer = flutterwave_customer
       result
     end
 
-    def update
+    def update(flutterwave_customer)
+      @flutterwave_customer = flutterwave_customer
       result
     end
 
-    def generate_checkout_url(send_webhook: true)
+    def generate_checkout_url(flutterwave_customer, send_webhook: true)
+      @flutterwave_customer = flutterwave_customer
       result.not_allowed_failure!(code: "feature_not_supported")
     end
-
-    private
 
     attr_accessor :flutterwave_customer
 

--- a/app/services/payment_provider_customers/gocardless_service.rb
+++ b/app/services/payment_provider_customers/gocardless_service.rb
@@ -3,14 +3,18 @@
 module PaymentProviderCustomers
   class GocardlessService < BaseService
     include Customers::PaymentProviderFinder
+    include TypedResults
 
-    def initialize(gocardless_customer = nil)
+    RESULTS = {
+      create: BaseResult[:gocardless_customer],
+      update: BaseResult,
+      generate_checkout_url: BaseResult[:checkout_url]
+    }.freeze
+
+    private
+
+    def create(gocardless_customer)
       @gocardless_customer = gocardless_customer
-
-      super(nil)
-    end
-
-    def create
       result.gocardless_customer = gocardless_customer
       return result if gocardless_customer.provider_customer_id?
 
@@ -27,11 +31,13 @@ module PaymentProviderCustomers
       result
     end
 
-    def update
+    def update(gocardless_customer)
+      @gocardless_customer = gocardless_customer
       result
     end
 
-    def generate_checkout_url(send_webhook: true)
+    def generate_checkout_url(gocardless_customer, send_webhook: true)
+      @gocardless_customer = gocardless_customer
       billing_request = create_billing_request(gocardless_customer.provider_customer_id)
       billing_request_flow = create_billing_request_flow(billing_request.id)
 
@@ -47,8 +53,6 @@ module PaymentProviderCustomers
 
       result
     end
-
-    private
 
     attr_accessor :gocardless_customer
 

--- a/app/services/payment_provider_customers/moneyhash_service.rb
+++ b/app/services/payment_provider_customers/moneyhash_service.rb
@@ -3,14 +3,20 @@
 module PaymentProviderCustomers
   class MoneyhashService < BaseService
     include Customers::PaymentProviderFinder
+    include TypedResults
 
-    def initialize(moneyhash_customer = nil)
+    RESULTS = {
+      create: BaseResult[:moneyhash_customer, :checkout_url],
+      update: BaseResult,
+      generate_checkout_url: BaseResult[:checkout_url],
+      update_payment_method: BaseResult[:moneyhash_customer, :payment_method],
+      delete_payment_method: BaseResult[:moneyhash_customer]
+    }.freeze
+
+    private
+
+    def create(moneyhash_customer)
       @moneyhash_customer = moneyhash_customer
-
-      super(nil)
-    end
-
-    def create
       result.moneyhash_customer = moneyhash_customer
       return result if moneyhash_customer.provider_customer_id?
       moneyhash_result = create_moneyhash_customer
@@ -28,17 +34,19 @@ module PaymentProviderCustomers
       )
       deliver_success_webhook
       result.moneyhash_customer = moneyhash_customer
-      checkout_url_result = generate_checkout_url
+      checkout_url_result = generate_checkout_url(moneyhash_customer)
       return result unless checkout_url_result.success?
       result.checkout_url = checkout_url_result.checkout_url
       result
     end
 
-    def update
+    def update(moneyhash_customer)
+      @moneyhash_customer = moneyhash_customer
       result
     end
 
-    def generate_checkout_url(send_webhook: true)
+    def generate_checkout_url(moneyhash_customer, send_webhook: true)
+      @moneyhash_customer = moneyhash_customer
       return result.not_found_failure!(resource: "moneyhash_payment_provider") unless moneyhash_payment_provider
       return result.not_found_failure!(resource: "moneyhash_customer") unless moneyhash_customer
 
@@ -108,8 +116,6 @@ module PaymentProviderCustomers
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     end
-
-    private
 
     attr_accessor :moneyhash_customer
 

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -3,14 +3,19 @@
 module PaymentProviderCustomers
   class StripeService < BaseService
     include Customers::PaymentProviderFinder
+    include TypedResults
 
-    def initialize(stripe_customer = nil)
+    RESULTS = {
+      create: BaseResult[:stripe_customer],
+      update: BaseResult,
+      generate_checkout_url: BaseResult[:checkout_url],
+      delete_payment_method: BaseResult[:stripe_customer, :payment_method]
+    }.freeze
+
+    private
+
+    def create(stripe_customer)
       @stripe_customer = stripe_customer
-
-      super(nil)
-    end
-
-    def create
       return result unless customer
 
       result.stripe_customer = stripe_customer
@@ -33,7 +38,8 @@ module PaymentProviderCustomers
       result
     end
 
-    def update
+    def update(stripe_customer)
+      @stripe_customer = stripe_customer
       return result if !stripe_payment_provider || stripe_customer.provider_customer_id.blank?
 
       ::Stripe::Customer.update(stripe_customer.provider_customer_id, stripe_update_payload, {api_key:})
@@ -72,7 +78,8 @@ module PaymentProviderCustomers
       result.record_validation_failure!(record: e.record)
     end
 
-    def generate_checkout_url(send_webhook: true)
+    def generate_checkout_url(stripe_customer, send_webhook: true)
+      @stripe_customer = stripe_customer
       return result unless customer # NOTE: Customer is nil when deleted.
       return result if customer.organization.webhook_endpoints.none? && send_webhook && payment_provider(customer)
 
@@ -101,8 +108,6 @@ module PaymentProviderCustomers
       message = ["Stripe authentication failed.", e.message.presence].compact.join(" ")
       result.unauthorized_failure!(message:)
     end
-
-    private
 
     attr_accessor :stripe_customer
 

--- a/app/services/payment_provider_customers/update_service.rb
+++ b/app/services/payment_provider_customers/update_service.rb
@@ -13,9 +13,8 @@ module PaymentProviderCustomers
     end
 
     def call
-      result = PaymentProviderCustomers::Factory.new_instance(provider_customer: customer.provider_customer).update
-      result.raise_if_error!
-      result
+      provider_customer = customer.provider_customer
+      PaymentProviderCustomers::Factory.for(provider_customer).call!(:update, provider_customer)
     end
   end
 end

--- a/app/services/payment_providers/adyen/handle_event_service.rb
+++ b/app/services/payment_providers/adyen/handle_event_service.rb
@@ -39,10 +39,7 @@ module PaymentProviders
 
           return result if amount != 0
 
-          service = PaymentProviderCustomers::AdyenService.new
-
-          result = service.preauthorise(organization, event)
-          result.raise_if_error!
+          PaymentProviderCustomers::AdyenService.call!(:preauthorise, organization, event)
         when "CANCELLATION"
           # Adyen uses originalReference to point at the cancelled payment;
           # pspReference is the cancel modification's own id.

--- a/app/services/payment_providers/moneyhash/handle_event_service.rb
+++ b/app/services/payment_providers/moneyhash/handle_event_service.rb
@@ -117,24 +117,26 @@ module PaymentProviders
       end
 
       def handle_card_token_deleted
-        PaymentProviderCustomers::MoneyhashService.new
-          .delete_payment_method(
+        PaymentProviderCustomers::MoneyhashService
+          .call!(
+            :delete_payment_method,
             organization_id: organization.id,
             customer_id: card_token.dig("custom_fields", "lago_customer_id"),
             payment_method_id: card_token["id"],
             metadata: card_token["custom_fields"]
-          ).raise_if_error!
+          )
       end
 
       def handle_card_token_created_or_updated
-        PaymentProviderCustomers::MoneyhashService.new
-          .update_payment_method(
+        PaymentProviderCustomers::MoneyhashService
+          .call!(
+            :update_payment_method,
             organization_id: organization.id,
             customer_id: card_token.dig("custom_fields", "lago_customer_id"),
             payment_method_id: card_token["id"],
             metadata: card_token["custom_fields"],
             card_details: extract_card_details
-          ).raise_if_error!
+          )
       end
 
       def card_token

--- a/app/services/payment_providers/stripe/handle_event_service.rb
+++ b/app/services/payment_providers/stripe/handle_event_service.rb
@@ -37,13 +37,13 @@ module PaymentProviders
         case event.type
         when "payment_method.detached"
           PaymentProviderCustomers::StripeService
-            .new
-            .delete_payment_method(
+            .call!(
+              :delete_payment_method,
               organization_id: organization.id,
               stripe_customer_id: event.data.object.customer || event.data.previous_attributes.customer,
               payment_method_id: event.data.object.id,
               metadata: event.data.object.metadata.to_h.symbolize_keys
-            ).raise_if_error!
+            )
         when "charge.refund.updated"
           CreditNotes::Refunds::StripeService
             .new.update_status(

--- a/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
@@ -7,18 +7,12 @@ RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob do
 
   let(:gocardless_customer) { create(:gocardless_customer) }
 
-  let(:gocardless_service) { instance_double(PaymentProviderCustomers::GocardlessService) }
-
   it "calls generate_checkout_url method" do
-    allow(PaymentProviderCustomers::GocardlessService).to receive(:new)
-      .with(gocardless_customer)
-      .and_return(gocardless_service)
-    allow(gocardless_service).to receive(:generate_checkout_url)
+    allow(PaymentProviderCustomers::GocardlessService).to receive(:call!)
       .and_return(BaseService::Result.new)
 
     gocardless_checkout_job.perform_now(gocardless_customer)
 
-    expect(PaymentProviderCustomers::GocardlessService).to have_received(:new)
-    expect(gocardless_service).to have_received(:generate_checkout_url)
+    expect(PaymentProviderCustomers::GocardlessService).to have_received(:call!).with(:generate_checkout_url, gocardless_customer)
   end
 end

--- a/spec/jobs/payment_provider_customers/gocardless_create_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_create_job_spec.rb
@@ -5,18 +5,12 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::GocardlessCreateJob do
   let(:gocardless_customer) { create(:gocardless_customer) }
 
-  let(:gocardless_service) { instance_double(PaymentProviderCustomers::GocardlessService) }
-
   it "calls the gocardless create service" do
-    allow(PaymentProviderCustomers::GocardlessService).to receive(:new)
-      .with(gocardless_customer)
-      .and_return(gocardless_service)
-    allow(gocardless_service).to receive(:create)
+    allow(PaymentProviderCustomers::GocardlessService).to receive(:call!)
       .and_return(BaseService::Result.new)
 
     described_class.perform_now(gocardless_customer)
 
-    expect(PaymentProviderCustomers::GocardlessService).to have_received(:new)
-    expect(gocardless_service).to have_received(:create)
+    expect(PaymentProviderCustomers::GocardlessService).to have_received(:call!).with(:create, gocardless_customer)
   end
 end

--- a/spec/jobs/payment_provider_customers/stripe_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_checkout_url_job_spec.rb
@@ -7,18 +7,12 @@ RSpec.describe PaymentProviderCustomers::StripeCheckoutUrlJob do
 
   let(:stripe_customer) { create(:stripe_customer) }
 
-  let(:stripe_service) { instance_double(PaymentProviderCustomers::StripeService) }
-
   it "calls generate_checkout_url method" do
-    allow(PaymentProviderCustomers::StripeService).to receive(:new)
-      .with(stripe_customer)
-      .and_return(stripe_service)
-    allow(stripe_service).to receive(:generate_checkout_url)
+    allow(PaymentProviderCustomers::StripeService).to receive(:call!)
       .and_return(BaseService::Result.new)
 
     stripe_checkout_job.perform_now(stripe_customer)
 
-    expect(PaymentProviderCustomers::StripeService).to have_received(:new)
-    expect(stripe_service).to have_received(:generate_checkout_url)
+    expect(PaymentProviderCustomers::StripeService).to have_received(:call!).with(:generate_checkout_url, stripe_customer)
   end
 end

--- a/spec/jobs/payment_provider_customers/stripe_create_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_create_job_spec.rb
@@ -5,18 +5,12 @@ require "rails_helper"
 RSpec.describe PaymentProviderCustomers::StripeCreateJob do
   let(:stripe_customer) { create(:stripe_customer) }
 
-  let(:stripe_service) { instance_double(PaymentProviderCustomers::StripeService) }
-
   it "calls the stripe create service" do
-    allow(PaymentProviderCustomers::StripeService).to receive(:new)
-      .with(stripe_customer)
-      .and_return(stripe_service)
-    allow(stripe_service).to receive(:create)
+    allow(PaymentProviderCustomers::StripeService).to receive(:call!)
       .and_return(BaseService::Result.new)
 
     described_class.perform_now(stripe_customer)
 
-    expect(PaymentProviderCustomers::StripeService).to have_received(:new)
-    expect(stripe_service).to have_received(:create)
+    expect(PaymentProviderCustomers::StripeService).to have_received(:call!).with(:create, stripe_customer)
   end
 end

--- a/spec/services/customers/generate_checkout_url_service_spec.rb
+++ b/spec/services/customers/generate_checkout_url_service_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Customers::GenerateCheckoutUrlService do
 
   describe ".call" do
     let(:stripe_provider) { create(:stripe_provider, organization:) }
-    let(:stripe_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
 
     context "when payment provider is linked" do
       before do
@@ -22,11 +21,8 @@ RSpec.describe Customers::GenerateCheckoutUrlService do
 
         customer.update(payment_provider: "stripe")
 
-        allow(PaymentProviderCustomers::StripeService).to receive(:new)
-          .and_return(stripe_customer_service)
-
-        allow(stripe_customer_service).to receive(:generate_checkout_url)
-          .with(send_webhook: false)
+        allow(PaymentProviderCustomers::StripeService).to receive(:call)
+          .with(:generate_checkout_url, anything, send_webhook: false)
           .and_return(BaseResult[:checkout_url].new.tap { |r| r.checkout_url = "http://foo.bar" })
       end
 

--- a/spec/services/payment_provider_customers/adyen_service_spec.rb
+++ b/spec/services/payment_provider_customers/adyen_service_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviderCustomers::AdyenService do
-  let(:adyen_service) { described_class.new(adyen_customer) }
   let(:customer) { create(:customer, organization:) }
   let(:adyen_provider) { create(:adyen_provider) }
   let(:organization) { adyen_provider.organization }
@@ -23,8 +22,8 @@ RSpec.describe PaymentProviderCustomers::AdyenService do
     allow(payment_links_api).to receive(:payment_links).and_return(payment_links_response)
   end
 
-  describe "#create" do
-    subject(:adyen_service_create) { adyen_service.create }
+  describe ".call(:create)" do
+    subject(:adyen_service_create) { described_class.call(:create, adyen_customer) }
 
     context "when customer does not have an adyen customer id yet" do
       it "calls adyen api client payment links" do
@@ -84,7 +83,7 @@ RSpec.describe PaymentProviderCustomers::AdyenService do
       end
 
       it "delivers an error webhook" do
-        expect { adyen_service.create }
+        expect { described_class.call(:create, adyen_customer) }
           .to raise_error(Adyen::AdyenError)
 
         expect(SendWebhookJob).to have_been_enqueued
@@ -106,7 +105,7 @@ RSpec.describe PaymentProviderCustomers::AdyenService do
       end
 
       it "delivers an error webhook" do
-        expect(adyen_service.create).to be_success
+        expect(described_class.call(:create, adyen_customer)).to be_success
 
         expect(SendWebhookJob).to have_been_enqueued
           .with(
@@ -121,14 +120,18 @@ RSpec.describe PaymentProviderCustomers::AdyenService do
     end
   end
 
-  describe "#update" do
+  describe ".call(:update)" do
     it "returns result" do
-      expect(adyen_service.update).to be_a(BaseService::Result)
+      expect(described_class.call(:update, adyen_customer)).to be_a(BaseResult)
     end
   end
 
   describe "#success_redirect_url" do
-    subject(:success_redirect_url) { adyen_service.__send__(:success_redirect_url) }
+    subject(:success_redirect_url) do
+      service = described_class.new
+      service.instance_variable_set(:@adyen_customer, adyen_customer)
+      service.__send__(:success_redirect_url)
+    end
 
     context "when payment provider has success redirect url" do
       it "returns payment provider's success redirect url" do
@@ -145,12 +148,12 @@ RSpec.describe PaymentProviderCustomers::AdyenService do
     end
   end
 
-  describe "#generate_checkout_url" do
+  describe ".call(:generate_checkout_url)" do
     context "when adyen payment provider is nil" do
       before { adyen_provider.destroy! }
 
       it "returns a not found error" do
-        result = adyen_service.generate_checkout_url
+        result = described_class.call(:generate_checkout_url, adyen_customer)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::NotFoundFailure)
@@ -159,7 +162,7 @@ RSpec.describe PaymentProviderCustomers::AdyenService do
     end
 
     context "when adyen payment provider is present" do
-      subject(:generate_checkout_url) { adyen_service.generate_checkout_url }
+      subject(:generate_checkout_url) { described_class.call(:generate_checkout_url, adyen_customer) }
 
       it "generates a checkout url" do
         expect(generate_checkout_url).to be_success
@@ -188,8 +191,8 @@ RSpec.describe PaymentProviderCustomers::AdyenService do
     end
   end
 
-  describe "#preauthorise" do
-    subject(:preauthorise) { described_class.new.preauthorise(organization, event) }
+  describe ".call(:preauthorise)" do
+    subject(:preauthorise) { described_class.call(:preauthorise, organization, event) }
 
     let(:payment_method_id) { "pm_adyen_123456" }
     let(:shopper_reference) { customer.external_id }

--- a/spec/services/payment_provider_customers/flutterwave_service_spec.rb
+++ b/spec/services/payment_provider_customers/flutterwave_service_spec.rb
@@ -3,33 +3,31 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviderCustomers::FlutterwaveService do
-  subject(:flutterwave_service) { described_class.new(flutterwave_customer) }
-
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization: organization) }
   let(:flutterwave_provider) { create(:flutterwave_provider, organization: organization) }
   let(:flutterwave_customer) { create(:flutterwave_customer, customer: customer, payment_provider: flutterwave_provider) }
 
-  describe "#create" do
+  describe ".call(:create)" do
     it "returns success with the flutterwave customer" do
-      result = flutterwave_service.create
+      result = described_class.call(:create, flutterwave_customer)
 
       expect(result).to be_success
       expect(result.flutterwave_customer).to eq(flutterwave_customer)
     end
   end
 
-  describe "#update" do
+  describe ".call(:update)" do
     it "returns success" do
-      result = flutterwave_service.update
+      result = described_class.call(:update, flutterwave_customer)
 
       expect(result).to be_success
     end
   end
 
-  describe "#generate_checkout_url" do
+  describe ".call(:generate_checkout_url)" do
     it "returns not allowed failure" do
-      result = flutterwave_service.generate_checkout_url
+      result = described_class.call(:generate_checkout_url, flutterwave_customer)
 
       expect(result).not_to be_success
       expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
@@ -38,7 +36,7 @@ RSpec.describe PaymentProviderCustomers::FlutterwaveService do
 
     context "when send_webhook is false" do
       it "returns not allowed failure" do
-        result = flutterwave_service.generate_checkout_url(send_webhook: false)
+        result = described_class.call(:generate_checkout_url, flutterwave_customer, send_webhook: false)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
@@ -50,7 +48,10 @@ RSpec.describe PaymentProviderCustomers::FlutterwaveService do
   describe "private methods" do
     describe "#customer" do
       it "delegates to flutterwave_customer" do
-        expect(flutterwave_service.send(:customer)).to eq(customer)
+        service = described_class.new
+        service.instance_variable_set(:@flutterwave_customer, flutterwave_customer)
+
+        expect(service.send(:customer)).to eq(customer)
       end
     end
   end

--- a/spec/services/payment_provider_customers/gocardless_service_spec.rb
+++ b/spec/services/payment_provider_customers/gocardless_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviderCustomers::GocardlessService do
-  subject(:gocardless_service) { described_class.new(gocardless_customer) }
-
   let(:customer) { create(:customer, organization:) }
   let(:gocardless_provider) { create(:gocardless_provider) }
   let(:organization) { gocardless_provider.organization }
@@ -17,7 +15,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
     create(:gocardless_customer, customer:, provider_customer_id: nil)
   end
 
-  describe ".create" do
+  describe ".call(:create)" do
     before do
       allow(GoCardlessPro::Client).to receive(:new)
         .and_return(gocardless_client)
@@ -29,7 +27,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
 
     context "when all customer details are present" do
       it "creates a customer with company_name, given_name, and family_name" do
-        gocardless_service.create
+        described_class.call(:create, gocardless_customer)
         expect(gocardless_customers_service).to have_received(:create).with(
           hash_including(
             params: {
@@ -44,14 +42,14 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
     end
 
     it "creates the gocardless customer" do
-      result = gocardless_service.create
+      result = described_class.call(:create, gocardless_customer)
 
       expect(gocardless_customers_service).to have_received(:create)
       expect(result.gocardless_customer.provider_customer_id).to eq("123")
     end
 
     it "delivers a success webhook" do
-      gocardless_service.create
+      described_class.call(:create, gocardless_customer)
 
       expect(gocardless_customers_service).to have_received(:create)
       expect(SendWebhookJob).to have_been_enqueued
@@ -59,7 +57,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
     end
 
     it "triggers checkout job" do
-      gocardless_service.create
+      described_class.call(:create, gocardless_customer)
 
       expect(gocardless_customers_service).to have_received(:create)
       expect(PaymentProviderCustomers::GocardlessCheckoutUrlJob).to have_been_enqueued
@@ -72,7 +70,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
       end
 
       it "does not call gocardless API" do
-        gocardless_service.create
+        described_class.call(:create, gocardless_customer)
 
         expect(gocardless_customers_service).not_to have_received(:create)
       end
@@ -83,7 +81,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
         allow(GoCardlessPro::Client).to receive(:new)
           .and_raise(GoCardlessPro::ApiError.new({"message" => "error"}))
 
-        expect { gocardless_service.create }
+        expect { described_class.call(:create, gocardless_customer) }
           .to raise_error(GoCardlessPro::ApiError)
 
         expect(SendWebhookJob).to have_been_enqueued
@@ -99,13 +97,13 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
     end
   end
 
-  describe "#update" do
+  describe ".call(:update)" do
     it "returns result" do
-      expect(gocardless_service.update).to be_a(BaseService::Result)
+      expect(described_class.call(:update, gocardless_customer)).to be_a(BaseResult)
     end
   end
 
-  describe ".generate_checkout_url" do
+  describe ".call(:generate_checkout_url)" do
     before do
       allow(GoCardlessPro::Client).to receive(:new)
         .and_return(gocardless_client)
@@ -121,14 +119,14 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
     end
 
     it "receives billing request flow response" do
-      gocardless_service.generate_checkout_url
+      described_class.call(:generate_checkout_url, gocardless_customer)
 
       expect(gocardless_billing_request_service).to have_received(:create)
       expect(gocardless_billing_request_flow_service).to have_received(:create)
     end
 
     it "delivers a webhook with checkout url" do
-      gocardless_service.generate_checkout_url
+      described_class.call(:generate_checkout_url, gocardless_customer)
 
       expect(gocardless_billing_request_service).to have_received(:create)
       expect(gocardless_billing_request_flow_service).to have_received(:create)
@@ -138,7 +136,11 @@ RSpec.describe PaymentProviderCustomers::GocardlessService do
   end
 
   describe "#success_redirect_url" do
-    subject(:success_redirect_url) { gocardless_service.__send__(:success_redirect_url) }
+    subject(:success_redirect_url) do
+      service = described_class.new
+      service.instance_variable_set(:@gocardless_customer, gocardless_customer)
+      service.__send__(:success_redirect_url)
+    end
 
     context "when payment provider has success redirect url" do
       it "returns payment provider's success redirect url" do

--- a/spec/services/payment_provider_customers/moneyhash_service_spec.rb
+++ b/spec/services/payment_provider_customers/moneyhash_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviderCustomers::MoneyhashService do
-  subject(:moneyhash_service) { described_class.new(moneyhash_customer) }
-
   let(:customer) { create(:customer, name: customer_name, organization:) }
   let(:moneyhash_provider) { create(:moneyhash_provider) }
   let(:organization) { moneyhash_provider.organization }
@@ -14,17 +12,15 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
     create(:moneyhash_customer, customer:, provider_customer_id: nil, payment_provider: moneyhash_provider)
   end
 
-  describe "#create" do
+  describe ".call(:create)" do
     context "when provider_customer_id is already present" do
-      before {
-        moneyhash_customer.update(provider_customer_id: SecureRandom.uuid)
-        allow(moneyhash_service).to receive(:create_moneyhash_customer) # rubocop:disable RSpec/SubjectStub
-      }
+      before { moneyhash_customer.update(provider_customer_id: SecureRandom.uuid) }
 
       it "does not call moneyhash customers API" do
-        result = moneyhash_service.create
+        expect_any_instance_of(described_class).not_to receive(:create_moneyhash_customer) # rubocop:disable RSpec/AnyInstance
+
+        result = described_class.call(:create, moneyhash_customer)
         expect(result).to be_success
-        expect(moneyhash_service).not_to have_received(:create_moneyhash_customer) # rubocop:disable RSpec/SubjectStub
       end
     end
 
@@ -37,32 +33,30 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
       let(:endpoint) { "#{PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/" }
 
       before do
-        allow(moneyhash_service).to receive(:create_moneyhash_customer).and_return(moneyhash_result) # rubocop:disable RSpec/SubjectStub
-        allow(moneyhash_service).to receive(:deliver_success_webhook) # rubocop:disable RSpec/SubjectStub
-
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(checkout_url_response.to_json)
       end
 
       it "creates the moneyhash customer, checkout_url, and sends a success webhook" do
-        result = moneyhash_service.create
+        allow_any_instance_of(described_class).to receive(:create_moneyhash_customer).and_return(moneyhash_result) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(described_class).to receive(:deliver_success_webhook) # rubocop:disable RSpec/AnyInstance
+
+        result = described_class.call(:create, moneyhash_customer)
         expect(result).to be_success
         expect(moneyhash_customer.reload.provider_customer_id).to eq(moneyhash_result["data"]["id"])
         expect(result.checkout_url).to eq("#{checkout_url_response["data"]["embed_url"]}?lago_request=generate_checkout_url")
-        expect(moneyhash_service).to have_received(:create_moneyhash_customer) # rubocop:disable RSpec/SubjectStub
-        expect(moneyhash_service).to have_received(:deliver_success_webhook) # rubocop:disable RSpec/SubjectStub
       end
     end
 
-    describe "#update" do
+    describe ".call(:update)" do
       it "returns a success result" do
-        result = moneyhash_service.update
+        result = described_class.call(:update, moneyhash_customer)
         expect(result).to be_success
       end
     end
 
-    describe "#update_payment_method" do
+    describe ".call(:update_payment_method)" do
       let(:custom_fields) do
         {
           lago_mit: false,
@@ -76,17 +70,16 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
 
       let(:payment_method_id) { SecureRandom.uuid }
 
-      let(:moneyhash_customer) do
+      let!(:moneyhash_customer) do
         create(:moneyhash_customer, customer:, provider_customer_id: SecureRandom.uuid)
       end
 
       it "updates the payment method for existing customer" do
-        result = moneyhash_service.update_payment_method(
+        result = described_class.call(:update_payment_method,
           organization_id: organization.id,
           customer_id: customer.id,
           payment_method_id: payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
         expect(result).to be_success
         expect(moneyhash_customer.reload.payment_method_id).to eq(payment_method_id)
       end
@@ -94,11 +87,10 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
       it "deletes the payment method for existing customer" do
         moneyhash_customer.update(payment_method_id: SecureRandom.uuid)
 
-        result = moneyhash_service.update_payment_method(
+        result = described_class.call(:update_payment_method,
           organization_id: organization.id,
           customer_id: customer.id,
-          payment_method_id: nil
-        )
+          payment_method_id: nil)
         expect(result).to be_success
         expect(moneyhash_customer.reload.payment_method_id).to be_nil
       end
@@ -106,24 +98,22 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
       it "overrides the payment method for existing customer" do
         moneyhash_customer.update(payment_method_id: SecureRandom.uuid)
 
-        result = moneyhash_service.update_payment_method(
+        result = described_class.call(:update_payment_method,
           organization_id: organization.id,
           customer_id: customer.id,
           payment_method_id: payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
         expect(result).to be_success
         expect(moneyhash_customer.reload.payment_method_id).to eq(payment_method_id)
       end
 
       it "returns result directly when lago_customer_id is not present" do
         custom_fields.delete("lago_customer_id")
-        result = moneyhash_service.update_payment_method(
+        result = described_class.call(:update_payment_method,
           organization_id: organization.id,
           customer_id: customer.id,
           payment_method_id: payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
 
         expect(result).to be_success
       end
@@ -131,12 +121,11 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
       it "returns result directly when customer is not found" do
         custom_fields["lago_customer_id"] = SecureRandom.uuid
 
-        result = moneyhash_service.update_payment_method(
+        result = described_class.call(:update_payment_method,
           organization_id: organization.id,
           customer_id: SecureRandom.uuid,
           payment_method_id: payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
 
         expect(result).to be_success
       end
@@ -145,12 +134,11 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
         customer = create(:customer, organization:)
         custom_fields["lago_customer_id"] = customer.id
 
-        result = moneyhash_service.update_payment_method(
+        result = described_class.call(:update_payment_method,
           organization_id: organization.id,
           customer_id: customer.id,
           payment_method_id: payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
 
         expect(result).to be_failure
         expect(result.error.to_s).to eq("moneyhash_customer_not_found")
@@ -158,12 +146,11 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
 
       it "creates a PaymentMethod record" do
         expect {
-          moneyhash_service.update_payment_method(
+          described_class.call(:update_payment_method,
             organization_id: organization.id,
             customer_id: customer.id,
             payment_method_id: payment_method_id,
-            metadata: custom_fields
-          )
+            metadata: custom_fields)
         }.to change(PaymentMethod, :count).by(1)
 
         payment_method = PaymentMethod.last
@@ -177,12 +164,11 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
       end
 
       it "returns the payment_method in the result" do
-        result = moneyhash_service.update_payment_method(
+        result = described_class.call(:update_payment_method,
           organization_id: organization.id,
           customer_id: customer.id,
           payment_method_id: payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
 
         expect(result).to be_success
         expect(result.payment_method).to be_present
@@ -201,13 +187,12 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
         end
 
         it "stores card details in PaymentMethod.details" do
-          result = moneyhash_service.update_payment_method(
+          result = described_class.call(:update_payment_method,
             organization_id: organization.id,
             customer_id: customer.id,
             payment_method_id: payment_method_id,
             metadata: custom_fields,
-            card_details: card_details
-          )
+            card_details: card_details)
 
           expect(result).to be_success
           expect(result.payment_method.details).to include(
@@ -224,13 +209,12 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
         it "does not call UpdateDetailsService" do
           allow(PaymentMethods::UpdateDetailsService).to receive(:call)
 
-          moneyhash_service.update_payment_method(
+          described_class.call(:update_payment_method,
             organization_id: organization.id,
             customer_id: customer.id,
             payment_method_id: payment_method_id,
             metadata: custom_fields,
-            card_details: {}
-          )
+            card_details: {})
 
           expect(PaymentMethods::UpdateDetailsService).not_to have_received(:call)
         end
@@ -246,12 +230,11 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
         )
 
         expect {
-          moneyhash_service.update_payment_method(
+          described_class.call(:update_payment_method,
             organization_id: organization.id,
             customer_id: customer.id,
             payment_method_id: payment_method_id,
-            metadata: custom_fields
-          )
+            metadata: custom_fields)
         }.not_to change(PaymentMethod, :count)
 
         expect(existing_payment_method.reload.is_default).to be(true)
@@ -259,17 +242,16 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
 
       it "does not create PaymentMethod when payment_method_id is nil" do
         expect {
-          moneyhash_service.update_payment_method(
+          described_class.call(:update_payment_method,
             organization_id: organization.id,
             customer_id: customer.id,
             payment_method_id: nil,
-            metadata: custom_fields
-          )
+            metadata: custom_fields)
         }.not_to change(PaymentMethod, :count)
       end
     end
 
-    describe "#generate_checkout_url currency fallback" do
+    describe ".call(:generate_checkout_url) currency fallback" do
       let(:lago_client) { instance_double(LagoHttpClient::Client) }
       let(:checkout_url_response) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/checkout_url_response.json"))) }
       let(:response) { instance_double(Net::HTTPOK) }
@@ -286,7 +268,7 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
         let(:customer) { create(:customer, name: customer_name, organization:, currency: nil) }
 
         it "falls back to the organization default currency" do
-          moneyhash_service.generate_checkout_url(send_webhook: false)
+          described_class.call(:generate_checkout_url, moneyhash_customer, send_webhook: false)
           expect(lago_client).to have_received(:post_with_response).with(
             hash_including(amount_currency: organization.default_currency),
             anything
@@ -295,7 +277,7 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
       end
     end
 
-    describe "#delete_payment_method" do
+    describe ".call(:delete_payment_method)" do
       let(:custom_fields) do
         {
           lago_customer_id: customer.id
@@ -304,17 +286,16 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
 
       let(:payment_method_id) { SecureRandom.uuid }
 
-      let(:moneyhash_customer) do
+      let!(:moneyhash_customer) do
         create(:moneyhash_customer, customer:, provider_customer_id: SecureRandom.uuid, payment_method_id:)
       end
 
       it "clears the default payment_method_id when it matches" do
-        result = moneyhash_service.delete_payment_method(
+        result = described_class.call(:delete_payment_method,
           organization_id: organization.id,
           customer_id: customer.id,
           payment_method_id: payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
 
         expect(result).to be_success
         expect(moneyhash_customer.reload.payment_method_id).to be_nil
@@ -323,12 +304,11 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
       it "does not clear payment_method_id when it does not match" do
         other_payment_method_id = SecureRandom.uuid
 
-        result = moneyhash_service.delete_payment_method(
+        result = described_class.call(:delete_payment_method,
           organization_id: organization.id,
           customer_id: customer.id,
           payment_method_id: other_payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
 
         expect(result).to be_success
         expect(moneyhash_customer.reload.payment_method_id).to eq(payment_method_id)
@@ -346,24 +326,22 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
 
         it "soft-deletes the PaymentMethod record" do
           expect {
-            moneyhash_service.delete_payment_method(
+            described_class.call(:delete_payment_method,
               organization_id: organization.id,
               customer_id: customer.id,
               payment_method_id: payment_method_id,
-              metadata: custom_fields
-            )
+              metadata: custom_fields)
           }.to change { payment_method.reload.discarded? }.from(false).to(true)
         end
 
         it "does not fail when PaymentMethod record does not exist" do
           payment_method.destroy!
 
-          result = moneyhash_service.delete_payment_method(
+          result = described_class.call(:delete_payment_method,
             organization_id: organization.id,
             customer_id: customer.id,
             payment_method_id: payment_method_id,
-            metadata: custom_fields
-          )
+            metadata: custom_fields)
 
           expect(result).to be_success
         end
@@ -373,12 +351,11 @@ RSpec.describe PaymentProviderCustomers::MoneyhashService do
         other_customer = create(:customer, organization:)
         custom_fields["lago_customer_id"] = other_customer.id
 
-        result = moneyhash_service.delete_payment_method(
+        result = described_class.call(:delete_payment_method,
           organization_id: organization.id,
           customer_id: other_customer.id,
           payment_method_id: payment_method_id,
-          metadata: custom_fields
-        )
+          metadata: custom_fields)
 
         expect(result).to be_failure
         expect(result.error.to_s).to eq("moneyhash_customer_not_found")

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviderCustomers::StripeService do
-  subject(:stripe_service) { described_class.new(stripe_customer) }
-
   let(:customer) { create(:customer, name: customer_name, organization:) }
   let(:stripe_provider) { create(:stripe_provider) }
   let(:organization) { stripe_provider.organization }
@@ -14,7 +12,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
     create(:stripe_customer, customer:, provider_customer_id: nil)
   end
 
-  describe "#create" do
+  describe ".call(:create)" do
     context "when customer is deleted" do
       before do
         customer.discard!
@@ -22,7 +20,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       end
 
       it "returns a deleted_customer failure" do
-        result = stripe_service.create
+        result = described_class.call(:create, stripe_customer)
 
         expect(result).to be_success
         expect(result.stripe_customer).to be_nil
@@ -37,7 +35,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
           .and_return(Stripe::Customer.new(id: "cus_123456"))
 
         expect do
-          stripe_service.create
+          described_class.call(:create, stripe_customer)
         end.to have_enqueued_job_after_commit(PaymentProviderCustomers::StripeCheckoutUrlJob).with(stripe_customer)
 
         expect(Stripe::Customer).to have_received(:create).with(hash_including(name: customer_name), anything)
@@ -53,7 +51,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       end
 
       it "enqueues StripeSyncFundingInstructionsJob" do
-        stripe_service.create
+        described_class.call(:create, stripe_customer)
 
         expect(PaymentProviderCustomers::StripeSyncFundingInstructionsJob)
           .to have_been_enqueued.with(stripe_customer)
@@ -65,7 +63,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       it "creates a stripe customer with the customer firstname and lastname" do
         allow(Stripe::Customer).to receive(:create)
           .and_return(Stripe::Customer.new(id: "cus_123456"))
-        stripe_service.create
+        described_class.call(:create, stripe_customer)
 
         expected_name = "#{customer.firstname} #{customer.lastname}"
         expect(Stripe::Customer).to have_received(:create).with(hash_including(name: expected_name), anything)
@@ -76,7 +74,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       allow(Stripe::Customer).to receive(:create)
         .and_return(Stripe::Customer.new(id: "cus_123456"))
 
-      result = stripe_service.create
+      result = described_class.call(:create, stripe_customer)
 
       expect(Stripe::Customer).to have_received(:create)
 
@@ -87,7 +85,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       allow(Stripe::Customer).to receive(:create)
         .and_return(Stripe::Customer.new(id: "cus_123456"))
 
-      stripe_service.create
+      described_class.call(:create, stripe_customer)
 
       expect(Stripe::Customer).to have_received(:create)
 
@@ -103,7 +101,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       it "does not call stripe API" do
         allow(Stripe::Customer).to receive(:create)
 
-        stripe_service.create
+        described_class.call(:create, stripe_customer)
 
         expect(Stripe::Customer).not_to have_received(:create)
       end
@@ -119,7 +117,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       it "does not call stripe API" do
         allow(Stripe::Customer).to receive(:create)
 
-        stripe_service.create
+        described_class.call(:create, stripe_customer)
 
         expect(Stripe::Customer).not_to have_received(:create)
       end
@@ -127,7 +125,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       it "returns success" do
         allow(Stripe::Customer).to receive(:create)
 
-        result = stripe_service.create
+        result = described_class.call(:create, stripe_customer)
 
         expect(result).to be_success
       end
@@ -140,7 +138,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       end
 
       it "returns an unauthorized error" do
-        result = stripe_service.create
+        result = described_class.call(:create, stripe_customer)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::UnauthorizedFailure)
@@ -148,7 +146,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       end
 
       it "delivers an error webhook" do
-        expect { stripe_service.create }.to enqueue_job(SendWebhookJob)
+        expect { described_class.call(:create, stripe_customer) }.to enqueue_job(SendWebhookJob)
           .with(
             "customer.payment_provider_error",
             customer,
@@ -165,7 +163,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
         allow(Stripe::Customer).to receive(:create)
           .and_raise(::Stripe::InvalidRequestError.new("error", {}))
 
-        stripe_service.create
+        described_class.call(:create, stripe_customer)
 
         expect(Stripe::Customer).to have_received(:create)
 
@@ -191,14 +189,14 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       end
 
       it "fetches the stripe customer from the API" do
-        result = stripe_service.create
+        result = described_class.call(:create, stripe_customer)
 
         expect(result.stripe_customer.provider_customer_id).to eq("cus_123456")
       end
     end
   end
 
-  describe "#update" do
+  describe ".call(:update)" do
     let(:stripe_customer) do
       create(:stripe_customer, customer:, provider_customer_id:)
     end
@@ -217,7 +215,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
           let(:stripe_error) { ::Stripe::InvalidRequestError.new("Invalid request", nil) }
 
           it "returns an error result" do
-            result = stripe_service.update
+            result = described_class.call(:update, stripe_customer)
 
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ThirdPartyFailure)
@@ -227,7 +225,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
           end
 
           it "delivers an error webhook" do
-            expect { stripe_service.update }.to enqueue_job(SendWebhookJob)
+            expect { described_class.call(:update, stripe_customer) }.to enqueue_job(SendWebhookJob)
               .with(
                 "customer.payment_provider_error",
                 customer,
@@ -243,7 +241,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
           let(:stripe_error) { Stripe::PermissionError.new("Permission error") }
 
           it "returns an error result" do
-            result = stripe_service.update
+            result = described_class.call(:update, stripe_customer)
 
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ThirdPartyFailure)
@@ -253,7 +251,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
           end
 
           it "delivers an error webhook" do
-            expect { stripe_service.update }.to enqueue_job(SendWebhookJob)
+            expect { described_class.call(:update, stripe_customer) }.to enqueue_job(SendWebhookJob)
               .with(
                 "customer.payment_provider_error",
                 customer,
@@ -269,7 +267,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
           let(:stripe_error) { ::Stripe::AuthenticationError.new("Invalid username.") }
 
           it "returns an error result" do
-            result = stripe_service.update
+            result = described_class.call(:update, stripe_customer)
 
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::UnauthorizedFailure)
@@ -277,7 +275,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
           end
 
           it "delivers an error webhook" do
-            expect { stripe_service.update }.to enqueue_job(SendWebhookJob)
+            expect { described_class.call(:update, stripe_customer) }.to enqueue_job(SendWebhookJob)
               .with(
                 "customer.payment_provider_error",
                 customer,
@@ -297,19 +295,19 @@ RSpec.describe PaymentProviderCustomers::StripeService do
 
         context "when stripe payment provider is present" do
           it "calls stripe API" do
-            stripe_service.update
+            described_class.call(:update, stripe_customer)
 
             expect(Stripe::Customer).to have_received(:update)
           end
 
           it "returns a successful result" do
-            result = stripe_service.update
+            result = described_class.call(:update, stripe_customer)
 
             expect(result).to be_success
           end
 
           it "does not deliver an error webhook" do
-            expect { stripe_service.update }.not_to enqueue_job(SendWebhookJob)
+            expect { described_class.call(:update, stripe_customer) }.not_to enqueue_job(SendWebhookJob)
           end
         end
 
@@ -317,19 +315,19 @@ RSpec.describe PaymentProviderCustomers::StripeService do
           before { stripe_provider.destroy! }
 
           it "does not call stripe API" do
-            stripe_service.update
+            described_class.call(:update, stripe_customer)
 
             expect(Stripe::Customer).not_to have_received(:update)
           end
 
           it "returns a successful result" do
-            result = stripe_service.update
+            result = described_class.call(:update, stripe_customer)
 
             expect(result).to be_success
           end
 
           it "does not deliver an error webhook" do
-            expect { stripe_service.update }.not_to enqueue_job(SendWebhookJob)
+            expect { described_class.call(:update, stripe_customer) }.not_to enqueue_job(SendWebhookJob)
           end
         end
       end
@@ -344,7 +342,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       end
 
       it "enqueues StripeSyncFundingInstructionsJob" do
-        stripe_service.update
+        described_class.call(:update, stripe_customer)
 
         expect(PaymentProviderCustomers::StripeSyncFundingInstructionsJob)
           .to have_been_enqueued.with(stripe_customer)
@@ -360,19 +358,19 @@ RSpec.describe PaymentProviderCustomers::StripeService do
 
       context "when stripe payment provider is present" do
         it "does not call stripe API" do
-          stripe_service.update
+          described_class.call(:update, stripe_customer)
 
           expect(Stripe::Customer).not_to have_received(:update)
         end
 
         it "returns a successful result" do
-          result = stripe_service.update
+          result = described_class.call(:update, stripe_customer)
 
           expect(result).to be_success
         end
 
         it "does not deliver an error webhook" do
-          expect { stripe_service.update }.not_to enqueue_job(SendWebhookJob)
+          expect { described_class.call(:update, stripe_customer) }.not_to enqueue_job(SendWebhookJob)
         end
       end
 
@@ -380,27 +378,25 @@ RSpec.describe PaymentProviderCustomers::StripeService do
         before { stripe_provider.destroy! }
 
         it "does not call stripe API" do
-          stripe_service.update
+          described_class.call(:update, stripe_customer)
 
           expect(Stripe::Customer).not_to have_received(:update)
         end
 
         it "returns a successful result" do
-          result = stripe_service.update
+          result = described_class.call(:update, stripe_customer)
 
           expect(result).to be_success
         end
 
         it "does not deliver an error webhook" do
-          expect { stripe_service.update }.not_to enqueue_job(SendWebhookJob)
+          expect { described_class.call(:update, stripe_customer) }.not_to enqueue_job(SendWebhookJob)
         end
       end
     end
   end
 
-  describe "#delete_payment_method" do
-    subject(:stripe_service) { described_class.new }
-
+  describe ".call(:delete_payment_method)" do
     let(:payment_method_id) { "card_12345" }
 
     let(:stripe_customer) do
@@ -413,11 +409,10 @@ RSpec.describe PaymentProviderCustomers::StripeService do
     end
 
     it "removes the customer payment method" do
-      result = stripe_service.delete_payment_method(
+      result = described_class.call(:delete_payment_method,
         organization_id: organization.id,
         stripe_customer_id: stripe_customer.provider_customer_id,
-        payment_method_id:
-      )
+        payment_method_id:)
 
       expect(result).to be_success
       expect(result.stripe_customer.payment_method_id).to be_nil
@@ -425,11 +420,10 @@ RSpec.describe PaymentProviderCustomers::StripeService do
 
     context "when customer payment method is not the deleted one" do
       it "does not remove the customer payment method" do
-        result = stripe_service.delete_payment_method(
+        result = described_class.call(:delete_payment_method,
           organization_id: organization.id,
           stripe_customer_id: stripe_customer.provider_customer_id,
-          payment_method_id: "other_payment_method_id"
-        )
+          payment_method_id: "other_payment_method_id")
 
         expect(result).to be_success
         expect(result.stripe_customer.payment_method_id).to eq(payment_method_id)
@@ -444,11 +438,10 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       before { payment_method }
 
       it "discards the payment method" do
-        result = stripe_service.delete_payment_method(
+        result = described_class.call(:delete_payment_method,
           organization_id: organization.id,
           stripe_customer_id: stripe_customer.provider_customer_id,
-          payment_method_id:
-        )
+          payment_method_id:)
 
         expect(result).to be_success
         expect(result.stripe_customer.payment_method_id).to be_nil
@@ -458,11 +451,10 @@ RSpec.describe PaymentProviderCustomers::StripeService do
 
       context "when payment method does not exist" do
         it "does not raise an error" do
-          result = stripe_service.delete_payment_method(
+          result = described_class.call(:delete_payment_method,
             organization_id: organization.id,
             stripe_customer_id: stripe_customer.provider_customer_id,
-            payment_method_id: "non_existent_pm"
-          )
+            payment_method_id: "non_existent_pm")
 
           expect(result).to be_success
           expect(result.payment_method).to be_nil
@@ -472,11 +464,10 @@ RSpec.describe PaymentProviderCustomers::StripeService do
 
     context "when customer is not found" do
       it "returns an empty result" do
-        result = stripe_service.delete_payment_method(
+        result = described_class.call(:delete_payment_method,
           organization_id: organization.id,
           stripe_customer_id: "cus_InvaLid",
-          payment_method_id: "pm_123456"
-        )
+          payment_method_id: "pm_123456")
 
         expect(result).to be_success
         expect(result.stripe_customer).to be_nil
@@ -484,14 +475,13 @@ RSpec.describe PaymentProviderCustomers::StripeService do
 
       context "when customer in metadata is not found" do
         it "returns an empty response" do
-          result = stripe_service.delete_payment_method(
+          result = described_class.call(:delete_payment_method,
             organization_id: organization.id,
             stripe_customer_id: "cus_InvaLid",
             payment_method_id: "pm_123456",
             metadata: {
               lago_customer_id: SecureRandom.uuid
-            }
-          )
+            })
 
           expect(result).to be_success
           expect(result.stripe_customer).to be_nil
@@ -500,14 +490,13 @@ RSpec.describe PaymentProviderCustomers::StripeService do
 
       context "when customer in metadata exists" do
         it "returns a not found error" do
-          result = stripe_service.delete_payment_method(
+          result = described_class.call(:delete_payment_method,
             organization_id: organization.id,
             stripe_customer_id: "cus_InvaLid",
             payment_method_id: "pm_123456",
             metadata: {
               lago_customer_id: customer.id
-            }
-          )
+            })
 
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::NotFoundFailure)
@@ -517,12 +506,12 @@ RSpec.describe PaymentProviderCustomers::StripeService do
     end
   end
 
-  describe "#generate_checkout_url" do
+  describe ".call(:generate_checkout_url)" do
     it "delivers a webhook with checkout url" do
       allow(::Stripe::Checkout::Session).to receive(:create)
         .and_return({"url" => "https://example.com"})
 
-      stripe_service.generate_checkout_url
+      described_class.call(:generate_checkout_url, stripe_customer)
 
       expect(SendWebhookJob).to have_been_enqueued
         .with("customer.checkout_url_generated", customer, checkout_url: "https://example.com")
@@ -532,7 +521,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       let(:customer) { create(:customer, :deleted, organization:) }
 
       it "does not deliver a webhook" do
-        described_class.new(stripe_customer.reload).generate_checkout_url
+        described_class.call(:generate_checkout_url, stripe_customer.reload)
 
         expect(SendWebhookJob).not_to have_been_enqueued
           .with("customer.checkout_url_generated", customer, checkout_url: "https://example.com")
@@ -543,7 +532,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       let(:stripe_customer) { create(:stripe_customer, customer:, provider_customer_id: nil, provider_payment_methods: %w[crypto]) }
 
       it "does not deliver a webhook" do
-        described_class.new(stripe_customer.reload).generate_checkout_url
+        described_class.call(:generate_checkout_url, stripe_customer.reload)
 
         expect(SendWebhookJob).not_to have_been_enqueued
           .with("customer.checkout_url_generated", customer, checkout_url: "https://example.com")
@@ -556,7 +545,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       before { allow(::Stripe::Checkout::Session).to receive(:create).and_raise(stripe_error) }
 
       it "returns an error result" do
-        result = described_class.new(stripe_customer).generate_checkout_url
+        result = described_class.call(:generate_checkout_url, stripe_customer)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ThirdPartyFailure)
@@ -570,7 +559,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       before { allow(::Stripe::Checkout::Session).to receive(:create).and_raise(stripe_error) }
 
       it "returns an error result" do
-        result = described_class.new(stripe_customer).generate_checkout_url
+        result = described_class.call(:generate_checkout_url, stripe_customer)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::UnauthorizedFailure)
@@ -578,7 +567,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       end
 
       it "delivers an error webhook" do
-        expect { described_class.new(stripe_customer).generate_checkout_url }.to enqueue_job(SendWebhookJob)
+        expect { described_class.call(:generate_checkout_url, stripe_customer) }.to enqueue_job(SendWebhookJob)
           .with(
             "customer.payment_provider_error",
             customer,
@@ -594,7 +583,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
       let(:stripe_customer) { create(:stripe_customer, customer:, provider_customer_id: nil, provider_payment_methods: %w[crypto]) }
 
       it "returns an error result" do
-        result = described_class.new(stripe_customer).generate_checkout_url
+        result = described_class.call(:generate_checkout_url, stripe_customer)
 
         expect(result).not_to be_success
         expect(result.error.messages).to eq(provider_payment_methods: ["no_payment_methods_to_setup_available"])
@@ -603,7 +592,11 @@ RSpec.describe PaymentProviderCustomers::StripeService do
   end
 
   describe "#success_redirect_url" do
-    subject(:success_redirect_url) { stripe_service.__send__(:success_redirect_url) }
+    subject(:success_redirect_url) do
+      service = described_class.new
+      service.instance_variable_set(:@stripe_customer, stripe_customer)
+      service.__send__(:success_redirect_url)
+    end
 
     context "when payment provider has success redirect url" do
       it "returns payment provider's success redirect url" do

--- a/spec/services/payment_provider_customers/update_service_spec.rb
+++ b/spec/services/payment_provider_customers/update_service_spec.rb
@@ -7,15 +7,10 @@ RSpec.describe PaymentProviderCustomers::UpdateService do
   let(:payment_provider) { create(:stripe_provider, organization: customer.organization) }
   let(:provider_name) { "Stripe" }
   let(:provider_service_class) { "PaymentProviderCustomers::#{provider_name}Service".constantize }
-  let(:provider_service) { provider_service_class.new(provider_customer) }
-  let(:provider_customer) { create(:"#{provider_name.downcase}_customer", customer:) }
+  let!(:provider_customer) { create(:"#{provider_name.downcase}_customer", customer:) }
 
   before do
-    allow("PaymentProviderCustomers::#{provider_name}Service".constantize)
-      .to receive(:new)
-      .and_return(provider_service)
-
-    allow(provider_service).to receive(:update).and_return(BaseService::Result.new)
+    allow(provider_service_class).to receive(:call).and_return(BaseService::Result.new)
     allow(Stripe::Customer).to receive(:update).and_return(true)
   end
 
@@ -25,8 +20,7 @@ RSpec.describe PaymentProviderCustomers::UpdateService do
     it "updates the provider customer" do
       described_class.call(customer)
 
-      expect(provider_service_class).to have_received(:new).with(provider_customer)
-      expect(provider_service).to have_received(:update)
+      expect(provider_service_class).to have_received(:call).with(:update, provider_customer)
     end
   end
 end

--- a/spec/services/payment_providers/adyen/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_event_service_spec.rb
@@ -9,17 +9,14 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
 
   describe "#call" do
     let(:payment_service) { instance_double(Invoices::Payments::AdyenService) }
-    let(:payment_provider_service) { instance_double(PaymentProviderCustomers::AdyenService) }
     let(:service_result) { BaseService::Result.new }
 
     before do
       allow(Invoices::Payments::AdyenService).to receive(:new)
         .and_return(payment_service)
-      allow(PaymentProviderCustomers::AdyenService).to receive(:new)
-        .and_return(payment_provider_service)
-      allow(payment_service).to receive(:update_payment_status)
+      allow(PaymentProviderCustomers::AdyenService).to receive(:call)
         .and_return(service_result)
-      allow(payment_provider_service).to receive(:preauthorise)
+      allow(payment_service).to receive(:update_payment_status)
         .and_return(service_result)
     end
 
@@ -37,8 +34,7 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
       it "routes the event to an other service" do
         event_service.call
 
-        expect(PaymentProviderCustomers::AdyenService).to have_received(:new)
-        expect(payment_provider_service).to have_received(:preauthorise)
+        expect(PaymentProviderCustomers::AdyenService).to have_received(:call).with(:preauthorise, any_args)
       end
     end
 

--- a/spec/services/payment_providers/stripe/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/stripe/handle_event_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe PaymentProviders::Stripe::HandleEventService do
   let(:organization) { create(:organization) }
 
   let(:payment_service) { instance_double(Invoices::Payments::StripeService) }
-  let(:provider_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
   let(:service_result) { BaseService::Result.new }
 
   before do
@@ -60,9 +59,7 @@ RSpec.describe PaymentProviders::Stripe::HandleEventService do
     let(:event_json) { get_stripe_fixtures("webhooks/payment_method_detached.json") }
 
     before do
-      allow(PaymentProviderCustomers::StripeService).to receive(:new)
-        .and_return(provider_customer_service)
-      allow(provider_customer_service).to receive(:delete_payment_method)
+      allow(PaymentProviderCustomers::StripeService).to receive(:call)
         .and_return(service_result)
     end
 
@@ -71,8 +68,7 @@ RSpec.describe PaymentProviders::Stripe::HandleEventService do
 
       expect(result).to be_success
 
-      expect(PaymentProviderCustomers::StripeService).to have_received(:new)
-      expect(provider_customer_service).to have_received(:delete_payment_method)
+      expect(PaymentProviderCustomers::StripeService).to have_received(:call).with(:delete_payment_method, any_args)
     end
   end
 


### PR DESCRIPTION
## Context

The `TypedResults` concern was introduced to let legacy multi-method services return typed Results instead of the deprecated LegacyResult (OpenStruct), as an intermediate step before a full single-call refactor.

## Description

This PR applies the pattern to the `PaymentProviderCustomers` sub-services (Stripe, Adyen, Cashfree, Flutterwave, Gocardless, Moneyhash).

Each service now includes the concern, declares a `RESULTS` constant mapping every method to its typed Result, and exposes those methods as private — reached through `Service.call(:method_name, *args)`. The former per-instance constructor is dropped in favor of arguments passed to each method.

Call sites are updated accordingly: jobs use `call!`, `Factory#new_instance` is removed in favor of `Factory.for(provider_customer)`, and specs exercise the services through the `.call(:method)` entry point.