### PR TITLE
fix(wallets): Unlock refresh jobs

### DIFF
--- a/app/jobs/customers/refresh_wallet_job.rb
+++ b/app/jobs/customers/refresh_wallet_job.rb
@@ -32,7 +32,7 @@ module Customers
       # when the job raises. Swallowing the error here also bypasses Sidekiq's death handler, so
       # the lock must be released explicitly: otherwise the customer stays locked for `lock_ttl`
       # and every re-enqueue from the clock job is silently dropped on conflict.
-      ActiveJob::Uniqueness.unlock!(job_class_name: job.class.name, arguments: job.arguments)
+      job.lock_strategy.unlock(resource: job.lock_key)
     end
 
     retry_on(*Integrations::Aggregator::BaseService.retryable_errors, wait: :polynomially_longer, attempts: 6)


### PR DESCRIPTION
## Context

#6056 released the uniqueness lock when `Customers::RefreshWalletJob` gives up after exhausting its throttling retries, using `ActiveJob::Uniqueness.unlock!`.
That helper resolves a key *wildcard*: it walks the whole Redis keyspace with `SCAN` and destructures each reply into a cursor and a list of keys. In production the reply did not always destructure into two elements, so the key list came back `nil` and the call raised `NoMethodError: undefined method 'empty?' for nil` (API-2PG).

The error was raised from inside the give-up block, so the block failed before doing its job: the lock was not released and the job died anyway the exact outcome #6056 set out to prevent.

## Description

Release the lock through the job's own uniqueness strategy, which deletes its single lock key with `DEL`, instead of through the wildcard helper. This is the same call the skipped `after_perform` callback would have made, with the same key and the same instrumentation, and it no longer depends on the shape of a `SCAN` reply. It also avoids scanning the entire Sidekiq Redis keyspace to delete one known key.