### PR TITLE
feat(multi-connections): add code and is_default to payment provider customers

### DIFF
--- a/app/models/payment_provider_customers/adyen_customer.rb
+++ b/app/models/payment_provider_customers/adyen_customer.rb
@@ -12,7 +12,9 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  deleted_at           :datetime
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -49,7 +49,9 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  deleted_at           :datetime
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/payment_provider_customers/cashfree_customer.rb
+++ b/app/models/payment_provider_customers/cashfree_customer.rb
@@ -14,7 +14,9 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  deleted_at           :datetime
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/payment_provider_customers/flutterwave_customer.rb
+++ b/app/models/payment_provider_customers/flutterwave_customer.rb
@@ -14,7 +14,9 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  deleted_at           :datetime
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/payment_provider_customers/gocardless_customer.rb
+++ b/app/models/payment_provider_customers/gocardless_customer.rb
@@ -11,7 +11,9 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  deleted_at           :datetime
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/payment_provider_customers/moneyhash_customer.rb
+++ b/app/models/payment_provider_customers/moneyhash_customer.rb
@@ -49,7 +49,9 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  deleted_at           :datetime
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -58,7 +58,9 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  deleted_at           :datetime
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/db/migrate/20260717133535_add_code_and_is_default_to_payment_provider_customers.rb
+++ b/db/migrate/20260717133535_add_code_and_is_default_to_payment_provider_customers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddCodeAndIsDefaultToPaymentProviderCustomers < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      change_table :payment_provider_customers, bulk: true do |t|
+        t.string :code
+        t.boolean :is_default, default: false, null: false
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3141,7 +3141,9 @@ CREATE TABLE public.payment_provider_customers (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    code character varying,
+    is_default boolean DEFAULT false NOT NULL
 );
 
 
@@ -12847,6 +12849,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260717133535'),
 ('20260716114156'),
 ('20260715142900'),
 ('20260710093947'),


### PR DESCRIPTION
## Context

Today a customer maps to exactly one payment connection per type. To let billing objects route to named connections, `payment_provider_customers` needs a per-customer routing key and a way to mark the customer's default connection.

## Description

Adds two columns to `payment_provider_customers`:
- `code (string, nullable)` — the per-customer routing key for the payment category.
- `is_default (boolean, default: false, null: false)` — marks the customer's default payment connection.

Purely additive and backward-compatible- no index or uniqueness changes, no model/validation changes (those land in later tasks).