### PR TITLE
chore(perf): Dedupe charge filter preload

### DIFF
--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -4,9 +4,13 @@ module Events
   class BillingPeriodFilterService < BaseService
     Result = BaseResult[:charges]
 
-    def initialize(subscription:, boundaries:)
+    # charges: optional pre-loaded collection of the plan charges, with :billable_metric
+    #          and filters: {values: :billable_metric_filter} associations loaded.
+    #          When provided, it is used instead of re-loading the same records from the database.
+    def initialize(subscription:, boundaries:, charges: nil)
       @subscription = subscription
       @boundaries = boundaries
+      @preloaded_charges = charges
       super
     end
 
@@ -23,7 +27,7 @@ module Events
 
     private
 
-    attr_reader :subscription, :boundaries
+    attr_reader :subscription, :boundaries, :preloaded_charges
 
     delegate :plan, :organization, to: :subscription
 
@@ -116,23 +120,43 @@ module Events
     def recurring_event_charges_and_filters
       result = {}
 
-      plan.charges.joins(:billable_metric).left_joins(:filters)
-        .where(billable_metrics: {recurring: true})
-        .group("charges.id, charge_filters.id")
-        .pluck("charges.id", "charge_filters.id")
-        .each { |charge_id, filter_id| record(result, charge_id, filter_id, period_start) }
+      recurring_charge_filter_pairs.each { |charge_id, filter_id| record(result, charge_id, filter_id, period_start) }
 
       # Recurring charges always expose the default (no-filter) bucket
       result.each_key { |charge_id| record(result, charge_id, nil, period_start) }
       result
     end
 
+    # [charge_id, filter_id] pairs of the recurring charges, with a nil filter_id for charges
+    # without filters.
+    def recurring_charge_filter_pairs
+      if preloaded_charges
+        current_recurring_charges.flat_map do |charge|
+          if charge.filters.empty?
+            [[charge.id, nil]]
+          else
+            charge.filters.map { |filter| [charge.id, filter.id] }
+          end
+        end
+      else
+        plan.charges.joins(:billable_metric).left_joins(:filters)
+          .where(billable_metrics: {recurring: true})
+          .group("charges.id, charge_filters.id")
+          .pluck("charges.id", "charge_filters.id")
+      end
+    end
+
     # Charges of the plan whose billable metric received events in the period (recurring or not)
     def charges_with_events(codes)
-      plan.charges
-        .joins(:billable_metric)
-        .where(billable_metrics: {code: codes})
-        .includes(billable_metric: :filters, filters: {values: :billable_metric_filter})
+      if preloaded_charges
+        codes_set = codes.to_set
+        preloaded_charges.select { codes_set.include?(it.billable_metric.code) }
+      else
+        plan.charges
+          .joins(:billable_metric)
+          .where(billable_metrics: {code: codes})
+          .includes(billable_metric: :filters, filters: {values: :billable_metric_filter})
+      end
     end
 
     # Union of every filter key defined across the plan billable metrics
@@ -233,11 +257,15 @@ module Events
 
     # Fetches all recurring charges for the current plan
     def current_recurring_charges
-      @current_recurring_charges ||= plan.charges
-        .joins(:billable_metric)
-        .where(billable_metrics: {recurring: true})
-        .includes(:filters)
-        .to_a
+      @current_recurring_charges ||= if preloaded_charges
+        preloaded_charges.select { it.billable_metric.recurring? }
+      else
+        plan.charges
+          .joins(:billable_metric)
+          .where(billable_metrics: {recurring: true})
+          .includes(:filters)
+          .to_a
+      end
     end
 
     # Fetches all recurring billable metrics IDs from previous subscriptions,

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -75,7 +75,7 @@ module Invoices
         .plan
         .charges
         .joins(:billable_metric)
-        .includes(:taxes, :applied_pricing_unit, billable_metric: :organization, filters: {values: :billable_metric_filter})
+        .includes(:taxes, :applied_pricing_unit, billable_metric: [:organization, :filters], filters: {values: :billable_metric_filter})
       if usage_filters.filter_by_charge_id.present?
         charges = charges.where(id: usage_filters.filter_by_charge_id)
       elsif usage_filters.filter_by_charge_code.present?
@@ -120,7 +120,7 @@ module Invoices
     def compute_charge_fees
       fees = []
       filters = event_filters(subscription, boundaries).charges
-      charges.find_each { |c| fees += charge_usage(c, filters[c.id] || {}) }
+      charges.each { |c| fees += charge_usage(c, filters[c.id] || {}) }
       return fees if usage_filters.has_charge_filter?
 
       fees.sort_by { |f| f.billable_metric.name.downcase }
