### PR TITLE
fix(usage): stop double-counting subset charge filters

### DIFF
--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -42,8 +42,10 @@ module ChargeFilters
       result.ignored_filters = children.map do |child|
         res = child.to_h_with_all_values.dup
 
-        if res.keys == result.matching_filters.keys
-          # NOTE: when child and filter have the same keys, we need to remove the filter value from the child
+        # NOTE: when child and filter have the same keys, we need to remove the filter value from the child.
+        #       When the child's values are a subset of the filter's values on every key, the child is kept
+        #       verbatim so that its events are excluded from the filter's bucket instead of being counted twice.
+        if res.keys == result.matching_filters.keys && !subset_of_matching_filters?(res)
           res.each do |key, values|
             next if filter.to_h[key] == [ChargeFilterValue::ALL_FILTER_VALUES]
 
@@ -63,6 +65,10 @@ module ChargeFilters
 
     def other_filters
       @other_filters ||= charge.filters.select { it.id != filter.id }
+    end
+
+    def subset_of_matching_filters?(child)
+      child.all? { |key, values| (values - result.matching_filters[key]).empty? }
     end
   end
 end

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -43,13 +43,20 @@ module ChargeFilters
         res = child.to_h_with_all_values.dup
 
         # NOTE: when child and filter have the same keys, we need to remove the filter value from the child.
-        #       When the child's values are a subset of the filter's values on every key, the child is kept
-        #       verbatim so that its events are excluded from the filter's bucket instead of being counted twice.
-        if res.keys == result.matching_filters.keys && !subset_of_matching_filters?(res)
-          res.each do |key, values|
-            next if filter.to_h[key] == [ChargeFilterValue::ALL_FILTER_VALUES]
+        #       When the child's values are a strict subset of the filter's values on every key, the child is
+        #       kept verbatim so that its events are excluded from the filter's bucket instead of being counted
+        #       twice. When the child's values are identical to the filter's, only the oldest filter
+        #       (tie-break on [created_at, id]) counts the events: newer identical children are dropped from
+        #       ignored_filters, while older ones are kept verbatim so the current filter counts zero.
+        if res.keys == result.matching_filters.keys
+          if identical_to_matching_filters?(res)
+            next unless older_than_filter?(child)
+          elsif !subset_of_matching_filters?(res)
+            res.each do |key, values|
+              next if filter.to_h[key] == [ChargeFilterValue::ALL_FILTER_VALUES]
 
-            res[key] = values - result.matching_filters[key]
+              res[key] = values - result.matching_filters[key]
+            end
           end
         end
 
@@ -69,6 +76,19 @@ module ChargeFilters
 
     def subset_of_matching_filters?(child)
       child.all? { |key, values| (values - result.matching_filters[key]).empty? }
+    end
+
+    def identical_to_matching_filters?(child)
+      child.all? { |key, values| values.sort == result.matching_filters[key].sort }
+    end
+
+    def older_than_filter?(child)
+      # NOTE: an unsaved filter (the default "no filter" bucket that callers build with
+      #       ChargeFilter.new when events match none of the charge's filters) has no
+      #       created_at; it is always considered the newest so persisted children are kept.
+      return true if filter.created_at.nil?
+
+      ([child.created_at, child.id] <=> [filter.created_at, filter.id]).negative?
     end
   end
 end

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -48,7 +48,11 @@ module ChargeFilters
         #       twice. When the child's values are identical to the filter's, only the oldest filter
         #       (tie-break on [created_at, id]) counts the events: newer identical children are dropped from
         #       ignored_filters, while older ones are kept verbatim so the current filter counts zero.
-        if res.keys == result.matching_filters.keys
+        # NOTE: keys are compared order-independently. to_h_with_all_values orders keys by the
+        #       values' updated_at (ChargeFilterValue default scope), so two filters with the same
+        #       keys can enumerate them in a different order; an order-sensitive comparison would skip
+        #       this branch and reintroduce double-counting (or zero every bucket for identical duplicates).
+        if res.keys.sort == result.matching_filters.keys.sort
           if identical_to_matching_filters?(res)
             next unless older_than_filter?(child)
           elsif !subset_of_matching_filters?(res)

