### PR TITLE
Chore: add 1s of delay before writing the cache

### DIFF
--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -58,15 +58,22 @@ class CacheService < BaseService
   def wrap(value, computed_at)
     return value unless track_created_at?
 
-    # cached_at is the moment the value was computed, never the timestamp of the last seen event.
-    # Stamping it with invalidate_if_older_than would store the exact value the next read compares
-    # against, so the entry would be discarded on every read and never serve.
+    # cached_at is a watermark of what the value aggregated, not a wall clock reading. It must stay
+    # the last seen event timestamp so that *any* event above it invalidates the entry.
+    #
+    # Stamping Time.current instead would open a hole: ClickHouse fills enriched_at with now(),
+    # which floors to the second, so an event inserted at 05:31:15.6 is recorded as 05:31:15.000 -
+    # earlier than a snapshot taken at 05:31:15.400. An event that landed after the aggregation
+    # would then compare as already covered, and the entry would serve usage that misses it for the
+    # rest of the billing period. Comparing a precise clock against a floored one is unsound.
     #
     # Keep sub-second precision: event timestamps carry milliseconds (ClickHouse enriched_at is
-    # DateTime64(3)) or microseconds (Postgres). A bare iso8601 floors to whole seconds, so an
-    # event enriched earlier in the same second as the computation would look newer than the entry
-    # and wrongly recompute on every read, defeating the cache.
-    {"cached_at" => computed_at.iso8601(6), "value" => value}
+    # DateTime64(3)) or microseconds (Postgres), and a bare iso8601 would floor them.
+    #
+    # With no event seen yet, fall back to the conservative bound the settle gate already used,
+    # never to Time.current, for the same reason.
+    cached_at = (invalidate_if_older_than || computed_at - SETTLE_WINDOW).iso8601(6)
+    {"cached_at" => cached_at, "value" => value}
   end
 
   # An event enriched at the boundary timestamp may still be committing when the aggregation runs.

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class CacheService < BaseService
+  # How long a boundary timestamp must have settled before the value computed at that boundary can
+  # be cached. See #settled? for why an unsettled boundary cannot be cached at all.
+  SETTLE_WINDOW = 1.second
+
   def initialize(*, expires_in: nil, invalidate_if_older_than: nil)
     @expires_in = expires_in
     @invalidate_if_older_than = invalidate_if_older_than

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -21,11 +21,16 @@ class CacheService < BaseService
     cached = Rails.cache.read(cache_key)
     return unwrap(cached) if cached && valid_cache?(cached)
 
+    # Snapshot the time *before* computing, so an event enriched while the block runs is stamped
+    # after the cache entry and invalidates it on the next read. Stamping after the block would
+    # swallow every event ingested during the aggregation, which is the slow part.
+    computed_at = Time.current
+
     value = yield
 
     # NOTE: It seems that passing expires_in: 0 is not a NO-OP, so bypass manually
-    if expires_in.nil? || expires_in > 0
-      Rails.cache.write(cache_key, wrap(value), expires_in:)
+    if (expires_in.nil? || expires_in > 0) && settled?(computed_at)
+      Rails.cache.write(cache_key, wrap(value, computed_at), expires_in:)
     end
 
     value
@@ -46,15 +51,33 @@ class CacheService < BaseService
     false
   end
 
-  def wrap(value)
+  def wrap(value, computed_at)
     return value unless track_created_at?
 
+    # cached_at is the moment the value was computed, never the timestamp of the last seen event.
+    # Stamping it with invalidate_if_older_than would store the exact value the next read compares
+    # against, so the entry would be discarded on every read and never serve.
+    #
     # Keep sub-second precision: event timestamps carry milliseconds (ClickHouse enriched_at is
