### PR TITLE
chore(clickhouse): Improve clickhouse dedup perf by using FINAL

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -18,14 +18,11 @@ module Events
             events_from = (from_datetime if force_from || use_from_boundary)
             events_to = (applicable_to_datetime if applicable_to_datetime)
 
-            deduplicated_subquery = <<~SQL.squish
-              WITH latest_enriched AS (#{latest_enriched_sql(from_datetime: events_from, to_datetime: events_to)})
-              #{deduplicated_events_sql(
-                from_datetime: events_from,
-                to_datetime: events_to,
-                deduplicated_columns: %w[value decimal_value properties precise_total_amount_cents]
-              )}
-            SQL
+            deduplicated_subquery = deduplicated_events_sql(
+              from_datetime: events_from,
+              to_datetime: events_to,
+              deduplicated_columns: %w[value decimal_value properties precise_total_amount_cents]
+            )
 
             ::Clickhouse::EventsEnriched.from("(#{deduplicated_subquery}) AS events_enriched")
           else
@@ -87,28 +84,18 @@ module Events
         query = arel_filters_scope(query)
 
         {
-          "latest_enriched" => latest_enriched_sql(from_datetime: events_from, to_datetime: events_to),
           "events_enriched" => deduplicated_events_sql(from_datetime: events_from, to_datetime: events_to, deduplicated_columns:),
           "events" => query.project(select).to_sql
         }
       end
 
       # ClickHouse cannot guarantee that events_enriched will be deduplicated all the time,
-      # so we deduplicate at query time using a two-pass strategy:
-      # 1. `latest_enriched_sql` groups events by their dedup key and gets the latest enriched_at.
-      # 2. `deduplicated_events_sql` filters `latest_enriched` and uses `INNER ANY JOIN` to
-      #    fetch the requested columns from events_enriched. `ANY JOIN` returns at most one
-      #    matching row, so duplicated enriched_at are filtered at the join layer
-      # This replaces a previous implementation with `argMax` which caused ClickHouse OOM on large subscriptions.
-      def latest_enriched_sql(from_datetime:, to_datetime:)
-        <<~SQL.squish
-          SELECT #{DEDUP_KEY_COLUMNS.join(", ")}, max(enriched_at) AS max_enriched_at
-          FROM events_enriched
-          WHERE #{deduplicated_events_where_sql(from_datetime:, to_datetime:)}
-          GROUP BY #{DEDUP_KEY_COLUMNS.join(", ")}
-        SQL
-      end
-
+      # so we deduplicate at query time with the `FINAL` modifier: the ReplacingMergeTree
+      # engine collapses the rows sharing the same sorting key at read time, keeping the
+      # row from the most recent part (the latest enrichment).
+      # This replaces a previous two-pass implementation (`GROUP BY` the dedup key +
+      # `INNER ANY JOIN`) which was dominating the ClickHouse cluster CPU, and an even
+      # earlier `argMax` version which caused ClickHouse OOM on large subscriptions.
       def deduplicated_events_sql(from_datetime:, to_datetime:, deduplicated_columns: [])
         columns = deduplicated_columns.dup
 
@@ -117,25 +104,20 @@ module Events
           columns << "properties"
         end
 
-        picked_columns = columns.uniq.map { "e.#{it}" }
-        selected_columns = (DEDUP_KEY_COLUMNS.map { "l.#{it}" } + picked_columns).join(", ")
-        join_conditions = (DEDUP_KEY_COLUMNS.map { "e.#{it} = l.#{it}" } + ["e.enriched_at = l.max_enriched_at"]).join(" AND ")
+        selected_columns = (DEDUP_KEY_COLUMNS + columns).uniq.join(", ")
 
         <<~SQL.squish
           SELECT #{selected_columns}
-          FROM latest_enriched AS l
-          INNER ANY JOIN events_enriched AS e ON #{join_conditions}
-          WHERE #{deduplicated_events_where_sql(from_datetime:, to_datetime:, alias_prefix: "e")}
+          FROM events_enriched FINAL
+          WHERE #{deduplicated_events_where_sql(from_datetime:, to_datetime:)}
         SQL
       end
 
