### PR TITLE
feat(stripe): expose consent setting in GraphQL

### DIFF
--- a/app/graphql/types/payment_providers/stripe.rb
+++ b/app/graphql/types/payment_providers/stripe.rb
@@ -9,6 +9,7 @@ module Types
       field :id, ID, null: false
       field :name, String, null: false
 
+      field :require_terms_of_service_consent, Boolean, null: true
       field :secret_key, ObfuscatedStringType, null: true, permission: "organization:integrations:view"
       field :success_redirect_url, String, null: true, permission: "organization:integrations:view"
       field :supports_3ds, Boolean, null: true

--- a/app/graphql/types/payment_providers/stripe_input.rb
+++ b/app/graphql/types/payment_providers/stripe_input.rb
@@ -7,6 +7,7 @@ module Types
 
       argument :code, String, required: true
       argument :name, String, required: true
+      argument :require_terms_of_service_consent, Boolean, required: false
       argument :secret_key, String, required: false
       argument :success_redirect_url, String, required: false
       argument :supports_3ds, Boolean, required: false

--- a/app/graphql/types/payment_providers/update_input.rb
+++ b/app/graphql/types/payment_providers/update_input.rb
@@ -11,6 +11,7 @@ module Types
       argument :name, String, required: false
       argument :success_redirect_url, String, required: false
 
+      argument :require_terms_of_service_consent, Boolean, required: false
       argument :supports_3ds, Boolean, required: false
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -488,6 +488,7 @@ input AddStripePaymentProviderInput {
   clientMutationId: String
   code: String!
   name: String!
+  requireTermsOfServiceConsent: Boolean
   secretKey: String
   successRedirectUrl: String
   supports3ds: Boolean
@@ -11721,6 +11722,7 @@ type StripeProvider {
   code: String!
   id: ID!
   name: String!
+  requireTermsOfServiceConsent: Boolean
   secretKey: ObfuscatedString
   successRedirectUrl: String
   supports3ds: Boolean
@@ -12845,6 +12847,7 @@ input UpdateAdyenPaymentProviderInput {
   flowId: String
   id: ID!
   name: String
+  requireTermsOfServiceConsent: Boolean
   successRedirectUrl: String
   supports3ds: Boolean
 }
@@ -12966,6 +12969,7 @@ input UpdateCashfreePaymentProviderInput {
   flowId: String
   id: ID!
   name: String
+  requireTermsOfServiceConsent: Boolean
   successRedirectUrl: String
   supports3ds: Boolean
 }
@@ -13200,6 +13204,7 @@ input UpdateFlutterwavePaymentProviderInput {
   flowId: String
   id: ID!
   name: String
+  requireTermsOfServiceConsent: Boolean
   successRedirectUrl: String
   supports3ds: Boolean
 }
@@ -13216,6 +13221,7 @@ input UpdateGocardlessPaymentProviderInput {
   flowId: String
   id: ID!
   name: String
+  requireTermsOfServiceConsent: Boolean
   successRedirectUrl: String
   supports3ds: Boolean
 }
@@ -13339,6 +13345,7 @@ input UpdateMoneyhashPaymentProviderInput {
   flowId: String
   id: ID!
   name: String
+  requireTermsOfServiceConsent: Boolean
   successRedirectUrl: String
   supports3ds: Boolean
 }
@@ -13576,6 +13583,7 @@ input UpdateStripePaymentProviderInput {
   flowId: String
   id: ID!
   name: String
+  requireTermsOfServiceConsent: Boolean
   successRedirectUrl: String
   supports3ds: Boolean
 }

--- a/schema.json
+++ b/schema.json
@@ -1740,6 +1740,18 @@
               "deprecationReason": null
             },
             {
+              "name": "requireTermsOfServiceConsent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "secretKey",
               "description": null,
               "type": {
@@ -63805,6 +63817,18 @@
               "deprecationReason": null
             },
             {
+              "name": "requireTermsOfServiceConsent",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "secretKey",
               "description": null,
               "args": [],
@@ -67516,6 +67540,18 @@
               "deprecationReason": null
             },
             {
+              "name": "requireTermsOfServiceConsent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "supports3ds",
               "description": null,
               "type": {
@@ -68387,6 +68423,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "requireTermsOfServiceConsent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,
@@ -70120,6 +70168,18 @@
               "deprecationReason": null
             },
             {
+              "name": "requireTermsOfServiceConsent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "supports3ds",
               "description": null,
               "type": {
@@ -70212,6 +70272,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "requireTermsOfServiceConsent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,
@@ -70980,6 +71052,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "requireTermsOfServiceConsent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,
@@ -72755,6 +72839,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "requireTermsOfServiceConsent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/payment_providers/stripe/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/create_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Create do
           name
           successRedirectUrl
           supports3ds
+          requireTermsOfServiceConsent
         }
       }
     GQL
@@ -44,7 +45,8 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Create do
           code:,
           name:,
           successRedirectUrl: success_redirect_url,
-          supports3ds: true
+          supports3ds: true,
+          requireTermsOfServiceConsent: true
         }
       }
     )
