### PR TITLE
[ING-536] fix(filters): Cascade charge filter changes to overridden plans

### DIFF
--- a/app/services/charge_filters/cascade_dispatcher.rb
+++ b/app/services/charge_filters/cascade_dispatcher.rb
@@ -8,36 +8,58 @@ module ChargeFilters
     # per change. `before` and `after` are arrays of:
     #   { values: {"key" => [...]}, properties: {...} | nil, invoice_display_name: "..." }
     # `values` and `properties` must be string-keyed.
+    #
+    # `values` is the filter's predicate, and it is what a job targets. Filters left on
+    # the same predicate by an older billable metric change are cascaded as one group.
     def call(charge:, before:, after:)
-      before_by_values = before.index_by { |f| f[:values] }
+      before_by_predicate = before.group_by { |filter| filter[:values] }
 
       after.each do |new_filter|
-        existing = before_by_values.delete(new_filter[:values])
+        previous_filters = before_by_predicate.delete(new_filter[:values]) || []
+        previous = previous_filters.first
 
-        next if existing &&
-          existing[:properties] == new_filter[:properties] &&
-          existing[:invoice_display_name] == new_filter[:invoice_display_name]
+        # Several filters on one predicate still need a job, even when the kept one is
+        # unchanged: the cascade is what discards the duplicates on the override
+        next if previous_filters.one? && unchanged?(previous, new_filter)
 