-      def deduplicated_events_where_sql(from_datetime:, to_datetime:, alias_prefix: nil)
-        prefix = alias_prefix ? "#{alias_prefix}." : ""
-
+      def deduplicated_events_where_sql(from_datetime:, to_datetime:)
         conditions = [
           ActiveRecord::Base.sanitize_sql_for_conditions(
             [
-              "#{prefix}organization_id = ? AND #{prefix}code = ? AND #{prefix}external_subscription_id = ?",
+              "organization_id = ? AND code = ? AND external_subscription_id = ?",
               subscription.organization_id,
               code,
               subscription.external_id
@@ -143,8 +125,8 @@ module Events
           )
         ]
 
-        conditions << ActiveRecord::Base.sanitize_sql_for_conditions(["#{prefix}timestamp >= ?", from_datetime]) if from_datetime
-        conditions << upper_timestamp_boundary_sql(to_datetime, prefix:) if to_datetime
+        conditions << ActiveRecord::Base.sanitize_sql_for_conditions(["timestamp >= ?", from_datetime]) if from_datetime
+        conditions << upper_timestamp_boundary_sql(to_datetime) if to_datetime
         conditions.join(" AND ")
       end
 
@@ -248,15 +230,12 @@ module Events
       end
 
       # Counting deduplicated events only needs the number of distinct dedup keys,
-      # not their latest enriched values. We therefore skip the `INNER ANY JOIN`
-      # performed by `events_cte_queries` (which materializes a column for every
-      # event and roughly doubles the memory of the dedup aggregation) and count
-      # the grouped keys directly. This avoids ClickHouse MEMORY_LIMIT_EXCEEDED on
-      # very large subscriptions.
+      # so we count directly on the deduplicated table without materializing any
+      # other column.
       #
       # When the count is filtered (grouped_by_values or matching/ignored filters)
-      # we keep the JOIN-based path so the filter still applies to the latest
-      # enriched row per dedup key (identical semantics).
+      # we keep the CTE-based path so the filter still applies to the deduplicated
+      # rows (identical semantics).
       def count_query
         filtered = grouped_by_values? || matching_filters.present? || ignored_filters.present?
 
@@ -271,12 +250,8 @@ module Events
 
         <<~SQL.squish
           SELECT count()
-          FROM (
-            SELECT 1
-            FROM events_enriched
-            WHERE #{deduplicated_events_where_sql(from_datetime: events_from, to_datetime: applicable_to_datetime)}
-            GROUP BY #{DEDUP_KEY_COLUMNS.join(", ")}
-          )
+          FROM events_enriched FINAL
+          WHERE #{deduplicated_events_where_sql(from_datetime: events_from, to_datetime: applicable_to_datetime)}
         SQL
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -18,14 +18,11 @@ module Events
             events_from = (from_datetime if force_from || use_from_boundary)
             events_to = (applicable_to_datetime if applicable_to_datetime)
 
-            deduplicated_subquery = <<~SQL.squish
-              WITH latest_enriched AS (#{latest_enriched_sql(from_datetime: events_from, to_datetime: events_to)})
-              #{deduplicated_events_sql(
-                from_datetime: events_from,
-                to_datetime: events_to,
-                deduplicated_columns: %w[value decimal_value properties precise_total_amount_cents]
-              )}
-            SQL
+            deduplicated_subquery = deduplicated_events_sql(
+              from_datetime: events_from,
+              to_datetime: events_to,
+              deduplicated_columns: %w[value decimal_value properties precise_total_amount_cents]
+            )
 
             ::Clickhouse::EventsEnriched.from("(#{deduplicated_subquery}) AS events_enriched")
           else
@@ -87,28 +84,18 @@ module Events
         query = arel_filters_scope(query)
 
         {
-          "latest_enriched" => latest_enriched_sql(from_datetime: events_from, to_datetime: events_to),
           "events_enriched" => deduplicated_events_sql(from_datetime: events_from, to_datetime: events_to, deduplicated_columns:),
           "events" => query.project(select).to_sql
         }
       end
 
       # ClickHouse cannot guarantee that events_enriched will be deduplicated all the time,
