### PR TITLE
fix(invoices): Lock invoice during refresh and finalize service

### DIFF
--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -13,11 +13,12 @@ module Invoices
       return result.not_found_failure!(resource: "invoice") if invoice.nil?
       return result.forbidden_failure! unless invoice.subscription?
 
-      return result unless invoice.draft?
-      return result.forbidden_failure!(code: "cannot_finalize_with_pending_taxes") if invoice.tax_pending?
-      drafted_issuing_date = invoice.issuing_date
+      invoice.with_lock do
+        result.invoice = invoice
+        return result unless invoice.draft?
+        return result.forbidden_failure!(code: "cannot_finalize_with_pending_taxes") if invoice.tax_pending?
+        drafted_issuing_date = invoice.issuing_date
 
-      ActiveRecord::Base.transaction do
         invoice.issuing_date = issuing_date
         refresh_result = Invoices::RefreshDraftService.call(invoice:, context: :finalize)
         if invoice.tax_pending?

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -458,5 +458,37 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService do
         end
       end
     end
+
+    context "with concurrent finalize requests", transaction: false do
+      let(:invoices) { Array.new(2) { Invoice.find(invoice.id) } }
+
+      before do
+        allow(Invoices::CreateInvoiceSubscriptionService).to receive(:call).and_wrap_original do |original, *args, **kwargs|
+          original.call(*args, **kwargs).tap { sleep 0.2 }
+        end
+      end
+
+      it "serializes requests and finalizes the invoice once" do
+        errors = Concurrent::Array.new
+        results = Concurrent::Array.new
+
+        threads = invoices.map do |current_invoice|
+          Thread.new do
+            results << described_class.call(invoice: current_invoice)
+          rescue => e
+            errors << e
+          ensure
+            ActiveRecord::Base.connection_pool.release_connection
+          end
+        end
+
+        threads.each(&:join)
+
+        expect(results.count(&:success?)).to eq(2)
+        expect(errors).to be_empty
+        expect(invoice.reload.invoice_subscriptions.where(subscription:).count).to eq(1)
+        expect(invoice).to be_finalized
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit changes the RefreshDraftAndFinalizeService to lock invoices and avoid RecordNotUnique errors

The root cause of the errors is the unique constraint 
`index_invoice_subscriptions_on_invoice_id_and_subscription_id` having the lock
we avoid to raise such exception.

Fixes BIL-99