### PR TITLE
misc(commitment): Fix Result when failed to create

### DIFF
--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -75,7 +75,7 @@ module Plans
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     rescue BaseService::FailedResult => e
-      e.result
+      result.fail_with_error!(e)
     end
 
     private

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -241,7 +241,7 @@ module Subscriptions
     end
 
     def override_plan(plan)
-      Plans::OverrideService.call(plan:, params: params[:plan_overrides].to_h.with_indifferent_access).plan
+      Plans::OverrideService.call!(plan:, params: params[:plan_overrides].to_h.with_indifferent_access).plan
     end
 
     def target_plan_for_new_subscription

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -255,6 +255,13 @@ RSpec.describe Plans::OverrideService do
         expect { override_service.call }.not_to change(Plan, :count)
         expect(override_service.call).not_to be_success
       end
+
+      it "returns the service's own result exposing plan" do
+        result = override_service.call
+
+        expect(result).to be_a(described_class::Result)
+        expect(result.plan).to be_nil
+      end
     end
 
     context "when subscription parameter is provided" do

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -598,6 +598,36 @@ RSpec.describe Subscriptions::CreateService do
         end
       end
 
+      context "when the plan override fails" do
+        let(:params) do
+          {
+            external_customer_id:,
+            plan_code:,
+            name:,
+            external_id:,
+            billing_time:,
+            subscription_at:,
+            subscription_id:,
+            started_at:,
+            plan_overrides: {
+              amount_cents: 12_345,
+              minimum_commitment: {amount_cents: nil}
+            }
+          }
+        end
+
+        it "returns a failed result without raising" do
+          result = nil
+          expect { result = create_service.call }.not_to raise_error
+
+          expect(result).not_to be_success
+        end
+
+        it "rolls back without creating a subscription" do
+          expect { create_service.call }.not_to change(Subscription, :count)
+        end
+      end
+
       context "with invoice custom sections" do
         let(:section_1) { create(:invoice_custom_section, organization:, code: "section_code_1") }
 


### PR DESCRIPTION
## Context

Creating a subscription with `plan_overrides` that include an invalid `minimum_commitment` crashed with a `NoMethodError` instead of returning a proper error response:

```
NoMethodError: undefined method 'plan' for an instance of Commitments::OverrideService::Result
```

`Plans::OverrideService` rescued `BaseService::FailedResult` and returned `e.result` — the *inner* failed result of the nested service (e.g. `Commitments::OverrideService::Result`). That object does not expose `#plan`, so  Subscriptions::CreateService#override_plan`, which reads `.plan` on the returned result, blew up and surfaced a 500 to the API caller.

The issue is a regression introduced by https://github.com/getlago/lago-api/pull/5958

## Description

- `Plans::OverrideService` now fails its own result with the caught error   (`result.fail_with_error!(e)`) instead of returning the nested service's result. Callers always get a `Plans::OverrideService::Result`, which exposes `#plan`, and the error is preserved for the error response.
- `Subscriptions::CreateService#override_plan` calls `OverrideService.call!` so an override failure raises and is handled by the existing `BaseService::FailedResult` rescue, producing a regular failed result and rolling back the transaction.
- Specs cover both levels: `Plans::OverrideService` returns its own result with a nil `plan` on failure, and `Subscriptions::CreateService` returns a failed result without raising (and creates no subscription) when the plan override fails.