### PR TITLE
[STA-8] misc: Remove OpenStructs from Okta specs

### DIFF
--- a/spec/graphql/mutations/auth/okta/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/okta/accept_invite_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Mutations::Auth::Okta::AcceptInvite, :premium, cache: :memory do
   let(:invite) { create(:invite, email: "foo@bar.com", organization:) }
   let(:okta_integration) { create(:okta_integration, domain: "bar.com", organization_name: "foo", organization:) }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }
-  let(:okta_token_response) { OpenStruct.new(body: {access_token: "access_token"}) }
-  let(:okta_userinfo_response) { OpenStruct.new({email: "foo@bar.com"}) }
+  let(:okta_token_response) { {"access_token" => "access_token"} }
+  let(:okta_userinfo_response) { {"email" => "foo@bar.com"} }
   let(:state) { SecureRandom.uuid }
 
   let(:mutation) do

--- a/spec/graphql/mutations/auth/okta/login_spec.rb
+++ b/spec/graphql/mutations/auth/okta/login_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Mutations::Auth::Okta::Login, :premium, cache: :memory do
   let(:okta_integration) { create(:okta_integration, domain: "bar.com", organization_name: "foo") }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }
-  let(:okta_token_response) { OpenStruct.new(body: {access_token: "access_token"}) }
-  let(:okta_userinfo_response) { OpenStruct.new({email: "foo@bar.com"}) }
+  let(:okta_token_response) { {"access_token" => "access_token"} }
+  let(:okta_userinfo_response) { {"email" => "foo@bar.com"} }
   let(:state) { SecureRandom.uuid }
 
   let(:mutation) do

--- a/spec/services/auth/okta/accept_invite_service_spec.rb
+++ b/spec/services/auth/okta/accept_invite_service_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Auth::Okta::AcceptInviteService, :premium, cache: :memory do
   let(:invite) { create(:invite, email: "foo@bar.com", organization:) }
   let(:invite_token) { invite.token }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }
-  let(:okta_token_response) { OpenStruct.new(body: {access_token: "access_token"}) }
-  let(:okta_userinfo_response) { OpenStruct.new({email: "foo@bar.com"}) }
+  let(:okta_token_response) { {"access_token" => "access_token"} }
+  let(:okta_userinfo_response) { {"email" => "foo@bar.com"} }
   let(:code) { "code" }
   let(:state) { SecureRandom.uuid }
 
@@ -99,7 +99,7 @@ RSpec.describe Auth::Okta::AcceptInviteService, :premium, cache: :memory do
     end
 
     context "when okta userinfo email is different from the state one" do
-      let(:okta_userinfo_response) { OpenStruct.new({email: "foo@test.com"}) }
+      let(:okta_userinfo_response) { {"email" => "foo@test.com"} }
 
       it "returns error" do
         result = service.call

--- a/spec/services/auth/okta/login_service_spec.rb
+++ b/spec/services/auth/okta/login_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Auth::Okta::LoginService, cache: :memory do
   let(:service) { described_class.new(code:, state:) }
   let(:okta_integration) { create(:okta_integration, domain: "bar.com", organization_name: "foo") }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }
-  let(:okta_token_response) { OpenStruct.new(body: {access_token: "access_token"}) }
-  let(:okta_userinfo_response) { OpenStruct.new({email: "foo@bar.com"}) }
+  let(:okta_token_response) { {"access_token" => "access_token"} }
+  let(:okta_userinfo_response) { {"email" => "foo@bar.com"} }
   let(:state) { SecureRandom.uuid }
   let(:code) { "code" }
 
@@ -94,7 +94,7 @@ RSpec.describe Auth::Okta::LoginService, cache: :memory do
     end
 
     context "when okta userinfo email is different from the state one" do
-      let(:okta_userinfo_response) { OpenStruct.new({email: "foo@test.com"}) }
+      let(:okta_userinfo_response) { {"email" => "foo@test.com"} }
 
       it "returns error" do
         result = service.call


### PR DESCRIPTION
## Context

Similarly to https://github.com/getlago/lago-api/pull/5920 and https://github.com/getlago/lago-api/pull/5922, this PR is part of the epic to remove all remaining instances of `OpenStruct` from the code base.

## Description

The PR replaces `OpenStruct` from Okta related specs with pure ruby `Hash`. The code is accessing the response using `['key']`, so Openstruct instances are not required
