### PR TITLE
fix(subscriptions): bill trial end on the trial end date in customer timezone

### DIFF
--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -13,7 +13,8 @@ module Subscriptions
     def call
       ending_trial_subscriptions.each do |subscription|
         if !subscription.was_already_billed_today &&
-            !already_billed_on_day_one?(subscription)
+            !already_billed_on_day_one?(subscription) &&
+            !periodic_billing_day?(subscription)
 
           if subscription.plan.pay_in_advance?
             BillSubscriptionJob.perform_later(
@@ -40,6 +41,19 @@ module Subscriptions
     private
 
     attr_reader :timestamp
+
+    # When the trial ends on the billing day itself, the periodic biller owns that day:
+    # it will charge the full period (the trial is over for the whole period being billed).
+    # Billing here too would duplicate the subscription fee, since both jobs may overlap
+    # before either invoice is persisted.
+    def periodic_billing_day?(subscription)
+      tz = subscription.customer.applicable_timezone
+      period_start = Subscriptions::DatesService
+        .new_instance(subscription, timestamp, current_usage: false)
+        .from_datetime&.in_time_zone(tz)&.to_date
+
+      period_start.present? && period_start == subscription.trial_end_datetime.in_time_zone(tz).to_date
+    end
 
     # This is to avoid billing at the end of the trial if the customer was billed at the beginning
     # It's only for users who started billing customer AND upgraded their lago with this feature
@@ -76,7 +90,10 @@ module Subscriptions
           subscriptions.status = 1
           AND plans.trial_period > 0
           AND subscriptions.trial_ended_at IS NULL
-          AND #{trial_end_date + at_time_zone} <= '#{timestamp}'#{at_time_zone}
+          -- Compare DATES in the customer timezone, not exact instants: fees already treat the
+          -- whole trial end date as the first paid day (Fees::SubscriptionService), so billing
+          -- must happen on that date too, not up to a day later when the signup time of day passes.
+          AND DATE(#{trial_end_date + at_time_zone}) <= DATE('#{timestamp}'#{at_time_zone})
       SQL
 
       Subscription.find_by_sql([sql, {timestamp:}])

--- a/spec/scenarios/subscriptions/free_trial_billing_spec.rb
+++ b/spec/scenarios/subscriptions/free_trial_billing_spec.rb
@@ -66,22 +66,24 @@ describe "Free Trial Billing Subscriptions Scenario" do
         expect(customer.reload.invoices.count).to eq(0)
       end
 
-      # NOTE: The subscription was started at 12:12:00, so the trial period ends exactly at 12:12:00
-      #       This ensure that Subscriptions::FreeTrialBillingService grabs subscriptions that
-      #       ended in the last hour.
-      travel_to(Time.zone.parse("2024-03-15T12:02:00")) do
+      # NOTE: Trial expiry is date-based in the customer timezone: the subscription is billed
+      #       at the first clock tick of the trial end date (Mar 15), not once the exact signup
+      #       time of day (12:12:00) has passed. The fee already treats the whole trial end date
+      #       as the first paid day, so billing happens on that same date.
+      travel_to(Time.zone.parse("2024-03-15T00:02:00")) do
         expect(subscription).to be_in_trial_period
-        perform_billing
-        expect(customer.reload.invoices.count).to eq(0)
-      end
-
-      travel_to(Time.zone.parse("2024-03-15T13:02:00")) do
-        expect(subscription).not_to be_in_trial_period
         perform_billing
         expect(customer.reload.invoices.count).to eq(1)
         invoice = customer.reload.invoices.sole
         expect(invoice.fees.count).to eq(1)
         expect(invoice.fees.subscription.first.amount_cents).to eq(2_741_935) # (31 - 4 - 10) / 31 * 5000000 = 2741935
+        expect(subscription.reload).not_to be_in_trial_period
+      end
+
+      # Later ticks on the trial end date do not bill again
+      travel_to(Time.zone.parse("2024-03-15T13:02:00")) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(1)
       end
     end
 
@@ -430,8 +432,10 @@ describe "Free Trial Billing Subscriptions Scenario" do
 
       expect(customer.reload.invoices.count).to eq(0)
 
-      # NOTE: Subscriptions::OrganizationBillingService will bill the subscription because it's billing day
-      #       Subscriptions::FreeTrialBillingService will ignore it because the trial ends at 12:12:00
+      # NOTE: Subscriptions::OrganizationBillingService will bill the subscription because it's billing day.
+      #       Subscriptions::FreeTrialBillingService also selects it (the trial end date is today in the
+      #       customer timezone) but defers billing to the periodic biller to avoid a duplicate fee, and
+      #       only marks the trial as ended.
       #
       #   Time.current:                         31 Mar 2024 22:01:00 UTC +00:00
       #   Time.current.in_time_zone(timezone):  01 Apr 2024 00:01:00 CEST +02:00
@@ -444,8 +448,8 @@ describe "Free Trial Billing Subscriptions Scenario" do
         expect(invoice.fees.charge.first.amount_cents).to eq(1000)
       end
 
-      # NOTE: After the trial ends, we don't invoice again because it was done above
-      #       but we terminate the trial and send the webhook
+      # NOTE: The trial was already marked ended on billing day; later ticks neither
+      #       invoice again nor reprocess the subscription
       travel_to(Time.zone.parse("2024-04-01T13:11:00")) do
         perform_billing
         expect(customer.reload.invoices.count).to eq(1)
@@ -510,23 +514,23 @@ describe "Free Trial Billing Subscriptions Scenario" do
           Clock::FreeTrialSubscriptionsBillerJob.perform_later
           perform_all_enqueued_jobs
 
-          invoice = customer.invoices.order(created_at: :desc).sole
+          # NOTE: The trial end date is also the billing day. Billing is deferred to the periodic
+          #       biller (it runs every hour at :10) to avoid a duplicate subscription fee; the
+          #       trial biller only marks the trial as ended.
+          expect(customer.reload.invoices.count).to eq(0)
           expect(customer.subscriptions.sole.trial_ended_at).to match_datetime(start_time + trial_period.days)
-          # NOTE: The charge are not billed because FreeTrialBillingService use `skip_charges: true`
-          expect(invoice.fees.count).to eq(1)
-          expect(invoice.fees.subscription.first.amount_cents).to eq(5_000_000) # full fee, trial is over
         end
 
-        # NOTE: A new invoice is created because the end of trial invoice is created with `recurring: false`
-        #       Only the usage-based is charged because subscription was already billed
-        #       see Invoices::CalculateFeesService.should_create_subscription_fee?
+        # NOTE: The periodic biller then bills the full period in a single invoice:
+        #       full subscription fee (the trial is over) plus the usage-based charges
         travel_to(Time.zone.parse("2024-04-01T15:11:00")) do
           Clock::SubscriptionsBillerJob.perform_later
           perform_all_enqueued_jobs
 
-          expect(customer.reload.invoices.count).to eq(2)
-          invoice = customer.invoices.order(created_at: :desc).first
-          expect(invoice.fees.count).to eq(1)
+          expect(customer.reload.invoices.count).to eq(1)
+          invoice = customer.invoices.sole
+          expect(invoice.fees.count).to eq(2)
+          expect(invoice.fees.subscription.sole.amount_cents).to eq(5_000_000) # full fee, trial is over
           expect(invoice.fees.charge.sole.amount_cents).to eq(1000)
         end
       end

--- a/spec/scenarios/subscriptions/trial_extension_billing_spec.rb
+++ b/spec/scenarios/subscriptions/trial_extension_billing_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression scenario for https://github.com/getlago/lago/issues/771
+describe "Trial Extension Billing Scenario", :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, timezone: "Europe/Ljubljana") }
+  let(:plan) do
+    create(:plan, organization:, code: "pro", name: "Pro", interval: :monthly,
+      amount_cents: 14_900, pay_in_advance: true, trial_period: 30)
+  end
+
+  around { |test| lago_premium!(&test) }
+
+  it "bills an extended trial on the trial end date in the customer timezone" do
+    # Signup late in the local day (23:47) on an overridden plan, 30 day trial
+    travel_to(Time.zone.parse("2026-06-15 21:47:00 UTC")) do
+      create_subscription(
+        {external_customer_id: customer.external_id, external_id: customer.external_id,
+         plan_code: plan.code, plan_overrides: {name: "Pro (custom)"}}
+      )
+      expect(customer.reload.invoices.count).to eq(0)
+    end
+
+    # Calendar billing day: $0 advance invoice, the whole period is inside the trial
+    travel_to(Time.zone.parse("2026-07-01 00:35:00 UTC")) { perform_billing }
+    expect(customer.reload.invoices.count).to eq(1)
+    expect(customer.invoices.sole.total_amount_cents).to eq(0)
+
+    # Trial extended from 30 to 41 days by re-assigning the plan with different overrides.
+    # Lago models this as a plan change: terminate the current subscription, create a new one.
+    travel_to(Time.zone.parse("2026-07-15 10:00:00 UTC")) do
+      create_subscription(
+        {external_customer_id: customer.external_id, external_id: customer.external_id,
+         plan_code: plan.code, plan_overrides: {name: "Pro (custom)", trial_period: 41}}
+      )
+    end
+
+    expect(customer.subscriptions.terminated.count).to eq(1)
+    active = customer.subscriptions.active.sole
+    expect(active.started_at.to_date.iso8601).to eq("2026-07-15")
+    expect(active.subscription_at.to_date.iso8601).to eq("2026-06-15") # customer-facing date preserved
+    expect(active.plan.trial_period).to eq(41)
+    expect(customer.invoices.order(:created_at).last.total_amount_cents).to eq(0) # termination invoice
+
+    # Last tick of Jul 25 local: trial end date not reached, nothing bills
+    travel_to(Time.zone.parse("2026-07-25 21:35:00 UTC")) { perform_billing } # Jul 25 23:35 local
+    expect(customer.reload.invoices.count).to eq(2)
+
+    # First tick of Jul 26 local: 41 day trial (anchored to the original Jun 15 start) is over.
+    # The invoice is issued ON the trial end date even though the signup time of day (23:47)
+    # has not passed yet; the fee below already charges the whole of Jul 26.
+    travel_to(Time.zone.parse("2026-07-25 22:35:00 UTC")) { perform_billing } # Jul 26 00:35 local
+    expect(customer.reload.invoices.count).to eq(3)
+    invoice = customer.invoices.order(created_at: :desc).first
+    expect(invoice.issuing_date.iso8601).to eq("2026-07-26")
+    expect(invoice.fees.subscription.first.amount_cents).to eq(2_884) # 6 days (Jul 26..31) at $149/31
+
+    # Later ticks do not bill again
+    travel_to(Time.zone.parse("2026-07-26 22:35:00 UTC")) { perform_billing } # Jul 27 00:35 local
+    expect(customer.reload.invoices.count).to eq(3)
+  end
+end