--- a/spec/scenarios/current_usage/with_identical_charge_filters_spec.rb
+++ b/spec/scenarios/current_usage/with_identical_charge_filters_spec.rb
@@ -7,7 +7,9 @@ require "rails_helper"
 #   the store-level defensive guards prevent them from rendering invalid SQL.
 # - Subset and identical duplicate filters used to be double-counted: events
 #   matching both a filter and a more specific sibling were counted in both
-#   buckets. Each event must only be counted in its most specific bucket.
+#   buckets. Each event must only be counted in its most specific bucket, and
+#   identical duplicates must count the event only in the oldest duplicate's
+#   bucket (tie-break on [created_at, id]).
 describe "Current Usage - Overlapping charge filters", transaction: false do
   [
     :postgres,
@@ -125,21 +127,22 @@ describe "Current Usage - Overlapping charge filters", transaction: false do
       end
 
       # Duplicate filters with identical values should not exist but can due
-      # to missing validations. Each duplicate is kept verbatim in the other's
-      # ignored_filters, so they exclude each other and neither counts events.
+      # to missing validations. The tie-break on [created_at, id] makes the
+      # oldest duplicate count the events; the newer duplicate keeps the older
+      # one in its ignored_filters and counts zero.
       context "when two charge filters have identical values" do
         before do
           cloud_filter = create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp])
 
           charge = create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"})
 
-          create(:charge_filter, charge:, properties: {amount: "5"}, invoice_display_name: "Duplicate A")
+          create(:charge_filter, charge:, properties: {amount: "5"}, invoice_display_name: "Duplicate A", created_at: 2.days.ago)
             .tap { |cf| create(:charge_filter_value, charge_filter: cf, billable_metric_filter: cloud_filter, values: ["aws"]) }
-          create(:charge_filter, charge:, properties: {amount: "3"}, invoice_display_name: "Duplicate B")
+          create(:charge_filter, charge:, properties: {amount: "3"}, invoice_display_name: "Duplicate B", created_at: 1.day.ago)
             .tap { |cf| create(:charge_filter_value, charge_filter: cf, billable_metric_filter: cloud_filter, values: ["aws"]) }
         end
 
