### PR TITLE
fix(applied-coupons): Wrap up applying coupons with advisory lock to avoid race conditions

### DIFF
--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -18,9 +18,27 @@ module AppliedCoupons
     )
 
     def call
-      check_preconditions
-      return result if result.error
+      return result.not_found_failure!(resource: "customer") unless customer
 
+      Customers::LockService.call(customer:, scope: :coupon) do
+        check_preconditions
+        return result if result.error
+
+        result.applied_coupon = apply_coupon
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :customer, :coupon, :params
+
+    def apply_coupon
       applied_coupon = AppliedCoupon.new(
         customer:,
         coupon:,
@@ -33,32 +51,20 @@ module AppliedCoupons
         frequency_duration_remaining: params[:frequency_duration] || coupon.frequency_duration
       )
 
-      if coupon.fixed_amount?
-        ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction do
+        if coupon.fixed_amount?
           Customers::UpdateCurrencyService
             .call(customer:, currency: params[:amount_currency] || coupon.amount_currency)
             .raise_if_error!
-
-          applied_coupon.save!
         end
-      else
+
         applied_coupon.save!
       end
 
-      result.applied_coupon = applied_coupon
-      result
-    rescue ActiveRecord::RecordInvalid => e
-      result.record_validation_failure!(record: e.record)
-    rescue BaseService::FailedResult => e
-      e.result
+      applied_coupon
     end
 
-    private
-
-    attr_reader :customer, :coupon, :params
-
     def check_preconditions
-      return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "coupon") unless coupon&.active?
       return result.not_allowed_failure!(code: "plan_overlapping") if plan_limitation_overlapping?
       return if reusable_coupon?

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -268,5 +268,33 @@ RSpec.describe AppliedCoupons::CreateService do
         expect(create_result.error.messages[:frequency_duration_remaining]).to eq(["value_is_mandatory", "is not a number"])
       end
     end
+
+    context "when there is a concurrent lock" do
+      before do
+        stub_const("Customers::LockService::ACQUIRE_LOCK_TIMEOUT", 1.second)
+      end
+
+      around do |test|
+        with_advisory_lock("customer-#{customer.id}-coupon", lock_released_after:) do
+          test.run
+        end
+      end
+
+      context "when it fails to acquire the lock" do
+        let(:lock_released_after) { 2.seconds }
+
+        it "raises a BaseLockService::FailedToAcquireLock error" do
+          expect { create_result }.to raise_error(BaseLockService::FailedToAcquireLock, "Failed to acquire lock customer-#{customer.id}-coupon")
+        end
+      end
+
+      context "when the lock is acquired" do
+        let(:lock_released_after) { 0.5.seconds }
+
+        it "successfully applies coupon to the customer" do
+          expect { create_result }.not_to raise_error
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

There's a TOCTOU race condition when applying a coupon through the `/api/v1/applied_coupons` REST API. If multiple requests hit at the same time for the same customer and a non-reusable coupon, they can bypass the `coupon_is_not_reusable` check and create multiple `AppliedCoupon` records. As a result, all of them get applied as discounts on the next invoice.

## Description

Since this issue has been around for a while, there may already be duplicate applied coupons for the same customer and coupon, so we can't safely add a unique database index.

Instead, this PR wraps the coupon application flow in an advisory lock using `Customers::LockService`, preventing concurrent requests from creating duplicates.
