### PR TITLE
[ING-536] fix(filters): Refuse metric edits that silently broaden charge filters

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -134,6 +134,7 @@ module Api
           :expression,
           :rounding_function,
           :rounding_precision,
+          :discard_impacted_charge_filters,
           filters: [[:key, values: []]]
         ])
       end

--- a/app/graphql/types/billable_metrics/update_input.rb
+++ b/app/graphql/types/billable_metrics/update_input.rb
@@ -19,6 +19,8 @@ module Types
       argument :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, required: false
 
       argument :filters, [Types::BillableMetricFilters::Input], required: false
+
+      argument :discard_impacted_charge_filters, Boolean, required: false
     end
   end
 end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -21,6 +21,13 @@ class ChargeFilter < ApplicationRecord
   # NOTE: Ensure filters are keeping the initial ordering
   default_scope -> { kept.order(updated_at: :asc) }
 
+  KEPT_VALUE_EXISTS_SQL = "EXISTS (SELECT 1 FROM charge_filter_values" \
+    " WHERE charge_filter_values.charge_filter_id = charge_filters.id" \
+    " AND charge_filter_values.deleted_at IS NULL)"
+
+  # NOTE: no kept values means an empty predicate, and an empty predicate matches every event of the charge.
+  scope :without_kept_values, -> { where("NOT #{KEPT_VALUE_EXISTS_SQL}") }
+
   def display_name(separator: ", ")
     invoice_display_name.presence || (values.map do |value|
       next value.billable_metric_filter.key if value.values == [ChargeFilterValue::ALL_FILTER_VALUES]

--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -5,10 +5,13 @@ module BillableMetricFilters
     Result = BaseResult[:filters]
 
     BATCH_SIZE = 1_000
+    IMPACTED_PLAN_CODES_LIMIT = 10
 
-    def initialize(billable_metric:, filters_params:)
+    def initialize(billable_metric:, filters_params:, discard_impacted_charge_filters: false)
       @billable_metric = billable_metric
       @filters_params = filters_params
+      @discard_impacted_charge_filters = discard_impacted_charge_filters
+      @touched_charge_filter_ids = Set.new
 
       super
     end
@@ -24,7 +27,8 @@ module BillableMetricFilters
 
       return result.validation_failure!(errors: {values: ["value_is_mandatory"]}) if any_filter_params_values_blank?
 
-      ActiveRecord::Base.transaction do
+      # NOTE: requires_new so the guard can undo its own discards; a nested block is not a savepoint.
+      ActiveRecord::Base.transaction(requires_new: true) do
         filters_params.each do |filter_param|
           filter = billable_metric.filters
             .create_with(organization_id: billable_metric.organization_id)
@@ -55,16 +59,27 @@ module BillableMetricFilters
         billable_metric.filters.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
           discard_filter(it)
         end
+
+        resolve_impacted_charge_filters!
       end
+
+      return result if result.failure?
 
       BillableMetricFilters::RefreshDraftInvoicesJob.perform_after_commit(billable_metric.id)
 
       result
+    rescue BaseService::FailedResult => e
+      e.result
     end
 
     private
 
-    attr_reader :billable_metric, :filters_params
+    attr_reader :billable_metric, :filters_params, :discard_impacted_charge_filters, :touched_charge_filter_ids
+
+    # NOTE: one per run. Bulk `update_all` skips PaperTrail, so this is the only trace, and the undo key.
+    def discarded_at
+      @discarded_at ||= Time.current
+    end
 
     def any_filter_params_values_blank?
       filters_params.any? do |filter_param|
@@ -73,8 +88,10 @@ module BillableMetricFilters
     end
 
     def discard_all_filters
-      ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) do
         billable_metric.filters.each { discard_filter(it) }
+
+        resolve_impacted_charge_filters!
       end
     end
 
@@ -89,7 +106,7 @@ module BillableMetricFilters
         values_to_trim, values_to_discard = filter_value_batch.partition { |fv| trimmable?(fv, new_values) }
 
         bulk_update_trimmed_filter_values(values_to_trim, new_values)
-        discard_filter_values_and_emptied_charge_filters(values_to_discard)
+        discard_filter_values(values_to_discard)
       end
     end
 
@@ -107,39 +124,76 @@ module BillableMetricFilters
       end
     end
 
