### PR TITLE
Chore(subscription-termination): change termination behaviour to hourly

### DIFF
--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -5,14 +5,15 @@ module Clock
     unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
+      # NOTE: Terminate every active subscription whose `ending_at` instant has already
+      #       passed. This runs hourly (see clock.rb), so a subscription ending at, say,
+      #       15:00 is terminated on the next hourly tick after 15:00 — not at midnight.
+      #       We compare timestamps (not calendar dates) so we never terminate a
+      #       subscription before it actually reaches its `ending_at`.
       Subscription
         .joins(customer: :billing_entity)
         .active
-        .where(
-          "DATE(subscriptions.ending_at#{Utils::Timezone.at_time_zone_sql}) = " \
-          "DATE(?#{Utils::Timezone.at_time_zone_sql})",
-          Time.current
-        )
+        .where("subscriptions.ending_at <= ?", Time.current)
         .find_each do |subscription|
           Subscriptions::TerminateEndedSubscriptionJob.perform_later(subscription)
         end

--- a/app/jobs/subscriptions/terminate_ended_subscription_job.rb
+++ b/app/jobs/subscriptions/terminate_ended_subscription_job.rb
@@ -9,7 +9,11 @@ module Subscriptions
     unique :until_executed, on_conflict: :log
 
     def perform(subscription)
-      Subscriptions::TerminateService.call!(subscription:)
+      # NOTE: Pin termination to the subscription's contractual end so billing stops exactly
+      #       at `ending_at`, regardless of when this (hourly) job actually runs. The
+      #       termination-side dedup in Invoices::CreateInvoiceSubscriptionService prevents a
+      #       period already billed periodically from being billed again.
+      Subscriptions::TerminateService.call!(subscription:, terminated_at: subscription.ending_at)
     end
   end
 end

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -87,6 +87,20 @@ class InvoiceSubscription < ApplicationRecord
     base_query.exists?
   end
 
+  # NOTE: True when a recurring (periodic) invoice already covers this period, i.e. the
+  #       period was billed by the periodic biller. Used to stop the termination flow from
+  #       re-billing a period the biller already invoiced. This is an OVERLAP check, not an
+  #       exact match: the periodic invoice spans the full period while termination bills up
+  #       to `ending_at`, so we match on the period start and require the recurring invoice to
+  #       extend at least as far as the termination boundary.
+  def self.period_already_billed?(subscription, boundaries)
+    recurring
+      .where(subscription_id: subscription.id)
+      .where(from_datetime: boundaries.from_datetime)
+      .where("invoice_subscriptions.to_datetime >= ?", boundaries.to_datetime)
+      .exists?
+  end
+
   def fees
     @fees ||= Fee.where(
       subscription_id: subscription.id,

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -53,13 +53,24 @@ class InvoiceSubscription < ApplicationRecord
       .order(Arel.sql("COALESCE(to_datetime, timestamp) ASC"))
   }
 
-  def self.matching?(subscription, boundaries, recurring: true)
+  def self.matching?(subscription, boundaries, recurring: true, include_terminating: false)
     base_query = InvoiceSubscription
       .where(subscription_id: subscription.id)
       .where(from_datetime: boundaries.from_datetime)
       .where(to_datetime: boundaries.to_datetime)
 
-    base_query = base_query.recurring if recurring
+    if recurring && include_terminating
+      # NOTE: A period already invoiced by the termination flow (recurring = false,
+      #       invoicing_reason = subscription_terminating) must also block a periodic
+      #       (recurring) bill of the same period. Progressive-billing rows are
+      #       intentionally NOT matched here, since they do not close the period.
+      base_query = base_query.where(
+        "invoice_subscriptions.recurring = TRUE OR invoice_subscriptions.invoicing_reason = ?",
+        INVOICING_REASONS[:subscription_terminating]
+      )
+    elsif recurring
+      base_query = base_query.recurring
+    end
 
     if subscription.plan.charges_billed_in_monthly_split_intervals?
       base_query = base_query

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -72,7 +72,11 @@ module Invoices
       subscriptions_boundaries.any? do |subscription_id, boundaries|
         subscription = Subscription.includes(:plan).find(subscription_id)
 
