### PR TITLE
[ING-483] fix(cache): Ensure correct cache expiration with clickhouse

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -41,3 +41,7 @@ fixed_charge_usage_delta_migration:
 multi_connection:
   description: "Allow organizations to configure multiple connections of the same type per customer"
   owners: ["@lovrocolic", "@mariohd"]
+
+lazy_charge_usage_cache:
+  description: "Validate the charge usage cache lazily at read time (compare cache creation time to the last event) instead of expiring it on every event reception"
+  owners: ["@vincent-pochet"]

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class CacheService < BaseService
-  def initialize(*, expires_in: nil)
+  def initialize(*, expires_in: nil, invalidate_if_older_than: nil)
     @expires_in = expires_in
+    @invalidate_if_older_than = invalidate_if_older_than
     super(nil)
   end
 
@@ -17,14 +18,14 @@ class CacheService < BaseService
   def call(&)
     # NOTE: We don't rely on fetch here because some services compute expires_in = 0
     #       and we think this is the root of an invalid expiration time passed to Redis
-    value = Rails.cache.read(cache_key)
-    return value if value
+    cached = Rails.cache.read(cache_key)
+    return unwrap(cached) if cached && valid_cache?(cached)
 
     value = yield
 
     # NOTE: It seems that passing expires_in: 0 is not a NO-OP, so bypass manually
     if expires_in.nil? || expires_in > 0
-      Rails.cache.write(cache_key, value, expires_in:)
+      Rails.cache.write(cache_key, wrap(value), expires_in:)
     end
 
     value
@@ -36,5 +37,46 @@ class CacheService < BaseService
 
   private
 
-  attr_reader :expires_in
+  attr_reader :expires_in, :invalidate_if_older_than
+
+  # Subclasses opting into lazy validation override this to wrap the stored value with its
+  # creation time, so the cache can be invalidated at read time by comparing it against the
+  # most recent event timestamp instead of relying on an external expiration.
+  def track_created_at?
+    false
+  end
+
+  # Stamp the cache with the timestamp of the most recent event the computation was based on
+  # (invalidate_if_older_than), NOT the write time. An event could be ingested between reading
+  # the events and writing the cache; stamping the write time would make cached_at more recent
+  # than that event and wrongly keep the stale entry valid. Fall back to the write time when the
+  # computation saw no event (nothing to compare against yet).
+  def wrap(value)
+    return value unless track_created_at?
+
+    # Keep sub-second precision: event timestamps carry milliseconds (ClickHouse enriched_at is
+    # DateTime64(3)) or microseconds (Postgres). A bare iso8601 floors to whole seconds, so a
+    # re-read for the very same event would compare a floored cached_at against the unfloored
+    # timestamp and wrongly recompute on every read, defeating the cache.
+    cached_at = (invalidate_if_older_than || Time.current).iso8601(6)
+    {"cached_at" => cached_at, "value" => value}
+  end
+
+  def unwrap(cached)
+    return cached unless track_created_at?
+
+    cached.is_a?(Hash) ? cached["value"] : cached
+  end
+
+  # Returns false when a more recent event was ingested after the cache was written, forcing a
+  # recompute. A legacy (unwrapped) entry is always considered stale so it gets rewritten.
+  def valid_cache?(cached)
+    return true unless track_created_at?
+    return true if invalidate_if_older_than.nil?
+
+    cached_at = cached.is_a?(Hash) ? cached["cached_at"] : nil
+    return false if cached_at.nil?
+
+    Time.iso8601(cached_at) >= invalidate_if_older_than
+  end
 end

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -46,11 +46,6 @@ class CacheService < BaseService
     false
   end
 
-  # Stamp the cache with the timestamp of the most recent event the computation was based on
-  # (invalidate_if_older_than), NOT the write time. An event could be ingested between reading
-  # the events and writing the cache; stamping the write time would make cached_at more recent
-  # than that event and wrongly keep the stale entry valid. Fall back to the write time when the
-  # computation saw no event (nothing to compare against yet).
   def wrap(value)
     return value unless track_created_at?
 
@@ -68,8 +63,8 @@ class CacheService < BaseService
     cached.is_a?(Hash) ? cached["value"] : cached
   end
 
-  # Returns false when a more recent event was ingested after the cache was written, forcing a
-  # recompute. A legacy (unwrapped) entry is always considered stale so it gets rewritten.
+  # Returns false when a more recent value is checked, forcing a recompute.
+  # A legacy (unwrapped) entry is always considered stale so it gets rewritten.
   def valid_cache?(cached)
     return true unless track_created_at?
     return true if invalidate_if_older_than.nil?

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -12,12 +12,10 @@ module Events
 
     # Return the charges and filters that will be used in the billing or usage computation.
     #
-    # result.charges is a nested hash: { charge_id => { filter_id => last_seen_at } }.
-    # The inner keys are the filter ids that received usage in the period (nil is the default,
-    # no-filter bucket). Each value is the ingestion timestamp of the most recent event for that
-    # charge/filter (created_at on PG, enriched_at on CH), or nil when no event was seen (e.g. a
-    # recurring charge whose usage carries over). The last-seen timestamps let the cache layer
-    # lazily invalidate stale usage.
+    # result.charges is a nested hash: { charge_id => { filter_id => last_seen_at } } (nil filter
+    # is the default bucket). last_seen_at is the most recent event ingestion timestamp for that
+    # charge/filter (created_at on PG, enriched_at on CH), used to lazily invalidate the cache.
+    # Recurring charges with no in-period event are seeded with the period start (see #period_start).
     def call
       result.charges = charges_and_filters
       result
@@ -28,6 +26,12 @@ module Events
     attr_reader :subscription, :boundaries
 
     delegate :plan, :organization, to: :subscription
