### PR TITLE
fix(payments): delay auto-payment for hosted-checkout customers

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -7,6 +7,9 @@ module Invoices
 
       include Customers::PaymentProviderFinder
 
+      # Delay the first auto-payment for hosted-checkout customers so their manual payment settles first.
+      CHECKOUT_AUTO_PAYMENT_DELAY = ENV.fetch("LAGO_CHECKOUT_AUTO_PAYMENT_DELAY_SECONDS", 600).to_i.seconds
+
       def initialize(invoice:, payment_provider: nil, payment_method_params: {})
         @invoice = invoice
         @provider = payment_provider&.to_sym
@@ -92,7 +95,15 @@ module Invoices
       def call_async
         return result unless provider
 
-        Invoices::Payments::CreateJob.perform_after_commit(invoice:, payment_provider: provider, payment_method_params:)
+        if defer_for_checkout_customer?
+          AfterCommitEverywhere.after_commit do
+            Invoices::Payments::CreateJob
+              .set(wait: CHECKOUT_AUTO_PAYMENT_DELAY)
+              .perform_later(invoice:, payment_provider: provider, payment_method_params:)
+          end
+        else
+          Invoices::Payments::CreateJob.perform_after_commit(invoice:, payment_provider: provider, payment_method_params:)
+        end
 
         result.payment_provider = provider
         result
@@ -106,6 +117,13 @@ module Invoices
 
       def provider
         @provider ||= invoice.customer.payment_provider&.to_sym
+      end
+
+      # Only the first automatic attempt is delayed; retries keep payment_attempts positive.
+      def defer_for_checkout_customer?
+        return false unless invoice.payment_attempts.zero?
+
+        PaymentIntent.joins(:invoice).where(invoices: {customer_id: invoice.customer_id}).exists?
       end
 
       def should_process_payment?

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -95,14 +95,13 @@ module Invoices
       def call_async
         return result unless provider
 
-        if defer_for_checkout_customer?
-          AfterCommitEverywhere.after_commit do
-            Invoices::Payments::CreateJob
-              .set(wait: CHECKOUT_AUTO_PAYMENT_DELAY)
-              .perform_later(invoice:, payment_provider: provider, payment_method_params:)
-          end
-        else
-          Invoices::Payments::CreateJob.perform_after_commit(invoice:, payment_provider: provider, payment_method_params:)
+        forced_delay = nil
+        forced_delay = CHECKOUT_AUTO_PAYMENT_DELAY if defer_for_checkout_customer?
+
+        AfterCommitEverywhere.after_commit do
+          Invoices::Payments::CreateJob
+            .set(wait: forced_delay)
+            .perform_later(invoice:, payment_provider: provider, payment_method_params:)
         end
 
         result.payment_provider = provider

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -8,7 +8,7 @@ module Invoices
       include Customers::PaymentProviderFinder
 
       # Delay the first auto-payment for hosted-checkout customers so their manual payment settles first.
-      CHECKOUT_AUTO_PAYMENT_DELAY = ENV.fetch("LAGO_CHECKOUT_AUTO_PAYMENT_DELAY_SECONDS", 600).to_i.seconds
+      CHECKOUT_AUTO_PAYMENT_DELAY = ENV.fetch("LAGO_CHECKOUT_AUTO_PAYMENT_DELAY_SECONDS", 10.minutes.to_i).to_i.seconds
 
       def initialize(invoice:, payment_provider: nil, payment_method_params: {})
         @invoice = invoice

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -746,43 +746,35 @@ RSpec.describe Invoices::Payments::CreateService do
     end
 
     context "when the customer has already used a checkout URL" do
-      let!(:payment_intent) { create(:payment_intent, invoice: create(:invoice, customer:, organization:)) }
+      before { create(:payment_intent, invoice: create(:invoice, customer:, organization:)) }
 
       it "delays the first auto-payment" do
-        allow(Invoices::Payments::CreateJob).to receive(:set).and_call_original
-
-        expect { create_service.call_async }
-          .to have_enqueued_job_after_commit(Invoices::Payments::CreateJob)
-          .with(invoice:, payment_provider: :stripe, payment_method_params: {})
-
-        expect(Invoices::Payments::CreateJob)
-          .to have_received(:set).with(wait: described_class::CHECKOUT_AUTO_PAYMENT_DELAY)
+        freeze_time do
+          expect { ApplicationRecord.transaction { create_service.call_async } }
+            .to have_enqueued_job(Invoices::Payments::CreateJob)
+            .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+            .at(described_class::CHECKOUT_AUTO_PAYMENT_DELAY.from_now)
+        end
       end
 
       context "when it is not the first payment attempt (retry)" do
         before { invoice.update!(payment_attempts: 1) }
 
         it "enqueues the payment immediately" do
