### PR TITLE
fix(payment-gated-subs): charge gated invoices without the checkout delay

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -121,6 +121,8 @@ module Invoices
       # Only the first automatic attempt is delayed; retries keep payment_attempts positive.
       def defer_for_checkout_customer?
         return false unless invoice.payment_attempts.zero?
+        # Payment-gated subscriptions activate synchronously, so charge now instead of deferring.
+        return false if invoice.subscription_payment_gated?
 
         PaymentIntent.joins(:invoice).where(invoices: {customer_id: invoice.customer_id}).exists?
       end

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -767,6 +767,17 @@ RSpec.describe Invoices::Payments::CreateService do
             .at(:no_wait)
         end
       end
+
+      context "when the invoice gates a payment-gated subscription" do
+        before { allow(invoice).to receive(:subscription_payment_gated?).and_return(true) }
+
+        it "enqueues the payment immediately" do
+          expect { ApplicationRecord.transaction { create_service.call_async } }
+            .to have_enqueued_job(Invoices::Payments::CreateJob)
+            .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+            .at(:no_wait)
+        end
+      end
     end
 
     context "when the customer has never used a checkout URL" do


### PR DESCRIPTION
## Context

For any org that has ever used hosted checkout (a `PaymentIntent` exists for the customer), Lago intentionally defers the **first** automatic charge on an invoice by `CHECKOUT_AUTO_PAYMENT_DELAY` (~10 min). This gives a customer-initiated checkout payment time to settle so we don't double-charge.

Payment-gated subscriptions break under this rule. The activation funnel is synchronous: a payment-gated subscription creates an **open** invoice and stays `incomplete` until that invoice's payment succeeds. There is no competing manual payment in this flow, so the 10-minute deferral just makes the user wait ~10 min for the subscription to activate witch dont make sense

## Description

`Invoices::Payments::CreateService#defer_for_checkout_customer?` now returns early for invoices that gate a payment-gated subscription (`invoice.subscription_payment_gated?`), so their auto-payment is enqueued immediately. The deferral is unchanged for every other hosted-checkout invoice.