### PR TITLE
feat(purchase_order_number) Add purchase_order_number to more invoices templates

### DIFF
--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -430,6 +430,10 @@ html
             tr
               td.body-1 = I18n.t('invoice.invoice_number')
               td.body-2 = number
+            - if purchase_order_number.present?
+              tr
+                td.body-1 = I18n.t('invoice.purchase_order_number')
+                td.body-2 = purchase_order_number
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -427,6 +427,10 @@ html
             tr
               td.body-1 = I18n.t('invoice.invoice_number')
               td.body-2 = number
+            - if purchase_order_number.present?
+              tr
+                td.body-1 = I18n.t('invoice.purchase_order_number')
+                td.body-2 = purchase_order_number
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)

--- a/app/views/templates/invoices/v4/fixed_charge.slim
+++ b/app/views/templates/invoices/v4/fixed_charge.slim
@@ -420,6 +420,10 @@ html
             tr
               td.body-1 = I18n.t('invoice.invoice_number')
               td.body-2 = number
+            - if purchase_order_number.present?
+              tr
+                td.body-1 = I18n.t('invoice.purchase_order_number')
+                td.body-2 = purchase_order_number
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -409,6 +409,10 @@ html
             tr
               td.body-1 = I18n.t('invoice.invoice_number')
               td.body-2 = number
+            - if purchase_order_number.present?
+              tr
+                td.body-1 = I18n.t('invoice.purchase_order_number')
+                td.body-2 = purchase_order_number
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)

--- a/spec/views/app/views/templates/invoices/v4.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4.slim_spec.rb
@@ -75,6 +75,30 @@ RSpec.describe "templates/invoices/v4.slim" do
   end
 
   context "when invoice_type is credit" do
+    context "with a purchase order number" do
+      let(:invoice) do
+        build_stubbed(
+          :invoice,
+          :credit,
+          :with_purchase_order_number,
+          organization: organization,
+          billing_entity: billing_entity,
+          customer: customer,
+          number: "LAGO-202509-001",
+          payment_due_date: Date.parse("2025-09-04"),
+          issuing_date: Date.parse("2025-09-04"),
+          total_amount_cents: 1050,
+          currency: "USD",
+          fees: [fee]
+        )
+      end
+
+      it "renders the purchase order number under the invoice number" do
+        expect(rendered_template).to include("Purchase Order Number")
+        expect(rendered_template).to include("PO-123")
+      end
+    end
+
     context "when wallet transaction has a name" do
       let(:wallet_transaction_name) { "Wallet Transaction Name" }
 

--- a/spec/views/app/views/templates/invoices/v4/charge.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4/charge.slim_spec.rb
@@ -72,6 +72,32 @@ RSpec.describe "templates/invoices/v4/charge.slim" do
     invoice_subscription
   end
 
+  context "with a purchase order number" do
+    let(:invoice) do
+      create(
+        :invoice,
+        :with_purchase_order_number,
+        customer:,
+        organization:,
+        number: "LAGO-202509-CH-001",
+        payment_due_date: Date.parse("2025-09-15"),
+        issuing_date: Date.parse("2025-09-01"),
+        invoice_type: :subscription,
+        total_amount_cents: 10000,
+        currency: "USD",
+        fees_amount_cents: 10000,
+        sub_total_excluding_taxes_amount_cents: 10000,
+        sub_total_including_taxes_amount_cents: 10000,
+        coupons_amount_cents: 0
+      )
+    end
+
+    it "renders the purchase order number under the invoice number" do
+      expect(rendered_template).to include("Purchase Order Number")
+      expect(rendered_template).to include("PO-123")
+    end
+  end
+
   context "with a single standard charge fee" do
     let(:charge) do
       create(:standard_charge, :pay_in_advance, plan:, billable_metric:)

--- a/spec/views/app/views/templates/invoices/v4/fixed_charge.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4/fixed_charge.slim_spec.rb
@@ -66,6 +66,32 @@ RSpec.describe "templates/invoices/v4/fixed_charge.slim" do
     invoice_subscription
   end
 
+  context "with a purchase order number" do
+    let(:invoice) do
+      create(
+        :invoice,
+        :with_purchase_order_number,
+        customer:,
+        organization:,
+        number: "LAGO-202509-FC-001",
+        payment_due_date: Date.parse("2025-09-15"),
+        issuing_date: Date.parse("2025-09-01"),
+        invoice_type: :subscription,
+        total_amount_cents: 10000,
+        currency: "USD",
+        fees_amount_cents: 10000,
+        sub_total_excluding_taxes_amount_cents: 10000,
+        sub_total_including_taxes_amount_cents: 10000,
+        coupons_amount_cents: 0
+      )
+    end
+
+    it "renders the purchase order number under the invoice number" do
+      expect(rendered_template).to include("Purchase Order Number")
+      expect(rendered_template).to include("PO-123")
+    end
+  end
+
   context "with a single fixed charge fee" do
     let(:fixed_charge) do
       create(:fixed_charge, :pay_in_advance, plan:, add_on:)

--- a/spec/views/app/views/templates/invoices/v4/self_billed.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4/self_billed.slim_spec.rb
@@ -63,6 +63,33 @@ RSpec.describe "templates/invoices/v4/self_billed.slim" do
     it "renders correctly" do
       expect(rendered_template).to match_html_snapshot
     end
+
+    context "with a purchase order number" do
+      let(:invoice) do
+        create(
+          :invoice,
+          :self_billed,
+          :with_purchase_order_number,
+          customer:,
+          organization:,
+          number: "LAGO-202509-SB-001",
+          payment_due_date: Date.parse("2025-09-15"),
+          issuing_date: Date.parse("2025-09-01"),
+          invoice_type: :one_off,
+          total_amount_cents: 50000,
+          currency: "USD",
+          fees_amount_cents: 50000,
+          sub_total_excluding_taxes_amount_cents: 50000,
+          sub_total_including_taxes_amount_cents: 50000,
+          coupons_amount_cents: 0
+        )
+      end
+
+      it "renders the purchase order number under the invoice number" do
+        expect(rendered_template).to include("Purchase Order Number")
+        expect(rendered_template).to include("PO-123")
+      end
+    end
   end
 
   context "with subscription invoice" do


### PR DESCRIPTION
Change invoice templates to add purchase_order_number 

- app/views/templates/invoices/v4.slim
- app/views/templates/invoices/v4/charge.slim
- app/views/templates/invoices/v4/fixed_charge.slim
- app/views/templates/invoices/v4/self_billed.slim

BIL-307