-        InvoiceSubscription.matching?(subscription, boundaries)
+        # NOTE: `include_terminating` also treats a period already invoiced by the
+        #       termination flow as billed, so the periodic biller cannot re-bill a
+        #       period that termination already covered (prevents the
+        #       termination-then-periodic double billing on the ending/billing day).
+        InvoiceSubscription.matching?(subscription, boundaries, include_terminating: true)
       end
     end
 

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -67,17 +67,32 @@ module Invoices
     end
 
     def duplicated_invoices?
-      return false unless recurring
+      if recurring
+        return subscriptions_boundaries.any? do |subscription_id, boundaries|
+          subscription = Subscription.includes(:plan).find(subscription_id)
 
-      subscriptions_boundaries.any? do |subscription_id, boundaries|
-        subscription = Subscription.includes(:plan).find(subscription_id)
-
-        # NOTE: `include_terminating` also treats a period already invoiced by the
-        #       termination flow as billed, so the periodic biller cannot re-bill a
-        #       period that termination already covered (prevents the
-        #       termination-then-periodic double billing on the ending/billing day).
-        InvoiceSubscription.matching?(subscription, boundaries, include_terminating: true)
+          # NOTE: `include_terminating` also treats a period already invoiced by the
+          #       termination flow as billed, so the periodic biller cannot re-bill a
+          #       period that termination already covered (prevents the
+          #       termination-then-periodic double billing on the ending/billing day).
+          InvoiceSubscription.matching?(subscription, boundaries, include_terminating: true)
+        end
       end
+
+      # NOTE: The termination flow must not re-bill a period that the periodic biller has
+      #       already invoiced (e.g. billing ran before the termination job on the ending/
+      #       billing day). We check the termination-adjusted boundaries — the period that
+      #       is actually about to be billed — against existing recurring invoices.
+      return false unless terminating?
+
+      impacted_subscriptions.any? do |subscription|
+        boundaries = termination_boundaries(subscription, subscriptions_boundaries[subscription.id])
+        InvoiceSubscription.period_already_billed?(subscription, boundaries)
+      end
+    end
+
+    def terminating?
+      invoicing_reason.to_sym == :subscription_terminating
     end
 
     def subscriptions_boundaries

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -109,7 +109,11 @@ module Invoices
       raise
     rescue BaseService::ServiceFailure => e
       raise unless e.code.to_s == "duplicated_invoices"