-        ChargeFilters::CascadeJob.perform_later(
-          charge.id,
-          existing ? "update" : "create",
+        enqueue(
+          charge,
+          previous ? "update" : "create",
           new_filter[:values],
-          existing&.dig(:properties),
+          previous&.dig(:properties),
           new_filter[:properties],
           new_filter[:invoice_display_name]
         )
       end
 
-      before_by_values.each_value do |old|
-        ChargeFilters::CascadeJob.perform_later(
-          charge.id,
+      # Predicates no filter in `after` claimed are the removed ones. A job targets a
+      # predicate and the cascade discards every child filter on it, so one job covers
+      # the group and any of its filters can carry the payload.
+      before_by_predicate.each_value do |removed_filters|
+        removed = removed_filters.first
+
+        enqueue(
+          charge,
           "destroy",
-          old[:values],
-          old[:properties],
+          removed[:values],
+          removed[:properties],
           nil,
-          old[:invoice_display_name]
+          removed[:invoice_display_name]
         )
       end
+    end
+
+    def unchanged?(previous, new_filter)
+      return false if previous.nil?
+
+      previous[:properties] == new_filter[:properties] &&
+        previous[:invoice_display_name] == new_filter[:invoice_display_name]
+    end
+
+    def enqueue(charge, action, values, old_properties, new_properties, invoice_display_name)
+      ChargeFilters::CascadeJob.perform_later(
+        charge.id, action, values, old_properties, new_properties, invoice_display_name
+      )
     end
   end
 end

--- a/app/services/charge_filters/cascade_service.rb
+++ b/app/services/charge_filters/cascade_service.rb
@@ -28,12 +28,12 @@ module ChargeFilters
         Charge.where(id: ids).includes(:billable_metric).find_each do |child_charge|
           Charge.no_touching do
             Plan.no_touching do
-              child_filter = matches[child_charge.id]
+              matching_filters = matches.fetch(child_charge.id, [])
 
               case action
-              when "update" then update_child_filter(child_charge, child_filter)
-              when "create" then create_child_filter(child_charge, child_filter)
-              when "destroy" then destroy_child_filter(child_filter)
+              when "update" then update_child_filters(child_charge, matching_filters)
+              when "create" then create_child_filter(child_charge) if matching_filters.empty?
+              when "destroy" then matching_filters.each { destroy_child_filter(it) }
               end
             end
           end
@@ -75,7 +75,16 @@ module ChargeFilters
         .where(id: candidate_ids)
         .includes(values: :billable_metric_filter)
         .select { |filter| filter.to_h == filter_values }
-        .index_by(&:charge_id)
+        .group_by(&:charge_id)
+    end
+
+    # The parent holds one filter per predicate, so the child converges on one too:
+    # duplicates left by an older billable metric change go with the update
+    def update_child_filters(child_charge, matching_filters)
+      surviving, *duplicates = matching_filters
+
+      update_child_filter(child_charge, surviving)
+      duplicates.each { destroy_child_filter(it) }
     end
 
     def update_child_filter(child_charge, child_filter)
@@ -95,9 +104,7 @@ module ChargeFilters
       child_filter.save!
     end
 
-    def create_child_filter(child_charge, existing_filter)
-      return if existing_filter
-
+    def create_child_filter(child_charge)
       # NOTE: Resolve against the current state of the billable metric filters
       # to avoid any changes that may have occurred since the job was enqueued
       return if resolved_filter_values.empty?

--- a/app/services/charge_filters/destroy_service.rb
+++ b/app/services/charge_filters/destroy_service.rb
@@ -16,9 +16,9 @@ module ChargeFilters
     def call
       return result.not_found_failure!(resource: "charge_filter") unless charge_filter
 
-      # Capture values before the transaction discards them — to_h uses the kept
-      # scope and would return an empty hash after discard.
-      filter_values = charge_filter.to_h_with_discarded
+      # Kept values only, captured before the transaction discards them: the children
+      # are matched on their live predicate, which a metric change shortened alike
+      filter_values = charge_filter.to_h
 
       ActiveRecord::Base.transaction do
         charge_filter.values.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations

--- a/spec/scenarios/plans/cascade_filters_over_metric_edits_spec.rb
+++ b/spec/scenarios/plans/cascade_filters_over_metric_edits_spec.rb
@@ -1,0 +1,399 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Walks a plan and its override through metric edits and plan edits, checking both sides
+# after every step. Each step lists the filters before and after, written out in full as
+# `{key: [values]} @price`, so the state is readable without running anything.
+#
+# Three things are pinned here:
+#   - filters left on a shared predicate by a metric edit are NOT deleted for the customer
+#   - a price negotiated on the override is NOT overwritten by a plan reprice
+#   - whatever the plan ends up with, the override follows
+#
+# Removing a metric value trims the value out of the charge filters referencing it rather
+# than destroying them, so predicates shorten and can collide. That is existing behaviour.
+RSpec.describe "Cascade filters over metric edits", :premium do
+  include ScenariosHelper
+
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:sum_billable_metric, organization:, code: "api_pages", field_name: "value") }
+
+  let(:models) { (1..10).map { "m#{it}" } }
+
+  let(:pages) { {"type" => %w[pages]} }
+  let(:m2) { {"type" => %w[pages], "model" => %w[m2]} }
+  let(:m3) { {"type" => %w[pages], "model" => %w[m3]} }
+  let(:m4) { {"type" => %w[pages], "model" => %w[m4]} }
+  let(:m5) { {"type" => %w[pages], "model" => %w[m5]} }
+
+  before do
+    create(:billable_metric_filter, billable_metric:, key: "type", values: %w[pages])
+    create(:billable_metric_filter, billable_metric:, key: "model", values: models)
+  end
+
+  def model_filter(model, amount)
+    {invoice_display_name: "Model #{model}", properties: {amount:}, values: {type: %w[pages], model: [model]}}
+  end
+
+  def pages_filter(amount)
+    {invoice_display_name: "Pages", properties: {amount:}, values: {type: %w[pages]}}
+  end
+
+  def plan_payload(filters, charge_id: nil, cascade: false)
+    charge = {
+      billable_metric_id: billable_metric.id,
+      charge_model: "standard",
+      code: "pages_charge",
+      pay_in_advance: false,
+      properties: {amount: "0.01"},
+      filters:
+    }
+    charge[:id] = charge_id if charge_id
+
+    payload = {
+      name: "API Plan", code: "api_plan", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false,
+      charges: [charge]
+    }
+    payload[:cascade_updates] = true if cascade
+    payload
+  end
+
+  def keep_metric_values(kept)
+    update_metric(billable_metric, {
+      filters: [{key: "type", values: %w[pages]}, {key: "model", values: kept}]
+    })
+  end
+
+  # Sorted so the comparisons do not depend on the order filters come back in
+  def predicates(charge)
+    charge.filters.reload.map(&:to_h).sort_by(&:to_s)
+  end
+
+  def prices_of(charge, predicate)
+    charge.filters.reload.select { it.to_h == predicate }.map { it.properties["amount"] }
+  end
+
+  # A plan whose charge carries four single-model filters and one on `type` alone, and a
+  # subscription whose charge is overridden, which deep-copies all five onto a child plan
+  def setup_plan_with_override
+    create_plan(plan_payload([
+      model_filter("m1", "1"),
+      model_filter("m2", "2"),
+      model_filter("m3", "3"),
+      model_filter("m5", "5"),
+      pages_filter("0.5")
+    ]))
+
+    parent_plan = organization.plans.find_by(code: "api_plan")
+    parent_charge = parent_plan.charges.find_by(code: "pages_charge")
+
+    create_subscription({
+      external_customer_id: customer.external_id,
+      external_id: "sub_api",
+      plan_code: "api_plan"
+    })
+
+    subscription = organization.subscriptions.find_by(external_id: "sub_api")
+    update_subscription_charge(subscription, "pages_charge", {properties: {amount: "0.01"}})
+
+    subscription.reload
+    {parent_plan:, parent_charge:, subscription:, child_charge: subscription.plan.charges.find_by(code: "pages_charge")}
+  end
+
+  # Three edits in a row: two metric edits that collapse filters onto a shared predicate,
+  # then one plan edit that adds, reprices, keeps and removes in the same request. Checks
+  # the parent and the override after each one.
+  it "keeps the override aligned with the plan across successive metric and plan edits" do
+    ctx = setup_plan_with_override
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    # STEP 0 — the override has just deep-copied the plan's filters, prices included.
+    # Parent and child both hold:
+    #
+    #   {type: [pages], model: [m1]}  @1
+    #   {type: [pages], model: [m2]}  @2
+    #   {type: [pages], model: [m3]}  @3
+    #   {type: [pages], model: [m5]}  @5
+    #   {type: [pages]}               @0.5
+    expect(predicates(parent_charge).size).to eq(5)
+    expect(predicates(child_charge)).to eq(predicates(parent_charge))
+
+    # STEP 1 — metric edit removing m1 and m2 in one go. Their filters lose the `model`
+    # key and land on `{type: [pages]}`, keeping their own price. Nothing is deleted, and
+    # no cascade runs: the metric edit walks charge_filter_values, which belong to no plan.
+    #
+    #   parent and child, before      ->  parent and child, after
+    #   {type: [pages], model: [m1]} @1   {type: [pages]}              @1
+    #   {type: [pages], model: [m2]} @2   {type: [pages]}              @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages], model: [m3]} @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @5
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    keep_metric_values(models - %w[m1 m2])
+
+    expect(predicates(parent_charge).count(pages)).to eq(3)
+    expect(predicates(child_charge)).to eq(predicates(parent_charge))
+
+    # STEP 2 — metric edit removing m3 too, so a fourth filter joins the same predicate
+    #
+    #   parent and child, before      ->  parent and child, after
+    #   {type: [pages]}              @1   {type: [pages]}              @1
+    #   {type: [pages]}              @2   {type: [pages]}              @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages]}              @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @5
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    keep_metric_values(models - %w[m1 m2 m3])
+
+    expect(predicates(parent_charge).count(pages)).to eq(4)
+    expect(predicates(child_charge)).to eq(predicates(parent_charge))
+
+    # STEP 3 — one plan edit doing all four things at once: `m4` added, `m5` repriced
+    # 5 -> 50, `{type: [pages]}` left untouched at 0.5, and the four duplicates dropped.
+    # This is the only step that needs the cascade: the override follows if it propagates.
+    #
+    #   parent and child, before      ->  parent and child, after
+    #   {type: [pages]}              @1   (dropped)
+    #   {type: [pages]}              @2   (dropped)
+    #   {type: [pages]}              @3   (dropped)
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @50
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    #                                     {type: [pages], model: [m4]} @4   (added)
+    update_plan(ctx[:parent_plan], plan_payload(
+      [model_filter("m4", "4"), model_filter("m5", "50"), pages_filter("0.5")],
+      charge_id: parent_charge.id, cascade: true
+    ))
+
+    expect(predicates(parent_charge)).to eq([pages, m4, m5].sort_by(&:to_s))
+    expect(predicates(child_charge)).to eq(predicates(parent_charge))
+
+    expect(prices_of(parent_charge, m5)).to eq(%w[50])
+    expect(prices_of(child_charge, m5)).to eq(%w[50])
+    expect(prices_of(child_charge, pages)).to eq(%w[0.5])
+  end
+
+  # We do not pick prices for the customer. A price negotiated on the override survives a
+  # plan reprice, including when its filter sits on a predicate shared with others, where
+  # the cascade has to choose which row survives.
+  it "keeps a price negotiated on the override when the plan reprices" do
+    ctx = setup_plan_with_override
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    # STEP 0 — the customer negotiates `m5` down from 5 to 0.5 on their own plan.
+    # Only the child changes here.
+    #
+    #   parent, unchanged                 child, after the negotiation
+    #   {type: [pages], model: [m1]} @1   {type: [pages], model: [m1]} @1
+    #   {type: [pages], model: [m2]} @2   {type: [pages], model: [m2]} @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages], model: [m3]} @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @0.5   <- negotiated
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    child_charge.filters.reload.find { it.to_h == m5 }.update!(properties: {"amount" => "0.5"})
+
+    # STEP 1 — metric edit removing m1 and m2, so `{type: [pages]}` ends up shared by three
+    #
+    #   parent, after                     child, after
+    #   {type: [pages]}              @1   {type: [pages]}              @1
+    #   {type: [pages]}              @2   {type: [pages]}              @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages], model: [m3]} @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @0.5
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    keep_metric_values(models - %w[m1 m2])
+
+    # STEP 2 — the plan reprices everything it still knows about: m3 to 30, m5 to 50 and
+    # `{type: [pages]}` to 5. The negotiated 0.5 on the child must not move.
+    #
+    #   parent, after                     child, after
+    #   {type: [pages], model: [m3]} @30  {type: [pages], model: [m3]} @30
+    #   {type: [pages], model: [m5]} @50  {type: [pages], model: [m5]} @0.5   <- kept
+    #   {type: [pages]}              @5   {type: [pages]}              @5
+    update_plan(ctx[:parent_plan], plan_payload(
+      [model_filter("m3", "30"), model_filter("m5", "50"), pages_filter("5")],
+      charge_id: parent_charge.id, cascade: true
+    ))
+
+    expect(prices_of(parent_charge, m5)).to eq(%w[50])
+    expect(prices_of(child_charge, m5)).to eq(%w[0.5])
+  end
+
+  # Removing a single value collapses only the filter that referenced it. This is the
+  # counterpart to the collapse cases: it guards against an over-eager fix that would
+  # also delete or rewrite the filters carrying the values that are still allowed.
+  it "leaves the untouched filters alone when a single value is removed" do
+    ctx = setup_plan_with_override
+
+    # STEP 1 — metric edit removing m1 only. Its filter loses the `model` key and joins
+    # `{type: [pages]}`; m2, m3 and m5 keep theirs and are left exactly as they were.
+    #
+    #   parent and child, before      ->  parent and child, after
+    #   {type: [pages], model: [m1]} @1   {type: [pages]}              @1
+    #   {type: [pages], model: [m2]} @2   {type: [pages], model: [m2]} @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages], model: [m3]} @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @5
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    keep_metric_values(models - %w[m1])
+
+    expect(predicates(ctx[:parent_charge])).to include(m2, m3, m5)
+    expect(predicates(ctx[:child_charge])).to eq(predicates(ctx[:parent_charge]))
+  end
+
+  # The cascade groups matching filters per child charge. With two charges on the same
+  # metric, a mistake there crosses filters between them.
+  it "cascades to the edited charge only, leaving the sibling charge untouched" do
+    create_plan({
+      name: "API Plan", code: "api_plan", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false,
+      charges: [
+        {billable_metric_id: billable_metric.id, charge_model: "standard", code: "pages_charge",
+         properties: {amount: "0.01"}, filters: [model_filter("m1", "1"), model_filter("m2", "2")]},
+        {billable_metric_id: billable_metric.id, charge_model: "standard", code: "tokens_charge",
+         properties: {amount: "0.02"}, filters: [model_filter("m1", "3"), model_filter("m2", "4")]}
+      ]
+    })
+
+    parent_plan = organization.plans.find_by(code: "api_plan")
+    pages = parent_plan.charges.find_by(code: "pages_charge")
+    tokens = parent_plan.charges.find_by(code: "tokens_charge")
+
+    create_subscription({external_customer_id: customer.external_id, external_id: "sub_api", plan_code: "api_plan"})
+    subscription = organization.subscriptions.find_by(external_id: "sub_api")
+    update_subscription_charge(subscription, "pages_charge", {properties: {amount: "0.01"}})
+    subscription.reload
+
+    child_pages = subscription.plan.charges.find_by(code: "pages_charge")
+    child_tokens = subscription.plan.charges.find_by(code: "tokens_charge")
+
+    # STEP 1 — the plan drops m2 from pages_charge only, with cascade on.
+    #
+    #   pages_charge   plan  before: {type: [pages], model: [m1]}  @1
+    #                              : {type: [pages], model: [m2]}  @2
+    #                        after:  {type: [pages], model: [m1]}  @1
+    #                  child before: {type: [pages], model: [m1]}  @1
+    #                              : {type: [pages], model: [m2]}  @2
+    #                        after:  {type: [pages], model: [m1]}  @1
+    #
+    #   tokens_charge  plan  before: {type: [pages], model: [m1]}  @3
+    #                              : {type: [pages], model: [m2]}  @4
+    #                        after:  {type: [pages], model: [m1]}  @3
+    #                              : {type: [pages], model: [m2]}  @4
+    #                  child before: {type: [pages], model: [m1]}  @3
+    #                              : {type: [pages], model: [m2]}  @4
+    #                        after:  {type: [pages], model: [m1]}  @3
+    #                              : {type: [pages], model: [m2]}  @4
+    update_plan(parent_plan, {
+      name: "API Plan", code: "api_plan", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false, cascade_updates: true,
+      charges: [
+        {id: pages.id, billable_metric_id: billable_metric.id, charge_model: "standard",
+         properties: {amount: "0.01"}, filters: [model_filter("m1", "1")]},
+        {id: tokens.id, billable_metric_id: billable_metric.id, charge_model: "standard",
+         properties: {amount: "0.02"}, filters: [model_filter("m1", "3"), model_filter("m2", "4")]}
+      ]
+    })
+
+    m1 = {"type" => %w[pages], "model" => %w[m1]}
+
+    expect(predicates(pages)).to eq([m1])
+    expect(predicates(child_pages)).to eq([m1])
+    expect(predicates(tokens)).to eq([m1, m2].sort_by(&:to_s))
+    expect(predicates(child_tokens)).to eq([m1, m2].sort_by(&:to_s))
+  end
+
+  # Two customers, each with their own override of the same plan. One plan edit has to
+  # reach both children: the cascade resolves matching filters per child charge, so a
+  # single-override test would never show the second one being skipped.
+  it "cascades to every override, not just the first" do
+    ctx = setup_plan_with_override
+    other = create(:customer, organization:)
+
+    create_subscription({external_customer_id: other.external_id, external_id: "sub_other", plan_code: "api_plan"})
+    second = organization.subscriptions.find_by(external_id: "sub_other")
+    update_subscription_charge(second, "pages_charge", {properties: {amount: "0.01"}})
+
+    # STEP 1 — the plan drops everything except m5, with cascade on.
+    #
+    #   before — plan, override A and override B each hold:
+    #     {type: [pages], model: [m1]}  @1
+    #     {type: [pages], model: [m2]}  @2
+    #     {type: [pages], model: [m3]}  @3
+    #     {type: [pages], model: [m5]}  @5
+    #     {type: [pages]}               @0.5
+    #
+    #   after — plan, override A and override B each hold:
+    #     {type: [pages], model: [m5]}  @5
+    update_plan(ctx[:parent_plan], plan_payload(
+      [model_filter("m5", "5")], charge_id: ctx[:parent_charge].id, cascade: true
+    ))
+
+    expect(predicates(ctx[:parent_charge])).to eq([m5])
+    expect(predicates(ctx[:child_charge])).to eq([m5])
+    expect(predicates(second.reload.plan.charges.find_by(code: "pages_charge"))).to eq([m5])
+  end
+
+  # `to_h` returns the sentinel itself, `to_h_with_all_values` expands it. The cascade
+  # matches on `to_h`, so a sentinel filter has to cascade like any other.
+  it "cascades a filter using the ALL_FILTER_VALUES sentinel" do
+    all_models = {"type" => %w[pages], "model" => [ChargeFilterValue::ALL_FILTER_VALUES]}
+    sentinel = {
+      invoice_display_name: "Any model", properties: {amount: "7"},
+      values: {type: %w[pages], model: [ChargeFilterValue::ALL_FILTER_VALUES]}
+    }
+
+    create_plan(plan_payload([sentinel, model_filter("m5", "5")]))
+    parent_plan = organization.plans.find_by(code: "api_plan")
+    parent_charge = parent_plan.charges.first
+
+    create_subscription({external_customer_id: customer.external_id, external_id: "sub_api", plan_code: "api_plan"})
+    subscription = organization.subscriptions.find_by(external_id: "sub_api")
+    update_subscription_charge(subscription, "pages_charge", {properties: {amount: "0.01"}})
+    child_charge = subscription.reload.plan.charges.first
+
+    expect(predicates(child_charge)).to include(all_models)
+
+    # STEP 1 — the plan drops the sentinel filter and keeps m5, with cascade on.
+    #
+    #   plan     before: {type: [pages], model: [__ALL_FILTER_VALUES__]}  @7
+    #                    {type: [pages], model: [m5]}                     @5
+    #            after:  {type: [pages], model: [m5]}                     @5
+    #   child    before: {type: [pages], model: [__ALL_FILTER_VALUES__]}  @7
+    #                    {type: [pages], model: [m5]}                     @5
+    #            after:  {type: [pages], model: [m5]}                     @5
+    update_plan(parent_plan, plan_payload(
+      [model_filter("m5", "5")], charge_id: parent_charge.id, cascade: true
+    ))
+
+    expect(predicates(parent_charge)).to eq([m5])
+    expect(predicates(child_charge)).to eq([m5])
+  end
+
+  # CascadeService targets children whose plan has an active or pending subscription
+  it "does not cascade to an override whose subscription is terminated" do
+    ctx = setup_plan_with_override
+    child_charge = ctx[:child_charge]
+
+    terminate_subscription(ctx[:subscription])
+
+    # STEP 1 — the plan drops everything except m5, with cascade on. The child plan is
+    # left alone because its subscription is no longer active or pending.
+    #
+    #   plan   before: {type: [pages], model: [m1]}  @1
+    #                  {type: [pages], model: [m2]}  @2
+    #                  {type: [pages], model: [m3]}  @3
+    #                  {type: [pages], model: [m5]}  @5
+    #                  {type: [pages]}               @0.5
+    #          after:  {type: [pages], model: [m5]}  @5
+    #   child  before: the same five filters
+    #          after:  the same five filters, untouched
+    before_predicates = predicates(child_charge)
+
+    update_plan(ctx[:parent_plan], plan_payload(
+      [model_filter("m5", "5")], charge_id: ctx[:parent_charge].id, cascade: true
+    ))
+
+    expect(predicates(ctx[:parent_charge])).to eq([m5])
+    expect(predicates(child_charge)).to eq(before_predicates)
+  end
+end

