### PR TITLE
misc(OpenStruct): Used type Results in specs

### DIFF
--- a/spec/graphql/mutations/auth/google/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/google/accept_invite_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Mutations::Auth::Google::AcceptInvite do
   let(:invite) { create(:invite) }
 
   let(:accept_invite_result) do
-    result = BaseService::Result.new
+    result = Auth::GoogleService::RESULTS.fetch(:accept_invite).new
     result.user = user
     result.token = "token"
     result
@@ -52,7 +52,7 @@ RSpec.describe Mutations::Auth::Google::AcceptInvite do
 
   context "when invite email and google email are different" do
     let(:accept_invite_result) do
-      result = BaseService::Result.new
+      result = Auth::GoogleService::RESULTS.fetch(:accept_invite).new
       result.single_validation_failure!(error_code: "invite_email_mistmatch")
       result
     end
@@ -78,7 +78,7 @@ RSpec.describe Mutations::Auth::Google::AcceptInvite do
 
   context "when invite does not exist" do
     let(:accept_invite_result) do
-      result = BaseService::Result.new
+      result = Auth::GoogleService::RESULTS.fetch(:accept_invite).new
       result.not_found_failure!(resource: "invite")
       result
     end

--- a/spec/graphql/mutations/auth/google/login_user_spec.rb
+++ b/spec/graphql/mutations/auth/google/login_user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Mutations::Auth::Google::LoginUser do
   let(:user) { membership.user }
 
   let(:login_result) do
-    result = BaseService::Result.new
+    result = Auth::GoogleService::RESULTS.fetch(:login).new
     result.user = user
     result.token = "token"
     result
@@ -51,7 +51,7 @@ RSpec.describe Mutations::Auth::Google::LoginUser do
 
   context "when user does not exist" do
     let(:login_result) do
-      result = BaseService::Result.new
+      result = Auth::GoogleService::RESULTS.fetch(:login).new
       result.single_validation_failure!(error_code: "user_does_not_exist")
       result
     end

--- a/spec/graphql/mutations/auth/google/register_user_spec.rb
+++ b/spec/graphql/mutations/auth/google/register_user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mutations::Auth::Google::RegisterUser do
   let(:user) { create(:user) }
 
   let(:register_user_result) do
-    result = BaseService::Result.new
+    result = Auth::GoogleService::RESULTS.fetch(:register_user).new
     result.user = user
     result.token = "token"
     result
@@ -51,7 +51,7 @@ RSpec.describe Mutations::Auth::Google::RegisterUser do
 
   context "when user already exists" do
     let(:register_user_result) do
-      result = BaseService::Result.new
+      result = Auth::GoogleService::RESULTS.fetch(:register_user).new
       result.single_validation_failure!(error_code: "user_already_exists")
       result
     end

--- a/spec/graphql/mutations/invoices/generate_payment_url_spec.rb
+++ b/spec/graphql/mutations/invoices/generate_payment_url_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Mutations::Invoices::GeneratePaymentUrl do
   end
 
   let(:service_result) do
-    result = BaseService::Result.new
+    result = Invoices::Payments::GeneratePaymentUrlService::Result.new
     result.payment_url = "https://payment.example.com/pay/123"
     result
   end
@@ -72,7 +72,7 @@ RSpec.describe Mutations::Invoices::GeneratePaymentUrl do
 
   context "when service returns an error" do
     let(:service_result) do
-      result = BaseService::Result.new
+      result = Invoices::Payments::GeneratePaymentUrlService::Result.new
       result.single_validation_failure!(error_code: "no_linked_payment_provider")
       result
     end
@@ -98,7 +98,7 @@ RSpec.describe Mutations::Invoices::GeneratePaymentUrl do
 
     context "when error is ThirdPartyFailure" do
       let(:service_result) do
-        result = BaseService::Result.new
+        result = Invoices::Payments::GeneratePaymentUrlService::Result.new
         result.third_party_failure!(third_party: "stripe", error_code: 500, error_message: "Hummm, there's an error!")
         result
       end

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -526,7 +526,7 @@ RSpec.describe Mutations::Plans::Create, :premium do
   context "when entitlements is an empty array" do
     it "calls PlanEntitlementsUpdateService to remove all entitlements" do
       allow(::Entitlement::PlanEntitlementsUpdateService).to receive(:call)
