### PR TITLE
test(stripe): keep consent off payment intents

### DIFF
--- a/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/authorize_service_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe PaymentProviders::Stripe::Payments::AuthorizeService do
 
         expect(PaymentProviders::CancelPaymentAuthorizationJob).to have_been_enqueued
       end
+
+      context "when consent collection is enabled on the provider" do
+        let(:provider_customer) do
+          create(:stripe_customer, payment_provider: create(:stripe_provider, require_terms_of_service_consent: true), customer:, payment_method_id:)
+        end
+
+        it "does not add consent collection to the payment intent" do
+          subject.call
+
+          expect(::Stripe::PaymentIntent).to have_received(:create).with(
+            hash_excluding(:consent_collection),
+            anything
+          )
+        end
+      end
     end
   end
 

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -108,6 +108,19 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
       expect(Stripe::PaymentIntent).to have_received(:create)
     end
 
+    context "when consent collection is enabled on the provider" do
+      let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:, require_terms_of_service_consent: true) }
+
+      it "does not add consent collection to the payment intent" do
+        create_service.call
+
+        expect(Stripe::PaymentIntent).to have_received(:create).with(
+          hash_excluding(:consent_collection),
+          anything
+        )
+      end
+    end
+
     context "when the invoice has already been paid" do
       before { invoice.update!(payment_status: :succeeded) }
 


### PR DESCRIPTION
Part of INT-163

## Context

Consent collection must never be sent on Stripe PaymentIntents, only on Checkout Sessions.

## Description

Add regression guards asserting that, even when the connection has consent collection enabled, the automated-charge and subscription pre-authorization `PaymentIntent` payloads never include `consent_collection`.