--- a/spec/scenarios/plans/cascade_filters_over_metric_edits_spec.rb
+++ b/spec/scenarios/plans/cascade_filters_over_metric_edits_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe "Cascade filters over metric edits", :premium do
     #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
     keep_metric_values(models - %w[m1 m2])
 
+    # note: only elements of {type: [pages]} are counted
     expect(predicates(parent_charge).count(pages)).to eq(3)
     expect(predicates(child_charge)).to eq(predicates(parent_charge))
 
@@ -367,6 +368,309 @@ RSpec.describe "Cascade filters over metric edits", :premium do
 
     expect(predicates(parent_charge)).to eq([m5])
     expect(predicates(child_charge)).to eq([m5])
+  end
+
+  # A full model x region matrix, so every metric edit collapses filters two at a time —
+  # once per region — instead of one at a time. Prices encode their origin: the first digit
+  # is the model, the second the region (1 = EU, 2 = US), so `21` is {model2, EU}. That
+  # makes it readable which row a collapsed predicate came from.
+  describe "a model x region matrix" do
+    let(:matrix_metric) { create(:sum_billable_metric, organization:, code: "api_calls", field_name: "value") }
+    let(:matrix_models) { (1..5).map { "model#{it}" } }
+
+    let(:eu) { {"region" => %w[EU]} }
+    let(:us) { {"region" => %w[US]} }
+
+    before do
+      create(:billable_metric_filter, billable_metric: matrix_metric, key: "region", values: %w[EU US])
+      create(:billable_metric_filter, billable_metric: matrix_metric, key: "model", values: matrix_models)
+    end
+
+    def combo(model, region)
+      {"region" => [region], "model" => [model]}
+    end
+
+    def combo_filter(model, region, amount)
+      {
+        invoice_display_name: "#{model} #{region}",
+        properties: {amount:},
+        values: {region: [region], model: [model]}
+      }
+    end
+
+    def region_filter(region, amount)
+      {invoice_display_name: "Any #{region}", properties: {amount:}, values: {region: [region]}}
+    end
+
+    def matrix_plan_payload(filters, charge_id: nil, cascade: false)
+      charge = {
+        billable_metric_id: matrix_metric.id,
+        charge_model: "standard",
+        code: "calls_charge",
+        pay_in_advance: false,
+        properties: {amount: "0.01"},
+        filters:
+      }
+      charge[:id] = charge_id if charge_id
+
+      payload = {
+        name: "Calls Plan", code: "calls_plan", interval: "monthly", amount_cents: 0,
+        amount_currency: "EUR", pay_in_advance: false,
+        charges: [charge]
+      }
+      payload[:cascade_updates] = true if cascade
+      payload
+    end
+
+    def keep_matrix_models(kept)
+      update_metric(matrix_metric, {
+        filters: [{key: "region", values: %w[EU US]}, {key: "model", values: kept}]
+      })
+    end
+
+    def tally(charge)
+      charge.filters.reload.map(&:to_h).tally
+    end
+
+    def filter_priced(charge, predicate, amount)
+      charge.filters.reload.find { it.to_h == predicate && it.properties["amount"] == amount }
+    end
+
+    # Every model x region combination priced individually, then overridden for a customer
+    def setup_matrix_with_override
+      create_plan(matrix_plan_payload(
+        matrix_models.each_with_index.flat_map do |model, index|
+          [combo_filter(model, "EU", "#{index + 1}1"), combo_filter(model, "US", "#{index + 1}2")]
+        end
+      ))
+
+      parent_plan = organization.plans.find_by(code: "calls_plan")
+      parent_charge = parent_plan.charges.find_by(code: "calls_charge")
+
+      create_subscription({
+        external_customer_id: customer.external_id,
+        external_id: "sub_calls",
+        plan_code: "calls_plan"
+      })
+
+      subscription = organization.subscriptions.find_by(external_id: "sub_calls")
+      update_subscription_charge(subscription, "calls_charge", {properties: {amount: "0.01"}})
+
+      subscription.reload
+      {parent_plan:, parent_charge:, subscription:,
+       child_charge: subscription.plan.charges.find_by(code: "calls_charge")}
+    end
+
+    # Three metric edits, each collapsing one model into both region predicates, then a
+    # single plan edit that drops, reprices and adds in one request.
+    it "carries the matrix through three metric edits and one plan edit" do
+      ctx = setup_matrix_with_override
+      parent_charge = ctx[:parent_charge]
+      child_charge = ctx[:child_charge]
+
+      # STEP 0 — ten filters, one per combination, deep-copied onto the override.
+      #
+      #   {region: [EU], model: [model1]} @11   {region: [US], model: [model1]} @12
+      #   {region: [EU], model: [model2]} @21   {region: [US], model: [model2]} @22
+      #   {region: [EU], model: [model3]} @31   {region: [US], model: [model3]} @32
+      #   {region: [EU], model: [model4]} @41   {region: [US], model: [model4]} @42
+      #   {region: [EU], model: [model5]} @51   {region: [US], model: [model5]} @52
+      expect(tally(parent_charge).values).to all(eq(1))
+      expect(tally(parent_charge).size).to eq(10)
+      expect(tally(child_charge)).to eq(tally(parent_charge))
+
+      # STEP 1 — metric edit dropping model1 and allowing model6. The two model1 filters
+      # lose the `model` key and land on the bare region predicates, keeping their prices.
+      # model6 becomes allowed but creates nothing on its own.
+      #
+      #   {region: [EU], model: [model1]} @11  ->  {region: [EU]} @11
+      #   {region: [US], model: [model1]} @12  ->  {region: [US]} @12
+      #   everything else unchanged
+      keep_matrix_models(matrix_models - %w[model1] + %w[model6])
+
+      expect(tally(parent_charge)[eu]).to eq(1)
+      expect(tally(parent_charge)[us]).to eq(1)
+      expect(tally(parent_charge).values.sum).to eq(10)
+      expect(tally(child_charge)).to eq(tally(parent_charge))
+
+      # STEP 2 — metric edit dropping model2, so a second filter joins each region
+      #
+      #   {region: [EU], model: [model2]} @21  ->  {region: [EU]} @21
+      #   {region: [US], model: [model2]} @22  ->  {region: [US]} @22
+      keep_matrix_models(%w[model3 model4 model5 model6])
+
+      expect(tally(parent_charge)[eu]).to eq(2)
+      expect(tally(parent_charge)[us]).to eq(2)
+      expect(tally(child_charge)).to eq(tally(parent_charge))
+
+      # STEP 3 — metric edit dropping model3, so a third joins each region
+      #
+      #   {region: [EU], model: [model3]} @31  ->  {region: [EU]} @31
+      #   {region: [US], model: [model3]} @32  ->  {region: [US]} @32
+      #
+      #   {region: [EU]} @11 @21 @31            {region: [US]} @12 @22 @32
+      #   {region: [EU], model: [model4]} @41   {region: [US], model: [model4]} @42
+      #   {region: [EU], model: [model5]} @51   {region: [US], model: [model5]} @52
+      keep_matrix_models(%w[model4 model5 model6])
+
+      expect(tally(parent_charge)[eu]).to eq(3)
+      expect(tally(parent_charge)[us]).to eq(3)
+      expect(tally(parent_charge).values.sum).to eq(10)
+      expect(tally(child_charge)).to eq(tally(parent_charge))
+
+      # STEP 4 — one plan edit stating the end state. A predicate can only be named once
+      # in a payload, so the three filters on each region collapse to the one kept here:
+      # EU stays at 11, US is repriced to 99, model4 and model5 are untouched, and model6
+      # is added for both regions. The cascade is what brings the override in line.
+      #
+      #   parent and child, before        ->  parent and child, after
+      #   {region: [EU]} @11 @21 @31          {region: [EU]} @11
+      #   {region: [US]} @12 @22 @32          {region: [US]} @99
+      #   {region: [EU], model: [model4]} @41 {region: [EU], model: [model4]} @41
+      #   {region: [US], model: [model4]} @42 {region: [US], model: [model4]} @42
+      #   {region: [EU], model: [model5]} @51 {region: [EU], model: [model5]} @51
+      #   {region: [US], model: [model5]} @52 {region: [US], model: [model5]} @52
+      #                                       {region: [EU], model: [model6]} @61  (added)
+      #                                       {region: [US], model: [model6]} @62  (added)
+      update_plan(ctx[:parent_plan], matrix_plan_payload([
+        region_filter("EU", "11"),
+        region_filter("US", "99"),
+        combo_filter("model4", "EU", "41"),
+        combo_filter("model4", "US", "42"),
+        combo_filter("model5", "EU", "51"),
+        combo_filter("model5", "US", "52"),
+        combo_filter("model6", "EU", "61"),
+        combo_filter("model6", "US", "62")
+      ], charge_id: parent_charge.id, cascade: true))
+
+      expected = {
+        eu => 1, us => 1,
+        combo("model4", "EU") => 1, combo("model4", "US") => 1,
+        combo("model5", "EU") => 1, combo("model5", "US") => 1,
+        combo("model6", "EU") => 1, combo("model6", "US") => 1
+      }
+
+      expect(tally(parent_charge)).to eq(expected)
+      expect(tally(child_charge)).to eq(expected)
+
+      expect(prices_of(parent_charge, us)).to eq(%w[99])
+      expect(prices_of(child_charge, us)).to eq(%w[99])
+      expect(prices_of(child_charge, eu)).to eq(%w[11])
+      expect(prices_of(child_charge, combo("model6", "EU"))).to eq(%w[61])
+      expect(prices_of(child_charge, combo("model6", "US"))).to eq(%w[62])
+    end
+
+    # The plan-level payload names a predicate once, so it cannot say "drop one of the
+    # three filters on {region: [EU]} and keep the other two". The filter endpoints address
+    # a filter by id and can. A cascade job only carries a predicate, so each of the three
+    # requests below is its own example: they fail independently, and a failure on the
+    # delete does not hide what the reprice or the create does.
+    #
+    # After the three metric edits both sides hold:
+    #
+    #   {region: [EU]} @11 @21 @31            {region: [US]} @12 @22 @32
+    #   {region: [EU], model: [model4]} @41   {region: [US], model: [model4]} @42
+    #   {region: [EU], model: [model5]} @51   {region: [US], model: [model5]} @52
+    def collapse_to_three_per_region
+      ctx = setup_matrix_with_override
+
+      keep_matrix_models(matrix_models - %w[model1] + %w[model6])
+      keep_matrix_models(%w[model3 model4 model5 model6])
+      keep_matrix_models(%w[model4 model5 model6])
+
+      expect(tally(ctx[:parent_charge])[eu]).to eq(3)
+      expect(tally(ctx[:parent_charge])[us]).to eq(3)
+      expect(tally(ctx[:child_charge])).to eq(tally(ctx[:parent_charge]))
+
+      ctx
+    end
+
+    # Deleting one filter of a collapsed group must leave the other two, on both sides. The
+    # job can only name {region: [EU]}, so a cascade that discards every child filter on the
+    # predicate takes the customer's other two with it.
+    it "deletes only the targeted filter of a collapsed group" do
+      ctx = collapse_to_three_per_region
+      parent_charge = ctx[:parent_charge]
+      child_charge = ctx[:child_charge]
+
+      # REQUEST 1 — delete the filter that used to be {model3, EU}, the one priced 31.
+      #
+      #   parent, before: {region: [EU]} @11 @21 @31
+      #          after:   {region: [EU]} @11 @21
+      #   child,  before: {region: [EU]} @11 @21 @31
+      #          after:   {region: [EU]} @11 @21
+      delete_plan_charge_filter(
+        ctx[:parent_plan], parent_charge.code, filter_priced(parent_charge, eu, "31").id,
+        {filter: {cascade_updates: true}}
+      )
+
+      expect(tally(parent_charge)[eu]).to eq(2)
+      expect(prices_of(parent_charge, eu).sort).to eq(%w[11 21])
+
+      expect(tally(child_charge)[eu]).to eq(2)
+      expect(prices_of(child_charge, eu).sort).to eq(%w[11 21])
+
+      # The US side was not touched by this request
+      expect(tally(child_charge)[us]).to eq(3)
+    end
+
+    # Repricing one filter of a collapsed group must leave the other two at their own
+    # prices. `update_child_filters` keeps one match and discards the rest, which is right
+    # when the plan collapsed the group itself and wrong when the plan still holds three.
+    it "reprices only the targeted filter of a collapsed group" do
+      ctx = collapse_to_three_per_region
+      parent_charge = ctx[:parent_charge]
+      child_charge = ctx[:child_charge]
+
+      # REQUEST 2 — reprice the filter that used to be {model2, US}, priced 22, to 99.
+      #
+      #   parent, before: {region: [US]} @12 @22 @32
+      #          after:   {region: [US]} @12 @99 @32
+      #   child,  before: {region: [US]} @12 @22 @32
+      #          after:   {region: [US]} @12 @99 @32
+      update_plan_charge_filter(
+        ctx[:parent_plan], parent_charge.code, filter_priced(parent_charge, us, "22").id,
+        {properties: {amount: "99"}, cascade_updates: true}
+      )
+
+      expect(tally(parent_charge)[us]).to eq(3)
+      expect(prices_of(parent_charge, us).sort).to eq(%w[12 32 99])
+
+      expect(tally(child_charge)[us]).to eq(3)
+      expect(prices_of(child_charge, us).sort).to eq(%w[12 32 99])
+
+      # The EU side was not touched by this request
+      expect(tally(child_charge)[eu]).to eq(3)
+    end
+
+    # model6 was allowed back by the first metric edit, so filters for it can be created.
+    # This one does not depend on the collapsed group being handled correctly.
+    it "creates filters for a value the metric allowed back" do
+      ctx = collapse_to_three_per_region
+      parent_charge = ctx[:parent_charge]
+      child_charge = ctx[:child_charge]
+
+      # REQUEST 3 and 4
+      #
+      #   parent and child, after: {region: [EU], model: [model6]} @61
+      #                            {region: [US], model: [model6]} @62
+      create_plan_charge_filter(ctx[:parent_plan], parent_charge.code,
+        combo_filter("model6", "EU", "61").merge(cascade_updates: true))
+      create_plan_charge_filter(ctx[:parent_plan], parent_charge.code,
+        combo_filter("model6", "US", "62").merge(cascade_updates: true))
+
+      expect(tally(parent_charge)[combo("model6", "EU")]).to eq(1)
+      expect(tally(parent_charge)[combo("model6", "US")]).to eq(1)
+
+      expect(tally(child_charge)[combo("model6", "EU")]).to eq(1)
+      expect(tally(child_charge)[combo("model6", "US")]).to eq(1)
+      expect(prices_of(child_charge, combo("model6", "EU"))).to eq(%w[61])
+      expect(prices_of(child_charge, combo("model6", "US"))).to eq(%w[62])
+
+      # Creating a filter must not disturb the collapsed groups
+      expect(tally(child_charge)[eu]).to eq(3)
+      expect(tally(child_charge)[us]).to eq(3)
+    end
   end
 
   # CascadeService targets children whose plan has an active or pending subscription

