### PR TITLE
feat(wallets): flag late payment failure [ING-419]

### DIFF
--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -21,7 +21,10 @@ module Invoices
         Wallets::ApplyPaidCreditsService.call(wallet_transaction:)
         Invoices::FinalizeOpenCreditService.call(invoice:)
       else
-        WalletTransactions::MarkAsFailedService.call(wallet_transaction:)
+        WalletTransactions::MarkAsFailedService.call(
+          wallet_transaction:,
+          notify_settled_failure: payment_status.to_sym == :failed
+        )
       end
     end
 

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -91,7 +91,8 @@ class SendWebhookJob < ApplicationJob
     "wallet.depleted_ongoing_balance" => Webhooks::Wallets::DepletedOngoingBalanceService,
     "wallet_transaction.created" => Webhooks::WalletTransactions::CreatedService,
     "wallet_transaction.updated" => Webhooks::WalletTransactions::UpdatedService,
-    "wallet_transaction.payment_failure" => Webhooks::PaymentProviders::WalletTransactionPaymentFailureService
+    "wallet_transaction.payment_failure" => Webhooks::PaymentProviders::WalletTransactionPaymentFailureService,
+    "wallet_transaction.payment_failure_after_settlement" => Webhooks::WalletTransactions::PaymentFailureAfterSettlementService
   }.freeze
 
   # This is a placeholder object to know which arguments were provided.

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -82,7 +82,8 @@ class SendWebhookJob < ApplicationJob
     "wallet.depleted_ongoing_balance" => Webhooks::Wallets::DepletedOngoingBalanceService,
     "wallet_transaction.created" => Webhooks::WalletTransactions::CreatedService,
     "wallet_transaction.updated" => Webhooks::WalletTransactions::UpdatedService,
-    "wallet_transaction.payment_failure" => Webhooks::PaymentProviders::WalletTransactionPaymentFailureService
+    "wallet_transaction.payment_failure" => Webhooks::PaymentProviders::WalletTransactionPaymentFailureService,
+    "wallet_transaction.payment_failure_after_settlement" => Webhooks::WalletTransactions::PaymentFailureAfterSettlementService
   }.freeze
 
   # This is a placeholder object to know which arguments were provided.

--- a/app/services/wallet_transactions/mark_as_failed_service.rb
+++ b/app/services/wallet_transactions/mark_as_failed_service.rb
@@ -4,8 +4,11 @@ module WalletTransactions
   class MarkAsFailedService < BaseService
     Result = BaseResult[:wallet_transaction]
 
-    def initialize(wallet_transaction:)
+    SETTLED_FAILURE_WEBHOOK = "wallet_transaction.payment_failure_after_settlement"
+
+    def initialize(wallet_transaction:, notify_settled_failure: false)
       @wallet_transaction = wallet_transaction
+      @notify_settled_failure = notify_settled_failure
       super
     end
 
@@ -17,8 +20,12 @@ module WalletTransactions
     def call
       return result unless wallet_transaction
       return result if wallet_transaction.failed?
-      # note: if a wallet transaction is settled, but they mark payment as failed, they need to void credits manually
-      return result if wallet_transaction.settled?
+
+      if wallet_transaction.settled?
+        # note: credits were already granted, they can only be voided manually
+        notify_settled_failure! if notify_settled_failure
+        return result
+      end
 
       wallet_transaction.mark_as_failed!
       after_commit { SendWebhookJob.perform_later("wallet_transaction.updated", wallet_transaction) }
@@ -29,6 +36,12 @@ module WalletTransactions
 
     private
 
-    attr_reader :wallet_transaction
+    attr_reader :wallet_transaction, :notify_settled_failure
+
+    def notify_settled_failure!
+      return if Webhook.exists?(object: wallet_transaction, webhook_type: SETTLED_FAILURE_WEBHOOK)
+
+      after_commit { SendWebhookJob.perform_later(SETTLED_FAILURE_WEBHOOK, wallet_transaction) }
+    end
   end
 end

--- a/app/services/webhooks/wallet_transactions/payment_failure_after_settlement_service.rb
+++ b/app/services/webhooks/wallet_transactions/payment_failure_after_settlement_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module WalletTransactions
+    class PaymentFailureAfterSettlementService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::WalletTransactionSerializer.new(object, root_name: "wallet_transaction", includes: %i[wallet])
+      end
+
+      def webhook_type
+        "wallet_transaction.payment_failure_after_settlement"
+      end
+
+      def object_type
+        "wallet_transaction"
+      end
+    end
+  end
+end

