### PR TITLE
[ING-493] fix(cache): Take past recurring events into account in current usage

### DIFF
--- a/app/services/events/billing_period_filter_service.rb
+++ b/app/services/events/billing_period_filter_service.rb
@@ -59,9 +59,19 @@ module Events
     # filters for non-recurring charges and refresh last_seen_at for recurring ones.
     def charges_and_filters_from_events
       combinations = event_store.distinct_codes_and_property_combinations(
-        codes: plan_codes,
+        codes: non_recurring_plan_codes,
         filter_keys: billable_metric_filter_keys
       )
+
+      # Recurring usage carries over all-time, so its lazy cache key must reflect events ingested
+      # for prior periods
+      if recurring_plan_codes.any?
+        combinations += event_store.distinct_codes_and_property_combinations(
+          codes: recurring_plan_codes,
+          filter_keys: billable_metric_filter_keys,
+          include_all_history: true
+        )
+      end
 
       # Group the [code, properties, last_seen_at] tuples by code
       combinations_by_code = combinations.group_by(&:first)
@@ -137,7 +147,13 @@ module Events
     # the period, including the recurring ones.
     # Shape: { charge_id => { filter_id => last_seen_at } } (nil filter is the default bucket).
     def charges_and_filters_from_pre_enriched_events
-      values = event_store.distinct_charges_and_filters(codes: plan_codes)
+      values = event_store.distinct_charges_and_filters(codes: non_recurring_plan_codes)
+
+      # Recurring usage carries over all-time, so its lazy cache key must reflect events ingested
+      # for prior periods
+      if recurring_plan_codes.any?
+        values += event_store.distinct_charges_and_filters(codes: recurring_plan_codes, include_all_history: true)
+      end
 
       charge_filter_ids = values.map { |v| v[1] }.reject(&:blank?)
       charge_ids = values.map(&:first).uniq
@@ -205,6 +221,14 @@ module Events
         record(result, charge.id, nil, period_start)
       end
       result
+    end
+
+    def recurring_plan_codes
+      @recurring_plan_codes ||= plan.billable_metrics.where(recurring: true).distinct.pluck(:code)
+    end
+
+    def non_recurring_plan_codes
+      @non_recurring_plan_codes ||= plan_codes - recurring_plan_codes
     end
 
     # Fetches all recurring charges for the current plan

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -35,7 +35,7 @@ module Events
     delegate :organization, to: :event
 
     def customer
-      @customer ||= subscriptions.first&.customer
+      @customer ||= (subscriptions.first || fallback_subscription)&.customer
     end
 
     def subscriptions
@@ -59,8 +59,22 @@ module Events
       @active_subscription ||= begin
         subs = subscriptions.select(&:active?)
         raise "Multiple active subscriptions found" if subs.length > 1
-        subs.first
+        subs.first || fallback_subscription
       end
+    end
+
+    # Fallback for recurring events: when a backdated event matches no subscription, attach it to
+    # the currently active one.
+    def fallback_subscription
+      return @fallback_subscription if defined?(@fallback_subscription)
+      return @fallback_subscription = nil unless subscriptions.empty?
+      return @fallback_subscription = nil unless billable_metric&.recurring
+
+      @fallback_subscription = organization.subscriptions
+        .where(external_id: event.external_subscription_id)
+        .active
+        .order(started_at: :desc)
+        .first
     end
 
     def billable_metric
@@ -88,7 +102,10 @@ module Events
     def track_subscription_activity
       # NOTE: We don't eager load usage_thresholds or alerts here so it could be considered an N+1 query
       #       But there should be only one active subscription here, so it's better to not re-requery to eager load
-      subscriptions.select(&:active?).each do |subscription|
+      subs = subscriptions.select(&:active?)
+      subs = [fallback_subscription].compact if subs.empty?
+
+      subs.each do |subscription|
         date = Time.current.in_time_zone(customer.applicable_timezone).to_date
         UsageMonitoring::TrackSubscriptionActivityService.call(organization:, subscription:, date:)
       end
