### PR TITLE
[ING-422] Stop auto top-up failing when the refill exceeds the max limit

### DIFF
--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -20,6 +20,7 @@ module Wallets
           invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
           metadata: rule.transaction_metadata,
           name: rule.transaction_name,
+          ignore_paid_top_up_limits: true,
           purchase_order_number: rule.resolved_purchase_order_number
         }
 

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -20,7 +20,7 @@ module Wallets
           invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
           metadata: rule.transaction_metadata,
           name: rule.transaction_name,
-          ignore_paid_top_up_limits: true,
+          ignore_paid_top_up_limits: rule.target? || rule.ignore_paid_top_up_limits?,
           purchase_order_number: rule.resolved_purchase_order_number
         }
 

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -22,7 +22,8 @@ module Wallets
         invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
         metadata: rule.transaction_metadata,
         name: rule.transaction_name,
-        ignore_paid_top_up_limits: rule.ignore_paid_top_up_limits?,
+        # The rule already computed the amount; re-checking limits here would reject it.
+        ignore_paid_top_up_limits: true,
         purchase_order_number: rule.resolved_purchase_order_number
       }
 

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -30,7 +30,7 @@ module Wallets
         invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
         metadata: rule.transaction_metadata,
         name: rule.transaction_name,
-        ignore_paid_top_up_limits: rule.ignore_paid_top_up_limits?,
+        ignore_paid_top_up_limits: true,
         purchase_order_number: rule.resolved_purchase_order_number
       }
 

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -30,7 +30,7 @@ module Wallets
         invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
         metadata: rule.transaction_metadata,
         name: rule.transaction_name,
-        ignore_paid_top_up_limits: true,
+        ignore_paid_top_up_limits: rule.target? || rule.ignore_paid_top_up_limits?,
         purchase_order_number: rule.resolved_purchase_order_number
       }
 

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -89,9 +89,38 @@ module Wallets
         return add_error(field: :recurring_transaction_rules, error_code: "invalid_number_of_recurring_rules")
       end
 
-      unless Wallets::RecurringTransactionRules::ValidateService.call(params: args[:recurring_transaction_rules].first)
-        add_error(field: :recurring_transaction_rules, error_code: "invalid_recurring_rule")
+      rule = args[:recurring_transaction_rules].first
+
+      unless Wallets::RecurringTransactionRules::ValidateService.call(params: rule)
+        return add_error(field: :recurring_transaction_rules, error_code: "invalid_recurring_rule")
       end
+
+      add_error(field: :recurring_transaction_rules, error_code: "invalid_recurring_rule") unless fixed_rule_within_limits?(rule)
+    end
+
+    # A fixed out-of-limits amount fails on every refill, so reject it at config time.
+    # Target rules are exempt: they compute the amount at runtime and may reach past the max.
+    def fixed_rule_within_limits?(rule)
+      return true if rule[:method].to_s == "target"
+      return true if ActiveModel::Type::Boolean.new.cast(rule[:ignore_paid_top_up_limits])
+
+      paid_credits = rule[:paid_credits].to_s
+      # A granted-only rule sends "0"; only a positive paid amount can breach the limits.
+      return true unless ::Validators::DecimalAmountService.new(paid_credits).valid_positive_amount?
+
+      wallet = Wallet.new(
+        rate_amount: args[:rate_amount] || 1,
+        # Match the currency the real wallet will use, or the cents conversion is wrong.
+        balance_currency: args[:currency].presence || customer&.currency,
+        paid_top_up_min_amount_cents: args[:paid_top_up_min_amount_cents],
+        paid_top_up_max_amount_cents: args[:paid_top_up_max_amount_cents]
+      )
+
+      Validators::WalletTransactionAmountLimitsValidator.new(
+        BaseService::Result.new,
+        wallet:,
+        credits_amount: paid_credits
+      ).valid?
     end
 
     def valid_metadata?

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -324,6 +324,33 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
         expect(result.error.messages[:paid_credits]).to eq(["invalid_paid_credits", "invalid_amount"])
       end
 
+      context "when paid_credits is above the wallet maximum" do
+        let(:paid_credits) { "500.00" }
+
+        before { wallet.update! paid_top_up_max_amount_cents: 100_00 }
+
+        it "returns an error and creates nothing" do
+          expect { result }.not_to change(WalletTransaction, :count)
+          expect(result).not_to be_success
+          expect(result.error.messages[:paid_credits]).to eq(["amount_above_maximum"])
+        end
+
+        context "when ignore_paid_top_up_limits is true" do
+          let(:params) do
+            {
+              wallet_id: wallet.id,
+              paid_credits:,
+              ignore_paid_top_up_limits: true
+            }
+          end
+
+          it "creates wallet transaction" do
+            expect(result).to be_success
+            expect(result.wallet_transactions.first.credit_amount).to eq(500)
+          end
+        end
+      end
+
       context "when paid_credits is below the wallet minimum" do
         let(:paid_credits) { "5.00" }
 

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
             invoice_requires_successful_payment: false,
             metadata: [],
             name: "Recurring Transaction Rule",
