### PR TITLE
fix(usage): Count exact duplicate charges only once

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -129,27 +129,35 @@ module Invoices
     # NOTE: Concurrent plan updates can transiently leave a plan with several copies of the
     #       same charge (only code/parent_id differ), which would multiply usage.
     #       Count exact copies once; charges differing in any billing attribute are preserved.
+    #       Filters are only compared between charges identical in everything else, and
+    #       since copies require a repeated billable metric, plans without one — the
+    #       common case — skip all signature work.
     def deduplicated_charges
-      charges.to_a.uniq { |charge| charge_definition_signature(charge) }
+      all_charges = charges.to_a
+      candidates = all_charges.group_by(&:billable_metric_id).values.reject(&:one?)
+      return all_charges if candidates.empty?
+
+      duplicates = candidates.flat_map do |charges_of_metric|
+        charges_of_metric
+          .group_by { |charge| charge_scalar_signature(charge) }
+          .values
+          .reject(&:one?)
+          .flat_map { |copies| copies - copies.uniq { |charge| charge_filters_signature(charge) } }
+      end
+
+      all_charges - duplicates
     end
 
-    def charge_definition_signature(charge)
+    def charge_scalar_signature(charge)
       [
-        charge.billable_metric_id,
-        charge.charge_model,
-        charge.properties,
-        charge.pay_in_advance,
-        charge.prorated,
-        charge.invoiceable,
-        charge.regroup_paid_fees,
-        charge.min_amount_cents,
-        charge.invoice_display_name,
-        charge.amount_currency,
-        charge.accepts_target_wallet,
+        charge.attributes.except("id", "code", "parent_id", "created_at", "updated_at", "deleted_at"),
         charge.taxes.map(&:id).sort,
-        charge.applied_pricing_unit&.slice(:pricing_unit_id, :conversion_rate),
-        charge.filters.map { |f| [f.properties, f.values.map { |v| [v.billable_metric_filter_id, v.values] }.sort_by(&:to_s)] }.sort_by(&:to_s)
+        charge.applied_pricing_unit&.slice(:pricing_unit_id, :conversion_rate)
       ]
+    end
+
+    def charge_filters_signature(charge)
+      charge.filters.map { |f| [f.properties, f.invoice_display_name, f.to_h.sort] }.sort_by(&:to_s)
     end
 
     def charge_usage(charge, applied_filters)

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -154,6 +154,10 @@ module Invoices
       ]
     end
 
+    # NOTE: ChargeFilter#to_h only serializes the filter keys and values, so it cannot be used
+    #       alone here: two filters matching on keys/values but priced differently would be
+    #       treated as duplicates and one of the fees would be dropped from the usage.
+    #       Sorting makes the signature independent from the filters ordering.
     def charge_filters_signature(charge)
       charge.filters.map { |f| [f.properties, f.invoice_display_name, f.to_h.sort] }.sort_by(&:to_s)
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -154,10 +154,6 @@ module Invoices
       ]
     end
 
-    # NOTE: ChargeFilter#to_h only serializes the filter keys and values, so it cannot be used
-    #       alone here: two filters matching on keys/values but priced differently would be
-    #       treated as duplicates and one of the fees would be dropped from the usage.
-    #       Sorting makes the signature independent from the filters ordering.
     def charge_filters_signature(charge)
       charge.filters.map { |f| [f.properties, f.invoice_display_name, f.to_h.sort] }.sort_by(&:to_s)
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -129,9 +129,7 @@ module Invoices
     # NOTE: Concurrent plan updates can transiently leave a plan with several copies of the
     #       same charge (only code/parent_id differ), which would multiply usage.
     #       Count exact copies once; charges differing in any billing attribute are preserved.
-    #       Filters are only compared between charges identical in everything else, and
-    #       since copies require a repeated billable metric, plans without one — the
-    #       common case — skip all signature work.
+    #       Filters are only compared between charges identical in everything else to reduce perf impact.
     def deduplicated_charges
       all_charges = charges.to_a
       candidates = all_charges.group_by(&:billable_metric_id).values.reject(&:one?)

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -120,10 +120,36 @@ module Invoices
     def compute_charge_fees
       fees = []
       filters = event_filters(subscription, boundaries).charges
-      charges.find_each { |c| fees += charge_usage(c, filters[c.id] || {}) }
+      deduplicated_charges.each { |c| fees += charge_usage(c, filters[c.id] || {}) }
       return fees if usage_filters.has_charge_filter?
 
       fees.sort_by { |f| f.billable_metric.name.downcase }
+    end
+
+    # NOTE: Concurrent plan updates can transiently leave a plan with several copies of the
+    #       same charge (only code/parent_id differ), which would multiply usage.
+    #       Count exact copies once; charges differing in any billing attribute are preserved.
+    def deduplicated_charges
+      charges.to_a.uniq { |charge| charge_definition_signature(charge) }
+    end
+
+    def charge_definition_signature(charge)
+      [
+        charge.billable_metric_id,
+        charge.charge_model,
+        charge.properties,
+        charge.pay_in_advance,
+        charge.prorated,
+        charge.invoiceable,
+        charge.regroup_paid_fees,
+        charge.min_amount_cents,
+        charge.invoice_display_name,
+        charge.amount_currency,
+        charge.accepts_target_wallet,
+        charge.taxes.map(&:id).sort,
+        charge.applied_pricing_unit&.slice(:pricing_unit_id, :conversion_rate),
+        charge.filters.map { |f| [f.properties, f.values.map { |v| [v.billable_metric_filter_id, v.values] }.sort_by(&:to_s)] }.sort_by(&:to_s)
+      ]
     end
 
     def charge_usage(charge, applied_filters)

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -822,8 +822,7 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
     end
 
     it "compares filters only between charges identical in everything else" do
