### PR TITLE
[STA-8] misc: Remove OpenStructs from specs

### DIFF
--- a/spec/factories/integration_taxes.rb
+++ b/spec/factories/integration_taxes.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tax_result, class: "Integrations::Aggregator::Taxes::TaxResult" do
+    skip_create
+    initialize_with do
+      new(item_key:, item_id:, item_code:, amount_cents:, tax_amount_cents:, tax_breakdown:)
+    end
+
+    item_key { nil }
+    item_id { nil }
+    item_code { nil }
+    amount_cents { nil }
+    tax_amount_cents { nil }
+    tax_breakdown { [] }
+  end
+
+  factory :tax_breakdown_item, class: "Integrations::Aggregator::Taxes::TaxResult::TaxBreakdownItem" do
+    skip_create
+    initialize_with { new(name:, rate:, tax_amount:, type:) }
+
+    name { nil }
+    rate { nil }
+    tax_amount { nil }
+    type { nil }
+  end
+end

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -154,8 +154,8 @@ RSpec.describe CreditNotes::ApplyTaxesService do
   end
 
   context "when taxes from tax provider are applied" do
-    let(:provider_tax_1) { OpenStruct.new(name: "provider tax 1", type: "providerTax1", rate: 12.0, code: "provider_tax_1") }
-    let(:provider_tax_2) { OpenStruct.new(name: "provider tax 2", type: "providerTax2", rate: 8.0, code: "provider_tax_2") }
+    let(:provider_tax_1) { build(:tax_breakdown_item, name: "provider tax 1", type: "providerTax1", rate: 12.0) }
+    let(:provider_tax_2) { build(:tax_breakdown_item, name: "provider tax 2", type: "providerTax2", rate: 8.0) }
 
     let(:fee_applied_tax11) do
       create(
@@ -215,7 +215,7 @@ RSpec.describe CreditNotes::ApplyTaxesService do
             credit_note: nil,
             tax: nil,
             tax_description: provider_tax_1.type,
-            tax_code: provider_tax_1.code,
+            tax_code: provider_tax_1.name.parameterize(separator: "_"),
             tax_name: provider_tax_1.name,
             tax_rate: provider_tax_1.rate,
             amount_currency: invoice.currency,
@@ -226,7 +226,7 @@ RSpec.describe CreditNotes::ApplyTaxesService do
             credit_note: nil,
             tax: nil,
             tax_description: provider_tax_2.type,
-            tax_code: provider_tax_2.code,
+            tax_code: provider_tax_2.name.parameterize(separator: "_"),
             tax_name: provider_tax_2.name,
             tax_rate: provider_tax_2.rate,
             amount_currency: invoice.currency,
@@ -263,8 +263,8 @@ RSpec.describe CreditNotes::ApplyTaxesService do
         )
       end
 
-      let(:provider_tax_1) { OpenStruct.new(name: "provider tax 1", type: "providerTax1", rate: 20.0, code: "provider_tax_1") }
-      let(:provider_tax_2) { OpenStruct.new(name: "provider tax 2", type: "providerTax2", rate: 10.0, code: "provider_tax_2") }
+      let(:provider_tax_1) { build(:tax_breakdown_item, name: "provider tax 1", type: "providerTax1", rate: 20.0) }
+      let(:provider_tax_2) { build(:tax_breakdown_item, name: "provider tax 2", type: "providerTax2", rate: 10.0) }
 
       describe "call" do
         it "creates applied taxes" do
@@ -279,7 +279,7 @@ RSpec.describe CreditNotes::ApplyTaxesService do
             credit_note: nil,
             tax: nil,
             tax_description: provider_tax_1.type,
-            tax_code: provider_tax_1.code,
+            tax_code: provider_tax_1.name.parameterize(separator: "_"),
             tax_name: provider_tax_1.name,
             tax_rate: provider_tax_1.rate,
             amount_currency: invoice.currency,
@@ -290,7 +290,7 @@ RSpec.describe CreditNotes::ApplyTaxesService do
             credit_note: nil,
             tax: nil,
             tax_description: provider_tax_2.type,