-    # DateTime64(3)) or microseconds (Postgres). A bare iso8601 floors to whole seconds, so a
-    # re-read for the very same event would compare a floored cached_at against the unfloored
-    # timestamp and wrongly recompute on every read, defeating the cache.
-    cached_at = (invalidate_if_older_than || Time.current).iso8601(6)
-    {"cached_at" => cached_at, "value" => value}
+    # DateTime64(3)) or microseconds (Postgres). A bare iso8601 floors to whole seconds, so an
+    # event enriched earlier in the same second as the computation would look newer than the entry
+    # and wrongly recompute on every read, defeating the cache.
+    {"cached_at" => computed_at.iso8601(6), "value" => value}
+  end
+
+  # An event enriched at the boundary timestamp may still be committing when the aggregation runs.
+  # ClickHouse populates enriched_at with now(), which has one-second resolution, so such a sibling
+  # is invisible to the invalidation: MAX(enriched_at) is byte-identical with or without it, and the
+  # entry would keep serving usage that misses it. Refuse to cache until the boundary has settled.
+  #
+  # The window is measured from the pre-aggregation snapshot rather than Time.current, because what
+  # matters is whether the boundary was already settled when the events were read, not how long the
+  # aggregation happened to take afterwards.
+  def settled?(computed_at)
+    return true unless track_created_at?
+    return true if invalidate_if_older_than.nil?
+
+    invalidate_if_older_than < computed_at - SETTLE_WINDOW
   end
 
   def unwrap(cached)
@@ -72,6 +95,6 @@ class CacheService < BaseService
     cached_at = cached.is_a?(Hash) ? cached["cached_at"] : nil
     return false if cached_at.nil?
 
-    Time.iso8601(cached_at) >= invalidate_if_older_than
+    Time.iso8601(cached_at) > invalidate_if_older_than
   end
 end

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -99,6 +99,6 @@ class CacheService < BaseService
     cached_at = cached.is_a?(Hash) ? cached["cached_at"] : nil
     return false if cached_at.nil?
 
-    Time.iso8601(cached_at) > invalidate_if_older_than
+    Time.iso8601(cached_at) >= invalidate_if_older_than
   end
 end

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class CacheService < BaseService
-  # How long a boundary timestamp must have settled before the value computed at that boundary can
-  # be cached. See #settled? for why an unsettled boundary cannot be cached at all.
+  # How long after latest event is enriched is needed to settle on Clickhouse side
   SETTLE_WINDOW = 1.second
 
   def initialize(*, expires_in: nil, invalidate_if_older_than: nil)
@@ -25,9 +24,9 @@ class CacheService < BaseService
     cached = Rails.cache.read(cache_key)
     return unwrap(cached) if cached && valid_cache?(cached)
 
-    # Snapshot the time *before* computing, so an event enriched while the block runs is stamped
-    # after the cache entry and invalidates it on the next read. Stamping after the block would
-    # swallow every event ingested during the aggregation, which is the slow part.
+    # Snapshot the time *before* computing, so the settle gate asks whether the boundary was already
+    # settled when the events were read. Reading the clock after the block would let a slow
+    # aggregation make a boundary that was hot at read time look settled by the time we write.
     computed_at = Time.current
 
     value = yield
@@ -61,29 +60,19 @@ class CacheService < BaseService
     # cached_at is a watermark of what the value aggregated, not a wall clock reading. It must stay
     # the last seen event timestamp so that *any* event above it invalidates the entry.
     #
-    # Stamping Time.current instead would open a hole: ClickHouse fills enriched_at with now(),
-    # which floors to the second, so an event inserted at 05:31:15.6 is recorded as 05:31:15.000 -
-    # earlier than a snapshot taken at 05:31:15.400. An event that landed after the aggregation
-    # would then compare as already covered, and the entry would serve usage that misses it for the
-    # rest of the billing period. Comparing a precise clock against a floored one is unsound.
-    #
-    # Keep sub-second precision: event timestamps carry milliseconds (ClickHouse enriched_at is
-    # DateTime64(3)) or microseconds (Postgres), and a bare iso8601 would floor them.
-    #
-    # With no event seen yet, fall back to the conservative bound the settle gate already used,
-    # never to Time.current, for the same reason.
+    # With no event seen yet there is no watermark to use, so fall back to the same conservative
+    # bound the settle gate applies rather than to Time.current
     cached_at = (invalidate_if_older_than || computed_at - SETTLE_WINDOW).iso8601(6)
     {"cached_at" => cached_at, "value" => value}
   end
 
   # An event enriched at the boundary timestamp may still be committing when the aggregation runs.
-  # ClickHouse populates enriched_at with now(), which has one-second resolution, so such a sibling
-  # is invisible to the invalidation: MAX(enriched_at) is byte-identical with or without it, and the
-  # entry would keep serving usage that misses it. Refuse to cache until the boundary has settled.
+  # ClickHouse stamps enriched_at with now64(3) when the insert *begins*, not when the row becomes
+  # readable, so a sibling sharing that timestamp can land after the aggregation and stay invisible
+  # to the invalidation: MAX(enriched_at) is unchanged with or without it, and the entry would keep
+  # serving usage that misses it until the billing period ends. Refuse to cache a boundary that fresh.
   #