-      other_metric = create(:billable_metric, organization:, aggregation_type: "count_agg")
-      create(:standard_charge, plan:, billable_metric: other_metric, properties: {amount: "5"})
+      create_charge_copy(code: "cheaper", properties: {amount: "5"})
 
       service = described_class.new(customer:, subscription:)
       allow(service).to receive(:charge_filters_signature).and_call_original

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -792,4 +792,40 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
       end
     end
   end
+
+  describe "transiently duplicated charges" do
+    subject(:usage_service) { described_class.new(customer:, subscription:) }
+
+    let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+    let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"}, invoice_display_name: "Usage") }
+
+    before do
+      create_list(:event, 3, organization:, subscription:, customer:, code: billable_metric.code, timestamp:)
+      charge
+      Rails.cache.clear
+    end
+
+    it "counts a charge of identical definition only once" do
+      create(:standard_charge, plan:, billable_metric:, code: "clone", properties: {amount: "10"}, invoice_display_name: "Usage")
+
+      result = usage_service.call
+
+      expect(result).to be_success
+      # 3 events x 10, counted once despite the duplicate charge
+      expect(result.usage.amount_cents).to eq(3000)
+      expect(result.usage.fees.size).to eq(1)
+    end
+
+    it "keeps charges that differ in a billing-relevant attribute" do
+      create(:standard_charge, plan:, billable_metric:, code: "other", properties: {amount: "5"})
+      create(:standard_charge, plan:, billable_metric:, code: "named", properties: {amount: "10"}, invoice_display_name: "Support fee")
+
+      result = usage_service.call
+
+      expect(result).to be_success
+      # 3 x 10 + 3 x 5 + 3 x 10
+      expect(result.usage.amount_cents).to eq(7500)
+      expect(result.usage.fees.size).to eq(3)
+    end
+  end
 end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -794,10 +794,15 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
   end
 
   describe "transiently duplicated charges" do
+    def create_charge_copy(code:, **attributes)
+      defaults = {plan:, billable_metric:, code:, properties: {amount: "10"}, invoice_display_name: "Usage"}
+      create(:standard_charge, **defaults.merge(attributes))
+    end
+
     subject(:usage_service) { described_class.new(customer:, subscription:) }
 
     let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
-    let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"}, invoice_display_name: "Usage") }
+    let(:charge) { create_charge_copy(code: "base") }
 
     before do
       create_list(:event, 3, organization:, subscription:, customer:, code: billable_metric.code, timestamp:)
@@ -806,7 +811,7 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
     end
 
     it "counts a charge of identical definition only once" do
-      create(:standard_charge, plan:, billable_metric:, code: "clone", properties: {amount: "10"}, invoice_display_name: "Usage")
+      create_charge_copy(code: "clone")
 
       result = usage_service.call
 
@@ -816,9 +821,38 @@ RSpec.describe Invoices::CustomerUsageService, cache: :memory do
       expect(result.usage.fees.size).to eq(1)
     end
 
+    it "compares filters only between charges identical in everything else" do
+      other_metric = create(:billable_metric, organization:, aggregation_type: "count_agg")
+      create(:standard_charge, plan:, billable_metric: other_metric, properties: {amount: "5"})
+
+      service = described_class.new(customer:, subscription:)
+      allow(service).to receive(:charge_filters_signature).and_call_original
+
+      expect(service.call).to be_success
+      expect(service).not_to have_received(:charge_filters_signature)
+    end
+
+    it "dedups by filter definition when charges are otherwise identical" do
+      bm_filter = create(:billable_metric_filter, billable_metric:, key: "region", values: %w[eu us])
+      clone_a, clone_b, priced_differently = [["fa", "5"], ["fb", "5"], ["fc", "7"]].map do |code, amount|
+        create_charge_copy(code:).tap do |copy|
+          filter = create(:charge_filter, charge: copy, properties: {amount:})
+          create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["eu"])
+        end
+      end
+
+      deduplicated = usage_service.send(:deduplicated_charges)
+
+      # the base charge (no filters), one of the two identical clones, and the
+      # charge whose filter carries a different price
+      expect(deduplicated.size).to eq(3)
+      expect(deduplicated).to include(charge, priced_differently)
+      expect(deduplicated & [clone_a, clone_b]).to be_one
+    end
+
     it "keeps charges that differ in a billing-relevant attribute" do
-      create(:standard_charge, plan:, billable_metric:, code: "other", properties: {amount: "5"})
-      create(:standard_charge, plan:, billable_metric:, code: "named", properties: {amount: "10"}, invoice_display_name: "Support fee")
+      create_charge_copy(code: "other", properties: {amount: "5"})
+      create_charge_copy(code: "named", invoice_display_name: "Support fee")
 
       result = usage_service.call
 


### PR DESCRIPTION
## Context
Concurrent plan updates and the async parent-to-child charge cascade can leave a plan with several live copies of the same charge. Current usage summed every copy, which had an impact on ongoing usage and triggered an erroneous threshold wallet top-up.

## Description

Deduplicate charges by their full billing definition before computing current usage: exact copies are counted once, charges differing in any billing-relevant attribute are preserved.
Invoice generation is not affected - this needs to be fixed in a follow-up PR.