+
+    # Floor for recurring charges without events: seeding last_seen_at here (instead of nil) lets
+    # any in-period event invalidate the lazy cache, which nil would keep valid forever.
+    def period_start
+      boundaries.charges_from_datetime
+    end
 
     def event_store
       @event_store ||= Events::Stores::StoreFactory.new_instance(
@@ -50,12 +54,9 @@ module Events
       charges_and_filters_from_pre_enriched_events
     end
 
-    # Return all charges and filters that received usage in the period, including recurring ones.
-    # Shape: { charge_id => { filter_id => last_seen_at } } (nil filter is the default bucket).
-    #
-    # For non-recurring charges, the exact filters are resolved by matching the distinct
-    # property combinations actually present in the events against the charge filters, so
-    # only the filters that received usage are returned.
+    # { charge_id => { filter_id => last_seen_at } } (nil filter is the default bucket).
+    # Recurring charges are seeded first (usage carries over); then matching events resolve the
+    # filters for non-recurring charges and refresh last_seen_at for recurring ones.
     def charges_and_filters_from_events
       combinations = event_store.distinct_codes_and_property_combinations(
         codes: plan_codes,
@@ -68,7 +69,7 @@ module Events
       # Recurring charges must always be billed as usage carries over from previous periods
       result = recurring_event_charges_and_filters
 
-      non_recurring_charges_with_events(combinations_by_code.keys).each do |charge|
+      charges_with_events(combinations_by_code.keys).each do |charge|
         code = charge.billable_metric.code
 
         combinations_by_code[code].each do |(_code, properties, last_seen_at)|
@@ -89,12 +90,8 @@ module Events
       result
     end
 
-    # Add a charge/filter to the accumulator, keeping the most recent last_seen_at (nil means
-    # no event was seen for that charge/filter yet, e.g. recurring usage carried over).
-    #
-    # Filters are stored as hash keys, so a given (charge, filter) is deduplicated by
-    # construction: writing the same pair twice only refreshes its timestamp, it never adds a
-    # duplicate. This replaces the previous explicit uniq pass on the filter lists.
+    # Add a charge/filter to the accumulator, keeping the most recent last_seen_at (nil never
+    # overwrites an existing timestamp). Filters are hash keys, so pairs are deduplicated.
     def record(accumulator, charge_id, filter_id, last_seen_at)
       bucket = (accumulator[charge_id] ||= {})
       current = bucket[filter_id]
@@ -113,18 +110,18 @@ module Events
         .where(billable_metrics: {recurring: true})
         .group("charges.id, charge_filters.id")
         .pluck("charges.id", "charge_filters.id")
-        .each { |charge_id, filter_id| record(result, charge_id, filter_id, nil) }
+        .each { |charge_id, filter_id| record(result, charge_id, filter_id, period_start) }
 
       # Recurring charges always expose the default (no-filter) bucket
-      result.each_key { |charge_id| record(result, charge_id, nil, nil) }
+      result.each_key { |charge_id| record(result, charge_id, nil, period_start) }
       result
     end
 
-    # Non-recurring charges of the plan whose billable metric received events in the period
-    def non_recurring_charges_with_events(codes)
+    # Charges of the plan whose billable metric received events in the period (recurring or not)
+    def charges_with_events(codes)
       plan.charges
         .joins(:billable_metric)
-        .where(billable_metrics: {code: codes, recurring: false})
+        .where(billable_metrics: {code: codes})
         .includes(billable_metric: :filters, filters: {values: :billable_metric_filter})
     end
 
@@ -204,8 +201,8 @@ module Events
       current_recurring_charges.each do |charge|
         next unless previous_bm_ids.include?(charge.billable_metric_id)
 
-        charge.filters.each { |filter| record(result, charge.id, filter.id, nil) }
-        record(result, charge.id, nil, nil)
+        charge.filters.each { |filter| record(result, charge.id, filter.id, period_start) }
+        record(result, charge.id, nil, period_start)
       end
       result
     end
@@ -260,10 +257,10 @@ module Events
         .pluck(:charge_id, :charge_filter_id)
     end
 
-    # Group charge/filter pairs (without a known timestamp) into the nested accumulator shape
+    # Group recurring charge/filter pairs from previous fees, seeded with the period start.
     def group_by_charge_id(rows)
       rows.each_with_object({}) do |(charge_id, filter_id), accumulator|
-        record(accumulator, charge_id, filter_id, nil)
+        record(accumulator, charge_id, filter_id, period_start)
       end
     end
 

--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -10,11 +10,16 @@ module Events
       super
     end
 
-    # Return the list of charges and filters that will be used in the billing or usage computation
-    # The result will be a hash where the key is the charge id and the value is an array of filter ids
-    # filter ids could also include "nil" as a default filter
+    # Return the charges and filters that will be used in the billing or usage computation.
+    #
+    # result.charges is a nested hash: { charge_id => { filter_id => last_seen_at } }.
+    # The inner keys are the filter ids that received usage in the period (nil is the default,
+    # no-filter bucket). Each value is the ingestion timestamp of the most recent event for that
+    # charge/filter (created_at on PG, enriched_at on CH), or nil when no event was seen (e.g. a
+    # recurring charge whose usage carries over). The last-seen timestamps let the cache layer
+    # lazily invalidate stale usage.
     def call
-      result.charges = deduplicate_filters(charges_and_filters)
+      result.charges = charges_and_filters
       result
     end
 
@@ -45,10 +50,8 @@ module Events
       charges_and_filters_from_pre_enriched_events
     end
 
-    # Return the list of all charges and filters that received usage in the period
-    # It also includes the recurring charges and filters
-    # The result will be a hash where the key is the charge id and the value is an array of filter ids
-    # filter ids also include "nil" as a default filter
+    # Return all charges and filters that received usage in the period, including recurring ones.
+    # Shape: { charge_id => { filter_id => last_seen_at } } (nil filter is the default bucket).
     #
     # For non-recurring charges, the exact filters are resolved by matching the distinct
     # property combinations actually present in the events against the charge filters, so
@@ -59,9 +62,8 @@ module Events
         filter_keys: billable_metric_filter_keys
       )
 
-      combinations_by_code = combinations
-        .group_by(&:first)
-        .transform_values { |rows| rows.map(&:last) }
+      # Group the [code, properties, last_seen_at] tuples by code
+      combinations_by_code = combinations.group_by(&:first)
 
       # Recurring charges must always be billed as usage carries over from previous periods
       result = recurring_event_charges_and_filters
@@ -69,7 +71,7 @@ module Events
       non_recurring_charges_with_events(combinations_by_code.keys).each do |charge|
         code = charge.billable_metric.code
 
-        combinations_by_code[code].each do |properties|
+        combinations_by_code[code].each do |(_code, properties, last_seen_at)|
           event = ::Event.new(code:, properties:)
           matching = ChargeFilters::EventMatchingService.call(charge:, event:).matching_charge_filters
 
@@ -77,9 +79,9 @@ module Events
           # Otherwise include every matching filter and let the aggregation cascade
           # assign the event to the most specific one (the others aggregate to zero).
           if matching.empty?
-            result[charge.id] << nil
+            record(result, charge.id, nil, last_seen_at)
           else
-            matching.each { |filter| result[charge.id] << filter.id }
+            matching.each { |filter| record(result, charge.id, filter.id, last_seen_at) }
           end
         end
       end
@@ -87,15 +89,35 @@ module Events
       result
     end
 
+    # Add a charge/filter to the accumulator, keeping the most recent last_seen_at (nil means
+    # no event was seen for that charge/filter yet, e.g. recurring usage carried over).
+    #
+    # Filters are stored as hash keys, so a given (charge, filter) is deduplicated by
+    # construction: writing the same pair twice only refreshes its timestamp, it never adds a
+    # duplicate. This replaces the previous explicit uniq pass on the filter lists.
+    def record(accumulator, charge_id, filter_id, last_seen_at)
+      bucket = (accumulator[charge_id] ||= {})
+      current = bucket[filter_id]
+
+      if !bucket.key?(filter_id) || (last_seen_at && (current.nil? || last_seen_at > current))
+        bucket[filter_id] = last_seen_at
+      end
+    end
+
     # Recurring charges and all their filters (including the default bucket).
     # They are always returned, even without events, as usage carries over.
     def recurring_event_charges_and_filters
+      result = {}
+
       plan.charges.joins(:billable_metric).left_joins(:filters)
         .where(billable_metrics: {recurring: true})
         .group("charges.id, charge_filters.id")
         .pluck("charges.id", "charge_filters.id")
-        .then { group_by_charge_id(it) }
-        .then { add_default_filter(it) }
+        .each { |charge_id, filter_id| record(result, charge_id, filter_id, nil) }
+
+      # Recurring charges always expose the default (no-filter) bucket
+      result.each_key { |charge_id| record(result, charge_id, nil, nil) }
+      result
     end
 
     # Non-recurring charges of the plan whose billable metric received events in the period
@@ -114,14 +136,13 @@ module Events
         .pluck(:key)
     end
 
-    # Return the list of charges and filters that matches the event pre enriched in clickhouse or Postgres for the period
-    # It also includes the recurring charges and filters
-    # The result will be a hash where the key is the charge id and the value is an array of filter ids
-    # filter ids also include "nil" as a default filter when applicable
+    # Return the charges and filters matching the events pre-enriched in ClickHouse or Postgres for
+    # the period, including the recurring ones.
+    # Shape: { charge_id => { filter_id => last_seen_at } } (nil filter is the default bucket).
     def charges_and_filters_from_pre_enriched_events
       values = event_store.distinct_charges_and_filters(codes: plan_codes)
 
-      charge_filter_ids = values.map(&:last).reject(&:blank?)
+      charge_filter_ids = values.map { |v| v[1] }.reject(&:blank?)
       charge_ids = values.map(&:first).uniq
 
       existing_charge_ids = plan.charges.where(id: charge_ids).pluck(:id)
@@ -129,19 +150,19 @@ module Events
 
       result = recurring_charges_and_filters
 
-      values.each do |charge_id, filter_id|
+      values.each do |charge_id, filter_id, last_seen_at|
         # Charge has been removed from the plan
         next unless existing_charge_ids.include?(charge_id)
 
         # Charge has no filters or only default bucket received usage in the period
         if filter_id.blank?
-          result[charge_id] << nil
+          record(result, charge_id, nil, last_seen_at)
           next
         end
 
         # Keep only existing filters
         next unless existing_charge_filters.include?(filter_id)
-        result[charge_id] << filter_id
+        record(result, charge_id, filter_id, last_seen_at)
       end
 
       result
@@ -149,7 +170,7 @@ module Events
 
     def recurring_charges_and_filters
       # First period: no previous usage exists, events from current period are enough
-      return Hash.new { |h, k| h[k] = [] } if subscription.started_at >= boundaries.charges_from_datetime
+      return {} if subscription.started_at >= boundaries.charges_from_datetime
 
       # If the subscription was upgraded, use the upgrade chain to filter recurring charges
       return recurring_charges_and_filters_from_upgrade_chain if subscription.previous_subscription_id.present?
@@ -161,7 +182,7 @@ module Events
     def recurring_charges_and_filters_from_previous_fees
       pairs = current_subscription_recurring_fees
 
-      return Hash.new { |h, k| h[k] = [] } if pairs.empty?
+      return {} if pairs.empty?
 
       filter_ids = pairs.map(&:last).compact
       if filter_ids.any?
@@ -169,13 +190,12 @@ module Events
         pairs = pairs.select { |_, f_id| f_id.nil? || existing_filter_ids.include?(f_id) }
       end
 
-      pairs.then { group_by_charge_id(it) }
+      group_by_charge_id(pairs)
     end
 
     def recurring_charges_and_filters_from_upgrade_chain
       # First, let's fetch fees from the current subscription created before the current period
-      result = current_subscription_recurring_fees
-        .then { group_by_charge_id(it) }
+      result = group_by_charge_id(current_subscription_recurring_fees)
 
       # Then, include all filters for charges whose billable metric had previous usage
       previous_bm_ids = previous_subscriptions_billable_metric_ids
@@ -184,8 +204,8 @@ module Events
       current_recurring_charges.each do |charge|
         next unless previous_bm_ids.include?(charge.billable_metric_id)
 
-        filter_ids = charge.filters.map(&:id)
-        result[charge.id] = (result[charge.id] + filter_ids + [nil]).uniq
+        charge.filters.each { |filter| record(result, charge.id, filter.id, nil) }
+        record(result, charge.id, nil, nil)
       end
       result
     end
@@ -240,22 +260,11 @@ module Events
         .pluck(:charge_id, :charge_filter_id)
     end
 
-    # Group all charges and filters by charge_id
+    # Group charge/filter pairs (without a known timestamp) into the nested accumulator shape
     def group_by_charge_id(rows)
-      rows.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(charge_id, filter_id), hash|
-        hash[charge_id] << filter_id
+      rows.each_with_object({}) do |(charge_id, filter_id), accumulator|
+        record(accumulator, charge_id, filter_id, nil)
       end
-    end
-
-    # Include "default" bucket for recurring charges
-    def add_default_filter(charges_and_filters)
-      charges_and_filters.each_value { it << nil }
-      charges_and_filters
-    end
-
-    # Make sure all filters are unique for each charge
-    def deduplicate_filters(charges_and_filters)
-      charges_and_filters.transform_values(&:uniq)
     end
 
     def fetch_existing_filters(charge_filter_ids)

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -68,6 +68,7 @@ module Events
     end
 
     def expire_cached_charges
+      return if organization.feature_flag_enabled?(:lazy_charge_usage_cache)
       return if active_subscription.nil?
       return unless billable_metric
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -104,7 +104,7 @@ module Events
       end
 
       def distinct_codes_and_property_combinations(codes:, filter_keys:)
-        nil
+        []
       end
 
       def prorated_events_values(total_duration)

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -150,6 +150,8 @@ module Events
         SQL
       end
 
+      # Returns [charge_id, charge_filter_id, last_seen_at] tuples, where last_seen_at is the
+      # enriched_at of the most recent event for that charge/filter in the period.
       def distinct_charges_and_filters(codes: nil)
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = ::Clickhouse::EventsEnrichedExpanded
@@ -158,7 +160,8 @@ module Events
             .where(timestamp: from_datetime..to_datetime)
 
           scope = scope.where(code: codes) unless codes.nil?
-          scope.distinct.pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"))
+          scope.group("charge_id", "charge_filter_id")
+            .pluck("charge_id", Arel.sql("nullIf(charge_filter_id, '')"), Arel.sql("MAX(enriched_at)"))
         end
       end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -157,10 +157,11 @@ module Events
         ).distinct_charges_and_filters(codes:)
       end
 