-      # so we deduplicate at query time using a two-pass strategy:
-      # 1. `latest_enriched_sql` groups events by their dedup key and gets the latest enriched_at.
-      # 2. `deduplicated_events_sql` filters `latest_enriched` and uses `INNER ANY JOIN` to
-      #    fetch the requested columns from events_enriched. `ANY JOIN` returns at most one
-      #    matching row, so duplicated enriched_at are filtered at the join layer
-      # This replaces a previous implementation with `argMax` which caused ClickHouse OOM on large subscriptions.
-      def latest_enriched_sql(from_datetime:, to_datetime:)
-        <<~SQL.squish
-          SELECT #{DEDUP_KEY_COLUMNS.join(", ")}, max(enriched_at) AS max_enriched_at
-          FROM events_enriched
-          WHERE #{deduplicated_events_where_sql(from_datetime:, to_datetime:)}
-          GROUP BY #{DEDUP_KEY_COLUMNS.join(", ")}
-        SQL
-      end
-
+      # so we deduplicate at query time with the `FINAL` modifier: the ReplacingMergeTree
+      # engine collapses the rows sharing the same sorting key at read time, keeping the
+      # row from the most recent part (the latest enrichment).
+      # This replaces a previous two-pass implementation (`GROUP BY` the dedup key +
+      # `INNER ANY JOIN`) which was dominating the ClickHouse cluster CPU, and an even
+      # earlier `argMax` version which caused ClickHouse OOM on large subscriptions.
       def deduplicated_events_sql(from_datetime:, to_datetime:, deduplicated_columns: [])
         columns = deduplicated_columns.dup
 
@@ -117,25 +104,20 @@ module Events
           columns << "properties"
         end
 
-        picked_columns = columns.uniq.map { "e.#{it}" }
-        selected_columns = (DEDUP_KEY_COLUMNS.map { "l.#{it}" } + picked_columns).join(", ")
-        join_conditions = (DEDUP_KEY_COLUMNS.map { "e.#{it} = l.#{it}" } + ["e.enriched_at = l.max_enriched_at"]).join(" AND ")
+        selected_columns = (DEDUP_KEY_COLUMNS + columns).uniq.join(", ")
 
         <<~SQL.squish
           SELECT #{selected_columns}
-          FROM latest_enriched AS l
-          INNER ANY JOIN events_enriched AS e ON #{join_conditions}
-          WHERE #{deduplicated_events_where_sql(from_datetime:, to_datetime:, alias_prefix: "e")}
+          FROM events_enriched FINAL
+          WHERE #{deduplicated_events_where_sql(from_datetime:, to_datetime:)}
         SQL
       end
 
