### PR TITLE
feat(observability): e2e latency metrics for wallet refresh and alerts

### DIFF
--- a/app/jobs/subscriptions/flag_refreshed_job.rb
+++ b/app/jobs/subscriptions/flag_refreshed_job.rb
@@ -10,8 +10,10 @@ module Subscriptions
       end
     end
 
-    def perform(subscription_id)
-      Subscriptions::FlagRefreshedService.call!(subscription_id)
+    # event_ingested_at is an epoch timestamp (the zset score set by the
+    # events-processor). Optional so jobs enqueued before this change deserialize fine.
+    def perform(subscription_id, event_ingested_at = nil)
+      Subscriptions::FlagRefreshedService.call!(subscription_id, event_ingested_at:)
     end
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -368,10 +368,18 @@ class Customer < ApplicationRecord
     )
   end
 
-  def flag_wallets_for_refresh
+  def flag_wallets_for_refresh(requested_at: nil)
     return unless wallets.active.exists?
 
-    update!(awaiting_wallet_refresh: true)
+    attributes = {awaiting_wallet_refresh: true}
+
+    # Keep the oldest pending request so the refresh latency metric measures
+    # the worst case, not the most recent trigger.
+    unless awaiting_wallet_refresh? && wallet_refresh_requested_at.present?
+      attributes[:wallet_refresh_requested_at] = requested_at || Time.current
+    end
+
+    update!(attributes)
   end
 
   def tax_customer
@@ -458,6 +466,7 @@ end
 #  timezone                                     :string
 #  url                                          :string
 #  vat_rate                                     :float
+#  wallet_refresh_requested_at                  :datetime
 #  zipcode                                      :string
 #  created_at                                   :datetime         not null
 #  updated_at                                   :datetime         not null

--- a/app/models/usage_monitoring/subscription_activity.rb
+++ b/app/models/usage_monitoring/subscription_activity.rb
@@ -12,12 +12,13 @@ end
 # Table name: usage_monitoring_subscription_activities
 # Database name: primary
 #
-#  id              :bigint           not null, primary key
-#  enqueued        :boolean          default(FALSE), not null
-#  enqueued_at     :datetime
-#  inserted_at     :datetime         not null
-#  organization_id :uuid             not null
-#  subscription_id :uuid             not null
+#  id                       :bigint           not null, primary key
+#  enqueued                 :boolean          default(FALSE), not null
+#  enqueued_at              :datetime
+#  inserted_at              :datetime         not null
+#  oldest_event_ingested_at :datetime
+#  organization_id          :uuid             not null
+#  subscription_id          :uuid             not null
 #
 # Indexes
 #

--- a/app/services/customers/refresh_wallets_service.rb
+++ b/app/services/customers/refresh_wallets_service.rb
@@ -33,7 +33,13 @@ module Customers
 
       Wallet.where(id: all_wallets.map(&:id)).touch_all(:last_ongoing_balance_sync_at) # rubocop:disable Rails/SkipsModelValidations
 
-      customer.update!(awaiting_wallet_refresh: false)
+      if customer.wallet_refresh_requested_at.present?
+        Yabeda.lago_pipeline.wallet_refresh_e2e_seconds.measure(
+          {}, Time.current - customer.wallet_refresh_requested_at
+        )
+      end
+
+      customer.update!(awaiting_wallet_refresh: false, wallet_refresh_requested_at: nil)
 
       result.wallets = customer.wallets.active.reload
       result

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -14,7 +14,7 @@ module Events
       expire_cached_charges
       create_enriched_events
       track_subscription_activity
-      customer&.flag_wallets_for_refresh
+      customer&.flag_wallets_for_refresh(requested_at: event.created_at)
       # TODO: update also event-processor to process targeted wallets
       check_targeted_wallets
 
@@ -90,7 +90,9 @@ module Events
       #       But there should be only one active subscription here, so it's better to not re-requery to eager load
       subscriptions.select(&:active?).each do |subscription|
         date = Time.current.in_time_zone(customer.applicable_timezone).to_date
