### PR TITLE
feat(orders): expose and trigger order execution via GraphQL

### DIFF
--- a/app/graphql/mutations/orders/execute.rb
+++ b/app/graphql/mutations/orders/execute.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Orders
+    class Execute < BaseMutation
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "orders:execute"
+
+      graphql_name "ExecuteOrder"
+      description "Execute an order"
+
+      input_object_class Types::Orders::ExecuteInput
+
+      type Types::Orders::Object
+
+      def resolve(**args)
+        order = current_organization.orders.find_by(id: args[:id])
+        result = ::Orders::ExecuteService.call(order:)
+
+        result.success? ? result.order : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/orders/execute.rb
+++ b/app/graphql/mutations/orders/execute.rb
@@ -20,6 +20,8 @@ module Mutations
         result = ::Orders::ExecuteService.call(order:)
 
         result.success? ? result.order : result_error(result)
+      rescue BaseLockService::FailedToAcquireLock
+        validation_error(messages: {base: ["concurrency_conflict"]})
       end
     end
   end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -152,6 +152,7 @@ module Types
 
     field :void_order_form, mutation: Mutations::OrderForms::Void
 
+    field :execute_order, mutation: Mutations::Orders::Execute
     field :update_order, mutation: Mutations::Orders::Update
 
     field :download_payment_receipt, mutation: Mutations::PaymentReceipts::Download

--- a/app/graphql/types/orders/execute_input.rb
+++ b/app/graphql/types/orders/execute_input.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class ExecuteInput < Types::BaseInputObject
+      description "Execute Order input arguments"
+
+      argument :id, ID, required: true
+    end
+  end
+end

--- a/app/graphql/types/orders/execution_record.rb
+++ b/app/graphql/types/orders/execution_record.rb
@@ -6,7 +6,7 @@ module Types
       graphql_name "OrderExecutionRecord"
 
       field :errors, [String], null: false
-      field :executed_at, String, null: true
+      field :executed_at, GraphQL::Types::ISO8601DateTime, null: true
       field :execution_mode, Types::Orders::ExecutionModeEnum, null: true
       field :invoice_id, ID, null: true
 

--- a/app/graphql/types/orders/execution_record.rb
+++ b/app/graphql/types/orders/execution_record.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  module Orders
+    class ExecutionRecord < Types::BaseObject
+      graphql_name "OrderExecutionRecord"
+
+      field :errors, [String], null: false
+      field :executed_at, String, null: true
+      field :execution_mode, Types::Orders::ExecutionModeEnum, null: true
+      field :invoice_id, ID, null: true
+
+      def errors
+        object["errors"] || []
+      end
+    end
+  end
+end

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -15,6 +15,7 @@ module Types
       field :currency, String, null: true
       field :execute_at, GraphQL::Types::ISO8601DateTime, null: true
       field :executed_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :execution_record, Types::Orders::ExecutionRecord, null: false
 
       field :customer, Types::Customers::Object, null: false
       field :order_form, Types::OrderForms::Object, null: false

--- a/app/serializers/v1/order_serializer.rb
+++ b/app/serializers/v1/order_serializer.rb
@@ -12,6 +12,7 @@ module V1
         billing_snapshot: model.billing_snapshot,
         currency: model.currency,
         executed_at: model.executed_at&.iso8601,
+        execution_record: model.execution_record,
         lago_organization_id: model.organization_id,
         lago_customer_id: model.customer_id,
         lago_order_form_id: model.order_form_id,

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -156,6 +156,8 @@ orders:
     - manager
   update:
     - manager
+  execute:
+    - manager
 organization:
   view:
     - finance