-      # Returns the distinct [code, properties] combinations present in the events of the
-      # period. Only properties present in the filter_keys are considered, so the result holds
-      # only the dimensions that can be matched against charge filters.
+      # Returns the distinct [code, properties, last_seen_at] combinations present in the events
+      # of the period. Only properties present in the filter_keys are considered, so the result
+      # holds only the dimensions that can be matched against charge filters.
       # An empty hash represents the default (no filter) bucket.
+      # last_seen_at is the enriched_at of the most recent event in the combination.
       #
       # ClickHouse stores properties as a Map(String, String); a missing key reads back as an
       # empty string, so blank values are dropped to mirror the Postgres jsonb behaviour.
@@ -175,19 +176,22 @@ module Events
             .where("events_enriched.timestamp >= ?", from_datetime)
             .where("events_enriched.timestamp <= ?", applicable_to_datetime)
 
-          selects = ["DISTINCT code AS code"]
+          selects = ["code AS code"]
+          group_columns = ["code"]
           filter_keys.each_with_index do |key, index|
             selects << ActiveRecord::Base.sanitize_sql_array(["properties[?] AS prop_#{index}", key.to_s])
+            group_columns << "prop_#{index}"
           end
+          selects << "MAX(enriched_at) AS last_seen_at"
 
-          scope.select(selects.join(", ")).map do |row|
+          scope.select(selects.join(", ")).group(group_columns.join(", ")).map do |row|
             combination = {}
             filter_keys.each_with_index do |key, index|
               value = row.read_attribute("prop_#{index}")
               combination[key] = value if value.present?
             end
 
-            [row.code, combination]
+            [row.code, combination, row.read_attribute("last_seen_at")]
           end
         end
       end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -22,19 +22,23 @@ module Events
         filters_scope(scope)
       end
 
+      # Returns [charge_id, charge_filter_id, last_seen_at] tuples, where last_seen_at is the
+      # enriched_at of the most recent event for that charge/filter in the period.
       def distinct_charges_and_filters(codes: nil)
         scope = EnrichedEvent.where(organization_id: subscription.organization_id)
           .where(subscription_id: subscription.id)
           .where(timestamp: from_datetime..to_datetime)
 
         scope = scope.where(code: codes) unless codes.nil?
-        scope.distinct.pluck(:charge_id, :charge_filter_id)
+        scope.group(:charge_id, :charge_filter_id)
+          .pluck(:charge_id, :charge_filter_id, Arel.sql("MAX(enriched_at)"))
       end
 
