### PR TITLE
feat(purchase_order_number): Subscription invoices stamping

### DIFF
--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -20,9 +20,11 @@ module Invoices
 
       return result if subscriptions.empty?
 
-      invoice = create_group_invoice
+      invoices = create_group_invoices
 
-      if invoice && !invoice.closed?
+      invoices.each do |invoice|
+        next if invoice.closed?
+
         SendWebhookJob.perform_later("invoice.created", invoice)
         Utils::ActivityLog.produce(invoice, "invoice.created")
         create_manual_payment(invoice)
@@ -32,7 +34,7 @@ module Invoices
         Utils::SegmentTrack.invoice_created(invoice)
       end
 
-      result.invoice = invoice
+      result.invoice = invoices.last
 
       result
     end
@@ -91,11 +93,20 @@ module Invoices
       ::Payments::ManualCreateJob.perform_later(organization:, params:)
     end
 
-    def create_group_invoice
+    # NOTE: The re-expanded subscription set (matched by external_id) can span several
+    #       purchase order numbers — e.g. a terminated and an active subscription sharing
+    #       an external_id after an upgrade. Each PO must produce its own invoice.
+    def create_group_invoices
+      subscriptions.group_by(&:purchase_order_number).values.filter_map do |subscriptions_group|
+        create_group_invoice(subscriptions_group)
+      end
+    end
+
+    def create_group_invoice(subscriptions_group)
       invoice = nil
 
       ActiveRecord::Base.transaction do
-        invoice = create_generating_invoice
+        invoice = create_generating_invoice(subscriptions_group)
         invoice.invoice_subscriptions.each do |is|
           is.subscription.fees
             .where(invoice: nil, payment_status: :succeeded)
@@ -125,7 +136,7 @@ module Invoices
       invoice
     end
 
-    def create_generating_invoice
+    def create_generating_invoice(subscriptions_group)
       # TODO: seems that skip_charges here might be deleted. Performed one test locally - worked without any additional charges.
       # Following the code - also did not find calling any service that would use this skip_charges
       invoice_result = Invoices::CreateGeneratingService.call(
@@ -134,12 +145,13 @@ module Invoices
         currency:,
         datetime: billing_at, # this is an int we need to convert it
         skip_charges: true,
-        billing_entity: initial_subscriptions.first&.billing_entity || customer.billing_entity
+        billing_entity: initial_subscriptions.first&.billing_entity || customer.billing_entity,
+        purchase_order_number: subscriptions_group.first&.purchase_order_number
       ) do |invoice|
         Invoices::CreateAdvanceChargesInvoiceSubscriptionService.call!(
           invoice:,
-          subscriptions_with_fees: subscriptions,
-          all_subscriptions: subscriptions + initial_subscriptions,
+          subscriptions_with_fees: subscriptions_group,
+          all_subscriptions: subscriptions_group + initial_subscriptions,
           timestamp: billing_at
         )
       end

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -158,7 +158,8 @@ module Invoices
         invoicing_reason:,
         currency:,
         datetime: Time.zone.at(timestamp),
-        skip_charges:
+        skip_charges:,
+        purchase_order_number: subscriptions.first&.purchase_order_number
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions:, timestamp:, invoicing_reason:)

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -246,6 +246,63 @@ RSpec.describe Invoices::AdvanceChargesService do
       end
     end
 
