### PR TITLE
fix(rds-proxy): route >16 KB queries around RDS Proxy via :direct role

### DIFF
--- a/app/controllers/concerns/credit_note_index.rb
+++ b/app/controllers/concerns/credit_note_index.rb
@@ -57,15 +57,23 @@ module CreditNoteIndex
     )
 
     if result.success?
-      render(
-        json: ::CollectionSerializer.new(
-          result.credit_notes,
-          ::V1::CreditNoteSerializer,
-          collection_name: "credit_notes",
-          meta: pagination_metadata(result.credit_notes),
-          includes: [:items, :applied_taxes, :error_details, {customer: [:integration_customers]}]
+      # Same shape as InvoiceIndex — five payment-provider join aliases on
+      # `customer` plus a deep `items → fee → …` chain push the rendered
+      # `.includes(...)` query past RDS Proxy's 16 KB per-statement pin
+      # threshold once a page of credit-note IDs is expanded into the
+      # `WHERE id IN (…)` clause. Route the query + serialization through
+      # `:direct` so the whole page render bypasses the pooler.
+      ApplicationRecord.connected_to(role: :direct) do
+        render(
+          json: ::CollectionSerializer.new(
+            result.credit_notes,
+            ::V1::CreditNoteSerializer,
+            collection_name: "credit_notes",
+            meta: pagination_metadata(result.credit_notes),
+            includes: [:items, :applied_taxes, :error_details, {customer: [:integration_customers]}]
+          )
         )
-      )
+      end
     else
       render_error_response(result)
     end

--- a/app/controllers/concerns/credit_note_index.rb
+++ b/app/controllers/concerns/credit_note_index.rb
@@ -57,12 +57,7 @@ module CreditNoteIndex
     )
 
     if result.success?
