### PR TITLE
feat(invoices): support discarded add-ons and after-commit jobs in one-off

### DIFF
--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -4,9 +4,10 @@ module Fees
   class OneOffService < BaseService
     Result = BaseResult[:fees]
 
-    def initialize(invoice:, fees:)
+    def initialize(invoice:, fees:, with_discarded_add_ons: false)
       @invoice = invoice
       @fees = fees
+      @with_discarded_add_ons = with_discarded_add_ons
 
       super(nil)
     end
@@ -76,14 +77,18 @@ module Fees
 
     private
 
-    attr_reader :invoice, :fees
+    attr_reader :invoice, :fees, :with_discarded_add_ons
 
     delegate :customer, :organization, to: :invoice
 
     def add_on(identifier:)
       finder = api_context? ? :code : :id
 
-      invoice.organization.add_ons.find_by(finder => identifier)
+      add_ons_scope.find_by(finder => identifier)
+    end
+
+    def add_ons_scope
+      with_discarded_add_ons ? invoice.organization.add_ons.with_discarded : invoice.organization.add_ons
     end
 
     def add_on_identifier

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -4,7 +4,7 @@ module Invoices
   class CreateOneOffService < BaseService
     Result = BaseResult[:invoice, :payment_method]
 
-    def initialize(customer:, currency:, fees:, timestamp:, skip_psp: false, voided_invoice_id: nil, payment_method_params: nil, invoice_custom_section: {}, billing_entity_id: nil, billing_entity_code: nil, purchase_order_number: nil)
+    def initialize(customer:, currency:, fees:, timestamp:, skip_psp: false, voided_invoice_id: nil, payment_method_params: nil, invoice_custom_section: {}, billing_entity_id: nil, billing_entity_code: nil, purchase_order_number: nil, with_discarded_add_ons: false)
       @customer = customer
       @currency = currency || customer&.currency
       @fees = fees
@@ -16,6 +16,7 @@ module Invoices
       @billing_entity_id = billing_entity_id
       @billing_entity_code = billing_entity_code
       @purchase_order_number = purchase_order_number
+      @with_discarded_add_ons = with_discarded_add_ons
 
       super(nil)
     end
@@ -76,11 +77,11 @@ module Invoices
       return result if tax_deferred
 
       unless invoice.closed?
-        Utils::SegmentTrack.invoice_created(invoice)
-        SendWebhookJob.perform_later("invoice.one_off_created", invoice)
-        GenerateDocumentsJob.perform_later(invoice:, notify: should_deliver_email?)
-        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-        Integrations::Aggregator::Invoices::Hubspot::CreateJob.perform_later(invoice:) if invoice.should_sync_hubspot_invoice?
+        after_commit { Utils::SegmentTrack.invoice_created(invoice) }
+        SendWebhookJob.perform_after_commit("invoice.one_off_created", invoice)
+        GenerateDocumentsJob.perform_after_commit(invoice:, notify: should_deliver_email?)
+        Integrations::Aggregator::Invoices::CreateJob.perform_after_commit(invoice:) if invoice.should_sync_invoice?
+        Integrations::Aggregator::Invoices::Hubspot::CreateJob.perform_after_commit(invoice:) if invoice.should_sync_hubspot_invoice?
         Invoices::Payments::CreateService.call_async(invoice:, payment_method_params:) unless invoice.skip_automatic_payment?
       end
 
@@ -98,7 +99,7 @@ module Invoices
     private
 
     attr_accessor :timestamp, :currency, :customer, :fees, :invoice, :skip_psp, :voided_invoice_id, :payment_method_params, :invoice_custom_section
-    attr_reader :billing_entity_id, :billing_entity_code, :billing_entity, :purchase_order_number
+    attr_reader :billing_entity_id, :billing_entity_code, :billing_entity, :purchase_order_number, :with_discarded_add_ons
 
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
@@ -131,7 +132,7 @@ module Invoices
     end
 
     def create_one_off_fees(invoice)
-      Fees::OneOffService.call!(invoice:, fees:)
+      Fees::OneOffService.call!(invoice:, fees:, with_discarded_add_ons:)
     end
 
     def should_deliver_email?
@@ -141,7 +142,11 @@ module Invoices
     def add_ons
       finder = api_context? ? :code : :id
 
-      customer.organization.add_ons.where(finder => add_on_identifiers)
+      add_ons_scope.where(finder => add_on_identifiers)
+    end
+
+    def add_ons_scope
+      with_discarded_add_ons ? customer.organization.add_ons.with_discarded : customer.organization.add_ons
     end
 
     def add_on_identifiers

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -366,5 +366,31 @@ RSpec.describe Fees::OneOffService do
         end
       end
     end
+
+    context "when an add-on is soft-deleted" do
+      before { add_on_first.discard! }
+
+      it "fails to resolve it by default" do
+        travel_to(current_time) do
+          result = one_off_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+        end
+      end
+
+      context "with with_discarded_add_ons enabled" do
+        subject(:one_off_service) { described_class.new(invoice:, fees:, with_discarded_add_ons: true) }
+
+        it "still bills the discarded add-on" do
+          travel_to(current_time) do
+            result = one_off_service.call
+
+            expect(result).to be_success
+            expect(result.fees.map(&:add_on_id)).to include(add_on_first.id)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -169,16 +169,34 @@ RSpec.describe Invoices::CreateOneOffService do
       end
     end
 
-    it "enqueues a SendWebhookJob" do
+    it "enqueues a SendWebhookJob after commit" do
       expect do
         described_class.call(**args)
-      end.to have_enqueued_job(SendWebhookJob)
+      end.to have_enqueued_job_after_commit(SendWebhookJob)
     end
 
-    it "enqueues GenerateDocumentsJob with email false" do
+    it "enqueues GenerateDocumentsJob with email false after commit" do
       expect do
         described_class.call(**args)
-      end.to have_enqueued_job(Invoices::GenerateDocumentsJob).with(hash_including(notify: false))
+      end.to have_enqueued_job_after_commit(Invoices::GenerateDocumentsJob).with(hash_including(notify: false))
+    end
+
+    context "when an add-on is soft-deleted" do
+      before { add_on_first.discard! }
+
+      it "is not found by default" do
+        result = described_class.call(**args)
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+      end
+
+      it "is billed when with_discarded_add_ons is true" do
+        result = described_class.call(**args.merge(with_discarded_add_ons: true))
+
+        expect(result).to be_success
+        expect(result.invoice.fees.where(fee_type: :add_on).count).to eq(2)
+      end
     end
 
     context "when there is tax provider integration" do


### PR DESCRIPTION
## Why

Order execution bills one-off invoices from add-ons that may have since been discarded, and its side-effect jobs must only fire once the invoice transaction has committed.

## What

- Add an opt-in `with_discarded_add_ons` flag to `Invoices::CreateOneOffService` and `Fees::OneOffService` so discarded add-ons can still be billed.
- Move post-creation side effects (segment tracking, webhook, document generation, integration syncs) to run after commit.