@@ -57,5 +59,6 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Create do
     expect(result_data["name"]).to eq(name)
     expect(result_data["successRedirectUrl"]).to eq(success_redirect_url)
     expect(result_data["supports3ds"]).to eq(true)
+    expect(result_data["requireTermsOfServiceConsent"]).to eq(true)
   end
 end

--- a/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Update do
           id
           successRedirectUrl
           supports3ds
+          requireTermsOfServiceConsent
         }
       }
     GQL
@@ -38,7 +39,8 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Update do
         input: {
           id: stripe_provider.id,
           successRedirectUrl: success_redirect_url,
-          supports3ds: true
+          supports3ds: true,
+          requireTermsOfServiceConsent: true
         }
       }
     )
@@ -47,6 +49,7 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Update do
 
     expect(result_data["successRedirectUrl"]).to eq(success_redirect_url)
     expect(result_data["supports3ds"]).to eq(true)
+    expect(result_data["requireTermsOfServiceConsent"]).to eq(true)
   end
 
   context "when success redirect url is nil" do

--- a/spec/graphql/types/payment_providers/stripe_input_spec.rb
+++ b/spec/graphql/types/payment_providers/stripe_input_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe Types::PaymentProviders::StripeInput do
     expect(subject).to accept_argument(:secret_key).of_type("String")
     expect(subject).to accept_argument(:success_redirect_url).of_type("String")
     expect(subject).to accept_argument(:supports_3ds).of_type("Boolean")
+    expect(subject).to accept_argument(:require_terms_of_service_consent).of_type("Boolean")
   end
 end

--- a/spec/graphql/types/payment_providers/stripe_spec.rb
+++ b/spec/graphql/types/payment_providers/stripe_spec.rb
@@ -13,5 +13,6 @@ RSpec.describe Types::PaymentProviders::Stripe do
     expect(subject).to have_field(:secret_key).of_type("ObfuscatedString").with_permission("organization:integrations:view")
     expect(subject).to have_field(:success_redirect_url).of_type("String").with_permission("organization:integrations:view")
     expect(subject).to have_field(:supports_3ds).of_type("Boolean")
+    expect(subject).to have_field(:require_terms_of_service_consent).of_type("Boolean")
   end
 end

--- a/spec/graphql/types/payment_providers/update_input_spec.rb
+++ b/spec/graphql/types/payment_providers/update_input_spec.rb
@@ -10,5 +10,6 @@ RSpec.describe Types::PaymentProviders::UpdateInput do
     expect(subject).to accept_argument(:name).of_type("String")
     expect(subject).to accept_argument(:id).of_type("ID!")
     expect(subject).to accept_argument(:success_redirect_url).of_type("String")
+    expect(subject).to accept_argument(:require_terms_of_service_consent).of_type("Boolean")
   end
 end


### PR DESCRIPTION
Part of INT-163

## Context

The `require_terms_of_service_consent` flag can be persisted on the Stripe provider but was not reachable through the GraphQL API.

## Description

Add the `require_terms_of_service_consent` argument to the Stripe create and update inputs and expose it as a field on the `StripeProvider` type, mirroring `supports_3ds`. Regenerate the schema dump accordingly.
