### PR TITLE
feat(stripe): consent on setup checkout URL

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -130,12 +130,18 @@ module PaymentProviderCustomers
     end
 
     def checkout_link_params
-      {
+      params = {
         success_url: success_redirect_url,
         mode: "setup",
         payment_method_types: stripe_customer.provider_payment_methods_with_setup,
         customer: stripe_customer.provider_customer_id
       }
+
+      if stripe_payment_provider.require_terms_of_service_consent
+        params[:consent_collection] = {terms_of_service: "required"}
+      end
+
+      params
     end
 
     def success_redirect_url

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -517,6 +517,32 @@ RSpec.describe PaymentProviderCustomers::StripeService do
         .with("customer.checkout_url_generated", customer, checkout_url: "https://example.com")
     end
 
+    it "does not require terms of service consent by default" do
+      allow(::Stripe::Checkout::Session).to receive(:create).and_return({"url" => "https://example.com"})
+
+      described_class.call(:generate_checkout_url, stripe_customer)
+
+      expect(::Stripe::Checkout::Session).to have_received(:create).with(
+        hash_excluding(:consent_collection),
+        anything
+      )
+    end
+
+    context "when consent collection is enabled on the provider" do
+      before { stripe_provider.update!(require_terms_of_service_consent: true) }
+
+      it "requires terms of service consent on the checkout session" do
+        allow(::Stripe::Checkout::Session).to receive(:create).and_return({"url" => "https://example.com"})
+
+        described_class.call(:generate_checkout_url, stripe_customer)
+
+        expect(::Stripe::Checkout::Session).to have_received(:create).with(
+          hash_including(consent_collection: {terms_of_service: "required"}),
+          anything
+        )
+      end
+    end
+
     context "without any customer" do
       let(:customer) { create(:customer, :deleted, organization:) }
 

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -529,7 +529,7 @@ RSpec.describe PaymentProviderCustomers::StripeService do
     end
 
     context "when consent collection is enabled on the provider" do
-      before { stripe_provider.update!(require_terms_of_service_consent: true) }
+      let(:stripe_provider) { create(:stripe_provider, require_terms_of_service_consent: true) }
 
       it "requires terms of service consent on the checkout session" do
         allow(::Stripe::Checkout::Session).to receive(:create).and_return({"url" => "https://example.com"})


### PR DESCRIPTION
Part of INT-163

## Context

The consent collection setting on the Stripe connection was stored and exposed but not yet applied to any checkout flow.

## Description

When require_terms_of_service_consent is enabled on the connection, add consent_collection[terms_of_service]=required to the setup-mode Checkout Session behind the customer checkout URL, so payers must accept the terms of service before saving a payment method. No change when the setting is off.