### PR TITLE
chore(clickhouse): Keep milliseconds in enriched_at

### DIFF
--- a/db/clickhouse_migrate/20260727090000_set_events_enriched_at_default_to_now64.rb
+++ b/db/clickhouse_migrate/20260727090000_set_events_enriched_at_default_to_now64.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class SetEventsEnrichedAtDefaultToNow64 < ActiveRecord::Migration[8.0]
+  TABLES = %w[events_enriched events_enriched_expanded].freeze
+
+  # now() returns a DateTime, whose resolution is one second, so inserting it into the
+  # DateTime64(3) enriched_at column zero-filled the fraction. Every event enriched within the
+  # same second got an identical enriched_at, which made MAX(enriched_at) unable to distinguish
+  # two separate inserts landing in that second and broke the lazy usage cache invalidation.
+  # now64(3) reads the clock with sub-second precision. Column type is unchanged, so this only
+  # updates the default expression and does not rewrite existing data.
+  def up
+    safety_assured do
+      TABLES.each do |table|
+        execute "ALTER TABLE #{table} MODIFY COLUMN enriched_at DateTime64(3) DEFAULT now64(3)"
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      TABLES.each do |table|
+        execute "ALTER TABLE #{table} MODIFY COLUMN enriched_at DateTime64(3) DEFAULT now()"
+      end
+    end
+  end
+end

--- a/db/clickhouse_migrate/cloud/02_events_enriched.sql
+++ b/db/clickhouse_migrate/cloud/02_events_enriched.sql
@@ -7,7 +7,7 @@ CREATE TABLE default.events_enriched
     `transaction_id` String,
     `properties` Map(String, String),
     `sorted_properties` Map(String, String) DEFAULT mapSort(properties),
-    `enriched_at` DateTime64(3) DEFAULT now(),
+    `enriched_at` DateTime64(3) DEFAULT now64(3),
     `value` Nullable(String),
     `decimal_value` Nullable(Decimal(38, 26)) DEFAULT toDecimal128OrZero(value, 26),
     `precise_total_amount_cents` Nullable(Decimal(40, 15))

--- a/db/clickhouse_migrate/cloud/05_events_enriched_expanded.sql
+++ b/db/clickhouse_migrate/cloud/05_events_enriched_expanded.sql
@@ -11,7 +11,7 @@ CREATE TABLE events_enriched_expanded
     `sorted_properties` Map(String, String) DEFAULT mapSort(JSONExtract(CAST(properties, 'String'), 'Map(String, String)')),
     `value` Nullable(String),
     `decimal_value` Nullable(Decimal(38, 26)) DEFAULT toDecimal128OrZero(value, 26),
-    `enriched_at` DateTime64(3) DEFAULT now(),
+    `enriched_at` DateTime64(3) DEFAULT now64(3),
     `precise_total_amount_cents` Nullable(Decimal(40, 15)),
     `subscription_id` String DEFAULT '',
     `plan_id` String DEFAULT '',

--- a/spec/services/events/enrich_service_spec.rb
+++ b/spec/services/events/enrich_service_spec.rb
@@ -53,6 +53,46 @@ RSpec.describe Events::EnrichService do
       )
     end
 
+    # enriched_at is what the lazy usage cache compares against to decide whether a cached usage
+    # value is stale, so losing its sub-second precision makes two enrichments within the same
+    # second indistinguishable. The assertion above (be_within(1.second)) would not catch that.
+    describe "enriched_at precision" do
+      # NOTE: travel_to and freeze_time zero out usec unless with_usec is passed, which would make
+      #       every assertion below pass trivially against a floored timestamp.
+      let(:frozen_at) { Time.zone.parse("2026-07-27T05:31:15.123456Z") }
+
+      # enriched_events is created with id: false and no primary key constraint, so #reload cannot
+      # build a WHERE clause. Re-query through the unique index instead.
+      def persisted_enriched_at
+        EnrichedEvent
+          .where(organization_id: organization.id, transaction_id: event.transaction_id)
+          .pick(:enriched_at)
+      end
+
+      it "stamps enriched_at with the full sub-second precision of the current time" do
+        enriched_event = travel_to(frozen_at, with_usec: true) do
+          enrich_service.call.enriched_events.first
+        end
+
+        expect(enriched_event.enriched_at).to eq(frozen_at)
+        expect(enriched_event.enriched_at.usec).to eq(123_456)
+      end
+
+      it "keeps the sub-second precision through the database round trip" do
+        travel_to(frozen_at, with_usec: true) { enrich_service.call }
+
+        # enriched_events.enriched_at is timestamp(6), so the microseconds must survive the write.
+        expect(persisted_enriched_at.usec).to eq(123_456)
+      end
+
+      it "does not floor enriched_at to the second" do
+        travel_to(frozen_at, with_usec: true) { enrich_service.call }
+
+        expect(persisted_enriched_at).to eq(frozen_at)
+        expect(persisted_enriched_at).not_to eq(frozen_at.change(usec: 0))
+      end
+    end
+
     context "with a precise_total_amount_cents set on the event" do
       let(:event) do
         create(


### PR DESCRIPTION
## Context

Change precision of default timestamp for enriched events
