### PR TITLE
refactor(config): centralize LAGO_FRONT_URL access

### DIFF
--- a/app/mailers/password_reset_mailer.rb
+++ b/app/mailers/password_reset_mailer.rb
@@ -8,8 +8,8 @@ class PasswordResetMailer < ApplicationMailer
     return if @password_reset.token.blank?
     return if @email.blank?
 
-    @reset_url = "#{ENV["LAGO_FRONT_URL"]}/reset-password/#{@password_reset.token}"
-    @forgot_url = "#{ENV["LAGO_FRONT_URL"]}/forgot-password"
+    @reset_url = "#{Rails.application.config.lago_front_url}/reset-password/#{@password_reset.token}"
+    @forgot_url = "#{Rails.application.config.lago_front_url}/forgot-password"
 
     I18n.with_locale(:en) do
       mail(

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -263,7 +263,7 @@ class Invoice < ApplicationRecord
   def web_url
     return if invisible?
 
-    front_url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+    front_url = Rails.application.config.lago_front_url
 
     URI.join(front_url, "/#{organization.slug}/customer/#{customer_id}/", "invoice/#{id}/overview").to_s
   end

--- a/app/services/auth/google_service.rb
+++ b/app/services/auth/google_service.rb
@@ -23,7 +23,7 @@ module Auth
         client_id,
         BASE_SCOPE,
         nil, # token_store is nil because we don't need to store the token
-        "#{ENV["LAGO_FRONT_URL"]}/auth/google/callback"
+        "#{Rails.application.config.lago_front_url}/auth/google/callback"
       )
 
       result.url = authorizer.get_authorization_url(request:)
@@ -171,7 +171,7 @@ module Auth
         client_id,
         BASE_SCOPE,
         nil, # token_store is nil because we don't need to store the token
-        "#{ENV["LAGO_FRONT_URL"]}/auth/google/callback"
+        "#{Rails.application.config.lago_front_url}/auth/google/callback"
       )
 
       credentials = authorizer.get_credentials_from_code(code:)

--- a/app/services/auth/okta/authorize_service.rb
+++ b/app/services/auth/okta/authorize_service.rb
@@ -24,7 +24,7 @@ module Auth
           response_type: "code",
           response_mode: "query",
           scope: "openid profile email",
-          redirect_uri: "#{ENV["LAGO_FRONT_URL"]}/auth/okta/callback",
+          redirect_uri: "#{Rails.application.config.lago_front_url}/auth/okta/callback",
           state:
         }
         result.url = URI::HTTPS.build(

--- a/app/services/auth/okta/base_service.rb
+++ b/app/services/auth/okta/base_service.rb
@@ -47,7 +47,7 @@ module Auth
           client_secret: result.okta_integration.client_secret,
           grant_type: "authorization_code",
           code:,
-          redirect_uri: "#{ENV["LAGO_FRONT_URL"]}/auth/okta/callback"
+          redirect_uri: "#{Rails.application.config.lago_front_url}/auth/okta/callback"
         }
 
         token_client = LagoHttpClient::Client.new("https://#{result.okta_integration.host}/oauth2/v1/token")

--- a/app/services/customer_portal/generate_url_service.rb
+++ b/app/services/customer_portal/generate_url_service.rb
@@ -16,7 +16,7 @@ module CustomerPortal
       public_authenticator = ActiveSupport::MessageVerifier.new(ENV["SECRET_KEY_BASE"])
       message = public_authenticator.generate(customer.id, expires_in: 12.hours)
 
-      result.url = "#{ENV["LAGO_FRONT_URL"]}/customer-portal/#{message}"
+      result.url = "#{Rails.application.config.lago_front_url}/customer-portal/#{message}"
 
       result
     end

--- a/app/services/integrations/aggregator/contacts/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/base_payload.rb
@@ -59,7 +59,7 @@ module Integrations
           end
 
           def customer_url
-            url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+            url = Rails.application.config.lago_front_url
 
             URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
           end

--- a/app/services/integrations/aggregator/subscriptions/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/subscriptions/payloads/base_payload.rb
@@ -22,7 +22,7 @@ module Integrations
           attr_reader :integration_customer, :subscription
 
           def subscription_url
-            url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+            url = Rails.application.config.lago_front_url
 
             URI.join(url, "/#{integration_customer.customer.organization.slug}/customer/#{integration_customer.customer.id}/subscription/#{subscription.id}/overview").to_s
           end