-        UsageMonitoring::TrackSubscriptionActivityService.call(organization:, subscription:, date:)
+        UsageMonitoring::TrackSubscriptionActivityService.call(
+          organization:, subscription:, date:, event_ingested_at: event.created_at
+        )
       end
     end
 

--- a/app/services/subscriptions/consume_subscription_refreshed_queue_service.rb
+++ b/app/services/subscriptions/consume_subscription_refreshed_queue_service.rb
@@ -24,17 +24,20 @@ module Subscriptions
         end
 
         threshold = (Time.current - SUBSCRIPTION_BUCKET_DURATION).to_i
-        values = redis_client.zrangebyscore(REDIS_STORE_NAME, "-inf", threshold, limit: [0, BATCH_SIZE])
+        values = redis_client.zrangebyscore(REDIS_STORE_NAME, "-inf", threshold, limit: [0, BATCH_SIZE], with_scores: true)
         break if values.blank?
 
-        values.each do |value|
+        values.each do |member, score|
           # Extract the subscription_id from the bucketed member key (org_id:sub_id|bucket)
-          subscription_id = value.split("|").first.split(":").last
+          subscription_id = member.split("|").first.split(":").last
 
-          Subscriptions::FlagRefreshedJob.perform_later(subscription_id)
+          # The score is the event timestamp set by the events-processor. Carrying it
+          # through the flag hop is what makes the end-to-end latency metrics
+          # (event ingested -> wallet refreshed / alert processed) measurable.
+          Subscriptions::FlagRefreshedJob.perform_later(subscription_id, score.to_f)
         end
 
-        redis_client.zrem(REDIS_STORE_NAME, values)
+        redis_client.zrem(REDIS_STORE_NAME, values.map(&:first))
       end
 
       result

--- a/app/services/subscriptions/flag_refreshed_service.rb
+++ b/app/services/subscriptions/flag_refreshed_service.rb
@@ -4,16 +4,17 @@ module Subscriptions
   class FlagRefreshedService < BaseService
     Result = BaseResult[:subscription_id]
 
-    def initialize(subscription_id)
+    def initialize(subscription_id, event_ingested_at: nil)
       @subscription_id = subscription_id
-      super
+      @event_ingested_at = event_ingested_at.present? ? Time.zone.at(event_ingested_at) : nil
+      super(subscription_id)
     end
 
     def call
       customer = subscription.customer
-      customer.flag_wallets_for_refresh
+      customer.flag_wallets_for_refresh(requested_at: event_ingested_at)
       date = Time.current.in_time_zone(customer.applicable_timezone).to_date
-      UsageMonitoring::TrackSubscriptionActivityService.call(subscription:, date:)
+      UsageMonitoring::TrackSubscriptionActivityService.call(subscription:, date:, event_ingested_at:)
 
       result.subscription_id = subscription_id
       result
@@ -21,7 +22,7 @@ module Subscriptions
 
     private
 
-    attr_reader :subscription_id
+    attr_reader :subscription_id, :event_ingested_at
 
     def subscription
       @subscription ||= Subscription.find(subscription_id)

--- a/app/services/usage_monitoring/process_subscription_activity_service.rb
+++ b/app/services/usage_monitoring/process_subscription_activity_service.rb
@@ -47,6 +47,12 @@ module UsageMonitoring
         exception_to_raise ||= e
       end
 
+      # Measured before the delete because the row is the only artifact linking the
+      # triggering event to its processing. Falls back to inserted_at (flag time)
+      # when the event ingestion timestamp was not propagated.
+      started_at = subscription_activity.oldest_event_ingested_at || subscription_activity.inserted_at
+      Yabeda.lago_pipeline.usage_alert_e2e_seconds.measure({}, Time.current - started_at)
+
       subscription_activity.delete
 
       if exception_to_raise

