### PR TITLE
Fix: create payment receipts dead jobs

### DIFF
--- a/app/jobs/payments/set_payment_method_and_create_receipt_job.rb
+++ b/app/jobs/payments/set_payment_method_and_create_receipt_job.rb
@@ -17,7 +17,7 @@ module Payments
 
       # Now that the payment method is saved in the payment, we generate the PaymentReceipt
       if payment.customer.organization.issue_receipts_enabled?
-        PaymentReceipts::CreateJob.perform_later(payment)
+        PaymentReceipts::CreateJob.perform_after_commit(payment)
       end
     end
 

--- a/app/jobs/payments/set_payment_method_and_create_receipt_job.rb
+++ b/app/jobs/payments/set_payment_method_and_create_receipt_job.rb
@@ -17,7 +17,7 @@ module Payments
 
       # Now that the payment method is saved in the payment, we generate the PaymentReceipt
       if payment.customer.organization.issue_receipts_enabled?
-        PaymentReceipts::CreateJob.perform_after_commit(payment)
+        PaymentReceipts::CreateJob.perform_later(payment)
       end
     end
 

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -73,8 +73,17 @@ module Invoices
 
         result
       rescue Invoices::Payments::AlreadyPaidError
-        # NOTE: The invoice was settled by another payment so we can drop the unused pending payment
-        result.payment&.destroy if result.payment&.provider_payment_id.nil?
+        # NOTE: The invoice was settled by another payment so we can drop the unused pending payment.
+        #
+        # Reload from the DB before destroying: a concurrent attempt shares this same row (only one
+        # pending/processing provider payment exists per payable) and may have already advanced it by
+        # setting a provider_payment_id or marking it succeeded. `result.payment` here is a stale
+        # in-memory copy, so relying on it can destroy a payment that maps to a real provider charge
+        # and orphan the PaymentReceipts::CreateJob already enqueued for it.
+        persisted_payment = result.payment && Payment.find_by(id: result.payment.id)
+        if persisted_payment && persisted_payment.provider_payment_id.nil? && persisted_payment.payable_payment_status != "succeeded"
+          persisted_payment.destroy
+        end
         result.payment = nil
         result
       rescue BaseService::ServiceFailure => e

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -69,14 +69,23 @@ module PaymentRequests
         update_invoices_payment_status(payment_status: payment_result.payment.payable_payment_status)
         update_invoices_paid_amount_cents(payment_status: payment_result.payment.payable_payment_status)
 
-        PaymentReceipts::CreateJob.perform_after_commit(payment) if payment.payable.organization.issue_receipts_enabled?
+        PaymentReceipts::CreateJob.perform_later(payment) if payment.payable.organization.issue_receipts_enabled?
 
         PaymentRequestMailer.with(payment_request: payable).requested.deliver_later if payable.payment_failed?
 
         result
       rescue Invoices::Payments::AlreadyPaidError
-        # The payment request was settled by another payment so we can drop the unused pending payment
-        result.payment&.destroy if result.payment&.provider_payment_id.nil?
+        # The payment request was settled by another payment so we can drop the unused pending payment.
+        #
+        # Reload from the DB before destroying: a concurrent attempt shares this same row (only one
+        # pending/processing provider payment exists per payable) and may have already advanced it by
+        # setting a provider_payment_id or marking it succeeded. `result.payment` here is a stale
+        # in-memory copy, so relying on it can destroy a payment that maps to a real provider charge
+        # and orphan the PaymentReceipts::CreateJob already enqueued for it.
+        persisted_payment = result.payment && Payment.find_by(id: result.payment.id)
+        if persisted_payment && persisted_payment.provider_payment_id.nil? && persisted_payment.payable_payment_status != "succeeded"
+          persisted_payment.destroy
+        end
         result.payment = nil
         result
       rescue BaseService::ServiceFailure => e

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -69,7 +69,7 @@ module PaymentRequests
         update_invoices_payment_status(payment_status: payment_result.payment.payable_payment_status)
         update_invoices_paid_amount_cents(payment_status: payment_result.payment.payable_payment_status)
 