--- a/schema.graphql
+++ b/schema.graphql
@@ -5864,6 +5864,17 @@ enum EventsStoreEnum {
 }
 
 """
+Execute Order input arguments
+"""
+input ExecuteOrderInput {
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  id: ID!
+}
+
+"""
 Organization Feature Flag Values
 """
 enum FeatureFlagEnum {
@@ -8099,6 +8110,16 @@ type Mutation {
   ): PaymentReceipt
 
   """
+  Execute an order
+  """
+  executeOrder(
+    """
+    Parameters for ExecuteOrder
+    """
+    input: ExecuteOrderInput!
+  ): Order
+
+  """
   Fetches taxes for one-off invoice
   """
   fetchDraftInvoiceTaxes(
@@ -9547,6 +9568,7 @@ enum PermissionEnum {
   order_forms_sign
   order_forms_view
   order_forms_void
+  orders_execute
   orders_update
   orders_view
   organization_emails_update
@@ -9665,6 +9687,7 @@ type Permissions {
   orderFormsSign: Boolean!
   orderFormsView: Boolean!
   orderFormsVoid: Boolean!
+  ordersExecute: Boolean!
   ordersUpdate: Boolean!
   ordersView: Boolean!
   organizationEmailsUpdate: Boolean!

--- a/schema.graphql
+++ b/schema.graphql
@@ -9165,6 +9165,7 @@ type Order {
   executeAt: ISO8601DateTime
   executedAt: ISO8601DateTime
   executionMode: OrderExecutionModeEnum
+  executionRecord: OrderExecutionRecord!
   id: ID!
   number: String!
   orderForm: OrderForm!
@@ -9197,6 +9198,13 @@ type OrderCollection {
 enum OrderExecutionModeEnum {
   execute_in_lago
   order_only
+}
+
+type OrderExecutionRecord {
+  errors: [String!]!
+  executedAt: String
+  executionMode: OrderExecutionModeEnum
+  invoiceId: ID
 }
 
 type OrderForm {

--- a/schema.graphql
+++ b/schema.graphql
@@ -9223,7 +9223,7 @@ enum OrderExecutionModeEnum {
 
 type OrderExecutionRecord {
   errors: [String!]!
-  executedAt: String
+  executedAt: ISO8601DateTime
   executionMode: OrderExecutionModeEnum
   invoiceId: ID
 }

--- a/schema.json
+++ b/schema.json
@@ -44040,6 +44040,22 @@
               "deprecationReason": null
             },
             {
+              "name": "executionRecord",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderExecutionRecord",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [],
@@ -44252,6 +44268,77 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OrderExecutionRecord",
+          "description": null,
+          "fields": [
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "executionMode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderExecutionModeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {

--- a/schema.json
+++ b/schema.json
@@ -28558,6 +28558,45 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ExecuteOrderInput",
+          "description": "Execute Order input arguments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "FeatureFlagEnum",
           "description": "Organization Feature Flag Values",
@@ -40390,6 +40429,35 @@
               "deprecationReason": null
             },
             {
+              "name": "executeOrder",
+              "description": "Execute an order",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for ExecuteOrder",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ExecuteOrderInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "fetchDraftInvoiceTaxes",
               "description": "Fetches taxes for one-off invoice",
               "args": [
@@ -46779,6 +46847,12 @@
               "deprecationReason": null
             },
             {
+              "name": "orders_execute",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization_view",
               "description": null,
               "isDeprecated": false,
@@ -48006,6 +48080,22 @@
             },
             {
               "name": "orderFormsVoid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ordersExecute",
               "description": null,
               "args": [],
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -44373,7 +44373,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/graphql/mutations/orders/execute_spec.rb
+++ b/spec/graphql/mutations/orders/execute_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe Mutations::Orders::Execute do
     end
   end
 
+  context "when the execution lock cannot be acquired", :premium do
+    before do
+      allow(Orders::ExecuteService).to receive(:call).and_raise(BaseLockService::FailedToAcquireLock)
+    end
+
+    it "returns an unprocessable entity error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: order.id}}
+      )
+
+      expect_unprocessable_entity(result, details: {base: ["concurrency_conflict"]})
+    end
+  end
+
   context "when order is not found" do
     it "returns an error" do
       result = execute_graphql(

--- a/spec/graphql/mutations/orders/execute_spec.rb
+++ b/spec/graphql/mutations/orders/execute_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::Orders::Execute do
+  let(:required_permission) { "orders:execute" }
+  let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
+  let(:membership) { create(:membership, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+  let(:quote_version) { create(:quote_version, :approved, quote:, organization:) }
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+  let(:order) { create(:order, organization:, customer:, order_form:, execution_mode: :order_only) }
+
+  let(:mutation) do
+    <<~GQL
+      mutation($input: ExecuteOrderInput!) {
+        executeOrder(input: $input) {
+          id
+          status
+          executedAt
+        }
+      }
+    GQL
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "orders:execute"
+
+  it "executes the order", :premium do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {input: {id: order.id}}
+    )
+
+    data = result["data"]["executeOrder"]
+
+    expect(data["id"]).to eq(order.id)
+    expect(data["status"]).to eq("executed")
+    expect(data["executedAt"]).to be_present
+  end
+
+  context "without a premium license" do
+    it "returns a forbidden error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: order.id}}
+      )
+
+      expect_graphql_error(result:, message: "feature_unavailable")
+    end
+  end
+
+  context "when the execution fails", :premium do
+    let(:order) { create(:order, organization:, customer:, order_form:, execution_mode: :execute_in_lago) }
+
+    let(:failed_result) do
+      Invoices::CreateOneOffService::Result.new.tap do |failed|
+        failed.single_validation_failure!(field: :currency, error_code: "currencies_does_not_match")
+      end
+    end
+
+    before do
+      allow(Invoices::CreateOneOffService).to receive(:call!).and_raise(failed_result.error)
+    end
+
+    it "surfaces the error and marks the order failed" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: order.id}}
+      )
+
+      expect_unprocessable_entity(result, details: {currency: ["currencies_does_not_match"]})
+
+      order.reload
+      expect(order.failed?).to eq(true)
+      expect(order.execution_record["errors"]).to eq(["currencies_does_not_match"])
+    end
+  end
+
+  context "when order is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input: {id: SecureRandom.uuid}}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/resolvers/order_resolver_spec.rb
+++ b/spec/graphql/resolvers/order_resolver_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Resolvers::OrderResolver do
           orderType
           createdAt
           updatedAt
+          executionRecord { errors executionMode invoiceId executedAt }
         }
       }
     GQL
@@ -48,6 +49,30 @@ RSpec.describe Resolvers::OrderResolver do
     expect(data["number"]).to eq(order.number)
     expect(data["status"]).to eq("created")
     expect(data["orderType"]).to eq("subscription_creation")
+    expect(data["executionRecord"]).to eq(
+      "errors" => [], "executionMode" => nil, "invoiceId" => nil, "executedAt" => nil
+    )
+  end
+
+  context "when the order failed" do
+    let(:order) { create(:order, :failed, organization:, customer:, order_form:) }
+
+    it "resolves the execution record trace" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {id: order.id}
+      )
+
+      record = result["data"]["order"]["executionRecord"]
+
+      expect(record["errors"]).to eq(["currencies_does_not_match"])
+      expect(record["executionMode"]).to eq("execute_in_lago")
+      expect(record["invoiceId"]).to be_nil
+      expect(record["executedAt"]).to be_nil
+    end
   end
 
   context "when order is not found" do

--- a/spec/graphql/types/orders/execute_input_spec.rb
+++ b/spec/graphql/types/orders/execute_input_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Orders::ExecuteInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:id).of_type("ID!")
+  end
+end

--- a/spec/graphql/types/orders/execution_record_spec.rb
+++ b/spec/graphql/types/orders/execution_record_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Types::Orders::ExecutionRecord do
 
   it do
     expect(subject).to have_field(:errors).of_type("[String!]!")
-    expect(subject).to have_field(:executed_at).of_type("String")
+    expect(subject).to have_field(:executed_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:execution_mode).of_type("OrderExecutionModeEnum")
     expect(subject).to have_field(:invoice_id).of_type("ID")
   end

--- a/spec/graphql/types/orders/execution_record_spec.rb
+++ b/spec/graphql/types/orders/execution_record_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Orders::ExecutionRecord do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:errors).of_type("[String!]!")
+    expect(subject).to have_field(:executed_at).of_type("String")
+    expect(subject).to have_field(:execution_mode).of_type("OrderExecutionModeEnum")
+    expect(subject).to have_field(:invoice_id).of_type("ID")
+  end
+end

--- a/spec/graphql/types/orders/object_spec.rb
+++ b/spec/graphql/types/orders/object_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Types::Orders::Object do
     expect(subject).to have_field(:currency).of_type("String")
     expect(subject).to have_field(:execute_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:executed_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:execution_record).of_type("OrderExecutionRecord!")
 
     expect(subject).to have_field(:customer).of_type("Customer!")
     expect(subject).to have_field(:order_form).of_type("OrderForm!")

--- a/spec/serializers/v1/order_serializer_spec.rb
+++ b/spec/serializers/v1/order_serializer_spec.rb
@@ -24,11 +24,28 @@ RSpec.describe ::V1::OrderSerializer do
       "billing_snapshot" => order.billing_snapshot,
       "currency" => "EUR",
       "executed_at" => nil,
+      "execution_record" => order.execution_record,
       "lago_organization_id" => order.organization_id,
       "lago_customer_id" => order.customer_id,
       "lago_order_form_id" => order.order_form_id,
       "created_at" => order.created_at.iso8601,
       "updated_at" => order.updated_at.iso8601
     )
+  end
+
+  context "when the order failed" do
+    let(:order) { create(:order, :failed, organization:, customer:, order_form:) }
+
+    it "serializes the execution record trace" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["order"]["status"]).to eq("failed")
+      expect(result["order"]["execution_record"]).to eq(
+        "executed_at" => nil,
+        "execution_mode" => "execute_in_lago",
+        "invoice_id" => nil,
+        "errors" => ["currencies_does_not_match"]
+      )
+    end
   end
 end


### PR DESCRIPTION
## Why

The dashboard needs to see an order's execution outcome and to trigger execution manually.

## What

- Expose the execution record on the order GraphQL type and the REST serializer.
- Add the `executeOrder` mutation, gated by a new permission.

## Stacked on

Based on #5953 `feat/orders/execution` (review/merge that first).
