### PR TITLE
feat(invoices): add deleted status to CreditNote model

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -38,7 +38,7 @@ module Api
       end
 
       def update
-        credit_note = current_organization.credit_notes.find_by(id: params[:id])
+        credit_note = current_organization.credit_notes.not_deleted.find_by(id: params[:id])
         return not_found_error(resource: "credit_note") unless credit_note
 
         result = ::CreditNotes::UpdateService.new(credit_note:, partial_metadata: true, **update_params).call
@@ -93,7 +93,7 @@ module Api
       end
 
       def void
-        credit_note = current_organization.credit_notes.find_by(id: params[:id])
+        credit_note = current_organization.credit_notes.not_deleted.find_by(id: params[:id])
         return not_found_error(resource: "credit_note") unless credit_note
 
         result = ::CreditNotes::VoidService.new(credit_note:).call

--- a/app/graphql/mutations/credit_notes/download.rb
+++ b/app/graphql/mutations/credit_notes/download.rb
@@ -17,7 +17,7 @@ module Mutations
 
       def resolve(**args)
         result = ::CreditNotes::GeneratePdfService.call(
-          credit_note: current_organization.credit_notes.find_by(id: args[:id])
+          credit_note: current_organization.credit_notes.not_deleted.find_by(id: args[:id])
         )
 
         result.success? ? result.credit_note : result_error(result)

--- a/app/graphql/mutations/credit_notes/download_xml.rb
+++ b/app/graphql/mutations/credit_notes/download_xml.rb
@@ -17,7 +17,7 @@ module Mutations
 
       def resolve(**args)
         result = ::CreditNotes::GenerateXmlService.call(
-          credit_note: current_organization.credit_notes.find_by(id: args[:id])
+          credit_note: current_organization.credit_notes.not_deleted.find_by(id: args[:id])
         )
 
         result.success? ? result.credit_note : result_error(result)

--- a/app/graphql/mutations/credit_notes/retry_tax_reporting.rb
+++ b/app/graphql/mutations/credit_notes/retry_tax_reporting.rb
@@ -15,7 +15,7 @@ module Mutations
       type Types::CreditNotes::Object
 
       def resolve(**args)
-        credit_note = current_organization.credit_notes.find_by(id: args[:id])
+        credit_note = current_organization.credit_notes.not_deleted.find_by(id: args[:id])
         result = ::CreditNotes::ProviderTaxes::ReportService.call(credit_note:)
 
         result.success? ? result.credit_note : result_error(result)

--- a/app/graphql/mutations/credit_notes/update.rb
+++ b/app/graphql/mutations/credit_notes/update.rb
@@ -17,7 +17,7 @@ module Mutations
 
       def resolve(**args)
         result = ::CreditNotes::UpdateService.new(
-          credit_note: current_organization.credit_notes.find_by(id: args[:id]),
+          credit_note: current_organization.credit_notes.not_deleted.find_by(id: args[:id]),
           **args.slice(:refund_status, :metadata)
         ).call
 

--- a/app/graphql/mutations/credit_notes/void.rb
+++ b/app/graphql/mutations/credit_notes/void.rb
@@ -17,7 +17,7 @@ module Mutations
 
       def resolve(id:)
         result = ::CreditNotes::VoidService.new(
-          credit_note: current_organization.credit_notes.find_by(id:)
+          credit_note: current_organization.credit_notes.not_deleted.find_by(id:)
         ).call
 
         result.success? ? result.credit_note : result_error(result)

--- a/app/graphql/mutations/integrations/sync_credit_note.rb
+++ b/app/graphql/mutations/integrations/sync_credit_note.rb
@@ -16,7 +16,7 @@ module Mutations
       field :credit_note_id, ID, null: true
 
       def resolve(**args)
-        credit_note = current_organization.credit_notes.find_by(id: args[:credit_note_id])
+        credit_note = current_organization.credit_notes.not_deleted.find_by(id: args[:credit_note_id])
 
         result = ::Integrations::Aggregator::CreditNotes::CreateService.call_async(credit_note:)
         result.success? ? result.credit_note_id : result_error(result)

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -64,7 +64,7 @@ class CreditNote < ApplicationRecord
   TYPES = %w[credit refund offset].freeze
 
   REASON = %i[duplicated_charge product_unsatisfactory order_change order_cancellation fraudulent_charge other].freeze
