### PR TITLE
chore(quotes): ignore unused share_token on quote_versions

### DIFF
--- a/app/graphql/types/quote_versions/object.rb
+++ b/app/graphql/types/quote_versions/object.rb
@@ -15,7 +15,6 @@ module Types
       field :mention_variables, GraphQL::Types::JSON, null: false
       field :organization, Types::Organizations::OrganizationType, null: false
       field :quote, Types::Quotes::Object, null: false
-      field :share_token, String, null: true
       field :start_date, GraphQL::Types::ISO8601Date, null: true
       field :status, Types::QuoteVersions::StatusEnum, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -18,7 +18,11 @@ class QuoteVersion < ApplicationRecord
 
   CASCADE_VOID_REASONS = VOID_REASONS.slice(:cascade_of_expired, :cascade_of_voided).freeze
 
-  before_save :ensure_share_token
+  # The quote sharing feature (public share link via `share_token`) is not ready yet:
+  # no share endpoint, no consumer of the token. Ignore the column so the app stops
+  # reading/writing it; the column and its unique index remain in the database for when
+  # the feature lands.
+  self.ignored_columns += %w[share_token]
 
   belongs_to :organization
   belongs_to :quote
@@ -30,11 +34,6 @@ class QuoteVersion < ApplicationRecord
   enum :void_reason, VOID_REASONS,
     instance_methods: false,
     validate: {allow_nil: true}
-
-  validates :share_token,
-    on: :update,
-    presence: true,
-    if: -> { draft? || approved? }
 
   validates :void_reason, :voided_at,
     presence: true,
@@ -50,14 +49,6 @@ class QuoteVersion < ApplicationRecord
   )
 
   def version = sequential_id
-
-  private
-
-  def ensure_share_token
-    return if voided?
-
-    self.share_token ||= SecureRandom.uuid
-  end
 end
 
 # == Schema Information
@@ -72,7 +63,6 @@ end
 #  currency          :string
 #  end_date          :date
 #  mention_variables :jsonb
-#  share_token       :string
 #  start_date        :date
 #  status            :enum             default("draft"), not null
 #  void_reason       :enum
@@ -89,7 +79,6 @@ end
 #  index_quote_versions_on_quote_id                    (quote_id)
 #  index_unique_quote_versions_on_quote_active_status  (quote_id) UNIQUE WHERE (status = ANY (ARRAY['draft'::quote_status, 'approved'::quote_status]))
 #  index_unique_quote_versions_on_quote_sequential_id  (quote_id,sequential_id) UNIQUE
-#  index_unique_quote_versions_on_share_token          (share_token) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -20,8 +20,8 @@ class QuoteVersion < ApplicationRecord
 
   # The quote sharing feature (public share link via `share_token`) is not ready yet:
   # no share endpoint, no consumer of the token. Ignore the column so the app stops
-  # reading/writing it; the column and its unique index remain in the database for when
-  # the feature lands.
+  # reading/writing it; the column stays in the database for when the feature lands
+  # (its now-unused unique index has been dropped).
   self.ignored_columns += %w[share_token]
 
   belongs_to :organization

--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -57,7 +57,6 @@ module QuoteVersions
       quote_version.dup.tap do |cloned|
         cloned.status = :draft
         cloned.sequential_id = nil
-        cloned.share_token = nil # regenerated on save
         cloned.void_reason = nil
         cloned.voided_at = nil
         cloned.approved_at = nil

--- a/app/services/quote_versions/void_service.rb
+++ b/app/services/quote_versions/void_service.rb
@@ -28,7 +28,6 @@ module QuoteVersions
             status: :voided,
             void_reason: reason,
             voided_at: Time.current,
-            share_token: nil,
             approved_at: nil
           )
 

--- a/db/migrate/20260716114156_remove_share_token_index_from_quote_versions.rb
+++ b/db/migrate/20260716114156_remove_share_token_index_from_quote_versions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class RemoveShareTokenIndexFromQuoteVersions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # The quote sharing feature is not ready and `share_token` is now ignored by the
+  # model, so its unique index is unused. Drop it; the column itself stays. `down`
+  # recreates the index for when the feature lands.
+  def up
+    remove_index :quote_versions,
+      name: "index_unique_quote_versions_on_share_token",
+      algorithm: :concurrently,
+      if_exists: true
+  end
+
+  def down
+    add_index :quote_versions, :share_token,
+      unique: true,
+      algorithm: :concurrently,
+      name: "index_unique_quote_versions_on_share_token",
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -388,7 +388,6 @@ DROP INDEX IF EXISTS public.index_unique_terminating_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_starting_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_sequential_id;
 DROP INDEX IF EXISTS public.index_unique_quotes_on_organization_number;
-DROP INDEX IF EXISTS public.index_unique_quote_versions_on_share_token;
 DROP INDEX IF EXISTS public.index_unique_quote_versions_on_quote_sequential_id;
 DROP INDEX IF EXISTS public.index_unique_quote_versions_on_quote_active_status;
 DROP INDEX IF EXISTS public.index_unique_quote_owners_on_quote_user;
@@ -9967,13 +9966,6 @@ CREATE UNIQUE INDEX index_unique_quote_versions_on_quote_sequential_id ON public
 
 
 --