-    def discard_filter_values_and_emptied_charge_filters(filter_values)
+    def discard_filter_values(filter_values)
       return if filter_values.empty?
 
-      filter_value_ids = filter_values.map(&:id)
-      bulk_discard_filter_values(filter_value_ids)
-      bulk_discard_emptied_charge_filters_for(filter_value_ids)
-    end
+      touched_charge_filter_ids.merge(filter_values.map(&:charge_filter_id))
 
-    def bulk_discard_filter_values(filter_value_ids)
       ChargeFilterValue
-        .where(id: filter_value_ids)
-        .update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+        .where(id: filter_values.map(&:id))
+        .update_all(deleted_at: discarded_at) # rubocop:disable Rails/SkipsModelValidations
     end
 
-    def bulk_discard_emptied_charge_filters_for(filter_value_ids)
-      charge_filter_ids = ChargeFilterValue
-        .with_discarded
-        .where(id: filter_value_ids)
+    def resolve_impacted_charge_filters!
+      emptied_ids, collapsed_ids = partition_touched_charge_filters
+
+      refuse_collapsed_charge_filters!(collapsed_ids) unless discard_impacted_charge_filters
+
+      discarded_ids = emptied_ids + collapsed_ids
+      return if discarded_ids.empty?
+
+      discarded = ChargeFilters::BulkDiscardService.call!(charge_filter_ids: discarded_ids, discarded_at:)
+
+      Rails.logger.info(
+        "Discarded charge filters after a billable metric filter change: " \
+        "billable_metric=#{billable_metric.id} discarded_at=#{discarded_at.iso8601(6)} " \
+        "emptied=#{emptied_ids.size} collapsed=#{collapsed_ids.size} discarded=#{discarded.discarded_count}"
+      )
+    end
+
+    def refuse_collapsed_charge_filters!(collapsed_ids)
+      return if collapsed_ids.empty?
+
+      result.validation_failure!(errors: collapsed_charge_filters_errors(collapsed_ids)).raise_if_error!
+    end
+
+    def partition_touched_charge_filters
+      emptied_ids = []
+      collapsed_ids = []
+
+      touched_charge_filter_ids.each_slice(BATCH_SIZE) do |ids|
+        kept_ids = ChargeFilter.where(id: ids, deleted_at: nil).unscope(:order).pluck(:id)
+        next if kept_ids.empty?
+
+        slice_emptied_ids = ChargeFilter
+          .where(id: kept_ids, deleted_at: nil)
+          .without_kept_values
+          .unscope(:order)
+          .pluck(:id)
+
+        emptied_ids.concat(slice_emptied_ids)
+        collapsed_ids.concat(kept_ids - slice_emptied_ids)
+      end
+
+      [emptied_ids, collapsed_ids]
+    end
+
+    def collapsed_charge_filters_errors(collapsed_ids)
+      {
+        filters: ["values_used_by_charge_filters"],
+        impacted_charge_filters_count: [collapsed_ids.size.to_s],
+        impacted_plan_codes: impacted_plan_codes(collapsed_ids)
+      }
+    end
+
+    def impacted_plan_codes(collapsed_ids)
+      ChargeFilter
+        .where(id: collapsed_ids.first(BATCH_SIZE))
+        .joins(charge: :plan)
         .unscope(:order)
         .distinct
-        .pluck(:charge_filter_id)
-
-      return if charge_filter_ids.empty?
-
-      ChargeFilter
-        .where(id: charge_filter_ids, deleted_at: nil)
-        .where(
-          "NOT EXISTS (SELECT 1 FROM charge_filter_values" \
-          " WHERE charge_filter_values.charge_filter_id = charge_filters.id" \
-          " AND charge_filter_values.deleted_at IS NULL)"
-        )
-        .unscope(:order)
-        .update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+        .limit(IMPACTED_PLAN_CODES_LIMIT)
+        .pluck("plans.code")
     end
   end
 end

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -32,7 +32,8 @@ module BillableMetrics
         if params.key?(:filters)
           BillableMetricFilters::CreateOrUpdateBatchService.call(
             billable_metric:,
-            filters_params: params[:filters].map { |f| f.to_h.with_indifferent_access }
+            filters_params: params[:filters].map { |f| f.to_h.with_indifferent_access },
+            discard_impacted_charge_filters:
           ).raise_if_error!
         end
 