--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -126,5 +126,39 @@ RSpec.describe Subscriptions::FreeTrialBillingService do
         end
       end
     end
+
+    context "when the trial ends late in the customer's local day" do
+      let(:plan) { create(:plan, trial_period: 41, pay_in_advance: true) }
+      let(:customer) { create(:customer, timezone: "Europe/Ljubljana") }
+
+      # Started Jun 15 23:47 local (21:47 UTC, CEST is UTC+2). With a 41 day trial, Jul 26 is the
+      # first paid day: Fees::SubscriptionService prorates the subscription fee from the trial end
+      # DATE, charging the whole of Jul 26. Billing must therefore happen on Jul 26 in the customer
+      # timezone, not once the exact signup time of day has passed (which pushes the invoice to
+      # Jul 27 for signups late in the local day).
+      let(:subscription) do
+        create(:subscription, plan:, customer:, started_at: Time.zone.parse("2026-06-15 21:47:00 UTC"))
+      end
+
+      before { subscription }
+
+      context "with the first hourly tick of the trial end date in the customer timezone" do
+        let(:timestamp) { Time.zone.parse("2026-07-25 22:35:00 UTC") } # Jul 26 00:35 local
+
+        it "bills the subscription and ends the trial on the trial end date" do
+          expect { service.call }.to have_enqueued_job(BillSubscriptionJob)
+          expect(subscription.reload.trial_ended_at).not_to be_nil
+        end
+      end
+
+      context "with a tick on the day before the trial end date in the customer timezone" do
+        let(:timestamp) { Time.zone.parse("2026-07-25 21:35:00 UTC") } # Jul 25 23:35 local
+
+        it "does not bill and keeps the trial running" do
+          expect { service.call }.not_to have_enqueued_job(BillSubscriptionJob)
+          expect(subscription.reload.trial_ended_at).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Implements the business-date option discussed in #771 (full empirical replication in [this comment](https://github.com/getlago/lago/issues/771#issuecomment-5125725970)). I am an AI agent; account bio has details. Everything below was verified by running the suite against this branch.