-      raise unless invoicing_reason.to_sym == :subscription_periodic
+      # NOTE: A duplicated period is benign for periodic billing (two billers racing) and now
+      #       also for termination (the period was already billed periodically — see
+      #       CreateInvoiceSubscriptionService#duplicated_invoices?). In both cases we skip
+      #       silently rather than erroring.
+      raise unless invoicing_reason.to_sym.in?(%i[subscription_periodic subscription_terminating])
 
       result
     rescue ActiveRecord::StaleObjectError, BaseLockService::FailedToAcquireLock

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -113,10 +113,13 @@ module Subscriptions
           AND DATE(subscriptions.started_at#{at_time_zone}) < DATE(:today#{at_time_zone})
           -- Do not bill subscriptions that were not created yet
           and DATE(subscriptions.created_at) <= Date(:today)
-          AND (
-            subscriptions.ending_at IS NULL OR
-            DATE(subscriptions.ending_at#{at_time_zone}) != DATE(:today#{at_time_zone})
-          )
+          -- NOTE: We intentionally DO bill subscriptions whose `ending_at` is today.
+          --       A completed period that rolls over on the ending day must be billed
+          --       by the periodic biller (as any other period); the termination flow
+          --       only bills the final partial period. The `already_billed_today` guard
+          --       and the period-based duplicate check in
+          --       Invoices::CreateInvoiceSubscriptionService prevent double billing when
+          --       termination has already invoiced the same period.
         GROUP BY subscriptions.id
       SQL
 

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -4,10 +4,15 @@ module Subscriptions
   class TerminateService < BaseService
     Result = BaseResult[:subscription]
 
-    def initialize(subscription:, async: true, upgrade: false, on_termination_credit_note: subscription&.on_termination_credit_note, on_termination_invoice: subscription&.on_termination_invoice)
+    def initialize(subscription:, async: true, upgrade: false, terminated_at: nil, on_termination_credit_note: subscription&.on_termination_credit_note, on_termination_invoice: subscription&.on_termination_invoice)
       @subscription = subscription
       @async = async
       @upgrade = upgrade
+      # NOTE: `terminated_at` lets the caller pin the termination instant. The clock that
+      #       terminates ended subscriptions passes `subscription.ending_at` so billing stops
+      #       exactly at the contractual end (no overshoot into the next period). Manual/API
+      #       termination leaves it nil and terminates at the current time.
+      @terminated_at = terminated_at
       @on_termination_credit_note = on_termination_credit_note.blank? ? :credit : on_termination_credit_note.to_sym
       @on_termination_invoice = on_termination_invoice.blank? ? :generate : on_termination_invoice.to_sym
 
@@ -29,7 +34,7 @@ module Subscriptions
             Utils::ActivityLog.produce_after_commit(previous, "subscription.updated")
           end
         elsif !subscription.terminated?
-          subscription.mark_as_terminated!
+          subscription.mark_as_terminated!(terminated_at || Time.current)
           update_on_termination_actions!
 
           if subscription.should_sync_hubspot_subscription?
@@ -90,7 +95,7 @@ module Subscriptions
 
     private
 
-    attr_reader :subscription, :async, :upgrade, :on_termination_credit_note, :on_termination_invoice
+    attr_reader :subscription, :async, :upgrade, :terminated_at, :on_termination_credit_note, :on_termination_invoice
 
     def cancel_next_subscription
       # NOTE: Upgrade path: next_subscription is the new subscription we just persisted, not a stale scheduled change

--- a/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
@@ -15,7 +15,7 @@ describe Clock::TerminateEndedSubscriptionsJob, job: true do
   end
 
   describe ".perform" do
-    it "enqueues a TerminateEndedSubscriptionJob for matching subscriptions" do
+    it "enqueues a TerminateEndedSubscriptionJob for subscriptions past their ending_at" do
       current_date = Time.current + 2.months
 
       travel_to(current_date) do
@@ -30,25 +30,25 @@ describe Clock::TerminateEndedSubscriptionsJob, job: true do
       end
     end
 
-    context "with customer timezone" do
-      let(:ending_at) { DateTime.parse("2022-10-21 00:30:00") }
+    context "when the subscription ends later in the day" do
+      # ending_at is at 15:00, so the midnight run must NOT terminate it yet.
+      let(:ending_at) { DateTime.parse("2026-10-21 15:00:00") }
 
-      before do
-        subscription1.customer.update!(timezone: "America/New_York")
+      it "does not terminate it when the clock runs before ending_at (e.g. midnight)" do
+        travel_to(DateTime.parse("2026-10-21 00:05:00")) do
+          described_class.perform_now
+
+          expect(Subscriptions::TerminateEndedSubscriptionJob)
+            .not_to have_been_enqueued.with(subscription1)
+        end
       end
 
-      it "takes timezone into account" do
-        current_date = ending_at
-
-        travel_to(current_date) do
+      it "terminates it on the next hourly run after ending_at has passed" do
+        travel_to(DateTime.parse("2026-10-21 15:05:00")) do
           described_class.perform_now
 
           expect(Subscriptions::TerminateEndedSubscriptionJob)
             .to have_been_enqueued.with(subscription1)
-          expect(Subscriptions::TerminateEndedSubscriptionJob)
-            .not_to have_been_enqueued.with(subscription2)
-          expect(Subscriptions::TerminateEndedSubscriptionJob)
-            .not_to have_been_enqueued.with(subscription3)
         end
       end
     end

--- a/spec/jobs/subscriptions/terminate_ended_subscription_job_spec.rb
+++ b/spec/jobs/subscriptions/terminate_ended_subscription_job_spec.rb
@@ -9,15 +9,16 @@ RSpec.describe Subscriptions::TerminateEndedSubscriptionJob do
   before do
     allow(Subscriptions::TerminateService).to receive(:call!).and_call_original
     allow(Subscriptions::TerminateService).to receive(:call)
-      .with(subscription:)
+      .with(subscription:, terminated_at: subscription.ending_at)
       .and_return(result)
   end
 
   describe "#perform" do
-    it "calls the subscription service" do
+    it "calls the subscription service, pinning termination to ending_at" do
       described_class.perform_now(subscription)
 
-      expect(Subscriptions::TerminateService).to have_received(:call!).with(subscription:)
+      expect(Subscriptions::TerminateService)
+        .to have_received(:call!).with(subscription:, terminated_at: subscription.ending_at)
     end
 
     context "when the service returns a failure" do

--- a/spec/scenarios/subscriptions/terminate_ended_before_ending_time_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_before_ending_time_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression test for the subscription-termination timing issue.
+#
+# Previously, Clock::TerminateEndedSubscriptionsJob matched subscriptions by
+# comparing calendar DATES (DATE(ending_at) = DATE(now)), so a subscription with
+# `ending_at` at 15:00 was terminated by the midnight run — several hours BEFORE
+# it actually ended, leaving the customer without a subscription in between.
+#
+# The job now compares timestamps (ending_at <= now) and runs hourly, so a
+# subscription is only terminated once its `ending_at` instant has passed.
+describe "Subscription is not terminated before its ending time" do
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: "") }
+
+  # Use UTC to isolate the timestamp behaviour from any timezone shifting.
+  let(:timezone) { "UTC" }
+  let(:customer) { create(:customer, organization:, timezone:) }
+
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      interval: "monthly",
+      amount_cents: 1000,
+      pay_in_advance: false
+    )
+  end
+
+  let(:creation_time)  { Time.zone.parse("2023-09-05T00:00:00") }
+  let(:subscription_at) { Time.zone.parse("2023-09-05T00:00:00") }
+
+  # Subscription is supposed to end at 15:00 UTC on 2023-09-06.
+  let(:ending_at) { Time.zone.parse("2023-09-06T15:00:00") }
+
+  it "keeps the subscription active at midnight and terminates it after ending_at" do
+    subscription = nil
+
+    travel_to(creation_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time: "anniversary",
+          subscription_at: subscription_at.iso8601,
+          ending_at: ending_at.iso8601
+        }
+      )
+
+      subscription = customer.subscriptions.first
+      expect(subscription).to be_active
+    end
+
+    # Midnight run on the ending day: ending_at (15:00) has NOT passed yet,
+    # so the subscription must stay active — no early termination, no gap.
+    travel_to(Time.zone.parse("2023-09-06T00:05:00")) do
+      Clock::TerminateEndedSubscriptionsJob.perform_now
+      perform_all_enqueued_jobs
+
+      subscription.reload
+      expect(subscription).to be_active
+      expect(subscription).not_to be_terminated
+      expect(subscription.terminated_at).to be_nil
+    end
+
+    # First hourly run after ending_at: now the subscription is terminated,
+    # and terminated_at is at/after ending_at (never before it).
+    travel_to(Time.zone.parse("2023-09-06T15:05:00")) do
+      Clock::TerminateEndedSubscriptionsJob.perform_now
+      perform_all_enqueued_jobs
+
+      subscription.reload
+      expect(subscription).to be_terminated
+      expect(subscription.terminated_at).to be >= subscription.ending_at
+    end
+  end
+end