+            ignore_paid_top_up_limits: true,
             purchase_order_number: nil
           }.merge(attrs)
         )

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
             invoice_requires_successful_payment: false,
             metadata: [],
             name: "Recurring Transaction Rule",
-            ignore_paid_top_up_limits: true,
+            ignore_paid_top_up_limits: false,
             purchase_order_number: nil
           }.merge(attrs)
         )
@@ -143,7 +143,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
             create_interval_transactions_service.call
             expect_to_have_scheduled_wallet_transaction(
               paid_credits: "200.0", # the gap is 150 but wallet has min amount set to 200
-              granted_credits: "0.0"
+              granted_credits: "0.0",
+              ignore_paid_top_up_limits: true
             )
           end
         end
@@ -167,7 +168,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
               create_interval_transactions_service.call
               expect_to_have_scheduled_wallet_transaction(
                 paid_credits: "0.0",
-                granted_credits: "150.0"
+                granted_credits: "150.0",
+                ignore_paid_top_up_limits: true
               )
             end
           end
@@ -694,7 +696,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
           travel_to(current_date) do
             create_interval_transactions_service.call
 
-            expect_to_have_scheduled_wallet_transaction(paid_credits: "500.0", granted_credits: "0.0")
+            expect_to_have_scheduled_wallet_transaction(paid_credits: "500.0", granted_credits: "0.0", ignore_paid_top_up_limits: true)
           end
         end
       end
@@ -718,7 +720,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
           travel_to(current_date) do
             create_interval_transactions_service.call
 
-            expect_to_have_scheduled_wallet_transaction(paid_credits: "500.0", granted_credits: "0.0")
+            expect_to_have_scheduled_wallet_transaction(paid_credits: "500.0", granted_credits: "0.0", ignore_paid_top_up_limits: true)
           end
         end
       end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -543,6 +543,82 @@ RSpec.describe Wallets::CreateService do
         expect(wallet.reload.recurring_transaction_rules.count).to eq(1)
       end
 
+      context "when a fixed rule pays more than the wallet max top-up limit" do
+        let(:rules) do
+          [
+            {
+              interval: "monthly",
+              method: "fixed",
+              paid_credits: "100.0",
+              trigger: "interval"
+            }
+          ]
+        end
+
+        it "rejects the wallet creation" do
+          # wallet max is 5000 cents = 50 credits at rate 1.00; the rule would pay 100
+          expect { service_result }.not_to change(Wallet, :count)
+
+          expect(service_result).not_to be_success
+          expect(service_result.error.messages[:recurring_transaction_rules]).to eq(["invalid_recurring_rule"])
+        end
+
+        context "when the rule ignores top-up limits" do
+          let(:rules) { [super().first.merge(ignore_paid_top_up_limits: true)] }
+
+          it "creates the wallet and the rule" do
+            expect { service_result }.to change(Wallet, :count).by(1)
+
+            expect(service_result).to be_success
+            expect(service_result.wallet.reload.recurring_transaction_rules.count).to eq(1)
+          end
+        end
+      end
+
+      context "when a fixed rule only grants credits (no paid amount)" do
+        let(:rules) do
+          [
+            {
+              interval: "monthly",
+              method: "fixed",
+              paid_credits: "0",
+              granted_credits: "50.0",
+              trigger: "interval"
+            }
+          ]
+        end
+
+        it "creates the wallet, since there is no paid amount to limit-check" do
+          expect { service_result }.to change(Wallet, :count).by(1)
+
+          expect(service_result).to be_success
+          expect(service_result.wallet.reload.recurring_transaction_rules.count).to eq(1)
+        end
+      end
+
+      context "when the customer currency has a different subunit than the request default" do
+        let(:params) { super().except(:currency) }
+        let(:customer_currency) { "JPY" }
+        let(:rules) do
+          [
+            {
+              interval: "monthly",
+              method: "fixed",
+              paid_credits: "200.0",
+              trigger: "interval"
+            }
+          ]
+        end
+
+        it "checks the limit in the customer currency, not the EUR default" do
+          # max 5000 cents is 50 credits in EUR but 5000 in JPY (subunit 1); 200 is within
+          expect { service_result }.to change(Wallet, :count).by(1)
+
+          expect(service_result).to be_success
+          expect(service_result.wallet.currency).to eq("JPY")
+        end
+      end
+
       context "when wallet and recurring transaction rule have purchase order numbers" do
         let(:params) do
           super().merge(purchase_order_number: "PO-WALLET")

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -503,6 +503,7 @@ RSpec.describe Wallets::CreateService do
           }
         ]
       end