-  # The window is measured from the pre-aggregation snapshot rather than Time.current, because what
-  # matters is whether the boundary was already settled when the events were read, not how long the
-  # aggregation happened to take afterwards.
+  # The window has to cover the insert-to-readable gap
   def settled?(computed_at)
     return true unless track_created_at?
     return true if invalidate_if_older_than.nil?

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -125,22 +125,7 @@ RSpec.describe CacheService do
     end
 
     describe "stamping" do
-      it "wraps the stored value with the computation time" do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-
-        freeze_time do
-          result = tracking_cache_service_class.new("test").call { new_value }
-
-          expect(result).to eq(new_value)
-          expect(Rails.cache).to have_received(:write).with(
-            cache_key,
-            {"cached_at" => Time.current.iso8601(6), "value" => new_value},
-            expires_in: nil
-          )
-        end
-      end
-
-      it "stamps cached_at with the computation time, not the last seen event timestamp" do
+      it "stamps cached_at with the last seen event timestamp, not the computation time" do
         allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
         last_seen_at = Time.zone.parse("2026-07-27T10:00:00.123Z")
         computed_at = Time.zone.parse("2026-07-27T10:05:00.000Z")
@@ -151,12 +136,42 @@ RSpec.describe CacheService do
 
         expect(Rails.cache).to have_received(:write).with(
           cache_key,
-          {"cached_at" => computed_at.iso8601(6), "value" => new_value},
+          {"cached_at" => last_seen_at.iso8601(6), "value" => new_value},
           expires_in: nil
         )
       end
 
-      it "stamps cached_at before the block runs, not after it returns" do
+      it "keeps the sub-second precision of the last seen event timestamp" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+        last_seen_at = Time.zone.parse("2026-07-27T10:00:00.750Z")
+
+        travel_to(last_seen_at + 1.hour, with_usec: true) do
+          tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at).call { new_value }
+        end
+
+        expect(Rails.cache).to have_received(:write).with(
+          cache_key,
+          {"cached_at" => "2026-07-27T10:00:00.750000Z", "value" => new_value},
+          expires_in: nil
+        )
+      end
+
+      it "falls back to the settle bound, never Time.current, when no event was seen" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+        computed_at = Time.zone.parse("2026-07-27T10:00:00.500Z")
+
+        travel_to(computed_at, with_usec: true) do
+          tracking_cache_service_class.new("test").call { new_value }
+        end
+
+        expect(Rails.cache).to have_received(:write).with(
+          cache_key,
+          {"cached_at" => (computed_at - described_class::SETTLE_WINDOW).iso8601(6), "value" => new_value},
+          expires_in: nil
+        )
+      end
+
+      it "takes the fallback bound before the block runs, not after it returns" do
         allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
         started_at = Time.zone.parse("2026-07-27T10:00:00.500Z")
 
@@ -170,21 +185,7 @@ RSpec.describe CacheService do
 
         expect(Rails.cache).to have_received(:write).with(
           cache_key,
-          {"cached_at" => started_at.iso8601(6), "value" => new_value},
-          expires_in: nil
-        )
-      end
-
-      it "keeps the sub-second precision of the computation time" do
-        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-
-        travel_to(Time.zone.parse("2026-07-27T10:00:00.750Z"), with_usec: true) do
-          tracking_cache_service_class.new("test").call { new_value }
-        end
-
-        expect(Rails.cache).to have_received(:write).with(
-          cache_key,
-          {"cached_at" => "2026-07-27T10:00:00.750000Z", "value" => new_value},
+          {"cached_at" => (started_at - described_class::SETTLE_WINDOW).iso8601(6), "value" => new_value},
           expires_in: nil
         )
       end
@@ -225,7 +226,7 @@ RSpec.describe CacheService do
 
         expect(Rails.cache).to have_received(:write).with(
           cache_key,
-          {"cached_at" => computed_at.iso8601(6), "value" => new_value},
+          {"cached_at" => boundary.iso8601(6), "value" => new_value},
           expires_in: nil
         )
       end
