### PR TITLE
[STA-10] misc: Remove OpenStruct from Serializers specs

### DIFF
--- a/spec/models/error_detail_spec.rb
+++ b/spec/models/error_detail_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe ErrorDetail do
     let(:error) { BaseService::ValidationFailure.new(result, messages: messages) }
     let(:messages) { ["message1", "message2"] }
 
-    let(:error_with_backtrace) do
-      error = OpenStruct.new
-      error.backtrace = "backtrace"
-      error
-    end
+    let(:error_with_backtrace) { Struct.new(:backtrace).new("backtrace") }
 
     describe ".create_generation_error_for" do
       it "does nothing if the invoice is nil" do

--- a/spec/serializers/v1/customers/past_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/past_usage_serializer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ::V1::Customers::PastUsageSerializer do
   let(:fee1) { create(:charge_fee, charge: charge1, invoice:, presentation_breakdowns: [build(:presentation_breakdown)]) }
   let(:fee2) { create(:charge_fee, charge: charge2, invoice:) }
 
-  let(:usage) { OpenStruct.new(invoice_subscription:, fees: [fee1, fee2]) }
+  let(:usage) { PastUsageQuery::UsagePeriods.new(invoice_subscription:, fees: [fee1, fee2]) }
 
   it "serializes the past usage" do
     result = JSON.parse(serializer.to_json)

--- a/spec/serializers/v1/customers/projected_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/projected_usage_serializer_spec.rb
@@ -28,23 +28,16 @@ RSpec.describe ::V1::Customers::ProjectedUsageSerializer do
       total_amount_cents: 6,
       taxes_amount_cents: 1,
       fees: [
-        OpenStruct.new(
-          billable_metric: billable_metric,
+        build(
+          :charge_fee,
           charge: charge,
-          charge_id: charge.id,
           subscription: subscription,
           units: "4.0",
           amount_cents: 5,
           amount_currency: "EUR",
           events_count: 1,
           charge_filter: nil,
-          grouped_by: {},
-          properties: {
-            "from_datetime" => from_datetime.iso8601,
-            "to_datetime" => to_datetime.iso8601,
-            "charges_duration" => 30
-          },
-          presentation_breakdowns: []
+          grouped_by: {}
         )
       ]
     )

--- a/spec/serializers/v1/customers/usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/usage_serializer_spec.rb
@@ -28,23 +28,16 @@ RSpec.describe ::V1::Customers::UsageSerializer do
       total_amount_cents: 6,
       taxes_amount_cents: 1,
       fees: [
-        OpenStruct.new(
-          billable_metric: billable_metric,
+        build(
+          :charge_fee,
           charge: charge,
-          charge_id: charge.id,
           subscription: subscription,
           units: "4.0",
           amount_cents: 5,
           amount_currency: "EUR",
           events_count: 1,
           charge_filter: nil,
-          grouped_by: {},
-          properties: {
-            "from_datetime" => from_datetime.iso8601,
-            "to_datetime" => to_datetime.iso8601,
-            "charges_duration" => 30
-          },
-          presentation_breakdowns: []
+          grouped_by: {}
         )
       ]
     )

--- a/spec/serializers/v1/event_error_serializer_spec.rb
+++ b/spec/serializers/v1/event_error_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ::V1::EventErrorSerializer do
   subject(:serializer) { described_class.new(event_error, root_name: "event_error") }
 
   let(:event_error) do
-    OpenStruct.new(
+    Webhooks::Events::ErrorService::EventError.new(
       error: {transaction_id: ["value_already_exist"]},
       event: create(:received_event)
     )

--- a/spec/services/customers/generate_checkout_url_service_spec.rb
+++ b/spec/services/customers/generate_checkout_url_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Customers::GenerateCheckoutUrlService do
 
         allow(stripe_customer_service).to receive(:generate_checkout_url)
           .with(send_webhook: false)
-          .and_return(OpenStruct.new(checkout_url: "http://foo.bar"))
+          .and_return(BaseResult[:checkout_url].new.tap { |r| r.checkout_url = "http://foo.bar" })
       end
 
       it "returns the generated checkout url" do

--- a/spec/services/daily_usages/fill_from_invoice_service_spec.rb
+++ b/spec/services/daily_usages/fill_from_invoice_service_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe DailyUsages::FillFromInvoiceService do
 
     let(:charge) { create(:standard_charge, plan: subscription.plan) }
 
-    it "returns an OpenStruct with correct datetime attributes" do
+    it "returns a Struct with correct datetime attributes" do
       expect(usage.from_datetime).to eq(invoice_subscription.charges_from_datetime.change(usec: 0))
       expect(usage.to_datetime).to eq(invoice_subscription.charges_to_datetime.change(usec: 0))
     end


### PR DESCRIPTION
## Context

Similarly to https://github.com/getlago/lago-api/pull/5920, https://github.com/getlago/lago-api/pull/5922 and https://github.com/getlago/lago-api/pull/5923, this PR is part of the epic to remove all remaining instances of `OpenStruct` from the code base.

## Description

The PR replaces `OpenStruct` from Serializers related specs with existing classes and structures