@@ -72,5 +73,10 @@ module BillableMetrics
     attr_reader :billable_metric, :params
 
     delegate :organization, to: :billable_metric
+
+    # NOTE: cast rather than rely on truthiness: "false" is truthy, and this flag deletes pricing config.
+    def discard_impacted_charge_filters
+      ActiveModel::Type::Boolean.new.cast(params[:discard_impacted_charge_filters]) || false
+    end
   end
 end

--- a/app/services/charge_filters/bulk_discard_service.rb
+++ b/app/services/charge_filters/bulk_discard_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  # Discards charge filters together with the values they still hold, in bounded statements.
+  # Callers can share a `discarded_at` so one run's rows can be listed, or restored, in a single statement.
+  class BulkDiscardService < BaseService
+    Result = BaseResult[:discarded_at, :discarded_count]
+
+    BATCH_SIZE = 1_000
+
+    def initialize(charge_filter_ids:, discarded_at: nil)
+      @charge_filter_ids = charge_filter_ids
+      @discarded_at = discarded_at || Time.current
+
+      super
+    end
+
+    def call
+      result.discarded_at = discarded_at
+      result.discarded_count = 0
+
+      charge_filter_ids.each_slice(BATCH_SIZE) do |ids|
+        # rubocop:disable Rails/SkipsModelValidations
+        ChargeFilterValue.where(charge_filter_id: ids).unscope(:order).update_all(deleted_at: discarded_at)
+        result.discarded_count += ChargeFilter
+          .where(id: ids, deleted_at: nil)
+          .unscope(:order)
+          .update_all(deleted_at: discarded_at)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :charge_filter_ids, :discarded_at
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -13020,6 +13020,7 @@ input UpdateBillableMetricInput {
   clientMutationId: String
   code: String!
   description: String!
+  discardImpactedChargeFilters: Boolean
   expression: String
   fieldName: String
   filters: [BillableMetricFiltersInput!]

--- a/schema.json
+++ b/schema.json
@@ -68607,6 +68607,18 @@
               "deprecationReason": null
             },
             {
+              "name": "discardImpactedChargeFilters",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {

--- a/spec/graphql/mutations/billable_metrics/update_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/update_spec.rb
@@ -59,4 +59,48 @@ RSpec.describe Mutations::BillableMetrics::Update do
     expect(result_data["recurring"]).to eq(false)
     expect(result_data["filters"].count).to eq(1)
   end
+
+  context "when removing a value that a charge filter relies on" do
+    let(:region) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[US Europe]) }
+    let(:cloud) { create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp]) }
+    let(:charge) { create(:standard_charge, billable_metric:, plan: create(:plan, organization:)) }
+    let(:charge_filter) { create(:charge_filter, charge:) }
+
+    let(:input) do
+      {
+        id: billable_metric.id,
+        name: billable_metric.name,
+        code: billable_metric.code,
+        description: billable_metric.description,
+        aggregationType: "count_agg",
+        filters: [
+          {key: "region", values: %w[Europe]},
+          {key: "cloud", values: %w[aws gcp]}
+        ]
+      }
+    end
+
+    before do
+      create(:charge_filter_value, charge_filter:, billable_metric_filter: region, values: %w[US])
+      create(:charge_filter_value, charge_filter:, billable_metric_filter: cloud, values: %w[aws])
+    end
+
+    it "returns a validation error naming the impacted plans" do
+      result = execute_query(query: mutation, input:)
+
+      error = result["errors"].first
+      expect(error["extensions"]["status"]).to eq(422)
+      expect(error["extensions"]["details"]["filters"]).to eq(["values_used_by_charge_filters"])
+      expect(error["extensions"]["details"]["impactedPlanCodes"]).to eq([charge.plan.code])
+
+      expect(charge_filter.reload).not_to be_discarded
+    end
+
+    it "discards the impacted charge filter when opted in" do
+      result = execute_query(query: mutation, input: input.merge(discardImpactedChargeFilters: true))
+
+      expect(result["errors"]).to be_nil
+      expect(charge_filter.reload).to be_discarded
+    end
+  end
 end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -16,6 +16,28 @@ RSpec.describe ChargeFilter do
     end
   end
 