--- a/app/services/usage_monitoring/track_subscription_activity_service.rb
+++ b/app/services/usage_monitoring/track_subscription_activity_service.rb
@@ -6,10 +6,11 @@ module UsageMonitoring
 
     # NOTE: The organization can be passed to avoid loading it from the subscription
     #       If not passed, it's lazy loaded from the subscription
-    def initialize(subscription:, date:, organization: nil)
+    def initialize(subscription:, date:, organization: nil, event_ingested_at: nil)
       @subscription = subscription
       @organization = organization
       @date = date
+      @event_ingested_at = event_ingested_at
       super
     end
 
@@ -22,8 +23,14 @@ module UsageMonitoring
 
       return result unless need_lifetime_usage? || has_alerts?
 
+      # NOTE: On conflict the existing row is kept untouched, so
+      #       oldest_event_ingested_at always reflects the first unprocessed event.
       UsageMonitoring::SubscriptionActivity.insert_all( # rubocop:disable Rails/SkipsModelValidations
-        [{organization_id: organization.id, subscription_id: subscription.id}],
+        [{
+          organization_id: organization.id,
+          subscription_id: subscription.id,
+          oldest_event_ingested_at: event_ingested_at
+        }],
         unique_by: :idx_subscription_unique
       )
 
@@ -32,7 +39,7 @@ module UsageMonitoring
 
     private
 
-    attr_reader :subscription, :date
+    attr_reader :subscription, :date, :event_ingested_at
 
     def organization
       @organization ||= subscription.organization

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -14,4 +14,16 @@ Yabeda.configure do
   default_tag :service, ENV["OTEL_SERVICE_NAME"] || "lago-api"
   default_tag :environment, Rails.env
   default_tag :version, ENV["LAGO_VERSION"] || "unknown"
+
+  group :lago_pipeline do
+    histogram :wallet_refresh_e2e_seconds,
+      comment: "Duration between event ingestion and wallet ongoing balance refresh completion",
+      unit: :seconds,
+      buckets: [5, 15, 30, 60, 120, 300, 600, 1800, 3600]
+
+    histogram :usage_alert_e2e_seconds,
+      comment: "Duration between event ingestion and subscription activity processing completion (alerts evaluated)",
+      unit: :seconds,
+      buckets: [5, 15, 30, 60, 120, 300, 600, 1800, 3600]
+  end
 end

--- a/db/migrate/20260722090000_add_wallet_refresh_requested_at_to_customers.rb
+++ b/db/migrate/20260722090000_add_wallet_refresh_requested_at_to_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWalletRefreshRequestedAtToCustomers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :customers, :wallet_refresh_requested_at, :datetime
+  end
+end

--- a/db/migrate/20260722090100_add_oldest_event_ingested_at_to_subscription_activities.rb
+++ b/db/migrate/20260722090100_add_oldest_event_ingested_at_to_subscription_activities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOldestEventIngestedAtToSubscriptionActivities < ActiveRecord::Migration[8.0]
+  def change
+    add_column :usage_monitoring_subscription_activities, :oldest_event_ingested_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2461,6 +2461,7 @@ CREATE TABLE public.customers (
     subscription_invoice_issuing_date_adjustment public.subscription_invoice_issuing_date_adjustments,
     awaiting_wallet_refresh boolean DEFAULT false NOT NULL,
     dunning_currency_attempts jsonb DEFAULT '{}'::jsonb NOT NULL,
+    wallet_refresh_requested_at timestamp(6) without time zone,
     CONSTRAINT check_customers_on_invoice_grace_period CHECK ((invoice_grace_period >= 0)),
     CONSTRAINT check_customers_on_net_payment_term CHECK ((net_payment_term >= 0))
 );
@@ -5274,7 +5275,8 @@ CREATE TABLE public.usage_monitoring_subscription_activities (
     subscription_id uuid NOT NULL,
     enqueued boolean DEFAULT false NOT NULL,
     inserted_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    enqueued_at timestamp(6) without time zone
+    enqueued_at timestamp(6) without time zone,
+    oldest_event_ingested_at timestamp(6) without time zone
 );
 
 