@@ -117,10 +134,10 @@ module Events
     end
 
     def charges
-      return Charge.none unless subscriptions.first
+      subscription = subscriptions.first || fallback_subscription
+      return Charge.none unless subscription
 
-      subscriptions
-        .first
+      subscription
         .plan
         .charges
         .pay_in_advance

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -103,7 +103,7 @@ module Events
         raise NotImplementedError
       end
 
-      def distinct_codes_and_property_combinations(codes:, filter_keys:)
+      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false)
         []
       end
 

--- a/app/services/events/stores/clickhouse_enriched_store.rb
+++ b/app/services/events/stores/clickhouse_enriched_store.rb
@@ -152,12 +152,13 @@ module Events
 
       # Returns [charge_id, charge_filter_id, last_seen_at] tuples, where last_seen_at is the
       # enriched_at of the most recent event for that charge/filter in the period.
-      def distinct_charges_and_filters(codes: nil)
+      def distinct_charges_and_filters(codes: nil, include_all_history: false)
+        lower_bound = include_all_history ? nil : from_datetime
         Events::Stores::Utils::ClickhouseConnection.with_retry do
           scope = ::Clickhouse::EventsEnrichedExpanded
             .where(external_subscription_id: subscription.external_id)
             .where(organization_id: subscription.organization_id)
-            .where(timestamp: from_datetime..to_datetime)
+            .where(timestamp: lower_bound..to_datetime)
 
           scope = scope.where(code: codes) unless codes.nil?
           scope.group("charge_id", "charge_filter_id")

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -148,13 +148,13 @@ module Events
         conditions.join(" AND ")
       end
 
-      def distinct_charges_and_filters(codes: nil)
+      def distinct_charges_and_filters(codes: nil, include_all_history: false)
         # Implementation relies directly on the events_enriched_expanded table,
         # so we delegate the implementation to the ClickhouseEnrichedStore
         Events::Stores::ClickhouseEnrichedStore.new(
           subscription:,
           boundaries:
-        ).distinct_charges_and_filters(codes:)
+        ).distinct_charges_and_filters(codes:, include_all_history:)
       end
 
       # Returns the distinct [code, properties, last_seen_at] combinations present in the events
@@ -165,7 +165,7 @@ module Events
       #
       # ClickHouse stores properties as a Map(String, String); a missing key reads back as an
       # empty string, so blank values are dropped to mirror the Postgres jsonb behaviour.
-      def distinct_codes_and_property_combinations(codes:, filter_keys:)
+      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false)
         return [] if codes.empty?
 
         Events::Stores::Utils::ClickhouseConnection.with_retry do
@@ -173,8 +173,8 @@ module Events
             .where(external_subscription_id: subscription.external_id)
             .where(organization_id: subscription.organization_id)
             .where(code: codes)
-            .where("events_enriched.timestamp >= ?", from_datetime)
             .where("events_enriched.timestamp <= ?", applicable_to_datetime)
+          scope = scope.where("events_enriched.timestamp >= ?", from_datetime) unless include_all_history
 
           selects = ["code AS code"]
           group_columns = ["code"]

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -24,10 +24,11 @@ module Events
 
       # Returns [charge_id, charge_filter_id, last_seen_at] tuples, where last_seen_at is the
       # enriched_at of the most recent event for that charge/filter in the period.
-      def distinct_charges_and_filters(codes: nil)
+      def distinct_charges_and_filters(codes: nil, include_all_history: false)
+        lower_bound = include_all_history ? nil : from_datetime
         scope = EnrichedEvent.where(organization_id: subscription.organization_id)
           .where(subscription_id: subscription.id)
-          .where(timestamp: from_datetime..to_datetime)
+          .where(timestamp: lower_bound..to_datetime)
 
         scope = scope.where(code: codes) unless codes.nil?
         scope.group(:charge_id, :charge_filter_id)