@@ -261,16 +262,27 @@ RSpec.describe CacheService do
         expect(Rails.cache).to have_received(:write).with(service.cache_key, new_value, expires_in: nil)
       end
 
-      # The production trace: events enriched at 05:31:13 and 05:31:15, usage aggregated at
-      # 05:31:15.4 between two inserts that both stamped 05:31:15. Caching there would have pinned
-      # a 4-event result that MAX(enriched_at) could never invalidate.
-      it "refuses to cache the usage aggregated between two inserts sharing a second" do
+      # End-to-end guard for the reported bug, and the example that fails without the settle gate.
+      #
+      # Production trace: events enriched at 05:31:13 and 05:31:15, usage aggregated at 05:31:15.4
+      # between two inserts that both floor to 05:31:15, so it counts only some of them. Without the
+      # gate the partial value is cached under cached_at = 05:31:15; the sibling never moves
+      # MAX(enriched_at), 05:31:15 >= 05:31:15 holds on every later read, and the partial usage is
+      # served until the entry expires at the end of the billing period.
+      it "does not serve a partial usage computed while the boundary was unsettled" do
         newest_event = Time.zone.parse("2026-07-27T05:31:15.000Z")
 
-        expect(write_entry(computed_at: newest_event + 0.4.seconds, invalidate_if_older_than: newest_event)).to be_nil
+        partial = write_entry(
+          computed_at: newest_event + 0.4.seconds,
+          invalidate_if_older_than: newest_event,
+          value: "partial-usage"
+        )
+        expect(partial).to be_nil
 
-        wrapped = write_entry(computed_at: newest_event + 10.seconds, invalidate_if_older_than: newest_event)
-        expect(wrapped).to eq({"cached_at" => (newest_event + 10.seconds).iso8601(6), "value" => "new_value"})
+        result, block_called = read_entry(partial, invalidate_if_older_than: newest_event)
+
+        expect(block_called).to be true
+        expect(result).to eq("recomputed")
       end
     end
 
@@ -286,17 +298,22 @@ RSpec.describe CacheService do
         expect(result).to eq("recomputed")
       end
 
-      # cached_at is a wall clock reading taken before the aggregation, so a boundary landing on the
-      # exact same microsecond was already ingested when the events were read. The comparison is
-      # inclusive on purpose; SETTLE_WINDOW is what guards an untrustworthy boundary.
-      it "serves the cached value when an event shares the exact microsecond of the computation" do
-        computed_at = Time.zone.parse("2026-07-27T10:00:00.123456Z")
+      # Regression guard. An event inserted *after* the aggregation can carry an *earlier*
+      # enriched_at, because ClickHouse fills it with now(), which floors to the second. Stamping
+      # cached_at with a wall clock reading compares a precise time against a floored one, treats
+      # that event as already covered, and pins the entry for the rest of the billing period.
+      # The stamp must stay the last seen event timestamp for this to invalidate.
+      it "recomputes when an event landing after the aggregation floors to an earlier second" do
+        last_seen_at = Time.zone.parse("2026-07-27T05:30:00.000Z")
+        computed_at = Time.zone.parse("2026-07-27T05:31:15.400Z")
+        # inserted at 05:31:15.6, recorded as 05:31:15.000 - before the computation
+        floored_enriched_at = Time.zone.parse("2026-07-27T05:31:15.000Z")
 
-        wrapped = write_entry(computed_at:, invalidate_if_older_than: computed_at - 1.hour)
-        result, block_called = read_entry(wrapped, invalidate_if_older_than: computed_at)
+        wrapped = write_entry(computed_at:, invalidate_if_older_than: last_seen_at)
+        result, block_called = read_entry(wrapped, invalidate_if_older_than: floored_enriched_at)
 
-        expect(block_called).to be false
-        expect(result).to eq("new_value")
+        expect(block_called).to be true
+        expect(result).to eq("recomputed")
       end
 
       it "serves the cached value on a re-read for the same last seen event" do

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe CacheService do
       wrapped = nil
       allow(Rails.cache).to receive(:write) { |_key, written, **| wrapped = written }
 
-      travel_to(computed_at) do
+      travel_to(computed_at, with_usec: true) do
         tracking_cache_service_class.new("test", invalidate_if_older_than:).call { value }
       end
 
