### PR TITLE
feat(multi-connection): Add mutation for editing integration customer

### DIFF
--- a/app/graphql/mutations/integration_customers/update.rb
+++ b/app/graphql/mutations/integration_customers/update.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Mutations
+  module IntegrationCustomers
+    class Update < BaseMutation
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "customers:update"
+
+      graphql_name "UpdateIntegrationCustomer"
+      description "Updates an integration customer connection"
+
+      input_object_class Types::IntegrationCustomers::UpdateInput
+
+      type Types::IntegrationCustomers::Object
+
+      def resolve(id:, **args)
+        integration_customer = ::IntegrationCustomers::BaseCustomer
+          .where(organization_id: current_organization.id)
+          .find_by(id:)
+
+        result = ::IntegrationCustomers::UpdateConnectionService.call(
+          integration_customer:,
+          params: args
+        )
+
+        result.success? ? result.integration_customer : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/integration_customers/update_input.rb
+++ b/app/graphql/types/integration_customers/update_input.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  module IntegrationCustomers
+    class UpdateInput < Types::BaseInputObject
+      graphql_name "UpdateIntegrationCustomerInput"
+      description "Update integration customer input arguments"
+
+      argument :id, ID, required: true
+
+      argument :code, String, required: false
+      argument :external_customer_id, String, required: false
+      argument :subsidiary_id, String, required: false
+      argument :sync_with_provider, Boolean, required: false
+      argument :targeted_object, Types::Integrations::Hubspot::TargetedObjectsEnum, required: false
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -96,6 +96,7 @@ module Types
 
     field :set_integration_customer_as_default, mutation: Mutations::IntegrationCustomers::SetAsDefault
     field :set_payment_provider_customer_as_default, mutation: Mutations::PaymentProviderCustomers::SetAsDefault
+    field :update_integration_customer, mutation: Mutations::IntegrationCustomers::Update
     field :update_payment_provider_customer, mutation: Mutations::PaymentProviderCustomers::Update
 
     field :create_netsuite_integration, mutation: Mutations::Integrations::Netsuite::Create