-        it "counts the event in neither duplicate's bucket" do
+        it "counts the event only in the oldest duplicate's bucket" do
           travel_to(DateTime.new(2024, 3, 5)) do
             create_subscription(
               {
@@ -166,9 +169,9 @@ describe "Current Usage - Overlapping charge filters", transaction: false do
             expect(filters.count).to eq(3)
 
             duplicate_a = filters.find { |f| f[:invoice_display_name] == "Duplicate A" }
-            expect(duplicate_a[:events_count]).to eq(0)
-            expect(duplicate_a[:units]).to eq("0.0")
-            expect(duplicate_a[:amount_cents]).to eq(0)
+            expect(duplicate_a[:events_count]).to eq(1)
+            expect(duplicate_a[:units]).to eq("10.0")
+            expect(duplicate_a[:amount_cents]).to eq(5000)
 
             duplicate_b = filters.find { |f| f[:invoice_display_name] == "Duplicate B" }
             expect(duplicate_b[:events_count]).to eq(0)

--- a/spec/scenarios/current_usage/with_identical_charge_filters_spec.rb
+++ b/spec/scenarios/current_usage/with_identical_charge_filters_spec.rb
@@ -2,12 +2,13 @@
 
 require "rails_helper"
 
-# Regression test for ISSUE-1799: ClickHouse query fails with empty Tuple()
-# when ignored_filters contains empty hashes or hashes with all-empty-array
-# values. These states should not occur — charge filters should always have
-# values and duplicates should not exist — but missing validations allow them
-# in production. The store-level defensive guards prevent invalid SQL.
-describe "Current Usage - Filters with empty ignored_filters entries", transaction: false do
+# Regression tests for overlapping charge filters on the same charge:
+# - ISSUE-1799: filters with no values produce empty hashes in ignored_filters;
+#   the store-level defensive guards prevent them from rendering invalid SQL.
+# - Subset and identical duplicate filters used to be double-counted: events
+#   matching both a filter and a more specific sibling were counted in both
+#   buckets. Each event must only be counted in its most specific bucket.
+describe "Current Usage - Overlapping charge filters", transaction: false do
   [
     :postgres,
     :clickhouse
@@ -60,9 +61,9 @@ describe "Current Usage - Filters with empty ignored_filters entries", transacti
         end
       end
 
-      # Duplicate filters with identical values should not exist but can due
-      # to missing validations. The child's subtraction zeroes out all arrays,
-      # producing {"cloud" => []} in ignored_filters.
+      # When a child filter's values are a subset of another filter's values,
+      # the child is kept verbatim in the parent's ignored_filters, so events
+      # matching the child are only counted in the child's bucket.
       context "when a child filter's values are a subset of the parent's" do
         before do
           cloud_filter = create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp])
@@ -75,7 +76,70 @@ describe "Current Usage - Filters with empty ignored_filters entries", transacti
             .tap { |cf| create(:charge_filter_value, charge_filter: cf, billable_metric_filter: cloud_filter, values: ["aws"]) }
         end
 
-        it "returns current usage without SQL errors" do
+        it "counts each event only in its most specific bucket" do
+          travel_to(DateTime.new(2024, 3, 5)) do
+            create_subscription(
+              {
+                external_customer_id: customer.external_id,
+                external_id: customer.external_id,
+                plan_code: plan.code
+              }
+            )
+          end
+
+          travel_to(DateTime.new(2024, 3, 6)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_subscription_id: customer.external_id,
+                properties: {cloud: "aws", value: 10}
+              }
+            )
+
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_subscription_id: customer.external_id,
+                properties: {cloud: "gcp", value: 7}
+              }
+            )
+
+            fetch_current_usage(customer:)
+
+            filters = json[:customer_usage][:charges_usage].first[:filters]
+            expect(filters.count).to eq(3)
+
+            all_clouds = filters.find { |f| f[:invoice_display_name] == "All clouds" }
+            expect(all_clouds[:events_count]).to eq(1)
+            expect(all_clouds[:units]).to eq("7.0")
+            expect(all_clouds[:amount_cents]).to eq(3500)
+
+            aws_only = filters.find { |f| f[:invoice_display_name] == "AWS only" }
+            expect(aws_only[:events_count]).to eq(1)
+            expect(aws_only[:units]).to eq("10.0")
+            expect(aws_only[:amount_cents]).to eq(3000)
+          end
+        end
+      end
+
+      # Duplicate filters with identical values should not exist but can due
+      # to missing validations. Each duplicate is kept verbatim in the other's
+      # ignored_filters, so they exclude each other and neither counts events.
+      context "when two charge filters have identical values" do
+        before do
+          cloud_filter = create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp])
+
+          charge = create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"})
+
+          create(:charge_filter, charge:, properties: {amount: "5"}, invoice_display_name: "Duplicate A")
+            .tap { |cf| create(:charge_filter_value, charge_filter: cf, billable_metric_filter: cloud_filter, values: ["aws"]) }
+          create(:charge_filter, charge:, properties: {amount: "3"}, invoice_display_name: "Duplicate B")
+            .tap { |cf| create(:charge_filter_value, charge_filter: cf, billable_metric_filter: cloud_filter, values: ["aws"]) }
+        end
+
+        it "counts the event in neither duplicate's bucket" do
           travel_to(DateTime.new(2024, 3, 5)) do
             create_subscription(
               {
@@ -98,7 +162,18 @@ describe "Current Usage - Filters with empty ignored_filters entries", transacti
 
             fetch_current_usage(customer:)
 
-            expect(json[:customer_usage][:charges_usage].first[:filters].count).to eq(3)
+            filters = json[:customer_usage][:charges_usage].first[:filters]
+            expect(filters.count).to eq(3)
+
+            duplicate_a = filters.find { |f| f[:invoice_display_name] == "Duplicate A" }
+            expect(duplicate_a[:events_count]).to eq(0)
+            expect(duplicate_a[:units]).to eq("0.0")
+            expect(duplicate_a[:amount_cents]).to eq(0)
+
+            duplicate_b = filters.find { |f| f[:invoice_display_name] == "Duplicate B" }
+            expect(duplicate_b[:events_count]).to eq(0)
+            expect(duplicate_b[:units]).to eq("0.0")
+            expect(duplicate_b[:amount_cents]).to eq(0)
           end
         end
       end

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -159,17 +159,19 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
   # children, and duplicate filters. Empty filters should not occur in normal
   # usage but missing validations allow them in production; the store-level
   # defensive guards (ISSUE-1799) prevent them from producing invalid SQL.
-  # Subset and identical children are kept verbatim in ignored_filters so
-  # their events are excluded from the parent's bucket instead of being
-  # counted in both buckets.
+  # Strict-subset children are kept verbatim in ignored_filters so their
+  # events are excluded from the parent's bucket instead of being counted in
+  # both buckets. Identical children are resolved with a tie-break on
+  # [created_at, id]: only the oldest duplicate counts the events, the others
+  # keep the older duplicate in their ignored_filters and count zero.
 
   context "when a filter has no values" do
     subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
 
     let(:isolated_charge) { create(:standard_charge, billable_metric:) }
 
-    let(:empty_a) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "empty_a") }
-    let(:empty_b) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "empty_b") }
+    let(:empty_a) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "empty_a", created_at: 2.days.ago) }
+    let(:empty_b) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "empty_b", created_at: 1.day.ago) }
     let(:with_values) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "with_values") }
 
     before do
