### PR TITLE
[STA-6] misc(payment_request): Migrate to TypedResult

### DIFF
--- a/app/jobs/payment_requests/payments/moneyhash_create_job.rb
+++ b/app/jobs/payment_requests/payments/moneyhash_create_job.rb
@@ -14,8 +14,7 @@ module PaymentRequests
       unique :until_executed
 
       def perform(payable)
-        result = PaymentRequests::Payments::MoneyhashService.new(payable).create
-        result.raise_if_error!
+        PaymentRequests::Payments::MoneyhashService.call!(:create, payable)
       end
     end
   end

--- a/app/services/payment_providers/adyen/handle_event_service.rb
+++ b/app/services/payment_providers/adyen/handle_event_service.rb
@@ -33,8 +33,7 @@ module PaymentProviders
           payment_type = event.dig("additionalData", "metadata.payment_type")
 
           if payment_type == "one-time"
-            update_result = update_payment_status(payment_type)
-            return update_result.raise_if_error!
+            return update_payment_status(payment_type)
           end
 
           return result if amount != 0
@@ -50,17 +49,12 @@ module PaymentProviders
           return result unless payment
 
           metadata = {lago_payable_type: payment.payable_type}
-          klass = payment_service_klass(metadata)
-          args = {provider_payment_id:, status: "Cancelled", metadata:}
-
-          # NOTE: Temporary branch until PaymentRequests::Payments services are migrated to
-          #       TypedResults too. Once they are, call `klass.call(:update_payment_status, **args)` directly.
-          update_result = if klass.include?(TypedResults)
-            klass.call(:update_payment_status, **args)
-          else
-            klass.new.update_payment_status(**args)
-          end
-          update_result.raise_if_error!
+          payment_service_klass(metadata).call!(
+            :update_payment_status,
+            provider_payment_id:,
+            status: "Cancelled",
+            metadata:
+          )
         when "REFUND"
           service = CreditNotes::Refunds::AdyenService.new
 
@@ -104,21 +98,13 @@ module PaymentProviders
           lago_payable_type: event.dig("additionalData", "metadata.lago_payable_type")
         }
 
-        klass = payment_service_klass(metadata)
-        args = {
+        payment_service_klass(metadata).call!(
+          :update_payment_status,
           provider_payment_id:,
           status:,
           amount_cents: event.dig("amount", "value"),
           metadata:
-        }
-
-        # NOTE: Temporary branch until PaymentRequests::Payments services are migrated to
-        #       TypedResults too. Once they are, call `klass.call(:update_payment_status, **args)` directly.
-        if klass.include?(TypedResults)
-          klass.call(:update_payment_status, **args)
-        else
-          klass.new.update_payment_status(**args)
-        end
+        )
       end
 
       def payment_service_klass(metadata)

--- a/app/services/payment_providers/cashfree/webhooks/payment_link_event_service.rb
+++ b/app/services/payment_providers/cashfree/webhooks/payment_link_event_service.rb
@@ -15,8 +15,8 @@ module PaymentProviders
           return result unless LINK_STATUS_ACTIONS.include?(link_status)
           return result if provider_payment_id.nil?
 
-          klass = payment_service_class
-          args = {
+          payment_service_class.call!(
+            :update_payment_status,
             organization_id: organization.id,
             status: link_status,
             amount_cents: link_amount_paid_cents,
@@ -25,17 +25,7 @@ module PaymentProviders
               status: link_status,
               metadata: event.dig("data", "link_notes").to_h.symbolize_keys || {}
             )
-          }
-
-          # NOTE: Temporary branch until PaymentRequests::Payments services are migrated to
-          #       TypedResults too. Once they are, call `klass.call(:update_payment_status, **args)` directly.
-          service_result = if klass.include?(TypedResults)
-            klass.call(:update_payment_status, **args)
-          else
-            klass.new.update_payment_status(**args)
-          end
-
-          service_result.raise_if_error!
+          )
         end
 
         private

--- a/app/services/payment_providers/flutterwave/webhooks/charge_completed_service.rb
+++ b/app/services/payment_providers/flutterwave/webhooks/charge_completed_service.rb
@@ -30,8 +30,8 @@ module PaymentProviders
           payable = find_payable
           return result unless payable
 
-          klass = payment_service_class
-          args = {
+          payment_service_class.call!(
+            :update_payment_status,
             organization_id:,
             status: verified_transaction[:status],
             amount_cents: verified_amount_cents(verified_transaction),
@@ -40,16 +40,7 @@ module PaymentProviders
               status: verified_transaction[:status],
               metadata: build_metadata(verified_transaction)
             )
-          }
-
-          # NOTE: Temporary branch until PaymentRequests::Payments services are migrated to
-          #       TypedResults too. Once they are, call `klass.call(:update_payment_status, **args)` directly.
-          service_result = if klass.include?(TypedResults)
-            klass.call(:update_payment_status, **args)
-          else
-            klass.new(payable:).update_payment_status(**args)
-          end
-          service_result.raise_if_error!
+          )
 
           result
         end

--- a/app/services/payment_providers/gocardless/handle_event_service.rb
+++ b/app/services/payment_providers/gocardless/handle_event_service.rb
@@ -24,17 +24,11 @@ module PaymentProviders
         case event.resource_type
         when "payments"
           if PAYMENT_ACTIONS.include?(event.action)
-            klass = payment_service_klass(event)
-            args = {provider_payment_id: event.links.payment, status: event.action}
-
-            # NOTE: Temporary branch until PaymentRequests::Payments services are migrated to
-            #       TypedResults too. Once they are, call `klass.call(:update_payment_status, **args)` directly.
-            service_result = if klass.include?(TypedResults)
-              klass.call(:update_payment_status, **args)
-            else
-              klass.new.update_payment_status(**args)
-            end
-            service_result.raise_if_error!
+            payment_service_klass(event).call!(
+              :update_payment_status,
+              provider_payment_id: event.links.payment,
+              status: event.action
+            )
           end
         when "refunds"
           if REFUND_ACTIONS.include?(event.action)