+  describe "Scopes" do
+    let(:billable_metric) { create(:billable_metric) }
+    let(:charge) { create(:standard_charge, billable_metric:) }
+    let(:region) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[US Europe]) }
+
+    let(:kept_filter) { create(:charge_filter, charge:) }
+    let(:emptied_filter) { create(:charge_filter, charge:) }
+
+    before do
+      create(:charge_filter_value, charge_filter: kept_filter, billable_metric_filter: region, values: %w[US])
+
+      create(:charge_filter_value, charge_filter: emptied_filter, billable_metric_filter: region, values: %w[US])
+        .discard!
+    end
+
+    describe ".without_kept_values" do
+      it "returns the filters whose values are all discarded" do
+        expect(described_class.without_kept_values).to eq([emptied_filter])
+      end
+    end
+  end
+
   describe "#validate_properties" do
     subject(:charge_filter) { build(:charge_filter, charge:, properties: charge_properties) }
 

--- a/spec/requests/api/v1/billable_metrics_controller_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_controller_spec.rb
@@ -180,6 +180,63 @@ RSpec.describe Api::V1::BillableMetricsController do
         expect(json[:billable_metric][:weighted_interval]).to eq("seconds")
       end
     end
+
+    context "when removing a filter value used by a charge filter with other keys" do
+      let(:region) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[US Europe]) }
+      let(:cloud) { create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp]) }
+      let(:charge) { create(:standard_charge, billable_metric:, plan: create(:plan, organization:)) }
+      let(:charge_filter) { create(:charge_filter, charge:) }
+
+      let(:update_params) do
+        {
+          name: "BM1",
+          filters: [
+            {key: "region", values: %w[Europe]},
+            {key: "cloud", values: %w[aws gcp]}
+          ]
+        }
+      end
+
+      before do
+        create(:charge_filter_value, charge_filter:, billable_metric_filter: region, values: %w[US])
+        create(:charge_filter_value, charge_filter:, billable_metric_filter: cloud, values: %w[aws])
+      end
+
+      it "returns unprocessable_entity and keeps the charge filter" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details][:filters]).to eq(["values_used_by_charge_filters"])
+        expect(json[:error_details][:impacted_charge_filters_count]).to eq(["1"])
+        expect(json[:error_details][:impacted_plan_codes]).to eq([charge.plan.code])
+
+        expect(charge_filter.reload).not_to be_discarded
+        expect(region.reload.values).to eq(%w[US Europe])
+      end
+
+      context "when discard_impacted_charge_filters is set" do
+        let(:update_params) { super().merge(discard_impacted_charge_filters: true) }
+
+        it "discards the impacted charge filter" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(charge_filter.reload).to be_discarded
+          expect(region.reload.values).to eq(%w[Europe])
+        end
+      end
+
+      context "when discard_impacted_charge_filters is the string \"false\"" do
+        let(:update_params) { super().merge(discard_impacted_charge_filters: "false") }
+
+        it "still returns unprocessable_entity" do
+          subject
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(charge_filter.reload).not_to be_discarded
+        end
+      end
+    end
   end
 
   describe "GET /api/v1/billable_metrics/:code" do

--- a/spec/scenarios/plans/create_and_update_filters_spec.rb
+++ b/spec/scenarios/plans/create_and_update_filters_spec.rb
@@ -76,24 +76,28 @@ RSpec.describe "Create and edit plans with charge filters" do
     charge = plan.charges.first
     expect(charge.filters.count).to eq(4)
 
-    # Update the typo on the charge filter values
+    # Update the typo on the charge filter values. f1 and f2 are both priced on the old image_size, so the
+    # update is refused until it says what should happen to them.
+    fixed_filters = [
+      {key: "image_size", values: %w[1024x1024 512x512]},
+      {key: "steps", values: %w[0-25 26-50 51-100]},
+      {key: "model_name", values: %w[llama-1 llama-2 llama-3]}
+    ]
+
     travel_to(Time.zone.parse("2024-03-27T14:00:00")) do
-      update_metric(
-        billable_metric,
-        {filters: [
-          {key: "image_size", values: %w[1024x1024 512x512]},
-          {key: "steps", values: %w[0-25 26-50 51-100]},
-          {key: "model_name", values: %w[llama-1 llama-2 llama-3]}
-        ]}
-      )
+      update_metric(billable_metric, {filters: fixed_filters}, raise_on_error: false)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json[:error_details][:filters]).to eq(["values_used_by_charge_filters"])
+
+      update_metric(billable_metric, {filters: fixed_filters, discard_impacted_charge_filters: true})
     end
 
     charge.reload
