### PR TITLE
fix(stripe): rebuild payment links when consent setting changes

### DIFF
--- a/app/jobs/payment_providers/stripe/expire_payment_intents_job.rb
+++ b/app/jobs/payment_providers/stripe/expire_payment_intents_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    class ExpirePaymentIntentsJob < ApplicationJob
+      queue_as "providers"
+
+      def perform(payment_provider)
+        PaymentProviders::Stripe::ExpirePaymentIntentsService.call!(payment_provider)
+      end
+    end
+  end
+end

--- a/app/services/payment_intents/expire_service.rb
+++ b/app/services/payment_intents/expire_service.rb
@@ -19,7 +19,9 @@ module PaymentIntents
             .call!(:expire_payment_url, invoice, payment_intent)
         end
 
-        payment_intent.expired!
+        # NOTE: also move expires_at into the past so the intent leaves the reuse window
+        #       (PaymentIntent.non_expired is time-based) and a fresh intent is generated next time.
+        payment_intent.update!(status: :expired, expires_at: Time.current)
       end
 
       result.payment_intents = payment_intents

--- a/app/services/payment_providers/stripe/expire_payment_intents_service.rb
+++ b/app/services/payment_providers/stripe/expire_payment_intents_service.rb
@@ -15,6 +15,11 @@ module PaymentProviders
 
       private
 
+      # NOTE: a customer has a single payment connection today, so this exactly
+      #       targets the connection whose setting changed. When multi-connection
+      #       (multi_connection) lands, re-scope to the invoice's snapshotted payment
+      #       connection (invoices.payment_provider_customer_id) — the customer will no
+      #       longer identify a single connection.
       def active_payment_intents
         PaymentIntent
           .active

--- a/app/services/payment_providers/stripe/expire_payment_intents_service.rb
+++ b/app/services/payment_providers/stripe/expire_payment_intents_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    class ExpirePaymentIntentsService < BaseService
+      Result = BaseResult
+
+      def call
+        active_payment_intents.find_each do |payment_intent|
+          PaymentIntents::ExpireService.call!(invoice: payment_intent.invoice)
+        end
+
+        result
+      end
+
+      private
+
+      def active_payment_intents
+        PaymentIntent
+          .active
+          .joins(invoice: :customer)
+          .where(customers: {id: payment_provider.customers.select(:id)})
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -24,6 +24,7 @@ module PaymentProviders
 
       is_new = stripe_provider.new_record?
       old_code = stripe_provider.code
+      consent_before = stripe_provider.require_terms_of_service_consent
 
       stripe_provider.secret_key = args[:secret_key] if args.key?(:secret_key) && is_new
       stripe_provider.code = args[:code] if args.key?(:code)
@@ -35,6 +36,12 @@ module PaymentProviders
 
       if is_new
         PaymentProviders::Stripe::RegisterWebhookJob.perform_later(stripe_provider)
+      end
+
+      if !is_new && stripe_provider.require_terms_of_service_consent != consent_before
+        # NOTE: the consent setting shapes the checkout payload, so outstanding payment links
+        #       must be rebuilt with the new setting on the next generation.
+        PaymentProviders::Stripe::ExpirePaymentIntentsJob.perform_later(stripe_provider)
       end
 
       if payment_provider_code_changed?(stripe_provider, old_code, args)

--- a/spec/jobs/payment_providers/stripe/expire_payment_intents_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/expire_payment_intents_job_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Stripe::ExpirePaymentIntentsJob do
+  it "calls the expire payment intents service" do
+    allow(PaymentProviders::Stripe::ExpirePaymentIntentsService).to receive(:call!)
+
+    provider = instance_double(PaymentProviders::StripeProvider)
+    described_class.perform_now(provider)
+
+    expect(PaymentProviders::Stripe::ExpirePaymentIntentsService).to have_received(:call!).with(provider)
+  end
+end

--- a/spec/services/payment_intents/expire_service_spec.rb
+++ b/spec/services/payment_intents/expire_service_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe PaymentIntents::ExpireService do
         expect { result }.to change { payment_intent.reload.status }.from("active").to("expired")
         expect(payment_provider_service).to have_received(:call!).with(:expire_payment_url, invoice, payment_intent)
       end