--- a/app/services/payment_providers/moneyhash/handle_event_service.rb
+++ b/app/services/payment_providers/moneyhash/handle_event_service.rb
@@ -61,8 +61,8 @@ module PaymentProviders
 
       def handle_intent_event
         if INTENT_WEBHOOKS_EVENTS.include?(event_code)
-          klass = payment_service_klass(@event_json)
-          args = {
+          payment_service_klass(@event_json).call!(
+            :update_payment_status,
             organization_id: @organization.id,
             provider_payment_id: @event_json.dig("data", "intent_id"),
             status: event_to_payment_status(event_code),
@@ -71,38 +71,20 @@ module PaymentProviders
               @event_json.dig("data", "intent", "amount_currency")
             ),
             metadata: @event_json.dig("data", "intent", "custom_fields")
-          }
-
-          # NOTE: Temporary branch until PaymentRequests::Payments services are migrated to
-          #       TypedResults too. Once they are, call `klass.call(:update_payment_status, **args)` directly.
-          service_result = if klass.include?(TypedResults)
-            klass.call(:update_payment_status, **args)
-          else
-            klass.new.update_payment_status(**args)
-          end
-          service_result.raise_if_error!
+          )
         end
       end
 
       def handle_transaction_event
         if TRANSACTION_WEBHOOKS_EVENTS.include?(event_code)
-          klass = payment_service_klass(@event_json)
-          args = {
+          payment_service_klass(@event_json).call!(
+            :update_payment_status,
             organization_id: @organization.id,
             provider_payment_id: @event_json.dig("intent", "id"),
             status: event_to_payment_status(event_code),
             amount_cents: intent_amount_cents(@event_json.dig("intent", "amount"), nil),
             metadata: @event_json.dig("intent", "custom_fields")
-          }
-
-          # NOTE: Temporary branch until PaymentRequests::Payments services are migrated to
-          #       TypedResults too. Once they are, call `klass.call(:update_payment_status, **args)` directly.
-          service_result = if klass.include?(TypedResults)
-            klass.call(:update_payment_status, **args)
-          else
-            klass.new.update_payment_status(**args)
-          end
-          service_result.raise_if_error!
+          )
         end
       end
 

--- a/app/services/payment_providers/stripe/webhooks/base_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/base_service.rb
@@ -60,8 +60,8 @@ module PaymentProviders
         end
 
         def update_payment_status!(status)
-          klass = payment_service_klass
-          args = {
+          payment_service_klass.call!(
+            :update_payment_status,
             organization_id: organization.id,
             status:,
             amount_cents: event.data.object.try(:amount),
@@ -71,17 +71,7 @@ module PaymentProviders
               metadata:,
               error_code: event.data.object.to_hash.dig(:last_payment_error, :code)
             )
-          }
-
-          # NOTE: Temporary branch until PaymentRequests::Payments services are migrated to
-          #       TypedResults too. Once they are, call `klass.call(:update_payment_status, **args)` directly.
-          service_result = if klass.include?(TypedResults)
-            klass.call(:update_payment_status, **args)
-          else
-            klass.new.update_payment_status(**args)
-          end
-
-          service_result.raise_if_error!
+          )
         end
       end
     end

--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -6,16 +6,19 @@ module PaymentRequests
       include Lago::Adyen::ErrorHandlable
       include Customers::PaymentProviderFinder
       include Updatable
+      include TypedResults
 
       PROVIDER_NAME = "Adyen"
 
-      def initialize(payable = nil)
+      RESULTS = {
+        generate_payment_url: BaseResult[:payment_url],
+        update_payment_status: BaseResult[:payment, :payable]
+      }.freeze
+
+      private
+
+      def generate_payment_url(payable)
         @payable = payable
-
-        super(nil)
-      end
-
-      def generate_payment_url
         result_url = client.checkout.payment_links_api.payment_links(
           Lago::Adyen::Params.new(payment_url_params).to_h
         )
@@ -38,8 +41,9 @@ module PaymentRequests
         end
         return result.not_found_failure!(resource: "adyen_payment") unless payment
 
+        @payable = payment.payable
         result.payment = payment
-        result.payable = payment.payable
+        result.payable = @payable
         return result if payment.payable.payment_succeeded?
 
         payment.status = status
@@ -62,9 +66,7 @@ module PaymentRequests
         result.fail_with_error!(e)
       end
 
-      private
-
-      attr_accessor :payable
+      attr_reader :payable
 
       delegate :organization, :customer, to: :payable
 

--- a/app/services/payment_requests/payments/cashfree_service.rb
+++ b/app/services/payment_requests/payments/cashfree_service.rb
@@ -5,6 +5,7 @@ module PaymentRequests
     class CashfreeService < BaseService
       include Customers::PaymentProviderFinder
       include Updatable
+      include TypedResults
 
       PENDING_STATUSES = %w[PARTIALLY_PAID].freeze
       SUCCESS_STATUSES = %w[PAID].freeze
@@ -12,13 +13,15 @@ module PaymentRequests
 
       PROVIDER_NAME = "Cashfree"
 
-      def initialize(payable = nil)
+      RESULTS = {
+        generate_payment_url: BaseResult[:payment_url],
+        update_payment_status: BaseResult[:payment, :payable]
+      }.freeze
+
+      private
+
+      def generate_payment_url(payable)
         @payable = payable
-
-        super
-      end
-
-      def generate_payment_url
         payment_link_response = create_payment_link(payment_url_params)
         result.payment_url = JSON.parse(payment_link_response.body)["link_url"]
 
@@ -35,8 +38,9 @@ module PaymentRequests
         end
         return result.not_found_failure!(resource: "cashfree_payment") unless payment
 
+        @payable = payment.payable
         result.payment = payment
-        result.payable = payment.payable
+        result.payable = @payable
         return result if payment.payable.payment_succeeded?
 
         payment.status = status
@@ -59,9 +63,7 @@ module PaymentRequests
         result.fail_with_error!(e)
       end
 
