### PR TITLE
feat(multi-connection): Add GQL mutation for payment provider customer edition

### DIFF
--- a/app/graphql/mutations/payment_provider_customers/update.rb
+++ b/app/graphql/mutations/payment_provider_customers/update.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Mutations
+  module PaymentProviderCustomers
+    class Update < BaseMutation
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "customers:update"
+
+      graphql_name "UpdatePaymentProviderCustomer"
+      description "Updates a payment provider customer connection"
+
+      input_object_class Types::PaymentProviderCustomers::UpdateInput
+
+      type Types::PaymentProviderCustomers::Provider
+
+      def resolve(id:, **args)
+        payment_provider_customer = ::PaymentProviderCustomers::BaseCustomer
+          .where(organization_id: current_organization.id)
+          .find_by(id:)
+
+        result = ::PaymentProviderCustomers::UpdateConnectionService.call(
+          payment_provider_customer:,
+          params: args
+        )
+
+        result.success? ? result.payment_provider_customer : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -96,6 +96,7 @@ module Types
 
     field :set_integration_customer_as_default, mutation: Mutations::IntegrationCustomers::SetAsDefault
     field :set_payment_provider_customer_as_default, mutation: Mutations::PaymentProviderCustomers::SetAsDefault
+    field :update_payment_provider_customer, mutation: Mutations::PaymentProviderCustomers::Update
 
     field :create_netsuite_integration, mutation: Mutations::Integrations::Netsuite::Create
     field :destroy_integration, mutation: Mutations::Integrations::Destroy

--- a/app/graphql/types/payment_provider_customers/update_input.rb
+++ b/app/graphql/types/payment_provider_customers/update_input.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentProviderCustomers
+    class UpdateInput < BaseInputObject
+      graphql_name "UpdatePaymentProviderCustomerInput"
+      description "Update payment provider customer input arguments"
+
+      argument :id, ID, required: true
+
+      argument :code, String, required: false
+      argument :provider_payment_methods, [Types::PaymentProviderCustomers::ProviderPaymentMethodsEnum], required: false
+    end
+  end
+end

--- a/app/graphql/types/payment_provider_customers/update_input.rb
+++ b/app/graphql/types/payment_provider_customers/update_input.rb
@@ -9,7 +9,9 @@ module Types
       argument :id, ID, required: true
 
       argument :code, String, required: false
+      argument :provider_customer_id, ID, required: false
       argument :provider_payment_methods, [Types::PaymentProviderCustomers::ProviderPaymentMethodsEnum], required: false
+      argument :sync_with_provider, Boolean, required: false
     end
   end
 end

--- a/app/services/payment_provider_customers/update_connection_service.rb
+++ b/app/services/payment_provider_customers/update_connection_service.rb
@@ -64,7 +64,7 @@ module PaymentProviderCustomers
         customer:,
         payment_provider_id: payment_provider_customer&.payment_provider&.id,
         params: provider_customer_params
-      ).call.raise_if_error!
+      ).call!
 
       customer.reload
     end

--- a/app/services/payment_provider_customers/update_connection_service.rb
+++ b/app/services/payment_provider_customers/update_connection_service.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class UpdateConnectionService < BaseService
+    include Customers::PaymentProviderFinder
+
+    Result = BaseResult[:payment_provider_customer]
+
+    def initialize(payment_provider_customer:, params:)
+      @payment_provider_customer = payment_provider_customer
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "payment_provider_customer") unless payment_provider_customer
+
+      ActiveRecord::Base.transaction do
+        if params.key?(:code)
+          payment_provider_customer.code = params[:code]
+          payment_provider_customer.save!
+        end
+
+        # NOTE: provider_payment_methods only exist on Stripe connections; it is silently
+        #       ignored for any other provider.
+        update_provider_payment_methods if update_provider_payment_methods?
+      end
+
+      result.payment_provider_customer = payment_provider_customer.reload
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :payment_provider_customer, :params
+
+    delegate :customer, to: :payment_provider_customer
+
+    def update_provider_payment_methods?
+      params.key?(:provider_payment_methods) &&
+        payment_provider_customer.is_a?(PaymentProviderCustomers::StripeCustomer)
+    end
+
+    # NOTE: mirrors the provider customer edition performed by Customers::UpdateService.
+    #       The provider CreateService is an upsert that applies provider_payment_methods
+    #       (with the Stripe model validations) on the existing connection.
+    def update_provider_payment_methods
+      PaymentProviders::CreateCustomerFactory.new_instance(
+        provider: "stripe",
+        customer:,
+        payment_provider_id: payment_provider(customer)&.id,
+        params: {provider_payment_methods: params[:provider_payment_methods]}
+      ).call.raise_if_error!
+    end
+  end
+end

