### PR TITLE
fix(subscriptions): Keep gated subs alive during 3DS

### DIFF
--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -36,6 +36,10 @@ module PaymentProviders
 
       payment_status
     end
+
+    def retriable_authentication_failure?(_error_code)
+      false
+    end
   end
 end
 

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -42,6 +42,10 @@ module PaymentProviders
     def payment_type
       "stripe"
     end
+
+    def retriable_authentication_failure?(error_code)
+      error_code == NEED_3DS_ERROR_CODE && supports_3ds.present?
+    end
   end
 end
 

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -91,7 +91,7 @@ module Invoices
 
         deliver_error_webhook(e) unless skip_error_webhook?(e)
 
-        update_invoice_payment_status(payment_status: e.result.payment.payable_payment_status)
+        update_invoice_payment_status(payment_status: invoice_payment_status_after(e))
 
         raise RetriableError if e.result.should_retry
 
@@ -168,6 +168,17 @@ module Invoices
       def current_payment_provider_customer
         @current_payment_provider_customer ||= customer.payment_provider_customers
           .find_by(payment_provider_id: current_payment_provider.id)
+      end
+
+      # A retried failure leaves the invoice awaiting payment. Recording it as
+      # failed would be terminal for a payment-gated subscription, which cancels
+      # before the retry can offer the customer an authentication challenge.
+      def invoice_payment_status_after(failure)
+        if failure.result.should_retry
+          :pending
+        else
+          failure.result.payment.payable_payment_status
+        end
       end
 
       def update_invoice_payment_status(payment_status:)

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -44,10 +44,7 @@ module Invoices
 
         deliver_webhook if payable_payment_status.to_sym == :succeeded
 
-        if status.to_s == "failed" && result.invoice.payments.excluding(result.payment).where(status: :requires_action).any?
-          # We don't update the invoice status because it's likely the webhook of a failed payment
-          # but there is already a retry in progress with 3DSecure authentication
-        else
+        unless authentication_retry_pending?(payment, status)
           update_invoice_payment_status(
             payment_status: payable_payment_status,
             processing: status == "processing"
@@ -61,6 +58,13 @@ module Invoices
         result
       rescue BaseService::FailedResult => e
         result.fail_with_error!(e)
+      end
+
+      def authentication_retry_pending?(payment, status)
+        return false unless status.to_s == "failed"
+
+        payment.payment_provider&.retriable_authentication_failure?(payment.error_code) ||
+          payment.payable.payments.excluding(payment).where(status: :requires_action).any?
       end
 
       def generate_payment_url(invoice, payment_intent)

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -148,6 +148,109 @@ describe "Payment Gated Subscription Activation Scenarios" do
     end
   end
 
+  describe "activation payment requiring 3D Secure" do
+    let(:authentication_required_body) do
+      JSON.parse(
+        get_stripe_fixtures("payment_intent_authentication_required_response.json", version: "2025-04-30.basil")
+      ).deep_symbolize_keys
+    end
+
+    let(:authentication_required_error) do
+      error = authentication_required_body[:error]
+
+      Stripe::CardError.new(
+        error[:message],
+        nil,
+        code: error[:code],
+        http_status: 400,
+        json_body: authentication_required_body
+      )
+    end
+
+    let(:requires_action_intent) do
+      Stripe::PaymentIntent.construct_from(
+        JSON.parse(
+          get_stripe_fixtures("payment_intent_requires_action_response.json", version: "2025-04-30.basil")
+        ).deep_symbolize_keys
+      )
+    end
+
+    def stub_off_session_rejection_then_on_session_retry
+      call_count = 0
+
+      allow_any_instance_of(::PaymentProviders::Stripe::Payments::CreateService) # rubocop:disable RSpec/AnyInstance
+        .to receive(:create_payment_intent) do
+          call_count += 1
+          raise authentication_required_error if call_count == 1
+
+          requires_action_intent
+        end
+    end
+
+    def simulate_rejected_intent_failure_webhook(payment)
+      PaymentProviders::Stripe::HandleEventService.call!(
+        organization:,
+        event_json: {
+          id: "evt_#{SecureRandom.hex(10)}",
+          object: "event",
+          type: "payment_intent.payment_failed",
+          data: {
+            object: {
+              id: payment.provider_payment_id,
+              object: "payment_intent",
+              status: "requires_payment_method",
+              last_payment_error: {code: "authentication_required"},
+              metadata: {
+                lago_invoice_id: payment.payable_id,
+                lago_customer_id: customer.id
+              }
+            }
+          }
+        }.to_json
+      )
+      perform_all_enqueued_jobs
+    end
+
+    context "when the Stripe connection supports 3DS" do
+      before do
+        stripe_provider.update!(supports_3ds: true)
+        stub_off_session_rejection_then_on_session_retry
+      end
+
+      it "keeps the subscription incomplete while the authentication retry is pending" do
+        create_subscription(subscription_params)
+        perform_all_enqueued_jobs
+
+        subscription = customer.subscriptions.sole
+        invoice = subscription.invoices.sole
+
+        expect(subscription).to be_incomplete
+        expect(subscription.cancellation_reason).to be_nil
+        expect(subscription.activation_rules.sole).to be_pending
+        expect(invoice.reload).to be_open
+        expect(invoice.payment_status).not_to eq("failed")
+        expect(invoice.payments.where(error_code: "authentication_required")).to exist
+      end
+
+      it "keeps the subscription incomplete when Stripe reports the rejected off-session intent as failed" do
+        create_subscription(subscription_params)
+        perform_all_enqueued_jobs
+
+        subscription = customer.subscriptions.sole
+        invoice = subscription.invoices.sole
+        rejected_payment = invoice.payments.find_by(error_code: "authentication_required")
+
+        simulate_rejected_intent_failure_webhook(rejected_payment)
+
+        expect(subscription.reload).to be_incomplete
+        expect(subscription.cancellation_reason).to be_nil
+        expect(subscription.activation_rules.sole).to be_pending
+        expect(invoice.reload).to be_open
+        expect(invoice.payment_status).not_to eq("failed")
+      end
+    end
+  end
+
   describe "payment failure: subscription canceled" do
     it "creates incomplete subscription, then cancels on payment failure" do
       # Stage 1: Create subscription — goes incomplete

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -288,6 +288,63 @@ RSpec.describe Invoices::Payments::StripeService do
         )
       end
 
