### PR TITLE
fix(wallet): validate fresh active recurring rules on wallet update

### DIFF
--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -45,13 +45,13 @@ end
 # Table name: item_metadata
 # Database name: primary
 #
-#  id              :uuid             not null, primary key
-#  owner_type      :string           not null
-#  value           :jsonb            not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organization_id :uuid             not null
-#  owner_id        :uuid             not null
+#  id                                             :uuid             not null, primary key
+#  owner_type(Polymorphic owner type)             :string           not null
+#  value(item_metadata key-value pairs)           :jsonb            not null
+#  created_at                                     :datetime         not null
+#  updated_at                                     :datetime         not null
+#  organization_id(Reference to the organization) :uuid             not null
+#  owner_id(Polymorphic owner id)                 :uuid             not null
 #
 # Indexes
 #

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -47,7 +47,14 @@ module Wallets
           Wallets::RecurringTransactionRules::UpdateService.call!(wallet:, params: params[:recurring_transaction_rules])
         end
 
-        wallet.recurring_transaction_rules.find_each { |rule| validate_rule!(rule:) }
+        # NOTE: validate through the .active scope (fresh query) rather than
+        # the bare association: the activity-log middleware serializes the
+        # wallet BEFORE the update, caching recurring_transaction_rules with
+        # their pre-update values — iterating the cached target validated the
+        # STALE rule against the freshly assigned min/max bounds (false
+        # invalid_recurring_rule) and never the values just written. The scope
+        # also skips terminated rules, which must not block the update.
+        wallet.recurring_transaction_rules.active.find_each { |rule| validate_rule!(rule:) }
 
         if params.key?(:applies_to)
           wallet.allowed_fee_types = params[:applies_to][:fee_types] if params[:applies_to].key?(:fee_types)


### PR DESCRIPTION
## Context

Updating a wallet's paid top-up bounds and its recurring rule in the same updateCustomerWallet call fails with a false 422 invalid_recurring_rule, even when the submitted rule complies with the new bounds (ING-501).

The post-update check wallet.recurring_transaction_rules.find_each { validate_rule! } has two problems:

The activity-log middleware serializes the wallet before the update, caching the association with pre-update values — so the check validates the old rule against the new bounds, and never the values just written. The bare association includes terminated rules, so an old out-of-bounds terminated rule fails every wallet update.

## Description

Validate through the .active scope: it builds a fresh query (bypasses the stale cached target) and skips terminated rules.

<!-- Linear link -->
Fixes ING-501