### PR TITLE
fix(entitlement): skip discarded features in payload

### DIFF
--- a/app/controllers/api/v1/plans/entitlements_controller.rb
+++ b/app/controllers/api/v1/plans/entitlements_controller.rb
@@ -8,6 +8,7 @@ module Api
 
         def index
           entitlements = current_organization.entitlements
+            .joins(:feature)
             .where(plan: plan)
             .includes(:feature, values: :privilege)
 

--- a/app/serializers/v1/entitlement/plan_entitlement_serializer.rb
+++ b/app/serializers/v1/entitlement/plan_entitlement_serializer.rb
@@ -15,7 +15,9 @@ module V1
       private
 
       def privileges
-        model.values.map do |ev|
+        model.values.filter_map do |ev|
+          next if ev.privilege.nil?
+
           {
             code: ev.privilege.code,
             name: ev.privilege.name,

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -58,7 +58,7 @@ module V1
 
     def entitlements
       ::CollectionSerializer.new(
-        model.entitlements.includes(:feature, values: :privilege),
+        model.entitlements.joins(:feature).includes(:feature, values: :privilege),
         ::V1::Entitlement::PlanEntitlementSerializer,
         collection_name: "entitlements"
       ).serialize

--- a/spec/requests/api/v1/plans/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements_controller_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe Api::V1::Plans::EntitlementsController do
       expect(json[:entitlements].first[:privileges].sole[:value]).to eq(30)
     end
 
+    context "when the entitlement feature is discarded" do
+      before { feature.discard! }
+
+      it "does not return the orphaned entitlement" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:entitlements]).to eq([])
+      end
+    end
+
     context "when plan has children (subscription plan overrides)" do
       it "always retrieve the parent plan" do
         # NOTE: It should be possible to create entitlements on a child plan,

--- a/spec/serializers/v1/entitlement/plan_entitlement_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/plan_entitlement_serializer_spec.rb
@@ -44,5 +44,15 @@ RSpec.describe V1::Entitlement::PlanEntitlementSerializer do
         }}
       )
     end
+
+    context "when a privilege is discarded" do
+      before { privilege.discard! }
+
+      it "does not serialize values of the discarded privilege" do
+        result = subject.serialize
+
+        expect(result[:privileges].map { |p| p[:code] }).to contain_exactly("bool", "str", "opt")
+      end
+    end
   end
 end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -159,6 +159,16 @@ RSpec.describe ::V1::PlanSerializer do
         ]
       })
     end
+
+    context "when the entitlement feature is discarded" do
+      before { feature.discard! }
+
+      it "does not serialize the orphaned entitlement" do
+        result = JSON.parse(serializer.to_json)
+
+        expect(result["plan"]["entitlements"]).to be_empty
+      end
+    end
   end
 
   context "when plan has fixed charges" do


### PR DESCRIPTION
## Context

A `plan.updated` webhook job died in production with `NoMethodError: undefined method 'code' for nil` (Sidekiq dead set, `SendWebhookJob`). The plan had a kept `Entitlement::Entitlement` pointing to a soft-deleted `Entitlement::Feature`, most likely created by a race between entitlement creation and feature deletion: `FeatureDestroyService` discards the feature and every entitlement visible to it in one transaction, but an entitlement committed concurrently survives as an orphan.

Since `Feature` and `Privilege` have `default_scope -> { kept }` and the `belongs_to` associations don't use `with_discarded`, the serializer dereferences `nil` and the webhook fails on every retry. The `GET /plans/:code/entitlements` index endpoint has the same weakness (500 instead of a dead job).

## Description

- `V1::PlanSerializer#entitlements` and the plan entitlements index now `joins(:feature)`, so the feature's kept default scope filters out entitlements whose feature is discarded.
- `V1::Entitlement::PlanEntitlementSerializer#privileges` skips entitlement values whose privilege is discarded.

Orphaned records are now ignored instead of raising. This does not address the write race that creates the orphan; it makes reads resilient to it.