--- a/spec/services/charge_filters/cascade_dispatcher_spec.rb
+++ b/spec/services/charge_filters/cascade_dispatcher_spec.rb
@@ -88,6 +88,169 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
       end
     end
 
+    # A charge can still hold several filters on one predicate from before collapsed
+    # filters were discarded. Whatever happens to them, the override has to end up
+    # with the same single filter the plan does.
+    context "when several filters share a predicate" do
+      let(:filter) { {values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"} }
+      let(:duplicate) { {values: us_values, properties: {"amount" => "20"}, invoice_display_name: "US bis"} }
+
+      let(:before) { [filter, duplicate] }
+
+      context "when one is kept unchanged" do
+        let(:after) { [filter] }
+
+        it "enqueues an update cascade job so the duplicates are reconciled" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "10"}, "US"
+          ).once
+        end
+      end
+
+      context "when one is kept and changed" do
+        let(:after) { [{values: us_values, properties: {"amount" => "15"}, invoice_display_name: "US"}] }
+
+        it "enqueues a single update cascade job carrying the new properties" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "15"}, "US"
+          ).once
+        end
+      end
+
+      context "when none is kept" do
+        let(:after) { [] }
+
+        it "enqueues a single destroy cascade job for the predicate" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "destroy", us_values, {"amount" => "10"}, nil, "US"
+          ).once
+        end
+      end
+
+      context "when three share it and two are kept with changes" do
+        let(:third) { {values: us_values, properties: {"amount" => "30"}, invoice_display_name: "US ter"} }
+        let(:before) { [filter, duplicate, third] }
+        let(:after) do
+          [
+            {values: us_values, properties: {"amount" => "11"}, invoice_display_name: "US"},
+            {values: us_values, properties: {"amount" => "22"}, invoice_display_name: "US bis"}
+          ]
+        end
+
+        # The first `after` filter consumes the whole group, so the second falls into
+        # the create branch. CascadeService only creates when nothing matches, so the
+        # child converges on the first one and the extras are discarded with it.
+        it "enqueues an update for the first and a create the child ignores" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "11"}, "US"
+          ).and have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "create", us_values, nil, {"amount" => "22"}, "US bis"
+          )
+        end
+
+        it "enqueues no destroy job" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.not_to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "destroy", any_args
+          )
+        end
+      end
+
+      # Convergence itself is asserted in ChargeFilters::CascadeService — here we only
+      # check the predicate is still cascaded rather than skipped as unchanged
+      context "when both are kept" do
+        let(:after) { [filter, duplicate] }
+
+        it "enqueues an update cascade job for the predicate" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "10"}, "US"
+          )
+        end
+      end
+    end
+
+    # The shape a real plan ends up in: several predicates carrying duplicates, each
+    # going a different way in one edit
+    context "with duplicates on several predicates changing at once" do
+      let(:asia_values) { {"region" => ["asia"]} }
+      let(:ca_values) { {"region" => ["ca"]} }
+
+      let(:before) do
+        [
+          # us: two filters, one kept and repriced
+          {values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US"},
+          {values: us_values, properties: {"amount" => "11"}, invoice_display_name: "US bis"},
+          # eu: three filters, one kept untouched
+          {values: eu_values, properties: {"amount" => "20"}, invoice_display_name: "EU"},
+          {values: eu_values, properties: {"amount" => "21"}, invoice_display_name: "EU bis"},
+          {values: eu_values, properties: {"amount" => "22"}, invoice_display_name: "EU ter"},
+          # asia: two filters, both removed
+          {values: asia_values, properties: {"amount" => "30"}, invoice_display_name: "Asia"},
+          {values: asia_values, properties: {"amount" => "31"}, invoice_display_name: "Asia bis"}
+        ]
+      end
+
+      let(:after) do
+        [
+          {values: us_values, properties: {"amount" => "15"}, invoice_display_name: "US"},
+          {values: eu_values, properties: {"amount" => "20"}, invoice_display_name: "EU"},
+          {values: ca_values, properties: {"amount" => "40"}, invoice_display_name: "CA"}
+        ]
+      end
+
+      # us repriced, eu kept, asia removed, ca added: four predicates touched, so four
+      # jobs. Seven `before` filters collapse to four because a job targets a predicate.
+      it "enqueues one job per touched predicate, none dropped" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).exactly(4).times
+      end
+
+      it "reprices the us predicate" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "15"}, "US"
+        )
+      end
+
+      # Untouched properties still need the job: it is what discards the duplicates
+      it "cascades the eu predicate even though the kept filter is unchanged" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "update", eu_values, {"amount" => "20"}, {"amount" => "20"}, "EU"
+        )
+      end
+
+      it "destroys the asia predicate once" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "destroy", asia_values, {"amount" => "30"}, nil, "Asia"
+        ).once
+      end
+
+      it "creates the new ca predicate" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "create", ca_values, nil, {"amount" => "40"}, "CA"
+        )
+      end
+    end
+
     context "with a mix of create, update, destroy and unchanged" do
       let(:asia_values) { {"region" => ["asia"]} }
       let(:ca_values) { {"region" => ["ca"]} }

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -49,6 +49,27 @@ RSpec.describe ChargeFilters::CascadeService do
         )
       end
 
