### PR TITLE
fix(search): rename MeiliSearch module to Meilisearch

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,7 +7,7 @@ class Invoice < ApplicationRecord
   include PaperTrailTraceable
   include Sequenced
   include RansackUuidSearch
-  include MeiliSearch::Rails
+  include Meilisearch::Rails
 
   meilisearch(index_uid: "invoices", auto_index: false, auto_remove: true) do
     attribute :number, :organization_id, :billing_entity_id, :currency, :customer_id,

--- a/config/initializers/meilisearch.rb
+++ b/config/initializers/meilisearch.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-MeiliSearch::Rails.configuration = {
+Meilisearch::Rails.configuration = {
   meilisearch_url: ENV["LAGO_MEILISEARCH_URL"] || "http://localhost:7700",
   meilisearch_api_key: ENV["LAGO_MEILISEARCH_API_KEY"],
   active: ENV["LAGO_MEILISEARCH_URL"].present?,


### PR DESCRIPTION
## Context

The `meilisearch-ruby` gem renamed its top-level module from `MeiliSearch` to `Meilisearch`. The old constant still works as a deprecated alias, so every time the API boots it logs a warning:

```
[meilisearch-ruby] The top-level module of Meilisearch has been renamed.
[meilisearch-ruby] Please update "MeiliSearch" to "Meilisearch".
```

## Description

Update the two references to the module to use the new `Meilisearch` name:

- `app/models/invoice.rb` — the `include Meilisearch::Rails`
- `config/initializers/meilisearch.rb` — the `Meilisearch::Rails.configuration` call

This removes the deprecation warning on every restart and future-proofs the code against the eventual removal of the old alias. Behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)