### PR TITLE
fix(wallets): Use linear retry backoff on wallet refresh throttling

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -55,4 +55,21 @@ class ApplicationJob < ActiveJob::Base
   def self.random_lock_retry_delay
     random_delay(MAX_LOCK_RETRY_DELAY)
   end
+
+  # This method is a generic proc for specifying a linearly growing wait between retries.
+  # The delay grows by `step_seconds` per attempt, is capped at `max_seconds` and carries its
+  # own jitter so that retries of jobs that failed on the same event do not realign on the
+  # same window.
+  #
+  # Usage:
+  # retry_on ExceptionClass, attempts: 10, wait: linear_delay(5, max_seconds: 30)
+  #
+  def self.linear_delay(step_seconds, max_seconds: nil)
+    lambda do |executions|
+      delay = step_seconds * executions
+      delay = [delay, max_seconds].min if max_seconds
+
+      delay + rand(0...step_seconds)
+    end
+  end
 end

--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -14,7 +14,21 @@ module Customers
     unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
 
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
-    retry_on BaseService::TooManyProviderRequestsFailure, wait: :polynomially_longer, attempts: 25
+
+    retry_on(
+      BaseService::TooManyProviderRequestsFailure,
+      wait: linear_delay(5, max_seconds: 30),
+      attempts: 10
+    ) do |job, error|
+      # Giving up is not a failure: the provider rate limit is shared and the clock job will
+      # pick the customer up again.
+      # Logged rather than raised to keep sustained throttling out of the dead set.
+      Rails.logger.warn(
+        "RefreshWalletJob reached max throttling retry attempts" \
+        "customer_id=#{job.arguments.first&.id} provider=#{error.provider_name}"
+      )
+    end
+
     retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)
 
     def perform(customer, wallet_ids: nil)

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe ApplicationJob do
     end
   end
 
+  describe ".linear_delay" do
+    it "grows the delay linearly with the number of executions" do
+      delay = described_class.linear_delay(10)
+
+      expect(delay.call(1)).to be_between(10, 20)
+      expect(delay.call(2)).to be_between(20, 30)
+      expect(delay.call(3)).to be_between(30, 40)
+    end
+
+    it "caps the delay at max_seconds" do
+      delay = described_class.linear_delay(5, max_seconds: 12)
+
+      expect(delay.call(10)).to be_between(12, 17)
+    end
+  end
+
   describe "#perform_after_commit" do
     it "performs the job after the commit" do
       ApplicationRecord.transaction do

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -140,6 +140,26 @@ RSpec.describe Customers::RefreshWalletJob do
         end
       end
 
+      context "when refresh customer's wallets is throttled by the tax provider" do
+        let(:error) do
+          BaseService::TooManyProviderRequestsFailure.new(
+            BaseService::Result.new,
+            provider_name: :anrok,
+            error: StandardError.new("too many requests")
+          )
+        end
+
+        before do
+          allow(Customers::RefreshWalletsService).to receive(:call).with(customer:).and_raise(error)
+        end
+
+        it "retries a bounded number of times then gives up without raising" do
+          assert_performed_jobs(10, only: [described_class]) do
+            expect { described_class.perform_later(customer) }.not_to raise_error
+          end
+        end
+      end
+
       context "when refresh customer's wallets fails with a non-tax error" do
         let(:result) { Customers::RefreshWalletsService::Result.new.validation_failure!(errors: {other_error: ["something"]}) }
 


### PR DESCRIPTION
## Context

`Customers::RefreshWalletJob` issues one draft-invoice call to `Anrok` or `Avalara` per active subscription, rate limited to 9 and 10 requests per second respectively. Recent performance work on `Invoices::CustomerUsageService` made the refresh faster, so more of these jobs now reach the tax provider per second and more of them are throttled.

Once throttled, the job retried on a polynomial backoff over 25 attempts - a schedule built for a provider outage, not for a per-second rate limit. It summed to roughly 20 days, and is why refresh jobs are now observed running a long time after being enqueued.

## Description

Throttling retries move to a linear, jittered backoff capped at 30 seconds, over 10 attempts: `min(5 * executions, 30)` seconds plus up to 5 seconds of jitter, so 5-10 s, 10-15 s, 15-20 s, 20-25 s, 25-30 s, then 30-35 s for the rest.

The budget is sized against the clock, not the provider. The refresh is idempotent and the customer keeps its `awaiting_wallet_refresh` flag until it succeeds, so `Clock::RefreshWalletsOngoingBalanceJob` re-enqueues it every 5 minutes - an unbounded outer retry loop already.
Ten attempts means nine waits, spanning 3 min 15 s to 4 min, which stays under that interval. The 30-second cap keeps the tail flat, since a limit measured in seconds gains nothing from longer waits; the jitter stops jobs that failed together in a burst from realigning and re-colliding.

Exhausting the attempts logs `RefreshWalletJob gave up on provider throttling` instead of raising, so a throttling burst does not fill the dead set. The clock picks the customer up shortly after.