### PR TITLE
feat(invoice): add web_url deep link to invoices

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -259,6 +259,14 @@ class Invoice < ApplicationRecord
     File.join(ENV["LAGO_API_URL"], blob_path)
   end
 
+  def web_url
+    return if invisible?
+
+    front_url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+
+    URI.join(front_url, "/#{organization.slug}/customer/#{customer_id}/", "invoice/#{id}/overview").to_s
+  end
+
   def fee_total_amount_cents
     amount_cents = fees.sum(:amount_cents)
     taxes_amount_cents = fees.sum { |f| f.amount_cents * f.taxes_rate }.fdiv(100).round

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -34,6 +34,7 @@ module V1
         prepaid_purchased_credit_amount_cents: model.prepaid_purchased_credit_amount_cents,
         file_url: model.file_url,
         xml_url: model.xml_url,
+        web_url: model.web_url,
         version_number: model.version_number,
         self_billed: model.self_billed,
         created_at: model.created_at.iso8601,

--- a/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
@@ -151,9 +151,7 @@ module Integrations
           end
 
           def invoice_url
-            url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
-
-            URI.join(url, "/#{invoice.customer.organization.slug}/customer/#{invoice.customer.id}/", "invoice/#{invoice.id}/overview").to_s
+            invoice.web_url
           end
         end
       end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1944,6 +1944,26 @@ RSpec.describe Invoice do
     end
   end
 
+  describe "#web_url" do
+    it "returns the lago frontend url of the invoice overview page" do
+      expect(invoice.web_url).to eq(
+        URI.join(
+          ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com",
+          "/#{invoice.organization.slug}/customer/#{invoice.customer_id}/",
+          "invoice/#{invoice.id}/overview"
+        ).to_s
+      )
+    end
+
+    context "when the invoice is not visible" do
+      let(:invoice) { create(:invoice, status: :closed) }
+
+      it "returns nil" do
+        expect(invoice.web_url).to be_nil
+      end
+    end
+  end
+
   describe "#creditable_amount_cents" do
     let(:invoice) { create(:invoice, version_number:, status:, payment_status:, fees_amount_cents:, taxes_amount_cents:, coupons_amount_cents:, progressive_billing_credit_amount_cents:) }
     let(:fees_amount_cents) { 1000 }

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       "total_due_amount_cents" => invoice.total_due_amount_cents,
       "file_url" => invoice.file_url,
       "xml_url" => invoice.xml_url,
+      "web_url" => invoice.web_url,
       "error_details" => [
         {
           "lago_id" => error_details1.id,


### PR DESCRIPTION
Close INT-179

## Context

The V1 invoice serializer already exposes `file_url` (PDF) and `xml_url` — links to file representations of an invoice — but nothing pointing at the invoice's page in the Lago dashboard. Consumers that receive the serialized invoice (the accounting-integration embeds, webhooks, custom dashboards) have to reconstruct that URL themselves, and in a multi-organization setup they can't: the payload carries `billing_entity_code`, which is only unique within an organization, not the organization `slug` the frontend URL needs.

## Description

Add a `web_url` attribute to the invoice, alongside `file_url` and `xml_url`:

- `Invoice#web_url` builds the frontend overview URL — `{LAGO_FRONT_URL}/{organization.slug}/customer/{customer_id}/invoice/{id}/overview`.
- It returns `nil` for `invisible` invoices (`generating`, `open`, `closed`, `deleted`), mirroring how `file_url` returns nil when the document is unavailable. The dashboard scopes every invoice view to `.visible`, so a link to an invisible invoice would 404 — a present `web_url` therefore always resolves.
- Exposed as `web_url` in `V1::InvoiceSerializer`, so it reaches the REST API, webhooks and the integration embeds uniformly.
- The NetSuite/HubSpot payload builders now delegate their `invoice_url` helper to `Invoice#web_url`, removing the duplicated construction. Behavior is unchanged for finalized invoices (the only ones synced).

## Notes for reviewers

- Naming: `web_url` pairs with `file_url`/`xml_url` (representation-by-kind).
- Self-hosted: the URL falls back to `https://app.getlago.com` when `LAGO_FRONT_URL` is unset (pre-existing behavior inherited from the integration helper); self-hosted deployments must set `LAGO_FRONT_URL`. A separate PR will centralize `LAGO_FRONT_URL` handling, currently it is all over the place.
- API surface: additive/backward-compatible field on a public serializer; OpenAPI docs to follow.