+      # Filters collapsed onto one predicate each carry their own negotiated price on the
+      # child. Only one can survive the predicate, so the rest go with it.
+      context "when the child holds several filters on the cascaded predicate" do
+        let(:duplicates) do
+          ["2", "3"].map do |amount|
+            filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US #{amount}", properties: {amount:})
+            create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
+            filter
+          end
+        end
+
+        before { duplicates }
+
+        it "keeps a single filter on the predicate and discards the rest" do
+          service
+
+          expect(child_filter.reload).not_to be_discarded
+          expect(duplicates.map { it.reload.discarded? }).to all(be(true))
+        end
+      end
+
       context "with several children" do
         let(:other_child_plan) { create(:plan, organization:, parent: parent_plan) }
         let(:other_child_charge) do
@@ -254,6 +275,62 @@ RSpec.describe ChargeFilters::CascadeService do
 
         expect(child_filter.reload).to be_discarded
         expect(child_filter.values.kept).to be_empty
+      end
+
+      # The child can hold several filters on the cascaded predicate, each with its own
+      # negotiated price, while other predicates on the same charge must stay untouched
+      context "when the child holds several filters on the cascaded predicate and others beside" do
+        let(:eu_filters) do
+          ["1", "2"].map do |amount|
+            filter = create(:charge_filter, charge: child_charge, invoice_display_name: "EU #{amount}", properties: {amount:})
+            create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["eu"])
+            filter
+          end
+        end
+
+        let(:extra_us_filters) do
+          ["2", "3"].map do |amount|
+            filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US #{amount}", properties: {amount:})
+            create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
+            filter
+          end
+        end
+
+        before do
+          eu_filters
+          extra_us_filters
+        end
+
+        it "discards every filter on the cascaded predicate" do
+          service
+
+          expect(child_filter.reload).to be_discarded
+          expect(extra_us_filters.map { it.reload.discarded? }).to all(be(true))
+        end
+
+        it "leaves the filters on the other predicate untouched" do
+          service
+
+          expect(eu_filters.map { it.reload.discarded? }).to all(be(false))
+          expect(eu_filters.map { it.reload.properties["amount"] }).to eq(%w[1 2])
+        end
+      end
+
+      context "when the child holds several filters with the same predicate" do
+        let(:duplicate_child_filter) do
+          filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US region bis", properties: {amount: "20"})
+          create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
+          filter
+        end
+
+        before { duplicate_child_filter }
+
+        it "discards every filter matching the predicate" do
+          service
+
+          expect(child_filter.reload).to be_discarded
+          expect(duplicate_child_filter.reload).to be_discarded
+        end
       end
 
       context "when child has no matching filter" do