--- a/spec/scenarios/subscriptions/terminate_ended_billing_order_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_billing_order_spec.rb
@@ -139,11 +139,12 @@ describe "Subscription termination vs billing order" do
 
       # (B) period 2, before ending
       travel_to(Time.zone.parse("2025-07-22T10:00:00")) { ingest_usage(20) }
-      # (C) 1 min after ending_at — still active (not yet terminated).
+      # (C) 1 min after ending_at — accepted (sub still active) but NOT billed, because
+      # terminated_at is pinned to ending_at (15:33).
       travel_to(Time.zone.parse("2025-07-22T16:34:00")) { ingest_usage(40) }
 
-      # Tick after ending: termination fires (terminated_at = 17:05), bills the
-      # partial period 2.
+      # Tick after ending: termination fires and bills the partial period 2, up to
+      # terminated_at = ending_at (15:33).
       travel_to(Time.zone.parse("2025-07-22T17:05:00")) do
         run_clock_terminate_then_bill
       end
@@ -152,11 +153,11 @@ describe "Subscription termination vs billing order" do
       expect(subscription).to be_terminated
       expect(subscription.invoices.count).to eq(2)
 
-      # No usage lost, none double-counted: A + B + C = 10 + 20 + 40 = 70.
-      # (C is included because terminated_at is the job run time, 17:05, > 16:34.)
-      expect(charge_units_total(subscription)).to eq(70)
+      # No usage lost, none double-counted. Usage up to ending_at is billed (A in period 1,
+      # B in period 2); the post-ending event C is excluded: A + B = 10 + 20 = 30.
+      expect(charge_units_total(subscription)).to eq(30)
 