-            tax_code: provider_tax_2.code,
+            tax_code: provider_tax_2.name.parameterize(separator: "_"),
             tax_name: provider_tax_2.name,
             tax_rate: provider_tax_2.rate,
             amount_currency: invoice.currency,

--- a/spec/services/fees/apply_provider_taxes_service_spec.rb
+++ b/spec/services/fees/apply_provider_taxes_service_spec.rb
@@ -17,13 +17,12 @@ RSpec.describe Fees::ApplyProviderTaxesService do
   let(:precise_coupons_amount_cents) { 0 }
 
   let(:fee_taxes) do
-    OpenStruct.new(
+    build(:tax_result,
       tax_amount_cents: 170,
       tax_breakdown: [
-        OpenStruct.new(name: "tax 2", type: "type2", rate: "0.12", tax_amount: 120),
-        OpenStruct.new(name: "tax 3", type: "type3", rate: "0.05", tax_amount: 50)
-      ]
-    )
+        build(:tax_breakdown_item, name: "tax 2", type: "type2", rate: "0.12", tax_amount: 120),
+        build(:tax_breakdown_item, name: "tax 3", type: "type3", rate: "0.05", tax_amount: 50)
+      ])
   end
 
   before do
@@ -46,13 +45,12 @@ RSpec.describe Fees::ApplyProviderTaxesService do
 
       context "when there is tax deduction" do
         let(:fee_taxes) do
-          OpenStruct.new(
+          build(:tax_result,
             tax_amount_cents: 136,
             tax_breakdown: [
-              OpenStruct.new(name: "tax 2", type: "type2", rate: "0.12", tax_amount: 96),
-              OpenStruct.new(name: "tax 3", type: "type3", rate: "0.05", tax_amount: 40)
-            ]
-          )
+              build(:tax_breakdown_item, name: "tax 2", type: "type2", rate: "0.12", tax_amount: 96),
+              build(:tax_breakdown_item, name: "tax 3", type: "type3", rate: "0.05", tax_amount: 40)
+            ])
         end
 
         it "creates applied_taxes based on the provider taxes" do
@@ -75,10 +73,9 @@ RSpec.describe Fees::ApplyProviderTaxesService do
 
       context "when taxes are paid by the seller" do
         let(:fee_taxes) do
-          OpenStruct.new(
+          build(:tax_result,
             tax_amount_cents: 0,
-            tax_breakdown: [OpenStruct.new(name: "Tax", type: "tax", rate: "0.00", tax_amount: 0)]
-          )
+            tax_breakdown: [build(:tax_breakdown_item, name: "Tax", type: "tax", rate: "0.00", tax_amount: 0)])
         end
 
         it "does not create applied_taxes" do
@@ -119,12 +116,11 @@ RSpec.describe Fees::ApplyProviderTaxesService do
       special_rules.each do |applied_rule|
         context "when tax provider returned specific rule applied to fees - #{applied_rule[:expected_name]}" do
           let(:fee_taxes) do
-            OpenStruct.new(
+            build(:tax_result,
               tax_amount_cents: 0,
               tax_breakdown: [
-                OpenStruct.new(name: applied_rule[:expected_name], type: applied_rule[:received_type], rate: "0.00", tax_amount: 0)
-              ]
-            )
+                build(:tax_breakdown_item, name: applied_rule[:expected_name], type: applied_rule[:received_type], rate: "0.00", tax_amount: 0)
+              ])
           end
 
           it "creates applied_taxes based on the provider rules" do

--- a/spec/services/invoices/apply_provider_taxes_service_spec.rb
+++ b/spec/services/invoices/apply_provider_taxes_service_spec.rb
@@ -24,17 +24,15 @@ RSpec.describe Invoices::ApplyProviderTaxesService do
 
   let(:fee_taxes) do
     [
-      OpenStruct.new(
+      build(:tax_result,
         tax_breakdown: [
-          OpenStruct.new(name: "tax 1", type: "type1", rate: "0.10")
-        ]
-      ),
-      OpenStruct.new(
+          build(:tax_breakdown_item, name: "tax 1", type: "type1", rate: "0.10")
+        ]),
+      build(:tax_result,
         tax_breakdown: [
-          OpenStruct.new(name: "tax 1", type: "type1", rate: "0.10"),
-          OpenStruct.new(name: "tax 2", type: "type2", rate: "0.12")
-        ]
-      )
+          build(:tax_breakdown_item, name: "tax 1", type: "type1", rate: "0.10"),
+          build(:tax_breakdown_item, name: "tax 2", type: "type2", rate: "0.12")
+        ])
     ]
   end
 