-        .and_return(BaseService::Result.new)
+        .and_return(::Entitlement::PlanEntitlementsUpdateService::Result.new)
 
       execute_graphql(
         current_user: membership.user,

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe Mutations::Plans::Update do
   context "when entitlements is an empty array" do
     it "calls PlanEntitlementsUpdateService to remove all entitlements" do
       allow(::Entitlement::PlanEntitlementsUpdateService).to receive(:call)
-        .and_return(BaseService::Result.new)
+        .and_return(::Entitlement::PlanEntitlementsUpdateService::Result.new)
 
       execute_graphql(
         current_user: membership.user,

--- a/spec/graphql/resolvers/ai_conversation_resolver_spec.rb
+++ b/spec/graphql/resolvers/ai_conversation_resolver_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Resolvers::AiConversationResolver do
   let(:ai_conversation) { create(:ai_conversation, organization:, mistral_conversation_id: "conv_123") }
   let(:fetch_messages_service) { instance_double(AiConversations::FetchMessagesService) }
   let(:service_result) do
-    result = BaseService::Result.new
+    result = AiConversations::FetchMessagesService::Result.new
     result.messages = [
       {
         "content" => "Hello",
@@ -122,7 +122,7 @@ RSpec.describe Resolvers::AiConversationResolver do
 
     context "when fetch messages service fails" do
       let(:failed_result) do
-        result = BaseService::Result.new
+        result = AiConversations::FetchMessagesService::Result.new
         result.service_failure!(code: "mistral_api_error", message: "API error")
         result
       end

--- a/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Resolvers::CustomerPortal::InvoicesResolver do
   context "when query fails" do
     it "returns an error" do
       allow(InvoicesQuery).to receive(:call).and_return(
-        BaseService::Result.new.tap { |r| r.validation_failure!(errors: {base: ["test_error"]}) }
+        InvoicesQuery::Result.new.tap { |r| r.validation_failure!(errors: {base: ["test_error"]}) }
       )
 
       result = execute_graphql(

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Resolvers::Customers::InvoicesResolver do
   context "when query fails" do
     it "returns an error" do
       allow(InvoicesQuery).to receive(:call).and_return(
-        BaseService::Result.new.tap { |r| r.validation_failure!(errors: {base: ["test_error"]}) }
+        InvoicesQuery::Result.new.tap { |r| r.validation_failure!(errors: {base: ["test_error"]}) }
       )
 
       result = execute_graphql(

--- a/spec/graphql/resolvers/superset/dashboards_resolver_spec.rb
+++ b/spec/graphql/resolvers/superset/dashboards_resolver_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Resolvers::Superset::DashboardsResolver do
   end
 
   let(:result) do
-    BaseService::Result.new.tap do |result|
+    Auth::SupersetService::Result.new.tap do |result|
       result.dashboards = dashboards
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe Resolvers::Superset::DashboardsResolver do
 
   context "when the superset service fails" do
     let(:result) do
-      BaseService::Result.new.tap do |r|
+      Auth::SupersetService::Result.new.tap do |r|
         r.service_failure!(code: "superset_auth_failed", message: "Failed to authenticate with Superset")
       end
     end

--- a/spec/jobs/bill_paid_credit_job_spec.rb
+++ b/spec/jobs/bill_paid_credit_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BillPaidCreditJob do
   let(:timestamp) { Time.current.to_i }
 
   let(:invoice_service) { instance_double(Invoices::PaidCreditService) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::PaidCreditService::Result.new }
 
   let(:invoice) { nil }
 
@@ -25,7 +25,7 @@ RSpec.describe BillPaidCreditJob do
 
   context "when result is a failure" do
     let(:result) do
-      BaseService::Result.new.single_validation_failure!(error_code: "error")
+      Invoices::PaidCreditService::Result.new.single_validation_failure!(error_code: "error")
     end
 
     it "raises an error" do

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BillSubscriptionJob do
 
   let(:invoice) { nil }
   let(:invoicing_reason) { :subscription_starting }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::SubscriptionService::Result.new }
 
   before do
     allow(Invoices::SubscriptionService).to receive(:call)
@@ -25,7 +25,7 @@ RSpec.describe BillSubscriptionJob do
 
     context "when result is a failure" do
       let(:result) do
-        result = BaseService::Result.new
+        result = Invoices::SubscriptionService::Result.new
         result.invoice = invoice
         result.single_validation_failure!(error_code: "error")
       end

--- a/spec/jobs/credit_notes/generate_documents_job_spec.rb
+++ b/spec/jobs/credit_notes/generate_documents_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CreditNotes::GenerateDocumentsJob do
   subject { described_class.perform_now(credit_note) }
 
   let(:credit_note) { create(:credit_note) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { CreditNotes::GeneratePdfService::Result.new }
 
   before do
     allow(CreditNotes::GeneratePdfService).to receive(:call).with(credit_note:, context: "api").and_return(result)

--- a/spec/jobs/credit_notes/generate_pdf_job_spec.rb
+++ b/spec/jobs/credit_notes/generate_pdf_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe CreditNotes::GeneratePdfJob do
   let(:credit_note) { create(:credit_note) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { CreditNotes::GeneratePdfService::Result.new }
 
   it "delegates to the Generate service" do
     allow(CreditNotes::GeneratePdfService).to receive(:call)

--- a/spec/jobs/credit_notes/generate_xml_job_spec.rb
+++ b/spec/jobs/credit_notes/generate_xml_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe CreditNotes::GenerateXmlJob do
   let(:credit_note) { create(:credit_note) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { CreditNotes::GenerateXmlService::Result.new }
 
   let(:generate_service) do
     instance_double(CreditNotes::GenerateXmlService)

--- a/spec/jobs/credit_notes/provider_taxes/report_job_spec.rb
+++ b/spec/jobs/credit_notes/provider_taxes/report_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CreditNotes::ProviderTaxes::ReportJob do
   let(:credit_note) { create(:credit_note, customer:) }
   let(:customer) { create(:customer, organization:) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { CreditNotes::ProviderTaxes::ReportService::Result.new }
 
   before do
     allow(CreditNotes::ProviderTaxes::ReportService).to receive(:call)

--- a/spec/jobs/credit_notes/refunds/adyen_create_job_spec.rb
+++ b/spec/jobs/credit_notes/refunds/adyen_create_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CreditNotes::Refunds::AdyenCreateJob do
       .with(credit_note)
       .and_return(refund_service)
     allow(refund_service).to receive(:create)
-      .and_return(BaseService::Result.new)
+      .and_return(CreditNotes::Refunds::AdyenService::Result.new)
 
     described_class.perform_now(credit_note)
 

--- a/spec/jobs/credit_notes/refunds/gocardless_create_job_spec.rb
+++ b/spec/jobs/credit_notes/refunds/gocardless_create_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CreditNotes::Refunds::GocardlessCreateJob do
       .with(credit_note)
       .and_return(refund_service)
     allow(refund_service).to receive(:create)
-      .and_return(BaseService::Result.new)
+      .and_return(CreditNotes::Refunds::GocardlessService::Result.new)
 
     described_class.perform_now(credit_note)
 

--- a/spec/jobs/credit_notes/refunds/stripe_create_job_spec.rb
+++ b/spec/jobs/credit_notes/refunds/stripe_create_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CreditNotes::Refunds::StripeCreateJob do
       .with(credit_note)
       .and_return(refund_service)
     allow(refund_service).to receive(:create)
-      .and_return(BaseService::Result.new)
+      .and_return(CreditNotes::Refunds::StripeService::Result.new)
 
     described_class.perform_now(credit_note)
 

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Customers::RefreshWalletJob do
 
     let(:customer) { create(:customer, awaiting_wallet_refresh:) }
     let(:organization) { customer.organization }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Customers::RefreshWalletsService::Result.new }
     let(:wallet_ids) { nil }
 
     before do
@@ -92,7 +92,7 @@ RSpec.describe Customers::RefreshWalletJob do
       end
 
       context "when refresh customer's wallets fails with a tax error" do
-        let(:result) { BaseService::Result.new.validation_failure!(errors: {tax_error: ["customerAddressCouldNotResolve"]}) }
+        let(:result) { Customers::RefreshWalletsService::Result.new.validation_failure!(errors: {tax_error: ["customerAddressCouldNotResolve"]}) }
 
         context "when the error is related to the customer's address" do
           it "creates a tax_error error_detail on the customer" do
@@ -128,7 +128,7 @@ RSpec.describe Customers::RefreshWalletJob do
         end
 
         context "when the tax error is an unknown failure" do
-          let(:result) { BaseService::Result.new.validation_failure!(errors: {tax_error: ["failure"]}) }
+          let(:result) { Customers::RefreshWalletsService::Result.new.validation_failure!(errors: {tax_error: ["failure"]}) }
 
           it "does not create an error_detail and re-raises the error" do
             expect { subject }.to raise_error(BaseService::ValidationFailure).and not_change { customer.error_details.count }
@@ -137,7 +137,7 @@ RSpec.describe Customers::RefreshWalletJob do
       end
 
       context "when refresh customer's wallets fails with a non-tax error" do
-        let(:result) { BaseService::Result.new.validation_failure!(errors: {other_error: ["something"]}) }
+        let(:result) { Customers::RefreshWalletsService::Result.new.validation_failure!(errors: {other_error: ["something"]}) }
 
         it "re-raises the error" do
           expect { subject }.to raise_error(BaseService::ValidationFailure)

--- a/spec/jobs/customers/terminate_relations_job_spec.rb
+++ b/spec/jobs/customers/terminate_relations_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Customers::TerminateRelationsJob do
     allow(Customers::TerminateRelationsService)
       .to receive(:call)
       .with(customer:)
-      .and_return(BaseService::Result.new)
+      .and_return(Customers::TerminateRelationsService::Result.new)
 
     described_class.perform_now(customer_id: customer.id)
 

--- a/spec/jobs/daily_usages/compute_job_spec.rb
+++ b/spec/jobs/daily_usages/compute_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DailyUsages::ComputeJob do
   let(:subscription) { create(:subscription) }
   let(:timestamp) { Time.current }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { DailyUsages::ComputeService::Result.new }
 
   describe ".perform" do
     it "delegates to DailyUsages::ComputeService" do

--- a/spec/jobs/daily_usages/fill_from_invoice_job_spec.rb
+++ b/spec/jobs/daily_usages/fill_from_invoice_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DailyUsages::FillFromInvoiceJob do
   let(:subscription) { create(:subscription) }
   let(:invoice) { create(:invoice, :subscription, subscriptions: [subscription]) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { DailyUsages::FillFromInvoiceService::Result.new }
 
   describe ".perform" do
     it "delegates its logic to the DailyUsages::FillFromInvoiceService" do

--- a/spec/jobs/data_exports/combine_parts_job_spec.rb
+++ b/spec/jobs/data_exports/combine_parts_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe DataExports::CombinePartsJob do
   let(:data_export) { create(:data_export) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { DataExports::CombinePartsService::Result.new }
 
   before do
     allow(DataExports::CombinePartsService)

--- a/spec/jobs/data_exports/export_resources_job_spec.rb
+++ b/spec/jobs/data_exports/export_resources_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe DataExports::ExportResourcesJob do
   let(:data_export) { create(:data_export) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { DataExports::ExportResourcesService::Result.new }
 
   before do
     allow(DataExports::ExportResourcesService)

--- a/spec/jobs/data_exports/process_part_job_spec.rb
+++ b/spec/jobs/data_exports/process_part_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe DataExports::ProcessPartJob do
   let(:data_export_part) { create(:data_export_part) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { DataExports::ProcessPartService::Result.new }
 
   before do
     allow(DataExports::ProcessPartService)

--- a/spec/jobs/dunning_campaigns/bulk_process_job_spec.rb
+++ b/spec/jobs/dunning_campaigns/bulk_process_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe DunningCampaigns::BulkProcessJob do
-  let(:result) { BaseService::Result.new }
+  let(:result) { DunningCampaigns::BulkProcessService::Result.new }
 
   before do
     allow(DunningCampaigns::BulkProcessService)

--- a/spec/jobs/dunning_campaigns/process_attempt_job_spec.rb
+++ b/spec/jobs/dunning_campaigns/process_attempt_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe DunningCampaigns::ProcessAttemptJob do
-  let(:result) { BaseService::Result.new }
+  let(:result) { DunningCampaigns::ProcessAttemptService::Result.new }
   let(:customer) { build :customer }
   let(:dunning_campaign_threshold) { build :dunning_campaign_threshold }
   let(:billing_entity) { build :billing_entity }

--- a/spec/jobs/events/pay_in_advance_job_spec.rb
+++ b/spec/jobs/events/pay_in_advance_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Events::PayInAdvanceJob do
   let(:pay_in_advance_service) { instance_double(Events::PayInAdvanceService) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Events::PayInAdvanceService::Result.new }
 
   let(:event) { build(:common_event) }
 

--- a/spec/jobs/events/post_process_job_spec.rb
+++ b/spec/jobs/events/post_process_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Events::PostProcessJob do
-  let(:result) { BaseService::Result.new }
+  let(:result) { Events::PostProcessService::Result.new }
 
   let(:event) do
     create(:event)

--- a/spec/jobs/fees/create_pay_in_advance_job_spec.rb
+++ b/spec/jobs/fees/create_pay_in_advance_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Fees::CreatePayInAdvanceJob do
   let(:charge) { create(:standard_charge, :pay_in_advance) }
   let(:event) { create(:event) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { Fees::CreatePayInAdvanceService::Result.new }
 
   it "delegates to the pay_in_advance aggregation service" do
     allow(Fees::CreatePayInAdvanceService).to receive(:call)

--- a/spec/jobs/inbound_webhooks/process_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/process_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe InboundWebhooks::ProcessJob do
   subject(:process_job) { described_class }
 
   let(:inbound_webhook) { create :inbound_webhook }
-  let(:result) { BaseService::Result.new }
+  let(:result) { InboundWebhooks::ProcessService::Result.new }
 
   before do
     allow(InboundWebhooks::ProcessService).to receive(:call).and_return(result)
@@ -22,7 +22,7 @@ RSpec.describe InboundWebhooks::ProcessJob do
 
   context "when result is a failure" do
     let(:result) do
-      BaseService::Result.new.service_failure!(code: "error", message: "error message")
+      InboundWebhooks::ProcessService::Result.new.service_failure!(code: "error", message: "error message")
     end
 
     it "raises an error" do

--- a/spec/jobs/integration_customers/update_job_spec.rb
+++ b/spec/jobs/integration_customers/update_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IntegrationCustomers::UpdateJob do
 
   let(:integration) { create(:netsuite_integration) }
   let(:integration_customer) { create(:netsuite_customer, integration:) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { IntegrationCustomers::UpdateService::Result.new }
   let(:integration_customer_params) do
     {
       sync_with_provider: true

--- a/spec/jobs/integrations/aggregator/invoices/hubspot/create_customer_association_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/hubspot/create_customer_association_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssoci
   subject(:create_job) { described_class }
 
   let(:invoice) { create(:invoice) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssociationService::Result.new }
 
   before do
     allow(Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssociationService)

--- a/spec/jobs/integrations/aggregator/subscriptions/hubspot/create_customer_association_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/subscriptions/hubspot/create_customer_association_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerA
   subject(:create_job) { described_class }
 
   let(:subscription) { create(:subscription) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerAssociationService::Result.new }
 
   before do
     allow(Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerAssociationService)

--- a/spec/jobs/integrations/aggregator/taxes/invoices/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/taxes/invoices/create_job_spec.rb
@@ -6,7 +6,7 @@ describe Integrations::Aggregator::Taxes::Invoices::CreateJob do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Integrations::Aggregator::Taxes::Invoices::CreateService::Result.new }
 
   before do
     allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call!).and_return(result)

--- a/spec/jobs/integrations/avalara/fetch_company_id_job_spec.rb
+++ b/spec/jobs/integrations/avalara/fetch_company_id_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Integrations::Avalara::FetchCompanyIdJob do
 
     let(:service) { instance_double(Integrations::Avalara::FetchCompanyIdService) }
     let(:integration) { create(:avalara_integration) }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Integrations::Avalara::FetchCompanyIdService::Result.new }
 
     before do
       allow(Integrations::Avalara::FetchCompanyIdService).to receive(:call).and_return(result)

--- a/spec/jobs/integrations/hubspot/save_portal_id_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/save_portal_id_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Integrations::Hubspot::SavePortalIdJob do
 
     let(:service) { instance_double(Integrations::Hubspot::SavePortalIdService) }
     let(:integration) { create(:hubspot_integration) }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Integrations::Hubspot::SavePortalIdService::Result.new }
 
     before do
       allow(Integrations::Hubspot::SavePortalIdService).to receive(:call).and_return(result)

--- a/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
+++ b/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob do
     let(:timestamp) { Time.current.to_i }
 
     let(:invoice) { nil }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Invoices::CreatePayInAdvanceChargeService::Result.new }
 
     before do
       allow(Invoices::CreatePayInAdvanceChargeService).to receive(:call)
@@ -25,7 +25,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob do
 
     context "when result is a failure" do
       let(:result) do
-        BaseService::Result.new.single_validation_failure!(error_code: "error")
+        Invoices::CreatePayInAdvanceChargeService::Result.new.single_validation_failure!(error_code: "error")
       end
 
       it "raises an error" do

--- a/spec/jobs/invoices/create_pay_in_advance_fixed_charges_job_spec.rb
+++ b/spec/jobs/invoices/create_pay_in_advance_fixed_charges_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesJob do
 
   let(:subscription) { create(:subscription) }
   let(:timestamp) { Time.current.to_i }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::CreatePayInAdvanceFixedChargesService::Result.new }
 
   describe "#perform" do
     before do
@@ -23,7 +23,7 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesJob do
 
     context "when result is a failure" do
       let(:result) do
-        BaseService::Result.new.single_validation_failure!(error_code: "error")
+        Invoices::CreatePayInAdvanceFixedChargesService::Result.new.single_validation_failure!(error_code: "error")
       end
 
       it "raises an error" do
@@ -37,7 +37,7 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesJob do
 
     context "when result is a tax error" do
       let(:result) do
-        BaseService::Result.new.validation_failure!(errors: {tax_error: ["taxDateTooFarInFuture"]})
+        Invoices::CreatePayInAdvanceFixedChargesService::Result.new.validation_failure!(errors: {tax_error: ["taxDateTooFarInFuture"]})
       end
 
       it "does not raise an error" do

--- a/spec/jobs/invoices/finalize_all_job_spec.rb
+++ b/spec/jobs/invoices/finalize_all_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Invoices::FinalizeAllJob do
   subject(:finalize_all_job) { described_class }
 
   let(:finalize_batch_service) { instance_double(Invoices::FinalizeBatchService) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::FinalizeBatchService::Result.new }
   let(:organization) { create(:organization) }
   let(:invoice) { create(:invoice, :draft, organization:) }
 

--- a/spec/jobs/invoices/finalize_job_spec.rb
+++ b/spec/jobs/invoices/finalize_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Invoices::FinalizeJob do
   let(:invoice) { create(:invoice) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::RefreshDraftAndFinalizeService::Result.new }
 
   it "delegates to the RefreshDraftAndFinalizeService service" do
     allow(Invoices::RefreshDraftAndFinalizeService).to receive(:call)

--- a/spec/jobs/invoices/finalize_pending_vies_invoice_job_spec.rb
+++ b/spec/jobs/invoices/finalize_pending_vies_invoice_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Invoices::FinalizePendingViesInvoiceJob do
   let(:invoice) { create(:invoice, :pending, tax_status: "pending") }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::FinalizePendingViesInvoiceService::Result.new }
 
   describe "#perform" do
     before do

--- a/spec/jobs/invoices/generate_documents_job_spec.rb
+++ b/spec/jobs/invoices/generate_documents_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Invoices::GenerateDocumentsJob do
   subject { described_class.perform_now(invoice:, notify:) }
 
   let(:invoice) { create(:invoice) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::GeneratePdfService::Result.new }
   let(:notify) { false }
 
   before do

--- a/spec/jobs/invoices/generate_pdf_job_spec.rb
+++ b/spec/jobs/invoices/generate_pdf_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Invoices::GeneratePdfJob do
   let(:invoice) { create(:invoice) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::GeneratePdfService::Result.new }
 
   it "delegates to the Generate service" do
     allow(Invoices::GeneratePdfService).to receive(:call)

--- a/spec/jobs/invoices/generate_xml_job_spec.rb
+++ b/spec/jobs/invoices/generate_xml_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Invoices::GenerateXmlJob do
   let(:invoice) { create(:invoice) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::GenerateXmlService::Result.new }
   let(:service_class) { Invoices::GenerateXmlService }
   let(:generate_service) do
     instance_double(Invoices::GenerateXmlService)

--- a/spec/jobs/invoices/payments/adyen_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/adyen_create_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invoices::Payments::AdyenCreateJob do
   it "calls the stripe create service" do
     allow(Invoices::Payments::CreateService).to receive(:call!)
       .with(invoice:, payment_provider: :adyen)
-      .and_return(BaseService::Result.new)
+      .and_return(Invoices::Payments::CreateService::Result.new)
 
     described_class.perform_now(invoice)
 

--- a/spec/jobs/invoices/payments/create_job_spec.rb
+++ b/spec/jobs/invoices/payments/create_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Invoices::Payments::CreateJob do
   it "calls the stripe create service" do
     allow(Invoices::Payments::CreateService).to receive(:call!)
       .with(invoice:, payment_provider:, payment_method_params: {})
-      .and_return(BaseService::Result.new)
+      .and_return(Invoices::Payments::CreateService::Result.new)
 
     described_class.perform_now(invoice:, payment_provider:, payment_method_params: {})
 

--- a/spec/jobs/invoices/payments/gocardless_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/gocardless_create_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invoices::Payments::GocardlessCreateJob do
   it "calls the stripe create service" do
     allow(Invoices::Payments::CreateService).to receive(:call!)
       .with(invoice:, payment_provider: :gocardless)
-      .and_return(BaseService::Result.new)
+      .and_return(Invoices::Payments::CreateService::Result.new)
 
     described_class.perform_now(invoice)
 

--- a/spec/jobs/invoices/payments/retry_all_job_spec.rb
+++ b/spec/jobs/invoices/payments/retry_all_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Invoices::Payments::RetryAllJob do
   subject(:retry_all_job) { described_class }
 
   let(:retry_batch_service) { instance_double(Invoices::Payments::RetryBatchService) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::Payments::RetryBatchService::Result.new }
   let(:organization) { create(:organization) }
   let(:invoice) { create(:invoice, organization:) }
 

--- a/spec/jobs/invoices/payments/stripe_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/stripe_create_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invoices::Payments::StripeCreateJob do
   it "calls the stripe create service" do
     allow(Invoices::Payments::CreateService).to receive(:call!)
       .with(invoice:, payment_provider: :stripe)
-      .and_return(BaseService::Result.new)
+      .and_return(Invoices::Payments::CreateService::Result.new)
 
     described_class.perform_now(invoice)
 

--- a/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob do
   let(:invoice) { create(:invoice, customer:) }
   let(:customer) { create(:customer, organization:) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::ProviderTaxes::PullTaxesAndApplyService::Result.new }
 
   before do
     allow(Invoices::ProviderTaxes::PullTaxesAndApplyService).to receive(:call)

--- a/spec/jobs/invoices/provider_taxes/void_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/void_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Invoices::ProviderTaxes::VoidJob do
   let(:invoice) { create(:invoice, customer:) }
   let(:customer) { create(:customer, organization:) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::ProviderTaxes::VoidService::Result.new }
 
   before do
     allow(Invoices::ProviderTaxes::VoidService).to receive(:call)

--- a/spec/jobs/invoices/refresh_draft_job_spec.rb
+++ b/spec/jobs/invoices/refresh_draft_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Invoices::RefreshDraftJob do
   let(:invoice) { create(:invoice, ready_to_be_refreshed: true) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::RefreshDraftService::Result.new }
 
   it "delegates to the RefreshDraft service" do
     allow(Invoices::RefreshDraftService).to receive(:call).with(invoice:).and_return(result)

--- a/spec/jobs/invoices/retry_all_job_spec.rb
+++ b/spec/jobs/invoices/retry_all_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Invoices::RetryAllJob do
   subject(:retry_all_job) { described_class }
 
   let(:retry_batch_service) { instance_double(Invoices::RetryBatchService) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::RetryBatchService::Result.new }
   let(:organization) { create(:organization) }
   let(:invoice) { create(:invoice, organization:) }
 

--- a/spec/jobs/payment_intents/expire_job_spec.rb
+++ b/spec/jobs/payment_intents/expire_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentIntents::ExpireJob do
 
   before do
     allow(PaymentIntents::ExpireService)
-      .to receive(:call!).with(invoice:).and_return(BaseService::Result.new)
+      .to receive(:call!).with(invoice:).and_return(PaymentIntents::ExpireService::Result.new)
   end
 
   it "calls the expire service" do

--- a/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob do
 
   it "calls generate_checkout_url method" do
     allow(PaymentProviderCustomers::GocardlessService).to receive(:call!)
-      .and_return(BaseService::Result.new)
+      .and_return(PaymentProviderCustomers::GocardlessService::RESULTS.fetch(:generate_checkout_url).new)
 
     gocardless_checkout_job.perform_now(gocardless_customer)
 

--- a/spec/jobs/payment_provider_customers/gocardless_create_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_create_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessCreateJob do
 
   it "calls the gocardless create service" do
     allow(PaymentProviderCustomers::GocardlessService).to receive(:call!)
-      .and_return(BaseService::Result.new)
+      .and_return(PaymentProviderCustomers::GocardlessService::RESULTS.fetch(:create).new)
 
     described_class.perform_now(gocardless_customer)
 

--- a/spec/jobs/payment_provider_customers/stripe_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_checkout_url_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PaymentProviderCustomers::StripeCheckoutUrlJob do
 
   it "calls generate_checkout_url method" do
     allow(PaymentProviderCustomers::StripeService).to receive(:call!)
-      .and_return(BaseService::Result.new)
+      .and_return(PaymentProviderCustomers::StripeService::RESULTS.fetch(:generate_checkout_url).new)
 
     stripe_checkout_job.perform_now(stripe_customer)
 

--- a/spec/jobs/payment_provider_customers/stripe_create_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_create_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentProviderCustomers::StripeCreateJob do
 
   it "calls the stripe create service" do
     allow(PaymentProviderCustomers::StripeService).to receive(:call!)
-      .and_return(BaseService::Result.new)
+      .and_return(PaymentProviderCustomers::StripeService::RESULTS.fetch(:create).new)
 
     described_class.perform_now(stripe_customer)
 

--- a/spec/jobs/payment_provider_customers/stripe_sync_funding_instructions_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_sync_funding_instructions_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PaymentProviderCustomers::StripeSyncFundingInstructionsJob do
       .with(stripe_customer)
       .and_return(stripe_service)
     allow(stripe_service).to receive(:call)
-      .and_return(BaseService::Result.new)
+      .and_return(PaymentProviderCustomers::Stripe::SyncFundingInstructionsService::Result.new)
 
     stripe_sync_funding_instructions_job.perform_now(stripe_customer)
 

--- a/spec/jobs/payment_providers/adyen/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/adyen/handle_event_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Adyen::HandleEventJob do
   subject(:handle_event_job) { described_class }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { PaymentProviders::Adyen::HandleEventService::Result.new }
   let(:organization) { create(:organization) }
   let(:event_json) { "{}" }
 

--- a/spec/jobs/payment_providers/cashfree/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/cashfree/handle_event_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::Cashfree::HandleEventJob do
-  let(:result) { BaseService::Result.new }
+  let(:result) { PaymentProviders::Cashfree::HandleEventService::Result.new }
   let(:organization) { create(:organization) }
 
   let(:cashfree_event) do

--- a/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PaymentProviders::Gocardless::HandleEventJob do
     JSON.parse(File.read(path))["events"].first.to_json
   end
 
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { PaymentProviders::Gocardless::HandleEventService::Result.new }
 
   it_behaves_like "a unique job" do
     let(:job_args) { [{payment_provider:, event_json:}] }

--- a/spec/jobs/payment_providers/moneyhash/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/moneyhash/handle_event_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::Moneyhash::HandleEventJob do
-  let(:result) { BaseService::Result.new }
+  let(:result) { PaymentProviders::Moneyhash::HandleEventService::Result.new }
   let(:organization) { create(:organization) }
 
   let(:moneyhash_event) { {} }

--- a/spec/jobs/payment_providers/stripe/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/handle_event_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::Stripe::HandleEventJob do
-  let(:result) { BaseService::Result.new }
+  let(:result) { PaymentProviders::Stripe::HandleEventService::Result.new }
   let(:organization) { create(:organization) }
 
   let(:stripe_event) do

--- a/spec/jobs/payment_receipts/create_job_spec.rb
+++ b/spec/jobs/payment_receipts/create_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PaymentReceipts::CreateJob do
 
   it "calls the create service" do
     allow(PaymentReceipts::CreateService)
-      .to receive(:call!).with(payment:).and_return(BaseService::Result.new)
+      .to receive(:call!).with(payment:).and_return(PaymentReceipts::CreateService::Result.new)
 
     described_class.perform_now(payment)
 

--- a/spec/jobs/payment_receipts/generate_documents_job_spec.rb
+++ b/spec/jobs/payment_receipts/generate_documents_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PaymentReceipts::GenerateDocumentsJob do
   subject { described_class.perform_now(payment_receipt:, notify:) }
 
   let(:payment_receipt) { create(:payment_receipt) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { PaymentReceipts::GeneratePdfService::Result.new }
   let(:notify) { false }
 
   before do

--- a/spec/jobs/payment_receipts/generate_pdf_job_spec.rb
+++ b/spec/jobs/payment_receipts/generate_pdf_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe PaymentReceipts::GeneratePdfJob do
   let(:payment_receipt) { create(:payment_receipt) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { PaymentReceipts::GeneratePdfService::Result.new }
 
   it "delegates to the Generate service" do
     allow(PaymentReceipts::GeneratePdfService).to receive(:call)

--- a/spec/jobs/payment_receipts/generate_xml_job_spec.rb
+++ b/spec/jobs/payment_receipts/generate_xml_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe PaymentReceipts::GenerateXmlJob do
   let(:payment_receipt) { create(:payment_receipt) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { PaymentReceipts::GenerateXmlService::Result.new }
 
   it "delegates to the Generate service" do
     allow(PaymentReceipts::GenerateXmlService).to receive(:call)

--- a/spec/jobs/payment_requests/payments/adyen_create_job_spec.rb
+++ b/spec/jobs/payment_requests/payments/adyen_create_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentRequests::Payments::AdyenCreateJob do
   let(:payment_request) { create(:payment_request) }
 
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { PaymentRequests::Payments::CreateService::Result.new }
 
   before do
     allow(PaymentRequests::Payments::CreateService).to receive(:call!)

--- a/spec/jobs/payment_requests/payments/create_job_spec.rb
+++ b/spec/jobs/payment_requests/payments/create_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentRequests::Payments::CreateJob do
   let(:payment_request) { create(:payment_request) }
 
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { PaymentRequests::Payments::CreateService::Result.new }
   let(:payment_provider) { "stripe" }
 
   before do

--- a/spec/jobs/payment_requests/payments/gocardless_create_job_spec.rb
+++ b/spec/jobs/payment_requests/payments/gocardless_create_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentRequests::Payments::GocardlessCreateJob do
   let(:payment_request) { create(:payment_request) }
 
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { PaymentRequests::Payments::CreateService::Result.new }
 
   before do
     allow(PaymentRequests::Payments::CreateService).to receive(:call!)

--- a/spec/jobs/payment_requests/payments/stripe_create_job_spec.rb
+++ b/spec/jobs/payment_requests/payments/stripe_create_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentRequests::Payments::StripeCreateJob do
   let(:payment_request) { create(:payment_request) }
 
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { PaymentRequests::Payments::CreateService::Result.new }
 
   before do
     allow(PaymentRequests::Payments::CreateService).to receive(:call!)

--- a/spec/jobs/payments/manual_create_job_spec.rb
+++ b/spec/jobs/payments/manual_create_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Payments::ManualCreateJob do
 
   it "calls the create service" do
     allow(Payments::ManualCreateService)
-      .to receive(:call!).with(organization:, params:).and_return(BaseService::Result.new)
+      .to receive(:call!).with(organization:, params:).and_return(Payments::ManualCreateService::Result.new)
 
     described_class.perform_now(organization:, params:)
 

--- a/spec/jobs/payments/set_payment_method_and_create_receipt_job_spec.rb
+++ b/spec/jobs/payments/set_payment_method_and_create_receipt_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Payments::SetPaymentMethodAndCreateReceiptJob do
 
   before do
     allow(Payments::SetPaymentMethodDataService)
-      .to receive(:call!).with(payment:, provider_payment_method_id:).and_return(BaseService::Result.new)
+      .to receive(:call!).with(payment:, provider_payment_method_id:).and_return(Payments::SetPaymentMethodDataService::Result.new)
   end
 
   it "calls the service" do

--- a/spec/jobs/plans/destroy_job_spec.rb
+++ b/spec/jobs/plans/destroy_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Plans::DestroyJob do
 
   let(:plan) { create(:plan) }
   let(:child_plan) { create(:plan, parent: plan) }
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { Plans::DestroyService::Result.new }
 
   before do
     plan.children << child_plan
@@ -34,7 +34,7 @@ RSpec.describe Plans::DestroyJob do
     end
 
     context "when destroy service succeeds" do
-      let(:service_result) { BaseService::Result.new }
+      let(:service_result) { Plans::DestroyService::Result.new }
 
       it "calls the destroy service for child plans first" do
         described_class.perform_now(plan)
@@ -53,7 +53,7 @@ RSpec.describe Plans::DestroyJob do
 
     context "when destroy service fails" do
       let(:service_result) do
-        BaseService::Result.new.service_failure!(
+        Plans::DestroyService::Result.new.service_failure!(
           code: "failure",
           message: "Destroy failed"
         )

--- a/spec/jobs/subscriptions/organization_billing_job_spec.rb
+++ b/spec/jobs/subscriptions/organization_billing_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Subscriptions::OrganizationBillingJob do
 
   describe ".perform" do
     let(:organization) { create(:organization, api_keys: []) }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Subscriptions::OrganizationBillingService::Result.new }
 
     it "calls the subscriptions biller service" do
       allow(Subscriptions::OrganizationBillingService).to receive(:call!)

--- a/spec/jobs/subscriptions/terminate_ended_subscription_job_spec.rb
+++ b/spec/jobs/subscriptions/terminate_ended_subscription_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Subscriptions::TerminateEndedSubscriptionJob do
   let(:subscription) { create(:subscription) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Subscriptions::TerminateService::Result.new }
 
   before do
     allow(Subscriptions::TerminateService).to receive(:call!).and_call_original
@@ -22,7 +22,7 @@ RSpec.describe Subscriptions::TerminateEndedSubscriptionJob do
 
     context "when the service returns a failure" do
       let(:result) do
-        BaseService::Result.new.not_found_failure!(resource: "subscription")
+        Subscriptions::TerminateService::Result.new.not_found_failure!(resource: "subscription")
       end
 
       it "raises a FailedResult error" do

--- a/spec/jobs/subscriptions/terminate_job_spec.rb
+++ b/spec/jobs/subscriptions/terminate_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Subscriptions::TerminateJob do
   let(:timestamp) { Time.zone.now.to_i }
 
   let(:subscription_service) { instance_double(Subscriptions::TerminateService) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Subscriptions::TerminateService::Result.new }
 
   it "calls the subscription service" do
     allow(Subscriptions::TerminateService).to receive(:new)
@@ -25,7 +25,7 @@ RSpec.describe Subscriptions::TerminateJob do
 
   context "when result is a failure" do
     let(:result) do
-      BaseService::Result.new.not_found_failure!(resource: "subscription")
+      Subscriptions::TerminateService::Result.new.not_found_failure!(resource: "subscription")
     end
 
     it "raises an error" do

--- a/spec/lib/tasks/recipes/clickhouse_rake_spec.rb
+++ b/spec/lib/tasks/recipes/clickhouse_rake_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "recipes:clickhouse:enable_clickhouse_events_store", clickhouse: 
 
     results = amount_cents_per_call.map do |cents|
       fees = cents.nil? ? [] : [Fee.new(amount_cents: cents)]
-      BaseService::LegacyResult.new.tap { |r| r.usage = SubscriptionUsage.new(fees:) }
+      BaseResult[:usage].new.tap { |r| r.usage = SubscriptionUsage.new(fees:) }
     end
     stub.and_return(*results)
   end

--- a/spec/mailers/payment_request_mailer_spec.rb
+++ b/spec/mailers/payment_request_mailer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PaymentRequestMailer do
   describe "#requested" do
     let(:payment_url) { Faker::Internet.url }
     let(:payment_url_result) do
-      BaseService::Result.new.tap do |result|
+      PaymentRequests::Payments::GeneratePaymentUrlService::Result.new.tap do |result|
         result.payment_url = payment_url
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe PaymentRequestMailer do
 
     context "when no payment url is available" do
       let(:payment_url_result) do
-        BaseService::Result.new.tap do |result|
+        PaymentRequests::Payments::GeneratePaymentUrlService::Result.new.tap do |result|
           result.single_validation_failure!(error_code: "invalid_payment_provider")
         end
       end

--- a/spec/mailers/previews/payment_request_mailer_preview.rb
+++ b/spec/mailers/previews/payment_request_mailer_preview.rb
@@ -48,7 +48,7 @@ class PaymentRequestMailerPreview < BasePreviewMailer
 
     ::PaymentRequests::Payments::GeneratePaymentUrlService.class_eval do
       def self.call(payable:)
-        BaseService::Result.new.tap do |result|
+        PaymentRequests::Payments::GeneratePaymentUrlService::Result.new.tap do |result|
           result.payment_url = "https://stripe.com/payment_url"
         end
       end

--- a/spec/requests/admin/invoices_controller_spec.rb
+++ b/spec/requests/admin/invoices_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Admin::InvoicesController, type: [:request, :admin] do
   let(:invoice) { create(:invoice) }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Invoices::GeneratePdfService::Result.new }
 
   before do
     allow(Invoices::GeneratePdfService).to receive(:call)

--- a/spec/requests/api/v1/data_api/usages_controller_spec.rb
+++ b/spec/requests/api/v1/data_api/usages_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::V1::DataApi::UsagesController do # rubocop:disable Rails/Fil
     let(:params) { {currency: "EUR"} }
 
     let(:result) do
-      BaseService::Result.new.tap do |result|
+      DataApi::UsagesService::Result.new.tap do |result|
         result.usages = [{amount_currency: nil, amount_cents: nil}]
       end
     end

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -849,7 +849,7 @@ RSpec.describe Api::V1::InvoicesController do
 
     before do
       allow(Invoices::Payments::RetryService).to receive(:new).and_return(retry_service)
-      allow(retry_service).to receive(:call).and_return(BaseService::Result.new)
+      allow(retry_service).to receive(:call).and_return(Invoices::Payments::RetryService::Result.new)
     end
 
     include_examples "requires API permission", "invoice", "write"
@@ -906,7 +906,7 @@ RSpec.describe Api::V1::InvoicesController do
     let!(:invoice) { create(:invoice, customer:, organization:) }
     let(:invoice_id) { invoice.id }
     let(:retry_service) { instance_double(Invoices::RetryService) }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Invoices::RetryService::Result.new }
 
     before do
       result.invoice = invoice
@@ -949,7 +949,7 @@ RSpec.describe Api::V1::InvoicesController do
 
     let!(:invoice) { create(:invoice, customer:, organization:) }
     let(:invoice_id) { invoice.id }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Invoices::SyncSalesforceIdService::Result.new }
 
     before do
       result.invoice = invoice

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::PaymentRequestsController do
 
     before do
       allow(PaymentRequests::CreateService).to receive(:call).and_return(
-        BaseService::Result.new.tap { |r| r.payment_request = payment_request }
+        PaymentRequests::CreateService::Result.new.tap { |r| r.payment_request = payment_request }
       )
     end
 

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::PaymentsController do
     context "when all parameters are valid" do
       before do
         allow(Payments::ManualCreateService).to receive(:call).and_return(
-          BaseService::Result.new.tap { |r| r.payment = payment }
+          Payments::ManualCreateService::Result.new.tap { |r| r.payment = payment }
         )
       end
 

--- a/spec/requests/data_api/v1/charges_controller_spec.rb
+++ b/spec/requests/data_api/v1/charges_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe DataApi::V1::ChargesController do # rubocop:disable Rails/FilePat
     end
 
     let(:result) do
-      BaseService::Result.new.tap do |result|
+      Charges::CalculatePriceService::Result.new.tap do |result|
         result.charge_amount_cents = 10
         result.subscription_amount_cents = 10
         result.total_amount_cents = 20

--- a/spec/serializers/v1/billable_metric_expression_result_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_expression_result_serializer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ::V1::BillableMetricExpressionResultSerializer do
   subject(:serializer) { described_class.new(billable_metric_expression_result, root_name: "expression_result") }
 
-  let(:billable_metric_expression_result) { BaseService::Result.new.tap { it.evaluation_result = "1.0" } }
+  let(:billable_metric_expression_result) { BillableMetrics::EvaluateExpressionService::Result.new.tap { it.evaluation_result = "1.0" } }
   let(:result) { JSON.parse(serializer.to_json) }
 
   it "serializes the object" do

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AdjustedFees::CreateService do
     before do
       allow(Invoices::RefreshDraftService)
         .to receive(:call).with(invoice: invoice)
-        .and_return(BaseService::Result.new)
+        .and_return(Invoices::RefreshDraftService::Result.new)
     end
 
     context "when license is premium", :premium do

--- a/spec/services/adjusted_fees/destroy_service_spec.rb
+++ b/spec/services/adjusted_fees/destroy_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AdjustedFees::DestroyService do
       adjusted_fee
       allow(Invoices::RefreshDraftService)
         .to receive(:call).with(invoice:)
-        .and_return(BaseService::Result.new)
+        .and_return(Invoices::RefreshDraftService::Result.new)
     end
 
     it "destroys the adjusted fee" do

--- a/spec/services/billable_metrics/aggregations/base_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/base_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::BaseService do
   describe ".null_result" do
     subject(:null_result) { described_class.null_result(result, **args) }
 
-    let(:result) { BaseService::Result.new }
+    let(:result) { described_class::Result.new }
     let(:args) { {} }
 
     context "without keyword arguments" do

--- a/spec/services/charge_models/custom_service_spec.rb
+++ b/spec/services/charge_models/custom_service_spec.rb
@@ -12,7 +12,7 @@ Rspec.describe ChargeModels::CustomService do
     )
   end
 
-  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
   let(:aggregation) { 10 }
   let(:total_aggregated_units) { nil }
   let(:full_units_number) { BigDecimal("10.0") }

--- a/spec/services/charge_models/dynamic_service_spec.rb
+++ b/spec/services/charge_models/dynamic_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ChargeModels::DynamicService do
     aggregation_result.precise_total_amount_cents = precise_total_amount_cents
   end
 
-  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
 
   let(:charge) { create(:dynamic_charge) }
 

--- a/spec/services/charge_models/factory_spec.rb
+++ b/spec/services/charge_models/factory_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ChargeModels::Factory do
   let(:charge) { build(:standard_charge) }
 
   describe "#new_instance" do
-    let(:aggregation_result) { BaseService::Result.new }
+    let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
     let(:properties) { charge.properties }
 
     let(:result) { factory.new_instance(chargeable: charge, aggregation_result:, properties:) }
@@ -27,14 +27,14 @@ RSpec.describe ChargeModels::Factory do
 
         context "when charge is grouped" do
           let(:charge) { build(:standard_charge, properties: {grouped_by: ["cloud"]}) }
-          let(:aggregation_result) { BaseService::Result.new.tap { |r| r.aggregations = [BaseService::Result.new] } }
+          let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new.tap { |r| r.aggregations = [BillableMetrics::Aggregations::BaseService::Result.new] } }
 
           it { expect(result).to be_a(ChargeModels::GroupedService) }
         end
 
         context "when charge accepts target wallet" do
           let(:charge) { build(:standard_charge, accepts_target_wallet: true) }
-          let(:aggregation_result) { BaseService::Result.new.tap { |r| r.aggregations = [BaseService::Result.new] } }
+          let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new.tap { |r| r.aggregations = [BillableMetrics::Aggregations::BaseService::Result.new] } }
 
           it { expect(result).to be_a(ChargeModels::GroupedService) }
         end
@@ -47,7 +47,7 @@ RSpec.describe ChargeModels::Factory do
 
         context "when charge is prorated" do
           let(:charge) { build(:graduated_charge, prorated: true) }
-          let(:aggregation_result) { BaseService::Result.new.tap { |r| r.aggregator = [BaseService::Result.new] } }
+          let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new.tap { |r| r.aggregator = [BillableMetrics::Aggregations::BaseService::Result.new] } }
 
           it { expect(result).to be_a(ChargeModels::ProratedGraduatedService) }
         end

--- a/spec/services/charge_models/graduated_percentage_service_spec.rb
+++ b/spec/services/charge_models/graduated_percentage_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ChargeModels::GraduatedPercentageService, :premium do
   end
 
   let(:aggregation_result) do
-    BaseService::Result.new.tap do |r|
+    BillableMetrics::Aggregations::BaseService::Result.new.tap do |r|
       r.aggregation = aggregation
       r.count = aggregation_count
     end

--- a/spec/services/charge_models/graduated_service_spec.rb
+++ b/spec/services/charge_models/graduated_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChargeModels::GraduatedService do
     aggregation_result.aggregation = aggregation
   end
 
-  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
 
   let(:charge) do
     create(

--- a/spec/services/charge_models/grouped_service_spec.rb
+++ b/spec/services/charge_models/grouped_service_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe ChargeModels::GroupedService do
     let(:charge_model) { ChargeModels::StandardService }
 
     let(:aggregation_result) do
-      BaseService::Result.new.tap do |result|
+      BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
         result.aggregations = group_results.map do |group_result|
-          BaseService::Result.new.tap do |aggregation|
+          BillableMetrics::Aggregations::BaseService::Result.new.tap do |aggregation|
             aggregation.aggregation = group_result[:aggregation]
             aggregation.count = group_result[:count]
             aggregation.grouped_by = group_result[:grouped_by]
@@ -76,9 +76,9 @@ RSpec.describe ChargeModels::GroupedService do
     let(:charge) { create(:dynamic_charge) }
 
     let(:aggregation_result) do
-      BaseService::Result.new.tap do |result|
+      BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
         result.aggregations = group_results.map do |group_result|
-          BaseService::Result.new.tap do |aggregation|
+          BillableMetrics::Aggregations::BaseService::Result.new.tap do |aggregation|
             aggregation.aggregation = group_result[:aggregation]
             aggregation.precise_total_amount_cents = group_result[:precise_total_amount_cents]
             aggregation.count = group_result[:count]

--- a/spec/services/charge_models/package_service_spec.rb
+++ b/spec/services/charge_models/package_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChargeModels::PackageService do
     aggregation_result.aggregation = aggregation
   end
 
-  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
   let(:aggregation) { 121 }
 
   let(:charge) do

--- a/spec/services/charge_models/percentage_service_spec.rb
+++ b/spec/services/charge_models/percentage_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ChargeModels::PercentageService do
   end
 
   let(:running_total) { [50, 150, 400] }
-  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
   let(:fixed_amount) { "2.0" }
   let(:aggregation) { 800 }
   let(:free_units_per_events) { 3 }
@@ -272,7 +272,7 @@ RSpec.describe ChargeModels::PercentageService do
     let(:free_units_per_total_aggregation) { "0" }
     let(:rate) { "2.99" }
 
-    let(:per_event_aggregation) { BaseService::Result.new.tap { |r| r.event_aggregation = [10, 80, 10_000] } }
+    let(:per_event_aggregation) { BillableMetrics::Aggregations::BaseService::PerEventAggregationResult.new.tap { |r| r.event_aggregation = [10, 80, 10_000] } }
     let(:running_total) { [] }
 
     before do

--- a/spec/services/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charge_models/prorated_graduated_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, organization:, plan:) }
 
-  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
   let(:billable_metric) { create(:sum_billable_metric, recurring: true) }
   let(:aggregation) { 5.96667 }
   let(:aggregator) do
@@ -29,7 +29,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   end
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:per_event_aggregation) do
-    BaseService::Result.new.tap do |r|
+    BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
       r.event_aggregation = [5, 5, 10, -6]
       r.event_prorated_aggregation = [3.5, 2.66667, 2, -2.2]
     end
@@ -77,7 +77,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   context "when zero usage" do
     let(:aggregation) { 0 }
     let(:per_event_aggregation) do
-      BaseService::Result.new.tap do |r|
+      BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
         r.event_aggregation = []
         r.event_prorated_aggregation = []
       end
@@ -98,7 +98,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   context "with event that cannot be fully placed into the range" do
     let(:aggregation) { 3.86667 }
     let(:per_event_aggregation) do
-      BaseService::Result.new.tap do |r|
+      BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
         r.event_aggregation = [2, 5, 10, -6]
         r.event_prorated_aggregation = [1.4, 2.66667, 2, -2.2]
       end
@@ -120,7 +120,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   context "with final number of units equals to zero" do
     let(:aggregation) { 1.613 }
     let(:per_event_aggregation) do
-      BaseService::Result.new.tap do |r|
+      BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
         r.event_aggregation = [1, 4, 1, -5, -1]
         r.event_prorated_aggregation = [0.7097, 1.54839, 0.2258, -0.80645, -0.0645]
       end
@@ -142,7 +142,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   context "with negative event that results in changing range" do
     let(:aggregation) { 2.5 }
     let(:per_event_aggregation) do
-      BaseService::Result.new.tap do |r|
+      BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
         r.event_aggregation = [5, -2]
         r.event_prorated_aggregation = [3.5, -1]
       end
@@ -163,7 +163,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
     context "with overflow and changing ranges" do
       let(:aggregation) { 3.2 }
       let(:per_event_aggregation) do
-        BaseService::Result.new.tap do |r|
+        BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
           r.event_aggregation = [4, 2, -3]
           r.event_prorated_aggregation = [2.8, 1, -0.6]
         end
@@ -185,7 +185,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
     context "with multiple overflows in both directions" do
       let(:aggregation) { 4.9 }
       let(:per_event_aggregation) do
-        BaseService::Result.new.tap do |r|
+        BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
           r.event_aggregation = [5, 2, -4, 10]
           r.event_prorated_aggregation = [3.5, 1, -1.6, 2]
         end
@@ -208,7 +208,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   context "with negative event that results in negative total amount" do
     let(:aggregation) { -31.33 }
     let(:per_event_aggregation) do
-      BaseService::Result.new.tap do |r|
+      BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
         r.event_aggregation = [5, -100]
         r.event_prorated_aggregation = [2, -33.33]
       end
@@ -229,7 +229,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
     context "with only one range used" do
       let(:aggregation) { -31.73 }
       let(:per_event_aggregation) do
-        BaseService::Result.new.tap do |r|
+        BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
           r.event_aggregation = [4, -100]
           r.event_prorated_aggregation = [1.6, -33.33]
         end
@@ -252,7 +252,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   context "when only one range is used" do
     let(:aggregation) { 0.7 }
     let(:per_event_aggregation) do
-      BaseService::Result.new.tap do |r|
+      BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
         r.event_aggregation = [1]
         r.event_prorated_aggregation = [0.7]
       end
@@ -303,7 +303,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
   context "with three ranges and one overflow" do
     let(:aggregation) { 6.36 }
     let(:per_event_aggregation) do
-      BaseService::Result.new.tap do |r|
+      BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
         r.event_aggregation = [2, 5, 10, -6, 4, 60]
         r.event_prorated_aggregation = [1.4, 2.5, 2, -2.2, 0.667, 2]
       end
@@ -352,7 +352,7 @@ RSpec.describe ChargeModels::ProratedGraduatedService do
     context "when there are two overflows" do
       let(:aggregation) { 75 }
       let(:per_event_aggregation) do
-        BaseService::Result.new.tap do |r|
+        BillableMetrics::ProratedAggregations::BaseService::ProratedPerEventAggregationResult.new.tap do |r|
           r.event_aggregation = [75]
           r.event_prorated_aggregation = [75]
         end

--- a/spec/services/charge_models/standard_service_spec.rb
+++ b/spec/services/charge_models/standard_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ChargeModels::StandardService do
     aggregation_result.full_units_number = full_units_number if full_units_number
   end
 
-  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
   let(:aggregation) { 10 }
   let(:total_aggregated_units) { nil }
   let(:full_units_number) { nil }

--- a/spec/services/charge_models/volume_service_spec.rb
+++ b/spec/services/charge_models/volume_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChargeModels::VolumeService do
     aggregation_result.aggregation = aggregation
   end
 
-  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
 
   let(:charge) do
     create(

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -68,11 +68,11 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
 
         allow(charge_model_class).to receive(:apply)
           .with(charge:, aggregation_result:, properties:)
-          .and_return(BaseService::Result.new.tap { |r| r.amount = 10 })
+          .and_return(charge_model_class::Result.new.tap { |r| r.amount = 10 })
 
         allow(charge_model_class).to receive(:apply)
           .with(charge:, aggregation_result: previous_agg_result, properties: properties.merge(exclude_event: true))
-          .and_return(BaseService::Result.new.tap { |r| r.amount = 8 })
+          .and_return(charge_model_class::Result.new.tap { |r| r.amount = 8 })
 
         result = charge_service.call
 
@@ -97,11 +97,11 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
 
           allow(charge_model_class).to receive(:apply)
             .with(charge:, aggregation_result:, properties:)
-            .and_return(BaseService::Result.new.tap { |r| r.amount = 8 })
+            .and_return(charge_model_class::Result.new.tap { |r| r.amount = 8 })
 
           allow(charge_model_class).to receive(:apply)
             .with(charge:, aggregation_result: non_persisted_agg_result, properties: properties.merge(include_event_value: true))
-            .and_return(BaseService::Result.new.tap { |r| r.amount = 10 })
+            .and_return(charge_model_class::Result.new.tap { |r| r.amount = 10 })
 
           result = charge_service.call
 

--- a/spec/services/charges/bulk_forecasted_usage_amount_service_spec.rb
+++ b/spec/services/charges/bulk_forecasted_usage_amount_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Charges::BulkForecastedUsageAmountService do
   let(:charge_filter) { create(:charge_filter, charge: charge1) }
 
   let(:price_result) do
-    BaseService::Result.new.tap do |result|
+    Charges::CalculatePriceService::Result.new.tap do |result|
       result.charge_amount_cents = 10
       result.subscription_amount_cents = 10
       result.total_amount_cents = 20

--- a/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
+++ b/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice do
         let(:amount) { 102 }
 
         let(:cn_ats_result) do
-          BaseService::Result.new.tap do |result|
+          CreditNotes::ApplyTaxesService::Result.new.tap do |result|
             result.coupons_adjustment_amount_cents = 102.0
             result.taxes_amount_cents = 0.0
             result.precise_taxes_amount_cents = 0.0

--- a/spec/services/customer_portal/customer_update_service_spec.rb
+++ b/spec/services/customer_portal/customer_update_service_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe CustomerPortal::CustomerUpdateService do
 
     context "when applying taxes fails" do
       let(:apply_taxes_result) do
-        BaseService::Result.new.not_found_failure!(resource: "tax")
+        Customers::ApplyTaxesService::Result.new.not_found_failure!(resource: "tax")
       end
 
       before do

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Customers::RefreshWalletsService do
         allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService)
           .to receive(:call)
           .and_return(
-            BaseService::Result.new.service_failure!(
+            Integrations::Aggregator::Taxes::Invoices::CreateDraftService::Result.new.service_failure!(
               code: "customerAddressCouldNotResolve",
               message: "Customer address could not resolve"
             )

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe Customers::UpdateService do
         allow(PaymentProviderCustomers::UpdateService)
           .to receive(:call)
           .with(customer)
-          .and_return(BaseService::Result.new)
+          .and_return(PaymentProviderCustomers::UpdateService::Result.new)
       end
 
       it "creates a payment provider customer" do

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -17,9 +17,8 @@ RSpec.describe DunningCampaigns::ProcessAttemptService do
   let(:payment_request) { create :payment_request, organization: }
 
   let(:payment_request_result) do
-    BaseService::Result.new.tap do |result|
+    PaymentRequests::CreateService::Result.new.tap do |result|
       result.payment_request = payment_request
-      result.customer = customer
     end
   end
 

--- a/spec/services/events/stores/clickhouse/enriched_store_migration/comparison_service_spec.rb
+++ b/spec/services/events/stores/clickhouse/enriched_store_migration/comparison_service_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonSer
 
     let(:legacy_usage) { SubscriptionUsage.new(fees: [legacy_fee]) }
     let(:enriched_usage) { SubscriptionUsage.new(fees: [enriched_fee]) }
-    let(:legacy_result) { BaseService::LegacyResult.new.tap { |r| r.usage = legacy_usage } }
-    let(:enriched_result) { BaseService::LegacyResult.new.tap { |r| r.usage = enriched_usage } }
+    let(:legacy_result) { BaseResult[:usage].new.tap { |r| r.usage = legacy_usage } }
+    let(:enriched_result) { BaseResult[:usage].new.tap { |r| r.usage = enriched_usage } }
 
     before do
       allow(Invoices::CustomerUsageService).to receive(:call)
@@ -146,7 +146,7 @@ RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonSer
 
     context "when legacy computation fails" do
       let(:legacy_result) do
-        BaseService::LegacyResult.new.tap { |r| r.service_failure!(code: "legacy_error", message: "legacy computation broke") }
+        BaseResult.new.tap { |r| r.service_failure!(code: "legacy_error", message: "legacy computation broke") }
       end
 
       it "returns the original error" do
@@ -174,7 +174,7 @@ RSpec.describe Events::Stores::Clickhouse::EnrichedStoreMigration::ComparisonSer
 
     context "when enriched computation fails" do
       let(:enriched_result) do
-        BaseService::LegacyResult.new.tap { |r| r.service_failure!(code: "enriched_error", message: "enriched computation broke") }
+        BaseResult.new.tap { |r| r.service_failure!(code: "enriched_error", message: "enriched computation broke") }
       end
 
       it "returns the original error" do

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -2743,7 +2743,7 @@ RSpec.describe Fees::ChargeService, :premium do
       end
       let(:aggregator_service) { instance_double(BillableMetrics::Aggregations::MaxService) }
       let(:error_result) do
-        BaseService::Result.new.service_failure!(code: "aggregation_failure", message: "Test message")
+        BillableMetrics::Aggregations::BaseService::Result.new.service_failure!(code: "aggregation_failure", message: "Test message")
       end
 
       it "returns an error" do
@@ -2961,7 +2961,7 @@ RSpec.describe Fees::ChargeService, :premium do
         end
         let(:aggregator_service) { instance_double(BillableMetrics::Aggregations::MaxService) }
         let(:error_result) do
-          BaseService::Result.new.service_failure!(code: "aggregation_failure", message: "Test message")
+          BillableMetrics::Aggregations::BaseService::Result.new.service_failure!(code: "aggregation_failure", message: "Test message")
         end
 
         it "returns an error" do
@@ -4291,7 +4291,7 @@ RSpec.describe Fees::ChargeService, :premium do
       let(:presentation_group_keys) { [{value: "department"}, {value: "region"}] }
       let(:filter_by_presentation) { nil }
       let(:aggregator) { instance_double("Aggregator") }
-      let(:aggregation_result) { BaseService::Result.new }
+      let(:aggregation_result) { BillableMetrics::Aggregations::BaseService::Result.new }
 
       before do
         allow(BillableMetrics::AggregationFactory).to receive(:new_instance).and_call_original

--- a/spec/services/fees/commitments/minimum/create_service_spec.rb
+++ b/spec/services/fees/commitments/minimum/create_service_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Fees::Commitments::Minimum::CreateService do
           )
         end
         let(:true_up_result) do
-          BaseService::Result.new.tap do |r|
+          Commitments::Minimum::CalculateTrueUpFeeService::Result.new.tap do |r|
             r.amount_cents = 500
             r.precise_amount_cents = 500.0
           end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Fees::CreatePayInAdvanceService do
 
   describe "#call" do
     let(:aggregation_result) do
-      BaseService::Result.new.tap do |result|
+      BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
         result.aggregation = 9
         result.count = 4
         result.options = {}
@@ -43,7 +43,7 @@ RSpec.describe Fees::CreatePayInAdvanceService do
     end
 
     let(:charge_result) do
-      BaseService::Result.new.tap do |result|
+      Charges::ApplyPayInAdvanceChargeModelService::Result.new.tap do |result|
         result.amount = 10
         result.precise_amount = 10.0
         result.unit_amount = 0.01111111111
@@ -133,7 +133,7 @@ RSpec.describe Fees::CreatePayInAdvanceService do
 
     context "when aggregation fails" do
       let(:aggregation_result) do
-        BaseService::Result.new.service_failure!(code: "failure", message: "Failure")
+        BillableMetrics::Aggregations::BaseService::Result.new.service_failure!(code: "failure", message: "Failure")
       end
 
       it "returns a failure" do
@@ -148,7 +148,7 @@ RSpec.describe Fees::CreatePayInAdvanceService do
 
     context "when charge model fails" do
       let(:charge_result) do
-        BaseService::Result.new.service_failure!(code: "failure", message: "Failure")
+        Charges::ApplyPayInAdvanceChargeModelService::Result.new.service_failure!(code: "failure", message: "Failure")
       end
 
       it "returns a failure" do
@@ -537,10 +537,8 @@ RSpec.describe Fees::CreatePayInAdvanceService do
 
     context "when in current and max aggregation result" do
       let(:aggregation_result) do
-        BaseService::Result.new.tap do |result|
-          result.amount = 10
+        BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
           result.count = 1
-          result.units = 9
           result.current_aggregation = 9
           result.max_aggregation = 9
           result.max_aggregation_with_proration = nil
@@ -572,10 +570,8 @@ RSpec.describe Fees::CreatePayInAdvanceService do
         end
         let(:event_properties) { {"cloud" => "aws", "region" => "us-east-1"} }
         let(:aggregation_result) do
-          BaseService::Result.new.tap do |result|
-            result.amount = 10
+          BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
             result.count = 1
-            result.units = 9
             result.current_aggregation = 9
             result.max_aggregation = 9
             result.max_aggregation_with_proration = nil
@@ -656,7 +652,7 @@ RSpec.describe Fees::CreatePayInAdvanceService do
         end
         let(:aggregation_result) { aggregation_results.fetch(event.transaction_id) }
         let(:charge_result) do
-          BaseService::Result.new.tap do |result|
+          Charges::ApplyPayInAdvanceChargeModelService::Result.new.tap do |result|
             result.amount = aggregation_result.pay_in_advance_breakdowns.sum { |breakdown| breakdown[:value] }
             result.precise_amount = result.amount.to_d
             result.unit_amount = 1
@@ -665,7 +661,7 @@ RSpec.describe Fees::CreatePayInAdvanceService do
           end
         end
         let(:first_aggregation_result) do
-          BaseService::Result.new.tap do |result|
+          BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
             result.aggregation = 3
             result.count = 1
             result.options = {}
@@ -676,7 +672,7 @@ RSpec.describe Fees::CreatePayInAdvanceService do
           end
         end
         let(:second_aggregation_result) do
-          BaseService::Result.new.tap do |result|
+          BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
             result.aggregation = 13
             result.count = 2
             result.options = {}
@@ -690,7 +686,7 @@ RSpec.describe Fees::CreatePayInAdvanceService do
           end
         end
         let(:third_aggregation_result) do
-          BaseService::Result.new.tap do |result|
+          BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
             result.aggregation = 20
             result.count = 3
             result.options = {}

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService do
 
   context "with charge model error" do
     let(:error_result) do
-      BaseService::Result.new.tap do |result|
+      ChargeModels::StandardService::Result.new.tap do |result|
         result.service_failure!(code: "error", message: "message")
       end
     end

--- a/spec/services/inbound_webhooks/create_service_spec.rb
+++ b/spec/services/inbound_webhooks/create_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe InboundWebhooks::CreateService do
   let(:signature) { "signature" }
   let(:payload) { event.merge(code:).to_json }
   let(:event_type) { "payment_intent.successful" }
-  let(:validation_payload_result) { BaseService::Result.new }
+  let(:validation_payload_result) { InboundWebhooks::ValidatePayloadService::Result.new }
 
   let(:event) do
     JSON.parse(get_stripe_fixtures("webhooks/payment_intent_succeeded.json"))
@@ -67,7 +67,7 @@ RSpec.describe InboundWebhooks::CreateService do
 
   context "when payload validation fails" do
     let(:validation_payload_result) do
-      BaseService::Result.new.service_failure!(
+      InboundWebhooks::ValidatePayloadService::Result.new.service_failure!(
         code: "webhook_error", message: "Invalid signature"
       )
     end

--- a/spec/services/integration_customers/avalara_service_spec.rb
+++ b/spec/services/integration_customers/avalara_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe IntegrationCustomers::AvalaraService do
 
     let(:contact_id) { SecureRandom.uuid }
     let(:create_result) do
-      result = BaseService::Result.new
+      result = Integrations::Aggregator::Contacts::CreateService::Result.new
       result.contact_id = contact_id
       result
     end

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe IntegrationCustomers::CreateService do
       let(:contact_id) { SecureRandom.uuid }
 
       let(:create_result) do
-        result = BaseService::Result.new
+        result = Integrations::Aggregator::Contacts::CreateService::Result.new
         result.contact_id = contact_id
         result
       end

--- a/spec/services/integration_customers/update_service_spec.rb
+++ b/spec/services/integration_customers/update_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe IntegrationCustomers::UpdateService do
       let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
 
       let(:update_result) do
-        result = BaseService::Result.new
+        result = Integrations::Aggregator::Contacts::UpdateService::Result.new
         result.contact_id = contact_id
         result
       end

--- a/spec/services/invoices/apply_provider_taxes_service_spec.rb
+++ b/spec/services/invoices/apply_provider_taxes_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Invoices::ApplyProviderTaxesService do
   end
   let(:fees_amount_cents) { 3000 }
   let(:coupons_amount_cents) { 0 }
-  let(:result) { BaseService::Result.new }
+  let(:result) { Integrations::Aggregator::Taxes::Invoices::CreateService::Result.new }
 
   let(:fee_taxes) do
     [

--- a/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
+++ b/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService do
       context "when there is no fees" do
         let(:fee_subscription) { nil }
         let(:fee_charge) { nil }
-        let(:result) { BaseService::Result.new }
+        let(:result) { Invoices::ComputeAmountsFromFees::Result.new }
 
         before do
           allow(Invoices::ComputeAmountsFromFees).to receive(:call)
@@ -199,7 +199,7 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService do
 
       context "with zero amount invoice" do
         let(:fee_charge) { nil }
-        let(:result) { BaseService::Result.new }
+        let(:result) { Invoices::ComputeAmountsFromFees::Result.new }
         let(:fee_subscription) do
           create(
             :fee,
@@ -251,7 +251,7 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService do
     end
 
     context "when there is NO tax provider" do
-      let(:result) { BaseService::Result.new }
+      let(:result) { Invoices::ComputeAmountsFromFees::Result.new }
 
       before do
         allow(Invoices::ComputeAmountsFromFees).to receive(:call)

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService do
 
   describe "#call" do
     let(:aggregation_result) do
-      BaseService::Result.new.tap do |result|
+      BillableMetrics::Aggregations::BaseService::Result.new.tap do |result|
         result.aggregation = 9
         result.count = 4
         result.options = {}
@@ -45,7 +45,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService do
     end
 
     let(:charge_result) do
-      BaseService::Result.new.tap do |result|
+      Charges::ApplyPayInAdvanceChargeModelService::Result.new.tap do |result|
         result.amount = 10
         result.precise_amount = 10.0
         result.unit_amount = 0.01111111111

--- a/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_fixed_charges_service_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe Invoices::CreatePayInAdvanceFixedChargesService do
       before do
         allow(Fees::BuildPayInAdvanceFixedChargeService)
           .to receive(:call)
-          .and_return(BaseService::Result.new.service_failure!(code: "code", message: "message"))
+          .and_return(Fees::BuildPayInAdvanceFixedChargeService::Result.new.service_failure!(code: "code", message: "message"))
       end
 
       it "fails with a service failure" do

--- a/spec/services/invoices/finalize_batch_service_spec.rb
+++ b/spec/services/invoices/finalize_batch_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Invoices::FinalizeBatchService do
 
   describe "#call" do
     let(:finalize_service) { instance_double(Invoices::RefreshDraftAndFinalizeService) }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Invoices::RefreshDraftAndFinalizeService::Result.new }
     let(:invoice_ids) { invoices.map(&:id) }
     let(:invoices) { create_list(:invoice, 3, status: "draft", customer:) }
 

--- a/spec/services/invoices/payments/flutterwave_service_spec.rb
+++ b/spec/services/invoices/payments/flutterwave_service_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
       end
 
       it "updates invoice payment status" do
-        allow(Invoices::UpdateService).to receive(:call).and_return(BaseService::Result.new)
+        allow(Invoices::UpdateService).to receive(:call).and_return(Invoices::UpdateService::Result.new)
 
         described_class.call(
           :update_payment_status,
@@ -184,7 +184,7 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
       before do
         existing_payment1
         existing_payment2
-        allow(Invoices::UpdateService).to receive(:call).and_return(BaseService::Result.new)
+        allow(Invoices::UpdateService).to receive(:call).and_return(Invoices::UpdateService::Result.new)
       end
 
       it "calculates total paid amount correctly" do
@@ -304,8 +304,8 @@ RSpec.describe Invoices::Payments::FlutterwaveService do
       let(:payment) { create(:payment, payable: invoice) }
 
       before do
-        flutterwave_service.instance_variable_set(:@result, BaseService::Result.new.tap { |r| r.invoice = invoice })
-        allow(Invoices::UpdateService).to receive(:call).and_return(BaseService::Result.new)
+        flutterwave_service.instance_variable_set(:@result, Invoices::Payments::FlutterwaveService::RESULTS.fetch(:update_payment_status).new.tap { |r| r.invoice = invoice })
+        allow(Invoices::UpdateService).to receive(:call).and_return(Invoices::UpdateService::Result.new)
       end
 
       it "calls invoice update service with correct parameters" do

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService do
 
       context "when failed to generate the invoice" do
         before do
-          allow(Invoices::RefreshDraftService).to receive(:call).and_return(BaseService::Result.new.service_failure!(code: "code", message: "message"))
+          allow(Invoices::RefreshDraftService).to receive(:call).and_return(Invoices::RefreshDraftService::Result.new.service_failure!(code: "code", message: "message"))
         end
 
         it "does not delete the invoice_generation_errors" do

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Invoices::RefreshDraftService do
 
         subscription2.mark_as_terminated!
 
-        allow(Invoices::CalculateFeesService).to receive(:call).and_return(BaseService::Result.new)
+        allow(Invoices::CalculateFeesService).to receive(:call).and_return(Invoices::CalculateFeesService::Result.new)
 
         invoice.update!(created_at: started_at)
       end

--- a/spec/services/invoices/retry_batch_service_spec.rb
+++ b/spec/services/invoices/retry_batch_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Invoices::RetryBatchService do
 
   describe "#call" do
     let(:retry_service) { instance_double(Invoices::RetryService) }
-    let(:result) { BaseService::Result.new }
+    let(:result) { Invoices::RetryService::Result.new }
     let(:invoice_ids) { [invoice_first.id, invoice_second.id] }
     let(:invoice_first) do
       create(

--- a/spec/services/lifetime_usages/check_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/check_thresholds_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe LifetimeUsages::CheckThresholdsService, transaction: false do
     end
 
     context "when there is tax provider error" do
-      let(:error_result) { BaseService::Result.new.unknown_tax_failure!(code: "tax_error", message: "") }
+      let(:error_result) { Invoices::ProgressiveBillingService::Result.new.unknown_tax_failure!(code: "tax_error", message: "") }
 
       before do
         allow(Invoices::ProgressiveBillingService).to receive(:call).and_return(error_result)

--- a/spec/services/payment_methods/validate_service_spec.rb
+++ b/spec/services/payment_methods/validate_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentMethods::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { BaseResult[:payment_method].new }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:payment_method) { create(:payment_method, organization:) }

--- a/spec/services/payment_provider_customers/update_service_spec.rb
+++ b/spec/services/payment_provider_customers/update_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PaymentProviderCustomers::UpdateService do
   let!(:provider_customer) { create(:"#{provider_name.downcase}_customer", customer:) }
 
   before do
-    allow(provider_service_class).to receive(:call).and_return(BaseService::Result.new)
+    allow(provider_service_class).to receive(:call).and_return(provider_service_class::RESULTS.fetch(:update).new)
     allow(Stripe::Customer).to receive(:update).and_return(true)
   end
 

--- a/spec/services/payment_providers/adyen/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_event_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
 
   describe "#call" do
     let(:payment_service) { instance_double(Invoices::Payments::AdyenService) }
-    let(:service_result) { BaseService::Result.new }
+    let(:service_result) { Invoices::Payments::AdyenService::RESULTS.fetch(:update_payment_status).new }
 
     before do
       allow(Invoices::Payments::AdyenService).to receive(:call)

--- a/spec/services/payment_providers/cashfree/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/handle_event_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PaymentProviders::Cashfree::HandleEventService do
   let(:organization) { create(:organization) }
 
   let(:payment_service) { instance_double(Invoices::Payments::CashfreeService) }
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { PaymentProviders::Cashfree::Webhooks::PaymentLinkEventService::Result.new }
 
   let(:event_json) do
     path = Rails.root.join("spec/fixtures/cashfree/payment_link_event_payment.json")

--- a/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PaymentProviders::Cashfree::Webhooks::PaymentLinkEventService do
   let(:event_json) { File.read("spec/fixtures/cashfree/payment_link_event_payment.json") }
 
   let(:payment_service) { instance_double(Invoices::Payments::CashfreeService) }
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { Invoices::Payments::CashfreeService::RESULTS.fetch(:update_payment_status).new }
 
   describe "#call" do
     context "when succeeded payment event" do

--- a/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PaymentProviders::Gocardless::HandleEventService do
   end
 
   let(:payment_service) { instance_double(Invoices::Payments::GocardlessService) }
-  let(:service_result) { BaseService::Result.new }
+  let(:service_result) { Invoices::Payments::GocardlessService::RESULTS.fetch(:update_payment_status).new }
   let(:payment_provider) { create(:gocardless_provider) }
 
   describe "#call" do
@@ -28,7 +28,7 @@ RSpec.describe PaymentProviders::Gocardless::HandleEventService do
     end
 
     context "when event metadata contains payable_type PaymentRequest" do
-      let(:service_result) { BaseService::Result.new }
+      let(:service_result) { PaymentRequests::Payments::GocardlessService::RESULTS.fetch(:update_payment_status).new }
 
       let(:event_json) do
         path = Rails.root.join("spec/fixtures/gocardless/events_payment_request.json")

--- a/spec/services/payment_providers/moneyhash/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/handle_event_service_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe PaymentProviders::Moneyhash::HandleEventService do
   end
 
   describe "amount_cents handling in metadata" do
-    let(:service_result) { BaseService::Result.new }
+    let(:service_result) { Invoices::Payments::MoneyhashService::RESULTS.fetch(:update_payment_status).new }
 
     before do
       allow(Invoices::Payments::MoneyhashService).to receive(:call).and_return(service_result)

--- a/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::AuthorizeService do
   let(:provider_method_id) { "pm_from_payment_method" }
   let(:payment_method_id) { "pm_from_provider_customer" }
   let(:stripe_result) do
-    result = BaseService::Result.new
+    result = PaymentProviderCustomers::Stripe::RetrieveLatestPaymentMethodService::Result.new
     result.payment_method_id = "pm_from_stripe"
     result
   end
@@ -30,7 +30,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::AuthorizeService do
       let(:payment_method) { nil }
       let(:payment_method_id) { nil }
       let(:stripe_result) do
-        result = BaseService::Result.new
+        result = PaymentProviderCustomers::Stripe::RetrieveLatestPaymentMethodService::Result.new
         result.payment_method_id = nil
         result
       end

--- a/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
     let(:provider_customer) { create(:cashfree_customer, payment_provider:, customer:) }
 
     let(:error_result) do
-      BaseService::Result.new.tap do |result|
+      PaymentRequests::Payments::CashfreeService::RESULTS.fetch(:generate_payment_url).new.tap do |result|
         result.fail_with_error!(
           BaseService::ThirdPartyFailure.new(
             result,
@@ -144,7 +144,7 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
 
   context "when provider service return an error" do
     let(:error_result) do
-      BaseService::Result.new.tap do |result|
+      PaymentRequests::Payments::StripeService::RESULTS.fetch(:generate_payment_url).new.tap do |result|
         result.fail_with_error!(
           BaseService::ServiceFailure.new(
             result,

--- a/spec/services/plans/update_amount_service_spec.rb
+++ b/spec/services/plans/update_amount_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Plans::UpdateAmountService do
       let(:pending_subscription) do
         create(:subscription, plan:, status: :pending, previous_subscription_id: subscription.id)
       end
-      let(:plan_upgrade_result) { BaseService::Result.new }
+      let(:plan_upgrade_result) { Subscriptions::PlanUpgradeService::Result.new }
 
       before do
         allow(Subscriptions::PlanUpgradeService)
@@ -101,7 +101,7 @@ RSpec.describe Plans::UpdateAmountService do
 
       context "when subscription upgrade fails" do
         let(:plan_upgrade_result) do
-          BaseService::Result.new.validation_failure!(
+          Subscriptions::PlanUpgradeService::Result.new.validation_failure!(
             errors: {billing_time: ["value_is_invalid"]}
           )
         end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -485,7 +485,7 @@ RSpec.describe Plans::UpdateService do
             amount_currency: "EUR"
           }
         end
-        let(:plan_upgrade_result) { BaseService::Result.new }
+        let(:plan_upgrade_result) { Subscriptions::PlanUpgradeService::Result.new }
 
         before do
           allow(Subscriptions::PlanUpgradeService)
@@ -545,7 +545,7 @@ RSpec.describe Plans::UpdateService do
 
         context "when subscription upgrade fails" do
           let(:plan_upgrade_result) do
-            BaseService::Result.new.validation_failure!(
+            Subscriptions::PlanUpgradeService::Result.new.validation_failure!(
               errors: {billing_time: ["value_is_invalid"]}
             )
           end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1116,7 +1116,7 @@ RSpec.describe Subscriptions::CreateService do
 
           context "when subscription upgrade fails" do
             let(:result_failure) do
-              BaseService::Result.new.validation_failure!(
+              Subscriptions::PlanUpgradeService::Result.new.validation_failure!(
                 errors: {billing_time: ["value_is_invalid"]}
               )
             end
@@ -1560,7 +1560,7 @@ RSpec.describe Subscriptions::CreateService do
 
           context "when subscription downgrade fails" do
             let(:result_failure) do
-              BaseService::Result.new.validation_failure!(
+              Subscriptions::PlanDowngradeService::Result.new.validation_failure!(
                 errors: {billing_time: ["value_is_invalid"]}
               )
             end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Subscriptions::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { Subscriptions::CreateService::Result.new }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
     end
 
     context "when kafka is configured", :kafka_configured do
-      let(:result) { BaseService::Result.new }
+      let(:result) { Coupons::UpdateService::Result.new }
 
       context "when providing a block" do
         let(:activity_type) { "coupon.updated" }

--- a/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
+++ b/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Validators::WalletTransactionAmountLimitsValidator do
-  let(:result) { BaseService::LegacyResult.new }
+  let(:result) { BaseResult.new }
   let(:wallet) { create(:wallet, paid_top_up_min_amount_cents:, paid_top_up_max_amount_cents:) }
   let(:paid_top_up_min_amount_cents) { 5_00 }
   let(:paid_top_up_max_amount_cents) { 100_00 }

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe WalletTransactions::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { BaseResult[:current_wallet, :payment_method].new }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/wallets/validate_limitations_service_spec.rb
+++ b/spec/services/wallets/validate_limitations_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Wallets::ValidateLimitationsService do
   subject(:validate_service) { described_class.new(result, **args) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { BaseResult[:billable_metrics, :billable_metric_identifiers].new }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:args) do

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Wallets::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
-  let(:result) { BaseService::Result.new }
+  let(:result) { Wallets::CreateService::Result.new }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }


### PR DESCRIPTION
## Description

This PR replaces occurrences of `BaseService::Result` with their correctly typed counterpart in all spec files, allowing a better test coverage and validation of expected attributes