-      # Returns the distinct [code, properties] combinations present in the events of the
-      # period. Only properties present in the filter_keys are considered, so the result holds
-      # only the dimensions that can be matched against charge filters.
+      # Returns the distinct [code, properties, last_seen_at] combinations present in the events
+      # of the period. Only properties present in the filter_keys are considered, so the result
+      # holds only the dimensions that can be matched against charge filters.
       # An empty hash represents the default (no filter) bucket.
+      # last_seen_at is the created_at of the most recent event in the combination.
       def distinct_codes_and_property_combinations(codes:, filter_keys:)
         scope = Event.where(external_subscription_id: subscription.external_id)
           .where(organization_id: subscription.organization_id)
@@ -44,14 +48,16 @@ module Events
 
         scope
           .select(Arel.sql(<<~SQL.squish))
-            DISTINCT events.code AS code,
+            events.code AS code,
             coalesce((
               SELECT jsonb_object_agg(props.key, props.value)
               FROM jsonb_each_text(events.properties) AS props(key, value)
               WHERE props.key = ANY(#{filter_keys_array_sql(filter_keys)})
-            ), '{}'::jsonb) AS combination
+            ), '{}'::jsonb) AS combination,
+            MAX(events.created_at) AS last_seen_at
           SQL
-          .map { |row| [row.code, parse_combination(row)] }
+          .group("code, combination")
+          .map { |row| [row.code, parse_combination(row), row.last_seen_at] }
       end
 
       def events_values(limit: nil, force_from: false, exclude_event: false)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -142,7 +142,7 @@ module Invoices
             plan:,
             customer:,
             skip_adjusted_fees: !adjusted_fee_exists,
-            filtered_aggregations: filters[charge.id] || []
+            filtered_aggregations: filters[charge.id]&.keys || []
           )
         end
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -120,7 +120,7 @@ module Invoices
     def compute_charge_fees
       fees = []
       filters = event_filters(subscription, boundaries).charges
-      charges.find_each { |c| fees += charge_usage(c, filters[c.id] || []) }
+      charges.find_each { |c| fees += charge_usage(c, filters[c.id] || {}) }
       return fees if usage_filters.has_charge_filter?
 
       fees.sort_by { |f| f.billable_metric.name.downcase }
@@ -131,7 +131,8 @@ module Invoices
         subscription:,
         charge:,
         to_datetime: boundaries.charges_to_datetime,
-        cache: cache_applicable?
+        cache: cache_applicable?,
+        last_seen_at: applied_filters
       )
 
       applied_boundaries = boundaries
@@ -152,7 +153,7 @@ module Invoices
           with_zero_units_filters:,
           # NOTE: current usage is computed on a non-persisted invoice, so adjusted fees never apply
           skip_adjusted_fees: true,
-          filtered_aggregations: applied_filters,
+          filtered_aggregations: applied_filters.keys,
           usage_filters:
         )
         .fees

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -211,6 +211,7 @@ module Invoices
       end
 
       context = OpenTelemetry::Context.current
+      charge_filters = Events::BillingPeriodFilterService.call!(subscription:, boundaries:).charges
 
       invoice.fees << Parallel.flat_map(charges, in_threads: ENV["LAGO_PARALLEL_THREADS_COUNT"]&.to_i || 0) do |charge|
         OpenTelemetry::Context.with_current(context) do
@@ -218,7 +219,8 @@ module Invoices
             cache_middleware = Subscriptions::ChargeCacheMiddleware.new(
               subscription:,
               charge:,
-              to_datetime: boundaries.charges_to_datetime
+              to_datetime: boundaries.charges_to_datetime,
+              last_seen_at: charge_filters[charge.id] || {}
             )
 
             Fees::ChargeService

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -211,7 +211,14 @@ module Invoices
       end
 
       context = OpenTelemetry::Context.current
-      charge_filters = Events::BillingPeriodFilterService.call!(subscription:, boundaries:).charges
+
+      # The last-seen timestamps are only consumed by the lazy cache validation. Skip the extra
+      # query when the feature flag is off, as the middleware ignores last_seen_at in that case.
+      charge_filters = if subscription.organization.feature_flag_enabled?(:lazy_charge_usage_cache)
+        Events::BillingPeriodFilterService.call!(subscription:, boundaries:).charges
+      else
+        {}
+      end
 
       invoice.fees << Parallel.flat_map(charges, in_threads: ENV["LAGO_PARALLEL_THREADS_COUNT"]&.to_i || 0) do |charge|
         OpenTelemetry::Context.with_current(context) do

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -101,7 +101,7 @@ module Invoices
           subscription:,
           context: :finalize,
           boundaries:,
-          filtered_aggregations: filters[charge.id] || []
+          filtered_aggregations: filters[charge.id]&.keys || []
         )
       end
     end

--- a/app/services/subscriptions/charge_cache_middleware.rb
+++ b/app/services/subscriptions/charge_cache_middleware.rb
@@ -4,17 +4,22 @@ module Subscriptions
   class ChargeCacheMiddleware
     EMPTY_ARRAY = [].freeze
 
-    def initialize(subscription:, charge:, to_datetime:, cache: true)
+    def initialize(subscription:, charge:, to_datetime:, cache: true, last_seen_at: nil)
       @subscription = subscription
       @charge = charge
       @to_datetime = to_datetime
       @cache = cache
+      @last_seen_at = last_seen_at || {}
     end
 
     def call(charge_filter:)
       return yield unless cache
 