@@ -229,20 +227,18 @@ RSpec.describe Invoices::ApplyProviderTaxesService do
             context "when tax provider returned specific rule applied to fees - #{applied_rule[:expected_name]}" do
               let(:fee_taxes) do
                 [
-                  OpenStruct.new(
+                  build(:tax_result,
                     tax_amount_cents: 0,
                     tax_breakdown: [
-                      OpenStruct.new(name: applied_rule[:expected_name], type: applied_rule[:received_type],
+                      build(:tax_breakdown_item, name: applied_rule[:expected_name], type: applied_rule[:received_type],
                         rate: "0.00", tax_amount: 0)
-                    ]
-                  ),
-                  OpenStruct.new(
+                    ]),
+                  build(:tax_result,
                     tax_amount_cents: 0,
                     tax_breakdown: [
-                      OpenStruct.new(name: applied_rule[:expected_name], type: applied_rule[:received_type],
+                      build(:tax_breakdown_item, name: applied_rule[:expected_name], type: applied_rule[:received_type],
                         rate: "0.00", tax_amount: 0)
-                    ]
-                  )
+                    ])
                 ]
               end
               let(:fee1) { create(:fee, invoice:, amount_cents: 1000, precise_coupons_amount_cents: 0) }
@@ -282,14 +278,12 @@ RSpec.describe Invoices::ApplyProviderTaxesService do
         context "with seller paying taxes" do
           let(:fee_taxes) do
             [
-              OpenStruct.new(
+              build(:tax_result,
                 tax_amount_cents: 0,
-                tax_breakdown: [OpenStruct.new(name: "Tax", type: "tax", rate: "0.00", tax_amount: 0)]
-              ),
-              OpenStruct.new(
+                tax_breakdown: [build(:tax_breakdown_item, name: "Tax", type: "tax", rate: "0.00", tax_amount: 0)]),
+              build(:tax_result,
                 tax_amount_cents: 0,
-                tax_breakdown: [OpenStruct.new(name: "Tax", type: "tax", rate: "0.00", tax_amount: 0)]
-              )
+                tax_breakdown: [build(:tax_breakdown_item, name: "Tax", type: "tax", rate: "0.00", tax_amount: 0)])
             ]
           end
           let(:fee1) { create(:fee, invoice:, amount_cents: 1000, precise_coupons_amount_cents: 0) }

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -130,14 +130,13 @@ RSpec.describe Invoices::ComputeAmountsFromFees do
     let(:fee2) { create(:fee, invoice: nil) }
 
     let(:fee_taxes) do
-      OpenStruct.new(
+      build(:tax_result,
         item_id: fee1.id,
         item_code: "lago_default_b2b",
         tax_breakdown: [
-          OpenStruct.new(name: "tax 1", type: "type1", rate: "0.50", tax_amount: 75.5),
-          OpenStruct.new(name: "tax 2", type: "type2", rate: "0.30", tax_amount: 45.3)
-        ]
-      )
+          build(:tax_breakdown_item, name: "tax 1", type: "type1", rate: "0.50", tax_amount: 75.5),
+          build(:tax_breakdown_item, name: "tax 2", type: "type2", rate: "0.30", tax_amount: 45.3)
+        ])
     end
 
     before do


### PR DESCRIPTION
## Context

This PR is part of the epic to remove all remaining instances of `OpenStruct` from the code base.

## Description

The PR replaces `OpenStruct` initialization with already existing types (`Integrations::Aggregator::Taxes::TaxResult` and `Integrations::Aggregator::Taxes::TaxResult::TaxBreakdownItem`) 