--- a/spec/services/charge_filters/destroy_service_spec.rb
+++ b/spec/services/charge_filters/destroy_service_spec.rb
@@ -76,6 +76,33 @@ RSpec.describe ChargeFilters::DestroyService do
           nil
         )
       end
+
+      # The filter holds card_location=domestic plus a tier=gold value that an earlier
+      # billable metric change discarded, so its live predicate is card_location alone
+      context "when the filter holds a value discarded by an earlier metric change" do
+        let(:tier_filter) do
+          create(:billable_metric_filter, billable_metric: charge.billable_metric, key: "tier", values: %w[gold])
+        end
+
+        before do
+          create(:charge_filter_value, charge_filter:, billable_metric_filter: tier_filter, values: ["gold"]).discard!
+        end
+
+        # The children lost tier=gold to the same metric change, so a predicate naming
+        # it would match none of them and the child filter would survive the delete
+        it "cascades the live predicate, without the discarded value" do
+          service
+
+          expect(ChargeFilters::CascadeJob).to have_been_enqueued.with(
+            charge.id,
+            "destroy",
+            {"card_location" => ["domestic"]},
+            nil,
+            nil,
+            nil
+          )
+        end
+      end
     end
 
     context "without cascade_updates when charge has children" do

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -129,9 +129,9 @@ module ScenariosHelper
     end
   end
 
-  def delete_plan_charge_filter(plan, charge_code, filter_id, **kwargs)
+  def delete_plan_charge_filter(plan, charge_code, filter_id, params = {}, **kwargs)
     api_call(**kwargs) do
-      delete_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge_code}/filters/#{filter_id}")
+      delete_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge_code}/filters/#{filter_id}", params)
     end
   end
 


### PR DESCRIPTION
## Context

Removing a billable metric filter value leaves the dependent charge filters alive
on a shortened predicate. Deleting those filters, or editing the plan, did not
reach the charge filters on overridden plans — the parent was cleaned and the
override kept billing at the old price.

Reported on ING-536. What to do about the collapsed filters themselves  is not part of this PR.

## Description

- `CascadeDispatcher` groups by predicate and consumes one `before` filter per
  `after` one, so filters sharing a predicate are no longer dropped from the diff
- `CascadeService` reconciles every child filter on the predicate, not just one
- `DestroyService` broadcasts the live predicate: including already-discarded
  values described a predicate no child could match, so nothing cascaded