### PR TITLE
feat(orders): execute one-off orders into billing

### DIFF
--- a/app/jobs/clock/execute_scheduled_orders_job.rb
+++ b/app/jobs/clock/execute_scheduled_orders_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Clock
+  class ExecuteScheduledOrdersJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
+    def perform
+      Order.executable.find_each do |order|
+        Orders::ExecuteOrderJob.perform_later(order)
+      end
+    end
+  end
+end

--- a/app/jobs/orders/execute_order_job.rb
+++ b/app/jobs/orders/execute_order_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Orders
+  class ExecuteOrderJob < ApplicationJob
+    queue_as :default
+
+    unique :until_executed, on_conflict: :log
+
+    retry_on BaseLockService::FailedToAcquireLock, attempts: MAX_LOCK_RETRY_ATTEMPTS, wait: random_lock_retry_delay
+
+    def perform(order)
+      Orders::ExecuteService.call!(order:)
+    end
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,7 +5,8 @@ class Order < ApplicationRecord
 
   STATUSES = {
     created: "created",
-    executed: "executed"
+    executed: "executed",
+    failed: "failed"
   }.freeze
 
   EXECUTION_MODES = {
@@ -29,6 +30,8 @@ class Order < ApplicationRecord
     validate: {allow_nil: true}
 
   validates :execution_mode, presence: true, if: -> { executed? || execute_at.present? }
+
+  scope :executable, -> { created.where(execute_at: ..Time.current) }
 
   delegate :order_type, to: :quote
   delegate :currency, to: :quote_version
@@ -64,22 +67,24 @@ end
 # Table name: orders
 # Database name: primary
 #
-#  id              :uuid             not null, primary key
-#  execute_at      :datetime
-#  executed_at     :datetime
-#  execution_mode  :enum
-#  number          :string           not null
-#  status          :enum             default("created"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  customer_id     :uuid             not null
-#  order_form_id   :uuid             not null
-#  organization_id :uuid             not null
-#  sequential_id   :integer          not null
+#  id               :uuid             not null, primary key
+#  execute_at       :datetime
+#  executed_at      :datetime
+#  execution_mode   :enum
+#  execution_record :jsonb            not null
+#  number           :string           not null
+#  status           :enum             default("created"), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  customer_id      :uuid             not null
+#  order_form_id    :uuid             not null
+#  organization_id  :uuid             not null
+#  sequential_id    :integer          not null
 #
 # Indexes
 #
 #  index_orders_on_customer_id                        (customer_id)
+#  index_orders_on_execute_at                         (execute_at) WHERE ((status = 'created'::order_status) AND (execute_at IS NOT NULL))
 #  index_orders_on_order_form_id                      (order_form_id) UNIQUE
 #  index_orders_on_organization_id_and_created_at     (organization_id,created_at)
 #  index_orders_on_organization_id_and_status         (organization_id,status)

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -46,8 +46,6 @@ module OrderForms
             execute_at:
           )
 
-          # TODO: Enqueue Orders::ExecuteOrderJob.perform_after_commit(result.order) when execution_mode == "execute_in_lago"
-
           result.order_form = order_form
         end
       end

--- a/app/services/orders/execute_service.rb
+++ b/app/services/orders/execute_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Orders
+  # Dispatches execution to the concrete service for the order's order_type.
+  # Only one_off is supported for now.
+  class ExecuteService < BaseService
+    include OrderForms::Premium
+
+    Result = BaseResult[:order]
+
+    def initialize(order:)
+      @order = order
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "order") unless order
+      return result.forbidden_failure! unless order_forms_enabled?(order.organization)
+
+      case order.order_type
+      when Quote::ORDER_TYPES[:one_off]
+        Orders::OneOff::ExecuteService.call(order:)
+      else
+        result.single_validation_failure!(field: :order_type, error_code: "unsupported_order_type")
+      end
+    end
+
+    private
+
+    attr_reader :order
+  end
+end

