### PR TITLE
fix(payments): scope checkout auto-payment delay to the org

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -96,7 +96,7 @@ module Invoices
         return result unless provider
 
         forced_delay = nil
-        forced_delay = CHECKOUT_AUTO_PAYMENT_DELAY if defer_for_checkout_customer?
+        forced_delay = CHECKOUT_AUTO_PAYMENT_DELAY if defer_for_checkout_organization?
 
         AfterCommitEverywhere.after_commit do
           Invoices::Payments::CreateJob
@@ -118,11 +118,15 @@ module Invoices
         @provider ||= invoice.customer.payment_provider&.to_sym
       end
 
-      # Only the first automatic attempt is delayed; retries keep payment_attempts positive.
-      def defer_for_checkout_customer?
+      # Delay the first automatic payment for every customer of an organization that uses hosted
+      # checkout (has ever generated a checkout URL), so an auto-payment can't race a customer's
+      # manual checkout and double-charge them. Scoping to the organization — not the customer —
+      # also covers a customer's very first invoice, which has no prior checkout signal of its own.
+      # Only the first attempt is delayed;
+      def defer_for_checkout_organization?
         return false unless invoice.payment_attempts.zero?
 
-        PaymentIntent.joins(:invoice).where(invoices: {customer_id: invoice.customer_id}).exists?
+        PaymentIntent.where(organization_id: invoice.organization_id).exists?
       end
 
       def should_process_payment?

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -745,7 +745,7 @@ RSpec.describe Invoices::Payments::CreateService do
       end
     end
 
-    context "when the customer has already used a checkout URL" do
+    context "when the organization has used a checkout URL" do
       before { create(:payment_intent, invoice: create(:invoice, customer:, organization:)) }
 
       it "delays the first auto-payment" do
@@ -769,7 +769,23 @@ RSpec.describe Invoices::Payments::CreateService do
       end
     end
 
-    context "when the customer has never used a checkout URL" do
+    context "when another customer of the same organization has used a checkout URL" do
+      before do
+        other_customer = create(:customer, organization:)
+        create(:payment_intent, invoice: create(:invoice, customer: other_customer, organization:))
+      end
+
+      it "still delays the first auto-payment (covers the customer's first invoice)" do
+        freeze_time do
+          expect { ApplicationRecord.transaction { create_service.call_async } }
+            .to have_enqueued_job(Invoices::Payments::CreateJob)
+            .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+            .at(described_class::CHECKOUT_AUTO_PAYMENT_DELAY.from_now)
+        end
+      end
+    end
+
+    context "when the organization has never used a checkout URL" do
       it "enqueues the payment immediately" do
         expect { ApplicationRecord.transaction { create_service.call_async } }
           .to have_enqueued_job(Invoices::Payments::CreateJob)


### PR DESCRIPTION
## Context

PR #5931 delays the first automatic payment for hosted-checkout customers so their manual checkout payment settles first, avoiding a double charge. It identified a "checkout customer" by whether that **customer** had ever generated a checkout URL (`PaymentIntent` on one of their invoices).

That misses a customer's **first** checkout invoice: at invoice-creation time the customer has no prior `PaymentIntent`, so the auto-payment is not delayed, races their manual checkout, and double-charges them.

Production confirmed this after the deploy — the remaining duplicates all had `prior_payment_intents = 0` (customers using checkout for the first time), with the two provider payments ~1–2 min apart (i.e. the delay never applied).

## Change

Decide the delay at the **organization** level instead of the customer level: if the organization has ever generated a checkout URL, delay the first automatic payment for **all** of its customers. This covers a customer's very first
invoice, which has no checkout signal of its own.

- Uses `payment_intents.organization_id` directly (indexed) — no join.
- Only the **first** attempt is delayed; retries no delay