### PR TITLE
perf(activity-logs): add external id bloom filter indexes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,12 @@ To create a webhook:
 - When adding a constraint with `validate: false` (`NOT VALID`), add a second migration right after it that validates the constraint (`validate_foreign_key` or `validate_check_constraint`), within the same PR. If validation is not possible yet (e.g. existing rows must be backfilled or fixed first), register the constraint in `db/not_valid_constraints.yml` with a `validate_by` deadline, and remove the entry once the constraint is validated. `spec/db/not_valid_constraints_spec.rb` enforces this.
 - When validating a foreign key on a table that has several foreign keys to the same target table, pass the `column:` option to `validate_foreign_key`, otherwise the wrong constraint may be validated silently.
 
+## Clickhouse migrations
+
+- Clickhouse migrations live in `db/clickhouse_migrate/` (self-hosted). The DDL for ClickHouse Cloud is kept separately in `db/clickhouse_migrate/cloud/*.sql`; those files are executed manually when creating a new cluster, so they are edited in place to reflect the current schema.
+- Clickhouse DDL is not transactional. Keep one DDL concern per migration (e.g. one index): if a migration runs several statements and a later one fails, the earlier ones are already applied while the migration is marked as failed.
+- Define explicit `up` and `down` methods (not `change`), and make `down` revert the DDL (e.g. `DROP INDEX IF EXISTS`). Use `IF NOT EXISTS` / `IF EXISTS` guards so retries are idempotent.
+
 # Backward Compatibility
 
 - New optional parameters must not break existing functionality

--- a/db/clickhouse_migrate/20260710115832_add_activity_logs_external_customer_id_index.rb
+++ b/db/clickhouse_migrate/20260710115832_add_activity_logs_external_customer_id_index.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddActivityLogsExternalCustomerIdIndex < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      execute "ALTER TABLE activity_logs ADD INDEX IF NOT EXISTS idx_external_customer_id external_customer_id TYPE bloom_filter(0.001) GRANULARITY 1"
+      execute "ALTER TABLE activity_logs MATERIALIZE INDEX idx_external_customer_id"
+    end
+  end
+
+  def down
+    safety_assured do
+      execute "ALTER TABLE activity_logs DROP INDEX IF EXISTS idx_external_customer_id"
+    end
+  end
+end

--- a/db/clickhouse_migrate/20260710115832_add_activity_logs_external_ids_indexes.rb
+++ b/db/clickhouse_migrate/20260710115832_add_activity_logs_external_ids_indexes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddActivityLogsExternalIdsIndexes < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      execute "ALTER TABLE activity_logs ADD INDEX IF NOT EXISTS idx_external_customer_id external_customer_id TYPE bloom_filter(0.001) GRANULARITY 1"
+      execute "ALTER TABLE activity_logs MATERIALIZE INDEX idx_external_customer_id"
+      execute "ALTER TABLE activity_logs ADD INDEX IF NOT EXISTS idx_external_subscription_id external_subscription_id TYPE bloom_filter(0.001) GRANULARITY 1"
+      execute "ALTER TABLE activity_logs MATERIALIZE INDEX idx_external_subscription_id"
+    end
+  end
+end

--- a/db/clickhouse_migrate/20260710124100_add_activity_logs_external_subscription_id_index.rb
+++ b/db/clickhouse_migrate/20260710124100_add_activity_logs_external_subscription_id_index.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-class AddActivityLogsExternalIdsIndexes < ActiveRecord::Migration[8.0]
+class AddActivityLogsExternalSubscriptionIdIndex < ActiveRecord::Migration[8.0]
   def up
     safety_assured do
-      execute "ALTER TABLE activity_logs ADD INDEX IF NOT EXISTS idx_external_customer_id external_customer_id TYPE bloom_filter(0.001) GRANULARITY 1"
-      execute "ALTER TABLE activity_logs MATERIALIZE INDEX idx_external_customer_id"
       execute "ALTER TABLE activity_logs ADD INDEX IF NOT EXISTS idx_external_subscription_id external_subscription_id TYPE bloom_filter(0.001) GRANULARITY 1"
       execute "ALTER TABLE activity_logs MATERIALIZE INDEX idx_external_subscription_id"
