### PR TITLE
fix(payment-providers): backfill orphaned customers

### DIFF
--- a/db/migrate/20260721163101_backfill_deleted_at_on_orphaned_payment_provider_customers.rb
+++ b/db/migrate/20260721163101_backfill_deleted_at_on_orphaned_payment_provider_customers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class BackfillDeletedAtOnOrphanedPaymentProviderCustomers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    # Before PaymentProviders::DestroyService soft deleted its provider customers, it only
+    # nullified their payment_provider_id, leaving them live (deleted_at IS NULL). A later
+    # provider reconnection then created a second live row for the same customer/type, which
+    # breaks the exports_customers view. Soft delete those orphaned rows using updated_at, the
+    # moment they were nullified, so only the reconnected row stays live.
+    PaymentProviderCustomers::BaseCustomer.unscoped
+      .where(payment_provider_id: nil, deleted_at: nil)
+      .in_batches(of: 1000)
+      .update_all("deleted_at = updated_at") # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def down
+    # irreversible
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -12865,6 +12865,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260721163101'),
 ('20260717163416'),
 ('20260717160544'),
 ('20260717133535'),


### PR DESCRIPTION
## Context

Before PaymentProviders::DestroyService soft deleted its provider customers, it only nullified their payment_provider_id and left the rows live (deleted_at IS NULL). A later provider reconnection then created a second live provider customer for the same customer and type, which breaks the exports_customers view and violates the intended one-live-row invariant. The destroy service is now fixed, but rows orphaned before that fix are still live in existing databases.

## Description

Add a batched data migration that soft deletes the already orphaned provider customers (payment_provider_id IS NULL AND deleted_at IS NULL), setting deleted_at from updated_at, the moment they were nullified. This clears the accumulated duplicates so affected exports recover.