@@ -181,11 +183,12 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     describe "for empty_a" do
       let(:current_filter) { empty_a }
 
-      it "produces empty hashes in ignored_filters from other empty filters" do
+      # empty_a and empty_b are vacuously identical (both match {}), so the
+      # tie-break applies: empty_a is older and drops empty_b's {} entry.
+      it "does not include the newer empty filter in ignored_filters" do
         expect(service_result.matching_filters).to eq({})
         expect(service_result.ignored_filters).to eq(
           [
-            {},
             {"size" => ["512"]}
           ]
         )
@@ -260,25 +263,41 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     end
   end
 
-  context "when two filters have identical keys and values" do
+  # Identical duplicates are resolved with a tie-break on [created_at, id]:
+  # the oldest duplicate drops the newer ones from its ignored_filters and
+  # counts the events; the newer ones keep at least one older identical
+  # sibling verbatim and count zero.
+  context "when filters have identical keys and values" do
     subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
 
     let(:isolated_charge) { create(:standard_charge, billable_metric:) }
 
-    let(:filter_a) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_a") }
-    let(:filter_b) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_b") }
+    let(:filter_a) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_a", created_at: 3.days.ago) }
+    let(:filter_b) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_b", created_at: 2.days.ago) }
+    let(:filter_c) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_c", created_at: 1.day.ago) }
 
     before do
       create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: filter_a)
       create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: filter_a)
       create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: filter_b)
       create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: filter_b)
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: filter_c)
+      create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: filter_c)
     end
 
-    describe "for filter_a" do
+    describe "for filter_a (oldest)" do
       let(:current_filter) { filter_a }
 
-      it "keeps the identical sibling verbatim" do
+      it "drops the newer identical siblings from ignored_filters" do
+        expect(service_result.matching_filters).to eq({"size" => ["512"], "steps" => ["25"]})
+        expect(service_result.ignored_filters).to eq([])
+      end
+    end
+
+    describe "for filter_b (middle)" do
+      let(:current_filter) { filter_b }
+
+      it "keeps only the older identical sibling verbatim" do
         expect(service_result.matching_filters).to eq({"size" => ["512"], "steps" => ["25"]})
         expect(service_result.ignored_filters).to eq(
           [{"size" => ["512"], "steps" => ["25"]}]
@@ -286,13 +305,56 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
       end
     end
 
-    describe "for filter_b" do
-      let(:current_filter) { filter_b }
+    describe "for filter_c (newest)" do
+      let(:current_filter) { filter_c }
 
-      it "keeps the identical sibling verbatim" do
+      it "keeps both older identical siblings verbatim" do
         expect(service_result.matching_filters).to eq({"size" => ["512"], "steps" => ["25"]})
         expect(service_result.ignored_filters).to eq(
-          [{"size" => ["512"], "steps" => ["25"]}]
+          [
+            {"size" => ["512"], "steps" => ["25"]},
+            {"size" => ["512"], "steps" => ["25"]}
+          ]
+        )
+      end
+    end
+  end
+
+  # When identical duplicates share the same created_at, the id part of the
+  # [created_at, id] tie-break decides: exactly one filter counts the events.
+  context "when identical filters share the same created_at" do
+    subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
+
+    let(:isolated_charge) { create(:standard_charge, billable_metric:) }
+    let(:created_at) { 1.day.ago }
+
+    let(:filter_a) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_a", created_at:) }
+    let(:filter_b) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "filter_b", created_at:) }
+
+    let(:winner) { [filter_a, filter_b].min_by(&:id) }
+    let(:loser) { [filter_a, filter_b].max_by(&:id) }
+
+    before do
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: filter_a)
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: filter_b)
+    end
+
+    describe "for the filter with the lowest id" do
+      let(:current_filter) { winner }
+
+      it "drops the identical sibling from ignored_filters" do
+        expect(service_result.matching_filters).to eq({"size" => ["512"]})
+        expect(service_result.ignored_filters).to eq([])
+      end
+    end
+
+    describe "for the filter with the highest id" do
+      let(:current_filter) { loser }
+
+      it "keeps the identical sibling verbatim" do
+        expect(service_result.matching_filters).to eq({"size" => ["512"]})
+        expect(service_result.ignored_filters).to eq(
+          [{"size" => ["512"]}]
         )
       end
     end

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -320,6 +320,37 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     end
   end
 