+    end
+  end
+
+  def down
+    safety_assured do
+      execute "ALTER TABLE activity_logs DROP INDEX IF EXISTS idx_external_subscription_id"
     end
   end
 end

--- a/db/clickhouse_migrate/cloud/03_activity_logs.sql
+++ b/db/clickhouse_migrate/cloud/03_activity_logs.sql
@@ -5,8 +5,6 @@ CREATE TABLE default.activity_logs
     `api_key_id` Nullable(String),
     `external_customer_id` Nullable(String),
     `external_subscription_id` Nullable(String),
-    INDEX idx_external_customer_id external_customer_id TYPE bloom_filter(0.001) GRANULARITY 1,
-    INDEX idx_external_subscription_id external_subscription_id TYPE bloom_filter(0.001) GRANULARITY 1,
     `activity_id` String,
     `activity_type` String,
     `activity_source` Enum8('api' = 1, 'front' = 2, 'system' = 3),
@@ -15,7 +13,9 @@ CREATE TABLE default.activity_logs
     `resource_id` String,
     `resource_type` String,
     `logged_at` DateTime64(3),
-    `created_at` DateTime64(3)
+    `created_at` DateTime64(3),
+    INDEX idx_external_customer_id external_customer_id TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_external_subscription_id external_subscription_id TYPE bloom_filter(0.001) GRANULARITY 1
 )
 ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
 PRIMARY KEY (organization_id, activity_type, activity_id, logged_at)

--- a/db/clickhouse_migrate/cloud/03_activity_logs.sql
+++ b/db/clickhouse_migrate/cloud/03_activity_logs.sql
@@ -5,6 +5,8 @@ CREATE TABLE default.activity_logs
     `api_key_id` Nullable(String),
     `external_customer_id` Nullable(String),
     `external_subscription_id` Nullable(String),
+    INDEX idx_external_customer_id external_customer_id TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_external_subscription_id external_subscription_id TYPE bloom_filter(0.001) GRANULARITY 1,
     `activity_id` String,
     `activity_type` String,
     `activity_source` Enum8('api' = 1, 'front' = 2, 'system' = 3),


### PR DESCRIPTION
## Context

Customer- and subscription-scoped activity log queries (GraphQL `CustomerActivityLogs`, REST `/api/v1/activity_logs`) filter the ClickHouse `activity_logs` table by `external_customer_id` / `external_subscription_id` and order by `logged_at DESC`. Neither column is part of the table's sort key, so ClickHouse has to read the whole organization partition to return a handful of rows. For a large organization (~100M rows) this takes a few seconds when queried directly and tens of seconds under load.

## Description

This adds `bloom_filter(0.001)` skip indexes with `GRANULARITY 1` on `external_customer_id` and `external_subscription_id`:

- two self-hosted migrations, one per index, each adding and materializing its index. ClickHouse DDL is not transactional, so keeping one index per migration means a failure leaves a clean state instead of a half-applied migration. Both use `IF NOT EXISTS` / `IF EXISTS` guards and a `down` that drops the index, so they are idempotent and reversible.
- the same `INDEX` declarations in the cloud DDL file, so new clusters get them at table creation.

A benchmark on a clone of the affected table showed rows read dropping from 100M+ to 300k and latency from 2.1s to 0.39s for the customer-scoped query, with identical results returned. No query or resolver change is needed; the indexes are transparent.

Note that `MATERIALIZE INDEX` runs as a background mutation: the migration returns immediately and the speedup on existing data applies once the mutation completes (visible in `system.mutations`).

The ClickHouse migration conventions used here (self-hosted vs cloud DDL, one concern per migration, explicit `up`/`down` with guards) were also documented in `AGENTS.md`.

Fixes ING-367
