### PR TITLE
fix(payments): scope checkout delay to manual wallet top-ups

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -138,7 +138,7 @@ module Invoices
       end
 
       def non_manual_wallet_topup?
-        invoice.credit? && invoice.wallet_transactions.where.not(source: :manual).exists?
+        invoice.credit? && invoice.wallet_transactions.inbound.where.not(source: :manual).exists?
       end
 
       def should_process_payment?

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -127,17 +127,18 @@ module Invoices
         @provider ||= invoice.customer.payment_provider&.to_sym
       end
 
-      # Delay the first automatic payment for every customer of an organization that uses hosted
-      # checkout (has ever generated a checkout URL), so an auto-payment can't race a customer's
-      # manual checkout and double-charge them. Scoping to the organization — not the customer —
-      # also covers a customer's very first invoice, which has no prior checkout signal of its own.
-      # Only the first attempt is delayed;
+      # Delay the first auto-payment for orgs using hosted checkout so it can't race a manual checkout
+      # and double-charge; skip flows that pay synchronously (gated subs, auto wallet top-ups).
       def defer_for_checkout_organization?
         return false unless invoice.payment_attempts.zero?
-        # Payment-gated subscriptions activate synchronously, so charge now instead of deferring.
-        return false if invoice.subscription_payment_gated?
+        return false if invoice.subscription? && invoice.subscription_payment_gated?
+        return false if non_manual_wallet_topup?
 
         PaymentIntent.where(organization_id: invoice.organization_id).exists?
+      end
+
+      def non_manual_wallet_topup?
+        invoice.credit? && invoice.wallet_transactions.where.not(source: :manual).exists?
       end
 
       def should_process_payment?

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -802,6 +802,10 @@ RSpec.describe Invoices::Payments::CreateService do
       end
 
       context "when the invoice gates a payment-gated subscription" do
+        let(:invoice) do
+          create(:invoice, customer:, organization:, total_amount_cents: 100, invoice_type: :subscription)
+        end
+
         before { allow(invoice).to receive(:subscription_payment_gated?).and_return(true) }
 
         it "enqueues the payment immediately" do
@@ -809,6 +813,40 @@ RSpec.describe Invoices::Payments::CreateService do
             .to have_enqueued_job(Invoices::Payments::CreateJob)
             .with(invoice:, payment_provider: :stripe, payment_method_params: {})
             .at(:no_wait)
+        end
+      end
+
+      context "when the invoice is an automatic (interval/threshold) wallet top-up" do
+        let(:invoice) { create(:invoice, :credit, customer:, organization:, total_amount_cents: 100) }
+
+        before do
+          wallet = create(:wallet, customer:, organization:)
+          create(:wallet_transaction, wallet:, invoice:, source: :interval)
+        end
+
+        it "enqueues the payment immediately" do
+          expect { ApplicationRecord.transaction { create_service.call_async } }
+            .to have_enqueued_job(Invoices::Payments::CreateJob)
+            .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+            .at(:no_wait)
+        end
+      end
+
+      context "when the invoice is a manual wallet top-up" do
+        let(:invoice) { create(:invoice, :credit, customer:, organization:, total_amount_cents: 100) }
+
+        before do
+          wallet = create(:wallet, customer:, organization:)
+          create(:wallet_transaction, wallet:, invoice:, source: :manual)
+        end
+
+        it "delays the first auto-payment" do
+          freeze_time do
+            expect { ApplicationRecord.transaction { create_service.call_async } }
+              .to have_enqueued_job(Invoices::Payments::CreateJob)
+              .with(invoice:, payment_provider: :stripe, payment_method_params: {})
+              .at(described_class::CHECKOUT_AUTO_PAYMENT_DELAY.from_now)
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

The checkout auto-payment delay (org-level, #5937) defers an invoice's first automatic payment for organizations that use hosted checkout, so the auto-payment can't race a customer's manual checkout and double-charge them.

That delay currently applies to **every** credit (wallet top-up) invoice. But automatic top-ups (`interval` / `threshold`) are triggered server-side —there's no customer checkout URL competing with them, so delaying them just postpones credit granting with no upside. All observed top-up double charges were `source = manual`.

## Change

- `defer_for_checkout_organization?` now skips **non-manual** wallet top-ups (`non_manual_wallet_topup?`). Only `manual` top-ups (which a customer can also pay via a checkout URL) are delayed. Whitelisting `manual` keeps any
  future server-triggered source excluded by default.