-    f1 = charge.filters.find_by(invoice_display_name: "f1")
-    expect(f1.to_h.keys).to match_array(%w[steps model_name])
-
-    f2 = charge.filters.find_by(invoice_display_name: "f2")
-    expect(f2.to_h.keys).to eq(%w[steps])
+    # Discarded rather than left matching every image size at the price set for one of them.
+    expect(charge.filters.count).to eq(2)
+    expect(charge.filters.find_by(invoice_display_name: "f1")).to be_nil
+    expect(charge.filters.find_by(invoice_display_name: "f2")).to be_nil
 
     f3 = charge.filters.find_by(invoice_display_name: "f3")
     expect(f3.to_h.keys).to match_array(%w[image_size steps])

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -3,9 +3,10 @@
 require "rails_helper"
 
 RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
-  subject(:service) { described_class.call(billable_metric:, filters_params:) }
+  subject(:service) { described_class.call(billable_metric:, filters_params:, discard_impacted_charge_filters:) }
 
   let(:billable_metric) { create(:billable_metric) }
+  let(:discard_impacted_charge_filters) { false }
 
   context "when filter params is empty" do
     let(:filters_params) { {} }
@@ -249,12 +250,54 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
           ]
         end
 
-        it "discards the filter_value but keeps the shared charge_filter" do
-          service
+        # NOTE: dropping "US" would leave it matching {cloud: aws} alone, at the {region: US, cloud: aws} price.
+        it "fails and leaves every row untouched" do
+          result = service
 
-          expect(shared_cfv_region.reload).to be_discarded
+          expect(result).not_to be_success
+          expect(result.error.messages[:filters]).to eq(["values_used_by_charge_filters"])
+          expect(result.error.messages[:impacted_charge_filters_count]).to eq(["1"])
+          expect(result.error.messages[:impacted_plan_codes]).to eq([charge.plan.code])
+
+          expect(shared_cfv_region.reload).not_to be_discarded
           expect(shared_cfv_cloud.reload).not_to be_discarded
           expect(shared_charge_filter.reload).not_to be_discarded
+          expect(filter.reload.values).to eq(%w[Europe US Asia])
+        end
+
+        it "does not enqueue the refresh draft invoices job" do
+          expect { service }.not_to have_enqueued_job(BillableMetricFilters::RefreshDraftInvoicesJob)
+        end
+
+        # NOTE: the rollback must not depend on the caller re-raising the failure.
+        it "undoes its own discards when a caller only reads the failure" do
+          ActiveRecord::Base.transaction do
+            expect(service).not_to be_success
+          end
+
+          expect(shared_cfv_region.reload).not_to be_discarded
+          expect(shared_charge_filter.reload).not_to be_discarded
+          expect(filter.reload.values).to eq(%w[Europe US Asia])
+        end
+
+        context "when discarding the impacted charge filters is opted in" do
+          let(:discard_impacted_charge_filters) { true }
+
+          it "discards the charge_filter along with its surviving filter_value" do
+            expect(service).to be_success
+
+            expect(shared_cfv_region.reload).to be_discarded
+            expect(shared_cfv_cloud.reload).to be_discarded
+            expect(shared_charge_filter.reload).to be_discarded
+            expect(filter.reload.values).to eq(%w[Europe])
+          end
+
+          it "stamps one deleted_at across the whole run" do
+            service
+
+            expect(shared_cfv_cloud.reload.deleted_at).to eq(shared_charge_filter.reload.deleted_at)
+            expect(shared_cfv_region.reload.deleted_at).to eq(shared_charge_filter.reload.deleted_at)
+          end
         end
       end
 
@@ -325,6 +368,70 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
           expect(filter.reload).to be_discarded
           expect(filter_value.reload).to be_discarded
           expect(charge_filter.reload).to be_discarded