-      # Same shape as InvoiceIndex — five payment-provider join aliases on
-      # `customer` plus a deep `items → fee → …` chain push the rendered
-      # `.includes(...)` query past RDS Proxy's 16 KB per-statement pin
-      # threshold once a page of credit-note IDs is expanded into the
-      # `WHERE id IN (…)` clause. Route the query + serialization through
-      # `:direct` so the whole page render bypasses the pooler.
+      # Eager-load exceeds RDS Proxy's 16 KB pin threshold — bypass the pooler.
       ApplicationRecord.connected_to(role: :direct) do
         render(
           json: ::CollectionSerializer.new(

--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -61,39 +61,48 @@ module InvoiceIndex
     )
 
     if result.success?
-      invoices = Invoice.preload_offset_amounts(
-        result.invoices.includes(
-          :metadata,
-          :applied_taxes,
-          :billing_entity,
-          :applied_usage_thresholds,
-          customer: [
-            :billing_entity,
+      # The `.includes(...)` chain here (5 payment-provider join aliases plus
+      # billing_entity, metadata, integration_customers, applied_taxes,
+      # applied_usage_thresholds) renders to ~16.2–16.7 KB once ActiveRecord
+      # expands the `WHERE invoices.id IN ($, $, …)` clause against a page of
+      # 100 invoice IDs — crossing RDS Proxy's 16 KB per-statement pin
+      # threshold. Route the eager-load + serializer traversal through the
+      # `:direct` role so this whole page render bypasses the pooler.
+      ApplicationRecord.connected_to(role: :direct) do
+        invoices = Invoice.preload_offset_amounts(
+          result.invoices.includes(
             :metadata,
-            :stripe_customer,
-            :gocardless_customer,
-            :cashfree_customer,
-            :adyen_customer,
-            :moneyhash_customer,
-            {integration_customers: :integration}
-          ]
+            :applied_taxes,
+            :billing_entity,
+            :applied_usage_thresholds,
+            customer: [
+              :billing_entity,
+              :metadata,
+              :stripe_customer,
+              :gocardless_customer,
+              :cashfree_customer,
+              :adyen_customer,
+              :moneyhash_customer,
+              {integration_customers: :integration}
+            ]
+          )
         )
-      )
 
-      render(
-        json: ::CollectionSerializer.new(
-          invoices,
-          ::V1::InvoiceSerializer,
-          collection_name: "invoices",
-          meta: pagination_metadata(
+        render(
+          json: ::CollectionSerializer.new(
             invoices,
-            key: "invoices",
-            organization_id: current_organization.id,
-            params: params.permit(*WHITELIST)
-          ),
-          includes: %i[customer integration_customers metadata applied_taxes]
+            ::V1::InvoiceSerializer,
+            collection_name: "invoices",
+            meta: pagination_metadata(
+              invoices,
+              key: "invoices",
+              organization_id: current_organization.id,
+              params: params.permit(*WHITELIST)
+            ),
+            includes: %i[customer integration_customers metadata applied_taxes]
+          )
         )
-      )
+      end
     else
       render_error_response(result)
     end

--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -61,13 +61,7 @@ module InvoiceIndex
     )
 
     if result.success?
-      # The `.includes(...)` chain here (5 payment-provider join aliases plus
-      # billing_entity, metadata, integration_customers, applied_taxes,
-      # applied_usage_thresholds) renders to ~16.2–16.7 KB once ActiveRecord
-      # expands the `WHERE invoices.id IN ($, $, …)` clause against a page of
-      # 100 invoice IDs — crossing RDS Proxy's 16 KB per-statement pin
-      # threshold. Route the eager-load + serializer traversal through the
-      # `:direct` role so this whole page render bypasses the pooler.
+      # Eager-load exceeds RDS Proxy's 16 KB pin threshold — bypass the pooler.
       ApplicationRecord.connected_to(role: :direct) do
         invoices = Invoice.preload_offset_amounts(
           result.invoices.includes(

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,32 +3,10 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 
-  # Two roles on the same physical database:
-  #   :writing (default) — DATABASE_PROXY_URL when set, else DATABASE_URL.
-  #                        Normal traffic, goes through the RDS Proxy where
-  #                        one is deployed.
-  #   :direct            — always DATABASE_URL. Bypasses the pooler for
-  #                        statements that would otherwise session-pin
-  #                        (>16 KB on RDS Proxy for Postgres).
-  # Use with `ApplicationRecord.connected_to(role: :direct) { ... }`.
-  # When DATABASE_PROXY_URL is unset both roles resolve to DATABASE_URL,
-  # so `:direct` becomes a no-op.
+  # :writing (default) uses DATABASE_PROXY_URL when set, else DATABASE_URL.
+  # :direct always uses DATABASE_URL to bypass the pooler for statements
+  # that would session-pin (>16 KB on RDS Proxy for Postgres).
   connects_to database: {writing: :primary, direct: :direct}
-
-  # In test env, Rails opens a distinct connection pool for `:direct`
-  # even though the config points at the same DB — separate pools mean
-  # separate PG sessions and separate transactions, and DatabaseCleaner
-  # only wraps the default (:writing) pool. Fixtures written via the
-  # default pool wouldn't be visible when the app switches to `:direct`,
-  # which would break every scenario spec that exercises the biller.
-  # Short-circuit the role swap so `:direct` queries land on the
-  # currently-active pool.
-  if Rails.env.test?
-    def self.connected_to(role: nil, **kwargs)
-      return yield if role == :direct
-      super
-    end
-  end
 
   # Avoid raising ActiveRecord::PreparedStatementCacheExpired
   # from transactions when a migration is adding a new column

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,6 +3,33 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 
+  # Two roles on the same physical database:
+  #   :writing (default) — DATABASE_PROXY_URL when set, else DATABASE_URL.
+  #                        Normal traffic, goes through the RDS Proxy where
+  #                        one is deployed.
+  #   :direct            — always DATABASE_URL. Bypasses the pooler for
+  #                        statements that would otherwise session-pin
+  #                        (>16 KB on RDS Proxy for Postgres).
+  # Use with `ApplicationRecord.connected_to(role: :direct) { ... }`.
+  # When DATABASE_PROXY_URL is unset both roles resolve to DATABASE_URL,
+  # so `:direct` becomes a no-op.
+  connects_to database: {writing: :primary, direct: :direct}
+
+  # In test env, Rails opens a distinct connection pool for `:direct`
+  # even though the config points at the same DB — separate pools mean
+  # separate PG sessions and separate transactions, and DatabaseCleaner
+  # only wraps the default (:writing) pool. Fixtures written via the
+  # default pool wouldn't be visible when the app switches to `:direct`,
+  # which would break every scenario spec that exercises the biller.
+  # Short-circuit the role swap so `:direct` queries land on the
+  # currently-active pool.
+  if Rails.env.test?
+    def self.connected_to(role: nil, **kwargs)
+      return yield if role == :direct
+      super
+    end
+  end
+
   # Avoid raising ActiveRecord::PreparedStatementCacheExpired
   # from transactions when a migration is adding a new column
   self.ignored_columns = [:__fake_column__]

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -208,15 +208,8 @@ class Invoice < ApplicationRecord
 
   # Batch-loads offset_amount_cents for a collection of invoices in a single query,
   # caching the result on each instance to avoid N+1 queries during serialization.
-  #
-  # `invoices.map(&:id)` iterates the relation, which is what materialises any
-  # chained `.includes(...)` — including the 5-payment-provider eager-load that
-  # invoice / credit-note index endpoints add on top. That materialised query
-  # renders to ~16.2–16.7 KB, above RDS Proxy's 16 KB per-statement pin
-  # threshold. Route both the eager-load fire AND the CreditNote batch through
-  # the `:direct` role so every caller (InvoiceIndex, CreditNoteIndex, GraphQL
-  # invoices resolvers, data exports) bypasses the pooler here — no need for
-  # each call site to remember the wrap.
+  # Wrapped in :direct — invoices.map(&:id) fires the eager-load, which exceeds
+  # RDS Proxy's 16 KB pin threshold under the index endpoints' .includes(...) chain.
   def self.preload_offset_amounts(invoices)
     return unless invoices
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -208,22 +208,33 @@ class Invoice < ApplicationRecord
 
   # Batch-loads offset_amount_cents for a collection of invoices in a single query,
   # caching the result on each instance to avoid N+1 queries during serialization.
+  #
+  # `invoices.map(&:id)` iterates the relation, which is what materialises any
+  # chained `.includes(...)` — including the 5-payment-provider eager-load that
+  # invoice / credit-note index endpoints add on top. That materialised query
+  # renders to ~16.2–16.7 KB, above RDS Proxy's 16 KB per-statement pin
+  # threshold. Route both the eager-load fire AND the CreditNote batch through
+  # the `:direct` role so every caller (InvoiceIndex, CreditNoteIndex, GraphQL
+  # invoices resolvers, data exports) bypasses the pooler here — no need for
+  # each call site to remember the wrap.
   def self.preload_offset_amounts(invoices)
     return unless invoices
 
-    invoice_ids = invoices.map(&:id).compact
+    ApplicationRecord.connected_to(role: :direct) do
+      invoice_ids = invoices.map(&:id).compact
 
-    offset_amounts = CreditNote
-      .where(invoice_id: invoice_ids)
-      .finalized
-      .group(:invoice_id)
-      .sum(:offset_amount_cents)
+      offset_amounts = CreditNote
+        .where(invoice_id: invoice_ids)
+        .finalized
+        .group(:invoice_id)
+        .sum(:offset_amount_cents)
 
-    invoices.each do |invoice|
-      invoice.precalculated_offset_amount_cents = (offset_amounts[invoice.id] || 0)
+      invoices.each do |invoice|
+        invoice.precalculated_offset_amount_cents = (offset_amounts[invoice.id] || 0)
+      end
+
+      invoices
     end
-
-    invoices
   end
 
   def payment_invoices

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -50,7 +50,12 @@ module Subscriptions
 
     attr_reader :today, :organization
 
-    # NOTE: Retrieve list of subscriptions that should be billed today
+    # NOTE: Retrieve list of subscriptions that should be billed today.
+    # The rendered SQL is ~28 KB and exceeds RDS Proxy's 16 KB
+    # per-statement pin threshold, so it runs on the `:direct` role
+    # (always DATABASE_URL) to bypass the pooler. In envs without a
+    # pooler, `:direct` resolves to the same connection as `:writing`
+    # (see config/database.yml).
     def billable_subscriptions
       sql = <<-SQL
         WITH
@@ -120,7 +125,9 @@ module Subscriptions
         GROUP BY subscriptions.id
       SQL
 
-      Subscription.find_by_sql([sql, {today:}])
+      ApplicationRecord.connected_to(role: :direct) do
+        Subscription.find_by_sql([sql, {today:}])
+      end
     end
 
     def base_subscription_scope(billing_time: nil, interval: nil, conditions: nil)

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -51,11 +51,8 @@ module Subscriptions
     attr_reader :today, :organization
 
     # NOTE: Retrieve list of subscriptions that should be billed today.
-    # The rendered SQL is ~28 KB and exceeds RDS Proxy's 16 KB
-    # per-statement pin threshold, so it runs on the `:direct` role
-    # (always DATABASE_URL) to bypass the pooler. In envs without a
-    # pooler, `:direct` resolves to the same connection as `:writing`
-    # (see config/database.yml).
+    # The rendered SQL (~28 KB) exceeds RDS Proxy's 16 KB pin threshold,
+    # so it runs on :direct to bypass the pooler.
     def billable_subscriptions
       sql = <<-SQL
         WITH

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,18 @@ default: &default
     idle_in_transaction_session_timeout: <%= ENV.fetch("LAGO_DATABASE_IDLE_TX_TIMEOUT", ":default") %>
     lock_timeout: <%= ENV.fetch("LAGO_DATABASE_LOCK_TIMEOUT", ":default") %>
 
+# URL contract
+#   DATABASE_URL       — direct connection to the physical database.
+#                        Always present. In envs without a connection pooler
+#                        this is also the URL every query uses.
+#   DATABASE_PROXY_URL — pooler / RDS Proxy URL. Optional. When set, becomes
+#                        the default connection for `:writing` and `:events`;
+#                        `:direct` still connects via DATABASE_URL to bypass
+#                        the pooler for statements that would session-pin
+#                        (>16 KB — see Subscriptions::OrganizationBillingService).
+# When only DATABASE_URL is set, every role points at it — the `:direct`
+# role is effectively a no-op.
+
 development:
   primary:
     <<: *default
@@ -14,6 +26,15 @@ development:
     database: lago
     pool: <%= ENV.fetch('DATABASE_POOL', 5) %>
     port: 5432
+  direct:
+    <<: *default
+    host: db
+    username: lago
+    password: changeme
+    database: lago
+    pool: <%= ENV.fetch('DATABASE_POOL', 5) %>
+    port: 5432
+    database_tasks: false
   events:
     <<: *default
     host: db
@@ -40,6 +61,11 @@ test:
     <<: *default
     url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
     schema_dump: <% if ENV['LAGO_DISABLE_SCHEMA_DUMP'].present? %> false <% else %> structure.sql <% end %>
+  direct:
+    <<: *default
+    url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
+    database_tasks: false
+    schema_dump: false
   events:
     <<: *default
     url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
@@ -59,12 +85,19 @@ test:
 staging:
   primary:
     <<: *default
-    url: <%= ENV['DATABASE_URL'] %>
+    url: <%= ENV.fetch('DATABASE_PROXY_URL', ENV['DATABASE_URL']) %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
-  events:
+    prepared_statements: <%= ENV['DATABASE_PROXY_URL'].blank? %>
+  direct:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
+    database_tasks: false
+  events:
+    <<: *default
+    url: <%= ENV.fetch('DATABASE_PROXY_URL', ENV['DATABASE_URL']) %>
+    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
+    prepared_statements: <%= ENV['DATABASE_PROXY_URL'].blank? %>
     database_tasks: false
   clickhouse:
     adapter: clickhouse
@@ -80,15 +113,24 @@ staging:
 production:
   primary:
     <<: *default
-    url: <%= ENV['DATABASE_URL'] %>
+    url: <%= ENV.fetch('DATABASE_PROXY_URL', ENV['DATABASE_URL']) %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
-    prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+    # RDS Proxy for Postgres session-pins on prepared statements, so
+    # this must be off whenever the primary role goes through a pooler
+    # — derived from DATABASE_PROXY_URL presence (single source of truth).
+    prepared_statements: <%= ENV['DATABASE_PROXY_URL'].blank? %>
     schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
-  events:
+  direct:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
-    prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+    schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
+    database_tasks: false
+  events:
+    <<: *default
+    url: <%= ENV.fetch('DATABASE_PROXY_URL', ENV['DATABASE_URL']) %>
+    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
+    prepared_statements: <%= ENV['DATABASE_PROXY_URL'].blank? %>
     schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
     database_tasks: false
   clickhouse:

--- a/config/database.yml
+++ b/config/database.yml
@@ -116,9 +116,10 @@ production:
     url: <%= ENV.fetch('DATABASE_PROXY_URL', ENV['DATABASE_URL']) %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
     # RDS Proxy for Postgres session-pins on prepared statements, so
-    # this must be off whenever the primary role goes through a pooler
-    # — derived from DATABASE_PROXY_URL presence (single source of truth).
-    prepared_statements: <%= ENV['DATABASE_PROXY_URL'].blank? %>
+    # this must be off whenever the primary role goes through a pooler.
+    # When DATABASE_PROXY_URL is unset, fall back to the previous
+    # DATABASE_PREPARED_STATEMENTS knob (default true).
+    prepared_statements: <%= ENV['DATABASE_PROXY_URL'].present? ? false : ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
     schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
   direct:
     <<: *default
@@ -130,7 +131,7 @@ production:
     <<: *default
     url: <%= ENV.fetch('DATABASE_PROXY_URL', ENV['DATABASE_URL']) %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
-    prepared_statements: <%= ENV['DATABASE_PROXY_URL'].blank? %>
+    prepared_statements: <%= ENV['DATABASE_PROXY_URL'].present? ? false : ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
     schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
     database_tasks: false
   clickhouse:

--- a/config/initializers/rds_proxy.rb
+++ b/config/initializers/rds_proxy.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-# Activates the RDS Proxy connection patch. See lib/lago/rds_proxy/connection_patch.rb
-# for what the patch does and why.
+# Activates the RDS Proxy connection patch when a pooler URL is configured.
+# See lib/lago/rds_proxy/connection_patch.rb for what the patch does and why.
+# Gated on `DATABASE_PROXY_URL` — its presence is the single source of truth
+# for "a pooler is in front of the database", matching config/database.yml.
 
-if ENV["DATABASE_VIA_RDS_PROXY"].present?
+if ENV["DATABASE_PROXY_URL"].present?
   require "lago/rds_proxy/connection_patch"
 
   # The pg gem auto-sends SET client_encoding when default_internal is set,

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationRecord do
+  describe "database roles" do
+    it "exposes the :writing role (default) mapped to the :primary config" do
+      expect {
+        described_class.connected_to(role: :writing) do
+          described_class.connection.execute("SELECT 1")
+        end
+      }.not_to raise_error
+    end
+
+    it "exposes the :direct role for RDS-Proxy-bypass queries" do
+      expect {
+        described_class.connected_to(role: :direct) do
+          described_class.connection.execute("SELECT 1")
+        end
+      }.not_to raise_error
+    end
+
+    it "restores the previous role after the connected_to block exits" do
+      described_class.connected_to(role: :direct) do
+        # inside block: role is :direct
+      end
+
+      # Outside the block we're back to the default role; a normal query works.
+      expect { described_class.connection.execute("SELECT 1") }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -1553,4 +1553,30 @@ RSpec.describe Subscriptions::OrganizationBillingService do
       end
     end
   end
+
+  describe "database routing" do
+    let(:billing_entity) { create(:billing_entity) }
+    let(:organization) { billing_entity.organization }
+    let(:billing_at) { Time.current }
+
+    it "wraps the >16 KB billable-subscriptions CTE in ApplicationRecord.connected_to(role: :direct)" do
+      # The rendered SQL is ~28 KB and would session-pin RDS Proxy for
+      # Postgres. Verify the query executes on the :direct role so it
+      # bypasses the pooler regardless of which Sidekiq worker picks
+      # the job up. We yield through the stub instead of `and_call_original`
+      # so the underlying query still runs on the default pool — that
+      # keeps this test independent of cross-pool transaction visibility
+      # in the test env, where :direct and :writing resolve to the same URL.
+      wrapped_role = nil
+      allow(ApplicationRecord).to receive(:connected_to) do |role:, &block|
+        wrapped_role = role
+        block.call
+      end
+
+      billing_service.call
+
+      expect(wrapped_role).to eq(:direct)
+      expect(ApplicationRecord).to have_received(:connected_to).with(role: :direct).at_least(:once)
+    end
+  end
 end

--- a/spec/support/monkey_patches/application_record.rb
+++ b/spec/support/monkey_patches/application_record.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# In test env, :direct and :writing point at the same DB but Rails opens
+# distinct pools — separate PG sessions, and DatabaseCleaner only wraps
+# the default pool. Short-circuit the role swap so :direct queries land
+# on the currently-active pool and see fixtures written via :writing.
+class ApplicationRecord < ActiveRecord::Base
+  def self.connected_to(role: nil, **kwargs)
+    return yield if role == :direct
+    super
+  end
+end


### PR DESCRIPTION
## Summary

Route every known >16 KB query away from the RDS Proxy by wrapping the emitting call sites in `ApplicationRecord.connected_to(role: :direct) { ... }`. Introduce a `:direct` role on `ApplicationRecord` that aliases a second connection pool always pointing at the physical database.

Fixes RDS Proxy session-pinning on prod-us-1 for the two query classes visible in `pg_stat_statements` today:

| Emitter | Length | Calls | Where |
|---|---|---|---|
| `Subscriptions::OrganizationBillingService#billable_subscriptions` (18-way UNION CTE + timezone COALESCE branches) | **28,595 B** | 220,375 | clock-worker (`Clock::SubscriptionsBillerJob` → `OrganizationBillingJob`) |
| `Invoice` list eager-load (5 payment-provider join aliases + `id IN ($, …)` page of 100) | **16,200–16,700 B** | ~140k combined across 7 shapes | `lago-api` invoice index endpoints |
| Same shape on `CreditNote` list (`items → fee → …` + 5 payment-provider aliases) | approaches 16 KB with big pages | fewer calls, same failure mode | `lago-api` credit-note index endpoints |

RDS Proxy for PostgreSQL pins any client session that runs a statement over its non-tunable 16 KB threshold. During prod-us-1 load we saw `pinned/borrowed ≈ 1:1` and 100% of proxy pin events attributed to _"SQL query which exceeded the 16384 byte limit"_ — this PR is the app-side half of the fix.

## Env-var contract

| Env vars set | `:writing` (default) | `:direct` | Effect |
|---|---|---|---|
| `DATABASE_URL` only | `DATABASE_URL` | `DATABASE_URL` | No pooler; single pool; `:direct` is a no-op |
| `DATABASE_URL` + `DATABASE_PROXY_URL` | `DATABASE_PROXY_URL` | `DATABASE_URL` | Pooler default; `:direct` bypasses it |

Reads more naturally than the previous shape (where `DATABASE_URL` was the proxy URL and a separate env held the direct connection) — the canonical DB is the DB; the pooler is an optional layer in front. Non-proxied deployments don't need to know the pattern exists.

## Call sites routed direct

1. **`app/services/subscriptions/organization_billing_service.rb`** — wrap the `Subscription.find_by_sql` inside `billable_subscriptions` in `connected_to(role: :direct)`. Only the 28 KB CTE hits `:direct`; the surrounding service continues on the default pool.
2. **`app/controllers/concerns/invoice_index.rb`** — wrap the eager-load + serializer render block. Every `.includes(...)` expansion + `CollectionSerializer` traversal executes on `:direct` for the duration of one page render.
3. **`app/controllers/concerns/credit_note_index.rb`** — same shape as `InvoiceIndex`, same wrapping.

The two concern-based fixes cover every controller that includes them: `Api::V1::InvoicesController`, `Api::V1::Customers::InvoicesController`, `Api::V1::CreditNotesController`, `Api::V1::Customers::CreditNotesController`.

## Deploy sequencing

Needs a matching infra change in `lago-infrastructure`:
1. Every Rails workload has `DATABASE_URL` pointing at the direct RDS endpoint (today it's the proxy).
2. Workloads that should use the proxy also set `DATABASE_PROXY_URL` pointing at the RDS Proxy.

Safe to merge/deploy this PR first — with `DATABASE_PROXY_URL` unset, both roles resolve to `DATABASE_URL` and behaviour is identical to today. The infra layer already has the direct URL sealed as `database.direct.uri` from the earlier lago-infrastructure PR — the follow-up rewires the two secret keys under the new contract.

## Test plan

- [ ] `spec/services/subscriptions/organization_billing_service_spec.rb` passes locally
- [ ] `spec/models/application_record_spec.rb` passes locally (both roles resolve)
- [ ] Local boot without `DATABASE_PROXY_URL` → `:direct` and `:writing` resolve to the same DB, biller returns expected subscriptions
- [ ] Local boot with `DATABASE_PROXY_URL` set → normal traffic hits the pooler, biller + invoice/credit-note index endpoints hit `:direct`
- [ ] After the infra PR lands: on prod-us-1, `DatabaseConnectionsCurrentlySessionPinned` on `lago-production-rails-proxy` drops toward zero
- [ ] RDS Proxy pin log stops reporting the "16384 byte limit" reason for both query classes