### PR TITLE
feat(ci): Switch build workflow to lago-deploy

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -1,52 +1,27 @@
 name: "Internal Build"
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
+      ref:
+        description: "Git ref to build from lago-api (SHA, tag, or branch). Defaults to main."
+        required: false
+        default: "main"
       sidekiq_pro:
         type: boolean
         default: true
         description: Enable Sidekiq Pro
-permissions: {}
+  push:
+    branches:
+      - main
 jobs:
-  build-api-image:
+  lago-internal:
+    name: Lago Internal
     runs-on: ubuntu-latest
-    name: Build API Image
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Add version into docker image
-        run: echo ${{ github.sha }} > ./LAGO_VERSION
-
-      - name: Docker tag
-        id: docker_tag
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: lago-api-production
-          IMAGE_TAG: ${{ github.sha }}
-        run: echo "tag=$(echo $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG)" >> $GITHUB_OUTPUT
-
-      - name: Build and push
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.docker_tag.outputs.tag }}
-          build-args: |
-            BUNDLE_WITH=${{ (github.event_name == 'push' || github.event.inputs.sidekiq_pro == 'true') && 'sidekiq-pro' || '' }}
-          secrets: |
-            "BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}"
+          token: ${{ secrets.GH_TOKEN}}
+          repository: getlago/lago-deploy
+          event-type: api-push-main
+          client-payload: '{"ref": "${{ github.event.client_payload.ref || inputs.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Description
Instead of triggering a workflow in this repo we are sending an event to
lago-deploy so the build takes place there.

This allows us to have a central place where all builds happen, for
easier management.