+    context "when re-expanded subscriptions carry different purchase order numbers" do
+      let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+
+      let(:charge) do
+        create(
+          :charge,
+          plan:,
+          billable_metric:,
+          prorated: true,
+          pay_in_advance: true,
+          invoiceable: false,
+          regroup_paid_fees: "invoice",
+          properties: {amount: "1"}
+        )
+      end
+
+      let(:subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at,
+          purchase_order_number: "PO-1"
+        )
+      end
+
+      # Same external_id as `subscription` (an upgrade rotation), so the re-expansion
+      # by external_id pulls it in alongside `subscription` despite a different PO.
+      let(:subscription_2) do
+        create(
+          :subscription,
+          external_id: subscription.external_id,
+          customer:,
+          status: :terminated,
+          terminated_at: Time.current,
+          started_at: Time.current - 1.year,
+          plan:,
+          purchase_order_number: "PO-2"
+        )
+      end
+
+      before do
+        create(:fee, :succeeded, organization_id: organization.id, succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days, invoice_id: nil, subscription:, amount_cents: 100, taxes_amount_cents: 0, properties: fee_boundaries, charge:)
+        create(:fee, :succeeded, organization_id: organization.id, succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days, invoice_id: nil, subscription: subscription_2, amount_cents: 200, taxes_amount_cents: 0, properties: fee_boundaries, charge:)
+      end
+
+      it "creates a separate advance-charges invoice per purchase order number" do
+        expect { invoice_service.call }
+          .to change { Invoice.where(invoice_type: :advance_charges).count }.by(2)
+
+        invoices = Invoice.where(invoice_type: :advance_charges)
+        expect(invoices.map(&:purchase_order_number)).to match_array(%w[PO-1 PO-2])
+      end
+    end
+
     context "with integration requiring sync" do
       before do
         tax

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -303,6 +303,108 @@ RSpec.describe Invoices::AdvanceChargesService do
       end
     end
 
+    context "when re-expanded subscriptions share the same purchase order number" do
+      let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+
+      let(:charge) do
+        create(
+          :charge,
+          plan:,
+          billable_metric:,
+          prorated: true,
+          pay_in_advance: true,
+          invoiceable: false,
+          regroup_paid_fees: "invoice",
+          properties: {amount: "1"}
+        )
+      end
+
+      let(:subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at,
+          purchase_order_number: "PO-1"
+        )
+      end
+
+      # Same external_id as `subscription` (an upgrade rotation), so the re-expansion
+      # by external_id pulls it in alongside `subscription`, sharing the same PO.
+      let(:subscription_2) do
+        create(
+          :subscription,
+          external_id: subscription.external_id,
+          customer:,
+          status: :terminated,
+          terminated_at: Time.current,
+          started_at: Time.current - 1.year,
+          plan:,
+          purchase_order_number: "PO-1"
+        )
+      end
+
+      before do
+        create(:fee, :succeeded, organization_id: organization.id, succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days, invoice_id: nil, subscription:, amount_cents: 100, taxes_amount_cents: 0, properties: fee_boundaries, charge:)
+        create(:fee, :succeeded, organization_id: organization.id, succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days, invoice_id: nil, subscription: subscription_2, amount_cents: 200, taxes_amount_cents: 0, properties: fee_boundaries, charge:)
+      end
+
+      it "consolidates both subscriptions onto one invoice stamped with the shared PO" do
+        expect { invoice_service.call }
+          .to change { Invoice.where(invoice_type: :advance_charges).count }.by(1)
+
+        invoice = Invoice.where(invoice_type: :advance_charges).sole
+        expect(invoice.purchase_order_number).to eq("PO-1")
+        expect(invoice.invoice_subscriptions.count).to eq(2)
+      end
+    end
+
+    context "when re-expanded subscriptions have no purchase order number" do
+      let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+
+      let(:charge) do
+        create(
+          :charge,
+          plan:,
+          billable_metric:,
+          prorated: true,
+          pay_in_advance: true,
+          invoiceable: false,
+          regroup_paid_fees: "invoice",
+          properties: {amount: "1"}
+        )
+      end
+
+      # Same external_id as `subscription` (an upgrade rotation); neither carries a PO.
+      let(:subscription_2) do
+        create(
+          :subscription,
+          external_id: subscription.external_id,
+          customer:,
+          status: :terminated,
+          terminated_at: Time.current,
+          started_at: Time.current - 1.year,
+          plan:
+        )
+      end
+
+      before do
+        create(:fee, :succeeded, organization_id: organization.id, succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days, invoice_id: nil, subscription:, amount_cents: 100, taxes_amount_cents: 0, properties: fee_boundaries, charge:)
+        create(:fee, :succeeded, organization_id: organization.id, succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days, invoice_id: nil, subscription: subscription_2, amount_cents: 200, taxes_amount_cents: 0, properties: fee_boundaries, charge:)
+      end
+
+      it "consolidates both subscriptions onto one invoice with no PO" do
+        expect { invoice_service.call }
+          .to change { Invoice.where(invoice_type: :advance_charges).count }.by(1)
+
+        invoice = Invoice.where(invoice_type: :advance_charges).sole
+        expect(invoice.purchase_order_number).to be_nil
+        expect(invoice.invoice_subscriptions.count).to eq(2)
+      end
+    end
+
     context "with integration requiring sync" do
       before do
         tax

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -219,6 +219,26 @@ RSpec.describe Invoices::SubscriptionService do
       end
     end
 