@@ -39,12 +40,12 @@ module Events
       # holds only the dimensions that can be matched against charge filters.
       # An empty hash represents the default (no filter) bucket.
       # last_seen_at is the created_at of the most recent event in the combination.
-      def distinct_codes_and_property_combinations(codes:, filter_keys:)
+      def distinct_codes_and_property_combinations(codes:, filter_keys:, include_all_history: false)
         scope = Event.where(external_subscription_id: subscription.external_id)
           .where(organization_id: subscription.organization_id)
           .where(code: codes)
-          .from_datetime(from_datetime)
           .to_datetime(applicable_to_datetime)
+        scope = scope.from_datetime(from_datetime) unless include_all_history
 
         scope
           .select(Arel.sql(<<~SQL.squish))

--- a/spec/services/events/billing_period_filter_service_spec.rb
+++ b/spec/services/events/billing_period_filter_service_spec.rb
@@ -607,6 +607,30 @@ RSpec.describe Events::BillingPeriodFilterService do
             expect(result.charges[recurring_charge.id][nil]).to eq(boundaries.charges_from_datetime)
           end
         end
+
+        context "with a backdated event ingested for a prior period" do
+          before do
+            create(
+              :event,
+              organization_id: organization.id,
+              external_subscription_id: subscription.external_id,
+              timestamp: boundaries.charges_from_datetime - 10.days,
+              code: recurring_billable_metric.code,
+              properties: {"region" => "eu"}
+            )
+          end
+
+          it "refreshes the matching bucket's last_seen_at from the backdated event's ingestion time" do
+            result = filter_service.call
+
+            expect(result).to be_success
+            expect(result.charges[recurring_charge.id].keys).to match_array([charge_filter.id, nil])
+            # The event's business timestamp is out of the period, but it was ingested now, so
+            # the recurring bucket must reflect it to invalidate the lazy usage cache.
+            expect(result.charges[recurring_charge.id][charge_filter.id]).to be > boundaries.charges_from_datetime
+            expect(result.charges[recurring_charge.id][nil]).to eq(boundaries.charges_from_datetime)
+          end
+        end
       end
 
       context "with events that does not match the boundaries" do
@@ -1135,6 +1159,44 @@ RSpec.describe Events::BillingPeriodFilterService do
 
       context "with recurring billable metric" do
         it_behaves_like "recurring billable metric filtering"