--- a/app/services/payment_provider_customers/update_connection_service.rb
+++ b/app/services/payment_provider_customers/update_connection_service.rb
@@ -17,14 +17,13 @@ module PaymentProviderCustomers
       return result.not_found_failure!(resource: "payment_provider_customer") unless payment_provider_customer
 
       ActiveRecord::Base.transaction do
-        if params.key?(:code)
-          payment_provider_customer.code = params[:code]
-          payment_provider_customer.save!
-        end
+        payment_provider_customer.update!(code: params[:code]) if params.key?(:code)
 
-        # NOTE: provider_payment_methods only exist on Stripe connections; it is silently
-        #       ignored for any other provider.
-        update_provider_payment_methods if update_provider_payment_methods?
+        update_provider_customer if editing_provider_customer?
+      end
+
+      if params[:provider_customer_id].present?
+        PaymentProviderCustomers::UpdateService.call(customer).raise_if_error!
       end
 
       result.payment_provider_customer = payment_provider_customer.reload
@@ -41,21 +40,33 @@ module PaymentProviderCustomers
 
     delegate :customer, to: :payment_provider_customer
 
-    def update_provider_payment_methods?
-      params.key?(:provider_payment_methods) &&
-        payment_provider_customer.is_a?(PaymentProviderCustomers::StripeCustomer)
+    def provider
+      @provider ||= payment_provider_customer.type.demodulize.underscore.delete_suffix("_customer")
     end
 
-    # NOTE: mirrors the provider customer edition performed by Customers::UpdateService.
-    #       The provider CreateService is an upsert that applies provider_payment_methods
-    #       (with the Stripe model validations) on the existing connection.
-    def update_provider_payment_methods
+    def editing_provider_customer?
+      params.key?(:provider_customer_id) ||
+        params.key?(:provider_payment_methods) ||
+        params.key?(:sync_with_provider)
+    end
+
+    def provider_customer_params
+      @provider_customer_params ||= params.slice(:provider_customer_id, :provider_payment_methods, :sync_with_provider)
+    end
+
+    def update_provider_customer
+      handle_provider_customer = provider_customer_params[:provider_customer_id].present?
+      handle_provider_customer ||= payment_provider_customer&.provider_customer_id.present?
+      return unless handle_provider_customer
+
       PaymentProviders::CreateCustomerFactory.new_instance(
-        provider: "stripe",
+        provider:,
         customer:,
-        payment_provider_id: payment_provider(customer)&.id,
-        params: {provider_payment_methods: params[:provider_payment_methods]}
+        payment_provider_id: payment_provider_customer&.payment_provider&.id,
+        params: provider_customer_params
       ).call.raise_if_error!