@@ -145,7 +145,7 @@ RSpec.describe CacheService do
         last_seen_at = Time.zone.parse("2026-07-27T10:00:00.123Z")
         computed_at = Time.zone.parse("2026-07-27T10:05:00.000Z")
 
-        travel_to(computed_at) do
+        travel_to(computed_at, with_usec: true) do
           tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at).call { new_value }
         end
 
@@ -160,10 +160,10 @@ RSpec.describe CacheService do
         allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
         started_at = Time.zone.parse("2026-07-27T10:00:00.500Z")
 
-        travel_to(started_at) do
+        travel_to(started_at, with_usec: true) do
           tracking_cache_service_class.new("test").call do
             # The aggregation is the slow part: simulate it taking 30 seconds.
-            travel_to(started_at + 30.seconds)
+            travel_to(started_at + 30.seconds, with_usec: true)
             new_value
           end
         end
@@ -178,7 +178,7 @@ RSpec.describe CacheService do
       it "keeps the sub-second precision of the computation time" do
         allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
 
-        travel_to(Time.zone.parse("2026-07-27T10:00:00.750Z")) do
+        travel_to(Time.zone.parse("2026-07-27T10:00:00.750Z"), with_usec: true) do
           tracking_cache_service_class.new("test").call { new_value }
         end
 
@@ -196,7 +196,7 @@ RSpec.describe CacheService do
       it "does not cache a value computed while the boundary is still unsettled" do
         allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
 
-        travel_to(boundary + 0.4.seconds) do
+        travel_to(boundary + 0.4.seconds, with_usec: true) do
           result = tracking_cache_service_class.new("test", invalidate_if_older_than: boundary).call { new_value }
 
           expect(result).to eq(new_value)
@@ -208,7 +208,7 @@ RSpec.describe CacheService do
       it "does not cache a value computed exactly at the edge of the window" do
         allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
 
-        travel_to(boundary + described_class::SETTLE_WINDOW) do
+        travel_to(boundary + described_class::SETTLE_WINDOW, with_usec: true) do
           tracking_cache_service_class.new("test", invalidate_if_older_than: boundary).call { new_value }
         end
 
@@ -219,7 +219,7 @@ RSpec.describe CacheService do
         allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
         computed_at = boundary + described_class::SETTLE_WINDOW + 1.second
 
-        travel_to(computed_at) do
+        travel_to(computed_at, with_usec: true) do
           tracking_cache_service_class.new("test", invalidate_if_older_than: boundary).call { new_value }
         end
 
@@ -234,9 +234,9 @@ RSpec.describe CacheService do
         allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
         started_at = boundary + 0.4.seconds
 
-        travel_to(started_at) do
+        travel_to(started_at, with_usec: true) do
           tracking_cache_service_class.new("test", invalidate_if_older_than: boundary).call do
-            travel_to(started_at + 30.seconds)
+            travel_to(started_at + 30.seconds, with_usec: true)
             new_value
           end
         end
@@ -286,14 +286,17 @@ RSpec.describe CacheService do
         expect(result).to eq("recomputed")
       end
 
-      it "recomputes when an event shares the exact microsecond of the computation" do
+      # cached_at is a wall clock reading taken before the aggregation, so a boundary landing on the
+      # exact same microsecond was already ingested when the events were read. The comparison is
+      # inclusive on purpose; SETTLE_WINDOW is what guards an untrustworthy boundary.
+      it "serves the cached value when an event shares the exact microsecond of the computation" do
         computed_at = Time.zone.parse("2026-07-27T10:00:00.123456Z")
 
         wrapped = write_entry(computed_at:, invalidate_if_older_than: computed_at - 1.hour)
         result, block_called = read_entry(wrapped, invalidate_if_older_than: computed_at)
 
-        expect(block_called).to be true
-        expect(result).to eq("recomputed")
+        expect(block_called).to be false
+        expect(result).to eq("new_value")
       end
 
       it "serves the cached value on a re-read for the same last seen event" do
@@ -310,7 +313,7 @@ RSpec.describe CacheService do
         last_seen_at = Time.zone.parse("2026-07-27T10:00:00.123Z")
         wrapped = write_entry(computed_at: last_seen_at + 10.seconds, invalidate_if_older_than: last_seen_at)
 
-        blocks_called = 3.times.map do
+        blocks_called = Array.new(3) do
           _result, block_called = read_entry(wrapped, invalidate_if_older_than: last_seen_at)
           block_called
         end

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -95,51 +95,240 @@ RSpec.describe CacheService do
 
     before { allow(Rails.cache).to receive(:write) }
 
