### PR TITLE
test(payment-providers): stub Stripe in destroy/reconnect scenario

### DIFF
--- a/spec/scenarios/payment_providers/destroy_and_reconnect_spec.rb
+++ b/spec/scenarios/payment_providers/destroy_and_reconnect_spec.rb
@@ -6,6 +6,18 @@ describe "Payment Provider Destroy And Reconnect Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 
+  before do
+    # Linking a Stripe provider customer enqueues FetchDefaultPaymentMethodJob,
+    # which reaches out to Stripe. Return a customer with no default and no cards
+    # so the job resolves to no payment method without any real HTTP call.
+    stub_request(:get, %r{/v1/customers/[^/]+$}).and_return(
+      status: 200, body: get_stripe_fixtures("customer_retrieve_response.json")
+    )
+    stub_request(:get, %r{/v1/customers/[^/]+/payment_methods}).and_return(
+      status: 200, body: get_stripe_fixtures("customer_list_payment_methods_empty_response.json")
+    )
+  end
+
   it "soft deletes provider customers on destroy and recreates them on reconnect" do
     provider = create(:stripe_provider, organization:)
     create_or_update_customer({

--- a/spec/scenarios/payment_providers/destroy_and_reconnect_spec.rb
+++ b/spec/scenarios/payment_providers/destroy_and_reconnect_spec.rb
@@ -7,9 +7,6 @@ describe "Payment Provider Destroy And Reconnect Scenarios" do
   let(:customer) { create(:customer, organization:) }
 
   before do
-    # Linking a Stripe provider customer enqueues FetchDefaultPaymentMethodJob,
-    # which reaches out to Stripe. Return a customer with no default and no cards
-    # so the job resolves to no payment method without any real HTTP call.
     stub_request(:get, %r{/v1/customers/[^/]+$}).and_return(
       status: 200, body: get_stripe_fixtures("customer_retrieve_response.json")
     )


### PR DESCRIPTION
## Context

The destroy-and-reconnect scenario spec links a Stripe provider customer with a provider_customer_id, which enqueues FetchDefaultPaymentMethodJob. That job calls the Stripe API to retrieve the customer, so the spec made a real HTTP request and failed under WebMock in CI.

## Description

Register WebMock stubs for the Stripe customer retrieve and list payment methods endpoints, reusing the existing fixtures. The customer has no default payment method and no cards, so the job resolves to no payment method without any network call.
