### PR TITLE
[ING-476] fix(lifetime_usage): retry wallet lock inline

### DIFF
--- a/app/jobs/lifetime_usages/recalculate_and_check_job.rb
+++ b/app/jobs/lifetime_usages/recalculate_and_check_job.rb
@@ -2,6 +2,12 @@
 
 module LifetimeUsages
   class RecalculateAndCheckJob < ApplicationJob
+    # Raised when the inline (perform_now) invocation cannot resolve a lock conflict within
+    # MAX_LOCK_RETRY_ATTEMPTS. It intentionally is NOT a class listed in `retry_on`, so the
+    # lock conflict never triggers an ActiveJob retry (which would fail to serialize the
+    # non-serializable current_usage). The original lock error is preserved as `cause`.
+    class InlineLockRetryExhausted < StandardError; end
+
     queue_as do
       if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
         :billing_low_priority
@@ -25,6 +31,25 @@ module LifetimeUsages
 
     # NOTE: do not pass current usage with perform_later as it will be a huge JSON
     def perform(lifetime_usage, current_usage: nil)
+      # When invoked inline via perform_now, current_usage is a non-serializable
+      # SubscriptionUsage struct. A lock conflict must be retried in-process here:
+      # reaching ActiveJob's retry_on would try to re-enqueue the job and fail to
+      # serialize current_usage. The async perform_later path (current_usage nil) keeps
+      # relying on retry_on so it does not hold a worker while waiting between attempts.
+      if current_usage
+        perform_with_inline_lock_retry(lifetime_usage, current_usage)
+      else
+        process(lifetime_usage, current_usage:)
+      end
+    end
+
+    def lock_key_arguments
+      [arguments.first]
+    end
+
+    private
+
+    def process(lifetime_usage, current_usage:)
       LifetimeUsages::CalculateService.call!(lifetime_usage:, current_usage:)
 
       if lifetime_usage.organization.progressive_billing_enabled?
@@ -32,8 +57,26 @@ module LifetimeUsages
       end
     end
 
-    def lock_key_arguments
-      [arguments.first]
+    def perform_with_inline_lock_retry(lifetime_usage, current_usage)
+      attempts = 0
+
+      begin
+        process(lifetime_usage, current_usage:)
+      rescue BaseLockService::FailedToAcquireLock, ActiveRecord::StaleObjectError => e
+        attempts += 1
+
+        if attempts < MAX_LOCK_RETRY_ATTEMPTS
+          sleep rand(0...MAX_LOCK_RETRY_DELAY)
+          retry
+        end
+
+        # Break the cause chain (cause: nil): ActiveJob's retry_on matches the exception's
+        # cause too, so keeping the lock error as cause would still trigger a retry and fail
+        # to serialize current_usage. The original error is kept in the message.
+        raise InlineLockRetryExhausted.new(
+          "Lock conflict unresolved after #{attempts} in-process retries: #{e.class}: #{e.message}"
+        ), cause: nil
+      end
     end
   end
 end

--- a/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
+++ b/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
@@ -65,6 +65,55 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckJob do
     end
   end
 
+  describe "in-process lock retry when invoked inline with current_usage" do
+    let(:current_usage) { SubscriptionUsage.new }
+
+    before do
+      allow(LifetimeUsages::CalculateService).to receive(:call!)
+      allow(LifetimeUsages::CheckThresholdsService).to receive(:call!)
+    end
+
+    it "forwards the current_usage to the Calculate service" do
+      described_class.perform_now(lifetime_usage, current_usage:)
+      expect(LifetimeUsages::CalculateService).to have_received(:call!).with(lifetime_usage:, current_usage:)
+    end
+
+    [
+      BaseLockService::FailedToAcquireLock.new("customer-1-prepaid_credit"),
+      ActiveRecord::StaleObjectError.new("Attempted to update a stale object: Wallet.")
+    ].each do |error|
+      context "when a #{error.class} is raised then resolves" do
+        before do
+          stub_const("ApplicationJob::MAX_LOCK_RETRY_DELAY", 1)
+          call_count = 0
+          allow(LifetimeUsages::CalculateService).to receive(:call!) do
+            call_count += 1
+            raise error if call_count == 1
+          end
+        end
+
+        it "retries in-process without raising ActiveJob::SerializationError" do
+          expect { described_class.perform_now(lifetime_usage, current_usage:) }.not_to raise_error
+          expect(LifetimeUsages::CalculateService).to have_received(:call!).twice
+        end
+      end
+
+      context "when a #{error.class} never resolves" do
+        before do
+          stub_const("ApplicationJob::MAX_LOCK_RETRY_ATTEMPTS", 3)
+          stub_const("ApplicationJob::MAX_LOCK_RETRY_DELAY", 1)
+          allow(LifetimeUsages::CalculateService).to receive(:call!).and_raise(error)
+        end
+
+        it "exhausts in-process retries and raises without reaching retry_on" do
+          expect { described_class.perform_now(lifetime_usage, current_usage:) }
+            .to raise_error(described_class::InlineLockRetryExhausted)
+          expect(LifetimeUsages::CalculateService).to have_received(:call!).exactly(3).times
+        end
+      end
+    end
+  end
+
   describe "discard_on" do
     context "when an Idempotency::IdempotencyError is raised", :premium do
       before do


### PR DESCRIPTION
## Context

When a subscription activity is processed, `UsageMonitoring::ProcessSubscriptionActivityService` runs the lifetime-usage recalculation inline via `RecalculateAndCheckJob.perform_now(lifetime_usage, current_usage:)`. `current_usage` is a `SubscriptionUsage` struct, which ActiveJob cannot serialize (it is only safe under `perform_now`, which does not serialize arguments).

The job retries wallet lock conflicts (`ActiveRecord::StaleObjectError`, `BaseLockService::FailedToAcquireLock`) through ActiveJob's `retry_on`. When a wallet optimistic-lock conflict happens during the inline run, `retry_on` tries to re-enqueue the job for a retry, which serializes the arguments and fails on the `SubscriptionUsage` struct. The result is a misleading `ActiveJob::SerializationError: Unsupported argument type: SubscriptionUsage` that masks the real underlying `StaleObjectError` on `Wallet`.

## Solution

Retry the lock conflict in-process on the inline path so it never reaches ActiveJob's `retry_on`. The async `perform_later` path (no `current_usage`) keeps relying on `retry_on`, so it does not hold a worker while waiting between attempts.

- Split `perform` into two paths: with `current_usage` present, wrap the work in an in-process retry (`MAX_LOCK_RETRY_ATTEMPTS`, `rand(0...MAX_LOCK_RETRY_DELAY)` backoff); otherwise call the services directly and let `retry_on` handle retries.
- On exhaustion, raise a dedicated `InlineLockRetryExhausted` error that is intentionally not listed in `retry_on`. It is raised with the cause chain broken (`cause: nil`) because `retry_on` also matches an exception's `cause` — otherwise the wrapped lock error would still trigger a retry and the same serialization failure. The original error is preserved in the message for observability.

## Testing

- New specs cover the inline `current_usage` path for both lock error classes: retries then resolves without raising `ActiveJob::SerializationError`, and exhausts to `InlineLockRetryExhausted` (never `SerializationError`).
- Existing `retry_on` (async) and `discard_on` behavior is unchanged and still covered.
- `RecalculateAndCheckJob` spec: 13 examples, 0 failures. `ProcessSubscriptionActivityService` spec: 12 examples, 0 failures. RuboCop clean on the changed files.
