### PR TITLE
[ING-480] misc(event): Add miliseconds precision to events_raw ingested_at

### DIFF
--- a/app/services/events/kafka_producer_service.rb
+++ b/app/services/events/kafka_producer_service.rb
@@ -46,7 +46,7 @@ module Events
         # NOTE: Default value to 0.0 is required for clickhouse parsing
         precise_total_amount_cents: event.precise_total_amount_cents.present? ? event.precise_total_amount_cents.to_s : "0.0",
         properties: event.properties,
-        ingested_at: Time.zone.now.iso8601[...-1],
+        ingested_at: Time.zone.now.iso8601(3)[...-1],
         source: EVENT_SOURCE,
         source_metadata: {
           api_post_processed: !organization.clickhouse_events_store?

--- a/app/services/events/stores/clickhouse/re_enrich_subscription_events_service.rb
+++ b/app/services/events/stores/clickhouse/re_enrich_subscription_events_service.rb
@@ -84,7 +84,7 @@ module Events
             code: event.code,
             precise_total_amount_cents: event.precise_total_amount_cents.present? ? event.precise_total_amount_cents.to_s : "0.0",
             properties:,
-            ingested_at: Time.zone.now.iso8601[...-1],
+            ingested_at: Time.zone.now.iso8601(3)[...-1],
             source: Events::KafkaProducerService::EVENT_SOURCE,
             source_metadata: {
               api_post_processed: true,

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe Events::CreateBatchService do
               expect(payload["precise_total_amount_cents"]).to eq(precise_total_amount_cents)
               expect(payload["properties"]).to eq(expected_params[:properties].stringify_keys)
               expect(payload["timestamp"]).to eq(timestamp.to_s)
-              expect(payload["ingested_at"]).to eq(Time.zone.now.iso8601[...-1])
+              expect(payload["ingested_at"]).to eq(Time.zone.now.iso8601(3)[...-1])
               expect(payload["source"]).to eq("http_ruby")
               expect(payload["source_metadata"]).to eq({"api_post_processed" => true})
             end

--- a/spec/services/events/kafka_producer_service_spec.rb
+++ b/spec/services/events/kafka_producer_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Events::KafkaProducerService, :capture_kafka_messages do
                   code: event.code,
                   precise_total_amount_cents: event.precise_total_amount_cents.present? ? event.precise_total_amount_cents.to_s : "0.0",
                   properties: event.properties,
-                  ingested_at: Time.zone.now.iso8601[...-1],
+                  ingested_at: Time.zone.now.iso8601(3)[...-1],
                   source: "http_ruby",
                   source_metadata: {
                     api_post_processed: true


### PR DESCRIPTION
## Context

`ingested_at` is stamped when the API receives an event and is stored in ClickHouse as a millisecond-precision timestamp. It was serialized without fractional seconds, so the value was truncated to the whole second before being written.

This makes the ingestion pipeline latency impossible to measure. The propagation delay is often sub-second, so the truncation hides the real distribution and biases every reading upwards by up to one second. It also produces negative delays, because
a truncated ingestion time can precede the moment the enriched event was written.

That measurement is needed to size the intervals driving wallet and usage refreshes: without it, propagation cannot be separated from scheduling.

## Description

Serialize `ingested_at` with millisecond precision on both produce paths, regular ingestion and re-enrichment.

The column type is unchanged, so only the written value becomes more precise. Existing rows keep their truncated values, and consumers already accept a fractional part, so nothing downstream needs to change.