### PR TITLE
fix: add null-byte Sanitizing

### DIFF
--- a/app/models/concerns/null_byte_sanitizable.rb
+++ b/app/models/concerns/null_byte_sanitizable.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Strips PostgreSQL-incompatible NULL bytes from string attributes.
+#
+# Postgres text/varchar columns cannot store a NULL byte. When one reaches the
+# adapter on write it raises ArgumentError (string contains null byte), which
+# surfaces to the API as an unhandled 500. Normalizing the value on assignment
+# turns that crash into clean, stored data.
+#
+# Usage:
+#
+#   class Customer < ApplicationRecord
+#     include NullByteSanitizable
+#
+#     sanitize_null_bytes :name, :firstname, :lastname
+#     sanitize_null_bytes(*ADDRESS_FIELDS, blank_to_nil: true)
+#   end
+#
+# blank_to_nil: when true, a value that is empty after stripping becomes nil
+# (preserves the historical behavior of the address-field normalizer).
+module NullByteSanitizable
+  extend ActiveSupport::Concern
+
+  NULL_BYTE = "\u0000"
+
+  class_methods do
+    def sanitize_null_bytes(*attributes, blank_to_nil: false)
+      attributes.flatten.each do |attribute|
+        normalizes attribute, with: ->(value) do
+          cleaned = value.delete(NULL_BYTE)
+          blank_to_nil ? cleaned.presence : cleaned
+        end
+      end
+    end
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -185,8 +185,7 @@ class Customer < ApplicationRecord
   # fields are only stripped so existing empty-string values are preserved.
   sanitize_null_bytes(*ADDRESS_FIELDS, blank_to_nil: true)
   sanitize_null_bytes :name, :firstname, :lastname, :legal_name, :legal_number,
-    :phone, :url, :logo_url, :tax_identification_number, :external_salesforce_id,
-    :external_id
+    :phone, :url, :logo_url, :tax_identification_number
 
   normalizes :email, with: ->(email) { EmailSanitizer.call(email) }
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -8,6 +8,7 @@ class Customer < ApplicationRecord
   include OrganizationTimezone
   include BillingEntityTimezone
   include Discard::Model
+  include NullByteSanitizable
 
   self.discard_column = :deleted_at
 
@@ -179,10 +180,13 @@ class Customer < ApplicationRecord
 
   ADDRESS_FIELDS = (BILLING_ADDRESS_FIELDS + SHIPPING_ADDRESS_FIELDS).freeze
 
-  ADDRESS_FIELDS.each do |attribute|
-    # NOTE: Null byte injection. Prevent 500 errors.
-    normalizes attribute, with: ->(value) { value.delete("\u0000").presence }
-  end
+  # NOTE: Null byte injection. Prevent 500 errors (ArgumentError: string contains null byte).
+  # Address fields keep the historical blank -> nil behavior; identity/free-text
+  # fields are only stripped so existing empty-string values are preserved.
+  sanitize_null_bytes(*ADDRESS_FIELDS, blank_to_nil: true)
+  sanitize_null_bytes :name, :firstname, :lastname, :legal_name, :legal_number,
+    :phone, :url, :logo_url, :tax_identification_number, :external_salesforce_id,
+    :external_id
 
   normalizes :email, with: ->(email) { EmailSanitizer.call(email) }
 

--- a/app/models/metadata/customer_metadata.rb
+++ b/app/models/metadata/customer_metadata.rb
@@ -7,6 +7,11 @@ module Metadata
     belongs_to :customer
     belongs_to :organization
 
+    include NullByteSanitizable
+
+    # NOTE: Null byte injection. Prevent 500 errors (ArgumentError: string contains null byte).
+    sanitize_null_bytes :key, :value
+
     validates :key, presence: true, uniqueness: {scope: :customer_id}, length: {maximum: 20}
     validates :value, presence: true, length: {maximum: 100}
 

--- a/app/models/metadata/invoice_metadata.rb
+++ b/app/models/metadata/invoice_metadata.rb
@@ -7,6 +7,11 @@ module Metadata
     belongs_to :invoice, touch: true
     belongs_to :organization
 
+    include NullByteSanitizable
+
+    # NOTE: Null byte injection. Prevent 500 errors (ArgumentError: string contains null byte).
+    sanitize_null_bytes :key, :value
+
     validates :key, presence: true, uniqueness: {scope: :invoice_id}, length: {maximum: 20}
     validates :value, presence: true
   end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -84,6 +84,46 @@ RSpec.describe Customer do
         expect(described_class.normalize_value_for(field, "")).to be_nil
       end
     end