+      context "when the off-session charge was rejected for authentication and 3DS is supported" do
+        let(:stripe_payment) do
+          PaymentProviders::StripeProvider::StripePayment.new(
+            id: "ch_123456",
+            status: "requires_payment_method",
+            metadata: {},
+            error_code: "authentication_required"
+          )
+        end
+
+        before { payment.payment_provider.update!(supports_3ds: true) }
+
+        # The on-session retry has not run yet, so no payment is in requires_action.
+        it "updates the payment status but not the invoice status" do
+          result = described_class.call(
+            :update_payment_status,
+            organization_id: organization.id,
+            status: "failed",
+            stripe_payment:
+          )
+
+          expect(result).to be_success
+          expect(result.payment.status).to eq("failed")
+          expect(result.payment.error_code).to eq("authentication_required")
+          expect(result.invoice.reload).to have_attributes(
+            payment_status: "pending",
+            ready_for_payment_processing: true
+          )
+        end
+      end
+
+      context "when the off-session charge was rejected for authentication and 3DS is not supported" do
+        let(:stripe_payment) do
+          PaymentProviders::StripeProvider::StripePayment.new(
+            id: "ch_123456",
+            status: "requires_payment_method",
+            metadata: {},
+            error_code: "authentication_required"
+          )
+        end
+
+        it "updates the invoice status because no retry will follow" do
+          result = described_class.call(
+            :update_payment_status,
+            organization_id: organization.id,
+            status: "failed",
+            stripe_payment:
+          )
+
+          expect(result).to be_success
+          expect(result.invoice.reload).to have_attributes(
+            payment_status: "failed",
+            ready_for_payment_processing: true
+          )
+        end
+      end
+
       context "when there is another payment in requires_action state for the invoice" do
         it "updates the payment status but not the invoice status" do
           # We can only have one `pending/processing` payment for an invoice


### PR DESCRIPTION
## Context

A payment-gated subscription is activated by its gating invoice being paid. When the activation charge lands on a card that requires 3D Secure, Stripe rejects the off-session attempt with `authentication_required` and Lago retries the charge on-session so the customer can authenticate.

That retry never got a chance to run. The rejection was recorded as a failed invoice payment before the retry was scheduled, and payment gating reads a failed payment as the terminal outcome of activation: the rule was rejected, the invoice closed and the subscription canceled with `payment_failed`. By the time the on-session retry ran, the subscription was already gone, so even a completed 3DS challenge could not activate it. The same happened a second way, through the `payment_intent.payment_failed` webhook Stripe emits for the rejected intent, which normally arrives before the retry is due.

For an ordinary invoice a failed payment status is transient bookkeeping that the retry overwrites, which is why this only broke gated subscriptions.

## Description

A failure that will be followed by another payment attempt no longer settles the invoice payment status: it stays pending, so gating leaves the activation rule untouched and the subscription waits for the customer to authenticate. Both the inline payment path and the Stripe webhook path respect this, since either can observe the rejection first.

Whether a rejection is followed by a retry is asked of the payment provider, which is where the knowledge of provider error codes and 3DS support belongs. Without 3DS support no retry follows, so the rejection stays terminal and the subscription is canceled as before.