--- Name: index_unique_quote_versions_on_share_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_unique_quote_versions_on_share_token ON public.quote_versions USING btree (share_token);
-
-
---
 -- Name: index_unique_quotes_on_organization_number; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12844,6 +12836,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260716114156'),
 ('20260709141039'),
 ('20260709141038'),
 ('20260709141037'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -11082,7 +11082,6 @@ type QuoteVersion {
   mentionVariables: JSON!
   organization: Organization!
   quote: Quote!
-  shareToken: String
   startDate: ISO8601Date
   status: StatusEnum!
   updatedAt: ISO8601DateTime!

--- a/schema.json
+++ b/schema.json
@@ -60599,18 +60599,6 @@
               "deprecationReason": null
             },
             {
-              "name": "shareToken",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "startDate",
               "description": null,
               "args": [],

--- a/spec/graphql/mutations/quote_versions/clone_spec.rb
+++ b/spec/graphql/mutations/quote_versions/clone_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Mutations::QuoteVersions::Clone do
           organization { id },
           version,
           status,
-          shareToken,
           voidReason,
           voidedAt
         }
@@ -59,13 +58,11 @@ RSpec.describe Mutations::QuoteVersions::Clone do
         )
         expect(cloned["id"]).to be_present
         expect(cloned["id"]).not_to eq(quote_version.id)
-        expect(cloned["shareToken"]).to be_present
 
         quote_version.reload
         expect(quote_version.voided?).to eq(true)
         expect(quote_version.void_reason).to eq("superseded")
         expect(quote_version.voided_at).to eq(Time.current)
-        expect(quote_version.share_token).to eq(nil)
       end
     end
   end

--- a/spec/graphql/types/quote_versions/object_spec.rb
+++ b/spec/graphql/types/quote_versions/object_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Types::QuoteVersions::Object do
     expect(subject).to have_field(:billing_items).of_type("JSON")
     expect(subject).to have_field(:content).of_type("String")
     expect(subject).to have_field(:mention_variables).of_type("JSON!")
-    expect(subject).to have_field(:share_token).of_type("String")
     expect(subject).to have_field(:status).of_type("StatusEnum!")
     expect(subject).to have_field(:version).of_type("Int!")
     expect(subject).to have_field(:void_reason).of_type("VoidReasonEnum")

--- a/spec/models/quote_version_spec.rb
+++ b/spec/models/quote_version_spec.rb
@@ -39,16 +39,6 @@ RSpec.describe QuoteVersion do
       expect(build(:quote_version)).to be_valid
     end
 
-    describe "share_token" do
-      it "is required for draft and approved statuses on update" do
-        draft = build(:quote_version, status: :draft, share_token: nil)
-        expect(draft.valid?(:update)).to be false
-
-        approved = build(:quote_version, status: :approved, share_token: nil, approved_at: Time.current)
-        expect(approved.valid?(:update)).to be false
-      end
-    end
-
     describe "void_reason and voided_at" do
       it "are required when status is voided" do
         quote_version = build(:quote_version, status: :voided, void_reason: nil, voided_at: nil)
@@ -79,24 +69,6 @@ RSpec.describe QuoteVersion do
       v1 = create(:quote_version, :voided, quote:, organization: quote.organization, sequential_id: nil)
       v2 = create(:quote_version, quote:, organization: quote.organization, sequential_id: nil)
       expect([v1.sequential_id, v2.sequential_id]).to eq([1, 2])
-    end
-  end
-
-  describe "ensure_share_token callback" do
-    it "generates a share_token for draft versions" do
-      quote_version = create(:quote_version, status: :draft, share_token: nil)
-      expect(quote_version.share_token).to be_present
-    end
-
-    it "does not generate a share_token for voided versions" do
-      quote_version = create(:quote_version, :voided)
-      expect(quote_version.share_token).to be_nil
-    end
-
-    it "preserves an explicitly assigned share_token" do
-      token = SecureRandom.uuid
-      quote_version = create(:quote_version, status: :draft, share_token: token)
-      expect(quote_version.share_token).to eq(token)
     end
   end
 

--- a/spec/services/quote_versions/create_service_spec.rb
+++ b/spec/services/quote_versions/create_service_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe QuoteVersions::CreateService do
         expect(result.quote_version.version).to eq(1)
         expect(result.quote_version.draft?).to eq(true)
         expect(result.quote_version.content).to eq("Test content")
-        expect(result.quote_version.share_token).not_to be_nil
         expect(result.quote_version.billing_items).to eq({})
         expect(result.quote_version.currency).to eq("USD")
         expect(result.quote_version.start_date).to eq(start_date)

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe QuoteVersions::VoidService do
           expect(result.quote_version.voided?).to eq(true)
           expect(result.quote_version.void_reason).to eq(reason)
           expect(result.quote_version.voided_at).to eq(Time.current)
-          expect(result.quote_version.share_token).to eq(nil)
           expect(result.quote_version.approved_at).to eq(nil)
         end
       end


### PR DESCRIPTION
The quote sharing feature (public share link) is not ready: no share endpoint, no consumer of the token. Instead of dropping the column (not allowed), we tell ActiveRecord to ignore `quote_versions.share_token` via `self.ignored_columns`, and remove the model callback/validation, the GraphQL field, and the service writes that touched it. The **column is kept** in the database; its now-unused **unique index is dropped** (reversible migration). Re-enable by removing the `ignored_columns` entry (and re-adding the index) when the feature lands.