-    it "wraps the stored value, falling back to the write time when no event was seen" do
+    # Writes an entry through the service and returns the wrapped hash handed to Rails.cache (nil
+    # when the service refused to cache), so a second call can read it back the way a subsequent
+    # usage query would. invalidate_if_older_than must be older than SETTLE_WINDOW for a write.
+    def write_entry(computed_at:, invalidate_if_older_than: nil, value: "new_value")
       allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
 
-      freeze_time do
-        result = tracking_cache_service_class.new("test").call { new_value }
+      wrapped = nil
+      allow(Rails.cache).to receive(:write) { |_key, written, **| wrapped = written }
 
-        expect(result).to eq(new_value)
+      travel_to(computed_at) do
+        tracking_cache_service_class.new("test", invalidate_if_older_than:).call { value }
+      end
+
+      wrapped
+    end
+
+    # Replays a usage query against an already stored entry, returning [result, block_called].
+    def read_entry(wrapped, invalidate_if_older_than:)
+      allow(Rails.cache).to receive(:read).with(cache_key).and_return(wrapped)
+
+      block_called = false
+      result = tracking_cache_service_class.new("test", invalidate_if_older_than:).call do
+        block_called = true
+        "recomputed"
+      end
+
+      [result, block_called]
+    end
+
+    describe "stamping" do
+      it "wraps the stored value with the computation time" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+
+        freeze_time do
+          result = tracking_cache_service_class.new("test").call { new_value }
+
+          expect(result).to eq(new_value)
+          expect(Rails.cache).to have_received(:write).with(
+            cache_key,
+            {"cached_at" => Time.current.iso8601(6), "value" => new_value},
+            expires_in: nil
+          )
+        end
+      end
+
+      it "stamps cached_at with the computation time, not the last seen event timestamp" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+        last_seen_at = Time.zone.parse("2026-07-27T10:00:00.123Z")
+        computed_at = Time.zone.parse("2026-07-27T10:05:00.000Z")
+
+        travel_to(computed_at) do
+          tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at).call { new_value }
+        end
+
         expect(Rails.cache).to have_received(:write).with(
           cache_key,
-          {"cached_at" => Time.current.iso8601(6), "value" => new_value},
+          {"cached_at" => computed_at.iso8601(6), "value" => new_value},
+          expires_in: nil
+        )
+      end
+
+      it "stamps cached_at before the block runs, not after it returns" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+        started_at = Time.zone.parse("2026-07-27T10:00:00.500Z")
+
+        travel_to(started_at) do
+          tracking_cache_service_class.new("test").call do
+            # The aggregation is the slow part: simulate it taking 30 seconds.
+            travel_to(started_at + 30.seconds)
+            new_value
+          end
+        end
+
+        expect(Rails.cache).to have_received(:write).with(
+          cache_key,
+          {"cached_at" => started_at.iso8601(6), "value" => new_value},
+          expires_in: nil
+        )
+      end
+
+      it "keeps the sub-second precision of the computation time" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+
+        travel_to(Time.zone.parse("2026-07-27T10:00:00.750Z")) do
+          tracking_cache_service_class.new("test").call { new_value }
+        end
+
+        expect(Rails.cache).to have_received(:write).with(
+          cache_key,
+          {"cached_at" => "2026-07-27T10:00:00.750000Z", "value" => new_value},
           expires_in: nil
         )
       end
     end
 
-    it "stamps cached_at with the last seen event timestamp, not the write time" do
-      allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-      last_seen_at = 3.hours.ago
+    describe "settle window" do
+      let(:boundary) { Time.zone.parse("2026-07-27T10:00:00.000Z") }
 
-      tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at).call { new_value }
+      it "does not cache a value computed while the boundary is still unsettled" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
 
