### PR TITLE
fix(invoices): Display PO number caption in one line in PDF

### DIFF
--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -224,6 +224,8 @@ html
       }
       .invoice-information-table tr td:first-child {
         padding: 0 16px 0 0;
+        white-space: nowrap;
+        width: 1%;
       }
       .invoice-information-table tr td:last-child {
         width: 55%;
@@ -235,7 +237,6 @@ html
       }
       .invoice-information-table {
         border-collapse: collapse;
-        table-layout: fixed;
         width: 100%;
       }
 

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -218,6 +218,8 @@ html
       }
       .invoice-information-table tr td:first-child {
         padding: 0 16px 0 0;
+        white-space: nowrap;
+        width: 1%;
       }
       .invoice-information-table tr td:last-child {
         width: 55%;
@@ -229,7 +231,6 @@ html
       }
       .invoice-information-table {
         border-collapse: collapse;
-        table-layout: fixed;
         width: 100%;
       }
 

--- a/app/views/templates/invoices/v4/fixed_charge.slim
+++ b/app/views/templates/invoices/v4/fixed_charge.slim
@@ -218,6 +218,8 @@ html
       }
       .invoice-information-table tr td:first-child {
         padding: 0 16px 0 0;
+        white-space: nowrap;
+        width: 1%;
       }
       .invoice-information-table tr td:last-child {
         width: 55%;
@@ -229,7 +231,6 @@ html
       }
       .invoice-information-table {
         border-collapse: collapse;
-        table-layout: fixed;
         width: 100%;
       }
 

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -224,6 +224,8 @@ html
       }
       .invoice-information-table tr td:first-child {
         padding: 0 16px 0 0;
+        white-space: nowrap;
+        width: 1%;
       }
       .invoice-information-table tr td:last-child {
         width: 55%;
@@ -235,7 +237,6 @@ html
       }
       .invoice-information-table {
         border-collapse: collapse;
-        table-layout: fixed;
         width: 100%;
       }
 


### PR DESCRIPTION
Original:
<img width="415" height="195" alt="Screenshot 2026-07-20 at 16 00 54" src="https://github.com/user-attachments/assets/9ef05d44-eefa-41de-949d-ecfef60c3ead" />
Fix:
<img width="349" height="180" alt="Screenshot 2026-07-20 at 16 01 52" src="https://github.com/user-attachments/assets/90693558-3283-466e-9a5d-9623fbab9737" />