-          allow(Invoices::Payments::CreateJob).to receive(:set).and_call_original
-
-          expect { create_service.call_async }
-            .to have_enqueued_job_after_commit(Invoices::Payments::CreateJob)
+          expect { ApplicationRecord.transaction { create_service.call_async } }
+            .to have_enqueued_job(Invoices::Payments::CreateJob)
             .with(invoice:, payment_provider: :stripe, payment_method_params: {})
-
-          expect(Invoices::Payments::CreateJob).not_to have_received(:set)
+            .at(:no_wait)
         end
       end
     end
 
     context "when the customer has never used a checkout URL" do
       it "enqueues the payment immediately" do
-        allow(Invoices::Payments::CreateJob).to receive(:set).and_call_original
-
-        expect { create_service.call_async }
-          .to have_enqueued_job_after_commit(Invoices::Payments::CreateJob)
+        expect { ApplicationRecord.transaction { create_service.call_async } }
+          .to have_enqueued_job(Invoices::Payments::CreateJob)
           .with(invoice:, payment_provider: :stripe, payment_method_params: {})
-
-        expect(Invoices::Payments::CreateJob).not_to have_received(:set)
+          .at(:no_wait)
       end
     end
   end

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -744,5 +744,46 @@ RSpec.describe Invoices::Payments::CreateService do
         }.not_to have_enqueued_job(Invoices::Payments::CreateJob)
       end
     end
+
+    context "when the customer has already used a checkout URL" do
+      let!(:payment_intent) { create(:payment_intent, invoice: create(:invoice, customer:, organization:)) }
+
+      it "delays the first auto-payment" do
+        allow(Invoices::Payments::CreateJob).to receive(:set).and_call_original
+
+        expect { create_service.call_async }
+          .to have_enqueued_job_after_commit(Invoices::Payments::CreateJob)
+          .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+
+        expect(Invoices::Payments::CreateJob)
+          .to have_received(:set).with(wait: described_class::CHECKOUT_AUTO_PAYMENT_DELAY)
+      end
+
+      context "when it is not the first payment attempt (retry)" do
+        before { invoice.update!(payment_attempts: 1) }
+
+        it "enqueues the payment immediately" do
+          allow(Invoices::Payments::CreateJob).to receive(:set).and_call_original
+
+          expect { create_service.call_async }
+            .to have_enqueued_job_after_commit(Invoices::Payments::CreateJob)
+            .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+
+          expect(Invoices::Payments::CreateJob).not_to have_received(:set)
+        end
+      end
+    end
+
+    context "when the customer has never used a checkout URL" do
+      it "enqueues the payment immediately" do
+        allow(Invoices::Payments::CreateJob).to receive(:set).and_call_original
+
+        expect { create_service.call_async }
+          .to have_enqueued_job_after_commit(Invoices::Payments::CreateJob)
+          .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+
+        expect(Invoices::Payments::CreateJob).not_to have_received(:set)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Customers paying through hosted **checkout URLs** listen to the `invoice.created` webhook, request a checkout URL and pay it. Meanwhile Lago's automatic payment is enqueued in the same `after_commit` as the webhook and runs within seconds. The two paths hit the provider as separate PaymentIntents and the customer is charged twice.

Investigation of the confirmed duplicates showed **100% of cases** were this `checkout_url + auto_payment` race. The existing "expire the checkout session once the invoice is paid" mechanism loses the race because it is async and only expires sessions still in `open` state.

## Change

`Invoices::Payments::CreateService#call_async` now delays the **first** automatic payment for customers who have ever generated a checkout URL:

- Delay only when `invoice.payment_attempts.zero?` (retries are never delayed) **and** the customer has an existing `PaymentIntent`.
- The delayed job is enqueued with `set(wait:)` — done in `call_async` (not `call`) because the `until_executed` uniqueness lock would drop a job re-enqueued from within its own perform.
- `should_process_payment?` already no-ops when the invoice is `payment_succeeded`, so the delayed attempt charges nothing if the manual payment settled in the meantime.
- Delay defaults to **10 minutes**, configurable via `LAGO_CHECKOUT_AUTO_PAYMENT_DELAY_SECONDS`.

## Why these values (prod data)

- **10 min delay**: the largest observed gap between the two payments was **6.5 min** (p90 5.3 min) — 10 min covers 100% of confirmed cases with margin.
- **Per-customer targeting**: only **0.4%** of finalized invoices belong to checkout customers, so the billing run is essentially unaffected. Payment-method configuration was ruled out as a signal (99% of checkout customers are plain `["card"]`, identical to everyone else).
- **Overhead**: the per-payment check averaged **0.85 ms** over the full ~488k auto-pay population (1 check >100 ms in 488k) only 1 above 100ms 