### PR TITLE
[ING-494] fix(lifetime_usage): Fix API end-points

### DIFF
--- a/app/controllers/api/v1/subscriptions/lifetime_usages_controller.rb
+++ b/app/controllers/api/v1/subscriptions/lifetime_usages_controller.rb
@@ -3,19 +3,17 @@
 module Api
   module V1
     module Subscriptions
-      class LifetimeUsagesController < Api::BaseController
+      class LifetimeUsagesController < BaseController
         def show
           # Note: lifetime usage is counted against all sub upgrades-downgrades
-          lifetime_usage = current_organization.subscriptions
-            .find_by(external_id: params[:subscription_external_id])&.lifetime_usage
+          lifetime_usage = subscription&.lifetime_usage
 
           return not_found_error(resource: "lifetime_usage") unless lifetime_usage
           render_lifetime_usage lifetime_usage
         end
 
         def update
-          lifetime_usage = current_organization.subscriptions
-            .find_by(external_id: params[:subscription_external_id])&.lifetime_usage
+          lifetime_usage = subscription&.lifetime_usage
 
           result = LifetimeUsages::UpdateService.call(
             lifetime_usage:,

--- a/spec/requests/api/v1/subscriptions/lifetime_usages_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/lifetime_usages_controller_spec.rb
@@ -44,6 +44,54 @@ RSpec.describe Api::V1::Subscriptions::LifetimeUsagesController do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "when subscription belongs to another organization" do
+      subject { get_with_token(other_organization, "/api/v1/subscriptions/#{external_id}/lifetime_usage") }
+
+      let(:other_organization) { create(:organization) }
+
+      it "returns not found" do
+        subject
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the subscription was upgraded and shares its external_id with a terminated one" do
+      let(:terminated_subscription) do
+        create(
+          :subscription,
+          :terminated,
+          plan:,
+          organization:,
+          customer:,
+          external_id: subscription.external_id
+        )
+      end
+      let!(:terminated_lifetime_usage) { create(:lifetime_usage, organization:, subscription: terminated_subscription) }
+
+      it "returns the active subscription lifetime_usage" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:lifetime_usage][:lago_id]).to eq(lifetime_usage.id)
+      end
+
+      context "when the terminated status is requested" do
+        subject do
+          get_with_token(
+            organization,
+            "/api/v1/subscriptions/#{external_id}/lifetime_usage?status=terminated"
+          )
+        end
+
+        it "returns the terminated subscription lifetime_usage" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:lifetime_usage][:lago_id]).to eq(terminated_lifetime_usage.id)
+        end
+      end
+    end
   end
 
   describe "PUT /api/v1/subscriptions/:subscription_external_id/lifetime_usage" do


### PR DESCRIPTION
## Context

When a subscription reuses the same `external_id` with a previously terminated one. The lifetime usage endpoint resolved it with a plain `find_by(external_id:)`, which could return the old terminated subscription and report a stale amount, disagreeing with the UI.

## Description

Inherit from `Subscriptions::BaseController` so the subscription is resolved through the shared `find_subscription`, scoped to the organization and defaulting to the `active` status. The endpoint now returns the current subscription's lifetime usage.