### PR TITLE
[ING-447] feat(integration_customers): add code column

### DIFF
--- a/app/models/integration_customers/anrok_customer.rb
+++ b/app/models/integration_customers/anrok_customer.rb
@@ -11,6 +11,7 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/avalara_customer.rb
+++ b/app/models/integration_customers/avalara_customer.rb
@@ -11,6 +11,7 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -81,6 +81,7 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/hubspot_customer.rb
+++ b/app/models/integration_customers/hubspot_customer.rb
@@ -20,6 +20,7 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/netsuite_customer.rb
+++ b/app/models/integration_customers/netsuite_customer.rb
@@ -12,6 +12,7 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/salesforce_customer.rb
+++ b/app/models/integration_customers/salesforce_customer.rb
@@ -11,6 +11,7 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/xero_customer.rb
+++ b/app/models/integration_customers/xero_customer.rb
@@ -11,6 +11,7 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/db/migrate/20260717160544_add_code_to_integration_customers.rb
+++ b/db/migrate/20260717160544_add_code_to_integration_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCodeToIntegrationCustomers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :integration_customers, :code, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3615,7 +3615,8 @@ CREATE TABLE public.integration_customers (
     settings jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    code character varying
 );
 
 
@@ -12849,6 +12850,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260717160544'),
 ('20260717133535'),
 ('20260716114156'),
 ('20260715142900'),


### PR DESCRIPTION
## Context

Groundwork for the multi-connection work on the customer: connections will be routed by a per-connection `code`. This adds the column ahead of the routing logic.

## Changes

Add a nullable `code` column to `integration_customers`. No-op and backward-compatible — no default, no index, no backfill, and nothing reads the column yet.

## Testing

Migration applied and rolled back cleanly; `db/structure.sql` regenerated and model annotations updated. No behavioral change to test.