@@ -12959,6 +12961,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260722090100'),
+('20260722090000'),
 ('20260721180721'),
 ('20260721163101'),
 ('20260717163416'),

--- a/spec/jobs/subscriptions/flag_refreshed_job_spec.rb
+++ b/spec/jobs/subscriptions/flag_refreshed_job_spec.rb
@@ -10,13 +10,26 @@ RSpec.describe Subscriptions::FlagRefreshedJob do
   end
 
   describe "#perform" do
-    it "calls the subscriptions flag refreshed job" do
+    it "calls the subscriptions flag refreshed service" do
       allow(Subscriptions::FlagRefreshedService).to receive(:call!)
 
       described_class.perform_now(subscription_id)
 
       expect(Subscriptions::FlagRefreshedService).to have_received(:call!)
-        .with(subscription_id)
+        .with(subscription_id, event_ingested_at: nil)
+    end
+
+    context "with an event ingestion timestamp" do
+      let(:event_ingested_at) { 30.seconds.ago.to_f }
+
+      it "passes the timestamp to the service" do
+        allow(Subscriptions::FlagRefreshedService).to receive(:call!)
+
+        described_class.perform_now(subscription_id, event_ingested_at)
+
+        expect(Subscriptions::FlagRefreshedService).to have_received(:call!)
+          .with(subscription_id, event_ingested_at:)
+      end
     end
   end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1359,6 +1359,29 @@ RSpec.describe Customer do
         it "marks customer as awaiting wallet refresh" do
           expect { subject }.to change(customer, :awaiting_wallet_refresh).from(false).to(true)
         end
+
+        it "records the refresh request time" do
+          expect { subject }.to change(customer, :wallet_refresh_requested_at).from(nil)
+        end
+      end
+
+      context "with a requested_at timestamp" do
+        subject { customer.flag_wallets_for_refresh(requested_at:) }
+
+        let(:awaiting_wallet_refresh) { false }
+        let(:requested_at) { 2.minutes.ago }
+
+        it "records the provided request time" do
+          expect { subject }.to change(customer, :wallet_refresh_requested_at).from(nil).to(be_within(0.001).of(requested_at))
+        end
+
+        context "when a refresh is already pending with a timestamp" do
+          let(:customer) { create(:customer, awaiting_wallet_refresh: true, wallet_refresh_requested_at: 10.minutes.ago) }
+
+          it "keeps the oldest pending request time" do
+            expect { subject }.not_to change { customer.reload.wallet_refresh_requested_at }
+          end
+        end
       end
     end
 

--- a/spec/services/customers/refresh_wallets_service_spec.rb
+++ b/spec/services/customers/refresh_wallets_service_spec.rb
@@ -99,6 +99,26 @@ RSpec.describe Customers::RefreshWalletsService do
       expect { subject }.to change(customer, :awaiting_wallet_refresh).from(true).to(false)
     end
 
+    it "records the wallet refresh e2e latency and clears the request timestamp" do
+      customer.update!(wallet_refresh_requested_at: 2.minutes.ago)
+      allow(Yabeda.lago_pipeline.wallet_refresh_e2e_seconds).to receive(:measure)
+
+      expect { subject }.to change(customer, :wallet_refresh_requested_at).to(nil)
+
+      expect(Yabeda.lago_pipeline.wallet_refresh_e2e_seconds).to have_received(:measure)
+        .with({}, be_within(10).of(120))
+    end
+
+    context "when no refresh request timestamp is set" do
+      it "does not record the latency metric" do
+        allow(Yabeda.lago_pipeline.wallet_refresh_e2e_seconds).to receive(:measure)
+
+        subject
+
+        expect(Yabeda.lago_pipeline.wallet_refresh_e2e_seconds).not_to have_received(:measure)
+      end
+    end
+
     context "when charges have presentation_group_keys" do
       before do
         allow(Invoices::CustomerUsageService).to receive(:call!).and_call_original

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe Events::PostProcessService do
       expect { process_service.call }.to change { customer.reload.awaiting_wallet_refresh }.from(false).to(true)
     end
 
