### PR TITLE
fix(fc-units-override): Add validation to prevent fixed charges updates for incomplete subscriptions

### DIFF
--- a/app/services/subscriptions/update_or_override_fixed_charge_service.rb
+++ b/app/services/subscriptions/update_or_override_fixed_charge_service.rb
@@ -20,6 +20,7 @@ module Subscriptions
     def call
       return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "subscription") unless subscription
+      return result.single_validation_failure!(error_code: "subscription_incomplete") if subscription.incomplete?
       return result.not_found_failure!(resource: "fixed_charge") unless fixed_charge
 
       ActiveRecord::Base.transaction do

--- a/spec/graphql/mutations/subscriptions/update_fixed_charge_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_fixed_charge_spec.rb
@@ -94,6 +94,17 @@ RSpec.describe Mutations::Subscriptions::UpdateFixedCharge, :premium do
     end
   end
 
+  context "when subscription is incomplete" do
+    let(:subscription) { create(:subscription, :incomplete, organization:, plan:) }
+
+    it "returns a validation error" do
+      result = subject
+
+      expect(result["errors"].first["extensions"]["code"]).to eq("unprocessable_entity")
+      expect(result["errors"].first["extensions"]["details"]["base"]).to eq(["subscription_incomplete"])
+    end
+  end
+
   context "when subscription already has plan override" do
     let(:overridden_plan) { create(:plan, organization:, parent: plan) }
     let(:subscription) { create(:subscription, organization:, plan: overridden_plan) }

--- a/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
@@ -223,6 +223,19 @@ RSpec.describe Api::V1::Subscriptions::FixedChargesController do
         end
       end
 
+      context "when subscription is incomplete" do
+        subject { put_with_token(organization, "/api/v1/subscriptions/#{external_id_query_param}/fixed_charges/#{fixed_charge.code}?status=incomplete", {fixed_charge: update_params}) }
+
+        let(:subscription) { create(:subscription, :incomplete, external_id:, customer:, plan:) }
+
+        it "returns a validation error" do
+          subject
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(json[:error_details]).to eq({base: %w[subscription_incomplete]})
+        end
+      end
+
       context "when subscription already has plan override" do
         let(:overridden_plan) { create(:plan, organization:, parent: plan) }
         let(:subscription) { create(:subscription, customer:, plan: overridden_plan, external_id:) }

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -618,7 +618,7 @@ describe "Payment Gated Subscription Activation Scenarios" do
         end
     end
 
-    it "bills an override unit increase applied immediately as a delta invoice on activation" do
+    it "rejects an override unit increase while the subscription is incomplete" do
       travel_to(Time.zone.local(2026, 3, 1, 10)) do
         fixed_charge
         create_subscription(subscription_params)
@@ -629,32 +629,28 @@ describe "Payment Gated Subscription Activation Scenarios" do
       expect(subscription).to be_incomplete
       expect(subscription.invoices.count).to eq(1)
 
-      # Mid-gap: the fixed charge units are overridden for this subscription only.
+      # Mid-gap: overriding the fixed charge units is rejected.
       travel_to(Time.zone.local(2026, 3, 10, 10)) do
-        Subscriptions::UpdateOrOverrideFixedChargeService.call!(
+        result = Subscriptions::UpdateOrOverrideFixedChargeService.call(
           subscription:,
           fixed_charge:,
           params: {units: 15, apply_units_immediately: true}
         )
         perform_all_enqueued_jobs
+
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({base: ["subscription_incomplete"]})
       end
 
-      subscription.reload
-      expect(subscription.plan).to eq(plan)
-
-      override = Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)
-      expect(override.units).to eq(15)
+      expect(Subscription::FixedChargeUnitsOverride.find_by(subscription:, fixed_charge:)).to be_nil
+      expect(subscription.fixed_charge_events.where(timestamp: Time.zone.local(2026, 3, 10, 10))).to be_empty
       expect(subscription.invoices.count).to eq(1)
 
       travel_to(Time.zone.local(2026, 3, 20, 10)) { simulate_stripe_webhook(status: "succeeded") }
 
       subscription.reload
       expect(subscription).to be_active
-      expect(subscription.invoices.count).to eq(2)
-
-      delta_fee = subscription.invoices.order(:created_at).last.fees.fixed_charge.sole
-      expect(delta_fee.fixed_charge).to eq(fixed_charge)
-      expect(delta_fee.units).to eq(5)
+      expect(subscription.invoices.count).to eq(1)
     end
   end
 

--- a/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
+++ b/spec/services/subscriptions/update_or_override_fixed_charge_service_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe Subscriptions::UpdateOrOverrideFixedChargeService do
         subscription
       end
 
+      context "when subscription is incomplete" do
+        let(:subscription) { create(:subscription, :incomplete, customer:, plan:) }
+
+        it "returns a validation error without applying the change" do
+          result = nil
+          expect { result = service.call }.not_to change(Plan, :count)
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({base: ["subscription_incomplete"]})
+        end
+      end
+
       it "creates a plan override" do
         expect { service.call }.to change(Plan, :count).by(1)
 


### PR DESCRIPTION
## Context

A subscription gated on a payment activation rule (`incomplete` status) must not be editable until the gating invoice is paid. `Subscriptions::UpdateService` already rejects edits on incomplete subscriptions, but the dedicated fixed-charge edition endpoint (`updateSubscriptionFixedCharge` mutation and `PUT /api/v1/subscriptions/:external_id/fixed_charges/:code`) did not: the edition was applied and the emitted fixed-charge event was billed by `BillFixedChargesDeltaJob` right after activation, bypassing the payment gate.

## Description

Reject any fixed-charge edition on an incomplete subscription with a `subscription_incomplete` validation failure at the top of `Subscriptions::UpdateOrOverrideFixedChargeService#call`, covering both the GraphQL and REST entry points. Pending and active subscriptions (including formerly gated ones) remain fully editable.