--- a/app/services/orders/one_off/execute_service.rb
+++ b/app/services/orders/one_off/execute_service.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module Orders
+  module OneOff
+    # Internal: premium/feature-flag gates live in Orders::ExecuteService, always call through it.
+    class ExecuteService < BaseService
+      Result = BaseResult[:order]
+
+      def initialize(order:)
+        @order = order
+
+        super
+      end
+
+      def call
+        return success_result if order.executed?
+
+        if order.execution_mode.blank?
+          return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
+        end
+
+        Order.transaction do
+          Quotes::LockService.call(quote: order.quote) do
+            order.reload
+            next success_result if order.executed?
+
+            invoice = execute_in_lago? ? bill_one_off : nil
+            mark_executed!(invoice)
+
+            result.order = order
+          end
+        end
+
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        record_execution_failure!(result.record_validation_failure!(record: e.record))
+      rescue BaseService::FailedResult => e
+        record_execution_failure!(e.result)
+      end
+
+      private
+
+      attr_reader :order
+
+      def success_result
+        result.order = order
+        result
+      end
+
+      def execute_in_lago?
+        order.execution_mode == Order::EXECUTION_MODES[:execute_in_lago]
+      end
+
+      def mark_executed!(invoice)
+        executed_at = Time.current
+
+        order.update!(
+          status: :executed,
+          executed_at:,
+          execution_record: {
+            executed_at: executed_at.iso8601,
+            execution_mode: order.execution_mode,
+            invoice_id: invoice&.id,
+            errors: []
+          }
+        )
+      end
+
+      # The transaction has already rolled back, so this trace is the only durable outcome
+      # of the attempt. Recording it moves the order to failed, excluding it from the
+      # executable scope; retrying is a deliberate manual action.
+      def record_execution_failure!(failed_result)
+        order.update!(
+          status: :failed,
+          executed_at: nil,
+          execution_record: {
+            executed_at: nil,
+            execution_mode: order.execution_mode,
+            invoice_id: nil,
+            errors: execution_errors(failed_result.error)
+          }
+        )
+
+        failed_result
+      end
+
+      def execution_errors(error)
+        if error.respond_to?(:messages)
+          error.messages.values.flatten
+        elsif error.respond_to?(:code)
+          [error.code]
+        else
+          [error.message]
+        end
+      end
+
+      def bill_one_off
+        Invoices::CreateOneOffService.call!(
+          customer: order.customer,
+          currency: order.currency,
+          fees: build_fees,
+          timestamp: Time.current.to_i,
+          with_discarded_add_ons: true
+        ).invoice
+      end
+
+      def build_fees
+        add_on_items.map do |item|
+          {
+            add_on_id: item["id"],
+            units: effective_value(item, "units"),
+            unit_amount_cents: effective_value(item, "unitAmountCents"),
+            invoice_display_name: effective_value(item, "invoiceDisplayName"),
+            # Description may ride in either section (the payload is free-form); overrides win.
+            # When neither carries one, the fee falls back to the add-on description in
+            # Fees::OneOffService.
+            description: effective_value(item, "description"),
+            from_datetime: effective_value(item, "fromDatetime"),
+            to_datetime: effective_value(item, "toDatetime")
+          }
+        end
+      end
+
+      def effective_value(item, field)
+        item.dig("overrides", field) || item.dig("payload", field)
+      end
+
+      def add_on_items
+        Array((quote_version.billing_items || {})["addOns"])
+      end
+
+      def quote_version
+        order.quote_version
+      end
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -154,6 +154,12 @@ module Clockwork
       .perform_later
   end
 
+  every(1.hour, "schedule:execute_scheduled_orders", at: "*:45") do
+    Clock::ExecuteScheduledOrdersJob
+      .set(sentry: {"slug" => "lago_execute_scheduled_orders", "cron" => "45 */1 * * *"})
+      .perform_later
+  end
+
   every(1.day, "schedule:clean_webhooks", at: "01:00") do
     Clock::WebhooksCleanupJob
       .set(sentry: {"slug" => "lago_clean_webhooks", "cron" => "0 1 * * *"})

--- a/db/migrate/20260707182656_add_execution_record_to_orders.rb
+++ b/db/migrate/20260707182656_add_execution_record_to_orders.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExecutionRecordToOrders < ActiveRecord::Migration[8.0]
+  def change
+    add_column :orders, :execution_record, :jsonb, default: {}, null: false
+  end
+end

