### PR TITLE
[ING-449] feat(integration_customers): add is_default and category

### DIFF
--- a/app/models/integration_customers/anrok_customer.rb
+++ b/app/models/integration_customers/anrok_customer.rb
@@ -12,6 +12,8 @@ end
 #
 #  id                   :uuid             not null, primary key
 #  code                 :string
+#  category             :enum
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/avalara_customer.rb
+++ b/app/models/integration_customers/avalara_customer.rb
@@ -12,6 +12,8 @@ end
 #
 #  id                   :uuid             not null, primary key
 #  code                 :string
+#  category             :enum
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -82,6 +82,8 @@ end
 #
 #  id                   :uuid             not null, primary key
 #  code                 :string
+#  category             :enum
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/hubspot_customer.rb
+++ b/app/models/integration_customers/hubspot_customer.rb
@@ -21,6 +21,8 @@ end
 #
 #  id                   :uuid             not null, primary key
 #  code                 :string
+#  category             :enum
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/netsuite_customer.rb
+++ b/app/models/integration_customers/netsuite_customer.rb
@@ -13,6 +13,8 @@ end
 #
 #  id                   :uuid             not null, primary key
 #  code                 :string
+#  category             :enum
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/salesforce_customer.rb
+++ b/app/models/integration_customers/salesforce_customer.rb
@@ -12,6 +12,8 @@ end
 #
 #  id                   :uuid             not null, primary key
 #  code                 :string
+#  category             :enum
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/app/models/integration_customers/xero_customer.rb
+++ b/app/models/integration_customers/xero_customer.rb
@@ -12,6 +12,8 @@ end
 #
 #  id                   :uuid             not null, primary key
 #  code                 :string
+#  category             :enum
+#  is_default           :boolean          default(FALSE), not null
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null

--- a/db/migrate/20260717163416_add_is_default_and_category_to_integration_customers.rb
+++ b/db/migrate/20260717163416_add_is_default_and_category_to_integration_customers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddIsDefaultAndCategoryToIntegrationCustomers < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :connection_category, %w[payment tax accounting crm]
+
+    add_column :integration_customers, :is_default, :boolean, default: false, null: false
+    add_column :integration_customers, :category, :connection_category
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1216,6 +1216,7 @@ DROP TYPE IF EXISTS public.enriched_store_sub_migration_status;
 DROP TYPE IF EXISTS public.enriched_store_migration_status;
 DROP TYPE IF EXISTS public.customer_type;
 DROP TYPE IF EXISTS public.customer_account_type;
+DROP TYPE IF EXISTS public.connection_category;
 DROP TYPE IF EXISTS public.billable_metric_weighted_interval;
 DROP TYPE IF EXISTS public.billable_metric_rounding_function;
 DROP EXTENSION IF EXISTS unaccent;
@@ -1283,6 +1284,18 @@ CREATE TYPE public.billable_metric_rounding_function AS ENUM (
 
 CREATE TYPE public.billable_metric_weighted_interval AS ENUM (
     'seconds'
+);
+
+
+--
+-- Name: connection_category; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.connection_category AS ENUM (
+    'payment',
+    'tax',
+    'accounting',
+    'crm'
 );
 
 
@@ -3616,7 +3629,9 @@ CREATE TABLE public.integration_customers (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     organization_id uuid NOT NULL,
-    code character varying
+    code character varying,
+    is_default boolean DEFAULT false NOT NULL,
+    category public.connection_category
 );
 
 
@@ -12850,6 +12865,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260717163416'),
 ('20260717160544'),
 ('20260717133535'),
 ('20260716114156'),


### PR DESCRIPTION
## Context

Groundwork for the multi-connection work on the customer: a connection will be marked as the default for its category, and routed per category. This adds the schema ahead of the routing and backfill logic.

## Changes

Add `is_default` (`boolean`, default `false`) and a nullable `category` column to `integration_customers`, backed by a new `integration_customer_category` enum (`tax`, `accounting`, `crm`). No-op and backward-compatible — no backfill, no index, and nothing reads the columns yet (`category` will be derived from the STI type in a later backfill).

## Testing

Migration applied and rolled back cleanly; `db/structure.sql` regenerated and model annotations updated. No behavioral change to test.