-      expect(Rails.cache).to have_received(:write).with(
-        cache_key,
-        {"cached_at" => last_seen_at.iso8601(6), "value" => new_value},
-        expires_in: nil
-      )
+        travel_to(boundary + 0.4.seconds) do
+          result = tracking_cache_service_class.new("test", invalidate_if_older_than: boundary).call { new_value }
+
+          expect(result).to eq(new_value)
+        end
+
+        expect(Rails.cache).not_to have_received(:write)
+      end
+
+      it "does not cache a value computed exactly at the edge of the window" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+
+        travel_to(boundary + described_class::SETTLE_WINDOW) do
+          tracking_cache_service_class.new("test", invalidate_if_older_than: boundary).call { new_value }
+        end
+
+        expect(Rails.cache).not_to have_received(:write)
+      end
+
+      it "caches once the boundary is older than the window" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+        computed_at = boundary + described_class::SETTLE_WINDOW + 1.second
+
+        travel_to(computed_at) do
+          tracking_cache_service_class.new("test", invalidate_if_older_than: boundary).call { new_value }
+        end
+
+        expect(Rails.cache).to have_received(:write).with(
+          cache_key,
+          {"cached_at" => computed_at.iso8601(6), "value" => new_value},
+          expires_in: nil
+        )
+      end
+
+      it "measures the window from before the block, so a slow aggregation cannot fake a settled boundary" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+        started_at = boundary + 0.4.seconds
+
+        travel_to(started_at) do
+          tracking_cache_service_class.new("test", invalidate_if_older_than: boundary).call do
+            travel_to(started_at + 30.seconds)
+            new_value
+          end
+        end
+
+        expect(Rails.cache).not_to have_received(:write)
+      end
+
+      it "caches when no last seen event timestamp is given" do
+        allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+
+        tracking_cache_service_class.new("test").call { new_value }
+
+        expect(Rails.cache).to have_received(:write)
+      end
+
+      it "does not gate services that do not track the creation time" do
+        service = test_cache_service_class.new("untracked")
+        allow(Rails.cache).to receive(:read).with(service.cache_key).and_return(nil)
+
+        service.call { new_value }
+
+        expect(Rails.cache).to have_received(:write).with(service.cache_key, new_value, expires_in: nil)
+      end
+
+      # The production trace: events enriched at 05:31:13 and 05:31:15, usage aggregated at
+      # 05:31:15.4 between two inserts that both stamped 05:31:15. Caching there would have pinned
+      # a 4-event result that MAX(enriched_at) could never invalidate.
+      it "refuses to cache the usage aggregated between two inserts sharing a second" do
+        newest_event = Time.zone.parse("2026-07-27T05:31:15.000Z")
+
+        expect(write_entry(computed_at: newest_event + 0.4.seconds, invalidate_if_older_than: newest_event)).to be_nil
+
+        wrapped = write_entry(computed_at: newest_event + 10.seconds, invalidate_if_older_than: newest_event)
+        expect(wrapped).to eq({"cached_at" => (newest_event + 10.seconds).iso8601(6), "value" => "new_value"})
+      end
     end
 
-    it "keeps the sub-second precision so a re-read for the same event stays valid" do
-      last_seen_at = Time.current.change(usec: 750_000)
+    describe "invalidation" do
+      it "recomputes when an event was enriched while the block was computing" do
+        computed_at = Time.zone.parse("2026-07-27T10:00:00.500Z")
+        enriched_mid_compute = computed_at + 2.seconds
 
-      allow(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-      tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at).call { new_value }
+        wrapped = write_entry(computed_at:, invalidate_if_older_than: computed_at - 3.hours)
+        result, block_called = read_entry(wrapped, invalidate_if_older_than: enriched_mid_compute)
 
-      wrapped = nil
-      expect(Rails.cache).to have_received(:write) { |_key, value, **| wrapped = value }
+        expect(block_called).to be true
+        expect(result).to eq("recomputed")
+      end
 
-      allow(Rails.cache).to receive(:read).with(cache_key).and_return(wrapped)
-      service = tracking_cache_service_class.new("test", invalidate_if_older_than: last_seen_at)
+      it "recomputes when an event shares the exact microsecond of the computation" do
+        computed_at = Time.zone.parse("2026-07-27T10:00:00.123456Z")
 
-      block_called = false
-      result = service.call { block_called = true }
+        wrapped = write_entry(computed_at:, invalidate_if_older_than: computed_at - 1.hour)
+        result, block_called = read_entry(wrapped, invalidate_if_older_than: computed_at)
 
