### PR TITLE
feat(purchase_order_number) Preserve PO number in invoice services

### DIFF
--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe CreditNotes::CreateFromTermination do
   let(:tax) { create(:tax, organization:, rate: tax_rate) }
   let(:tax_rate) { 20 }
   let(:coupon_amount) { 0 }
+  let(:invoice_purchase_order_number) { nil }
 
   let(:fee_and_invoice) { generate_invoice_and_fee(plan_amount_cents) }
   let(:invoice) { fee_and_invoice[:invoice] }
@@ -68,6 +69,7 @@ RSpec.describe CreditNotes::CreateFromTermination do
       total_amount_cents: total_amount_cents,
       total_paid_amount_cents: paid_amount,
       payment_status: ((paid_amount == total_amount_cents) ? :succeeded : :pending),
+      purchase_order_number: invoice_purchase_order_number,
       created_at: at
     )
     create(:invoice_applied_tax, invoice:, tax:, tax_rate: tax.rate, amount_cents: invoice_taxes_amount_cents)
@@ -206,6 +208,22 @@ RSpec.describe CreditNotes::CreateFromTermination do
         precise_item_amount_cents: 16_00,
         tax_amount_cents: 3_20
       })
+    end
+
+    context "when the parent invoice has a purchase order number" do
+      let(:invoice_purchase_order_number) { "PO-123" }
+
+      it "exposes the parent invoice purchase order number" do
+        credit_note = test_credit_note_creation_from_termination(expectations: {
+          total_amount_cents: 19_20,
+          credit_amount_cents: 19_20,
+          precise_item_amount_cents: 16_00,
+          tax_amount_cents: 3_20
+        })
+
+        expect(credit_note.invoice.purchase_order_number).to eq("PO-123")
+        expect(credit_note.purchase_order_number).to eq("PO-123")
+      end
     end
 
     context "with amount details attached to the fee" do

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -20,6 +20,25 @@ RSpec.describe Invoices::FinalizeService do
         expect(result.invoice.finalized_at).to be_within(1.second).of(Time.current)
       end
 
+      context "when the subscription has a different purchase order number" do
+        let(:invoice) do
+          create(:invoice, :draft, customer:, organization:, purchase_order_number: "PO-ORIGINAL")
+        end
+
+        let(:subscription) do
+          create(:subscription, customer:, organization:, purchase_order_number: "PO-UPDATED")
+        end
+
+        before { create(:invoice_subscription, invoice:, subscription:) }
+
+        it "keeps the invoice purchase order number" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.invoice.reload.purchase_order_number).to eq("PO-ORIGINAL")
+        end
+      end
+
       context "when Meilisearch is enabled" do
         before do
           invoice

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -143,6 +143,42 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService do
       expect(result.invoice.fees.subscription.count).to eq(1)
     end
 
+    context "when the subscription purchase order number changed before finalization" do
+      let(:invoice) do
+        create(
+          :invoice,
+          :draft,
+          :with_subscriptions,
+          organization:,
+          customer:,
+          subscriptions: [subscription],
+          currency: "EUR",
+          issuing_date: Time.zone.at(timestamp).to_date,
+          purchase_order_number: "PO-ORIGINAL"
+        )
+      end
+
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan:,
+          subscription_at: started_at,
+          started_at:,
+          created_at: started_at,
+          purchase_order_number: "PO-UPDATED"
+        )
+      end
+
+      it "keeps the draft invoice purchase order number" do
+        result = finalize_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to be_finalized
+        expect(result.invoice.purchase_order_number).to eq("PO-ORIGINAL")
+      end
+    end
+
     it_behaves_like "syncs invoice" do
       let(:service_call) { finalize_service.call }
     end

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -190,6 +190,36 @@ RSpec.describe Invoices::RefreshDraftService do
         .to change { invoice.reload.progressive_billing_credit_amount_cents }.from(1239000).to(0)
     end
 
+    context "when the subscription purchase order number changed after draft creation" do
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          organization:,
+          subscription_at: started_at,
+          started_at:,
+          created_at: started_at,
+          purchase_order_number: "PO-UPDATED"
+        )
+      end
+
+      let(:invoice) do
+        create(
+          :invoice,
+          status:,
+          organization:,
+          customer:,
+          purchase_order_number: "PO-ORIGINAL"
+        )
+      end
+
+      it "keeps the draft invoice purchase order number" do
+        refresh_service.call
+
+        expect(invoice.reload.purchase_order_number).to eq("PO-ORIGINAL")
+      end
+    end
+
     it_behaves_like "applies invoice_custom_sections" do
       let(:service_call) { refresh_service.call }
     end


### PR DESCRIPTION
This commit adds specs to RefreshDraftService and FinalizeService

We're adding coverage to RefreshDraftService, FinalizeService and RefreshDraftAndFinalizeService to make sure the initial PO number used in invoice will keep after each state change.
