### PR TITLE
fix(stripe-webhooks): Remove transaction from PaymentProviderCustomers::Stripe::UpdatePaymentMethodService

### DIFF
--- a/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
@@ -17,22 +17,20 @@ module PaymentProviderCustomers
         return result.not_found_failure!(resource: "stripe_customer") unless stripe_customer
         return result.service_failure!(code: :deleted_customer, message: "Customer associated to this stripe customer was deleted") if deleted_customer
 
-        ActiveRecord::Base.transaction do
-          stripe_customer.payment_method_id = payment_method_id
-          stripe_customer.save!
+        stripe_customer.payment_method_id = payment_method_id
+        stripe_customer.save!
 
-          find_or_create_result = PaymentMethods::FindOrCreateFromProviderService.call(
-            customer:,
-            payment_provider_customer: stripe_customer,
-            provider_method_id: payment_method_id,
-            params: {
-              provider_payment_methods: stripe_customer.provider_payment_methods,
-              details: payment_method_details
-            },
-            set_as_default: true
-          )
-          result.payment_method = find_or_create_result.payment_method
-        end
+        find_or_create_result = PaymentMethods::FindOrCreateFromProviderService.call(
+          customer:,
+          payment_provider_customer: stripe_customer,
+          provider_method_id: payment_method_id,
+          params: {
+            provider_payment_methods: stripe_customer.provider_payment_methods,
+            details: payment_method_details
+          },
+          set_as_default: true
+        )
+        result.payment_method = find_or_create_result.payment_method
 
         reprocess_pending_invoices
 

--- a/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
@@ -30,16 +30,20 @@ RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService do
         expect(customer.payment_methods.count).to eq(1)
       end
 
-      context "when the default flip fails mid-transaction" do
+      context "when the default flip fails" do
         let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: "pm_old") }
 
         before do
           allow(PaymentMethods::FindOrCreateFromProviderService).to receive(:call).and_raise(ActiveRecord::Deadlocked)
         end
 
-        it "rolls back the settings accessor so it cannot split from the record" do
+        it "propagates the error so the job can retry" do
           expect { update_service.call }.to raise_error(ActiveRecord::Deadlocked)
-          expect(stripe_customer.reload.payment_method_id).to eq("pm_old")
+        end
+
+        it "keeps the already saved settings, to be reconciled by the retry" do
+          expect { update_service.call }.to raise_error(ActiveRecord::Deadlocked)
+          expect(stripe_customer.reload.payment_method_id).to eq(payment_method_id)
         end
       end
 

--- a/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
@@ -37,10 +37,6 @@ RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService do
           allow(PaymentMethods::FindOrCreateFromProviderService).to receive(:call).and_raise(ActiveRecord::Deadlocked)
         end
 
-        it "propagates the error so the job can retry" do
-          expect { update_service.call }.to raise_error(ActiveRecord::Deadlocked)
-        end
-
         it "keeps the already saved settings, to be reconciled by the retry" do
           expect { update_service.call }.to raise_error(ActiveRecord::Deadlocked)
           expect(stripe_customer.reload.payment_method_id).to eq(payment_method_id)


### PR DESCRIPTION
## Context

#5878 wrapped the `StripeCustomer` settings write and the payment-method find-or-create in a single transaction to keep them in sync. However, `PaymentMethods::FindOrCreateFromProviderService` recovers from a concurrent creation of the same payment method (`ActiveRecord::RecordNotUnique`) by querying the winning record — and PostgreSQL rejects any statement issued inside a transaction that has already failed. When `HandleEventJob` raced `FetchDefaultPaymentMethodJob` at customer creation, the losing insert aborted the wrapping transaction and the recovery query raised `PG::InFailedSqlTransaction`, dead-lettering the job since `ActiveRecord::StatementInvalid` is not retried.

## Description

Remove the wrapping transaction so the recovery query runs on a healthy connection again. A failure between the settings write and the default flip is now reconciled by the job retries introduced in #5878, since the service is idempotent.