+        end
+
+        # NOTE: the ticket's reproduction: it would keep the {region: US} price while matching every region.
+        context "when the charge_filter also holds a value from a filter that survives" do
+          let(:other_filter) { create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp]) }
+
+          let(:filters_params) do
+            [
+              {key: "country", values: %w[USA France Germany]},
+              {key: "cloud", values: %w[aws gcp]}
+            ]
+          end
+
+          let!(:other_filter_value) do
+            create(
+              :charge_filter_value,
+              charge_filter:,
+              billable_metric_filter: other_filter,
+              values: %w[aws]
+            )
+          end
+
+          it "fails and leaves every row untouched" do
+            result = service
+
+            expect(result).not_to be_success
+            expect(result.error.messages[:filters]).to eq(["values_used_by_charge_filters"])
+
+            expect(filter.reload).not_to be_discarded
+            expect(filter_value.reload).not_to be_discarded
+            expect(other_filter_value.reload).not_to be_discarded
+            expect(charge_filter.reload).not_to be_discarded
+          end
+
+          context "when discarding the impacted charge filters is opted in" do
+            let(:discard_impacted_charge_filters) { true }
+
+            it "discards the filter, both filter_values, and the charge_filter" do
+              expect(service).to be_success
+
+              expect(filter.reload).to be_discarded
+              expect(filter_value.reload).to be_discarded
+              expect(other_filter_value.reload).to be_discarded
+              expect(charge_filter.reload).to be_discarded
+            end
+          end
+
+          # NOTE: both dimensions go, in separate batches. Nothing survives to broaden, so no need to ask.
+          context "when the charge_filter loses its surviving key in the same call" do
+            let(:filters_params) do
+              [
+                {key: "country", values: %w[USA France Germany]},
+                {key: "cloud", values: %w[gcp]}
+              ]
+            end
+
+            it "discards the emptied charge_filter without failing" do
+              expect(service).to be_success
+
+              expect(filter_value.reload).to be_discarded
+              expect(other_filter_value.reload).to be_discarded
+              expect(charge_filter.reload).to be_discarded
+            end
+          end
         end
       end
     end

--- a/spec/services/charge_filters/bulk_discard_service_spec.rb
+++ b/spec/services/charge_filters/bulk_discard_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeFilters::BulkDiscardService do
+  subject(:service) { described_class.call(charge_filter_ids:) }
+
+  let(:billable_metric) { create(:billable_metric) }
+  let(:charge) { create(:standard_charge, billable_metric:) }
+  let(:region) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[US Europe]) }
+  let(:charge_filter) { create(:charge_filter, charge:) }
+  let(:charge_filter_ids) { [charge_filter.id] }
+
+  let(:filter_value) { create(:charge_filter_value, charge_filter:, billable_metric_filter: region, values: %w[US]) }
+
+  before { filter_value }
+
+  it "discards the filter and its values with a single timestamp" do
+    expect(service).to be_success
+
+    expect(charge_filter.reload).to be_discarded
+    expect(filter_value.reload).to be_discarded
+    expect(filter_value.reload.deleted_at).to eq(charge_filter.reload.deleted_at)
+    expect(service.discarded_count).to eq(1)
+  end
+
+  it "returns a timestamp that selects exactly what the run touched" do
+    service
+
+    expect(ChargeFilter.with_discarded.where(deleted_at: service.discarded_at)).to eq([charge_filter])
+    expect(ChargeFilterValue.with_discarded.where(deleted_at: service.discarded_at)).to eq([filter_value])
+  end
+
+  context "when a timestamp is given" do
+    subject(:service) { described_class.call(charge_filter_ids:, discarded_at:) }
+
+    let(:discarded_at) { 2.days.ago.beginning_of_minute }
+
+    it "uses it, so a caller can group several calls into one reversible run" do
+      service
+
+      expect(charge_filter.reload.deleted_at).to eq(discarded_at)
+      expect(filter_value.reload.deleted_at).to eq(discarded_at)
+    end
+  end
+
+  context "when a value is already discarded" do
+    let(:discarded_value) do
+      create(:charge_filter_value, charge_filter:, billable_metric_filter: region, values: %w[Europe])
+    end
+
+    before { discarded_value.discard! }
+
+    it "leaves its deleted_at untouched" do
+      expect { service }.not_to change { discarded_value.reload.deleted_at }
+    end
+  end
+
+  context "when the filter is already discarded" do
+    before { charge_filter.discard! }
+
+    it "is not counted again" do
+      expect(service.discarded_count).to eq(0)
+    end
+  end
+
+  context "with an empty list" do
+    let(:charge_filter_ids) { [] }
+
+    it "does nothing" do
+      expect(service.discarded_count).to eq(0)
+      expect(charge_filter.reload).not_to be_discarded
+    end
+  end
+end