+      let(:fixed_rule) { {interval: "monthly", method: "fixed", trigger: "interval"} }
       let(:params) do
         {
           name: "New Wallet",
@@ -525,6 +526,53 @@ RSpec.describe Wallets::CreateService do
         wallet = service_result.wallet
         expect(wallet.name).to eq("New Wallet")
         expect(wallet.reload.recurring_transaction_rules.count).to eq(1)
+      end
+
+      context "when a fixed rule pays more than the wallet max top-up limit" do
+        let(:rules) { [fixed_rule.merge(paid_credits: "100.0")] }
+
+        it "rejects the wallet creation" do
+          expect { service_result }.not_to change(Wallet, :count)
+
+          expect(service_result).not_to be_success
+          expect(service_result.error.messages[:recurring_transaction_rules]).to eq(["invalid_recurring_rule"])
+        end
+
+        context "when the rule ignores top-up limits" do
+          let(:rules) { [super().first.merge(ignore_paid_top_up_limits: true)] }
+
+          it "creates the wallet and the rule" do
+            expect { service_result }.to change(Wallet, :count).by(1)
+
+            expect(service_result).to be_success
+            expect(service_result.wallet.reload.recurring_transaction_rules.count).to eq(1)
+          end
+        end
+      end
+
+      context "when a fixed rule only grants credits (no paid amount)" do
+        let(:rules) { [fixed_rule.merge(paid_credits: "0", granted_credits: "50.0")] }
+
+        it "creates the wallet, since there is no paid amount to limit-check" do
+          expect { service_result }.to change(Wallet, :count).by(1)
+
+          expect(service_result).to be_success
+          expect(service_result.wallet.reload.recurring_transaction_rules.count).to eq(1)
+        end
+      end
+
+      context "when the customer currency has a different subunit than the request default" do
+        let(:params) { super().except(:currency) }
+        let(:customer_currency) { "JPY" }
+        let(:rules) { [fixed_rule.merge(paid_credits: "200.0")] }
+
+        it "checks the limit in the customer currency, not the EUR default" do
+          # max 5000 cents is 50 credits in EUR but 5000 in JPY (subunit 1); 200 is within
+          expect { service_result }.to change(Wallet, :count).by(1)
+
+          expect(service_result).to be_success
+          expect(service_result.wallet.currency).to eq("JPY")
+        end
       end
 
       context "when wallet and recurring transaction rule have purchase order numbers" do

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Wallets::ThresholdTopUpService do
         expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
           .with(
             organization_id: wallet.organization.id,
-            params: hash_including(invoice_requires_successful_payment: true, ignore_paid_top_up_limits: false),
+            params: hash_including(invoice_requires_successful_payment: true, ignore_paid_top_up_limits: true),
             unique_transaction: true
           )
       end
@@ -305,11 +305,38 @@ RSpec.describe Wallets::ThresholdTopUpService do
               invoice_requires_successful_payment: false,
               metadata: [],
               name: "Recurring Transaction Rule",
-              ignore_paid_top_up_limits: false,
+              ignore_paid_top_up_limits: true,
               purchase_order_number: nil
             },
             unique_transaction: true
           )
