### PR TITLE
feat(multi-connection): Add multi_connection feature flag

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -37,3 +37,7 @@ stripe_shared_payment_token:
 fixed_charge_usage_delta_migration:
   description: "Count fees from discarded recurring usage charges as already-paid units when computing pay-in-advance fixed charge deltas (temporary bridge for usage-to-fixed-charge migrations)"
   owners: ["@osmarluz"]
+
+multi_connection:
+  description: "Allow organizations to configure multiple connections of the same type per customer"
+  owners: ["@lovrocolic", "@mariohd"]

--- a/schema.graphql
+++ b/schema.graphql
@@ -5870,6 +5870,7 @@ enum FeatureFlagEnum {
   enriched_events_aggregation
   fixed_charge_usage_delta_migration
   meilisearch
+  multi_connection
   multi_currency
   multi_entity_billing
   order_forms

--- a/schema.json
+++ b/schema.json
@@ -28624,6 +28624,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "multi_connection",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null


### PR DESCRIPTION
## Context

Introduce a feature flag to gate the multi-connection capability, which lets organizations configure multiple connections of the same type per customer.

## Description

Add the `multi_connection` feature flag to `app/config/feature_flags.yaml` and update graphql schema