+
+        context "with a backdated event ingested for a prior period" do
+          let(:recurring_billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+          let(:recurring_charge) { create(:standard_charge, plan:, billable_metric: recurring_billable_metric) }
+
+          let(:backdated_event) do
+            create(
+              :event,
+              organization_id: organization.id,
+              external_subscription_id: subscription.external_id,
+              code: recurring_billable_metric.code,
+              timestamp: boundaries.charges_from_datetime - 10.days
+            )
+          end
+
+          let(:backdated_enriched_event) do
+            create(
+              :enriched_event,
+              event: backdated_event,
+              subscription:,
+              value: 12,
+              decimal_value: 12.0,
+              charge: recurring_charge,
+              charge_filter_id: nil
+            )
+          end
+
+          before { backdated_enriched_event }
+
+          it "includes the recurring charge with a last_seen_at from the backdated ingestion time" do
+            result = filter_service.call
+
+            expect(result).to be_success
+            # The enriched event's business timestamp is out of the period, but it was ingested
+            # now, so the recurring bucket must reflect it to invalidate the lazy usage cache.
+            expect(result.charges[recurring_charge.id][nil]).to be > boundaries.charges_from_datetime
+          end
+        end
       end
 
       context "with unknown charges" do

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -86,6 +86,49 @@ RSpec.describe Events::PostProcessService do
       end
     end
 
+    context "when the event is backdated before the subscription started" do
+      let(:timestamp) { started_at - 7.days }
+
+      context "with a recurring billable metric" do
+        let(:billable_metric) do
+          create(:billable_metric, organization:, recurring: true, aggregation_type: "sum_agg", field_name: "item_id")
+        end
+        let(:event_properties) { {"item_id" => "12"} }
+
+        it "falls back on the currently active subscription to expire the charge usage cache" do
+          allow(Subscriptions::ChargeCacheService).to receive(:expire_cache)
+
+          process_service.call
+
+          expect(Subscriptions::ChargeCacheService).to have_received(:expire_cache)
+            .with(subscription:, charge:, charge_filter: nil)
+        end
+
+        it "tracks subscription activity on the fallback subscription" do
+          allow(UsageMonitoring::TrackSubscriptionActivityService).to receive(:call)
+
+          process_service.call
+
+          expect(UsageMonitoring::TrackSubscriptionActivityService).to have_received(:call)
+            .with(subscription:, organization:, date: kind_of(Date))
+        end
+
+        it "enqueues a pay in advance job" do
+          expect { process_service.call }.to have_enqueued_job(Events::PayInAdvanceJob)
+        end
+      end
+
+      context "with a non-recurring billable metric" do
+        it "does not fall back and skips the charge usage cache expiration" do
+          allow(Subscriptions::ChargeCacheService).to receive(:expire_cache)
+
+          process_service.call
+
+          expect(Subscriptions::ChargeCacheService).not_to have_received(:expire_cache)
+        end
+      end
+    end
+
     context "when subscription is incomplete" do
       let(:subscription) do
         create(:subscription, :incomplete, organization:, customer:, plan:, started_at:)

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -2814,6 +2814,30 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true, excludi
           expect(result.map { |row| row[0..1] }).not_to include([code, {"region" => "apac", "provider" => "azure"}])
         end
       end
+
+      context "with an event before from_datetime" do
+        before do
+          create_event(
+            timestamp: subscription_started_at - 1.day,
+            value: 1,
+            properties: {"region" => "apac", "provider" => "azure"}
+          )
+        end
+
+        it "excludes it by default" do
+          result = event_store.distinct_codes_and_property_combinations(codes: [code], filter_keys: %w[region provider])
+
+          expect(result.map { |row| row[0..1] }).not_to include([code, {"region" => "apac", "provider" => "azure"}])
+        end
+
+        it "includes it when include_all_history is true" do
+          result = event_store.distinct_codes_and_property_combinations(
+            codes: [code], filter_keys: %w[region provider], include_all_history: true
+          )
+
+          expect(result.map { |row| row[0..1] }).to include([code, {"region" => "apac", "provider" => "azure"}])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Recurring metrics aggregate all-time usage (`use_from_boundary = !recurring`), so seats persist across periods and subscriptions. But a backdated recurring event (timestamp before the current period) didn't show in current usage until an unrelated in-period event was sent, forcing the recomputing.

Two boundary gaps, both from applying the event timestamp to backdated events:

1. **Triggering refresh and alerts**: `PostProcessService` matches a subscription by `started_at <= timestamp <= terminated_at`. Backdated events match none, so they skip enrichment, cache expiry, pay-in-advance, and activity tracking.

2. **Lazy cache invalidation**: `BillingPeriodFilterService` computes `last_seen_at` from events filtered to the period by `timestamp`. A backdated event (ingested now, old timestamp) never advances it, so `lazy_charge_usage_cache` keeps the stale entry, even though the recurring aggregation reads all-time.

## Description

1. **Recurring fallback in PostProcessService**: when no subscription matches the timestamp and the metric is recurring, fall back on the currently active subscription. Non-recurring behavior unchanged. (also fixed in events-processor path with https://github.com/getlago/lago/pull/768)
2. `Align invalidation with aggregation`: new `include_all_history`: flag drops the lower timestamp bound on the `distinct_* queries` and recurring codes are queried unbounded and fed through the existing matching path, so a backdated event advances `last_seen_at` and busts the cache at read time. No eager expiry reintroduced. Covers Postgres ClickHouse stores.