+
+      customer.reload
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -13559,7 +13559,9 @@ input UpdatePaymentProviderCustomerInput {
   clientMutationId: String
   code: String
   id: ID!
+  providerCustomerId: ID
   providerPaymentMethods: [ProviderPaymentMethodsEnum!]
+  syncWithProvider: Boolean
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -9024,6 +9024,16 @@ type Mutation {
   ): CurrentOrganization
 
   """
+  Updates a payment provider customer connection
+  """
+  updatePaymentProviderCustomer(
+    """
+    Parameters for UpdatePaymentProviderCustomer
+    """
+    input: UpdatePaymentProviderCustomerInput!
+  ): ProviderCustomer
+
+  """
   Updates an existing Plan
   """
   updatePlan(
@@ -13537,6 +13547,19 @@ input UpdateOrganizationInput {
   timezone: TimezoneEnum
   webhookUrl: String
   zipcode: String
+}
+
+"""
+Update payment provider customer input arguments
+"""
+input UpdatePaymentProviderCustomerInput {
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  code: String
+  id: ID!
+  providerPaymentMethods: [ProviderPaymentMethodsEnum!]
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -72405,6 +72405,18 @@
               "deprecationReason": null
             },
             {
+              "name": "providerCustomerId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "providerPaymentMethods",
               "description": null,
               "type": {
@@ -72419,6 +72431,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "syncWithProvider",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -43427,6 +43427,35 @@
               "deprecationReason": null
             },
             {
+              "name": "updatePaymentProviderCustomer",
+              "description": "Updates a payment provider customer connection",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdatePaymentProviderCustomer",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdatePaymentProviderCustomerInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProviderCustomer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updatePlan",
               "description": "Updates an existing Plan",
               "args": [
@@ -72319,6 +72348,77 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdatePaymentProviderCustomerInput",
+          "description": "Update payment provider customer input arguments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "providerPaymentMethods",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ProviderPaymentMethodsEnum",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/payment_provider_customers/update_spec.rb
+++ b/spec/graphql/mutations/payment_provider_customers/update_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Mutations::PaymentProviderCustomers::Update do
           id
           code
           providerPaymentMethods
+          syncWithProvider
         }
       }
     GQL
@@ -81,6 +82,23 @@ RSpec.describe Mutations::PaymentProviderCustomers::Update do
 
       data = result["data"]["updatePaymentProviderCustomer"]
       expect(data["code"]).to eq("new_code")
+    end
+  end
+
+  context "when updating sync_with_provider" do
+    it "updates sync_with_provider" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {id: payment_provider_customer.id, syncWithProvider: true}
+        }
+      )
+
+      data = result["data"]["updatePaymentProviderCustomer"]
+      expect(data["syncWithProvider"]).to be(true)
     end
   end
 

--- a/spec/graphql/mutations/payment_provider_customers/update_spec.rb
+++ b/spec/graphql/mutations/payment_provider_customers/update_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::PaymentProviderCustomers::Update do
+  let(:required_permission) { "customers:update" }
+  let(:membership) { create(:membership, organization:) }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:payment_provider_customer) do
+    create(:stripe_customer, organization:, customer:, code: "old_code", provider_payment_methods: %w[card])
+  end
+
+  let(:mutation) do
+    <<-GQL
+      mutation($input: UpdatePaymentProviderCustomerInput!) {
+        updatePaymentProviderCustomer(input: $input) {
+          id
+          code
+          providerPaymentMethods
+        }
+      }
+    GQL
+  end
+
+  before { payment_provider_customer }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "customers:update"
+
+  it "updates the code and the provider payment methods" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {
+        input: {id: payment_provider_customer.id, code: "new_code", providerPaymentMethods: %w[card sepa_debit]}
+      }
+    )
+
+    data = result["data"]["updatePaymentProviderCustomer"]
+    expect(data["id"]).to eq(payment_provider_customer.id)
+    expect(data["code"]).to eq("new_code")
+    expect(data["providerPaymentMethods"]).to match_array(%w[card sepa_debit])
+  end
+
+  context "when updating only the code of a non-stripe connection" do
+    let(:payment_provider_customer) { create(:adyen_customer, organization:, customer:, code: "old_code") }
+
+    it "updates the code" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {id: payment_provider_customer.id, code: "new_code"}
+        }
+      )
+
+      data = result["data"]["updatePaymentProviderCustomer"]
+      expect(data["code"]).to eq("new_code")
+    end
+  end
+
+  context "when editing a non-stripe connection with provider payment methods" do
+    let(:payment_provider_customer) { create(:adyen_customer, organization:, customer:, code: "old_code") }
+
+    it "updates the code and ignores the provider payment methods" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {id: payment_provider_customer.id, code: "new_code", providerPaymentMethods: %w[card]}
+        }
+      )
+
+      data = result["data"]["updatePaymentProviderCustomer"]
+      expect(data["code"]).to eq("new_code")
+    end
+  end
+
+  context "when payment provider customer is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {id: "unknown", code: "new_code"}
+        }
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/services/payment_provider_customers/update_connection_service_spec.rb
+++ b/spec/services/payment_provider_customers/update_connection_service_spec.rb
@@ -40,20 +40,6 @@ RSpec.describe PaymentProviderCustomers::UpdateConnectionService do
           expect(result.payment_provider_customer).to eq(payment_provider_customer)
         end
       end