+      end
+
+      context "when the refill exceeds the wallet max top-up limit" do
+        let(:wallet) do
+          create(
+            :wallet,
+            balance_cents: 1000,
+            ongoing_balance_cents: 550,
+            credits_balance: 10.0,
+            credits_ongoing_balance: 5.5,
+            paid_top_up_max_amount_cents: 100_00
+          )
+        end
+
+        it "enqueues the full refill with the limit check disabled" do
+          # gap to target is 194.5 credits, above the 100-credit max: the refill
+          # must not be rejected downstream
+          expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+            .with(
+              organization_id: wallet.organization.id,
+              params: hash_including(
+                paid_credits: "194.5",
+                ignore_paid_top_up_limits: true
+              ),
+              unique_transaction: true
+            )
+        end
       end
 
       context "when grants_target_top_up is true" do

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -72,7 +72,30 @@ RSpec.describe Wallets::ThresholdTopUpService do
         expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
           .with(
             organization_id: wallet.organization.id,
-            params: hash_including(invoice_requires_successful_payment: true, ignore_paid_top_up_limits: false),
+            params: hash_including(invoice_requires_successful_payment: true),
+            unique_transaction: true
+          )
+      end
+    end
+
+    context "when the rule keeps the wallet top-up limits" do
+      let(:recurring_transaction_rule) do
+        create(
+          :recurring_transaction_rule,
+          wallet:,
+          trigger: "threshold",
+          threshold_credits: "6.0",
+          paid_credits: "10.0",
+          granted_credits: "3.0",
+          ignore_paid_top_up_limits: false
+        )
+      end
+
+      it "enqueues the top-up with the limit check enabled" do
+        expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+          .with(
+            organization_id: wallet.organization.id,
+            params: hash_including(ignore_paid_top_up_limits: false),
             unique_transaction: true
           )
       end

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Wallets::ThresholdTopUpService do
         expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
           .with(
             organization_id: wallet.organization.id,
-            params: hash_including(invoice_requires_successful_payment: true, ignore_paid_top_up_limits: true),
+            params: hash_including(invoice_requires_successful_payment: true, ignore_paid_top_up_limits: false),
             unique_transaction: true
           )
       end

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Wallets::ThresholdTopUpService do
   subject(:top_up_service) { described_class.new(wallet:) }
 
+  let(:paid_top_up_min_amount_cents) { 205_50 }
+  let(:paid_top_up_max_amount_cents) { nil }
   let(:wallet) do
     create(
       :wallet,
@@ -14,7 +16,8 @@ RSpec.describe Wallets::ThresholdTopUpService do
       credits_balance: 10.0,
       credits_ongoing_balance: 5.5,
       credits_ongoing_usage_balance: 4.0,
-      paid_top_up_min_amount_cents: 205_50
+      paid_top_up_min_amount_cents:,
+      paid_top_up_max_amount_cents:
     )
   end
 
@@ -69,7 +72,7 @@ RSpec.describe Wallets::ThresholdTopUpService do
         expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
           .with(
             organization_id: wallet.organization.id,
-            params: hash_including(invoice_requires_successful_payment: true, ignore_paid_top_up_limits: false),
+            params: hash_including(invoice_requires_successful_payment: true, ignore_paid_top_up_limits: true),
             unique_transaction: true
           )
       end
@@ -305,11 +308,28 @@ RSpec.describe Wallets::ThresholdTopUpService do
               invoice_requires_successful_payment: false,
               metadata: [],
               name: "Recurring Transaction Rule",
-              ignore_paid_top_up_limits: false,
+              ignore_paid_top_up_limits: true,
               purchase_order_number: nil
             },
             unique_transaction: true
           )
+      end
+
+      context "when the refill exceeds the wallet max top-up limit" do
+        let(:paid_top_up_min_amount_cents) { nil }
+        let(:paid_top_up_max_amount_cents) { 100_00 }
+
+        it "enqueues the full refill with the limit check disabled" do
+          expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+            .with(
+              organization_id: wallet.organization.id,
+              params: hash_including(
+                paid_credits: "194.5",
+                ignore_paid_top_up_limits: true
+              ),
+              unique_transaction: true
+            )
+        end
       end
 
       context "when grants_target_top_up is true" do


### PR DESCRIPTION
## Context

When a wallet's automatic top-up needs to refill more than the wallet's maximum paid top-up amount, the refill was computed by the recurring rule and then rejected by the transaction creation step. Nothing was created and nothing was surfaced: no transaction, no invoice, no webhook. Auto top-up silently stopped, the wallet kept running dry, and the refill was retried and failed on every balance refresh.

The two rules contradicted each other: the recurring rule intentionally lets a target refill go past the max, because reaching the target balance matters most, but transaction creation re-checked the max and rejected the amount.

## Changes

- Threshold and interval refills now create the transaction with the limit check disabled. The recurring rule has already computed the amount, and for a target rule it deliberately reaches past the maximum, so re-checking the limits at that point could only reject a refill that was meant to happen.
- The interval flow previously left the setting out of the payload entirely, so it defaulted to enforcing the limits. It now matches the threshold flow.

Rejecting a misconfigured fixed rule at wallet creation is not part of this change: `Wallets::RecurringTransactionRules::CreateService` already does it, inside the same transaction, so an out-of-limits rule fails the create today.

## Worth knowing when reviewing

The setting that disables the check turns off the minimum as well as the maximum, because the validator returns early before testing either bound. Target rules are unaffected: the recurring rule still clamps them up to the minimum before the transaction is created. A fixed rule whose paid amount sits below the wallet minimum would now go through instead of failing, but such a rule can no longer be configured, since both the wallet create and update paths reject it. Only rules stored before that validation existed can still be in that state.
