### PR TITLE
fix(salesforce): scope invoice resync to visible

### DIFF
--- a/app/graphql/mutations/integrations/salesforce/sync_invoice.rb
+++ b/app/graphql/mutations/integrations/salesforce/sync_invoice.rb
@@ -17,11 +17,10 @@ module Mutations
         field :invoice_id, ID, null: true
 
         def resolve(**args)
-          invoice = current_organization.invoices.find_by(id: args[:invoice_id])
+          invoice = current_organization.invoices.visible.find_by(id: args[:invoice_id])
 
           result = ::Integrations::Salesforce::Invoices::SyncService.call(invoice)
-          result.success? ? result.invoice_id : result_error(result)
-          result
+          result.success? ? result : result_error(result)
         end
       end
     end

--- a/spec/graphql/mutations/integrations/salesforce/sync_invoice_spec.rb
+++ b/spec/graphql/mutations/integrations/salesforce/sync_invoice_spec.rb
@@ -38,4 +38,16 @@ RSpec.describe Mutations::Integrations::Salesforce::SyncInvoice do
   it "sends resync invoice webhook" do
     expect(SendWebhookJob).to have_been_enqueued.with("invoice.resynced", invoice)
   end
+
+  context "when the invoice is not visible" do
+    let(:invoice) { create(:invoice, customer:, organization:, status: :closed) }
+
+    it "does not enqueue the resync webhook" do
+      expect(SendWebhookJob).not_to have_been_enqueued.with("invoice.resynced", invoice)
+    end
+
+    it "returns a not found error" do
+      expect_graphql_error(result: execute_graphql_call, message: "Resource not found")
+    end
+  end
 end


### PR DESCRIPTION
## Context

The `SyncSalesforceInvoice` mutation loads its target with `current_organization.invoices.find_by(id:)`, bypassing the `.visible` scope that every other single-invoice entry point applies — `InvoiceResolver`, `Api::V1::InvoicesController#show`, and the inbound `sync_salesforce_id` callback. It then hands the invoice to a service that unconditionally emits the `invoice.resynced` webhook, whose payload is the full `V1::InvoiceSerializer` snapshot.

So a caller with `organization:integrations:update` can pass the id of an `invisible` invoice (e.g. a payment-gated `closed` invoice) and have its complete serialized payload delivered over the webhook. Those invoices are never synced to Salesforce to begin with (sync requires `finalized?`), so a resync is both meaningless and a disclosure — the consumer has no matching record. And since a numbered/finalized invoice only ever moves to voided (still visible) and never back to an invisible status, restricting the lookup to `.visible` cannot suppress a legitimate resync.

The method also discarded its own error: the
`success? ? ... : result_error(result)` expression was evaluated and thrown away while a trailing `result` was returned, so a not-found invoice yielded `invoiceId: null` with no GraphQL error. The missing `.visible` scope had made that path effectively unreachable, hiding it.

## Description

Scope the lookup to `.visible` and return the success/error expression so a rejected invoice surfaces a proper "Resource not found" error. Add specs asserting an invisible invoice neither enqueues the resync webhook nor returns success.