+  # to_h_with_all_values orders keys by the values' updated_at (ChargeFilterValue
+  # default scope), so two filters with the same keys can enumerate them in a
+  # different order. The identical/subset logic must compare keys
+  # order-independently; otherwise the same-keys branch is skipped and the older
+  # parent wrongly excludes the identical duplicate's events, counting zero.
+  context "when an identical child enumerates its keys in a different order" do
+    subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
+
+    let(:isolated_charge) { create(:standard_charge, billable_metric:) }
+    let(:parent_filter) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "parent", created_at: 2.days.ago) }
+    let(:duplicate) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "duplicate", created_at: 1.day.ago) }
+
+    before do
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: parent_filter, updated_at: 2.days.ago)
+      create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: parent_filter, updated_at: 1.day.ago)
+      # Reversed order: steps is updated before size, so the duplicate enumerates
+      # its keys as [steps, size] while the parent enumerates them as [size, steps].
+      create(:charge_filter_value, values: ["25"], billable_metric_filter: filter_steps, charge_filter: duplicate, updated_at: 2.days.ago)
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: duplicate, updated_at: 1.day.ago)
+    end
+
+    describe "for the older parent" do
+      let(:current_filter) { parent_filter }
+
+      it "recognizes the reordered duplicate and drops it from ignored_filters" do
+        expect(service_result.matching_filters).to eq({"size" => ["512"], "steps" => ["25"]})
+        expect(service_result.ignored_filters).to eq([])
+      end
+    end
+  end
+
   # When identical duplicates share the same created_at, the id part of the
   # [created_at, id] tie-break decides: exactly one filter counts the events.
   context "when identical filters share the same created_at" do

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -155,12 +155,13 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     end
   end
 
-  # The following contexts cover edge cases where ignored_filters contains
-  # empty hashes or hashes with all-empty-array values. These states should
-  # not occur in normal usage — charge filters should always have values,
-  # and duplicate filters should not exist — but missing validations allow
-  # them in production. The store-level defensive guards (ISSUE-1799) prevent
-  # these from producing invalid SQL.
+  # The following contexts cover edge cases with empty filters, subset
+  # children, and duplicate filters. Empty filters should not occur in normal
+  # usage but missing validations allow them in production; the store-level
+  # defensive guards (ISSUE-1799) prevent them from producing invalid SQL.
+  # Subset and identical children are kept verbatim in ignored_filters so
+  # their events are excluded from the parent's bucket instead of being
+  # counted in both buckets.
 
   context "when a filter has no values" do
     subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
@@ -220,13 +221,40 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     describe "for parent_filter" do
       let(:current_filter) { parent_filter }
 