-
-      context "when provider payment methods are also provided" do
-        let(:params) { {code: "new_code", provider_payment_methods: %w[card]} }
-
-        it "updates the code and ignores the provider payment methods" do
-          expect(result).to be_success
-          expect(payment_provider_customer.reload.code).to eq("new_code")
-        end
-
-        it "does not create a stripe connection" do
-          expect { update_service.call }
-            .not_to change(PaymentProviderCustomers::StripeCustomer, :count)
-        end
-      end
     end
 
     context "with a stripe connection" do
@@ -129,7 +115,7 @@ RSpec.describe PaymentProviderCustomers::UpdateConnectionService do
         end
       end
 
-      context "when the connection cannot be handled" do
+      context "when provider_customer does not exist and is not provided" do
         let(:payment_provider_customer) do
           create(:stripe_customer, organization:, customer:, provider_customer_id: nil, provider_payment_methods: %w[card])
         end

--- a/spec/services/payment_provider_customers/update_connection_service_spec.rb
+++ b/spec/services/payment_provider_customers/update_connection_service_spec.rb
@@ -23,16 +23,16 @@ RSpec.describe PaymentProviderCustomers::UpdateConnectionService do
     end
 
     context "with a non-stripe connection" do
-      let(:payment_provider_customer) { create(:adyen_customer, organization:, customer:, code: "old_code") }
+      let(:payment_provider_customer) do
+        create(:adyen_customer, organization:, customer:, code: "old_code")
+      end
 
       context "when updating the code" do
         let(:params) { {code: "new_code"} }
 
         it "updates the code" do
           expect { update_service.call }
-            .to change { payment_provider_customer.reload.code }
-            .from("old_code")
-            .to("new_code")
+            .to change { payment_provider_customer.reload.code }.from("old_code").to("new_code")
         end
 
         it "returns the payment provider customer" do
@@ -61,6 +61,17 @@ RSpec.describe PaymentProviderCustomers::UpdateConnectionService do
         create(:stripe_customer, organization:, customer:, code: "old_code", provider_payment_methods: %w[card])
       end
 
+      context "when only the code is updated" do
+        let(:params) { {code: "new_code"} }
+
+        before { allow(PaymentProviders::CreateCustomerFactory).to receive(:new_instance).and_call_original }
+
+        it "does not run the provider customer upsert" do
+          update_service.call
+          expect(PaymentProviders::CreateCustomerFactory).not_to have_received(:new_instance)
+        end
+      end
+
       context "when updating both code and provider payment methods" do
         let(:params) { {code: "new_code", provider_payment_methods: %w[card sepa_debit]} }
 
@@ -85,8 +96,48 @@ RSpec.describe PaymentProviderCustomers::UpdateConnectionService do
           expect(result.error).to be_a(BaseService::ValidationFailure)
         end
 
-        it "does not update the code" do
+        it "rolls back the code change" do
           expect { update_service.call }.not_to change { payment_provider_customer.reload.code }
