### PR TITLE
fix(search): Retry invoice index failures

### DIFF
--- a/app/jobs/invoices/search_index_job.rb
+++ b/app/jobs/invoices/search_index_job.rb
@@ -4,6 +4,17 @@ module Invoices
   class SearchIndexJob < ApplicationJob
     queue_as :meilisearch
 
+    retry_on Meilisearch::CommunicationError,
+      Meilisearch::ApiError,
+      Meilisearch::TimeoutError,
+      Errno::ECONNRESET,
+      Errno::ECONNREFUSED,
+      Errno::EHOSTUNREACH,
+      Errno::ETIMEDOUT,
+      Net::OpenTimeout,
+      Net::ReadTimeout,
+      EOFError, wait: :polynomially_longer, attempts: 3
+
     def perform(invoice_id)
       invoice = Invoice.find_by(id: invoice_id)
 

--- a/app/jobs/invoices/search_index_job.rb
+++ b/app/jobs/invoices/search_index_job.rb
@@ -11,6 +11,7 @@ module Invoices
       Errno::ECONNREFUSED,
       Errno::EHOSTUNREACH,
       Errno::ETIMEDOUT,
+      HTTParty::UnsupportedURIScheme,
       Net::OpenTimeout,
       Net::ReadTimeout,
       EOFError, wait: :polynomially_longer, attempts: 3

--- a/spec/jobs/invoices/search_index_job_spec.rb
+++ b/spec/jobs/invoices/search_index_job_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Invoices::SearchIndexJob do
       Errno::ECONNREFUSED.new,
       Errno::EHOSTUNREACH.new,
       Errno::ETIMEDOUT.new,
+      HTTParty::UnsupportedURIScheme.new("Unsupported URI scheme"),
       Net::OpenTimeout.new,
       Net::ReadTimeout.new,
       EOFError.new

--- a/spec/jobs/invoices/search_index_job_spec.rb
+++ b/spec/jobs/invoices/search_index_job_spec.rb
@@ -35,4 +35,37 @@ RSpec.describe Invoices::SearchIndexJob do
       expect(Invoices::Search::RemoveFromIndexService).to have_received(:call!).with(invoice_id:)
     end
   end
+
+  describe "retry_on" do
+    let(:invoice_id) { invoice.id }
+
+    [
+      Meilisearch::CommunicationError.new("Connection refused"),
+      Meilisearch::ApiError.new(408, "Request Timeout", ""),
+      Meilisearch::TimeoutError.new("Net::ReadTimeout"),
+      Errno::ECONNRESET.new,
+      Errno::ECONNREFUSED.new,
+      Errno::EHOSTUNREACH.new,
+      Errno::ETIMEDOUT.new,
+      Net::OpenTimeout.new,
+      Net::ReadTimeout.new,
+      EOFError.new
+    ].each do |error|
+      error_class = error.class
+
+      context "when a #{error_class.name} error is raised" do
+        before do
+          allow(Invoices::Search::IndexService).to receive(:call!).and_raise(error)
+        end
+
+        it "retries the job" do
+          assert_performed_jobs(3, only: [described_class]) do
+            expect do
+              described_class.perform_later(invoice_id)
+            end.to raise_error(error_class)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Invoices::SearchIndexJob can fail when Meilisearch has transient connectivity or timeout issues. These failures showed up in Sentry as API-EU-RH, API-EU-RG, API-EU-R9, API-EU-RE, and API-EU-RA.

## Description

Retry invoice search indexing jobs for transient Meilisearch and network errors. Limit retries to three attempts so short-lived outages can recover without leaving failed indexing jobs immediately.