-      # Period 1 full month + period 2 prorate.
+      # Period 1 full month + period 2 prorate (up to ending_at).
       expect(subscription_fees_cents(subscription)).to be > 10_000
     end
   end
@@ -229,11 +230,11 @@ describe "Subscription termination vs billing order" do
 
       subscription.reload
       expect(subscription).to be_terminated
-      expect(charge_units_total(subscription)).to eq(15)          # NOT 30
-      expect(subscription_fees_cents(subscription)).to be < 20_000 # July billed once, not twice
+      expect(charge_units_total(subscription)).to eq(15)           # billed once, not doubled
+      expect(subscription_fees_cents(subscription)).to eq(10_000)  # July once, no next-period sliver
       expect(
         invoice_subscriptions_for(subscription, from: started_at, to: Time.zone.parse("2025-07-31")).count
-      ).to eq(1)                                                  # July billed exactly once
+      ).to eq(1)                                                   # July billed exactly once
     end
   end
 end

--- a/spec/scenarios/subscriptions/terminate_ended_billing_order_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_billing_order_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Path A behaviour: the periodic biller is NOT prevented from billing on the
+# ending day. Completed periods are billed by the periodic biller (as usual),
+# and the termination flow bills only the final partial period. A period-based
+# dedup guard ensures a period billed by termination cannot also be billed
+# periodically (and vice versa).
+#
+# Clock order within an hour (see clock.rb):
+#   *:05  Clock::TerminateEndedSubscriptionsJob   (terminate ended subscriptions)
+#   *:10  Clock::SubscriptionsBillerJob           (bill customers)
+describe "Subscription termination vs billing order" do
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: "") }
+  let(:timezone) { "UTC" }
+  let(:customer) { create(:customer, organization:, timezone:) }
+
+  # Monthly, billed in arrears. Subscription fee = 100.00.
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      interval: "monthly",
+      amount_cents: 10_000,
+      pay_in_advance: false
+    )
+  end
+
+  # Metered usage: sum of the `amount` property. Standard charge at 1.00 / unit,
+  # billed in arrears, so N units => N units of charge fees => N * 100 cents.
+  let(:billable_metric) do
+    create(
+      :billable_metric,
+      organization:,
+      name: "Usage",
+      code: "usage",
+      aggregation_type: "sum_agg",
+      field_name: "amount",
+      recurring: false
+    )
+  end
+
+  before do
+    create(
+      :standard_charge,
+      billable_metric:,
+      plan:,
+      invoiceable: true,
+      pay_in_advance: false,
+      properties: {amount: "1"}
+    )
+  end
+
+  # --- helpers -------------------------------------------------------------
+
+  def create_test_subscription(started_at:, ending_at:, billing_time:)
+    travel_to(started_at) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+          subscription_at: started_at.iso8601,
+          ending_at: ending_at.iso8601
+        }
+      )
+    end
+    customer.subscriptions.first
+  end
+
+  def ingest_usage(amount)
+    create_event(
+      {
+        code: billable_metric.code,
+        transaction_id: SecureRandom.uuid,
+        external_subscription_id: customer.external_id,
+        properties: {amount: amount.to_s}
+      }
+    )
+  end
+
+  # Real Clock order: terminate (*:05) before bill (*:10).
+  def run_clock_terminate_then_bill
+    Clock::TerminateEndedSubscriptionsJob.perform_now
+    perform_all_enqueued_jobs
+    Clock::SubscriptionsBillerJob.perform_now
+    perform_all_enqueued_jobs
+  end
+
+  # Reverse order: the biller runs while the termination enqueued at *:05 has not
+  # been processed yet (queue lag). This is the double-billing window.
+  def run_clock_bill_then_terminate
+    Clock::SubscriptionsBillerJob.perform_now
+    perform_all_enqueued_jobs
+    Clock::TerminateEndedSubscriptionsJob.perform_now
+    perform_all_enqueued_jobs
+  end
+
+  def charge_units_total(subscription)
+    subscription.reload.invoices.sum { |inv| inv.fees.where(fee_type: :charge).sum(:units) }.to_i
+  end
+
+  def subscription_fees_cents(subscription)
+    subscription.reload.invoices.sum { |inv| inv.fees.where(fee_type: :subscription).sum(:amount_cents) }
+  end
+
+  # Count of invoice_subscriptions covering the exact same [from, to] period,
+  # used to prove a period is billed at most once.
+  def invoice_subscriptions_for(subscription, from:, to:)
+    subscription.invoice_subscriptions.where(
+      from_datetime: from.beginning_of_day.utc..to.end_of_day.utc
+    )
+  end
+
+  # --- 1. Mid-day ending on the billing day (usage accounting) -------------
+  #
+  # start 22 Jun 15:33, end 22 Jul 15:33 (anniversary). 22 Jul is both the
+  # billing day and the ending day. Under Path A the biller invoices the
+  # completed period 1 at 00:xx (sub still active), and termination later bills
+  # the partial period 2. No usage is dropped.
+  context "when an anniversary subscription ends mid-day on its billing day" do
+    let(:started_at) { Time.zone.parse("2025-06-22T15:33:00") }
+    let(:ending_at) { Time.zone.parse("2025-07-22T15:33:00") }
+
+    it "bills the completed period periodically and the partial period on termination" do
+      subscription = create_test_subscription(started_at:, ending_at:, billing_time: "anniversary")
+
+      # (A) period 1
+      travel_to(Time.zone.parse("2025-07-05T12:00:00")) { ingest_usage(10) }
+
+      # Anniversary day tick: sub still active (ends 15:33), biller bills period 1.
+      travel_to(Time.zone.parse("2025-07-22T00:05:00")) do
+        run_clock_terminate_then_bill
+        expect(subscription.reload).to be_active
+        expect(subscription.invoices.count).to eq(1)
+      end
+
+      # (B) period 2, before ending
+      travel_to(Time.zone.parse("2025-07-22T10:00:00")) { ingest_usage(20) }
+      # (C) 1 min after ending_at — still active (not yet terminated).
+      travel_to(Time.zone.parse("2025-07-22T16:34:00")) { ingest_usage(40) }
+
+      # Tick after ending: termination fires (terminated_at = 17:05), bills the
+      # partial period 2.
+      travel_to(Time.zone.parse("2025-07-22T17:05:00")) do
+        run_clock_terminate_then_bill
+      end
+
+      subscription.reload
+      expect(subscription).to be_terminated
+      expect(subscription.invoices.count).to eq(2)
+
+      # No usage lost, none double-counted: A + B + C = 10 + 20 + 40 = 70.
+      # (C is included because terminated_at is the job run time, 17:05, > 16:34.)
+      expect(charge_units_total(subscription)).to eq(70)
+
+      # Period 1 full month + period 2 prorate.
+      expect(subscription_fees_cents(subscription)).to be > 10_000
+    end
+  end
+
+  # --- 2. Ending exactly at the period boundary (known-good contrast) -------
+  context "when an anniversary subscription ends exactly at the period boundary" do
+    let(:started_at) { Time.zone.parse("2025-06-22T00:00:00") }
+    let(:ending_at) { Time.zone.parse("2025-07-22T00:00:00") }
+
+    it "bills the full period once, with all its usage" do
+      subscription = create_test_subscription(started_at:, ending_at:, billing_time: "anniversary")
+
+      travel_to(Time.zone.parse("2025-07-05T12:00:00")) { ingest_usage(10) }
+      travel_to(Time.zone.parse("2025-07-21T12:00:00")) { ingest_usage(20) }
+
+      # Termination fires at 00:05 (before the biller in the same tick) and bills
+      # the completed period; the biller then skips the now-terminated sub.
+      travel_to(Time.zone.parse("2025-07-22T00:05:00")) do
+        run_clock_terminate_then_bill
+      end
+
+      subscription.reload
+      expect(subscription).to be_terminated
+      expect(charge_units_total(subscription)).to eq(30)          # 10 + 20, all period 1
+      expect(subscription_fees_cents(subscription)).to eq(10_000) # full month, once
+
+      # The completed period is billed exactly once.
+      expect(
+        invoice_subscriptions_for(subscription, from: started_at, to: ending_at - 1.day).count
+      ).to eq(1)
+    end
+  end
+
+  # --- 3. Near-midnight calendar ending, realistic clock order --------------
+  #
+  # Calendar monthly bills on the 1st. Sub ends 31 Jul 23:59, so termination
+  # slips to the next tick (1 Aug 00:05), which is the billing day. Terminate
+  # runs first and bills July; the biller then skips the terminated sub.
+  context "when a calendar subscription ends just before midnight of the billing day" do
+    let(:started_at) { Time.zone.parse("2025-07-01T00:00:00") }
+    let(:ending_at) { Time.zone.parse("2025-07-31T23:59:00") }
+
+    it "bills July exactly once (terminate before bill)" do
+      subscription = create_test_subscription(started_at:, ending_at:, billing_time: "calendar")
+
+      travel_to(Time.zone.parse("2025-07-10T12:00:00")) { ingest_usage(15) }
+
+      travel_to(Time.zone.parse("2025-08-01T00:05:00")) do
+        run_clock_terminate_then_bill
+      end
+
+      subscription.reload
+      expect(subscription).to be_terminated
+      expect(charge_units_total(subscription)).to eq(15)          # billed once, not doubled
+      expect(
+        invoice_subscriptions_for(subscription, from: started_at, to: Time.zone.parse("2025-07-31")).count
+      ).to eq(1)                                                  # July billed exactly once
+    end
+
+    # Reverse order: the biller bills July while the sub is still active (the
+    # termination job hasn't processed yet). Termination must NOT re-bill July.
+    it "does not double-bill July when billing runs before termination" do
+      subscription = create_test_subscription(started_at:, ending_at:, billing_time: "calendar")
+
+      travel_to(Time.zone.parse("2025-07-10T12:00:00")) { ingest_usage(15) }
+
+      travel_to(Time.zone.parse("2025-08-01T00:10:00")) do
+        run_clock_bill_then_terminate
+      end
+
+      subscription.reload
+      expect(subscription).to be_terminated
+      expect(charge_units_total(subscription)).to eq(15)          # NOT 30
+      expect(subscription_fees_cents(subscription)).to be < 20_000 # July billed once, not twice
+      expect(
+        invoice_subscriptions_for(subscription, from: started_at, to: Time.zone.parse("2025-07-31")).count
+      ).to eq(1)                                                  # July billed exactly once
+    end
+  end
+end

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -276,7 +276,7 @@ describe "Subscriptions Termination Scenario" do
           expect(subscription).to be_active
         end
 