+        end
+      end
+
+      context "when updating sync_with_provider" do
+        let(:params) { {sync_with_provider: true} }
+
+        it "updates sync_with_provider" do
+          expect { update_service.call }
+            .to change { payment_provider_customer.reload.sync_with_provider }.to(true)
+        end
+      end
+
+      context "when a provider customer id is provided" do
+        let(:payment_provider_customer) do
+          create(:stripe_customer, organization:, customer:, provider_customer_id: "cus_old", provider_payment_methods: %w[card])
+        end
+        let(:params) { {provider_customer_id: "cus_new"} }
+
+        before { allow(PaymentProviderCustomers::UpdateService).to receive(:call).and_return(BaseResult.new) }
+
+        it "updates the provider customer id" do
+          expect { update_service.call }
+            .to change { payment_provider_customer.reload.provider_customer_id }.from("cus_old").to("cus_new")
+        end
+
+        it "syncs the provider customer with the provider" do
+          update_service.call
+          expect(PaymentProviderCustomers::UpdateService).to have_received(:call).with(customer)
+        end
+      end
+
+      context "when the connection cannot be handled" do
+        let(:payment_provider_customer) do
+          create(:stripe_customer, organization:, customer:, provider_customer_id: nil, provider_payment_methods: %w[card])
+        end
+        let(:params) { {provider_payment_methods: %w[card sepa_debit]} }
+
+        it "does not update the provider payment methods" do
+          expect { update_service.call }
+            .not_to change { payment_provider_customer.reload.provider_payment_methods }
         end
       end
     end

--- a/spec/services/payment_provider_customers/update_connection_service_spec.rb
+++ b/spec/services/payment_provider_customers/update_connection_service_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviderCustomers::UpdateConnectionService do
+  subject(:update_service) { described_class.new(payment_provider_customer:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:params) { {} }
+
+  describe "#call" do
+    subject(:result) { update_service.call }
+
+    context "when payment provider customer is not found" do
+      let(:payment_provider_customer) { nil }
+      let(:params) { {code: "new_code"} }
+
+      it "returns an error" do
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("payment_provider_customer_not_found")
+      end
+    end
+
+    context "with a non-stripe connection" do
+      let(:payment_provider_customer) { create(:adyen_customer, organization:, customer:, code: "old_code") }
+
+      context "when updating the code" do
+        let(:params) { {code: "new_code"} }
+
+        it "updates the code" do
+          expect { update_service.call }
+            .to change { payment_provider_customer.reload.code }
+            .from("old_code")
+            .to("new_code")
+        end
+
+        it "returns the payment provider customer" do
+          expect(result).to be_success
+          expect(result.payment_provider_customer).to eq(payment_provider_customer)
+        end
+      end
+
+      context "when provider payment methods are also provided" do
+        let(:params) { {code: "new_code", provider_payment_methods: %w[card]} }
+
+        it "updates the code and ignores the provider payment methods" do
+          expect(result).to be_success
+          expect(payment_provider_customer.reload.code).to eq("new_code")
+        end
+
+        it "does not create a stripe connection" do
+          expect { update_service.call }
+            .not_to change(PaymentProviderCustomers::StripeCustomer, :count)
+        end
+      end
+    end
+
+    context "with a stripe connection" do
+      let(:payment_provider_customer) do
+        create(:stripe_customer, organization:, customer:, code: "old_code", provider_payment_methods: %w[card])
+      end
+
+      context "when updating both code and provider payment methods" do
+        let(:params) { {code: "new_code", provider_payment_methods: %w[card sepa_debit]} }
+
+        it "updates the code" do
+          expect { update_service.call }
+            .to change { payment_provider_customer.reload.code }.from("old_code").to("new_code")
+        end
+
+        it "updates the provider payment methods" do
+          expect { update_service.call }
+            .to change { payment_provider_customer.reload.provider_payment_methods }
+            .from(%w[card])
+            .to(%w[card sepa_debit])
+        end
+      end
+
+      context "when the provider payment methods are invalid" do
+        let(:params) { {code: "new_code", provider_payment_methods: %w[invalid_method]} }
+
+        it "returns a validation failure" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+        end
+
+        it "does not update the code" do
+          expect { update_service.call }.not_to change { payment_provider_customer.reload.code }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently customers can be attached to only one connection of the same type. In order to change it, Lago is adding possibility to have multiple connections of the same type per customer.

## Description

This PR adds mutation to update payment provider customer. Currently it is possible to do it along with customer edition. This is the dedicated mutation, created only for this purpose.