-  STATUS = %i[draft finalized].freeze
+  STATUS = %i[draft finalized deleted].freeze
 
   enum :credit_status, CREDIT_STATUS
   enum :refund_status, REFUND_STATUS, validate: {allow_nil: true}

--- a/db/migrate/20260715142900_update_exports_credit_notes_to_version_5.rb
+++ b/db/migrate/20260715142900_update_exports_credit_notes_to_version_5.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateExportsCreditNotesToVersion5 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :exports_credit_notes, version: 5, revert_to_version: 4
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3051,7 +3051,8 @@ CREATE VIEW public.exports_credit_notes AS
     ( SELECT json_agg(json_build_object('lago_id', ed.id, 'error_code', ed.error_code, 'details', ed.details)) AS json_agg
            FROM public.error_details ed
           WHERE (((ed.owner_type)::text = 'CreditNote'::text) AND (ed.owner_id = cn.id))) AS error_details
-   FROM public.credit_notes cn;
+   FROM public.credit_notes cn
+  WHERE (cn.status <> 2);
 
 
 --
@@ -12844,6 +12845,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260715142900'),
 ('20260709141039'),
 ('20260709141038'),
 ('20260709141037'),

--- a/db/views/exports_credit_notes_v05.sql
+++ b/db/views/exports_credit_notes_v05.sql
@@ -1,0 +1,105 @@
+SELECT
+  cn.organization_id,
+  cn.id AS lago_id,
+  cn.sequential_id,
+  cn.number,
+  cn.invoice_id AS lago_invoice_id,
+  cn.issuing_date,
+  CASE cn.credit_status
+    WHEN 0 THEN 'available'
+    WHEN 1 THEN 'consumed'
+    WHEN 2 THEN 'voided'
+  END AS credit_status,
+  CASE cn.refund_status
+    WHEN 0 THEN 'pending'
+    WHEN 1 THEN 'succeeded'
+    WHEN 2 THEN 'failed'
+  END AS refund_status,
+  CASE cn.reason
+    WHEN 0 THEN 'duplicated_charge'
+    WHEN 1 THEN 'product_unsatisfactory'
+    WHEN 2 THEN 'order_change'
+    WHEN 3 THEN 'order_cancellation'
+    WHEN 4 THEN 'fraudulent_charge'
+    WHEN 5 THEN 'other'
+  END as reason,
+  cn.description,
+  cn.total_amount_currency AS currency,
+  cn.total_amount_cents,
+  cn.taxes_amount_cents,
+  ROUND(
+    (
+      SELECT
+        SUM(ci.precise_amount_cents)::bigint
+      FROM
+        credit_note_items AS ci
+      WHERE
+        ci.credit_note_id = cn.id
+    ) - cn.precise_coupons_adjustment_amount_cents
+  )::bigint AS sub_total_excluding_taxes_amount_cents,
+  cn.balance_amount_cents,
+  cn.credit_amount_cents,
+  cn.refund_amount_cents,
+  cn.coupons_adjustment_amount_cents,
+  cn.taxes_rate,
+  cn.created_at,
+  cn.updated_at,
+  cn.refunded_at,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'lago_id',
+          ci.id,
+          'amount_cents',
+          ci.amount_cents,
+          'amount_currency',
+          ci.amount_currency,
+          'lago_fee_id',
+          ci.fee_id
+        )
+      )
+    FROM
+      credit_note_items AS ci
+    WHERE
+      ci.credit_note_id = cn.id
+  ) AS items,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'key',
+          je.key,
+          'value',
+          je.value
+        )
+      )
+    FROM
+      item_metadata AS im,
+      jsonb_each_text (im.value) AS je
+    WHERE
+      im.owner_type = 'CreditNote'
+      AND im.owner_id = cn.id
+  ) AS metadata,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'lago_id',
+          ed.id,
+          'error_code',
+          ed.error_code,
+          'details',
+          ed.details
+        )
+      )
+    FROM
+      error_details AS ed
+    WHERE
+      ed.owner_type = 'CreditNote'
+      AND ed.owner_id = cn.id
+  ) AS error_details
+FROM
+  credit_notes AS cn
+WHERE
+  cn.status != 2; -- exclude deleted credit notes

