### PR TITLE
feat(stripe): consent on payment request URL

### DIFF
--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -155,7 +155,7 @@ module PaymentRequests
       end
 
       def payment_url_payload
-        {
+        payload = {
           line_items: line_items,
           mode: "payment",
           success_url: success_redirect_url,
@@ -171,6 +171,12 @@ module PaymentRequests
             }
           }
         }
+
+        if stripe_payment_provider.require_terms_of_service_consent
+          payload[:consent_collection] = {terms_of_service: "required"}
+        end
+
+        payload
       end
 
       def handle_missing_payment(organization_id, stripe_payment)

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -100,6 +100,34 @@ RSpec.describe PaymentRequests::Payments::StripeService do
         )
     end
 
+    it "does not require terms of service consent by default" do
+      described_class.call(:generate_payment_url, payment_request)
+
+      expect(::Stripe::Checkout::Session)
+        .to have_received(:create)
+        .with(
+          hash_excluding(:consent_collection),
+          hash_including({api_key: an_instance_of(String)})
+        )
+    end
+
+    context "when consent collection is enabled on the provider" do
+      let(:stripe_payment_provider) do
+        create(:stripe_provider, organization:, code:, require_terms_of_service_consent: true)
+      end
+
+      it "requires terms of service consent on the checkout session" do
+        described_class.call(:generate_payment_url, payment_request)
+
+        expect(::Stripe::Checkout::Session)
+          .to have_received(:create)
+          .with(
+            hash_including(consent_collection: {terms_of_service: "required"}),
+            hash_including({api_key: an_instance_of(String)})
+          )
+      end
+    end
+
     context "when payment request is related to a single overdue invoice" do
       let(:invoices) { [invoice_1] }
 


### PR DESCRIPTION
Part of INT-163

## Context

The consent collection setting applied to the customer checkout URL but not to the payment-request payment page.

## Description

When `require_terms_of_service_consent` is enabled on the connection, add `consent_collection[terms_of_service]=required` to the payment-mode Checkout Session behind the payment-request payment URL, so payers must accept the terms of service before paying. No change when the setting is off.