-      json = Subscriptions::ChargeCacheService.call(subscription:, charge:, charge_filter:, expires_in: cache_expiration) do
+      # Lazily invalidate the cache when a more recent event was ingested for this charge/filter.
+      # last_seen_at is the { filter_id => timestamp } bucket for the current charge.
+      invalidate_if_older_than = last_seen_at[charge_filter&.id]
+
+      json = Subscriptions::ChargeCacheService.call(subscription:, charge:, charge_filter:, expires_in: cache_expiration, invalidate_if_older_than:) do
         yield
           .map do |fee|
             fee.attributes.merge(
@@ -47,7 +52,7 @@ module Subscriptions
 
     private
 
-    attr_reader :subscription, :charge, :to_datetime, :cache
+    attr_reader :subscription, :charge, :to_datetime, :cache, :last_seen_at
 
     def cache_expiration
       return 0 unless to_datetime

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -3,6 +3,10 @@
 module Subscriptions
   class ChargeCacheService < CacheService
     CACHE_KEY_VERSION = "1"
+    # Lazy validation stores a different value shape (wrapped with its creation time), so it uses
+    # its own version. Enabling the feature flag gradually migrates an organization's entries to
+    # this version instead of invalidating every organization's cache at once.
+    LAZY_CACHE_KEY_VERSION = "2"
 
     def self.expire_for_subscriptions(subscription_ids)
       Subscription
@@ -27,12 +31,12 @@ module Subscriptions
       expire_cache(subscription:, charge:)
     end
 
-    def initialize(subscription:, charge:, charge_filter: nil, expires_in: nil)
+    def initialize(subscription:, charge:, charge_filter: nil, expires_in: nil, invalidate_if_older_than: nil)
       @subscription = subscription
       @charge = charge
       @charge_filter = charge_filter
 
-      super(expires_in:)
+      super(expires_in:, invalidate_if_older_than:)
     end
 
     # IMPORTANT
@@ -40,7 +44,7 @@ module Subscriptions
     def cache_key
       [
         "charge-usage",
-        CACHE_KEY_VERSION,
+        cache_key_version,
         charge.id,
         subscription.id,
         charge.updated_at.iso8601,
@@ -52,5 +56,19 @@ module Subscriptions
     private
 
     attr_reader :subscription, :charge, :charge_filter
+
+    def cache_key_version
+      lazy_validation? ? LAZY_CACHE_KEY_VERSION : CACHE_KEY_VERSION
+    end
+
+    def track_created_at?
+      lazy_validation?
+    end
+
+    def lazy_validation?
+      return @lazy_validation if defined?(@lazy_validation)
+
+      @lazy_validation = subscription.organization.feature_flag_enabled?(:lazy_charge_usage_cache)
+    end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5880,6 +5880,7 @@ Organization Feature Flag Values
 enum FeatureFlagEnum {
   enriched_events_aggregation
   fixed_charge_usage_delta_migration
+  lazy_charge_usage_cache
   meilisearch
   multi_connection
   multi_currency

--- a/schema.json
+++ b/schema.json
@@ -28669,6 +28669,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "lazy_charge_usage_cache",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -70,6 +70,122 @@ RSpec.describe CacheService do
     end
   end
 
+  describe "#call with lazy validation" do
+    let(:tracking_cache_service_class) do
+      Class.new(described_class) do
+        def initialize(key_suffix = nil, expires_in: nil, invalidate_if_older_than: nil)
+          @key_suffix = key_suffix
+          super(nil, expires_in:, invalidate_if_older_than:)
+        end
+
+        def cache_key
+          "tracking_cache_service:#{@key_suffix}"
+        end
+
+        private
+
+        def track_created_at?
+          true
+        end
+      end
+    end
+
+    let(:cache_key) { "tracking_cache_service:test" }
+    let(:new_value) { "new_value" }
+
+    before { allow(Rails.cache).to receive(:write) }
+
+    it "wraps the stored value, falling back to the write time when no event was seen" do
+      allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+
+      freeze_time do
+        result = tracking_cache_service_class.new("test").call { new_value }
+
+        expect(result).to eq(new_value)
+        expect(Rails.cache).to have_received(:write).with(
+          cache_key,
+          {"cached_at" => Time.current.iso8601(6), "value" => new_value},
+          expires_in: nil
+        )
+      end
+    end
+
+    it "stamps cached_at with the last seen event timestamp, not the write time" do
+      allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+      last_seen_at = 3.hours.ago
+
+      tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at).call { new_value }
+
+      expect(Rails.cache).to have_received(:write).with(
+        cache_key,
+        {"cached_at" => last_seen_at.iso8601(6), "value" => new_value},
+        expires_in: nil
+      )
+    end
+
+    it "keeps the sub-second precision so a re-read for the same event stays valid" do
+      last_seen_at = Time.current.change(usec: 750_000)
+
+      allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+      tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at).call { new_value }
+
+      wrapped = nil
+      expect(Rails.cache).to have_received(:write) { |_key, value, **| wrapped = value }
+
+      allow(Rails.cache).to receive(:read).with(cache_key).and_return(wrapped)
+      service = tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at)
+
+      block_called = false
+      result = service.call { block_called = true }
+
+      expect(result).to eq(new_value)
+      expect(block_called).to be false
+    end
+
+    context "when a wrapped value exists" do
+      let(:cached_at) { 1.hour.ago }
+      let(:cached) { {"cached_at" => cached_at.iso8601, "value" => "cached_value"} }
+
+      before { allow(Rails.cache).to receive(:read).with(cache_key).and_return(cached) }
+
+      it "returns the unwrapped value when no newer event was ingested" do
+        service = tracking_cache_service_class.new("test", invalidate_if_older_than: 2.hours.ago)
+
+        block_called = false
+        result = service.call { block_called = true }
+
+        expect(result).to eq("cached_value")
+        expect(block_called).to be false
+      end
+
+      it "recomputes when a more recent event was ingested" do
+        service = tracking_cache_service_class.new("test", invalidate_if_older_than: Time.current)
+
+        result = service.call { new_value }
+
+        expect(result).to eq(new_value)
+      end
+
+      it "returns the unwrapped value when no last event timestamp is given" do
+        result = tracking_cache_service_class.new("test").call { new_value }
+
+        expect(result).to eq("cached_value")
+      end
+    end
+
+    context "when a legacy unwrapped value exists" do
+      before { allow(Rails.cache).to receive(:read).with(cache_key).and_return("legacy_value") }
+
+      it "recomputes so the entry is rewritten in the new shape" do
+        service = tracking_cache_service_class.new("test", invalidate_if_older_than: 1.hour.ago)
+
+        result = service.call { new_value }
+
+        expect(result).to eq(new_value)
+      end
+    end
+  end
+
   describe "#expire_cache" do
     let(:cache_service) { test_cache_service_class.new("test") }
     let(:cache_key) { cache_service.cache_key }

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         result = filter_service.call
 
         expect(result).to be_success
-        expect(result.charges).to eq({})
+        expect(result.charges.transform_values(&:keys)).to eq({})
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         result = filter_service.call
 
         expect(result).to be_success
-        expect(result.charges).to eq({recurring_charge.id => [charge_filter.id]})
+        expect(result.charges.transform_values(&:keys)).to eq({recurring_charge.id => [charge_filter.id]})
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         result = filter_service.call
 
         expect(result).to be_success
-        expect(result.charges).to eq({})
+        expect(result.charges.transform_values(&:keys)).to eq({})
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         result = filter_service.call
 
         expect(result).to be_success
-        expect(result.charges).to eq({})
+        expect(result.charges.transform_values(&:keys)).to eq({})
       end
     end
 
@@ -140,7 +140,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({recurring_charge.id => [nil]})
+          expect(result.charges.transform_values(&:keys)).to eq({recurring_charge.id => [nil]})
         end
       end
 
@@ -166,7 +166,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({recurring_charge.id => [nil]})
+          expect(result.charges.transform_values(&:keys)).to eq({recurring_charge.id => [nil]})
         end
       end
 
@@ -192,7 +192,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
 
@@ -214,7 +214,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to match({recurring_charge.id => contain_exactly(charge_filter.id, nil)})
+          expect(result.charges.transform_values(&:keys)).to match({recurring_charge.id => contain_exactly(charge_filter.id, nil)})
         end
       end
 
@@ -237,7 +237,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to match({recurring_charge.id => contain_exactly(charge_filter.id, nil)})
+          expect(result.charges.transform_values(&:keys)).to match({recurring_charge.id => contain_exactly(charge_filter.id, nil)})
         end
       end
 
@@ -268,7 +268,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to match({recurring_charge.id => contain_exactly(charge_filter.id, nil)})
+          expect(result.charges.transform_values(&:keys)).to match({recurring_charge.id => contain_exactly(charge_filter.id, nil)})
         end
 
         context "when previous fees have no units" do
@@ -287,7 +287,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to eq({})
+            expect(result.charges.transform_values(&:keys)).to eq({})
           end
         end
       end
@@ -297,7 +297,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
 
@@ -328,7 +328,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to match({recurring_charge.id => contain_exactly(charge_filter.id, nil)})
+          expect(result.charges.transform_values(&:keys)).to match({recurring_charge.id => contain_exactly(charge_filter.id, nil)})
         end
       end
     end
@@ -355,7 +355,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         result = filter_service.call
 
         expect(result).to be_success
-        expect(result.charges).to eq({})
+        expect(result.charges.transform_values(&:keys)).to eq({})
       end
     end
   end
@@ -401,7 +401,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         result = filter_service.call
 
         expect(result).to be_success
-        expect(result.charges).to eq({})
+        expect(result.charges.transform_values(&:keys)).to eq({})
       end
 
       context "with events matching the boundaries" do
@@ -429,7 +429,14 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({charge.id => [nil]})
+          expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil]})
+        end
+
+        it "returns the last seen timestamp per charge/filter" do
+          result = filter_service.call
+
+          expect(result.charges[charge.id].keys).to eq([nil])
+          expect(result.charges[charge.id][nil]).to be_present
         end
 
         context "with multiple charges for the same billable_metric" do