+
+      it "retires the payment intent from the reuse window" do
+        result
+
+        expect(PaymentIntent.non_expired.where(invoice:)).to be_empty
+      end
     end
 
     context "when an active payment intent has no provider session id" do

--- a/spec/services/payment_providers/stripe/expire_payment_intents_service_spec.rb
+++ b/spec/services/payment_providers/stripe/expire_payment_intents_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Stripe::ExpirePaymentIntentsService do
+  subject(:result) { described_class.call(payment_provider) }
+
+  let(:payment_provider) { create(:stripe_provider) }
+  let(:organization) { payment_provider.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:payment_intent) { create(:payment_intent, invoice:) }
+
+  before do
+    create(:stripe_customer, customer:, payment_provider:)
+    payment_intent
+  end
+
+  it "expires active payment intents of the provider's invoices" do
+    expect { result }.to change { payment_intent.reload.status }.from("active").to("expired")
+  end
+
+  it "is successful" do
+    expect(result).to be_success
+  end
+
+  context "when the payment intent belongs to another provider's customer" do
+    let(:other_provider) { create(:stripe_provider, organization:) }
+    let(:other_customer) { create(:customer, organization:) }
+    let(:other_invoice) { create(:invoice, customer: other_customer, organization:) }
+    let(:other_payment_intent) { create(:payment_intent, invoice: other_invoice) }
+
+    before do
+      create(:stripe_customer, customer: other_customer, payment_provider: other_provider)
+      other_payment_intent
+    end
+
+    it "does not expire it" do
+      expect { result }.not_to change { other_payment_intent.reload.status }
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -129,6 +129,38 @@ RSpec.describe PaymentProviders::StripeService do
       end
     end
 
+    context "when consent collection changes on an existing provider" do
+      let(:stripe_provider) do
+        create(:stripe_provider, organization:, code:, name:, secret_key: "secret", require_terms_of_service_consent: false)
+      end
+
+      before { stripe_provider }
+
+      it "enqueues a job to expire the connection's payment intents" do
+        stripe_service.create_or_update(
+          id: stripe_provider.id,
+          organization_id: organization.id,
+          code:,
+          name:,
+          require_terms_of_service_consent: true
+        )
+
+        expect(PaymentProviders::Stripe::ExpirePaymentIntentsJob).to have_been_enqueued.with(stripe_provider)
+      end
+
+      it "does not enqueue the job when the value is unchanged" do
+        stripe_service.create_or_update(
+          id: stripe_provider.id,
+          organization_id: organization.id,
+          code:,
+          name:,
+          require_terms_of_service_consent: false
+        )
+
+        expect(PaymentProviders::Stripe::ExpirePaymentIntentsJob).not_to have_been_enqueued
+      end
+    end
+
     context "with validation error" do
       it "returns an error result" do
         result = stripe_service.create_or_update(


### PR DESCRIPTION
Part of INT-163

## Context

Invoice and payment-request links are cached on a `PaymentIntent` for up to 24h. The cache is keyed on the invoice, not on the connection settings that shaped the link — so toggling a Stripe connection's **Consent collection** setting did not affect links that were already generated. After *enabling* consent, existing links (and their still-live Stripe checkout sessions) kept letting customers pay **without** accepting the terms of service until the intent expired — a real gap for what is a compliance setting.

## What changed

When the consent setting changes on an existing Stripe connection, the connection's outstanding active payment intents are expired, so the next generation rebuilds the link with the current setting and the old Stripe sessions are closed.

- `PaymentProviders::StripeService#create_or_update` enqueues `PaymentProviders::Stripe::ExpirePaymentIntentsJob` when `require_terms_of_service_consent` changes on an existing connection.
- `PaymentProviders::Stripe::ExpirePaymentIntentsService` expires the active payment intents of the connection's customers, reusing `PaymentIntents::ExpireService` (which also expires the hosted Stripe checkout session).
- `PaymentIntents::ExpireService` now also moves `expires_at` into the past. Previously it only flipped the status, but the reuse lookup (`PaymentIntent.non_expired`) is time-based — so an "expired" intent with a future `expires_at` was still re-found and its cached (now dead) URL returned. Expiry now actually retires the intent so a fresh one is generated next time.
