### PR TITLE
refactor: replace direct OpenStruct usages with Data value objects

### DIFF
--- a/app/graphql/mutations/integrations/fetch_draft_invoice_taxes.rb
+++ b/app/graphql/mutations/integrations/fetch_draft_invoice_taxes.rb
@@ -27,11 +27,33 @@ module Mutations
 
       private
 
-      # Note: We need to pass invoice object to the service that return taxes. This service should
-      # work with real invoice objects. In this case, it should also work with invoice that is not stored yet,
-      # because we need to fetch taxes for one-off invoice UI form.
+      # One-off invoices previewed from the UI are not persisted yet, so we build lightweight
+      # stand-ins exposing only the subset of the Invoice / Fee interface the tax payloads read.
+      # They fail loudly if a payload starts reading an attribute we did not anticipate.
+      DraftInvoice = Data.define(:issuing_date, :currency, :customer) do
+        def voided? = false
+      end
+
+      DraftFee = Data.define(:add_on_id, :item_id, :sub_total_excluding_taxes_amount_cents) do
+        def id = nil
+
+        def item_key = nil
+
+        def units = nil
+
+        def amount_cents = nil
+
+        def charge? = false
+
+        def fixed_charge? = false
+
+        def commitment? = false
+
+        def subscription? = false
+      end
+
       def invoice(customer, args)
-        OpenStruct.new(
+        DraftInvoice.new(
           issuing_date: Time.current.in_time_zone(customer.applicable_timezone).to_date,
           currency: args[:currency],
           customer:
@@ -43,7 +65,7 @@ module Mutations
           unit_amount_cents = fee[:unit_amount_cents]
           units = fee[:units]&.to_f || 1
 
-          OpenStruct.new(
+          DraftFee.new(
             add_on_id: fee[:add_on_id],
             item_id: fee[:add_on_id],
             sub_total_excluding_taxes_amount_cents: (unit_amount_cents * units).round

--- a/app/services/invoices/apply_provider_taxes_service.rb
+++ b/app/services/invoices/apply_provider_taxes_service.rb
@@ -4,6 +4,9 @@ module Invoices
   class ApplyProviderTaxesService < BaseService
     Result = BaseResult[:applied_taxes, :invoice]
 
+    # Minimal tax descriptor used only to group fees under a common key in indexed_fees.
+    GroupingTax = Data.define(:name, :rate, :type)
+
     def initialize(invoice:, provider_taxes: nil)
       @invoice = invoice
       @provider_taxes = provider_taxes || fetch_provider_taxes_result.fees
@@ -79,7 +82,7 @@ module Invoices
     def indexed_fees
       @indexed_fees ||= invoice.fees.each_with_object({}) do |fee, applied_taxes|
         fee.applied_taxes.each do |applied_tax|
-          tax = OpenStruct.new(
+          tax = GroupingTax.new(
             name: applied_tax.tax_name,
             rate: applied_tax.tax_rate,
             type: applied_tax.tax_description

--- a/benchmarks/device_info_benchmark.rb
+++ b/benchmarks/device_info_benchmark.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 require "benchmark"
-require "ostruct"
 
-request = OpenStruct.new(
+request = Data.define(:user_agent, :remote_ip).new(
   user_agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
   remote_ip: "192.168.1.1"
 )

--- a/lib/tasks/custom_aggregation.rake
+++ b/lib/tasks/custom_aggregation.rake
@@ -14,7 +14,7 @@ namespace :custom_aggregation do
     # Intial state
     previous_state = {total_units: BigDecimal("0"), amount: BigDecimal("0")}
     # Event list - TODO: change me
-    events = [OpenStruct.new(properties: {})]
+    events = [Data.define(:properties).new(properties: {})]
 
     amount = 0
 


### PR DESCRIPTION
## Context

OpenStruct is banned in this codebase, but a handful of direct usages remained. This removes all of them except the deprecated `BaseService::LegacyResult < OpenStruct`, whose removal depends on migrating the ~89 services still using the default result and will be done separately.

## Description

- `FetchDraftInvoiceTaxes` mutation: replace the fake invoice/fee `OpenStructs` with `DraftInvoice/DraftFee` `Data` stand-ins that declare exactly the interface the Anrok/Avalara tax payloads read.
- `ApplyProviderTaxesService`: replace the internal fee-grouping struct with a `GroupingTax` `Data` value object.
- `device_info_benchmark.rb`: use a `Data` request and drop the `ostruct` require.
- `custom_aggregation.rake`: use a `Data` placeholder event.

Behavior is unchanged; unanticipated attribute reads now raise instead of silently returning `nil`.