-        travel_to(ending_at - 5.hours) do
+        travel_to(ending_at + 15.minutes) do
           Clock::TerminateEndedSubscriptionsJob.perform_now
 
           perform_all_enqueued_jobs
@@ -313,7 +313,7 @@ describe "Subscriptions Termination Scenario" do
           expect(subscription).to be_active
         end
 
-        travel_to(ending_at - 5.hours) do
+        travel_to(ending_at + 15.minutes) do
           Clock::TerminateEndedSubscriptionsJob.perform_now
 
           perform_all_enqueued_jobs

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -417,7 +417,10 @@ describe "Subscriptions Termination Scenario" do
       end
 
       context "with already triggered subscription job" do
-        it "bills correctly the previous period since billing job is not performed on ending day" do
+        # Path A: the periodic biller is no longer skipped on the ending day, so it bills
+        # the completed period; the termination flow then only adds the final partial
+        # period, and never re-bills the completed one.
+        it "bills the completed period via the periodic biller on the ending day" do
           subscription = nil
 
           travel_to(creation_time) do
@@ -443,7 +446,11 @@ describe "Subscriptions Termination Scenario" do
             perform_billing
 
             expect(subscription.reload).to be_active
-            expect(subscription.reload.invoices.count).to eq(0)
+            expect(subscription.reload.invoices.count).to eq(1)
+
+            invoice = subscription.invoices.first
+            expect(invoice.total_amount_cents).to eq(1000)
+            expect(invoice.issuing_date.iso8601).to eq("2023-10-01")
           end
 
           travel_to(ending_at + 15.minutes) do
