### PR TITLE
feat(db): Avoid RDS Proxy connection pinning

### DIFF
--- a/config/initializers/rds_proxy.rb
+++ b/config/initializers/rds_proxy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Activates the RDS Proxy connection patch. See lib/lago/rds_proxy/connection_patch.rb
+# for what the patch does and why.
+
+if ENV["DATABASE_VIA_RDS_PROXY"].present?
+  require "lago/rds_proxy/connection_patch"
+
+  # The pg gem auto-sends SET client_encoding when default_internal is set,
+  # bypassing configure_connection. Reset to nil to suppress.
+  Encoding.default_internal = nil
+
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(
+      Lago::RdsProxy::ConnectionPatch
+    )
+  end
+end

--- a/lib/lago/rds_proxy/connection_patch.rb
+++ b/lib/lago/rds_proxy/connection_patch.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Patches PostgreSQLAdapter#configure_connection to skip session-level SET
+# commands that cause RDS Proxy to pin the connection. The skipped settings
+# must be configured via the proxy's initQuery instead:
+#
+#   SET client_encoding = 'UTF8';
+#   SET client_min_messages TO 'warning';
+#   SET search_path TO 'public';
+#   SET standard_conforming_strings = on;
+#   SET intervalstyle = iso_8601;
+#   SET timezone TO 'UTC'
+#
+# `@schema_search_path` is cached locally to avoid an extra `SHOW search_path`
+# query on first access. This assumes the proxy's initQuery sets a `search_path`
+# matching `@config[:schema_search_path]` (both default to 'public').
+#
+# `reconfigure_connection_timezone` is overridden to a no-op because it is
+# invoked by `add_pg_decoders` during type map setup and would otherwise emit
+# `SET SESSION timezone TO 'UTC'`.
+#
+# See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-pinning.html
+module Lago
+  module RdsProxy
+    module ConnectionPatch
+      def configure_connection
+        check_version
+
+        @schema_search_path = @config[:schema_search_path] || @config[:schema_order]
+
+        unless ActiveRecord.db_warnings_action.nil?
+          @raw_connection.set_notice_receiver do |result|
+            message = result.error_field(PG::Result::PG_DIAG_MESSAGE_PRIMARY)
+            code = result.error_field(PG::Result::PG_DIAG_SQLSTATE)
+            level = result.error_field(PG::Result::PG_DIAG_SEVERITY)
+            @notice_receiver_sql_warnings << SQLWarning.new(message, code, level, nil, @pool)
+          end
+        end
+
+        # User-defined variables from database.yml will still pin the connection.
+        variables = @config.fetch(:variables, {}).stringify_keys
+        variables.each do |k, v|
+          if v == ":default" || v == :default
+            internal_execute("SET SESSION #{k} TO DEFAULT", "SCHEMA")
+          elsif !v.nil?
+            internal_execute("SET SESSION #{k} TO #{quote(v)}", "SCHEMA")
+          end
+        end
+
+        add_pg_encoders
+        add_pg_decoders
+        reload_type_map
+      end
+
+      private
+
+      def reconfigure_connection_timezone
+        # no-op: proxy's initQuery sets the timezone
+      end
+    end
+  end
+end

--- a/lib/lago/rds_proxy/connection_patch.rb
+++ b/lib/lago/rds_proxy/connection_patch.rb
@@ -37,15 +37,11 @@ module Lago
           end
         end
 
-        # User-defined variables from database.yml will still pin the connection.
-        variables = @config.fetch(:variables, {}).stringify_keys
-        variables.each do |k, v|
-          if v == ":default" || v == :default
-            internal_execute("SET SESSION #{k} TO DEFAULT", "SCHEMA")
-          elsif !v.nil?
-            internal_execute("SET SESSION #{k} TO #{quote(v)}", "SCHEMA")
-          end
-        end
+        # Deliberately skip database.yml `variables:` — each one emits a session-level
+        # SET (even `TO DEFAULT`) that pins the connection on RDS Proxy. Configure any
+        # required session settings via the proxy initQuery or role-level defaults
+        # (ALTER ROLE ... SET ...) instead. Lago's statement_timeout / lock_timeout /
+        # idle_in_transaction_session_timeout are set as `lago` role defaults.
 
         add_pg_encoders
         add_pg_decoders