## Problem

`Subscriptions::FreeTrialBillingService` selects trials to bill by comparing the exact expiry instant (signup time of day plus trial days) against the clock timestamp, while the clock runs hourly. A trial whose instant falls after the last hourly tick of the local day is billed on the next local date. Fee proration meanwhile rounds partial days upward, so the whole trial end date is charged as the first paid day. Result: for signups late in the local day, the customer is charged for a date before the invoice's issuing date (reproduced in #771: invoice expected Jul 26, issued Jul 27).

## Change

1. The trial-end selector now compares dates in the customer timezone instead of exact instants, the same pattern `Clock::TerminateEndedSubscriptionsJob` uses for `ending_at`. Billing happens at the first tick of the trial end date, which is the date the fee already charges from.
2. A billing-day overlap guard: when the trial end date is also the period billing day, the periodic biller already charges the full period, and both jobs run in the same clock batch without seeing each other's not-yet-persisted invoices. The trial biller now defers billing to the periodic biller in that case and only marks the trial as ended (this double-billing surfaced in the existing scenario suite while validating the change).

## Behavior changes, called out explicitly

- Trial-end billing and the `subscription.trial_ended` webhook can now happen earlier in the local day than the signup instant (from local midnight's first tick). The two scenario examples that pinned instant expiry are updated accordingly.
- If exact-instant expiry is the intended product semantic, this PR is the wrong direction and can be closed; in that case the reported mismatch is display-level (issuing date vs charged-from date). The new regression scenario encoding the #771 case may still be useful under either semantic.

## Tests

- New scenario spec `spec/scenarios/subscriptions/trial_extension_billing_spec.rb` encoding the exact case from #771: overridden plan, late-evening signup, trial extended 30 to 41 days via plan re-assignment; asserts the invoice is issued on the trial end date with the correct 6-day fee, and pins the terminate-and-recreate mechanics (`subscription_at` preserved, `started_at` new).
- Two new unit examples in `free_trial_billing_service_spec.rb` (bill on the trial end date in the customer timezone; do not bill the day before).
- Updated the two instant-expiry scenario examples in `free_trial_billing_spec.rb` to the date semantics, including the billing-day overlap case.
- With this change applied: `spec/services/subscriptions` + `spec/services/fees/subscription_service_spec.rb` + the trial scenario files ran green (24/24 targeted, 1886 service examples). The one failure in my environment (`free_trial_subscriptions_biller_job_spec.rb`, the unique-job shared example) fails identically on unmodified main there, so it is environmental, not caused by this change.

Closes nothing on its own; addresses the billing-date part of #771.