--- a/spec/db/views/exports_credit_notes_spec.rb
+++ b/spec/db/views/exports_credit_notes_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe "exports_credit_notes view" do # rubocop:disable RSpec/DescribeCl
     row
   end
 
+  describe "deleted credit notes" do
+    it "excludes them from the export" do
+      deleted_credit_note = create(:credit_note, :deleted)
+
+      expect(row_for(credit_note.id)).to be_present
+      expect(row_for(deleted_credit_note.id)).to be_nil
+    end
+  end
+
   describe "full row" do
     context "with a fully populated credit note" do
       let(:credit_note) do

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -33,6 +33,10 @@ FactoryBot.define do
       status { :draft }
     end
 
+    trait :deleted do
+      status { :deleted }
+    end
+
     trait :with_tax_error do
       after :create do |i|
         create(:error_detail, owner: i, error_code: "tax_error")

--- a/spec/graphql/mutations/credit_notes/update_spec.rb
+++ b/spec/graphql/mutations/credit_notes/update_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Mutations::CreditNotes::Update do
     end
   end
 
+  context "when credit note is deleted" do
+    let(:credit_note) { create(:credit_note, :deleted, customer:, invoice:) }
+
+    it "returns an error" do
+      result = execute_query(
+        query: mutation,
+        input: {
+          id: credit_note.id,
+          refundStatus: "succeeded"
+        }
+      )
+
+      expect_not_found(result)
+    end
+  end
+
   context "with metadata" do
     let(:mutation) do
       <<~GQL

--- a/spec/graphql/mutations/credit_notes/void_spec.rb
+++ b/spec/graphql/mutations/credit_notes/void_spec.rb
@@ -48,4 +48,17 @@ RSpec.describe Mutations::CreditNotes::Void do
       expect_not_found(result)
     end
   end
+
+  context "when credit note is deleted" do
+    let(:credit_note) { create(:credit_note, :deleted, customer:, invoice:) }
+
+    it "returns an error" do
+      result = execute_query(
+        query: mutation,
+        input: {id: credit_note.id}
+      )
+
+      expect_not_found(result)
+    end
+  end
 end

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe CreditNote do
     end
   end
 
+  describe "enums" do
+    it do
+      expect(subject).to define_enum_for(:status).with_values(draft: 0, finalized: 1, deleted: 2)
+    end
+  end
+
   describe "sequential_id" do
     let(:invoice) { create(:invoice) }
     let(:customer) { invoice.customer }

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -178,6 +178,15 @@ RSpec.describe Api::V1::CreditNotesController do
       end
     end
 
+    context "when credit note is deleted" do
+      let(:credit_note) { create(:credit_note, :deleted, invoice:, customer:) }
+
+      it "returns a not found error" do
+        subject
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context "with metadata" do
       before do
         create(:item_metadata, owner: credit_note, organization:, value: {"existing" => "value"})
@@ -709,6 +718,15 @@ RSpec.describe Api::V1::CreditNotesController do
       it "returns an unprocessable entity error" do
         subject
         expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
+
+    context "when credit note is deleted" do
+      let(:credit_note) { create(:credit_note, :deleted, invoice:, customer:) }
+
+      it "returns a not found error" do
+        subject
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
## Context

_Part of the "Delete a draft invoice" feature._

Right now operators can't remove a draft invoice created by mistake (duplicate subscription, test data, config error).

We want to add a delete action for draft invoices. The invoice disappears should disappear as if it never existed: no AR entry, no email, no external sync. The subscription should be untouched and should keep billing from the next period.

The `deleted` status for invoices was introduced in another PR https://github.com/getlago/lago-api/pull/5905

## Description

This PR introduces the `deleted` status on `CreditNote` and makes sure it stays invisible.

## What's included

- **New `deleted` status**
- **Keeps deleted credit notes invisible:** the `void` and `update` controller finders now scope to `.not_deleted`
- **Data export:** `exports_credit_notes` (v5) now filters `WHERE cn.status != 2`