--- a/spec/lib/lago/rds_proxy/connection_patch_spec.rb
+++ b/spec/lib/lago/rds_proxy/connection_patch_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "lago/rds_proxy/connection_patch"
+
+RSpec.describe Lago::RdsProxy::ConnectionPatch do
+  # Stub class mimicking PostgreSQLAdapter's interface for the methods our
+  # patch interacts with. We assert on call ordering and absence of SETs.
+  let(:adapter_class) do
+    Class.new do
+      attr_accessor :schema_search_path, :calls
+
+      def initialize(config)
+        @config = config
+        @raw_connection = Object.new
+        @notice_receiver_sql_warnings = []
+        @pool = Object.new
+        @calls = []
+      end
+
+      def check_version
+        @calls << :check_version
+      end
+
+      def add_pg_encoders
+        @calls << :add_pg_encoders
+      end
+
+      def add_pg_decoders
+        @calls << :add_pg_decoders
+      end
+
+      def reload_type_map
+        @calls << :reload_type_map
+      end
+
+      def internal_execute(sql, _name = nil)
+        @calls << [:internal_execute, sql]
+      end
+
+      def quote(value)
+        "'#{value}'"
+      end
+
+      def reconfigure_connection_timezone
+        @calls << :original_reconfigure_connection_timezone
+      end
+
+      prepend Lago::RdsProxy::ConnectionPatch
+    end
+  end
+
+  let(:adapter) { adapter_class.new(config) }
+
+  before { allow(ActiveRecord).to receive(:db_warnings_action).and_return(nil) }
+
+  describe "#configure_connection" do
+    context "with a basic config" do
+      let(:config) { {schema_search_path: "public"} }
+
+      before { adapter.configure_connection }
+
+      it "calls check_version" do
+        expect(adapter.calls).to include(:check_version)
+      end
+
+      it "caches the schema_search_path from config" do
+        expect(adapter.schema_search_path).to eq("public")
+      end
+
+      it "calls add_pg_encoders, add_pg_decoders and reload_type_map" do
+        expect(adapter.calls).to include(:add_pg_encoders, :add_pg_decoders, :reload_type_map)
+      end
+
+      it "does not send any SET commands" do
+        sets = adapter.calls.select { |c| c.is_a?(Array) && c[0] == :internal_execute }
+        expect(sets).to be_empty
+      end
+    end
+
+    context "with no schema_search_path in config" do
+      let(:config) { {} }
+
+      it "leaves @schema_search_path nil for the lazy getter to populate" do
+        adapter.configure_connection
+        expect(adapter.schema_search_path).to be_nil
+      end
+    end
+
+    context "with schema_order fallback" do
+      let(:config) { {schema_order: "tenant_a,public"} }
+
+      it "uses schema_order when schema_search_path is absent" do
+        adapter.configure_connection
+        expect(adapter.schema_search_path).to eq("tenant_a,public")
+      end
+    end
+
+    context "with user-defined variables" do
+      let(:config) { {variables: {statement_timeout: "30s", lock_timeout: :default}} }
+
+      before { adapter.configure_connection }
+
+      it "still applies SET SESSION for explicit variables (and accepts the pinning cost)" do
+        expect(adapter.calls).to include([:internal_execute, "SET SESSION statement_timeout TO '30s'"])
+        expect(adapter.calls).to include([:internal_execute, "SET SESSION lock_timeout TO DEFAULT"])
+      end
+    end
+
+    context "with nil values in variables" do
+      let(:config) { {variables: {statement_timeout: nil}} }
+
+      it "skips nil values" do
+        adapter.configure_connection
+        sets = adapter.calls.select { |c| c.is_a?(Array) && c[0] == :internal_execute }
+        expect(sets).to be_empty
+      end
+    end
+  end
+
+  describe "#reconfigure_connection_timezone" do
+    let(:config) { {} }
+
+    it "is a no-op so add_pg_decoders does not emit SET SESSION timezone" do
+      adapter.send(:reconfigure_connection_timezone)
+      expect(adapter.calls).not_to include(:original_reconfigure_connection_timezone)
+    end
+  end
+end

--- a/spec/lib/lago/rds_proxy/connection_patch_spec.rb
+++ b/spec/lib/lago/rds_proxy/connection_patch_spec.rb
@@ -116,4 +116,45 @@ RSpec.describe Lago::RdsProxy::ConnectionPatch do
       expect(adapter.calls).not_to include(:original_reconfigure_connection_timezone)
     end
   end
