### PR TITLE
[ING-428] Filter wallet transactions by metadata

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -33,7 +33,9 @@ module Api
           filters: {
             status: params[:status],
             transaction_type: params[:transaction_type],
-            transaction_status: params[:transaction_status]
+            transaction_status: params[:transaction_status],
+            # Only a nested hash param (?metadata[key]=value) responds to permit!; scalar/array shapes are ignored.
+            metadata: params[:metadata].respond_to?(:permit!) ? params[:metadata].permit!.to_h : {}
           }
         )
 

--- a/app/queries/wallet_transactions_query.rb
+++ b/app/queries/wallet_transactions_query.rb
@@ -2,7 +2,7 @@
 
 class WalletTransactionsQuery < BaseQuery
   Result = BaseResult[:wallet_transactions]
-  Filters = BaseFilters[:transaction_type, :status, :transaction_status]
+  Filters = BaseFilters[:transaction_type, :status, :transaction_status, :metadata]
 
   def initialize(organization:, wallet_id:, pagination: DEFAULT_PAGINATION_PARAMS, filters: {}, search_term: nil, order: nil)
     @wallet = organization.wallets.find_by(id: wallet_id)
@@ -26,6 +26,8 @@ class WalletTransactionsQuery < BaseQuery
       wallet_transactions = with_transaction_status(wallet_transactions)
     end
 
+    wallet_transactions = with_metadata(wallet_transactions) if filters.metadata.is_a?(Hash) && filters.metadata.present?
+
     result.wallet_transactions = wallet_transactions
     result
   end
@@ -44,6 +46,18 @@ class WalletTransactionsQuery < BaseQuery
 
   def with_transaction_status(scope)
     scope.where(transaction_status: filters.transaction_status)
+  end
+
+  def with_metadata(scope)
+    filters.metadata.reduce(scope) do |relation, (key, value)|
+      next relation if value.blank?
+
+      relation.where(
+        "EXISTS (SELECT 1 FROM jsonb_array_elements(wallet_transactions.metadata) AS pair " \
+        "WHERE pair->>'key' = ? AND pair->>'value' = ?)",
+        key.to_s, value.to_s
+      )
+    end
   end
 
   def valid_status?(status)

--- a/spec/queries/wallet_transactions_query_spec.rb
+++ b/spec/queries/wallet_transactions_query_spec.rb
@@ -103,6 +103,54 @@ RSpec.describe WalletTransactionsQuery do
     end
   end
 
+  context "when filtering by metadata" do
+    let(:wallet_transaction_first) { create(:wallet_transaction, wallet:, metadata: [{"key" => "site_id", "value" => "alpha"}]) }
+    let(:wallet_transaction_second) { create(:wallet_transaction, wallet:, metadata: [{"key" => "site_id", "value" => "beta"}]) }
+    let(:wallet_transaction_third) { create(:wallet_transaction, wallet:, metadata: []) }
+
+    let(:filters) { {metadata: {"site_id" => "alpha"}} }
+
+    it "returns only the transaction tagged with that key and value" do
+      expect(returned_ids).to eq([wallet_transaction_first.id])
+    end
+
+    context "with several key/value pairs" do
+      let(:wallet_transaction_first) do
+        create(:wallet_transaction, wallet:, metadata: [{"key" => "site_id", "value" => "alpha"}, {"key" => "tier", "value" => "pro"}])
+      end
+      let(:filters) { {metadata: {"site_id" => "alpha", "tier" => "pro"}} }
+
+      it "requires every pair to match (containment)" do
+        expect(returned_ids).to eq([wallet_transaction_first.id])
+      end
+    end
+
+    context "when no transaction carries the pair" do
+      let(:filters) { {metadata: {"site_id" => "missing"}} }
+
+      it "returns nothing" do
+        expect(returned_ids).to be_empty
+      end
+    end
+
+    context "when the filter value is blank" do
+      let(:filters) { {metadata: {"site_id" => ""}} }
+
+      it "carries no constraint rather than matching empty values" do
+        expect(returned_ids.count).to eq(3)
+      end
+    end
+
+    context "when the stored value is a number" do
+      let(:wallet_transaction_first) { create(:wallet_transaction, wallet:, metadata: [{"key" => "count", "value" => 100}]) }
+      let(:filters) { {metadata: {"count" => "100"}} }
+
+      it "matches the numeric value against the string filter" do
+        expect(returned_ids).to eq([wallet_transaction_first.id])
+      end
+    end
+  end
+
   context "when transaction_status filter is present" do
     # Override outer context transactions to avoid interference
     let(:wallet_transaction_first) { nil }

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -244,6 +244,31 @@ RSpec.describe Api::V1::WalletTransactionsController do
       end
     end
 
+    context "with metadata param" do
+      let(:params) { {metadata: {site_id: "alpha"}} }
+      let(:wallet_transaction_first) { create(:wallet_transaction, wallet:, metadata: [{"key" => "site_id", "value" => "alpha"}]) }
+      let(:wallet_transaction_second) { create(:wallet_transaction, wallet:, metadata: [{"key" => "site_id", "value" => "beta"}]) }
+
+      it "returns only the transactions tagged with that key and value" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:wallet_transactions].count).to eq(1)
+        expect(json[:wallet_transactions].first[:lago_id]).to eq(wallet_transaction_first.id)
+      end
+    end
+
+    context "when metadata is sent with a malformed shape" do
+      let(:params) { {metadata: "foo"} }
+
+      it "ignores the filter instead of erroring" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:wallet_transactions].count).to eq(2)
+      end
+    end
+
     context "with transaction_status filter" do
       # Override outer context transactions to avoid interference
       let(:wallet_transaction_first) { nil }


### PR DESCRIPTION
## Context

Wallet transactions accept `metadata` on create and return it when read by id, but the list endpoint could not filter by it. A customer tagging a grant with, say, `site_id` had no way to find that grant again without pulling the whole history and matching client-side.

## Changes

- Add a `metadata` filter to `GET /wallets/:id/wallet_transactions`, following the invoices/customers convention: `?metadata[key]=value`. Several pairs read as AND.
- `metadata` is a jsonb array of key/value objects, so each requested pair adds an `EXISTS` over the array. Values are compared as text, so a stored number or boolean still matches its string form from the query params. A blank value carries no constraint, and a malformed `metadata` param (a scalar or array instead of a nested hash) is ignored rather than erroring.
- The lookup is always scoped to a single wallet, so it runs over a small set and needs no dedicated index.
