### PR TITLE
feat(stripe): consent on invoice payment URL

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -148,7 +148,7 @@ module Invoices
       end
 
       def payment_url_payload(payment_intent)
-        {
+        payload = {
           line_items: [
             {
               quantity: 1,
@@ -178,6 +178,12 @@ module Invoices
             }
           }
         }
+
+        if stripe_payment_provider.require_terms_of_service_consent
+          payload[:consent_collection] = {terms_of_service: "required"}
+        end
+
+        payload
       end
 
       def description

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe Invoices::Payments::StripeService do
         }
       end
 
+      it "does not require terms of service consent by default" do
+        expect(payment_url_payload).not_to have_key(:consent_collection)
+      end
+
+      context "when consent collection is enabled on the provider" do
+        let(:stripe_payment_provider) do
+          create(:stripe_provider, organization:, code:, require_terms_of_service_consent: true)
+        end
+
+        it "requires terms of service consent" do
+          expect(payment_url_payload[:consent_collection]).to eq(terms_of_service: "required")
+        end
+      end
+
       context "when paid amount is not zero" do
         let(:total_paid_amount_cents) { 1 }
 


### PR DESCRIPTION
Part of INT-163


## Context

Consent collection applied to the customer checkout URL and payment requests but not to the single-invoice payment page.

## Description

When `require_terms_of_service_consent` is enabled on the connection, add `consent_collection[terms_of_service]=required` to the payment-mode Checkout Session behind the invoice payment URL, so payers must accept the terms of service before paying. No change when the setting is off.