@@ -271,8 +271,10 @@ module Invoices
     end
 
     def event_filters(subscription, boundaries)
+      # NOTE: passing the pre-loaded charges avoids re-loading the same
+      #       charges/filters/values associations from the database
       Events::BillingPeriodFilterService.call!(
-        subscription:, boundaries:
+        subscription:, boundaries:, charges:
       )
     end
 

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe Events::BillingPeriodFilterService do
   before { charge }
 
   describe "#call" do
-    context "when relying on event codes" do
+    shared_examples "billing period filtering from event codes" do
       it "returns the filtered charge_ids" do
         result = filter_service.call
 
@@ -679,6 +679,34 @@ RSpec.describe Events::BillingPeriodFilterService do
 
         expect(event_store).to have_received(:distinct_codes_and_property_combinations)
           .with(codes: [billable_metric.code], filter_keys: [])
+      end
+    end
+
+    context "when relying on event codes" do
+      it_behaves_like "billing period filtering from event codes"
+
+      context "when charges are preloaded" do
+        subject(:filter_service) { described_class.new(subscription:, boundaries:, charges: preloaded_charges) }
+
+        let(:preloaded_charges) do
+          plan.charges
+            .includes(billable_metric: :filters, filters: {values: :billable_metric_filter})
+            .to_a
+        end
+
+        it_behaves_like "billing period filtering from event codes"
+
+        it "does not load charges or filters from the database" do
+          preloaded_charges
+
+          queries = []
+          callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+          ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+            filter_service.call
+          end
+
+          expect(queries.grep(/FROM "charges"|FROM "charge_filters"/)).to be_empty
+        end
       end
     end
 
@@ -1196,6 +1224,18 @@ RSpec.describe Events::BillingPeriodFilterService do
             # now, so the recurring bucket must reflect it to invalidate the lazy usage cache.
             expect(result.charges[recurring_charge.id][nil]).to be > boundaries.charges_from_datetime
           end
+        end
+
+        context "when charges are preloaded" do
+          subject(:filter_service) { described_class.new(subscription:, boundaries:, charges: preloaded_charges) }
+
+          let(:preloaded_charges) do
+            plan.charges
+              .includes(billable_metric: :filters, filters: {values: :billable_metric_filter})
+              .to_a
+          end
+
+          it_behaves_like "recurring billable metric filtering"
         end
       end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -89,6 +89,28 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
         .with(hash_including(skip_adjusted_fees: true))
     end
 
+    it "passes the preloaded charges to the billing period filter service" do
+      passed_charges = nil
+      allow(Events::BillingPeriodFilterService).to receive(:call!).and_wrap_original do |original, **kwargs|
+        passed_charges = kwargs[:charges]
+        original.call(**kwargs)
+      end
+
+      usage_service.call
+
+      expect(passed_charges).to eq([charge])
+    end
+
+    it "loads the charge filters only once" do
+      queries = []
+      callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        usage_service.call
+      end
+
+      expect(queries.grep(/FROM "charge_filters"/).size).to eq(1)
+    end
+
     context "when initializes an invoice" do
       let(:current_date) { DateTime.parse("2025-06-15") }
       let(:timestamp) { current_date }


### PR DESCRIPTION
## Context
  
  When computing customer usage, the plan's charges and their filter tree (`charge_filters` + `charge_filter_values` with their large `properties` jsonb) are
  loaded from PostgreSQL twice per computation:

  1. `Invoices::CustomerUsageService#charges` preloads them for the fee loop
  2. `Events::BillingPeriodFilterService#non_recurring_charges_with_events` re-loads the exact same associations for the same plan

  On large plans (~1,600 charge filters) each load costs seconds, and `RefreshWalletsService` pays this per subscription.

  ## Description

  Load the charge/filter set once and share it:

  - `Events::BillingPeriodFilterService` accepts an optional `charges:` argument (pre-loaded charges with `billable_metric` and `filters: {values:
  :billable_metric_filter}`). When provided, `non_recurring_charges_with_events`, `recurring_event_charges_and_filters` and `current_recurring_charges` are
  resolved in memory instead of re-querying. Without it, behavior is unchanged, so `CalculateFeesService` and `ProgressiveBillingService` are unaffected.
  - `Invoices::CustomerUsageService` passes its memoized charges relation to the service; since it is the same object, the fee loop then reuses the loaded
  records.
  - `find_each` is replaced by `each` in the fee loop: `find_each` always re-queries in batches, which would have triggered the preload a second time.
  - The usage preload now includes `billable_metric: :filters`, required by `ChargeFilters::EventMatchingService` to stay query-free on pre-loaded charges.