-      def deduplicated_events_where_sql(from_datetime:, to_datetime:, alias_prefix: nil)
-        prefix = alias_prefix ? "#{alias_prefix}." : ""
-
+      def deduplicated_events_where_sql(from_datetime:, to_datetime:)
         conditions = [
           ActiveRecord::Base.sanitize_sql_for_conditions(
             [
-              "#{prefix}organization_id = ? AND #{prefix}code = ? AND #{prefix}external_subscription_id = ?",
+              "organization_id = ? AND code = ? AND external_subscription_id = ?",
               subscription.organization_id,
               code,
               subscription.external_id
@@ -143,8 +125,8 @@ module Events
           )
         ]
 
-        conditions << ActiveRecord::Base.sanitize_sql_for_conditions(["#{prefix}timestamp >= ?", from_datetime]) if from_datetime
-        conditions << upper_timestamp_boundary_sql(to_datetime, prefix:) if to_datetime
+        conditions << ActiveRecord::Base.sanitize_sql_for_conditions(["timestamp >= ?", from_datetime]) if from_datetime
+        conditions << upper_timestamp_boundary_sql(to_datetime) if to_datetime
         conditions.join(" AND ")
       end
 
@@ -254,15 +236,12 @@ module Events
       end
 
       # Counting deduplicated events only needs the number of distinct dedup keys,
-      # not their latest enriched values. We therefore skip the `INNER ANY JOIN`
-      # performed by `events_cte_queries` (which materializes a column for every
-      # event and roughly doubles the memory of the dedup aggregation) and count
-      # the grouped keys directly. This avoids ClickHouse MEMORY_LIMIT_EXCEEDED on
-      # very large subscriptions.
+      # so we count directly on the deduplicated table without materializing any
+      # other column.
       #
       # When the count is filtered (grouped_by_values or matching/ignored filters)
-      # we keep the JOIN-based path so the filter still applies to the latest
-      # enriched row per dedup key (identical semantics).
+      # we keep the CTE-based path so the filter still applies to the deduplicated
+      # rows (identical semantics).
       def count_query
         filtered = grouped_by_values? || matching_filters.present? || ignored_filters.present?
 
@@ -277,12 +256,8 @@ module Events
 
         <<~SQL.squish
           SELECT count()
-          FROM (
-            SELECT 1
-            FROM events_enriched
-            WHERE #{deduplicated_events_where_sql(from_datetime: events_from, to_datetime: applicable_to_datetime)}
-            GROUP BY #{DEDUP_KEY_COLUMNS.join(", ")}
-          )
+          FROM events_enriched FINAL
+          WHERE #{deduplicated_events_where_sql(from_datetime: events_from, to_datetime: applicable_to_datetime)}
         SQL
       end
 

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -55,9 +55,10 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
     # Regression test for https://github.com/getlago/lago-api/pull/5359
     #
     # Two rows share the same (transaction_id, timestamp) but carry different
-    # filterable properties. Deduplication via argMax(enriched_at) must resolve
-    # to a single row FIRST — otherwise the same logical event could be counted
-    # in multiple filter/group buckets (once per property value it ever had).
+    # filterable properties. Deduplication must resolve to a single row (the
+    # latest enrichment) FIRST — otherwise the same logical event could be
+    # counted in multiple filter/group buckets (once per property value it ever
+    # had).
     describe "filters applied after deduplication" do
       subject(:event_store) do
         described_class.new(
@@ -139,11 +140,11 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
     end
   end
 
-  # Pins the query shape behind #count. The deduplicated + unfiltered count must
-  # avoid the INNER ANY JOIN (which only fetches the value column and caused
-  # ClickHouse OOM on large subscriptions); filtered and non-deduplicated counts
-  # must keep using the JOIN-based path so the filter is applied to the latest
-  # enriched row per dedup key.
+  # Pins the query shape behind #count. Deduplication relies on the `FINAL`
+  # modifier (ReplacingMergeTree collapses duplicated sorting keys at read time).
+  # The deduplicated + unfiltered count queries the table directly; filtered
+  # counts go through the events CTE so the filter is applied to the
+  # deduplicated rows; non-deduplicated counts must not use `FINAL`.
   describe "#count_query" do
     subject(:event_store) do
       described_class.new(code: billable_metric.code, subscription:, boundaries:, filters:, deduplicate:)
@@ -165,54 +166,62 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
     let(:filters) { {} }
 
     context "when deduplicated and unfiltered" do
-      it "counts distinct dedup keys without a JOIN" do
+      it "counts directly on the deduplicated table without a CTE" do
         sql = event_store.count_query
 
-        expect(sql).not_to include("JOIN")
-        expect(sql).to include("GROUP BY #{described_class::DEDUP_KEY_COLUMNS.join(", ")}")
+        expect(sql).not_to include("WITH")
+        expect(sql).to include("FROM events_enriched FINAL")
       end
     end
 
     context "when grouped_by_values is set" do
       let(:filters) { {grouped_by_values: {"region" => "europe"}} }
 
-      it "uses the JOIN-based deduplication path" do
-        expect(event_store.count_query).to include("INNER ANY JOIN")
+      it "uses the CTE-based deduplication path" do
+        sql = event_store.count_query
+
+        expect(sql).to include("WITH")
+        expect(sql).to include("FROM events_enriched FINAL")
       end
     end
 
     context "when matching_filters are set" do
       let(:filters) { {matching_filters: {"region" => ["europe"]}} }
 
-      it "uses the JOIN-based deduplication path" do
-        expect(event_store.count_query).to include("INNER ANY JOIN")
+      it "uses the CTE-based deduplication path" do
+        sql = event_store.count_query
+
+        expect(sql).to include("WITH")
+        expect(sql).to include("FROM events_enriched FINAL")
       end
     end
 
     context "when ignored_filters are set" do
       let(:filters) { {ignored_filters: [{"region" => ["europe"]}]} }
 
-      it "uses the JOIN-based deduplication path" do
-        expect(event_store.count_query).to include("INNER ANY JOIN")
+      it "uses the CTE-based deduplication path" do
+        sql = event_store.count_query
+
+        expect(sql).to include("WITH")
+        expect(sql).to include("FROM events_enriched FINAL")
       end
     end
 
     context "when deduplication is disabled" do
       let(:deduplicate) { false }
 
-      it "does not build the deduplication CTEs" do
+      it "does not deduplicate" do
         sql = event_store.count_query
 
-        expect(sql).not_to include("JOIN")
-        expect(sql).not_to include("latest_enriched")
+        expect(sql).not_to include("FINAL")
       end
     end
 
     context "when grouped_by is set without grouped_by_values or filters" do
       let(:filters) { {grouped_by: ["region"]} }
 
-      it "still uses the JOIN-free fast path (grouped_by alone does not filter a count)" do
-        expect(event_store.count_query).not_to include("JOIN")
+      it "still uses the CTE-free fast path (grouped_by alone does not filter a count)" do
+        expect(event_store.count_query).not_to include("WITH")
       end
     end
 
@@ -221,7 +230,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
         event_store.use_from_boundary = false
         sql = event_store.count_query
 
-        expect(sql).not_to include("JOIN")
+        expect(sql).not_to include("WITH")
         expect(sql.upcase).not_to include("NULL")
         expect(sql).not_to include("timestamp >=")
         expect(sql).to include("timestamp <=")
@@ -229,10 +238,10 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
     end
   end
 
-  # Real-data equivalence: the deduplicated + unfiltered #count uses the JOIN-free
-  # fast path. These assert it returns the SAME number as the original JOIN-based
-  # query on identical data, across re-enrichment duplicates and boundary edges.
-  describe "#count fast-path equivalence with the JOIN-based query" do
+  # Real-data equivalence: the deduplicated + unfiltered #count uses the CTE-free
+  # fast path. These assert it returns the SAME number as the CTE-based query on
+  # identical data, across re-enrichment duplicates and boundary edges.
+  describe "#count fast-path equivalence with the CTE-based query" do
     subject(:event_store) do
       described_class.new(code: billable_metric.code, subscription:, boundaries:, filters: {}, deduplicate: true)
     end
@@ -266,7 +275,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       )
     end
 
-    def join_based_count
+    def cte_based_count
       sql = event_store.send(
         :with_ctes,
         event_store.events_cte_queries(deduplicated_columns: %w[value]),
@@ -283,7 +292,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       insert_event(transaction_id: SecureRandom.uuid, timestamp: ts + 1.day, enriched_at: Time.current)
 
       expect(event_store.count.value).to eq(2)
-      expect(event_store.count.value).to eq(join_based_count)
+      expect(event_store.count.value).to eq(cte_based_count)
     end
 
     it "treats the same transaction_id at different timestamps as distinct events" do
@@ -292,7 +301,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       insert_event(transaction_id: txn, timestamp: ts + 1.hour, enriched_at: Time.current)
 
       expect(event_store.count.value).to eq(2)
-      expect(event_store.count.value).to eq(join_based_count)
+      expect(event_store.count.value).to eq(cte_based_count)
     end
 
     it "excludes events outside the boundaries" do
@@ -300,12 +309,12 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true}
       insert_event(transaction_id: SecureRandom.uuid, timestamp: boundaries[:to_datetime] + 2.days, enriched_at: Time.current)
 
       expect(event_store.count.value).to eq(1)
-      expect(event_store.count.value).to eq(join_based_count)
+      expect(event_store.count.value).to eq(cte_based_count)
     end
 
     it "returns zero when there are no events" do
       expect(event_store.count.value).to eq(0)
-      expect(event_store.count.value).to eq(join_based_count)
+      expect(event_store.count.value).to eq(cte_based_count)
     end
   end
 


### PR DESCRIPTION
## Context
  
  The query-time deduplication in `Events::Stores::ClickhouseStore` (a `GROUP BY` on the dedup key + `INNER ANY JOIN` back to `events_enriched`) accounted for
  **69% of all SELECT CPU** on the ClickHouse cluster (7-day `query_log` analysis), while the duplicates it removes represent only 0.2–1.8% of rows. Each
  aggregation scanned the event range twice, built a hash aggregation over a 5-column key, then a hash join — up to ~9 CPU-s and 2.4 GiB memory per call on
  large subscriptions.

  ## Description

  Replace the two-pass dedup with the `FINAL` modifier: `events_enriched` is a `ReplacingMergeTree`, so the engine collapses duplicated sorting keys at read
  time — single scan, no join. The CTE names and exposed columns are unchanged, so all aggregation queries (`UniqueCountQuery`, `WeightedSumQuery`, grouped
  variants) work as before. The JOIN-free `count_query` fast path, which existed only to avoid the join's memory usage, simplifies to a direct `count()` with
  `FINAL`.

  Validated on production data:
  - **Correctness**: row-level comparison on a subscription with ~17k unmerged duplicates with diverging `enriched_at`: `FINAL` keeps the exact same row as the
  previous `max(enriched_at)` semantics on every key. Also pinned by the existing dedup regression specs, which run against a real ClickHouse.
  - **Performance** (per call, warm): 9.4 → 1.4 CPU-s (**6.6×**), 2.3s → 147ms wall (**15.6×**), 2.75 GiB → 325 MiB peak memory (**8.7×**) on the
  duplicate-heavy subscription; 9.5× CPU on the largest production query pattern.

  `ClickhouseEnrichedStore` is out of scope: `events_enriched_expanded` is not a Replacing engine on ClickHouse Cloud, so it keeps the CTE-based dedup.