### PR TITLE
fix(wallets): Release wallet refresh lock when giving up

### DIFF
--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -11,7 +11,7 @@ module Customers
       )
     end
 
-    unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+    unique :until_executed, on_conflict: :log, lock_ttl: 2.hours
 
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
 
@@ -27,6 +27,12 @@ module Customers
         "RefreshWalletJob reached max throttling retry attempts" \
         "customer_id=#{job.arguments.first&.id} provider=#{error.provider_name}"
       )
+
+      # The uniqueness lock is only released by the `after_perform` callback, which is skipped
+      # when the job raises. Swallowing the error here also bypasses Sidekiq's death handler, so
+      # the lock must be released explicitly: otherwise the customer stays locked for `lock_ttl`
+      # and every re-enqueue from the clock job is silently dropped on conflict.
+      ActiveJob::Uniqueness.unlock!(job_class_name: job.class.name, arguments: job.arguments)
     end
 
     retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)

--- a/spec/jobs/customers/refresh_wallet_job_spec.rb
+++ b/spec/jobs/customers/refresh_wallet_job_spec.rb
@@ -158,6 +158,23 @@ RSpec.describe Customers::RefreshWalletJob do
             expect { described_class.perform_later(customer) }.not_to raise_error
           end
         end
+
+        context "with the uniqueness lock enforced" do
+          around do |example|
+            ActiveJob::Uniqueness.reset_manager!
+            example.run
+            described_class.unlock!(customer)
+            ActiveJob::Uniqueness.test_mode!
+          end
+
+          it "releases the uniqueness lock when giving up" do
+            assert_performed_jobs(10, only: [described_class]) do
+              described_class.perform_later(customer)
+            end
+
+            expect { described_class.perform_later(customer) }.to change { enqueued_jobs.count }.by(1) # rubocop:disable RSpec/ExpectChange
+          end
+        end
       end
 
       context "when refresh customer's wallets fails with a non-tax error" do


### PR DESCRIPTION
## Context

`Customers::RefreshWalletJob` uses the `until_executed` uniqueness strategy, whose lock is released by the `after_perform` callback. That callback is skipped whenever `perform` raises, and `retry_on` handlers run outside of it.

When the job exhausted its throttling retries, the give-up block logged the failure without re-raising, so Sidekiq considered the job successful and its death handler never ran either. The lock therefore survived until its TTL expired, and every re-enqueue from the clock job was silently dropped on conflict, leaving the customer out of the refresh cycle for up to 12 hours.

## Description

Release the uniqueness lock explicitly when the job gives up after reaching the maximum number of throttling retries, so the clock job can pick the customer up again on its next run.

Lower the lock TTL to 2 hours. The TTL is only a safety net for locks that are never released, and it comfortably outlasts the longest possible run including retries, while bounding how long a leaked lock can keep a customer from being refreshed.