@@ -441,7 +448,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to eq({charge.id => [nil], charge_2.id => [nil]})
+            expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil], charge_2.id => [nil]})
           end
         end
 
@@ -466,7 +473,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to eq({charge.id => [nil], charge_2.id => [nil]})
+            expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil], charge_2.id => [nil]})
           end
         end
 
@@ -486,7 +493,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id, charge_filter2.id)})
+            expect(result.charges.transform_values(&:keys)).to match({charge.id => contain_exactly(charge_filter.id, charge_filter2.id)})
           end
         end
 
@@ -510,7 +517,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to eq({charge.id => [charge_filter.id]})
+            expect(result.charges.transform_values(&:keys)).to eq({charge.id => [charge_filter.id]})
           end
         end
 
@@ -538,7 +545,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id, nil)})
+            expect(result.charges.transform_values(&:keys)).to match({charge.id => contain_exactly(charge_filter.id, nil)})
           end
         end
       end
@@ -563,7 +570,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({recurring_charge.id => [charge_filter.id, nil]})
+          expect(result.charges.transform_values(&:keys)).to eq({recurring_charge.id => [charge_filter.id, nil]})
         end
       end
 
@@ -582,7 +589,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
 
@@ -601,7 +608,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
 
@@ -625,7 +632,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         result = filter_service.call
 
         expect(result).to be_success
-        expect(result.charges).to eq({})
+        expect(result.charges.transform_values(&:keys)).to eq({})
       end
 
       context "with events matching the boundaries" do
@@ -675,7 +682,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({charge.id => [nil]})
+          expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil]})
         end
 
         context "with multiple charges for the same billable_metric" do
@@ -725,7 +732,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to eq({charge.id => [nil], charge_2.id => [nil]})
+            expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil], charge_2.id => [nil]})
           end
         end
 
@@ -760,7 +767,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to eq({charge.id => [nil], charge_2.id => [nil]})
+            expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil], charge_2.id => [nil]})
           end
         end
 
@@ -780,7 +787,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id)})
+            expect(result.charges.transform_values(&:keys)).to match({charge.id => contain_exactly(charge_filter.id)})
           end
 
           context "when events matches the default bucket" do
@@ -826,7 +833,7 @@ RSpec.describe Events::BillingPeriodFilterService do
               result = filter_service.call
 
               expect(result).to be_success
-              expect(result.charges).to match({charge.id => [nil]})
+              expect(result.charges.transform_values(&:keys)).to match({charge.id => [nil]})
             end
           end
         end
@@ -862,7 +869,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
 
@@ -890,7 +897,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
     end
@@ -904,7 +911,7 @@ RSpec.describe Events::BillingPeriodFilterService do
         result = filter_service.call
 
         expect(result).to be_success
-        expect(result.charges).to eq({})
+        expect(result.charges.transform_values(&:keys)).to eq({})
       end
 
       context "with events matching the boundaries" do
@@ -949,7 +956,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({charge.id => [nil]})
+          expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil]})
         end
 
         context "with multiple charges for the same billable_metric" do
@@ -980,7 +987,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to eq({charge.id => [nil], charge_2.id => [nil]})
+            expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil], charge_2.id => [nil]})
           end
         end
 
@@ -1034,7 +1041,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to eq({charge.id => [nil], charge_2.id => [nil]})
+            expect(result.charges.transform_values(&:keys)).to eq({charge.id => [nil], charge_2.id => [nil]})
           end
         end
 
@@ -1054,7 +1061,7 @@ RSpec.describe Events::BillingPeriodFilterService do
             result = filter_service.call
 
             expect(result).to be_success
-            expect(result.charges).to match({charge.id => contain_exactly(charge_filter.id)})
+            expect(result.charges.transform_values(&:keys)).to match({charge.id => contain_exactly(charge_filter.id)})
           end
 
           context "when events matches the default bucket" do
@@ -1085,7 +1092,7 @@ RSpec.describe Events::BillingPeriodFilterService do
               result = filter_service.call
 
               expect(result).to be_success
-              expect(result.charges).to match({charge.id => [nil]})
+              expect(result.charges.transform_values(&:keys)).to match({charge.id => [nil]})
             end
           end
         end
@@ -1130,7 +1137,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
 
@@ -1167,7 +1174,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
 
@@ -1203,7 +1210,7 @@ RSpec.describe Events::BillingPeriodFilterService do
           result = filter_service.call
 
           expect(result).to be_success
-          expect(result.charges).to eq({})
+          expect(result.charges.transform_values(&:keys)).to eq({})
         end
       end
 

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe Events::BillingPeriodFilterService do
         expect(result).to be_success
         expect(result.charges.transform_values(&:keys)).to eq({recurring_charge.id => [charge_filter.id]})
       end
+
+      it "seeds the carried-over usage with the period start" do
+        result = filter_service.call
+
+        expect(result.charges[recurring_charge.id][charge_filter.id]).to eq(boundaries.charges_from_datetime)
+      end
     end
 
     context "when no previous fees exist" do
@@ -571,6 +577,35 @@ RSpec.describe Events::BillingPeriodFilterService do
 
           expect(result).to be_success
           expect(result.charges.transform_values(&:keys)).to eq({recurring_charge.id => [charge_filter.id, nil]})
+        end
+
+        it "seeds every recurring bucket with the period start when there are no events" do
+          result = filter_service.call
+
+          expect(result.charges[recurring_charge.id][charge_filter.id]).to eq(boundaries.charges_from_datetime)
+          expect(result.charges[recurring_charge.id][nil]).to eq(boundaries.charges_from_datetime)
+        end
+
+        context "with events in the period" do
+          before do
+            create(
+              :event,
+              organization_id: organization.id,
+              external_subscription_id: subscription.external_id,
+              timestamp: boundaries.charges_from_datetime + 5.days,
+              code: recurring_billable_metric.code,
+              properties: {"region" => "eu"}
+            )
+          end
+
+          it "refreshes the matching bucket's last_seen_at while leaving the unmatched bucket seeded" do
+            result = filter_service.call
+
+            expect(result).to be_success
+            expect(result.charges[recurring_charge.id].keys).to match_array([charge_filter.id, nil])
+            expect(result.charges[recurring_charge.id][charge_filter.id]).to be > boundaries.charges_from_datetime
+            expect(result.charges[recurring_charge.id][nil]).to eq(boundaries.charges_from_datetime)
+          end
         end
       end
 

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -49,6 +49,29 @@ RSpec.describe Events::PostProcessService do
         .with(subscription:, organization:, date: expected_date)
     end
 
+    describe "charge usage cache expiration" do
+      it "expires the charge usage cache for the matching charges" do
+        allow(Subscriptions::ChargeCacheService).to receive(:expire_cache)
+
+        process_service.call
+
+        expect(Subscriptions::ChargeCacheService).to have_received(:expire_cache)
+          .with(subscription:, charge:, charge_filter: nil)
+      end
+
+      context "when the lazy charge usage cache flag is enabled" do
+        let(:organization) { create(:organization, feature_flags: [:lazy_charge_usage_cache]) }
+
+        it "does not expire the cache, letting the read-time validation handle it" do
+          allow(Subscriptions::ChargeCacheService).to receive(:expire_cache)
+
+          process_service.call
+
+          expect(Subscriptions::ChargeCacheService).not_to have_received(:expire_cache)
+        end
+      end
+    end
+
     context "with events enrichment" do
       it "does not create an enriched event" do
         expect { process_service.call }.not_to change(EnrichedEvent, :count)

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -2727,21 +2727,25 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         )
       end
 