+    context "when the subscription has a purchase_order_number" do
+      let(:subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at,
+          purchase_order_number: "PO-123"
+        )
+      end
+
+      it "stamps the purchase_order_number on the invoice" do
+        invoice = invoice_service.call.invoice
+
+        expect(invoice.purchase_order_number).to eq("PO-123")
+      end
+    end
+
     it_behaves_like "syncs invoice" do
       let(:service_call) { invoice_service.call }
     end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -239,6 +239,87 @@ RSpec.describe Invoices::SubscriptionService do
       end
     end
 
+    context "when multiple subscriptions share the same purchase_order_number" do
+      let(:other_subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at,
+          purchase_order_number: "PO-1"
+        )
+      end
+      let(:subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at,
+          purchase_order_number: "PO-1"
+        )
+      end
+      let(:subscriptions) { [subscription, other_subscription] }
+
+      it "stamps the shared purchase_order_number on the single invoice" do
+        result = invoice_service.call
+
+        expect(result).to be_success
+        expect(result.invoice.purchase_order_number).to eq("PO-1")
+      end
+    end
+
+    context "when the subscription has no purchase_order_number" do
+      it "leaves the invoice purchase_order_number nil" do
+        invoice = invoice_service.call.invoice
+
+        expect(invoice.purchase_order_number).to be_nil
+      end
+    end
+
+    context "when retrying an existing generating invoice" do
+      let(:subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          subscription_at: started_at.to_date,
+          started_at:,
+          created_at: started_at,
+          purchase_order_number: "PO-CURRENT"
+        )
+      end
+
+      let(:existing_invoice) do
+        create(
+          :invoice,
+          customer:,
+          organization:,
+          invoice_type: :subscription,
+          status: :generating,
+          purchase_order_number: "PO-STAMPED"
+        )
+      end
+
+      before do
+        create(:invoice_subscription, invoice: existing_invoice, subscription:, timestamp:)
+      end
+
+      it "preserves the stamped purchase_order_number instead of re-resolving from the subscription" do
+        described_class.new(
+          subscriptions:,
+          timestamp: timestamp.to_i,
+          invoicing_reason:,
+          invoice: existing_invoice
+        ).call
+
+        expect(existing_invoice.reload.purchase_order_number).to eq("PO-STAMPED")
+      end
+    end
+
     it_behaves_like "syncs invoice" do
       let(:service_call) { invoice_service.call }
     end


### PR DESCRIPTION
## Context

The purchase order number set in the subscription should be stamped on related invoices.

## Description

- `SubscriptionService` - stamps `subscriptions.first.purchase_order_number` on the generated invoice.
- `AdvanceChargesService` - re-expands its subscription set by `external_id`, which can mix POs (e.g. a terminated + active pair after an upgrade). It splits the re-expanded set by PO and produces one stamped advance-charges invoice per PO.
