### PR TITLE
[ING-480] feat(alerts): Reduce alerting interval

### DIFF
--- a/app/jobs/usage_monitoring/process_wallet_alerts_job.rb
+++ b/app/jobs/usage_monitoring/process_wallet_alerts_job.rb
@@ -4,7 +4,7 @@ module UsageMonitoring
   class ProcessWalletAlertsJob < ApplicationJob
     queue_as do
       if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_ALERTS"])
-        :alerts
+        :alerts_high_priority
       else
         :default
       end

--- a/app/services/usage_monitoring/process_subscription_activity_service.rb
+++ b/app/services/usage_monitoring/process_subscription_activity_service.rb
@@ -39,7 +39,7 @@ module UsageMonitoring
         when "lifetime_usage_amount"
           ProcessAlertService.call(alert:, alertable: subscription, current_metrics: lifetime_usage)
         when *Alert::BILLABLE_METRIC_LIFETIME_USAGE_TYPES
-          UsageMonitoring::ProcessLifetimeUsageAlertJob.set(wait: 5.minutes).perform_later(alert:, subscription:)
+          UsageMonitoring::ProcessLifetimeUsageAlertJob.set(wait: processing_interval).perform_later(alert:, subscription:)
         when *Alert::CURRENT_USAGE_TYPES
           ProcessAlertService.call(alert:, alertable: subscription, current_metrics: current_usage)
         end
@@ -61,6 +61,10 @@ module UsageMonitoring
     delegate :organization, to: :subscription
 
     attr_reader :subscription_activity, :subscription
+
+    def processing_interval
+      (ENV["LAGO_SUBSCRIPTION_ACTIVITY_PROCESSING_INTERVAL_SECONDS"].presence || 1.minute).to_i.seconds
+    end
 
     def current_usage
       @current_usage ||= ::Invoices::CustomerUsageService.call(

--- a/config/sidekiq/sidekiq_alerts.yml
+++ b/config/sidekiq/sidekiq_alerts.yml
@@ -1,9 +1,12 @@
 concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10) %>
 timeout: 25
 retry: 1
+# Weighted (not strict) ordering: alerts_high_priority is favored 2:1 but the
+# alerts queue is still polled every cycle, so the high-priority queue cannot
+# starve the bulk subscription-activity processing on the alerts queue.
 queues:
-  - alerts_high_priority
-  - alerts
+  - ["alerts_high_priority", 2]
+  - ["alerts", 1]
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 5) %>

--- a/spec/jobs/usage_monitoring/process_wallet_alerts_job_spec.rb
+++ b/spec/jobs/usage_monitoring/process_wallet_alerts_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::ProcessWalletAlertsJob do
-  it_behaves_like "a configurable queue", "alerts", "SIDEKIQ_ALERTS" do
+  it_behaves_like "a configurable queue", "alerts_high_priority", "SIDEKIQ_ALERTS" do
     let(:arguments) { create(:wallet) }
   end
 

--- a/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
@@ -187,14 +187,28 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, :premium do
       alert_5
     end
 
-    it "enqueues ProcessLifetimeUsageAlertJob with a 5 minute delay" do
+    it "enqueues ProcessLifetimeUsageAlertJob with the default processing interval delay" do
       freeze_time do
         service.call
 
         expect(UsageMonitoring::ProcessLifetimeUsageAlertJob)
-          .to have_been_enqueued.with(alert: alert_5, subscription:).at(5.minutes.from_now)
+          .to have_been_enqueued.with(alert: alert_5, subscription:).at(1.minute.from_now)
       end
       expect { subscription_activity.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "when LAGO_SUBSCRIPTION_ACTIVITY_PROCESSING_INTERVAL_SECONDS is set" do
+      before { ENV["LAGO_SUBSCRIPTION_ACTIVITY_PROCESSING_INTERVAL_SECONDS"] = "30" }
+      after { ENV.delete("LAGO_SUBSCRIPTION_ACTIVITY_PROCESSING_INTERVAL_SECONDS") }
+
+      it "enqueues ProcessLifetimeUsageAlertJob with the configured delay" do
+        freeze_time do
+          service.call
+
+          expect(UsageMonitoring::ProcessLifetimeUsageAlertJob)
+            .to have_been_enqueued.with(alert: alert_5, subscription:).at(30.seconds.from_now)
+        end
+      end
     end
 
     context "when the job enqueue raises" do


### PR DESCRIPTION
## Context

The dedicated alerts worker processes two queues, `alerts_high_priority` and `alerts`. Wallet alert jobs were routed to the low-priority `alerts` queue, where they queued behind the bulk subscription-activity processing. Low-balance and depleted-credit alerts are latency-sensitive, so they should not wait on that backlog.

## Description

- Route `ProcessWalletAlertsJob` to `alerts_high_priority` (when `SIDEKIQ_ALERTS` is enabled) so wallet threshold alerts are processed ahead of usage-activity jobs.
- Switch the alerts worker queues from strict ordering to weighted (`alerts_high_priority` 2, `alerts` 1). The high-priority queue is favored but the `alerts` queue is still polled every cycle, so promoting wallet alerts cannot starve subscription-activity processing.