-      expect(result).to eq(new_value)
-      expect(block_called).to be false
+        expect(block_called).to be true
+        expect(result).to eq("recomputed")
+      end
+
+      it "serves the cached value on a re-read for the same last seen event" do
+        last_seen_at = Time.zone.parse("2026-07-27T10:00:00.123Z")
+
+        wrapped = write_entry(computed_at: last_seen_at + 10.seconds, invalidate_if_older_than: last_seen_at)
+        result, block_called = read_entry(wrapped, invalidate_if_older_than: last_seen_at)
+
+        expect(result).to eq("new_value")
+        expect(block_called).to be false
+      end
+
+      it "keeps serving the cached value across repeated usage queries" do
+        last_seen_at = Time.zone.parse("2026-07-27T10:00:00.123Z")
+        wrapped = write_entry(computed_at: last_seen_at + 10.seconds, invalidate_if_older_than: last_seen_at)
+
+        blocks_called = 3.times.map do
+          _result, block_called = read_entry(wrapped, invalidate_if_older_than: last_seen_at)
+          block_called
+        end
+
+        expect(blocks_called).to all(be false)
+      end
+
+      it "serves the cached value for a recurring charge seeded with the period start" do
+        # Recurring charges without in-period events are seeded with boundaries.charges_from_datetime,
+        # a constant for the whole period, so they must still benefit from the cache.
+        period_start = Time.zone.parse("2026-07-01T00:00:00.000Z")
+
+        wrapped = write_entry(computed_at: period_start + 5.days, invalidate_if_older_than: period_start)
+        result, block_called = read_entry(wrapped, invalidate_if_older_than: period_start)
+
+        expect(result).to eq("new_value")
+        expect(block_called).to be false
+      end
     end
 
     context "when a wrapped value exists" do
@@ -170,6 +359,18 @@ RSpec.describe CacheService do
         result = tracking_cache_service_class.new("test").call { new_value }
 
         expect(result).to eq("cached_value")
+      end
+    end
+
+    context "when the wrapped value has no cached_at" do
+      before { allow(Rails.cache).to receive(:read).with(cache_key).and_return({"value" => "cached_value"}) }
+
+      it "recomputes rather than assuming the entry is fresh" do
+        service = tracking_cache_service_class.new("test", invalidate_if_older_than: 1.hour.ago)
+
+        result = service.call { new_value }
+
+        expect(result).to eq(new_value)
       end
     end
 

--- a/spec/services/subscriptions/charge_cache_middleware_spec.rb
+++ b/spec/services/subscriptions/charge_cache_middleware_spec.rb
@@ -47,13 +47,29 @@ RSpec.describe Subscriptions::ChargeCacheMiddleware do
         expect(result.map(&:amount_cents)).to eq([999])
       end
 
-      it "stores the value wrapped with its creation time" do
+      # No event has been seen for this charge yet (last_seen_at is empty), so cached_at falls back to
+      # the settle bound rather than Time.current. Stepping a full window back is what guarantees the
+      # first event to arrive invalidates the entry: ClickHouse floors enriched_at to the second, so
+      # an event inserted just after the write is recorded at floor(write_time), which is always
+      # greater than write_time - SETTLE_WINDOW but not necessarily greater than write_time itself.
+      it "stores the value wrapped with the settle bound when no event was seen" do
         freeze_time do
           middleware.call(charge_filter:) { [fee] }
 
           cached = Rails.cache.read(cache_key)
-          expect(cached["cached_at"]).to eq(Time.current.iso8601(6))
+          expect(cached["cached_at"]).to eq((Time.current - CacheService::SETTLE_WINDOW).iso8601(6))
           expect(JSON.parse(cached["value"]).first["amount_cents"]).to eq(999)
+        end
+      end
+
+      context "when an event was already seen for the charge" do
+        let(:last_seen_at) { {nil => 2.hours.ago} }
+
+        it "stamps cached_at with the last seen event timestamp" do
+          middleware.call(charge_filter:) { [fee] }
+
+          cached = Rails.cache.read(cache_key)
+          expect(cached["cached_at"]).to eq(last_seen_at[nil].iso8601(6))
         end
       end
     end


### PR DESCRIPTION
## Context

Adding a 1s delay to write in the cache, because events, that were inserted at the same milli-second on Clickhouse might be in different states: one is ready to be read and another - not yet. As result, querying the usage at this moment can lead to cache with one event recorded only and we won't have an algorithm to invalidate it, because our current invalidation relies on the enriched_at timestamp, which is identical for these events

## Description

added a 1s delay to write in the cache
