### PR TITLE
[STA-8] misc: Remove OpenStruct from Integrations

### DIFF
--- a/app/services/integrations/aggregator/account_information_service.rb
+++ b/app/services/integrations/aggregator/account_information_service.rb
@@ -3,6 +3,8 @@
 module Integrations
   module Aggregator
     class AccountInformationService < BaseService
+      AccountInformation = Data.define(:id)
+
       def action_path
         "v1/account-information"
       end
@@ -12,7 +14,7 @@ module Integrations
 
         response = http_client.get(headers:)
 
-        result.account_information = OpenStruct.new(response)
+        result.account_information = AccountInformation.new(id: response["id"])
         result
       end
 

--- a/app/services/integrations/aggregator/custom_object_service.rb
+++ b/app/services/integrations/aggregator/custom_object_service.rb
@@ -3,6 +3,8 @@
 module Integrations
   module Aggregator
     class CustomObjectService < BaseService
+      CustomObject = Data.define(:id, :object_type_id)
+
       def initialize(integration:, name:)
         @name = name
         super(integration:)
@@ -17,7 +19,7 @@ module Integrations
 
         response = http_client.get(headers:, body:)
 
-        result.custom_object = OpenStruct.new(response)
+        result.custom_object = CustomObject.new(id: response["id"], object_type_id: response["objectTypeId"])
         result
       rescue LagoHttpClient::HttpError => e
         result.service_failure!(code: e.error_code, message: e.message)

--- a/app/services/integrations/aggregator/taxes/credit_notes/payloads/anrok.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payloads/anrok.rb
@@ -52,11 +52,10 @@ module Integrations
               elsif fee.subscription?
                 subscription_item
               end
-              mapped_item ||= OpenStruct.new
 
               {
                 "item_id" => fee.item_id,
-                "item_code" => mapped_item.external_id,
+                "item_code" => mapped_item&.external_id,
                 "amount_cents" => item.sub_total_excluding_taxes_amount_cents.round * -1
               }
             end

--- a/app/services/integrations/aggregator/taxes/credit_notes/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payloads/avalara.rb
@@ -61,11 +61,10 @@ module Integrations
               elsif fee.subscription?
                 subscription_item
               end
-              mapped_item ||= OpenStruct.new
 
               {
                 "item_id" => fee.item_id,
-                "item_code" => mapped_item.external_id,
+                "item_code" => mapped_item&.external_id,
                 "unit" => fee.units,
                 "amount" => item_amount(item, fee)
               }

--- a/app/services/integrations/aggregator/taxes/invoices/payloads/anrok.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payloads/anrok.rb
@@ -50,12 +50,11 @@ module Integrations
               elsif fee.subscription?
                 subscription_item
               end
-              mapped_item ||= empty_struct
 
               {
                 "item_key" => fee.item_key,
                 "item_id" => fee.id || fee.item_id,
-                "item_code" => mapped_item.external_id,
+                "item_code" => mapped_item&.external_id,
                 "amount_cents" => fee.sub_total_excluding_taxes_amount_cents&.to_i
               }
             end
@@ -63,10 +62,6 @@ module Integrations
             private
 
             attr_reader :customer, :integration_customer, :invoice, :fees
-
-            def empty_struct
-              @empty_struct ||= OpenStruct.new
-            end
 
             def issuing_date
               # NOTE: Anrok API requires issuing date to be 30 days in the future at  most.

--- a/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
@@ -57,12 +57,11 @@ module Integrations
               elsif fee.subscription?
                 subscription_item
               end
-              mapped_item ||= empty_struct
 
               {
                 "item_key" => fee.item_key,
                 "item_id" => fee.id || fee.item_id,
-                "item_code" => mapped_item.external_id,
+                "item_code" => mapped_item&.external_id,
                 "unit" => fee.units,
                 "amount" => item_amount(fee)
               }
@@ -71,10 +70,6 @@ module Integrations
             private
 
             attr_reader :customer, :integration_customer, :invoice, :fees
-
-            def empty_struct
-              @empty_struct ||= OpenStruct.new
-            end
 
             def item_amount(fee)
               amount = fee.sub_total_excluding_taxes_amount_cents&.to_i&.fdiv(subunit_to_unit(fee))

--- a/app/services/integrations/hubspot/invoices/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/invoices/deploy_object_service.rb
@@ -18,7 +18,7 @@ module Integrations
 
           custom_object_result = Integrations::Aggregator::CustomObjectService.call(integration:, name: "LagoInvoices")
           if custom_object_result.success?
-            save_object_type_id(custom_object_result.custom_object&.objectTypeId)
+            save_object_type_id(custom_object_result.custom_object&.object_type_id)
             return result
           end
 

--- a/app/services/integrations/hubspot/subscriptions/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/subscriptions/deploy_object_service.rb
@@ -19,7 +19,7 @@ module Integrations
 
           custom_object_result = Integrations::Aggregator::CustomObjectService.call(integration:, name: "LagoSubscriptions")
           if custom_object_result.success?
-            save_object_type_id(custom_object_result.custom_object&.objectTypeId)
+            save_object_type_id(custom_object_result.custom_object&.object_type_id)
             return result
           end
 