@@ -451,12 +458,10 @@ describe "Subscriptions Termination Scenario" do
 
             perform_all_enqueued_jobs
 
-            invoice = subscription.invoices.order(created_at: :desc).first
-
             expect(subscription.reload).to be_terminated
-            expect(subscription.reload.invoices.count).to eq(1)
-            expect(invoice.total_amount_cents).to eq(1000)
-            expect(invoice.issuing_date.iso8601).to eq("2023-10-01")
+            # The completed period is billed exactly once by the periodic biller; the
+            # termination flow does not re-bill it.
+            expect(subscription.invoices.where(total_amount_cents: 1000).count).to eq(1)
           end
         end
       end

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -312,8 +312,13 @@ RSpec.describe Subscriptions::OrganizationBillingService do
           let(:billing_at) { billed_on.first }
           let(:ending_at) { billing_at }
 
-          it "does not bill" do
-            expect { billing_service.call }.not_to have_enqueued_job
+          # NOTE: The biller is no longer skipped on the ending day — it bills the completed
+          #       period like any other. The termination flow only bills the final partial
+          #       period, and the period-based dedup prevents double billing.
+          it "bills the completed period" do
+            billing_service.call
+
+            expect_to_bill_together([subscription], billing_at)
           end
         end
 


### PR DESCRIPTION
## Context

Before we were comparing date of ending_at to date of today, resulting in subscirptions terminating sometimes long before their actual termination date

Now we'll be terminating each hour subscriptions that ended during this hour

## Description
Changed TerminateEndedSubscriptionsJob to check which subscriptions need to be terminated by checking which of them are in the past


## Edge cases:
1) Billing is at 00:10
  termination is at 23:59
  after billing, before subscription there is usage
  make sure no usage is lost

2) billing is at 00:10
  termination is at 00:10
  make sure there are no double-billing
  
3) Termination is at 00:01
  Billing is at 00:10
  no double invoices