+
+  # The specs above use a fake adapter to assert call ordering / absence of SETs
+  # in isolation. This block exercises the REAL PostgreSQLAdapter against the test
+  # database, so we catch any drift in `configure_connection`'s internals across
+  # Rails upgrades (per review feedback: the fake could hide such a change).
+  describe "against the real PostgreSQLAdapter" do
+    let(:db_config) { ActiveRecord::Base.connection_db_config.configuration_hash }
+
+    # Plain adapter = control; the patched one uses an isolated subclass so the
+    # prepend never leaks onto the shared connection pool.
+    let(:plain_adapter) do
+      ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config)
+    end
+
+    let(:patched_adapter) do
+      Class.new(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) do
+        prepend Lago::RdsProxy::ConnectionPatch
+      end.new(db_config)
+    end
+
+    after do
+      plain_adapter.disconnect!
+      patched_adapter.disconnect!
+    end
+
+    # Rails' configure_connection drives these away from the Postgres server
+    # defaults; the patch must leave them alone. Asserting "not the Rails value"
+    # (rather than a hardcoded default) keeps this robust across environments.
+    it "applies Rails' session SETs without the patch (control)" do
+      expect(plain_adapter.select_value("SHOW intervalstyle")).to eq("iso_8601")
+      expect(plain_adapter.select_value("SHOW client_min_messages")).to eq("warning")
+    end
+
+    it "skips the session SETs and keeps the connection fully functional" do
+      expect(patched_adapter.select_value("SHOW intervalstyle")).not_to eq("iso_8601")
+      expect(patched_adapter.select_value("SHOW client_min_messages")).not_to eq("warning")
+
+      # Connection is usable and decoders are loaded (integers cast, not raw strings):
+      expect(patched_adapter.select_value("SELECT 1")).to eq(1)
+    end
+  end
 end

--- a/spec/lib/lago/rds_proxy/connection_patch_spec.rb
+++ b/spec/lib/lago/rds_proxy/connection_patch_spec.rb
@@ -101,17 +101,7 @@ RSpec.describe Lago::RdsProxy::ConnectionPatch do
 
       before { adapter.configure_connection }
 
-      it "still applies SET SESSION for explicit variables (and accepts the pinning cost)" do
-        expect(adapter.calls).to include([:internal_execute, "SET SESSION statement_timeout TO '30s'"])
-        expect(adapter.calls).to include([:internal_execute, "SET SESSION lock_timeout TO DEFAULT"])
-      end
-    end
-
-    context "with nil values in variables" do
-      let(:config) { {variables: {statement_timeout: nil}} }
-
-      it "skips nil values" do
-        adapter.configure_connection
+      it "does not emit SET SESSION for variables (they pin the connection on RDS Proxy)" do
         sets = adapter.calls.select { |c| c.is_a?(Array) && c[0] == :internal_execute }
         expect(sets).to be_empty
       end


### PR DESCRIPTION
## Context

Lago's EU staging deployment is introducing AWS RDS Proxy in front of PostgreSQL for connection multiplexing and faster blue/green cutovers. However, RDS Proxy pins any connection where it detects a client-side session SET. ActiveRecord's PostgreSQLAdapter sends five SET commands during configure_connection and a sixth (SET SESSION timezone) via add_pg_decoders. With those pins in place, the proxy degrades to a 1:1 passthrough and connection multiplexing is lost.

AWS does not offer a session-pinning filter for PostgreSQL: the only available filter (EXCLUDE_VARIABLE_SETS) is MySQL-only. For PostgreSQL, the path to unpinned connections is to stop sending session SETs from the client and configure equivalent state via the proxy's initQuery.

This was re-opened to test in the lago-staging-eu-1 environment with a new RDS proxy specifically for Rails.

## Description

Adds Lago::RdsProxy::ConnectionPatch, a module prepended onto ActiveRecord::ConnectionAdapters::PostgreSQLAdapter when the DATABASE_VIA_RDS_PROXY environment variable is set. The patch replaces configure_connection with an equivalent that skips all session-level SET commands, and overrides reconfigure_connection_timezone as a no-op to prevent add_pg_decoders from emitting SET SESSION timezone.

Local dev, tests, and deployments without the flag are unaffected.

The proxy's initQuery must cover the six equivalent settings: client_encoding, client_min_messages, search_path, standard_conforming_strings, intervalstyle, timezone.
