### PR TITLE
feat(stripe): Add consent collection setting

### DIFF
--- a/app/models/concerns/settings_storable.rb
+++ b/app/models/concerns/settings_storable.rb
@@ -4,10 +4,11 @@ module SettingsStorable
   extend ActiveSupport::Concern
 
   class_methods do
-    def settings_accessors(*method_names)
+    def settings_accessors(*method_names, default: nil)
       method_names.each do |name|
         define_method(name) do
-          get_from_settings(name.to_s)
+          value = get_from_settings(name.to_s)
+          value.nil? ? default : value
         end
 
         define_method(:"#{name}=") do |value|

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -37,6 +37,7 @@ module PaymentProviders
     settings_accessors :webhook_id
     secrets_accessors :secret_key
     settings_accessors :supports_3ds
+    settings_accessors :require_terms_of_service_consent, default: false
 
     def payment_type
       "stripe"

--- a/spec/models/payment_providers/stripe_provider_spec.rb
+++ b/spec/models/payment_providers/stripe_provider_spec.rb
@@ -46,4 +46,15 @@ RSpec.describe PaymentProviders::StripeProvider do
       expect(stripe_provider.success_redirect_url).to eq success_redirect_url
     end
   end
+
+  describe "require_terms_of_service_consent" do
+    it "assigns and retrieve a setting" do
+      stripe_provider.require_terms_of_service_consent = true
+      expect(stripe_provider.require_terms_of_service_consent).to eq(true)
+    end
+
+    it "defaults to false when not set" do
+      expect(stripe_provider.require_terms_of_service_consent).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Stripe Checkout can require customers to accept a merchant's terms of service before paying, via `consent_collection[terms_of_service]`. Lago did not expose this option on Stripe connections.

## Description

Add a `require_terms_of_service_consent` accessor on the Stripe provider, stored in the existing settings JSONB and defaulting to `false`, so existing connections are unaffected. Extend `settings_accessors` with an optional `default:` value so an absent key reads as `false` instead of `nil`. Consuming the flag in the checkout flows comes in follow-up changes.
