### PR TITLE
feat(sentry): Add git commit sha to Sentry release version

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,7 +3,7 @@
 if ENV["SENTRY_DSN"].present?
   Sentry.init do |config|
     config.dsn = ENV["SENTRY_DSN"]
-    config.release = LagoUtils::Version.call(default: Rails.env).number
+    config.release = LagoUtils::Version.call(default: Rails.env).sha_or_number
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
     config.traces_sample_rate = 0
     config.traces_sample_rate = ENV["SENTRY_TRACES_SAMPLE_RATE"].to_f

--- a/lib/lago_utils/lago_utils/version.rb
+++ b/lib/lago_utils/lago_utils/version.rb
@@ -5,14 +5,24 @@ module LagoUtils
     VERSION_FILE = Rails.root.join("LAGO_VERSION")
     GITHUB_BASE_URL = "https://github.com/getlago/lago-api"
 
-    Result = Data.define(:number, :github_url)
+    Result = Data.define(:number, :github_url, :sha) do
+      def sha_or_number
+        sha || number
+      end
+    end
 
     class << self
       def call(default:)
-        Result.new(version_number(default:), github_url)
+        Result.new(version_number(default:), github_url, sha)
       end
 
       private
+
+      def sha
+        file_content if git_hash?
+      rescue Errno::ENOENT
+        nil
+      end
 
       def version_number(default:)
         return release_date if git_hash?

--- a/spec/lib/lago_utils/version_spec.rb
+++ b/spec/lib/lago_utils/version_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LagoUtils::Version do
+  describe ".call" do
+    subject(:result) { described_class.call(default: "test-default") }
+
+    let(:version_file) { Rails.root.join("LAGO_VERSION") }
+
+    context "when the file contains a git commit SHA" do
+      let(:sha) { "0f425aee1b9e7c927eb9559055fd1d11708bc7b5" }
+      let(:release_date) { Date.new(2026, 7, 24) }
+
+      before do
+        allow(File).to receive(:read).with(version_file).and_return("#{sha}\n")
+        allow(File).to receive(:ctime).with(version_file).and_return(release_date.to_time)
+      end
+
+      it "returns the release date as the number" do
+        expect(result.number).to eq(release_date.iso8601)
+      end
+
+      it "returns the SHA" do
+        expect(result.sha).to eq(sha)
+      end
+
+      it "returns the github url pointing at the SHA" do
+        expect(result.github_url).to eq("https://github.com/getlago/lago-api/tree/#{sha}")
+      end
+
+      it "returns the SHA as the sha_or_number" do
+        expect(result.sha_or_number).to eq(sha)
+      end
+    end
+
+    context "when the file contains a version tag" do
+      before do
+        allow(File).to receive(:read).with(version_file).and_return("v1.20.0\n")
+      end
+
+      it "returns the tag as the number" do
+        expect(result.number).to eq("v1.20.0")
+      end
+
+      it "returns a nil SHA" do
+        expect(result.sha).to be_nil
+      end
+
+      it "returns the github url pointing at the tag" do
+        expect(result.github_url).to eq("https://github.com/getlago/lago-api/tree/v1.20.0")
+      end
+
+      it "returns the tag as the sha_or_number" do
+        expect(result.sha_or_number).to eq("v1.20.0")
+      end
+    end
+
+    context "when the file cannot be read" do
+      before do
+        allow(File).to receive(:read).with(version_file).and_raise(Errno::ENOENT)
+      end
+
+      it "returns the default as the number" do
+        expect(result.number).to eq("test-default")
+      end
+
+      it "returns a nil SHA" do
+        expect(result.sha).to be_nil
+      end
+
+      it "returns the base github url" do
+        expect(result.github_url).to eq("https://github.com/getlago/lago-api")
+      end
+
+      it "returns the default as the sha_or_number" do
+        expect(result.sha_or_number).to eq("test-default")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Small change in sentry config in order to make it easier the track errors

Today, when a error happens code level, we use the date (release) as a version in Sentry, it's easier when we have one release per day, but having multiple releases in the same date is harder to track issues correctly from Sentry. Instead, we're changing to use the git commit sha and when is not available, fallsback to the release date.
