### PR TITLE
misc(finance_assistant): bound and observe the /ask call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,10 @@ To create a webhook:
 - When a change introduces a new environment variable, document it in this file (name, purpose, example value)
 - `LAGO_ENABLE_YJIT` — when true, enables YJIT (`config.yjit`). Disabled by default. Example: `LAGO_ENABLE_YJIT=true`
 - `SIDEKIQ_WALLETS` — when true, wallet jobs (e.g. `Customers::RefreshWalletJob`) are routed to the `wallets` queue, processed by the dedicated wallet worker (`scripts/start.wallets.worker.sh`). Example: `SIDEKIQ_WALLETS=true`
+- `SIDEKIQ_AI_AGENT` — when true, AI conversation jobs (`AiConversations::StreamJob`) are routed to the `ai_agent` queue. Example: `SIDEKIQ_AI_AGENT=true`
+- `LAGO_FINANCE_ASSISTANT_URL` — base URL of the finance assistant service that answers `askFinanceAssistant`. When blank the feature is unavailable and the mutation returns a forbidden failure. Example: `LAGO_FINANCE_ASSISTANT_URL=http://lago-data-agent:8000`
+- `LAGO_FINANCE_ASSISTANT_OPEN_TIMEOUT` — connection timeout, in seconds, for the finance assistant call. Defaults to 5. Example: `LAGO_FINANCE_ASSISTANT_OPEN_TIMEOUT=5`
+- `LAGO_FINANCE_ASSISTANT_READ_TIMEOUT` — response timeout, in seconds, for the finance assistant call. Defaults to 60. Must stay above the assistant's own run deadline (`ASK_DEADLINE_SECS`, 55s today) so that a slow answer is received instead of being cut off. Example: `LAGO_FINANCE_ASSISTANT_READ_TIMEOUT=60`
 - Sensitive values (keys, secrets, passwords, tokens, credentials embedded in URLs) must always be masked in examples, e.g. `LAGO_SMTP_PASSWORD=***` or `DATABASE_URL=postgresql://***@db:5432/lago`
 
 # Service

--- a/app/services/finance_assistant/ask_service.rb
+++ b/app/services/finance_assistant/ask_service.rb
@@ -7,6 +7,13 @@ module FinanceAssistant
     # Keys the GraphQL FinanceAssistantAnswer type exposes as non-nullable
     REQUIRED_ANSWER_KEYS = %w[explanation results session_id session_expired message_id].freeze
 
+    # The read timeout must stay above the assistant's own run deadline
+    # (ASK_DEADLINE_SECS on its side). Past that deadline it answers with a
+    # graceful explanation, and hanging up first turns that answer into a
+    # transport error.
+    DEFAULT_OPEN_TIMEOUT = 5
+    DEFAULT_READ_TIMEOUT = 60
+
     def initialize(organization:, question:, session_id: nil)
       @organization = organization
       @question = question
@@ -16,6 +23,8 @@ module FinanceAssistant
     end
 
     def call
+      started_at = monotonic_now
+
       return result.forbidden_failure! if finance_assistant_url.blank?
       return result.single_validation_failure!(error_code: "value_is_mandatory", field: :question) if question.blank?
 
@@ -23,6 +32,8 @@ module FinanceAssistant
       body = JSON.parse(response.body.presence || "{}")
 
       unless valid_answer?(body)
+        log_failure(code: "finance_assistant_invalid_response", started_at:)
+
         return result.service_failure!(
           code: "finance_assistant_invalid_response",
           message: "Malformed response from the finance assistant"
@@ -32,14 +43,20 @@ module FinanceAssistant
       result.answer = body
       result
     rescue LagoHttpClient::HttpError => e
+      log_failure(code: "finance_assistant_error", started_at:, error: e)
+
       result.service_failure!(
         code: "finance_assistant_error",
         message: e.json_message["detail"].presence || e.message,
         error: e
       )
     rescue JSON::ParserError => e
+      log_failure(code: "finance_assistant_invalid_response", started_at:, error: e)
+
       result.service_failure!(code: "finance_assistant_invalid_response", message: e.message, error: e)
     rescue => e
+      log_failure(code: "finance_assistant_error", started_at:, error: e)
+
       result.service_failure!(code: "finance_assistant_error", message: e.message, error: e)
     end
 
@@ -49,6 +66,25 @@ module FinanceAssistant
 
     def valid_answer?(body)
       body.is_a?(Hash) && REQUIRED_ANSWER_KEYS.all? { |key| !body[key].nil? }
+    end
+
+    # Every failure reaches the caller as the same generic GraphQL error, so the
+    # duration is the only way to tell a timeout after a minute of work from an
+    # immediate refusal.
+    def log_failure(code:, started_at:, error: nil)
+      context = {
+        organization_id: organization.id,
+        code:,
+        duration: (monotonic_now - started_at).round(2),
+        error: error&.class&.name,
+        error_message: error&.message&.inspect
+      }
+
+      Rails.logger.warn("FinanceAssistant::AskService failed #{context.map { |k, v| "#{k}=#{v}" }.join(" ")}")
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def request_body
@@ -64,9 +100,17 @@ module FinanceAssistant
     def http_client
       LagoHttpClient::Client.new(
         "#{finance_assistant_url.chomp("/")}/ask",
-        open_timeout: 5,
-        read_timeout: 60
+        open_timeout: timeout_from_env("LAGO_FINANCE_ASSISTANT_OPEN_TIMEOUT", DEFAULT_OPEN_TIMEOUT),
+        read_timeout: timeout_from_env("LAGO_FINANCE_ASSISTANT_READ_TIMEOUT", DEFAULT_READ_TIMEOUT)
       )
+    end
+
+    # Net::HTTP reads a zero timeout as "give up immediately", so anything that is
+    # not a positive number of seconds falls back to the default.
+    def timeout_from_env(name, default)
+      seconds = ENV[name].to_i
+
+      seconds.positive? ? seconds : default
     end
 
     def finance_assistant_url

--- a/spec/services/finance_assistant/ask_service_spec.rb
+++ b/spec/services/finance_assistant/ask_service_spec.rb
@@ -109,12 +109,26 @@ RSpec.describe FinanceAssistant::AskService do
   context "when the request to the finance assistant times out" do
     before do
       stub_request(:post, "#{finance_assistant_url}/ask").to_timeout
+      allow(Rails.logger).to receive(:warn)
     end
 
     it "returns a service failure" do
       expect(result).to be_failure
       expect(result.error).to be_a(BaseService::ServiceFailure)
       expect(result.error.code).to eq("finance_assistant_error")
+    end
+
+    it "logs the failure with the time spent waiting for the assistant" do
+      result
+
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_including(
+          "FinanceAssistant::AskService failed",
+          "organization_id=#{organization.id}",
+          "code=finance_assistant_error",
+          "duration="
+        )
+      )
     end
   end
 
@@ -172,12 +186,24 @@ RSpec.describe FinanceAssistant::AskService do
     before do
       stub_request(:post, "#{finance_assistant_url}/ask")
         .to_return(status: 200, body: {explanation: "Missing the rest"}.to_json)
+      allow(Rails.logger).to receive(:warn)
     end
 
     it "returns an invalid response failure" do
       expect(result).to be_failure
       expect(result.error).to be_a(BaseService::ServiceFailure)
       expect(result.error.code).to eq("finance_assistant_invalid_response")
+    end
+
+    it "logs the failure" do
+      result
+
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_including(
+          "FinanceAssistant::AskService failed",
+          "code=finance_assistant_invalid_response"
+        )
+      )
     end
   end
 