-      it "produces all-empty-values entry from subset child and keeps different-key children intact" do
+      it "keeps the subset child verbatim and keeps different-key children intact" do
         expect(service_result.matching_filters).to eq({"size" => %w[512 1024]})
         expect(service_result.ignored_filters).to eq(
           [
-            {"size" => []},
+            {"size" => ["512"]},
             {"size" => ["512"], "steps" => ["25"]}
           ]
+        )
+      end
+    end
+  end
+
+  context "when a child is a subset on one key but not on another" do
+    subject(:service_result) { described_class.call(charge: isolated_charge, filter: current_filter) }
+
+    let(:isolated_charge) { create(:standard_charge, billable_metric:) }
+
+    let(:parent_filter) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "parent") }
+    let(:mixed_child) { create(:charge_filter, charge: isolated_charge, invoice_display_name: "mixed_child") }
+
+    before do
+      create(:charge_filter_value, values: %w[512 1024], billable_metric_filter: filter_size, charge_filter: parent_filter)
+      create(:charge_filter_value, values: %w[25 50], billable_metric_filter: filter_steps, charge_filter: parent_filter)
+      create(:charge_filter_value, values: ["512"], billable_metric_filter: filter_size, charge_filter: mixed_child)
+      create(:charge_filter_value, values: %w[25 75], billable_metric_filter: filter_steps, charge_filter: mixed_child)
+    end
+
+    describe "for parent_filter" do
+      let(:current_filter) { parent_filter }
+
+      it "subtracts the matching values from the non-subset child" do
+        expect(service_result.matching_filters).to eq({"size" => %w[512 1024], "steps" => %w[25 50]})
+        expect(service_result.ignored_filters).to eq(
+          [{"size" => [], "steps" => ["75"]}]
         )
       end
     end
@@ -250,10 +278,21 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     describe "for filter_a" do
       let(:current_filter) { filter_a }
 
-      it "produces all-empty-values entry from the identical sibling" do
+      it "keeps the identical sibling verbatim" do
         expect(service_result.matching_filters).to eq({"size" => ["512"], "steps" => ["25"]})
         expect(service_result.ignored_filters).to eq(
-          [{"size" => [], "steps" => []}]
+          [{"size" => ["512"], "steps" => ["25"]}]
+        )
+      end
+    end
+
+    describe "for filter_b" do
+      let(:current_filter) { filter_b }
+
+      it "keeps the identical sibling verbatim" do
+        expect(service_result.matching_filters).to eq({"size" => ["512"], "steps" => ["25"]})
+        expect(service_result.ignored_filters).to eq(
+          [{"size" => ["512"], "steps" => ["25"]}]
         )
       end
     end


### PR DESCRIPTION
## Context

When a charge has two filters on the same key where one filter's values are a subset of the other's (for example `cloud=[aws, gcp]` plus `cloud=[aws]`), events matching the subset were counted in both buckets: a single `cloud=aws` event showed up in the parent filter and in the child filter, so the usage was billed twice. Two identical duplicate filters double-counted every event the same way.

The cause is in `ChargeFilters::MatchingAndIgnoredService`: for a same-keys child, the ignored entry was computed by subtracting the filter's own values from the child's, which yields an empty array for a subset child. The stores render an empty array as `NOT (... IN (NULL))`, a vacuous clause, so the parent bucket never excluded the child's events. This is the non-crash half of the behavior addressed by #5329, which guards the SQL rendering but intentionally left the double-count in place.

## Description

When a same-keys child's values are a subset of the filter's matching values on every key, the child is now kept verbatim in `ignored_filters`, so the filter's bucket renders `NOT (child condition)` and excludes the child's events. On the parent + subset example above, the parent bucket becomes `cloud IN ('aws', 'gcp') AND NOT cloud IN ('aws')` and the `aws` event is only counted in the child.

Superset and partial-overlap children keep the previous subtraction behavior, and cross-key children are unchanged.

Identical duplicate filters (a config error, a write-time uniqueness validation is left to a follow-up) now bill exactly once: a tie-break on `[created_at, id]` makes the oldest filter count the events, while newer duplicates exclude it and count zero. An unsaved filter (the default "no filter" bucket built by the fee services) has no `created_at` and is treated as the newest, which preserves its previous behavior.

The scenario spec now asserts per-filter `events_count`, `units` and `amount_cents` instead of only the filter count, and covers the subset, parent-only and identical-duplicate cases on both postgres and clickhouse stores. All the new assertions fail without the service fix.

Fixes ING-29
