### PR TITLE
Remove meilisearch from sidekiq.yml config

### DIFF
--- a/config/sidekiq/sidekiq.yml
+++ b/config/sidekiq/sidekiq.yml
@@ -12,7 +12,6 @@ queues:
   - integrations
   - low_priority
   - long_running
-  - meilisearch
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10) %>


### PR DESCRIPTION
This commit fixes a issue in us cluster due wrong config of sidekiq

meilisearch was wrongly added to sidekiq.yml but the queue has a proper config and should run in separated workers.