--- a/config/webhook_event_types.yml
+++ b/config/webhook_event_types.yml
@@ -373,3 +373,8 @@ wallet_transaction_payment_failure:
   description: A payment attempt for a wallet transaction has failed on a payment provider
   category: Wallets and Credits
   deprecated: false
+wallet_transaction_payment_failure_after_settlement:
+  name: wallet_transaction.payment_failure_after_settlement
+  description: A payment failure was recorded for a wallet transaction whose credits were already settled, requiring a manual review
+  category: Wallets and Credits
+  deprecated: false

--- a/config/webhook_event_types.yml
+++ b/config/webhook_event_types.yml
@@ -328,3 +328,8 @@ wallet_transaction_payment_failure:
   description: A payment attempt for a wallet transaction has failed on a payment provider
   category: Wallets and Credits
   deprecated: false
+wallet_transaction_payment_failure_after_settlement:
+  name: wallet_transaction.payment_failure_after_settlement
+  description: A payment failure was recorded for a wallet transaction whose credits were already settled, requiring a manual review
+  category: Wallets and Credits
+  deprecated: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -5876,6 +5876,7 @@ enum EventTypeEnum {
   wallet_terminated
   wallet_transaction_created
   wallet_transaction_payment_failure
+  wallet_transaction_payment_failure_after_settlement
   wallet_transaction_updated
   wallet_updated
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -6371,6 +6371,7 @@ enum EventTypeEnum {
   wallet_terminated
   wallet_transaction_created
   wallet_transaction_payment_failure
+  wallet_transaction_payment_failure_after_settlement
   wallet_transaction_updated
   wallet_updated
 }

--- a/schema.json
+++ b/schema.json
@@ -30877,6 +30877,12 @@
               "deprecationReason": null
             },
             {
+              "name": "wallet_transaction_payment_failure_after_settlement",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "all",
               "description": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -28664,6 +28664,12 @@
               "deprecationReason": null
             },
             {
+              "name": "wallet_transaction_payment_failure_after_settlement",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "all",
               "description": null,
               "isDeprecated": false,

--- a/spec/jobs/invoices/prepaid_credit_job_spec.rb
+++ b/spec/jobs/invoices/prepaid_credit_job_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe Invoices::PrepaidCreditJob do
     it "marks the wallet transaction as failed" do
       allow(WalletTransactions::MarkAsFailedService).to receive(:new).and_call_original
       described_class.perform_now(invoice, payment_status)
-      expect(WalletTransactions::MarkAsFailedService).to have_received(:new).with(wallet_transaction: wallet_transaction)
+      expect(WalletTransactions::MarkAsFailedService).to have_received(:new)
+        .with(wallet_transaction: wallet_transaction, notify_settled_failure: payment_status == :failed)
       expect(wallet_transaction.reload.status).to eq("failed")
     end
 
@@ -86,6 +87,26 @@ RSpec.describe Invoices::PrepaidCreditJob do
 
   context "when payment fails" do
     it_behaves_like "does not grant credits", :failed
+
+    context "when the wallet transaction is already settled" do
+      let(:wallet_transaction) do
+        create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: "settled")
+      end
+
+      it "keeps the wallet transaction settled and does not change the wallet balance" do
+        expect {
+          described_class.perform_now(invoice, :failed)
+        }.to not_change { wallet_transaction.reload.status }
+          .and not_change { wallet.reload.balance_cents }
+      end
+
+      it "enqueues a SendWebhookJob to notify about the failed payment" do
+        expect {
+          described_class.perform_now(invoice, :failed)
+        }.to have_enqueued_job(SendWebhookJob)
+          .with("wallet_transaction.payment_failure_after_settlement", wallet_transaction)
+      end
+    end
   end
 
   context "when invoice is paid by credit note" do
@@ -96,6 +117,19 @@ RSpec.describe Invoices::PrepaidCreditJob do
     end
 
     it_behaves_like "does not grant credits", :succeeded
+
+    context "when the wallet transaction is already settled" do
+      let(:wallet_transaction) do
+        create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: "settled")
+      end
+
+      it "does not enqueue a payment failure webhook" do
+        expect {
+          described_class.perform_now(invoice, :succeeded)
+        }.not_to have_enqueued_job(SendWebhookJob)
+          .with("wallet_transaction.payment_failure_after_settlement", wallet_transaction)
+      end
+    end
   end
 
   context "when payment_status is not provided (Default to :succeeded for old jobs)" do

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -741,6 +741,12 @@ RSpec.describe SendWebhookJob do
         Webhooks::BillableMetrics::DeletedService
     end
 