+    it "records the event ingestion time as the wallet refresh request time" do
+      expect { process_service.call }.to change { customer.reload.wallet_refresh_requested_at }
+        .from(nil).to(event.created_at)
+    end
+
     it "tracks subscription activity" do
       allow(UsageMonitoring::TrackSubscriptionActivityService).to receive(:call)
 
@@ -46,7 +51,7 @@ RSpec.describe Events::PostProcessService do
 
       expected_date = Time.current.in_time_zone(customer.applicable_timezone).to_date
       expect(UsageMonitoring::TrackSubscriptionActivityService).to have_received(:call)
-        .with(subscription:, organization:, date: expected_date)
+        .with(subscription:, organization:, date: expected_date, event_ingested_at: event.created_at)
     end
 
     describe "charge usage cache expiration" do

--- a/spec/services/subscriptions/consume_subscription_refreshed_queue_service_spec.rb
+++ b/spec/services/subscriptions/consume_subscription_refreshed_queue_service_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe Subscriptions::ConsumeSubscriptionRefreshedQueueService do
       (Time.current.to_i - 20) / described_class::SUBSCRIPTION_BUCKET_DURATION
     ) * described_class::SUBSCRIPTION_BUCKET_DURATION
   end
+  let(:event_ingested_at) { (Time.current - 20).to_f }
   let(:values) do
     [
-      "#{SecureRandom.uuid}:#{subscription_id1}|#{bucket}",
-      "#{SecureRandom.uuid}:#{subscription_id2}|#{bucket}"
+      ["#{SecureRandom.uuid}:#{subscription_id1}|#{bucket}", event_ingested_at],
+      ["#{SecureRandom.uuid}:#{subscription_id2}|#{bucket}", event_ingested_at]
     ]
   end
   let(:loop_values) { [values, []] }
@@ -38,8 +39,8 @@ RSpec.describe Subscriptions::ConsumeSubscriptionRefreshedQueueService do
       result = service.call
 
       expect(result).to be_success
-      expect(Subscriptions::FlagRefreshedJob).to have_been_enqueued.with(subscription_id1)
-      expect(Subscriptions::FlagRefreshedJob).to have_been_enqueued.with(subscription_id2)
+      expect(Subscriptions::FlagRefreshedJob).to have_been_enqueued.with(subscription_id1, event_ingested_at)
+      expect(Subscriptions::FlagRefreshedJob).to have_been_enqueued.with(subscription_id2, event_ingested_at)
     end
 
     it "queries with the correct threshold" do
@@ -49,7 +50,7 @@ RSpec.describe Subscriptions::ConsumeSubscriptionRefreshedQueueService do
         service.call
 
         expect(redis_client).to have_received(:zrangebyscore)
-          .with(described_class::REDIS_STORE_NAME, "-inf", threshold, limit: [0, described_class::BATCH_SIZE])
+          .with(described_class::REDIS_STORE_NAME, "-inf", threshold, limit: [0, described_class::BATCH_SIZE], with_scores: true)
           .at_least(:once)
       end
     end
@@ -57,7 +58,7 @@ RSpec.describe Subscriptions::ConsumeSubscriptionRefreshedQueueService do
     it "removes processed values with zrem" do
       service.call
 
-      expect(redis_client).to have_received(:zrem).with(described_class::REDIS_STORE_NAME, values)
+      expect(redis_client).to have_received(:zrem).with(described_class::REDIS_STORE_NAME, values.map(&:first))
     end
 
     context "with multiple batches" do

