### PR TITLE
chore(ci): trigger build workflow smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Check the wiki [guide](https://github.com/getlago/lago-api/wiki)
 ## License
 
 Lago is distributed under [AGPL-3.0](LICENSE).
+

--- a/README.md
+++ b/README.md
@@ -26,4 +26,3 @@ Check the wiki [guide](https://github.com/getlago/lago-api/wiki)
 ## License
 
 Lago is distributed under [AGPL-3.0](LICENSE).
-

--- a/config.ru
+++ b/config.ru
@@ -6,3 +6,4 @@ require_relative "config/environment"
 
 run Rails.application
 Rails.application.load_server
+


### PR DESCRIPTION
## Context

Dummy no-op PR to verify the internal build workflow works end-to-end after #6045 switched it to dispatch builds to `lago-deploy`.

## Description

- Adds a single trailing newline in `README.md`.
- Once merged, the push to `main` fires `internal-build.yml`, which sends a `repository_dispatch` (`api-push-main`) to `getlago/lago-deploy` — that's the path we want to confirm still works.

## Test plan

- [ ] Verify PR CI (linters, migrations, spec) stays green
- [ ] After merge, check the `Internal Build` workflow run succeeds
- [ ] Verify the corresponding build in `lago-deploy` is triggered

Safe to revert immediately after the smoke test.