--- a/spec/factories/flutterwave_payments.rb
+++ b/spec/factories/flutterwave_payments.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flutterwave_payment, class: "PaymentProviders::FlutterwaveProvider::FlutterwavePayment" do
+    skip_create
+    initialize_with { new(id:, status:, metadata:) }
+
+    id { "flw_payment_123" }
+    status { nil }
+    metadata { {} }
+  end
+end

--- a/spec/services/integrations/aggregator/custom_object_service_spec.rb
+++ b/spec/services/integrations/aggregator/custom_object_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Integrations::Aggregator::CustomObjectService do
       expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
       expect(lago_client).to have_received(:get)
       expect(custom_object.id).to eq("35482707")
-      expect(custom_object.objectTypeId).to eq("2-35482707")
+      expect(custom_object.object_type_id).to eq("2-35482707")
     end
   end
 end

--- a/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployObjectService do
         instance_double(
           "CustomObjectResult",
           success?: true,
-          custom_object: instance_double("CustomObject", objectTypeId: "123")
+          custom_object: instance_double("CustomObject", object_type_id: "123")
         )
       end
 

--- a/spec/services/integrations/hubspot/save_portal_id_service_spec.rb
+++ b/spec/services/integrations/hubspot/save_portal_id_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Integrations::Hubspot::SavePortalIdService do
     let(:integration) { create(:hubspot_integration) }
     let(:service_call) { described_class.call(integration:) }
     let(:result) { BaseService::Result.new }
-    let(:account_information) { OpenStruct.new(id: portal_id) }
+    let(:account_information) { Integrations::Aggregator::AccountInformationService::AccountInformation.new(id: portal_id) }
 
     before do
       result.account_information = account_information

--- a/spec/services/invoices/payments/flutterwave_service_spec.rb
+++ b/spec/services/invoices/payments/flutterwave_service_spec.rb
@@ -17,13 +17,12 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
 
   describe "#update_payment_status" do
     let(:flutterwave_payment) do
-      OpenStruct.new(
+      build(:flutterwave_payment,
         id: "flw_payment_123",
         metadata: {
           payment_type: "one-time",
           lago_invoice_id: invoice.id
-        }
-      )
+        })
     end
 
     context "when creating a new payment" do
@@ -83,10 +82,9 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
       end
 
       let(:flutterwave_payment) do
-        OpenStruct.new(
+        build(:flutterwave_payment,
           id: "flw_payment_123",
-          metadata: {payment_type: "recurring"}
-        )
+          metadata: {payment_type: "recurring"})
       end
 
       before { existing_payment }
@@ -121,10 +119,9 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
 
     context "when payment is not found" do
       let(:flutterwave_payment) do
-        OpenStruct.new(
+        build(:flutterwave_payment,
           id: "nonexistent_payment",
-          metadata: {payment_type: "recurring"}
-        )
+          metadata: {payment_type: "recurring"})
       end
 
       it "returns not found failure" do
@@ -151,10 +148,9 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
       end
 
       let(:flutterwave_payment) do
-        OpenStruct.new(
+        build(:flutterwave_payment,
           id: "flw_payment_123",
-          metadata: {payment_type: "recurring"}
-        )
+          metadata: {payment_type: "recurring"})
       end
 
       before { existing_payment }

--- a/spec/services/payment_requests/payments/flutterwave_service_spec.rb
+++ b/spec/services/payment_requests/payments/flutterwave_service_spec.rb
@@ -101,13 +101,12 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
 
   describe "#update_payment_status" do
     let(:flutterwave_payment) do
-      OpenStruct.new(
+      build(:flutterwave_payment,
         id: "flw_payment_123",
         metadata: {
           payment_type: "one-time",
           lago_payable_id: payment_request.id
-        }
-      )
+        })
     end
 
     context "when creating a new payment" do
@@ -143,10 +142,9 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       end
 
       let(:flutterwave_payment) do
-        OpenStruct.new(
+        build(:flutterwave_payment,
           id: "flw_payment_123",
-          metadata: {payment_type: "recurring"}
-        )
+          metadata: {payment_type: "recurring"})
       end
 
       before { existing_payment }
@@ -166,10 +164,9 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
 
     context "when payment is not found" do
       let(:flutterwave_payment) do
-        OpenStruct.new(
+        build(:flutterwave_payment,
           id: "nonexistent_payment",
-          metadata: {payment_type: "recurring"}
-        )
+          metadata: {payment_type: "recurring"})
       end
 
       it "returns not found failure" do
@@ -196,10 +193,9 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       end
 
       let(:flutterwave_payment) do
-        OpenStruct.new(
+        build(:flutterwave_payment,
           id: "flw_payment_123",
-          metadata: {payment_type: "recurring"}
-        )
+          metadata: {payment_type: "recurring"})
       end
 
       before { existing_payment }
@@ -221,13 +217,12 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
 
     context "when payment fails" do
       let(:flutterwave_payment) do
-        OpenStruct.new(
+        build(:flutterwave_payment,
           id: "flw_payment_123",
           metadata: {
             payment_type: "one-time",
             lago_payable_id: payment_request.id
-          }
-        )
+          })
       end
 
       before do


### PR DESCRIPTION
## Context

Similarly to https://github.com/getlago/lago-api/pull/5920, https://github.com/getlago/lago-api/pull/5922 and https://github.com/getlago/lago-api/pull/5923, this PR is part of the epic to remove all remaining instances of `OpenStruct` from the code base.

## Description

The PR replaces `OpenStruct` from integration and payment providers with proper objects