### PR TITLE
fix(clickhouse): Align events_dead_letter_mv with production

### DIFF
--- a/db/clickhouse_migrate/cloud/08_events_dead_letter_mv.sql
+++ b/db/clickhouse_migrate/cloud/08_events_dead_letter_mv.sql
@@ -19,7 +19,7 @@ AS SELECT
   event.transaction_id AS transaction_id,
   coalesce(
     toDateTime64OrNull(toString(event.timestamp), 3),
-    toDateTime64(toFloat64OrNull(event.timestamp), 3),
+    toDateTime64(toFloat64OrNull(toString(event.timestamp)), 3),
     toDateTime64(event.ingested_at, 3)
   ) AS timestamp,
   toDateTime64(event.ingested_at, 3) AS ingested_at,


### PR DESCRIPTION
## Description

The events_dead_letter_mv materialized view was recently patched directly in production to fix an event timestamp that failed to parse as a float. This PR back-ports that patch into the ClickHouse DB creation script, so the fix is applied to any cluster created or updated in the future.