### PR DESCRIPTION
## Context

A charge filter is a price tag with a condition on it. The condition is not stored on the filter, it is derived from the filter's values. Delete a key from the billable metric and its values go away, but the filter survives with a shorter condition and its original price.

```mermaid
flowchart LR
  A["Filter<br/>region = US<br/>AND tier = gold<br/><b>$10.00 / unit</b>"]
  B["Filter<br/>region = US<br/><br/><b>$10.00 / unit</b>"]
  C["Now matches every US event,<br/>at the price meant for gold only"]
  A -- "the tier key is removed<br/>from the billable metric" --> B --> C
  style A fill:#e8f5e9,stroke:#43a047
  style B fill:#fff8e1,stroke:#fb8c00
  style C fill:#ffebee,stroke:#e53935
```

The API returns 200, nothing warns, and the filter keeps its `invoice_display_name`, so the invoice line still advertises a condition that is no longer applied.

What that costs, on the reproduction from the ticket, where the charge's default price is $0.01 and the filter is $10.00:

| | Filter row | Default row | Total |
| --- | --- | --- | --- |
| Before | 0 units | 100 units @ $0.01 | **$1.00** |
| After removing an unrelated key | 100 units @ $10.00 | 0 units | **$1,000.00** |

And when the shortened condition happens to match a sibling filter, both match the same events, so the usage is billed twice:

```mermaid
flowchart LR
  A1["Filter A<br/>region = US, tier = gold<br/>$10.00"] -- "tier removed" --> A2["Filter A<br/>region = US<br/>$10.00"]
  B1["Filter B<br/>region = US<br/>$0.50"] --> B2["Filter B<br/>region = US<br/>$0.50"]
  A2 --> Z["Same condition, two prices:<br/>the same units are billed by both"]
  B2 --> Z
  style Z fill:#ffebee,stroke:#e53935
```

This has been the behaviour since charge filters shipped in #1609, so it is not a regression. It has caused a confirmed overcharge on a paid invoice for a customer: [ING-536](https://linear.app/getlago/issue/ING-536).

## Changes

`BillableMetricFilters::CreateOrUpdateBatchService` now classifies the affected charge filters once, after every batch has run, and acts on what each one lost:

| What the filter lost | Behaviour |
| --- | --- |
| every value | discarded, as before: no condition is left to misapply |
| some values of a key, others kept | unchanged: the condition only narrows |
| a whole key, other keys kept | **the update is refused**, naming the impacted plans |

The refusal returns 422 with `values_used_by_charge_filters` plus the impacted plan codes and a count in `error_details`, so the pricing decision goes back to whoever owns it.

Passing `discard_impacted_charge_filters` opts into discarding those filters instead. That is deliberately not the default: the freed usage then falls to the charge's default price, which is another silent price change.

Discards go through the new `ChargeFilters::BulkDiscardService`, which stamps one timestamp per run so a run's rows can be listed, or reversed, in a single statement. That matters because the bulk `update_all` on this path skips PaperTrail.

## Before merging

`PUT /api/v1/billable_metrics/:code` now returns 422 where it returned 200 for this case. It needs a changelog and docs note, and the UI wants a confirmation dialog in the same release, otherwise someone editing filters on an affected plan hits an error they cannot get past.

<details>
<summary>Three decisions worth knowing about while reviewing</summary>

- **Classification happens once at the end, not per batch.** A charge filter's values can be split across `in_batches` boundaries, so whether it ends up emptied or merely narrowed is only known after the last batch. A spec covers the case per-batch classification gets wrong.
- **The transaction is `requires_new: true`.** Callers already hold a transaction, and a plain nested block is a pass-through rather than a savepoint, so the guard could not otherwise undo its own discards if a caller read the failed result without re-raising it. A spec covers that caller.
- **Auto-de-duplicating filters whose conditions become identical is not here.** It needs a condition comparison across every filter of every affected charge, inside the request, which is the cost profile #5478 and #5648 removed from this path. Doing it as remediation instead also lets the survivor be chosen deliberately, which matters because the two filters can carry different prices.

</details>

Finding and cleaning up the filters already broken by this is a follow-up, not in this PR.