--- a/app/services/invites/create_service.rb
+++ b/app/services/invites/create_service.rb
@@ -62,7 +62,7 @@ module Invites
     end
 
     def build_invite_url(token)
-      frontend_url = ENV.fetch("LAGO_FRONT_URL", "http://localhost:3000")
+      frontend_url = Rails.application.config.lago_front_url
       "#{frontend_url}/invitation/#{token}"
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,7 @@ module LagoApi
 
     config.api_only = true
     config.active_job.queue_adapter = :sidekiq
+    config.lago_front_url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
 
     # Configuration for active record encryption
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,6 +60,7 @@ Rails.application.configure do
   config.hosts << "api"
 
   config.license_url = ENV.fetch("LAGO_LICENSE_URL", "http://license:3000")
+  config.lago_front_url = ENV["LAGO_FRONT_URL"].presence || "http://localhost:3000"
   config.api_key_cache_ttl = 10.seconds
 
   config.action_mailer.perform_caching = false

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1948,7 +1948,7 @@ RSpec.describe Invoice do
     it "returns the lago frontend url of the invoice overview page" do
       expect(invoice.web_url).to eq(
         URI.join(
-          ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com",
+          Rails.application.config.lago_front_url,
           "/#{invoice.organization.slug}/customer/#{invoice.customer_id}/",
           "invoice/#{invoice.id}/overview"
         ).to_s

--- a/spec/services/integrations/aggregator/companies/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/create_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
   end
 
   let(:customer_link) do
-    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+    url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
   end

--- a/spec/services/integrations/aggregator/companies/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/update_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
   end
 
   let(:customer_link) do
-    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+    url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
   end

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
   end
 
   let(:customer_link) do
-    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+    url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
   end

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
   end
 
   let(:customer_link) do
-    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+    url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/", customer.id).to_s
   end

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
   end
 
   let(:invoice_url) do
-    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+    url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{invoice.customer.organization.slug}/customer/#{invoice.customer.id}/", "invoice/#{invoice.id}/overview").to_s
   end

--- a/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/hubspot_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Hubspot do
   let(:organization) { create(:organization) }
   let(:file_url) { Faker::Internet.url }
   let(:invoice_url) do
-    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+    url = Rails.application.config.lago_front_url
 
     URI.join(url, "/#{customer.organization.slug}/customer/#{customer.id}/", "invoice/#{invoice.id}/overview").to_s
   end

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
     end
 
     let(:invoice_link) do
-      url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+      url = Rails.application.config.lago_front_url
 
       URI.join(url, "/#{customer.organization.slug}/customer/#{customer.id}/", "invoice/#{invoice.id}/overview").to_s
     end

--- a/spec/services/integrations/aggregator/subscriptions/payloads/hubspot_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/payloads/hubspot_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Payloads::Hubspot do
   end
 
   let(:subscription_url) do
-    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+    url = Rails.application.config.lago_front_url
     URI.join(url, "/#{customer.organization.slug}/customer/#{customer.id}/subscription/#{subscription.id}/overview").to_s
   end
 


### PR DESCRIPTION
## Context

The Lago frontend base URL was read as `ENV["LAGO_FRONT_URL"]` in ~9 places across the app, each with its own fallback — three different behaviors when the variable is unset:

- `.presence || "https://app.getlago.com"` — integration payload builders
- no fallback (bare `ENV[...]`, i.e. `nil`) — password-reset mailer, Google/Okta auth callbacks, customer portal
- "http://localhost:3000" — invites

The same expression was also re-inlined in ~9 spec files to build expected URLs.

## Description

Introduce a single `config.lago_front_url`:

- Defined once in config/application.rb (`ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"`), overridden in development to default to http://localhost:3000 — mirroring the existing `config.license_url` convention.
- Every app call site now reads `Rails.application.config.lago_front_url` (mailer, Google/Okta auth, customer portal, invoices/contacts/subscriptions payload builders, invites, and `Invoice#web_url`).
- Specs reference the same config instead of re-inlining the fallback.

An explicit `LAGO_FRONT_URL` still wins in every environment; only the previously-divergent unset fallbacks are unified — which affects dev/test and misconfigured deployments only, since the variable is set in real deployments. CORS origin handling (config/initializers/cors.rb) is intentionally left untouched (it's a presence check, not a URL builder).

Part of INT-179