+
+    it "strips null bytes from identity and free-text attributes" do
+      normalized_customer = build(
+        :customer,
+        name: "Foo\u0000Bar",
+        firstname: "Jo\u0000hn",
+        lastname: "Do\u0000e",
+        legal_name: "Foo\u0000Corp",
+        legal_number: "12\u000034",
+        phone: "555\u00000199",
+        url: "https://ex\u0000ample.test",
+        logo_url: "https://ex\u0000ample.test/l.png",
+        tax_identification_number: "FR\u000012345",
+        external_salesforce_id: "sf\u0000id"
+      )
+
+      expect(normalized_customer.name).to eq("FooBar")
+      expect(normalized_customer.firstname).to eq("John")
+      expect(normalized_customer.lastname).to eq("Doe")
+      expect(normalized_customer.legal_name).to eq("FooCorp")
+      expect(normalized_customer.legal_number).to eq("1234")
+      expect(normalized_customer.phone).to eq("5550199")
+      expect(normalized_customer.url).to eq("https://example.test")
+      expect(normalized_customer.logo_url).to eq("https://example.test/l.png")
+      expect(normalized_customer.tax_identification_number).to eq("FR12345")
+      expect(normalized_customer.external_salesforce_id).to eq("sfid")
+    end
+
+    it "strips null bytes from external_id" do
+      normalized_customer = build(:customer, external_id: "ext\u0000id")
+
+      expect(normalized_customer.external_id).to eq("extid")
+    end
+
+    it "keeps empty identity values as empty strings (not nil)" do
+      normalized_customer = build(:customer, firstname: "\u0000", lastname: "\u0000")
+
+      expect(normalized_customer.firstname).to eq("")
+      expect(normalized_customer.lastname).to eq("")
+    end
   end
 
   describe "validations" do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -96,8 +96,7 @@ RSpec.describe Customer do
         phone: "555\u00000199",
         url: "https://ex\u0000ample.test",
         logo_url: "https://ex\u0000ample.test/l.png",
-        tax_identification_number: "FR\u000012345",
-        external_salesforce_id: "sf\u0000id"
+        tax_identification_number: "FR\u000012345"
       )
 
       expect(normalized_customer.name).to eq("FooBar")
@@ -109,13 +108,6 @@ RSpec.describe Customer do
       expect(normalized_customer.url).to eq("https://example.test")
       expect(normalized_customer.logo_url).to eq("https://example.test/l.png")
       expect(normalized_customer.tax_identification_number).to eq("FR12345")
-      expect(normalized_customer.external_salesforce_id).to eq("sfid")
-    end
-
-    it "strips null bytes from external_id" do
-      normalized_customer = build(:customer, external_id: "ext\u0000id")
-
-      expect(normalized_customer.external_id).to eq("extid")
     end
 
     it "keeps empty identity values as empty strings (not nil)" do

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -45,4 +45,14 @@ RSpec.describe Metadata::CustomerMetadata do
       it { expect(metadata).not_to be_valid }
     end
   end
+
+  describe "normalizations" do
+    let(:key) { "he\u0000llo" }
+    let(:value) { "wo\u0000rld" }
+
+    it "strips null bytes from key and value" do
+      expect(metadata.key).to eq("hello")
+      expect(metadata.value).to eq("world")
+    end
+  end
 end

--- a/spec/models/metadata/invoice_metadata_spec.rb
+++ b/spec/models/metadata/invoice_metadata_spec.rb
@@ -38,4 +38,14 @@ RSpec.describe Metadata::InvoiceMetadata do
       it { expect(metadata).not_to be_valid }
     end
   end
+
+  describe "normalizations" do
+    let(:key) { "he\u0000llo" }
+    let(:value) { "wo\u0000rld" }
+
+    it "strips null bytes from key and value" do
+      expect(metadata.key).to eq("hello")
+      expect(metadata.value).to eq("world")
+    end
+  end
 end

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -23,6 +23,27 @@ RSpec.describe Api::V1::CustomersController do
 
     include_examples "requires API permission", "customer", "write"
 
+    context "when firstname and lastname contain null bytes" do
+      let(:create_params) do
+        {
+          external_id: SecureRandom.uuid,
+          name: "Foo\u0000Bar",
+          firstname: "\u0000",
+          lastname: "\u0000",
+          currency: "EUR"
+        }
+      end
+
+      it "strips the null bytes instead of returning a 500" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:customer][:name]).to eq("FooBar")
+        expect(json[:customer][:firstname]).to eq("")
+        expect(json[:customer][:lastname]).to eq("")
+      end
+    end
+
     it "returns a success" do
       subject
 


### PR DESCRIPTION
## Context

When null-byte is sent as `customer.firstname` or `lastname`, customer creation crashes with 500 error

## Description


Added a null-byte-sanytiser that can be included in any models requirung null-byte sanytising