-      private
-
-      attr_accessor :payable
+      attr_reader :payable
 
       delegate :organization, :customer, to: :payable
 

--- a/app/services/payment_requests/payments/flutterwave_service.rb
+++ b/app/services/payment_requests/payments/flutterwave_service.rb
@@ -5,14 +5,17 @@ module PaymentRequests
     class FlutterwaveService < BaseService
       include Customers::PaymentProviderFinder
       include Updatable
+      include TypedResults
 
-      def initialize(payable = nil)
+      RESULTS = {
+        generate_payment_url: BaseResult[:payment_url],
+        update_payment_status: BaseResult[:payment, :payable]
+      }.freeze
+
+      private
+
+      def generate_payment_url(payable)
         @payable = payable
-
-        super(nil)
-      end
-
-      def call
         result.payment_url = payment_url
         result
       rescue LagoHttpClient::HttpError => e
@@ -29,8 +32,9 @@ module PaymentRequests
         end
         return result.not_found_failure!(resource: "flutterwave_payment") unless payment
 
+        @payable = payment.payable
         result.payment = payment
-        result.payable = payment.payable
+        result.payable = @payable
         return result if payment.payable.payment_succeeded?
 
         payment.status = status
@@ -52,8 +56,6 @@ module PaymentRequests
       rescue BaseService::FailedResult => e
         result.fail_with_error!(e)
       end
-
-      private
 
       attr_reader :payable
 

--- a/app/services/payment_requests/payments/generate_payment_url_service.rb
+++ b/app/services/payment_requests/payments/generate_payment_url_service.rb
@@ -30,8 +30,8 @@ module PaymentRequests
           return result.single_validation_failure!(error_code: "missing_payment_provider_customer")
         end
 
-        payment_url_result = PaymentRequests::Payments::PaymentProviders::Factory.new_instance(payable:).generate_payment_url
-        payment_url_result.raise_if_error!
+        payment_url_result = PaymentRequests::Payments::PaymentProviders::Factory.for(payable)
+          .call!(:generate_payment_url, payable)
 
         return result.single_validation_failure!(error_code: "payment_provider_error") if payment_url_result.payment_url.blank?
 

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -5,6 +5,11 @@ module PaymentRequests
     class GocardlessService < BaseService
       include Customers::PaymentProviderFinder
       include Updatable
+      include TypedResults
+
+      RESULTS = {
+        update_payment_status: BaseResult[:payment, :payable]
+      }.freeze
 
       class MandateNotFoundError < StandardError
         DEFAULT_MESSAGE = "No mandate available for payment"
@@ -19,18 +24,15 @@ module PaymentRequests
         end
       end
 
-      def initialize(payable = nil)
-        @payable = payable
-
-        super(nil)
-      end
+      private
 
       def update_payment_status(provider_payment_id:, status:)
         payment = Payment.find_by(provider_payment_id:)
         return result.not_found_failure!(resource: "gocardless_payment") unless payment
 
+        @payable = payment.payable
         result.payment = payment
-        result.payable = payment.payable
+        result.payable = @payable
         return result if payment.payable.payment_succeeded?
 
         payment.status = status
@@ -53,9 +55,7 @@ module PaymentRequests
         result.fail_with_error!(e)
       end
 
-      private
-
-      attr_accessor :payable
+      attr_reader :payable
 
       delegate :organization, :customer, to: :payable
 

--- a/app/services/payment_requests/payments/moneyhash_service.rb
+++ b/app/services/payment_requests/payments/moneyhash_service.rb
@@ -4,14 +4,17 @@ module PaymentRequests
   module Payments
     class MoneyhashService < BaseService
       include Customers::PaymentProviderFinder
+      include TypedResults
 
-      def initialize(payable = nil)
+      RESULTS = {
+        create: BaseResult[:payable, :payment, :payable_payment_status],
+        update_payment_status: BaseResult[:payment, :payable]
+      }.freeze
+
+      private
+
+      def create(payable)
         @payable = payable
-
-        super(nil)
-      end
-
-      def create
         result.payable = payable
         return result.not_found_failure!(resource: "moneyhash_customer") if customer&.moneyhash_customer&.provider_customer_id.blank?
         return result.not_found_failure!(resource: "payment_method") if moneyhash_payment_method_id.nil?
@@ -67,8 +70,9 @@ module PaymentRequests
 
         return handle_missing_payment(organization_id, metadata) unless payment
 
+        @payable = payment.payable
         result.payment = payment
-        result.payable = payment.payable
+        result.payable = @payable
         return result if payment.payable.payment_succeeded?
         payment.update!(status: moneyhash_payment_provider.determine_payment_status(status))
 
@@ -84,9 +88,7 @@ module PaymentRequests
         result.fail_with_error!(e)
       end
 
-      private
-
-      attr_accessor :payable
+      attr_reader :payable
 
       delegate :organization, :customer, to: :payable
 

--- a/app/services/payment_requests/payments/payment_providers/factory.rb
+++ b/app/services/payment_requests/payments/payment_providers/factory.rb
@@ -4,8 +4,8 @@ module PaymentRequests
   module Payments
     module PaymentProviders
       class Factory
-        def self.new_instance(payable:)
-          service_class(payable.customer&.payment_provider).new(payable)
+        def self.for(payable)
+          service_class(payable.customer&.payment_provider)
         end
 
         def self.service_class(payment_provider)

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -5,16 +5,19 @@ module PaymentRequests
     class StripeService < BaseService
       include Customers::PaymentProviderFinder
       include Updatable
+      include TypedResults
 
       PROVIDER_NAME = "Stripe"
 
-      def initialize(payable = nil)
+      RESULTS = {
+        generate_payment_url: BaseResult[:payment_url],
+        update_payment_status: BaseResult[:payment, :payable]
+      }.freeze
+
+      private
+
+      def generate_payment_url(payable)
         @payable = payable