-        PaymentReceipts::CreateJob.perform_later(payment) if payment.payable.organization.issue_receipts_enabled?
+        PaymentReceipts::CreateJob.perform_after_commit(payment) if payment.payable.organization.issue_receipts_enabled?
 
         PaymentRequestMailer.with(payment_request: payable).requested.deliver_later if payable.payment_failed?
 

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -496,6 +496,39 @@ RSpec.describe Invoices::Payments::CreateService do
       end
     end
 
+    context "when a concurrent attempt already advanced the shared payment (regression)" do
+      it "does not destroy a payment that now has a provider reference" do
+        # A parallel attempt operates on the same pending row (only one pending/processing
+        # provider payment exists per payable). It sets a real provider reference just before
+        # this attempt finds the invoice already paid.
+        allow(provider_service).to receive(:call!) do
+          invoice.reload.payments.first.update!(provider_payment_id: "pi_concurrent")
+          raise Invoices::Payments::AlreadyPaidError
+        end
+
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.payment).to be_nil
+
+        payment = invoice.reload.payments.first
+        expect(payment).to be_present
+        expect(payment.provider_payment_id).to eq("pi_concurrent")
+      end
+
+      it "does not destroy a payment that was already marked succeeded" do
+        allow(provider_service).to receive(:call!) do
+          invoice.reload.payments.first.update!(payable_payment_status: "succeeded")
+          raise Invoices::Payments::AlreadyPaidError
+        end
+
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(invoice.reload.payments.first).to be_present
+      end
+    end
+
     context "when provider service raises a service failure" do
       let(:original_error) { ::Stripe::StripeError.new("card declined") }
       let(:result) do

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -439,6 +439,39 @@ RSpec.describe PaymentRequests::Payments::CreateService do
       end
     end
 
+    context "when a concurrent attempt already advanced the shared payment (regression)" do
+      it "does not destroy a payment that now has a provider reference" do
+        # A parallel attempt operates on the same pending row (only one pending/processing
+        # provider payment exists per payable). It sets a real provider reference just before
+        # this attempt finds the payable already paid.
+        allow(provider_service).to receive(:call!) do
+          payment_request.reload.payments.first.update!(provider_payment_id: "pi_concurrent")
+          raise Invoices::Payments::AlreadyPaidError
+        end
+
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.payment).to be_nil
+
+        payment = payment_request.reload.payments.first
+        expect(payment).to be_present
+        expect(payment.provider_payment_id).to eq("pi_concurrent")
+      end
+
+      it "does not destroy a payment that was already marked succeeded" do
+        allow(provider_service).to receive(:call!) do
+          payment_request.reload.payments.first.update!(payable_payment_status: "succeeded")
+          raise Invoices::Payments::AlreadyPaidError
+        end
+
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(payment_request.reload.payments.first).to be_present
+      end
+    end
+
     context "when provider service raises a service failure" do
       let(:service_result) do
         BaseService::Result.new.tap do |r|


### PR DESCRIPTION
## Context

We have several dead `PaymentReceipts::CreateJob` and `Payments::SetPaymentMethodAndCreateReceiptJob`
thanks to the last it was possible to get an idea what's going on:
(found received stripe webhook, found the invoice that is mark as paid from the stripe webhook, but there is no payment associated to the invoice)
most likely scenario is that two workers are creating payment in parallel
- first worker creates a payment
- second uses `find_or_create_by` and finds just created payment
- in the meantime first worker succeeds with the payment and marks invoice / payment request as paid + upates payment -> schedules generate_receipt job
- second worker tries to create payment, but invoice is already paid -> AlreadyPaid error is triggered -> locally loaded version of payment is not succeeded and does not have a provider_payment_id -> we delete the payment
- generate receipt job tries to execute, but payment is deleted by the second worker

## Description

When failing with Already paid error, reload the payment and only delete it if it actually does not have provider_payment_id and is not succeeded