### PR TITLE
chore(order_forms): remove activity_loggable from services

### DIFF
--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -16,11 +16,6 @@ module OrderForms
       super
     end
 
-    activity_loggable(
-      action: "order_form.signed",
-      record: -> { order_form }
-    )
-
     def call
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.forbidden_failure! unless order_forms_enabled?(order_form.organization)

--- a/app/services/order_forms/void_service.rb
+++ b/app/services/order_forms/void_service.rb
@@ -12,11 +12,6 @@ module OrderForms
       super
     end
 
-    activity_loggable(
-      action: "order_form.voided",
-      record: -> { order_form }
-    )
-
     def call
       return result.not_found_failure!(resource: "order_form") unless order_form
       return result.forbidden_failure! unless order_forms_enabled?(order_form.organization)


### PR DESCRIPTION
Remove the `activity_loggable` declarations from `OrderForms::MarkAsSignedService` and `OrderForms::VoidService`. Activity logging is premature for these still-in-progress domains.