-
-        super(nil)
-      end
-
-      def generate_payment_url
         result_url = ::Stripe::Checkout::Session.create(
           payment_url_payload,
           {
@@ -43,8 +46,9 @@ module PaymentRequests
 
         if payment.payable.payment_succeeded?
           if payment.persisted?
+            @payable = payment.payable
             result.payment = payment
-            result.payable = payment.payable
+            result.payable = @payable
           end
 
           return result
@@ -57,8 +61,9 @@ module PaymentRequests
         payment.payable_payment_status = payable_payment_status
         payment.save!
 
+        @payable = payment.payable
         result.payment = payment
-        result.payable = payment.payable
+        result.payable = @payable
 
         update_payable_payment_status(payment_status: payable_payment_status, processing:)
         update_invoices_payment_status(payment_status: payable_payment_status, processing:)
@@ -76,17 +81,16 @@ module PaymentRequests
         #       caller can still enqueue downstream side effects (e.g. SetPaymentMethodAndCreateReceiptJob).
         payment = Payment.find_by(provider_payment_id: stripe_payment.id)
         if payment
+          @payable = payment.payable
           result.payment = payment
-          result.payable = payment.payable
+          result.payable = @payable
         end
         result
       rescue BaseService::FailedResult => e
         result.fail_with_error!(e)
       end
 
-      private
-
-      attr_accessor :payable
+      attr_reader :payable
 
       delegate :organization, :customer, to: :payable
 

--- a/spec/services/payment_providers/adyen/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_event_service_spec.rb
@@ -63,8 +63,6 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
     end
 
     context "when succeeded authorisation event for processed one-time payment belonging to a Payment Request" do
-      let(:payment_service) { instance_double(PaymentRequests::Payments::AdyenService) }
-
       let(:event_json) do
         JSON.parse(event_response_json)["notificationItems"]
           .first&.dig("NotificationRequestItem").to_json
@@ -76,17 +74,14 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
       end
 
       before do
-        allow(PaymentRequests::Payments::AdyenService).to receive(:new)
-          .and_return(payment_service)
-        allow(payment_service).to receive(:update_payment_status)
+        allow(PaymentRequests::Payments::AdyenService).to receive(:call)
           .and_return(service_result)
       end
 
       it "routes the event to an other service" do
         event_service.call
 
-        expect(PaymentRequests::Payments::AdyenService).to have_received(:new)
-        expect(payment_service).to have_received(:update_payment_status)
+        expect(PaymentRequests::Payments::AdyenService).to have_received(:call).with(:update_payment_status, any_args)
       end
     end
 
@@ -205,8 +200,6 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
     end
 
     context "when cancellation event is for a payment request payment" do
-      let(:payment_service) { instance_double(PaymentRequests::Payments::AdyenService) }
-
       let(:event_json) do
         JSON.parse(event_response_json)["notificationItems"]
           .first&.dig("NotificationRequestItem").to_json
@@ -225,17 +218,15 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
           provider_payment_id: "PSPREF123", payable_payment_status: :pending,
           status: "Authorised")
 
-        allow(PaymentRequests::Payments::AdyenService).to receive(:new)
-          .and_return(payment_service)
-        allow(payment_service).to receive(:update_payment_status)
+        allow(PaymentRequests::Payments::AdyenService).to receive(:call)
           .and_return(service_result)
       end
 
       it "routes to the payment request payments service" do
         event_service.call
 
-        expect(PaymentRequests::Payments::AdyenService).to have_received(:new)
-        expect(payment_service).to have_received(:update_payment_status).with(
+        expect(PaymentRequests::Payments::AdyenService).to have_received(:call).with(
+          :update_payment_status,
           provider_payment_id: "PSPREF123",
           status: "Cancelled",
           metadata: {lago_payable_type: "PaymentRequest"}

--- a/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
@@ -35,25 +35,22 @@ RSpec.describe PaymentProviders::Cashfree::Webhooks::PaymentLinkEventService do
     end
 
     context "when succeeded payment_request event" do
-      let(:payment_service) { instance_double(PaymentRequests::Payments::CashfreeService) }
-
       let(:event_json) do
         path = Rails.root.join("spec/fixtures/cashfree/payment_link_event_payment_request.json")
         File.read(path)
       end
 
       before do
-        allow(PaymentRequests::Payments::CashfreeService).to receive(:new)
-          .and_return(payment_service)
-        allow(payment_service).to receive(:update_payment_status)
+        allow(PaymentRequests::Payments::CashfreeService).to receive(:call)
           .and_return(service_result)
       end
 
       it "routes the event to an other service" do
         webhook_service.call
 
-        expect(PaymentRequests::Payments::CashfreeService).to have_received(:new)
-        expect(payment_service).to have_received(:update_payment_status)
+        expect(PaymentRequests::Payments::CashfreeService).to have_received(:call).with(
+          :update_payment_status, hash_including(organization_id: organization.id, status: "PAID")
+        )
       end
     end
   end

--- a/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave/webhooks/charge_completed_service_spec.rb
@@ -332,21 +332,20 @@ RSpec.describe PaymentProviders::Flutterwave::Webhooks::ChargeCompletedService d
       end
 
       let(:http_client) { instance_double(LagoHttpClient::Client) }
-      let(:payment_service) { instance_double(PaymentRequests::Payments::FlutterwaveService) }
 
       before do
         payment_request
         allow(LagoHttpClient::Client).to receive(:new).and_return(http_client)
         allow(http_client).to receive(:get).and_return(verification_response)
-        allow(PaymentRequests::Payments::FlutterwaveService).to receive(:new).and_return(payment_service)
-        allow(payment_service).to receive(:update_payment_status).and_return(instance_double("BaseService::Result", raise_if_error!: nil))
+        allow(PaymentRequests::Payments::FlutterwaveService).to receive(:call).and_return(update_payment_status_result)
       end
 
       it "uses the PaymentRequest service" do
         charge_completed_service.call
 
-        expect(PaymentRequests::Payments::FlutterwaveService).to have_received(:new).with(payable: payment_request)
-        expect(payment_service).to have_received(:update_payment_status)
+        expect(PaymentRequests::Payments::FlutterwaveService).to have_received(:call).with(
+          :update_payment_status, hash_including(organization_id: organization.id, status: "successful")
+        )
       end
     end
 

--- a/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe PaymentProviders::Gocardless::HandleEventService do
     end
 
     context "when event metadata contains payable_type PaymentRequest" do
-      let(:payment_service) { instance_double(PaymentRequests::Payments::GocardlessService) }
       let(:service_result) { BaseService::Result.new }
 
       let(:event_json) do
@@ -37,15 +36,13 @@ RSpec.describe PaymentProviders::Gocardless::HandleEventService do
       end
 
       it "routes the event to an other service" do
-        allow(PaymentRequests::Payments::GocardlessService).to receive(:new)
-          .and_return(payment_service)
-        allow(payment_service).to receive(:update_payment_status)
+        allow(PaymentRequests::Payments::GocardlessService).to receive(:call)
           .and_return(service_result)
 
         event_service.call
 
-        expect(PaymentRequests::Payments::GocardlessService).to have_received(:new)
-        expect(payment_service).to have_received(:update_payment_status)
+        expect(PaymentRequests::Payments::GocardlessService).to have_received(:call)
+          .with(:update_payment_status, provider_payment_id: "PM0068WBTXDQ0Q", status: "paid_out")
       end
     end
 

--- a/spec/services/payment_requests/payments/adyen_service_spec.rb
+++ b/spec/services/payment_requests/payments/adyen_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::AdyenService do
-  subject(:adyen_service) { described_class.new(payment_request) }
-
   let(:customer) { create(:customer, payment_provider_code: code) }
   let(:organization) { customer.organization }
   let(:adyen_payment_provider) { create(:adyen_provider, organization:, code:) }
@@ -49,7 +47,7 @@ RSpec.describe PaymentRequests::Payments::AdyenService do
     )
   end
 
-  describe "#generate_payment_url" do
+  describe ".call(:generate_payment_url)" do
     let(:payment_links_api) { Adyen::PaymentLinksApi.new(adyen_client, 70) }
     let(:payment_links_response) { generate(:adyen_payment_links_response) }
 
@@ -69,7 +67,7 @@ RSpec.describe PaymentRequests::Payments::AdyenService do
 
     it "generates payment url" do
       freeze_time do
-        adyen_service.generate_payment_url
+        described_class.call(:generate_payment_url, payment_request)
 
         expect(payment_links_api)
           .to have_received(:payment_links)
@@ -109,7 +107,7 @@ RSpec.describe PaymentRequests::Payments::AdyenService do
       end
 
       it "returns a failed result" do
-        result = adyen_service.generate_payment_url
+        result = described_class.call(:generate_payment_url, payment_request)
 
         expect(result).not_to be_success
 
@@ -120,9 +118,11 @@ RSpec.describe PaymentRequests::Payments::AdyenService do
     end
   end
 
-  describe "#update_payment_status" do
+  describe ".call(:update_payment_status)" do
     subject(:result) do
-      adyen_service.update_payment_status(provider_payment_id:, status:)
+      described_class.call(
+        :update_payment_status, provider_payment_id:, status:
+      )
     end
 
     let(:status) { "Authorised" }
@@ -311,7 +311,8 @@ RSpec.describe PaymentRequests::Payments::AdyenService do
       end
 
       it "creates a payment and updates payment request and invoices payment status" do
-        result = adyen_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           provider_payment_id:,
           status:,
           metadata: {

--- a/spec/services/payment_requests/payments/cashfree_service_spec.rb
+++ b/spec/services/payment_requests/payments/cashfree_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::CashfreeService do
-  subject(:cashfree_service) { described_class.new(payment_request) }
-
   let(:customer) { create(:customer, payment_provider_code: code) }
   let(:organization) { customer.organization }
   let(:cashfree_payment_provider) { create(:cashfree_provider, organization:, code:) }
@@ -46,7 +44,7 @@ RSpec.describe PaymentRequests::Payments::CashfreeService do
     )
   end
 
-  describe "#update_payment_status" do
+  describe ".call(:update_payment_status)" do
     let(:payment) do
       create(
         :payment,
@@ -66,7 +64,8 @@ RSpec.describe PaymentRequests::Payments::CashfreeService do
     end
 
     let(:result) do
-      cashfree_service.update_payment_status(
+      described_class.call(
+        :update_payment_status,
         organization_id: organization.id,
         status: cashfree_payment.status,
         cashfree_payment:
@@ -156,7 +155,8 @@ RSpec.describe PaymentRequests::Payments::CashfreeService do
       end
 
       it "updates the payment, payment_request and invoices status" do
-        result = cashfree_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           status: cashfree_payment.status,
           cashfree_payment:
@@ -311,7 +311,7 @@ RSpec.describe PaymentRequests::Payments::CashfreeService do
     end
   end
 
-  describe ".generate_payment_url" do
+  describe ".call(:generate_payment_url)" do
     let(:payment_links_response) { Net::HTTPResponse.new("1.0", "200", "OK") }
 
     before do
@@ -327,7 +327,7 @@ RSpec.describe PaymentRequests::Payments::CashfreeService do
     end
 
     it "generates payment url" do
-      result = cashfree_service.generate_payment_url
+      result = described_class.call(:generate_payment_url, payment_request)
 
       expect(result.payment_url).to be_present
     end
@@ -350,7 +350,7 @@ RSpec.describe PaymentRequests::Payments::CashfreeService do
       end
 
       it "returns a third party error" do
-        result = cashfree_service.generate_payment_url
+        result = described_class.call(:generate_payment_url, payment_request)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ThirdPartyFailure)

--- a/spec/services/payment_requests/payments/flutterwave_service_spec.rb
+++ b/spec/services/payment_requests/payments/flutterwave_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::FlutterwaveService do
-  subject(:flutterwave_service) { described_class.new(payment_request) }
-
   let(:organization) { create(:organization, name: "Test Organization") }
   let(:customer) { create(:customer, organization: organization, email: "customer@example.com", name: "John Doe") }
   let(:flutterwave_provider) { create(:flutterwave_provider, organization: organization, secret_key: "FLWSECK_TEST-secret") }
@@ -25,7 +23,7 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
     flutterwave_customer
   end
 
-  describe "#call" do
+  describe ".call(:generate_payment_url)" do
     let(:http_client) { instance_double(LagoHttpClient::Client) }
     let(:successful_response) do
       {
@@ -42,14 +40,14 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
     end
 
     it "creates a checkout session and returns payment URL" do
-      result = flutterwave_service.call
+      result = described_class.call(:generate_payment_url, payment_request)
 
       expect(result).to be_success
       expect(result.payment_url).to eq("https://checkout.flutterwave.com/v3/hosted/pay/test_link")
     end
 
     it "sends correct parameters to Flutterwave API" do
-      flutterwave_service.call
+      described_class.call(:generate_payment_url, payment_request)
 
       expect(http_client).to have_received(:post_with_response) do |body, headers|
         expect(body[:amount]).to eq(500.0)
@@ -76,7 +74,7 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       end
 
       it "delivers error webhook and returns service failure" do
-        result = flutterwave_service.call
+        result = described_class.call(:generate_payment_url, payment_request)
 
         expect(result).not_to be_success
         expect(result.error.code).to eq("action_script_runtime_error")
@@ -84,7 +82,7 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       end
 
       it "sends webhook notification about payment failure" do
-        flutterwave_service.call
+        described_class.call(:generate_payment_url, payment_request)
 
         expect(SendWebhookJob).to have_been_enqueued.with(
           "payment_request.payment_failure",
@@ -99,7 +97,7 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
     end
   end
 
-  describe "#update_payment_status" do
+  describe ".call(:update_payment_status)" do
     let(:flutterwave_payment) do
       build(:flutterwave_payment,
         id: "flw_payment_123",
@@ -111,7 +109,8 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
 
     context "when creating a new payment" do
       it "creates a new payment and updates payment request status" do
-        result = flutterwave_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           status: :succeeded,
           flutterwave_payment: flutterwave_payment
@@ -126,7 +125,11 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       end
 
       it "increments payment attempts on the payment request" do
-        expect { flutterwave_service.update_payment_status(organization_id: organization.id, status: :succeeded, flutterwave_payment: flutterwave_payment) }
+        expect {
+          described_class.call(
+            :update_payment_status, organization_id: organization.id, status: :succeeded, flutterwave_payment: flutterwave_payment
+          )
+        }
           .to change { payment_request.reload.payment_attempts }.by(1)
       end
     end
@@ -150,7 +153,8 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       before { existing_payment }
 
       it "updates the existing payment status" do
-        result = flutterwave_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           status: :succeeded,
           flutterwave_payment: flutterwave_payment
@@ -170,7 +174,8 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       end
 
       it "returns not found failure" do
-        result = flutterwave_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           status: :succeeded,
           flutterwave_payment: flutterwave_payment
@@ -198,20 +203,21 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
           metadata: {payment_type: "recurring"})
       end
 
-      before { existing_payment }
+      before do
+        existing_payment
+        allow(PaymentRequests::UpdateService).to receive(:call).and_call_original
+      end
 
       it "returns early without processing" do
-        service = described_class.new(payable: succeeded_payment_request)
-        allow(service).to receive(:update_payable_payment_status)
-
-        result = service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           status: :succeeded,
           flutterwave_payment: flutterwave_payment
         )
 
         expect(result).to be_success
-        expect(service).not_to have_received(:update_payable_payment_status)
+        expect(PaymentRequests::UpdateService).not_to have_received(:call)
       end
     end
 
@@ -235,7 +241,8 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       end
 
       it "sends payment failure email" do
-        flutterwave_service.update_payment_status(
+        described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           status: :failed,
           flutterwave_payment: flutterwave_payment
@@ -252,7 +259,8 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
 
       it "leaves the already-succeeded invoice untouched" do
         expect do
-          flutterwave_service.update_payment_status(
+          described_class.call(
+            :update_payment_status,
             organization_id: organization.id,
             status: :failed,
             flutterwave_payment: flutterwave_payment
@@ -276,7 +284,7 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       it "uses correct currency conversion" do
         payment_request.update!(currency: "NGN", total_amount_cents: 1000000) # 10,000 NGN
 
-        flutterwave_service.call
+        described_class.call(:generate_payment_url, payment_request)
 
         expect(http_client).to have_received(:post_with_response) do |body|
           expect(body[:amount]).to eq(10000.0)
@@ -285,7 +293,7 @@ RSpec.describe PaymentRequests::Payments::FlutterwaveService do
       end
 
       it "includes correct meta parameters" do
-        flutterwave_service.call
+        described_class.call(:generate_payment_url, payment_request)
 
         expect(http_client).to have_received(:post_with_response) do |body|
           meta = body[:meta]

--- a/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
     let(:provider) { "cashfree" }
     let(:code) { "cashfree_1" }
 
-    let(:payment_provider_service) { instance_double(PaymentRequests::Payments::CashfreeService) }
     let(:payment_provider) { create(:cashfree_provider, code:, organization:) }
     let(:provider_customer) { create(:cashfree_customer, payment_provider:, customer:) }
 
@@ -117,10 +116,8 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
       provider_customer
 
       allow(PaymentRequests::Payments::CashfreeService)
-        .to receive(:new)
-        .and_return(payment_provider_service)
-
-      allow(payment_provider_service).to receive(:generate_payment_url)
+        .to receive(:call)
+        .with(:generate_payment_url, payment_request)
         .and_return(error_result)
     end
 
@@ -146,8 +143,6 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
   end
 
   context "when provider service return an error" do
-    let(:payment_provider_service) { instance_double(PaymentRequests::Payments::StripeService) }
-
     let(:error_result) do
       BaseService::Result.new.tap do |result|
         result.fail_with_error!(
@@ -164,10 +159,8 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
       provider_customer
 
       allow(PaymentRequests::Payments::StripeService)
-        .to receive(:new)
-        .and_return(payment_provider_service)
-
-      allow(payment_provider_service).to receive(:generate_payment_url)
+        .to receive(:call)
+        .with(:generate_payment_url, payment_request)
         .and_return(error_result)
     end
 

--- a/spec/services/payment_requests/payments/gocardless_service_spec.rb
+++ b/spec/services/payment_requests/payments/gocardless_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::GocardlessService do
-  subject(:gocardless_service) { described_class.new(payment_request) }
-
   let(:organization) { create(:organization, webhook_url: "https://webhook.com") }
   let(:customer) { create(:customer, organization:, payment_provider_code: code) }
   let(:gocardless_payment_provider) { create(:gocardless_provider, organization:, code:) }
@@ -48,9 +46,11 @@ RSpec.describe PaymentRequests::Payments::GocardlessService do
     )
   end
 
-  describe "#update_payment_status" do
+  describe ".call(:update_payment_status)" do
     subject(:result) do
-      gocardless_service.update_payment_status(provider_payment_id:, status:)
+      described_class.call(
+        :update_payment_status, provider_payment_id:, status:
+      )
     end
 
     let(:status) { "paid_out" }
@@ -236,33 +236,6 @@ RSpec.describe PaymentRequests::Payments::GocardlessService do
 
       it "does not send payment requested email" do
         expect { result }.not_to have_enqueued_mail(PaymentRequestMailer, :requested)
-      end
-    end
-
-    context "when payment request is not passed to constructor" do
-      let(:gocardless_service) { described_class.new(nil) }
-      let(:status) { "paid_out" }
-
-      before do
-        payment_request
-      end
-
-      it "updates the payment and invoice payment_status" do
-        expect(result).to be_success
-        expect(result.payment.status).to eq(status)
-        expect(result.payment.payable_payment_status).to eq("succeeded")
-
-        expect(result.payable).to be_payment_succeeded
-        expect(result.payable.ready_for_payment_processing).to eq(false)
-
-        expect(invoice_1.reload).to be_payment_succeeded
-        expect(invoice_1.ready_for_payment_processing).to eq(false)
-
-        expect(invoice_2.reload).to be_payment_succeeded
-        expect(invoice_2.ready_for_payment_processing).to eq(false)
-
-        expect(invoice_1.total_paid_amount_cents).to eq(0)
-        expect(invoice_2.total_paid_amount_cents).to eq(0)
       end
     end
   end

--- a/spec/services/payment_requests/payments/moneyhash_service_spec.rb
+++ b/spec/services/payment_requests/payments/moneyhash_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::MoneyhashService do
-  subject(:moneyhash_service) { described_class.new(payable) }
-
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
@@ -52,7 +50,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
     create(:payment_method, customer:, payment_provider_customer: moneyhash_customer, provider_method_id: "test_payment_method")
   end
 
-  describe "#create" do
+  describe ".call(:create)" do
     before do
       moneyhash_provider
       moneyhash_customer
@@ -64,7 +62,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       before { moneyhash_customer.update!(provider_customer_id: nil) }
 
       it "returns not found failure" do
-        result = moneyhash_service.create
+        result = described_class.call(:create, payable)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::NotFoundFailure)
@@ -76,7 +74,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       before { default_payment_method.update!(is_default: false) }
 
       it "returns not found failure" do
-        result = moneyhash_service.create
+        result = described_class.call(:create, payable)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::NotFoundFailure)
@@ -93,7 +91,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       end
 
       it "processes the payment using the provider customer payment method id" do
-        result = moneyhash_service.create
+        result = described_class.call(:create, payable)
 
         expect(result).to be_success
         expect(result.payment).to be_present
@@ -107,7 +105,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
         before { payable.update!(payment_status: :succeeded) }
 
         it "returns success without payment" do
-          result = moneyhash_service.create
+          result = described_class.call(:create, payable)
 
           expect(result).to be_success
           expect(result.payment).to be_nil
@@ -118,7 +116,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
         before { moneyhash_provider.destroy }
 
         it "returns success without payment" do
-          result = moneyhash_service.create
+          result = described_class.call(:create, payable)
 
           expect(result).to be_success
           expect(result.payment).to be_nil
@@ -130,7 +128,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       before { payable.update!(amount_cents: 0) }
 
       it "marks payment as succeeded without processing" do
-        result = moneyhash_service.create
+        result = described_class.call(:create, payable)
 
         expect(result).to be_success
         expect(result.payment).to be_nil
@@ -145,7 +143,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       end
 
       it "increments payment attempts, creates a payment and updates payment statuses for payable and invoices" do
-        result = moneyhash_service.create
+        result = described_class.call(:create, payable)
 
         expect(result).to be_success
         expect(result.payment).to be_present
@@ -164,7 +162,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
         end
 
         it "marks payment as failed" do
-          result = moneyhash_service.create
+          result = described_class.call(:create, payable)
 
           expect(result).to be_success
           expect(result.payment).to be_nil
@@ -190,7 +188,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       end
 
       it "uses customer default payment_method provider_method_id as card_token" do
-        moneyhash_service.create
+        described_class.call(:create, payable)
 
         expect(lago_client).to have_received(:post_with_response) do |params, _headers|
           expect(params[:card_token]).to eq("pm_test_123")
@@ -199,7 +197,7 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
     end
   end
 
-  describe "#update_payment_status" do
+  describe ".call(:update_payment_status)" do
     let(:payment) do
       create(:payment,
         payment_provider: moneyhash_provider,
@@ -220,7 +218,8 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
 
     context "when payment exists" do
       it "updates payment, payable and invoices status" do
-        result = moneyhash_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           provider_payment_id: payment_response_json.dig("data", "id"),
           status: payment_response_json.dig("data", "status"),
@@ -241,7 +240,8 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       let(:metadata) { {"lago_payable_id" => payable.id} }
 
       it "creates a new payment" do
-        result = moneyhash_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           provider_payment_id: "new_payment_id",
           status: "SUCCESSFUL",
@@ -260,10 +260,10 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
 
       context "when payable is not found" do
         let(:metadata) { {"lago_payable_id" => "invalid_id"} }
-        let(:moneyhash_service) { described_class.new(nil) }
 
         it "returns not found error" do
-          result = moneyhash_service.update_payment_status(
+          result = described_class.call(
+            :update_payment_status,
             organization_id: organization.id,
             provider_payment_id: "new_payment_id",
             status: "SUCCESSFUL",
@@ -284,7 +284,8 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       end
 
       it "does not update the status" do
-        result = moneyhash_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           provider_payment_id: payment_response_json.dig("data", "id"),
           status: "FAILED",
@@ -305,7 +306,8 @@ RSpec.describe PaymentRequests::Payments::MoneyhashService do
       end
 
       it "leaves already-succeeded invoices untouched" do
-        result = moneyhash_service.update_payment_status(
+        result = described_class.call(
+          :update_payment_status,
           organization_id: organization.id,
           provider_payment_id: payment_response_json.dig("data", "id"),
           status: "FAILED",

--- a/spec/services/payment_requests/payments/payment_providers/factory_spec.rb
+++ b/spec/services/payment_requests/payments/payment_providers/factory_spec.rb
@@ -3,16 +3,16 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory do
-  subject(:factory_service) { described_class.new_instance(payable:) }
+  subject(:factory_service) { described_class.for(payable) }
 
   let(:payment_provider) { "stripe" }
   let(:payable) { create(:payment_request, customer:) }
   let(:customer) { create(:customer, payment_provider:) }
 
-  describe "#self.new_instance" do
+  describe ".for" do
     context "when stripe" do
       it "returns correct class" do
-        expect(factory_service.class.to_s).to eq("PaymentRequests::Payments::StripeService")
+        expect(factory_service).to eq(PaymentRequests::Payments::StripeService)
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory do
       let(:payment_provider) { "adyen" }
 
       it "returns correct class" do
-        expect(factory_service.class.to_s).to eq("PaymentRequests::Payments::AdyenService")
+        expect(factory_service).to eq(PaymentRequests::Payments::AdyenService)
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory do
       let(:payment_provider) { "cashfree" }
 
       it "returns correct class" do
-        expect(factory_service.class.to_s).to eq("PaymentRequests::Payments::CashfreeService")
+        expect(factory_service).to eq(PaymentRequests::Payments::CashfreeService)
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory do
       let(:payment_provider) { "gocardless" }
 
       it "returns correct class" do
-        expect(factory_service.class.to_s).to eq("PaymentRequests::Payments::GocardlessService")
+        expect(factory_service).to eq(PaymentRequests::Payments::GocardlessService)
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory do
       let(:payment_provider) { "moneyhash" }
 
       it "returns correct class" do
-        expect(factory_service.class.to_s).to eq("PaymentRequests::Payments::MoneyhashService")
+        expect(factory_service).to eq(PaymentRequests::Payments::MoneyhashService)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory do
       let(:payment_provider) { "flutterwave" }
 
       it "returns correct class" do
-        expect(factory_service.class.to_s).to eq("PaymentRequests::Payments::FlutterwaveService")
+        expect(factory_service).to eq(PaymentRequests::Payments::FlutterwaveService)
       end
     end
   end

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentRequests::Payments::StripeService do
-  subject(:stripe_service) { described_class.new(payment_request) }
-
   let(:customer) { create(:customer, payment_provider_code: code) }
   let(:organization) { customer.organization }
   let(:billing_entity) { organization.default_billing_entity }
@@ -50,7 +48,7 @@ RSpec.describe PaymentRequests::Payments::StripeService do
     )
   end
 
-  describe "#generate_payment_url" do
+  describe ".call(:generate_payment_url)" do
     before do
       stripe_payment_provider
       stripe_customer
@@ -60,7 +58,7 @@ RSpec.describe PaymentRequests::Payments::StripeService do
     end
 
     it "generates payment url" do
-      stripe_service.generate_payment_url
+      described_class.call(:generate_payment_url, payment_request)
 
       expect(::Stripe::Checkout::Session)
         .to have_received(:create)
@@ -106,7 +104,7 @@ RSpec.describe PaymentRequests::Payments::StripeService do
       let(:invoices) { [invoice_1] }
 
       it "includes the invoice number in stripe data" do
-        stripe_service.generate_payment_url
+        described_class.call(:generate_payment_url, payment_request)
 
         expect(::Stripe::Checkout::Session)
           .to have_received(:create)
@@ -148,7 +146,7 @@ RSpec.describe PaymentRequests::Payments::StripeService do
       end
 
       it "returns a failed result" do
-        result = stripe_service.generate_payment_url
+        result = described_class.call(:generate_payment_url, payment_request)
 
         expect(result).not_to be_success
 
@@ -159,9 +157,10 @@ RSpec.describe PaymentRequests::Payments::StripeService do
     end
   end
 
-  describe "#update_payment_status" do
+  describe ".call(:update_payment_status)" do
     subject(:result) do
-      stripe_service.update_payment_status(
+      described_class.call(
+        :update_payment_status,
         organization_id: organization.id,
         stripe_payment:,
         status:


### PR DESCRIPTION
## Context

The `TypedResults` concern was introduced to let legacy multi-method services return typed Results instead of the deprecated LegacyResult (OpenStruct), as an intermediate step before a full single-call refactor.

## Description

This PR applies the pattern to the `PaymentRequests::Payments` sub-services (Stripe, Adyen, Cashfree, Flutterwave, Gocardless, Moneyhash).

Each service now includes the concern, declares a `RESULTS` constant mapping every method to its typed Result, and exposes those methods as private — reached through `Service.call(:method_name, *args)`. The former per-instance constructor is dropped in favor of arguments passed to each method.

Call sites are updated accordingly: jobs use `call!`, `Factory#new_instance` is removed in favor of Factory.for(provider_customer)`, and specs exercise the services through the `.call(:method)` entry point.