-      it "returns distinct charges and filters" do
-        expect(event_store.distinct_charges_and_filters).to match_array([[charge.id, charge_filter.id]])
+      it "returns distinct charges and filters with the last seen timestamp" do
+        result = event_store.distinct_charges_and_filters
+
+        expect(result.map { |row| row[0..1] }).to match_array([[charge.id, charge_filter.id]])
+        expect(result.map(&:last)).to all(be_present)
       end
 
       context "when charge_filter is nil" do
         let(:charge_filter) { nil }
 
         it "returns the distinct event codes" do
-          expect(event_store.distinct_charges_and_filters).to match_array([[charge.id, nil]])
+          expect(event_store.distinct_charges_and_filters.map { |row| row[0..1] }).to match_array([[charge.id, nil]])
         end
       end
 
       context "when codes are provided" do
         it "returns only the charges and filters matching the provided codes" do
-          expect(event_store.distinct_charges_and_filters(codes: [code])).to match_array([[charge.id, charge_filter.id]])
+          matching = event_store.distinct_charges_and_filters(codes: [code])
+          expect(matching.map { |row| row[0..1] }).to match_array([[charge.id, charge_filter.id]])
           expect(event_store.distinct_charges_and_filters(codes: ["unknown_code"])).to eq([])
         end
       end
@@ -2762,17 +2766,18 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
       it "returns the distinct property combinations sliced to the filter keys" do
         result = event_store.distinct_codes_and_property_combinations(codes: [code], filter_keys: %w[region provider])
 