--- a/db/migrate/20260708144431_add_executable_index_on_orders.rb
+++ b/db/migrate/20260708144431_add_executable_index_on_orders.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddExecutableIndexOnOrders < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :orders,
+      :execute_at,
+      where: "status = 'created' AND execute_at IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260710093947_add_failed_to_order_status.rb
+++ b/db/migrate/20260710093947_add_failed_to_order_status.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddFailedToOrderStatus < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      execute "ALTER TYPE order_status ADD VALUE IF NOT EXISTS 'failed'"
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "PostgreSQL cannot remove a value from an enum type"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -513,6 +513,7 @@ DROP INDEX IF EXISTS public.index_organizations_on_api_key;
 DROP INDEX IF EXISTS public.index_orders_on_organization_id_and_status;
 DROP INDEX IF EXISTS public.index_orders_on_organization_id_and_created_at;
 DROP INDEX IF EXISTS public.index_orders_on_order_form_id;
+DROP INDEX IF EXISTS public.index_orders_on_execute_at;
 DROP INDEX IF EXISTS public.index_orders_on_customer_id;
 DROP INDEX IF EXISTS public.index_order_forms_on_quote_version_id;
 DROP INDEX IF EXISTS public.index_order_forms_on_organization_id_and_status;
@@ -1440,7 +1441,8 @@ CREATE TYPE public.order_form_void_reason AS ENUM (
 
 CREATE TYPE public.order_status AS ENUM (
     'created',
-    'executed'
+    'executed',
+    'failed'
 );
 
 
@@ -4783,6 +4785,7 @@ CREATE TABLE public.orders (
     executed_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    execution_record jsonb DEFAULT '{}'::jsonb NOT NULL,
     CONSTRAINT orders_constraint_sequential_id_positive CHECK ((sequential_id > 0))
 );
 
@@ -9092,6 +9095,13 @@ CREATE INDEX index_orders_on_customer_id ON public.orders USING btree (customer_
 
 
 --
+-- Name: index_orders_on_execute_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orders_on_execute_at ON public.orders USING btree (execute_at) WHERE ((status = 'created'::public.order_status) AND (execute_at IS NOT NULL));
+
+
+--
 -- Name: index_orders_on_order_form_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12839,6 +12849,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260716114156'),
 ('20260715142900'),
+('20260710093947'),
 ('20260709141039'),
 ('20260709141038'),
 ('20260709141037'),
@@ -12852,7 +12863,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260709135720'),
 ('20260709135718'),
 ('20260709135717'),
+('20260708144431'),
 ('20260708095857'),
+('20260707182656'),
 ('20260706173746'),
 ('20260706131152'),
 ('20260703164249'),
@@ -13903,4 +13916,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
-

--- a/schema.graphql
+++ b/schema.graphql
@@ -9247,6 +9247,7 @@ enum OrderFormVoidReasonEnum {
 enum OrderStatusEnum {
   created
   executed
+  failed
 }
 
 enum OrderTypeEnum {

--- a/schema.json
+++ b/schema.json
@@ -44603,6 +44603,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "failed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -265,6 +265,27 @@ describe Clockwork do
     end
   end
 
+  describe "schedule:execute_scheduled_orders" do
+    let(:job) { "schedule:execute_scheduled_orders" }
+    let(:start_time) { Time.zone.parse("1 Apr 2022 00:30:00") }
+    let(:end_time) { Time.zone.parse("1 Apr 2022 01:30:00") }
+
+    it "enqueues an execute scheduled orders job" do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.minute
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(1)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::ExecuteScheduledOrdersJob).to have_been_enqueued
+    end
+  end
+
   describe "schedule:clean_inbound_webhooks" do
     let(:job) { "schedule:clean_inbound_webhooks" }
     let(:start_time) { Time.zone.parse("1 Apr 2022 00:01:00") }

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -17,5 +17,13 @@ FactoryBot.define do
       execution_mode { :order_only }
       executed_at { Time.current }
     end
+
+    trait :failed do
+      status { :failed }
+      execution_mode { :execute_in_lago }
+      execution_record do
+        {executed_at: nil, execution_mode: "execute_in_lago", invoice_id: nil, errors: ["currencies_does_not_match"]}
+      end
+    end
   end
 end

--- a/spec/jobs/clock/execute_scheduled_orders_job_spec.rb
+++ b/spec/jobs/clock/execute_scheduled_orders_job_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Clock::ExecuteScheduledOrdersJob, job: true do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let!(:due_order) { create(:order, organization:, customer:, execution_mode: :execute_in_lago, execute_at: 1.hour.ago) }
+  let!(:future_order) { create(:order, organization:, customer:, execution_mode: :execute_in_lago, execute_at: 1.hour.from_now) }
+  let!(:executed_order) { create(:order, :executed_in_lago, organization:, customer:, execute_at: 1.hour.ago) }
+  let!(:failed_order) { create(:order, :failed, organization:, customer:, execute_at: 1.hour.ago) }
+
+  describe ".perform" do
+    it "enqueues ExecuteOrderJob only for due, created orders" do
+      described_class.perform_now
+
+      expect(Orders::ExecuteOrderJob).to have_been_enqueued.with(due_order)
+      expect(Orders::ExecuteOrderJob).not_to have_been_enqueued.with(future_order)
+      expect(Orders::ExecuteOrderJob).not_to have_been_enqueued.with(executed_order)
+      expect(Orders::ExecuteOrderJob).not_to have_been_enqueued.with(failed_order)
+    end
+  end
+end

--- a/spec/jobs/orders/execute_order_job_spec.rb
+++ b/spec/jobs/orders/execute_order_job_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orders::ExecuteOrderJob, job: true do
+  let(:order) { create(:order) }
+
+  it "calls ExecuteService" do
+    allow(Orders::ExecuteService).to receive(:call!)
+
+    described_class.perform_now(order)
+
+    expect(Orders::ExecuteService).to have_received(:call!).with(order:)
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Order do
       expect(order).to define_enum_for(:status)
         .backed_by_column_of_type(:enum)
         .validating
-        .with_values(created: "created", executed: "executed")
+        .with_values(created: "created", executed: "executed", failed: "failed")
         .with_default(:created)
 
       expect(order).to define_enum_for(:execution_mode)
@@ -28,6 +28,25 @@ RSpec.describe Order do
       expect(order).to belong_to(:order_form)
       expect(order).to have_one(:quote_version).through(:order_form)
       expect(order).to have_one(:quote).through(:quote_version)
+    end
+  end
+
+  describe "Scopes" do
+    describe ".executable" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:) }
+      let!(:due) { create(:order, organization:, customer:, execution_mode: :execute_in_lago, execute_at: 1.hour.ago) }
+
+      before do
+        create(:order, organization:, customer:, execution_mode: :execute_in_lago, execute_at: 1.hour.from_now)
+        create(:order, organization:, customer:, execute_at: nil)
+        create(:order, :executed_in_lago, organization:, customer:, execute_at: 1.hour.ago)
+        create(:order, :failed, organization:, customer:, execute_at: 1.hour.ago)
+      end
+
+      it "returns due created orders" do
+        expect(described_class.executable).to eq([due])
+      end
     end
   end
 

--- a/spec/services/orders/execute_service_spec.rb
+++ b/spec/services/orders/execute_service_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orders::ExecuteService do
+  subject(:execute_service) { described_class.new(order:) }
+
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type:) }
+  let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+  let(:order) { create(:order, organization:, customer:, order_form:, execution_mode: :order_only) }
+  let(:order_type) { :one_off }
+
+  describe "#call" do
+    context "without premium license" do
+      it "returns a forbidden failure" do
+        result = execute_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        expect(result.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "with premium license", :premium do
+      context "when the order does not exist" do
+        let(:order) { nil }
+
+        it "returns a not found failure" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("order")
+        end
+      end
+
+      context "when the order_forms feature flag is disabled" do
+        let(:organization) { create(:organization) }
+
+        it "returns a forbidden failure" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        end
+      end
+
+      context "when the order is a one_off" do
+        it "delegates to the one_off execute service" do
+          allow(Orders::OneOff::ExecuteService).to receive(:call).and_call_original
+
+          execute_service.call
+
+          expect(Orders::OneOff::ExecuteService).to have_received(:call).with(order:)
+        end
+      end
+
+      context "when the order type is not supported yet" do
+        let(:order_type) { :subscription_creation }
+
+        it "returns a validation failure" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:order_type]).to include("unsupported_order_type")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/orders/one_off/execute_service_spec.rb
+++ b/spec/services/orders/one_off/execute_service_spec.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orders::OneOff::ExecuteService do
+  subject(:execute_service) { described_class.new(order:) }
+
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
+  let(:add_on) { create(:add_on, organization:, amount_cents: 10_000) }
+  let(:add_on_item) do
+    {
+      "id" => add_on.id,
+      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "payload" => {
+        "code" => add_on.code,
+        "units" => 2,
+        "unitAmountCents" => 5_000,
+        "totalAmountCents" => 10_000,
+        "invoiceDisplayName" => "Catalog setup"
+      },
+      "overrides" => overrides
+    }.compact
+  end
+  let(:overrides) { {"unitAmountCents" => 6_000} }
+  let(:billing_items) { {"addOns" => [add_on_item]} }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+  let(:quote_version) { create(:quote_version, :approved, quote:, organization:, currency: "EUR", billing_items:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+  let(:order) { create(:order, organization:, customer:, order_form:, execution_mode:) }
+  let(:execution_mode) { :execute_in_lago }
+
+  # Add-ons are resolved by id only outside api context, and CurrentContext
+  # leaks across spec files (no global reset), so pin it.
+  before { CurrentContext.source = nil }
+
+  describe "#call" do
+    context "with execute_in_lago mode" do
+      it "creates a one-off invoice and marks the order executed" do
+        result = nil
+        expect { result = execute_service.call }.to change(Invoice, :count).by(1)
+
+        expect(result).to be_success
+
+        invoice = customer.invoices.sole
+        expect(invoice.invoice_type).to eq("one_off")
+        expect(invoice.currency).to eq("EUR")
+
+        order.reload
+        expect(order.executed?).to eq(true)
+        expect(order.executed_at).to be_present
+        expect(order.execution_record["executed_at"]).to be_present
+        expect(order.execution_record["execution_mode"]).to eq("execute_in_lago")
+        expect(order.execution_record["invoice_id"]).to eq(invoice.id)
+        expect(order.execution_record["errors"]).to eq([])
+      end
+
+      it "bills the payload values" do
+        execute_service.call
+
+        fee = customer.invoices.sole.fees.sole
+        expect(fee.add_on_id).to eq(add_on.id)
+        expect(fee.units).to eq(2)
+        expect(fee.invoice_display_name).to eq("Catalog setup")
+        expect(fee.description).to eq(add_on.description)
+      end
+
+      context "with overrides" do
+        let(:overrides) do
+          {
+            "units" => 3,
+            "unitAmountCents" => 6_000,
+            "invoiceDisplayName" => "Negotiated setup",
+            "description" => "Negotiated onboarding"
+          }
+        end
+
+        it "bills the overridden values" do
+          execute_service.call
+
+          fee = customer.invoices.sole.fees.sole
+          expect(fee.units).to eq(3)
+          expect(fee.unit_amount_cents).to eq(6_000)
+          expect(fee.invoice_display_name).to eq("Negotiated setup")
+          expect(fee.description).to eq("Negotiated onboarding")
+        end
+      end
+
+      context "without overrides" do
+        let(:overrides) { nil }
+
+        it "bills the payload unit amount" do
+          execute_service.call
+
+          fee = customer.invoices.sole.fees.sole
+          expect(fee.unit_amount_cents).to eq(5_000)
+          expect(fee.units).to eq(2)
+        end
+      end
+
+      context "when the description is carried by the payload" do
+        let(:overrides) { nil }
+
+        before { add_on_item["payload"]["description"] = "Snapshotted onboarding" }
+
+        it "bills the payload description" do
+          execute_service.call
+
+          expect(customer.invoices.sole.fees.sole.description).to eq("Snapshotted onboarding")
+        end
+      end
+
+      context "when the add-on is discarded" do
+        before { add_on.discard! }
+
+        it "still bills it" do
+          result = nil
+          expect { result = execute_service.call }.to change(Invoice, :count).by(1)
+
+          expect(result).to be_success
+          expect(customer.invoices.sole.fees.sole.add_on_id).to eq(add_on.id)
+        end
+      end
+
+      context "when the invoice creation fails" do
+        let(:failed_result) do
+          Invoices::CreateOneOffService::Result.new.tap do |failed|
+            failed.single_validation_failure!(field: :currency, error_code: "currencies_does_not_match")
+          end
+        end
+
+        before do
+          allow(Invoices::CreateOneOffService).to receive(:call!).and_raise(failed_result.error)
+        end
+
+        it "records the failure and marks the order failed" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["executed_at"]).to be_nil
+          expect(order.execution_record["invoice_id"]).to be_nil
+          expect(order.execution_record["errors"]).to eq(["currencies_does_not_match"])
+        end
+      end
+
+      context "when the invoice creation fails with a coded service failure" do
+        let(:failed_result) do
+          Invoices::CreateOneOffService::Result.new.tap do |failed|
+            failed.service_failure!(code: "provider_error", message: "boom")
+          end
+        end
+
+        before do
+          allow(Invoices::CreateOneOffService).to receive(:call!).and_raise(failed_result.error)
+        end
+
+        it "records the error code and marks the order failed" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["provider_error"])
+        end
+      end
+
+      context "when the invoice creation fails with a resource-not-found failure" do
+        let(:failed_result) do
+          Invoices::CreateOneOffService::Result.new.tap do |failed|
+            failed.not_found_failure!(resource: "add_on")
+          end
+        end
+
+        before do
+          allow(Invoices::CreateOneOffService).to receive(:call!).and_raise(failed_result.error)
+        end
+
+        it "records the failure message and marks the order failed" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["add_on_not_found"])
+        end
+      end
+
+      context "when taxes are deferred to a provider" do
+        let(:deferred_invoice) { create(:invoice, organization:, customer:, status: :pending) }
+        let(:deferred_result) do
+          Invoices::CreateOneOffService::Result.new.tap { |deferred| deferred.invoice = deferred_invoice }
+        end
+
+        before do
+          allow(Invoices::CreateOneOffService).to receive(:call!).and_return(deferred_result)
+        end
+
+        it "marks the order executed optimistically with the invoice id" do
+          execute_service.call
+
+          order.reload
+          expect(order.executed?).to eq(true)
+          expect(order.execution_record["invoice_id"]).to eq(deferred_invoice.id)
+        end
+      end
+    end
+
+    context "with order_only mode" do
+      let(:execution_mode) { :order_only }
+
+      it "marks the order executed without billing" do
+        result = nil
+        expect { result = execute_service.call }.not_to change(Invoice, :count)
+
+        expect(result).to be_success
+
+        order.reload
+        expect(order.executed?).to eq(true)
+        expect(order.execution_record["execution_mode"]).to eq("order_only")
+        expect(order.execution_record["invoice_id"]).to be_nil
+        expect(order.execution_record["errors"]).to eq([])
+      end
+    end
+
+    context "when the order is already executed" do
+      let(:order) { create(:order, :executed_in_lago, organization:, customer:, order_form:) }
+
+      it "is idempotent and does nothing" do
+        result = nil
+        expect { result = execute_service.call }.not_to change(Invoice, :count)
+
+        expect(result).to be_success
+        expect(result.order).to eq(order)
+      end
+    end
+
+    context "when execution raises a record validation error" do
+      let(:invalid_record) do
+        build(:add_on).tap { |record| record.errors.add(:base, "some_validation_error") }
+      end
+
+      before do
+        allow(Invoices::CreateOneOffService).to receive(:call!).and_raise(ActiveRecord::RecordInvalid.new(invalid_record))
+      end
+
+      it "records the failure and marks the order failed" do
+        result = execute_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+
+        order.reload
+        expect(order.failed?).to eq(true)
+        expect(order.execution_record["executed_at"]).to be_nil
+        expect(order.execution_record["errors"]).to eq(["some_validation_error"])
+      end
+    end
+
+    context "when the order has no execution_mode" do
+      let(:order) { create(:order, organization:, customer:, order_form:, execution_mode: nil) }
+
+      it "returns a validation failure without touching the order" do
+        result = nil
+        expect { result = execute_service.call }.not_to change(Invoice, :count)
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:execution_mode]).to eq(["value_is_mandatory"])
+
+        order.reload
+        expect(order.executed?).to eq(false)
+        expect(order.execution_record).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why

Signed one-off orders need to be turned into invoices, on schedule, with a durable record of each execution attempt.

## What

- Add an `execution_record` JSONB column and a `failed` status to orders, plus an index for executable orders.
- Add `Orders::ExecuteService` / `Orders::OneOff::ExecuteService` to bill a one-off order's add-ons into a one-off invoice.
- Schedule due orders from the clock via `Clock::ExecuteScheduledOrdersJob` and `Orders::ExecuteOrderJob`.

## Stacked on

Based #5952 on `feat/invoices/one-off-discarded-add-ons` (review/merge that first).
