### PR TITLE
feat(stripe): persist consent collection setting

### DIFF
--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -30,6 +30,7 @@ module PaymentProviders
       stripe_provider.name = args[:name] if args.key?(:name)
       stripe_provider.success_redirect_url = args[:success_redirect_url] if args.key?(:success_redirect_url)
       stripe_provider.supports_3ds = args[:supports_3ds] if args.key?(:supports_3ds)
+      stripe_provider.require_terms_of_service_consent = args[:require_terms_of_service_consent] if args.key?(:require_terms_of_service_consent)
       stripe_provider.save!
 
       if is_new

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -25,12 +25,14 @@ RSpec.describe PaymentProviders::StripeService do
           code:,
           name:,
           success_redirect_url:,
-          supports_3ds: true
+          supports_3ds: true,
+          require_terms_of_service_consent: true
         )
 
         expect(PaymentProviders::Stripe::RegisterWebhookJob).to have_been_enqueued
           .with(result.stripe_provider)
         expect(result.stripe_provider.supports_3ds).to be(true)
+        expect(result.stripe_provider.require_terms_of_service_consent).to be(true)
       end.to change(PaymentProviders::StripeProvider, :count).by(1)
     end
 


### PR DESCRIPTION
Part of INT-163

## Context

The `require_terms_of_service_consent` flag exists on the Stripe provider but could not yet be set through the provider create/update flow.

## Description

Copy `require_terms_of_service_consent` from the arguments in `create_or_update`, mirroring the existing `supports_3ds` handling, so the setting can be turned on or off per connection.