-        expect(result).to match_array([
+        expect(result.map { |row| row[0..1] }).to match_array([
           [code, {"region" => "eu", "provider" => "aws"}],
           [code, {"region" => "us", "provider" => "gcp"}],
           [code, {"region" => "eu"}]
         ])
+        expect(result.map(&:last)).to all(be_present)
       end
 
       it "ignores property keys that are not filter keys" do
         result = event_store.distinct_codes_and_property_combinations(codes: [code], filter_keys: ["region"])
 
-        expect(result).to match_array([
+        expect(result.map { |row| row[0..1] }).to match_array([
           [code, {"region" => "eu"}],
           [code, {"region" => "us"}]
         ])
@@ -2782,7 +2787,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         it "returns the default bucket combination" do
           result = event_store.distinct_codes_and_property_combinations(codes: [code], filter_keys: [])
 
-          expect(result).to eq([[code, {}]])
+          expect(result.map { |row| row[0..1] }).to eq([[code, {}]])
         end
       end
 
@@ -2806,7 +2811,7 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
         it "excludes them from the combinations" do
           result = event_store.distinct_codes_and_property_combinations(codes: [code], filter_keys: %w[region provider])
 
-          expect(result).not_to include([code, {"region" => "apac", "provider" => "azure"}])
+          expect(result.map { |row| row[0..1] }).not_to include([code, {"region" => "apac", "provider" => "azure"}])
         end
       end
     end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Fees::ChargeService, :premium do
+  # The charge usage cache wraps its payload with a creation time; unwrap it for assertions.
+  def read_cached_usage(key)
+    cached = Rails.cache.read(key)
+    cached.is_a?(Hash) ? cached["value"] : cached
+  end
+
   subject(:charge_subscription_service) do
     described_class.new(
       invoice:,
@@ -3489,7 +3495,7 @@ RSpec.describe Fees::ChargeService, :premium do
             it "caches an empty array" do
               charge_subscription_service.call
 
-              cached_value = Rails.cache.read(cache_key)
+              cached_value = read_cached_usage(cache_key)
               expect(cached_value).to eq("[]")
             end
 
@@ -3524,7 +3530,7 @@ RSpec.describe Fees::ChargeService, :premium do
               it "caches empty array and returns zero fee with correct amount_details on subsequent call" do
                 charge_subscription_service.call
 
-                cached_value = Rails.cache.read(cache_key)
+                cached_value = read_cached_usage(cache_key)
                 expect(cached_value).to eq("[]")
 
                 second_result = charge_subscription_service.call
@@ -3560,7 +3566,7 @@ RSpec.describe Fees::ChargeService, :premium do
               it "caches empty array and returns zero fee with correct amount_details on subsequent call" do
                 charge_subscription_service.call
 
-                cached_value = Rails.cache.read(cache_key)
+                cached_value = read_cached_usage(cache_key)
                 expect(cached_value).to eq("[]")
 
                 second_result = charge_subscription_service.call
@@ -3590,7 +3596,7 @@ RSpec.describe Fees::ChargeService, :premium do
               it "caches empty array and returns zero fee with correct amount_details on subsequent call" do
                 charge_subscription_service.call
 
-                cached_value = Rails.cache.read(cache_key)
+                cached_value = read_cached_usage(cache_key)
                 expect(cached_value).to eq("[]")
 
                 second_result = charge_subscription_service.call
@@ -3626,7 +3632,7 @@ RSpec.describe Fees::ChargeService, :premium do
               it "caches empty array and returns zero fee without raising on subsequent call" do
                 charge_subscription_service.call
 
-                cached_value = Rails.cache.read(cache_key)
+                cached_value = read_cached_usage(cache_key)
                 expect(cached_value).to eq("[]")
 
                 second_result = charge_subscription_service.call
@@ -3666,7 +3672,7 @@ RSpec.describe Fees::ChargeService, :premium do
               it "caches empty array and returns zero fee with correct amount_details on subsequent call" do
                 charge_subscription_service.call
 
-                cached_value = Rails.cache.read(cache_key)
+                cached_value = read_cached_usage(cache_key)
                 expect(cached_value).to eq("[]")
 
                 second_result = charge_subscription_service.call
@@ -3699,7 +3705,7 @@ RSpec.describe Fees::ChargeService, :premium do
               it "caches empty array and returns zero fee with correct amount_details on subsequent call" do
                 charge_subscription_service.call
 
-                cached_value = Rails.cache.read(cache_key)
+                cached_value = read_cached_usage(cache_key)
                 expect(cached_value).to eq("[]")
 
                 second_result = charge_subscription_service.call
@@ -3735,7 +3741,7 @@ RSpec.describe Fees::ChargeService, :premium do
               it "caches empty array and returns zero fee with correct grouped_by on subsequent call" do
                 charge_subscription_service.call
 
-                cached_value = Rails.cache.read(cache_key)
+                cached_value = read_cached_usage(cache_key)
                 expect(cached_value).to eq("[]")
 
                 second_result = charge_subscription_service.call
@@ -3761,7 +3767,7 @@ RSpec.describe Fees::ChargeService, :premium do
             it "caches the fee data" do
               charge_subscription_service.call
 
-              cached_value = Rails.cache.read(cache_key)
+              cached_value = read_cached_usage(cache_key)
               parsed = JSON.parse(cached_value)
               expect(parsed.length).to eq(1)
               expect(parsed.first["events_count"]).to eq(1)
@@ -3805,7 +3811,7 @@ RSpec.describe Fees::ChargeService, :premium do
 
               it "keeps presentation_breakdowns on subsequent calls from cache" do
                 first_result = charge_subscription_service.call
-                cached_value = Rails.cache.read(cache_key)
+                cached_value = read_cached_usage(cache_key)
                 second_result = charge_subscription_service.call
 
                 expect(first_result).to be_success
@@ -3868,14 +3874,14 @@ RSpec.describe Fees::ChargeService, :premium do
                 europe_cache_key = Subscriptions::ChargeCacheService.new(
                   subscription:, charge:, charge_filter: europe_filter
                 ).cache_key
-                europe_cached = JSON.parse(Rails.cache.read(europe_cache_key))
+                europe_cached = JSON.parse(read_cached_usage(europe_cache_key))
                 expect(europe_cached.length).to eq(1)
                 expect(europe_cached.first["events_count"]).to eq(1)
 
                 usa_cache_key = Subscriptions::ChargeCacheService.new(
                   subscription:, charge:, charge_filter: usa_filter
                 ).cache_key
-                expect(Rails.cache.read(usa_cache_key)).to eq("[]")
+                expect(read_cached_usage(usa_cache_key)).to eq("[]")
               end
 
               it "returns consistent results on subsequent calls from cache" do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -513,6 +513,28 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
                 preview_service.call
               end.to change { Rails.cache.exist?(key) }.from(false).to(true)
             end
+
+            context "when the lazy charge usage cache flag is enabled", transaction: false do
+              before { organization.enable_feature_flag!(:lazy_charge_usage_cache) }
+
+              it "resolves the last-seen timestamps to feed the lazy cache" do
+                allow(Events::BillingPeriodFilterService).to receive(:call!).and_call_original
+
+                travel_to(timestamp) { preview_service.call }
+
+                expect(Events::BillingPeriodFilterService).to have_received(:call!)
+              end
+            end
+
+            context "when the lazy charge usage cache flag is disabled", transaction: false do
+              it "does not resolve the last-seen timestamps" do
+                allow(Events::BillingPeriodFilterService).to receive(:call!).and_call_original
+
+                travel_to(timestamp) { preview_service.call }
+
+                expect(Events::BillingPeriodFilterService).not_to have_received(:call!)
+              end
+            end
           end
 
           context "with fixed charges" do

--- a/spec/services/subscriptions/charge_cache_middleware_spec.rb
+++ b/spec/services/subscriptions/charge_cache_middleware_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ChargeCacheMiddleware do
+  subject(:middleware) do
+    described_class.new(subscription:, charge:, to_datetime:, cache: cache_enabled, last_seen_at:)
+  end
+
+  let(:subscription) { create(:subscription) }
+  let(:charge) { create(:standard_charge, plan: subscription.plan) }
+  let(:to_datetime) { Time.current + 1.day }
+  let(:cache_enabled) { true }
+  let(:last_seen_at) { {} }
+  let(:charge_filter) { nil }
+
+  let(:cache_key) do
+    Subscriptions::ChargeCacheService.new(subscription:, charge:, charge_filter:).cache_key
+  end
+
+  before do
+    subscription.organization.enable_feature_flag!(:lazy_charge_usage_cache)
+    Rails.cache.clear
+  end
+
+  describe "#call", cache: :memory do
+    context "when caching is disabled" do
+      let(:cache_enabled) { false }
+
+      it "yields and returns the block result without touching the cache" do
+        fees = [build(:charge_fee, subscription:, charge:)]
+        allow(Rails.cache).to receive(:read)
+
+        result = middleware.call(charge_filter:) { fees }
+
+        expect(result).to eq(fees)
+        expect(Rails.cache).not_to have_received(:read)
+      end
+    end
+
+    context "when the cache is empty" do
+      let(:fee) { build(:charge_fee, subscription:, charge:, amount_cents: 999) }
+
+      it "computes and returns the rebuilt fees" do
+        result = middleware.call(charge_filter:) { [fee] }
+
+        expect(result.map(&:amount_cents)).to eq([999])
+      end
+
+      it "stores the value wrapped with its creation time" do
+        freeze_time do
+          middleware.call(charge_filter:) { [fee] }
+
+          cached = Rails.cache.read(cache_key)
+          expect(cached["cached_at"]).to eq(Time.current.iso8601(6))
+          expect(JSON.parse(cached["value"]).first["amount_cents"]).to eq(999)
+        end
+      end
+    end
+
+    context "when a valid cache entry exists" do
+      before do
+        Rails.cache.write(
+          cache_key,
+          {"cached_at" => 1.hour.ago.iso8601, "value" => [{"amount_cents" => 500}].to_json}
+        )
+      end
+
+      it "returns the cached fees without calling the block" do
+        block_called = false
+        result = middleware.call(charge_filter:) do
+          block_called = true
+          []
+        end
+
+        expect(block_called).to be false
+        expect(result.map(&:amount_cents)).to eq([500])
+      end
+
+      context "when a more recent event was ingested for the charge" do
+        let(:last_seen_at) { {nil => Time.current} }
+
+        it "recomputes by calling the block" do
+          fee = build(:charge_fee, subscription:, charge:, amount_cents: 777)
+
+          result = middleware.call(charge_filter:) { [fee] }
+
+          expect(result.map(&:amount_cents)).to eq([777])
+        end
+      end
+
+      context "when an older event was ingested for the charge" do
+        let(:last_seen_at) { {nil => 2.hours.ago} }
+
+        it "returns the cached fees without calling the block" do
+          block_called = false
+          result = middleware.call(charge_filter:) do
+            block_called = true
+            []
+          end
+
+          expect(block_called).to be false
+          expect(result.map(&:amount_cents)).to eq([500])
+        end
+      end
+    end
+
+    context "with a charge filter" do
+      let(:charge_filter) { create(:charge_filter, charge:) }
+      let(:last_seen_at) { {charge_filter.id => Time.current} }
+
+      before do
+        Rails.cache.write(
+          cache_key,
+          {"cached_at" => 1.hour.ago.iso8601, "value" => [{"amount_cents" => 500}].to_json}
+        )
+      end
+
+      it "looks up the last seen timestamp by charge and filter" do
+        fee = build(:charge_fee, subscription:, charge:, amount_cents: 321)
+
+        result = middleware.call(charge_filter:) { [fee] }
+
+        expect(result.map(&:amount_cents)).to eq([321])
+      end
+    end
+
+    context "when the cached fee carries a pricing unit usage and presentation breakdowns" do
+      let(:pricing_unit_usage) { build(:pricing_unit_usage) }
+      let(:fee) do
+        build(:charge_fee, subscription:, charge:, amount_cents: 42, pricing_unit_usage:)
+      end
+
+      it "reconstructs them from the cache" do
+        result = middleware.call(charge_filter:) { [fee] }
+
+        expect(result.first.amount_cents).to eq(42)
+        expect(result.first.pricing_unit_usage).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Subscriptions::ChargeCacheService do
           .to eq("charge-usage/#{described_class::CACHE_KEY_VERSION}/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}/#{charge_filter.id}/#{charge_filter.updated_at.iso8601}")
       end
     end
+
+    context "when the lazy charge usage cache flag is enabled" do
+      before { subscription.organization.enable_feature_flag!(:lazy_charge_usage_cache) }
+
+      it "uses the lazy cache key version" do
+        expect(cache_service.cache_key)
+          .to eq("charge-usage/#{described_class::LAZY_CACHE_KEY_VERSION}/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}")
+      end
+    end
   end
 
   describe "#expire_cache" do


### PR DESCRIPTION
## Context

Charge usage cache was invalidated eagerly, deleting entries on every event reception. With ClickHouse events are ingested asynchronously, so it leads to race condition depending how the cache was invalidated and rebuilt.

## Description

This PR adds a lazy cache validation strategy behind the `lazy_charge_usage_cache` feature flag.
Entries are stamped with the ingestion timestamp of the most recent event they were computed from, and recomputed at read time when a newer event exists, instead of being deleted on reception.

`Events::BillingPeriodFilterService` now returns the last-seen timestamp per charge/filter (`created_at` on Postgres, `enriched_at` on ClickHouse), exposed by the event store stores. The result becomes `{ charge_id => { filter_id => last_seen_at } }`.

Recurring charges carry over from previous periods and might not have in-period event, so they are seeded with the period start. This makes sure that the cache will be invalidated at the start of the period and lets any in-period event invalidate it and guards against ingestion lag.