--- a/spec/services/subscriptions/flag_refreshed_service_spec.rb
+++ b/spec/services/subscriptions/flag_refreshed_service_spec.rb
@@ -25,7 +25,24 @@ RSpec.describe Subscriptions::FlagRefreshedService, :premium do
       expect(result).to be_success
       expect(subscription.subscription_activity).to be_present
       expected_date = Time.current.in_time_zone(customer.applicable_timezone).to_date
-      expect(UsageMonitoring::TrackSubscriptionActivityService).to have_received(:call).with(subscription:, date: expected_date)
+      expect(UsageMonitoring::TrackSubscriptionActivityService).to have_received(:call)
+        .with(subscription:, date: expected_date, event_ingested_at: nil)
+    end
+
+    context "when an event ingestion timestamp is provided" do
+      subject(:result) { described_class.call(subscription.id, event_ingested_at:) }
+
+      let(:event_ingested_at) { 5.minutes.ago.to_f }
+
+      it "propagates the timestamp to the wallet refresh flag and the subscription activity" do
+        expect { subject }.to change { customer.reload.wallet_refresh_requested_at&.to_f }
+          .from(nil).to(be_within(0.001).of(event_ingested_at))
+
+        expect(result).to be_success
+        expected_date = Time.current.in_time_zone(customer.applicable_timezone).to_date
+        expect(UsageMonitoring::TrackSubscriptionActivityService).to have_received(:call)
+          .with(subscription:, date: expected_date, event_ingested_at: Time.zone.at(event_ingested_at))
+      end
     end
   end
 end

--- a/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
@@ -38,6 +38,33 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, :premium do
     end
   end
 
+  context "when measuring end-to-end latency" do
+    let(:premium_integrations) { %w[lifetime_usage] }
+
+    it "records the usage alert e2e latency before deleting the activity" do
+      allow(Yabeda.lago_pipeline.usage_alert_e2e_seconds).to receive(:measure)
+
+      service.call
+
+      expect(Yabeda.lago_pipeline.usage_alert_e2e_seconds).to have_received(:measure).with({}, kind_of(Numeric))
+    end
+
+    context "with an event ingestion timestamp on the activity" do
+      let(:subscription_activity) do
+        create(:subscription_activity, subscription:, organization:, oldest_event_ingested_at: 90.seconds.ago)
+      end
+
+      it "measures from the event ingestion time" do
+        allow(Yabeda.lago_pipeline.usage_alert_e2e_seconds).to receive(:measure)
+
+        service.call
+
+        expect(Yabeda.lago_pipeline.usage_alert_e2e_seconds).to have_received(:measure)
+          .with({}, be_within(5).of(90))
+      end
+    end
+  end
+
   context "when lifetime_usage and progressive_billing are both disabled" do
     let(:premium_integrations) { ["salesforce"] }
 

--- a/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
@@ -23,6 +23,25 @@ RSpec.describe UsageMonitoring::TrackSubscriptionActivityService, :premium do
     end
   end
 
+  context "when an event ingestion timestamp is provided" do
+    subject { described_class.new(organization:, subscription:, date:, event_ingested_at:) }
+
+    let(:event_ingested_at) { 3.minutes.ago }
+
+    before { create(:usage_threshold, plan: subscription.plan) }
+
+    it "stores the timestamp on the subscription activity" do
+      subject.call
+      expect(subscription.subscription_activity.oldest_event_ingested_at).to be_within(0.001).of(event_ingested_at)
+    end
+
+    it "keeps the oldest timestamp when an activity already exists" do
+      create(:subscription_activity, subscription:, organization:, oldest_event_ingested_at: 10.minutes.ago)
+
+      expect { subject.call }.not_to change { subscription.subscription_activity.reload.oldest_event_ingested_at }
+    end
+  end
+
   context "when last_received_event_on is already set to the same date" do
     before { subscription.update(last_received_event_on: date) }
 


### PR DESCRIPTION
Emits two histograms: event ingested -> wallet refreshed, and event ingested -> alert processed