### PR TITLE
feat(purchase_order_number): Restrict PO number editing on subscriptions

### DIFF
--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -25,6 +25,10 @@ module Subscriptions
       return result.not_found_failure!(resource: "subscription") unless subscription
       return result.not_allowed_failure!(code: "subscription_incomplete") if subscription.incomplete?
 
+      if params.key?(:purchase_order_number) && !subscription.pending? && !subscription.active?
+        return result.not_allowed_failure!(code: "purchase_order_number_not_editable")
+      end
+
       unless valid?(
         customer: subscription.customer,
         plan: subscription.plan,

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -35,6 +35,37 @@ RSpec.describe Subscriptions::UpdateService do
       end
     end
 
+    context "with purchase_order_number" do
+      let(:params) { {purchase_order_number: "PO-123"} }
+
+      %i[pending active].each do |status|
+        context "when subscription is #{status}" do
+          let(:subscription) { create(:subscription, status:) }
+
+          it "updates the purchase_order_number" do
+            result = update_service.call
+
+            expect(result).to be_success
+            expect(result.subscription.purchase_order_number).to eq("PO-123")
+          end
+        end
+      end
+
+      %i[terminated canceled].each do |status|
+        context "when subscription is #{status}" do
+          let(:subscription) { create(:subscription, status:) }
+
+          it "returns a not allowed error and does not update" do
+            result = update_service.call
+
+            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+            expect(result.error.code).to eq("purchase_order_number_not_editable")
+            expect(subscription.reload.purchase_order_number).to be_nil
+          end
+        end
+      end
+    end
+
     context "when both usage_thresholds and plan_overrides.usage_thresholds are present" do
       let(:params) do
         {


### PR DESCRIPTION
## Description

Requirement: the PO number can be edited any time while the subscription is in `pending` or `active` state.