+    context "with wallet transaction webhooks" do
+      it_behaves_like "a webhook service",
+        "wallet_transaction.payment_failure_after_settlement",
+        Webhooks::WalletTransactions::PaymentFailureAfterSettlementService
+    end
+
     context "when webhook_type is dunning_campaign.finished" do
       let(:webhook_service) { instance_double(Webhooks::DunningCampaigns::FinishedService) }
       let(:customer) { create(:customer) }

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -789,6 +789,12 @@ RSpec.describe SendWebhookJob do
         Webhooks::Orders::ExecutedService
     end
 
+    context "with wallet transaction webhooks" do
+      it_behaves_like "a webhook service",
+        "wallet_transaction.payment_failure_after_settlement",
+        Webhooks::WalletTransactions::PaymentFailureAfterSettlementService
+    end
+
     context "when webhook_type is dunning_campaign.finished" do
       let(:webhook_service) { instance_double(Webhooks::DunningCampaigns::FinishedService) }
       let(:customer) { create(:customer) }

--- a/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
+++ b/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
@@ -52,14 +52,41 @@ RSpec.describe WalletTransactions::MarkAsFailedService do
         let(:wallet) { create(:wallet, credits_balance: 100, balance_cents: 100) }
         let(:wallet_transaction) { create(:wallet_transaction, wallet:, status: "settled", amount: 100, credit_amount: 100) }
 
-        before do
-          wallet_transaction
-        end
-
-        it "does not do anything" do
+        it "does not change the wallet_transaction status" do
           expect {
             service.call
           }.not_to change(wallet_transaction, :status)
+        end
+
+        it "does not enqueue a SendWebhookJob" do
+          expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+        end
+
+        context "with notify_settled_failure" do
+          subject(:service) { described_class.new(wallet_transaction:, notify_settled_failure: true) }
+
+          it "does not change the wallet_transaction status" do
+            expect {
+              service.call
+            }.not_to change(wallet_transaction, :status)
+          end
+
+          it "enqueues a SendWebhookJob to notify about the failed payment" do
+            expect {
+              service.call
+            }.to have_enqueued_job(SendWebhookJob)
+              .with("wallet_transaction.payment_failure_after_settlement", wallet_transaction)
+          end
+
+          context "when the webhook was already emitted for this wallet_transaction" do
+            before do
+              create(:webhook, object: wallet_transaction, webhook_type: "wallet_transaction.payment_failure_after_settlement")
+            end
+
+            it "does not enqueue a SendWebhookJob" do
+              expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+            end
+          end
         end
       end
     end

--- a/spec/services/webhooks/wallet_transactions/payment_failure_after_settlement_service_spec.rb
+++ b/spec/services/webhooks/wallet_transactions/payment_failure_after_settlement_service_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::WalletTransactions::PaymentFailureAfterSettlementService do
+  subject(:webhook_service) { described_class.new(object: wallet_transaction) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:) }
+  let(:wallet_transaction) { create(:wallet_transaction, wallet:, status: "settled") }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "wallet_transaction.payment_failure_after_settlement", "wallet_transaction",
+      {"lago_id" => String, "wallet" => Hash}
+  end
+end


### PR DESCRIPTION
## Context

When a prepaid credit invoice is marked as paid, the wallet is credited and the wallet transaction is settled. If a payment failure is recorded afterwards (late provider outcome, or a payment status correction via API), `WalletTransactions::MarkAsFailedService` silently no-ops on the settled transaction: the org is never told that credits were granted for a payment now marked as failed, and the only remediation (manual void) never happens. This hit a customer recently: see https://linear.app/getlago/issue/ING-419 for the full investigation.

## Changes

- Emit a new `wallet_transaction.payment_failure_after_settlement` webhook when the prepaid credit flow records a payment failure on an already settled wallet transaction, at most once per wallet transaction.
- Only the failed-payment path opts in; the credit-note settlement path keeps the silent no-op, since no payment failed there.
- The settled transaction itself is deliberately left untouched: credits may be partially consumed, a retry may still succeed, and the failure signal can even be wrong (in the reported case the payment had actually succeeded). The webhook is a signal to review, not an automatic void.