### PR TITLE
feat(purchase_order_number): Add the new field to regenerate-from-voided invoice

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -173,6 +173,7 @@ GraphQL/ExtractInputType:
     - "app/graphql/mutations/applied_coupons/create.rb"
     - "app/graphql/mutations/credit_notes/create.rb"
     - "app/graphql/mutations/invites/accept.rb"
+    - "app/graphql/mutations/invoices/regenerate_from_voided.rb"
     - "app/graphql/mutations/plans/create.rb"
     - "app/graphql/mutations/plans/update.rb"
     - "app/graphql/mutations/register_user.rb"

--- a/app/graphql/mutations/invoices/regenerate_from_voided.rb
+++ b/app/graphql/mutations/invoices/regenerate_from_voided.rb
@@ -13,13 +13,18 @@ module Mutations
       description "Regenerate an invoice from a voided invoice"
 
       argument :fees, [Types::Invoices::VoidedInvoiceFeeInput], required: true
+      argument :purchase_order_number, String, required: false
       argument :voided_invoice_id, ID, required: true
 
       type Types::Invoices::Object
 
-      def resolve(voided_invoice_id:, fees:)
+      def resolve(voided_invoice_id:, fees:, purchase_order_number: :inherit)
         invoice = current_organization.invoices.visible.find_by(id: voided_invoice_id)
-        result = ::Invoices::RegenerateFromVoidedService.new(voided_invoice: invoice, fees_params: fees).call
+        result = ::Invoices::RegenerateFromVoidedService.new(
+          voided_invoice: invoice,
+          fees_params: fees,
+          purchase_order_number:
+        ).call
 
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/services/invoices/regenerate_from_voided_service.rb
+++ b/app/services/invoices/regenerate_from_voided_service.rb
@@ -4,9 +4,10 @@ module Invoices
   class RegenerateFromVoidedService < BaseService
     Result = BaseResult[:invoice]
 
-    def initialize(voided_invoice:, fees_params:)
+    def initialize(voided_invoice:, fees_params:, purchase_order_number: :inherit)
       @voided_invoice = voided_invoice
       @fees_params = fees_params
+      @purchase_order_number = purchase_order_number
       @regenerated_invoice = nil
       super
     end
@@ -59,7 +60,7 @@ module Invoices
     private
 
     attr_accessor :regenerated_invoice
-    attr_reader :voided_invoice, :fees_params
+    attr_reader :voided_invoice, :fees_params, :purchase_order_number
 
     delegate :customer, to: :voided_invoice
 
@@ -269,7 +270,18 @@ module Invoices
         datetime: voided_invoice.created_at,
         billing_entity: voided_invoice.billing_entity
       ).invoice.tap do |invoice|
-        invoice.update!(voided_invoice_id: voided_invoice.id)
+        invoice.update!(
+          voided_invoice_id: voided_invoice.id,
+          purchase_order_number: resolved_purchase_order_number
+        )
+      end
+    end
+
+    def resolved_purchase_order_number
+      if purchase_order_number == :inherit
+        voided_invoice.purchase_order_number
+      else
+        purchase_order_number
       end
     end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -11152,6 +11152,7 @@ input RegenerateInvoiceInput {
   """
   clientMutationId: String
   fees: [VoidedInvoiceFeeInput!]!
+  purchaseOrderNumber: String
   voidedInvoiceId: ID!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -61174,6 +61174,18 @@
               "deprecationReason": null
             },
             {
+              "name": "purchaseOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "voidedInvoiceId",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/invoices/regenerate_from_voided_spec.rb
+++ b/spec/graphql/mutations/invoices/regenerate_from_voided_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Mutations::Invoices::RegenerateFromVoided do
         regenerateFromVoided(input: $input) {
           id
           voidedInvoiceId
+          purchaseOrderNumber
           fees {
             id
             invoiceDisplayName
@@ -99,6 +100,53 @@ RSpec.describe Mutations::Invoices::RegenerateFromVoided do
       expect(result_data["fees"].first["units"]).to eq(fee_input[:units])
       expect(result_data["fees"].first["preciseUnitAmount"]).to eq(fee_input[:unitAmountCents])
       expect(result_data["status"]).to eq("finalized")
+    end
+  end
+
+  context "when a purchaseOrderNumber is provided" do
+    it "stores the normalized value on the regenerated invoice" do
+      freeze_time do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {
+            input: {
+              voidedInvoiceId: voided_invoice.id,
+              fees: [fee_input],
+              purchaseOrderNumber: "  PO-EDITED  "
+            }
+          }
+        )
+
+        result_data = result.dig("data", "regenerateFromVoided")
+        expect(result_data["purchaseOrderNumber"]).to eq("PO-EDITED")
+      end
+    end
+  end
+
+  context "when purchaseOrderNumber is not provided" do
+    before { voided_invoice.update!(purchase_order_number: "PO-INHERIT") }
+
+    it "inherits the purchase order number from the voided invoice" do
+      freeze_time do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {
+            input: {
+              voidedInvoiceId: voided_invoice.id,
+              fees: [fee_input]
+            }
+          }
+        )
+
+        result_data = result.dig("data", "regenerateFromVoided")
+        expect(result_data["purchaseOrderNumber"]).to eq("PO-INHERIT")
+      end
     end
   end
 end

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -69,6 +69,36 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
       end
     end
 
+    context "with the purchase order number" do
+      before { voided_invoice.update!(purchase_order_number: "PO-ORIGINAL") }
+
+      context "when no purchase_order_number is provided" do
+        it "inherits the value from the voided invoice" do
+          expect(regenerate_result.invoice.purchase_order_number).to eq("PO-ORIGINAL")
+        end
+      end
+
+      context "when a purchase_order_number is provided" do
+        it "stores the normalized provided value on the regenerated invoice" do
+          result = Invoices::RegenerateFromVoidedService.call!(
+            voided_invoice:, fees_params:, purchase_order_number: "  PO-EDITED  "
+          )
+
+          expect(result.invoice.purchase_order_number).to eq("PO-EDITED")
+        end
+      end
+
+      context "when a blank purchase_order_number is provided" do
+        it "clears the value on the regenerated invoice" do
+          result = Invoices::RegenerateFromVoidedService.call!(
+            voided_invoice:, fees_params:, purchase_order_number: "   "
+          )
+
+          expect(result.invoice.purchase_order_number).to be_nil
+        end
+      end
+    end
+
     context "when voided fee has pay_in_advance_event_transaction_id" do
       before do
         original_fee.update!(pay_in_advance_event_transaction_id: "txn_123", pay_in_advance: true)


### PR DESCRIPTION
## Context
When regenerating voided invoice, it should be possible to edit, remove or keep the purchase order number.

## Description
Adds an optional `purchaseOrderNumber` argument to the `regenerateFromVoided` mutation.
- Omitted → inherit the voided invoice's PO number.
- Provided (value or nil) → stamp that value on the regenerated invoice.