--- a/app/services/integration_customers/update_connection_service.rb
+++ b/app/services/integration_customers/update_connection_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class UpdateConnectionService < ::BaseService
+    NON_SYNCING_TYPES = %w[
+      IntegrationCustomers::AnrokCustomer
+      IntegrationCustomers::SalesforceCustomer
+    ].freeze
+
+    Result = BaseResult[:integration_customer]
+
+    def initialize(integration_customer:, params:)
+      @integration_customer = integration_customer
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "integration_customer") unless integration_customer
+
+      integration_customer.update!(code: params[:code]) if params.key?(:code)
+
+      sync_provider_customer if sync_provider_customer?
+
+      result.integration_customer = integration_customer.reload
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :integration_customer, :params
+
+    delegate :customer, :integration, to: :integration_customer
+
+    def sync_provider_customer?
+      return false if customer.partner_account?
+
+      NON_SYNCING_TYPES.exclude?(integration_customer.type)
+    end
+
+    def integration_customer_params
+      @integration_customer_params ||= params
+        .slice(:external_customer_id, :subsidiary_id, :sync_with_provider, :targeted_object)
+        .merge(integration_type: integration.provider_key, integration_code: integration.code)
+    end
+
+    def sync_provider_customer
+      IntegrationCustomers::UpdateJob.perform_later(
+        integration_customer_params:,
+        integration:,
+        integration_customer:
+      )
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -8924,6 +8924,16 @@ type Mutation {
   ): CollectionMapping
 
   """
+  Updates an integration customer connection
+  """
+  updateIntegrationCustomer(
+    """
+    Parameters for UpdateIntegrationCustomer
+    """
+    input: UpdateIntegrationCustomerInput!
+  ): IntegrationCustomer
+
+  """
   Update integration mapping
   """
   updateIntegrationMapping(
@@ -13372,6 +13382,22 @@ input UpdateIntegrationCollectionMappingInput {
   taxCode: String
   taxNexus: String
   taxType: String
+}
+
+"""
+Update integration customer input arguments
+"""
+input UpdateIntegrationCustomerInput {
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  code: String
+  externalCustomerId: String
+  id: ID!
+  subsidiaryId: String
+  syncWithProvider: Boolean
+  targetedObject: HubspotTargetedObjectsEnum
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -43137,6 +43137,35 @@
               "deprecationReason": null
             },
             {
+              "name": "updateIntegrationCustomer",
+              "description": "Updates an integration customer connection",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdateIntegrationCustomer",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateIntegrationCustomerInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "UNION",
+                "name": "IntegrationCustomer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updateIntegrationMapping",
               "description": "Update integration mapping",
               "args": [
@@ -71177,6 +71206,105 @@
               "type": {
                 "kind": "ENUM",
                 "name": "MappingTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateIntegrationCustomerInput",
+          "description": "Update integration customer input arguments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalCustomerId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subsidiaryId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "syncWithProvider",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetedObject",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "HubspotTargetedObjectsEnum",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/integration_customers/update_spec.rb
+++ b/spec/graphql/mutations/integration_customers/update_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::IntegrationCustomers::Update do
+  let(:required_permission) { "customers:update" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:integration_customer) do
+    create(:netsuite_customer, integration:, customer:, code: "old_code", category: "accounting", is_default: true)
+  end
+
+  let(:mutation) do
+    <<-GQL
+      mutation($input: UpdateIntegrationCustomerInput!) {
+        updateIntegrationCustomer(input: $input) {
+          ... on NetsuiteCustomer {
+            id
+            code
+            category
+            isDefault
+            externalCustomerId
+            integrationCode
+            integrationType
+          }
+        }
+      }
+    GQL
+  end
+
+  before { integration_customer }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "customers:update"
+
+  it "updates the code of the connection" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {
+        input: {id: integration_customer.id, code: "new_code"}
+      }
+    )
+
+    data = result["data"]["updateIntegrationCustomer"]
+
+    expect(data["id"]).to eq(integration_customer.id)
+    expect(data["code"]).to eq("new_code")
+    expect(data["category"]).to eq("accounting")
+    expect(data["isDefault"]).to be(true)
+    expect(data["integrationCode"]).to eq(integration.code)
+    expect(data["integrationType"]).to eq("netsuite")
+  end
+
+  it "enqueues the update job when the external customer id is provided" do
+    expect do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {id: integration_customer.id, externalCustomerId: "external-123", syncWithProvider: true}
+        }
+      )
+    end.to have_enqueued_job(IntegrationCustomers::UpdateJob)
+  end
+
+  context "when the integration customer belongs to another organization" do
+    let(:integration_customer) { create(:netsuite_customer, code: "old_code") }
+
+    it "returns a not found error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {id: integration_customer.id, code: "new_code"}
+        }
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+
+  context "when the integration customer is not found" do
+    it "returns a not found error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {id: "unknown", code: "new_code"}
+        }
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/services/integration_customers/update_connection_service_spec.rb
+++ b/spec/services/integration_customers/update_connection_service_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IntegrationCustomers::UpdateConnectionService do
+  subject(:update_service) { described_class.new(integration_customer:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:integration_customer) { create(:netsuite_customer, integration:, customer:, code: "old_code") }
+  let(:params) { {} }
+
+  describe "#call" do
+    subject(:result) { update_service.call }
+
+    context "when integration customer is not found" do
+      let(:integration_customer) { nil }
+      let(:params) { {code: "new_code"} }
+
+      it "returns an error" do
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("integration_customer_not_found")
+      end
+    end
+
+    context "when only the code is updated" do
+      let(:params) { {code: "new_code"} }
+
+      it "updates the code" do
+        expect { update_service.call }
+          .to change { integration_customer.reload.code }.from("old_code").to("new_code")
+      end
+
+      it "returns the integration customer" do
+        expect(result).to be_success
+        expect(result.integration_customer).to eq(integration_customer)
+      end
+
+      it "enqueues the update job" do
+        expect { update_service.call }.to have_enqueued_job(IntegrationCustomers::UpdateJob).with(
+          integration_customer_params: {
+            integration_type: "netsuite",
+            integration_code: integration.code
+          },
+          integration:,
+          integration_customer:
+        )
+      end
+    end
+
+    context "when the external customer id is updated" do
+      let(:params) { {code: "new_code", external_customer_id: "external-123"} }
+
+      it "updates the code" do
+        expect { update_service.call }
+          .to change { integration_customer.reload.code }.from("old_code").to("new_code")
+      end
+
+      it "enqueues the update job with the integration customer params" do
+        expect { update_service.call }.to have_enqueued_job(IntegrationCustomers::UpdateJob).with(
+          integration_customer_params: {
+            external_customer_id: "external-123",
+            integration_type: "netsuite",
+            integration_code: integration.code
+          },
+          integration:,
+          integration_customer:
+        )
+      end
+    end
+
+    context "when the subsidiary id and the sync with provider flag are updated" do
+      let(:params) { {subsidiary_id: "sub-1", sync_with_provider: true} }
+
+      it "enqueues the update job with the integration customer params" do
+        expect { update_service.call }.to have_enqueued_job(IntegrationCustomers::UpdateJob).with(
+          integration_customer_params: {
+            subsidiary_id: "sub-1",
+            sync_with_provider: true,
+            integration_type: "netsuite",
+            integration_code: integration.code
+          },
+          integration:,
+          integration_customer:
+        )
+      end
+    end
+
+    context "with a hubspot connection" do
+      let(:integration) { create(:hubspot_integration, organization:) }
+      let(:integration_customer) { create(:hubspot_customer, integration:, customer:, code: "old_code") }
+      let(:params) { {targeted_object: "companies"} }
+
+      it "enqueues the update job with the integration customer params" do
+        expect { update_service.call }.to have_enqueued_job(IntegrationCustomers::UpdateJob).with(
+          integration_customer_params: {
+            targeted_object: "companies",
+            integration_type: "hubspot",
+            integration_code: integration.code
+          },
+          integration:,
+          integration_customer:
+        )
+      end
+    end
+
+    context "with a salesforce connection" do
+      let(:integration) { create(:salesforce_integration, organization:) }
+      let(:integration_customer) { create(:salesforce_customer, integration:, customer:, code: "old_code") }
+      let(:params) { {code: "new_code", external_customer_id: "external-123"} }
+
+      it "updates the code" do
+        expect { update_service.call }
+          .to change { integration_customer.reload.code }.from("old_code").to("new_code")
+      end
+
+      it "does not enqueue the update job" do
+        expect { update_service.call }.not_to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+    end
+
+    context "with an anrok connection" do
+      let(:integration) { create(:anrok_integration, organization:) }
+      let(:integration_customer) { create(:anrok_customer, integration:, customer:, code: "old_code") }
+      let(:params) { {code: "new_code", external_customer_id: "external-123"} }
+
+      it "updates the code" do
+        expect { update_service.call }
+          .to change { integration_customer.reload.code }.from("old_code").to("new_code")
+      end
+
+      it "does not enqueue the update job" do
+        expect { update_service.call }.not_to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+    end
+
+    context "when the customer is a partner account" do
+      let(:customer) { create(:customer, organization:, account_type: "partner") }
+      let(:params) { {code: "new_code", external_customer_id: "external-123"} }
+
+      it "updates the code" do
+        expect { update_service.call }
+          .to change { integration_customer.reload.code }.from("old_code").to("new_code")
+      end
+
+      it "does not enqueue the update job" do
+        expect { update_service.call }.not_to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently customers can be attached to only one connection of the same type. In order to change it, Lago is adding possibility to have multiple connections of the same type per customer.

## Description

This PR adds mutation to update integration customer. Currently it is possible to do it along with customer edition. This is the dedicated mutation, created only for this purpose.