### PR TITLE
fix(hubspot): scope invoice resync to visible

### DIFF
--- a/app/graphql/mutations/integrations/hubspot/sync_invoice.rb
+++ b/app/graphql/mutations/integrations/hubspot/sync_invoice.rb
@@ -17,11 +17,10 @@ module Mutations
         field :invoice_id, ID, null: true
 
         def resolve(**args)
-          invoice = current_organization.invoices.find_by(id: args[:invoice_id])
+          invoice = current_organization.invoices.visible.find_by(id: args[:invoice_id])
 
           result = ::Integrations::Aggregator::Invoices::Hubspot::CreateService.call_async(invoice:)
-          result.success? ? result.invoice_id : result_error(result)
-          result
+          result.success? ? result : result_error(result)
         end
       end
     end

--- a/spec/graphql/mutations/integrations/hubspot/sync_invoice_spec.rb
+++ b/spec/graphql/mutations/integrations/hubspot/sync_invoice_spec.rb
@@ -54,4 +54,12 @@ RSpec.describe Mutations::Integrations::Hubspot::SyncInvoice do
     expect(::Integrations::Aggregator::Invoices::Hubspot::CreateService).to have_received(:new).with(invoice:)
     expect(service).to have_received(:call_async)
   end
+
+  context "when the invoice is not visible" do
+    let(:invoice) { create(:invoice, customer:, organization:, status: :closed) }
+
+    it "does not sync the invisible invoice" do
+      expect(::Integrations::Aggregator::Invoices::Hubspot::CreateService).to have_received(:new).with(invoice: nil)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Like the Salesforce resync mutation, SyncHubspotInvoice loaded its target with current_organization.invoices.find_by(id:), bypassing the `.visible` scope applied everywhere else, and discarded its own error via a trailing `result`.

Unlike Salesforce this is not a disclosure: the HubSpot sync runs through Aggregator::Invoices::Hubspot::CreateService, which is gated on invoice.finalized? and emits no full-invoice webhook. The fix aligns the mutation with the rest of the app and stops an invisible invoice from being handed to the sync service.

## Description

Scope the lookup to `.visible` and return the success/error expression so a genuine failure surfaces. Add a spec asserting an invisible invoice is filtered to nil rather than passed to the sync service.