@@ -189,6 +215,74 @@ RSpec.describe FinanceAssistant::AskService do
     it "returns an invalid response failure" do
       expect(result).to be_failure
       expect(result.error.code).to eq("finance_assistant_invalid_response")
+    end
+  end
+
+  describe "http timeouts" do
+    before do
+      stub_request(:post, "#{finance_assistant_url}/ask").to_return(
+        status: 200,
+        body: {
+          explanation: "Here is the result.",
+          results: "| Month | MRR |",
+          session_id:,
+          message_id:,
+          session_expired: false
+        }.to_json
+      )
+
+      allow(LagoHttpClient::Client).to receive(:new).and_call_original
+    end
+
+    it "leaves room for the agent deadline by default" do
+      result
+
+      expect(LagoHttpClient::Client).to have_received(:new).with(
+        "#{finance_assistant_url}/ask",
+        open_timeout: 5,
+        read_timeout: 60
+      )
+    end
+
+    context "when timeouts are set in the environment" do
+      around do |example|
+        previous_open = ENV["LAGO_FINANCE_ASSISTANT_OPEN_TIMEOUT"]
+        previous_read = ENV["LAGO_FINANCE_ASSISTANT_READ_TIMEOUT"]
+        ENV["LAGO_FINANCE_ASSISTANT_OPEN_TIMEOUT"] = "3"
+        ENV["LAGO_FINANCE_ASSISTANT_READ_TIMEOUT"] = "90"
+        example.run
+        ENV["LAGO_FINANCE_ASSISTANT_OPEN_TIMEOUT"] = previous_open
+        ENV["LAGO_FINANCE_ASSISTANT_READ_TIMEOUT"] = previous_read
+      end
+
+      it "uses the configured values" do
+        result
+
+        expect(LagoHttpClient::Client).to have_received(:new).with(
+          "#{finance_assistant_url}/ask",
+          open_timeout: 3,
+          read_timeout: 90
+        )
+      end
+    end
+
+    context "when a timeout is set to a non positive value" do
+      around do |example|
+        previous_read = ENV["LAGO_FINANCE_ASSISTANT_READ_TIMEOUT"]
+        ENV["LAGO_FINANCE_ASSISTANT_READ_TIMEOUT"] = "0"
+        example.run
+        ENV["LAGO_FINANCE_ASSISTANT_READ_TIMEOUT"] = previous_read
+      end
+
+      it "falls back to the default" do
+        result
+
+        expect(LagoHttpClient::Client).to have_received(:new).with(
+          "#{finance_assistant_url}/ask",
+          open_timeout: 5,
+          read_timeout: 60
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

The finance assistant bounds a single run on its own wall-clock deadline so that a slow turn answers with a graceful explanation instead of being killed mid-flight. That only works if we wait long enough to receive it, so the two sides of the budget have to be tuned together — but our side was a pair of hardcoded literals, which meant a deploy of this repo to change either one.

Once the call does fail, nothing on our side records it. Every failure mode — a timeout, an error status, a malformed body — reaches the caller as the same generic GraphQL error, and the only latency data we have for this feature comes from the browser, which is a poor place to depend on: it is sampled, and it goes missing entirely for anyone whose browser blocks the reporting endpoint.

## Description

The connection and response timeouts are now read from the environment, keeping the current values as defaults. A non-positive value falls back to the default rather than disabling the timeout, which is what Net::HTTP would otherwise do with a zero. The comment on the defaults records why the response timeout has to stay above the assistant's own deadline, and the environment variables are documented alongside the others, including the ones the finance assistant and the AI conversation queue already relied on undocumented.

Failures are now logged with the organization, the failure code, the exception and how long we waited before giving up. That last part is the signal: the assistant is allowed to spend most of a minute on a question, so a timeout after a full minute of work and an immediate refusal call for very different fixes, and they are currently indistinguishable. Successful calls stay silent to keep the logs usable.