### PR TITLE
feat/quotes/subscription creation validator

### DIFF
--- a/app/services/quote_versions/validators.rb
+++ b/app/services/quote_versions/validators.rb
@@ -2,6 +2,9 @@
 
 module QuoteVersions
   module Validators
+    # NOTE: subscription_amendment has no validator yet, so it returns nil and the callers
+    # (ApproveService, UpdateService) let it through. Orders::ExecuteService refuses that order
+    # type anyway, until the amendment validator lands.
     def self.for(result, quote_version:, scope:)
       case quote_version.quote.order_type
       when Quote::ORDER_TYPES[:one_off]

--- a/app/services/quote_versions/validators.rb
+++ b/app/services/quote_versions/validators.rb
@@ -6,6 +6,8 @@ module QuoteVersions
       case quote_version.quote.order_type
       when Quote::ORDER_TYPES[:one_off]
         OneOffValidator.new(result, quote_version:, scope:)
+      when Quote::ORDER_TYPES[:subscription_creation]
+        SubscriptionCreationValidator.new(result, quote_version:, scope:)
       end
     end
   end

--- a/app/services/quote_versions/validators/base_order_type_validator.rb
+++ b/app/services/quote_versions/validators/base_order_type_validator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    # Runs the structural pass before the business one so DB lookups only ever see a payload
+    # of the expected shape. Subclasses name the two passes for their order type.
+    class BaseOrderTypeValidator < ::BaseValidator
+      def initialize(result, quote_version:, scope:)
+        @quote_version = quote_version
+        @scope = scope
+
+        super
+      end
+
+      def valid?
+        return false unless structural_validator_class.new(result, billing_items:, scope:).valid?
+
+        business_validator_class.new(result, quote_version:, billing_items:, scope:).valid?
+      end
+
+      private
+
+      attr_reader :quote_version, :scope
+
+      def structural_validator_class
+        raise NotImplementedError, "#{self.class} must implement #structural_validator_class"
+      end
+
+      def business_validator_class
+        raise NotImplementedError, "#{self.class} must implement #business_validator_class"
+      end
+
+      def billing_items
+        @billing_items ||= normalized_billing_items
+      end
+
+      def normalized_billing_items
+        items = quote_version.billing_items || {}
+
+        if items.is_a?(Hash)
+          items.deep_stringify_keys
+        else
+          items
+        end
+      end
+    end
+  end
+end

--- a/app/services/quote_versions/validators/base_structural_validator.rb
+++ b/app/services/quote_versions/validators/base_structural_validator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    # Turns JSON schema errors into the flat `billing_items.<pointer>` => [error_code] shape the
+    # API surfaces. Subclasses only pick the schema to validate against.
+    class BaseStructuralValidator < ::BaseValidator
+      def initialize(result, billing_items:, scope:)
+        @billing_items = billing_items || {}
+        @scope = scope
+
+        super
+      end
+
+      def valid?
+        schemer.validate(billing_items).each do |schema_error|
+          add_schema_error(schema_error)
+        end
+
+        if errors?
+          result.validation_failure!(errors:)
+          return false
+        end
+
+        true
+      end
+
+      private
+
+      attr_reader :billing_items, :scope
+
+      def schemer
+        raise NotImplementedError, "#{self.class} must implement #schemer"
+      end
+
+      def add_schema_error(schema_error)
+        if schema_error["type"] == "required"
+          schema_error.dig("details", "missing_keys").each do |missing_key|
+            field = field_for("#{schema_error["data_pointer"]}/#{missing_key}")
+            add_error(field:, error_code: code_for(schema_error))
+          end
+        else
+          add_error(field: field_for(schema_error["data_pointer"]), error_code: code_for(schema_error))
+        end
+      end
+
+      def field_for(pointer)
+        ["billing_items", *pointer.split("/").reject(&:empty?)].join(".").to_sym
+      end
+
+      def code_for(schema_error)
+        if schema_error["x-error"]
+          schema_error["error"]
+        else
+          "is_invalid"
+        end
+      end
+    end
+  end
+end

--- a/app/services/quote_versions/validators/currency_validation.rb
+++ b/app/services/quote_versions/validators/currency_validation.rb
@@ -4,8 +4,17 @@ module QuoteVersions
   module Validators
     # The deal currency is validated the same way whatever the order type: mandatory once the
     # version is approved, and always an ISO 4217 code when set.
+    #
+    # Expects the includer to expose `quote_version` and `scope`.
     module CurrencyValidation
       extend ActiveSupport::Concern
+
+      # Currencies defines currency_list in its own included hook, so it exists only on a class that
+      # includes Currencies itself, never as Currencies.currency_list. Pulling it in here means an
+      # includer cannot forget it and lose the check to a NoMethodError.
+      included do
+        include Currencies
+      end
 
       private
 

--- a/app/services/quote_versions/validators/currency_validation.rb
+++ b/app/services/quote_versions/validators/currency_validation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    # The deal currency is validated the same way whatever the order type: mandatory once the
+    # version is approved, and always an ISO 4217 code when set.
+    module CurrencyValidation
+      extend ActiveSupport::Concern
+
+      private
+
+      def validate_currency
+        currency = quote_version.currency
+
+        if currency.blank?
+          add_error(field: :currency, error_code: "value_is_mandatory") if scope == :approve
+        elsif self.class.currency_list.exclude?(currency)
+          add_error(field: :currency, error_code: "invalid_currency")
+        end
+      end
+    end
+  end
+end

--- a/app/services/quote_versions/validators/one_off/business_validator.rb
+++ b/app/services/quote_versions/validators/one_off/business_validator.rb
@@ -5,6 +5,7 @@ module QuoteVersions
     module OneOff
       class BusinessValidator < ::BaseValidator
         include Currencies
+        include CurrencyValidation
 
         def initialize(result, quote_version:, billing_items:, scope:)
           @quote_version = quote_version
@@ -29,16 +30,6 @@ module QuoteVersions
         private
 
         attr_reader :quote_version, :billing_items, :scope
-
-        def validate_currency
-          currency = quote_version.currency
-
-          if currency.blank?
-            add_error(field: :currency, error_code: "value_is_mandatory") if scope == :approve
-          elsif self.class.currency_list.exclude?(currency)
-            add_error(field: :currency, error_code: "invalid_currency")
-          end
-        end
 
         def validate_add_ons
           add_ons.each_with_index do |add_on, index|

--- a/app/services/quote_versions/validators/one_off/structural_validator.rb
+++ b/app/services/quote_versions/validators/one_off/structural_validator.rb
@@ -3,52 +3,11 @@
 module QuoteVersions
   module Validators
     module OneOff
-      class StructuralValidator < ::BaseValidator
-        def initialize(result, billing_items:, scope:)
-          @billing_items = billing_items || {}
-          @scope = scope
-
-          super
-        end
-
-        def valid?
-          Schema.schemer(scope).validate(billing_items).each do |schema_error|
-            add_schema_error(schema_error)
-          end
-
-          if errors?
-            result.validation_failure!(errors:)
-            return false
-          end
-
-          true
-        end
-
+      class StructuralValidator < BaseStructuralValidator
         private
 
-        attr_reader :billing_items, :scope
-
-        def add_schema_error(schema_error)
-          if schema_error["type"] == "required"
-            schema_error.dig("details", "missing_keys").each do |missing_key|
-              field = field_for("#{schema_error["data_pointer"]}/#{missing_key}")
-              add_error(field:, error_code: code_for(schema_error))
-            end
-          else
-            add_error(field: field_for(schema_error["data_pointer"]), error_code: code_for(schema_error))
-          end
-        end
-
-        def field_for(pointer)
-          ["billing_items", *pointer.split("/").reject(&:empty?)].join(".").to_sym
-        end
-
-        def code_for(schema_error)
-          if schema_error["x-error"]
-            schema_error["error"]
-          else
-            "is_invalid"
-          end
+        def schemer
+          Schema.schemer(scope)
         end
       end
     end

--- a/app/services/quote_versions/validators/one_off_validator.rb
+++ b/app/services/quote_versions/validators/one_off_validator.rb
@@ -2,37 +2,15 @@
 
 module QuoteVersions
   module Validators
-    class OneOffValidator < ::BaseValidator
-      def initialize(result, quote_version:, scope:)
-        @quote_version = quote_version
-        @scope = scope
-
-        super
-      end
-
-      def valid?
-        structural = OneOff::StructuralValidator.new(result, billing_items:, scope:)
-        return false unless structural.valid?
-
-        OneOff::BusinessValidator.new(result, quote_version:, billing_items:, scope:).valid?
-      end
-
+    class OneOffValidator < BaseOrderTypeValidator
       private
 
-      attr_reader :quote_version, :scope
-
-      def billing_items
-        @billing_items ||= normalized_billing_items
+      def structural_validator_class
+        OneOff::StructuralValidator
       end
 
-      def normalized_billing_items
-        items = quote_version.billing_items || {}
-
-        if items.is_a?(Hash)
-          items.deep_stringify_keys
-        else
-          items
-        end
+      def business_validator_class
+        OneOff::BusinessValidator
       end
     end
   end

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -91,6 +91,8 @@ module QuoteVersions
           fixed_charge_overrides = (plan_item["overrides"] || {})["fixedCharges"] || []
 
           fixed_charge_overrides.each_with_index do |fixed_charge_override, fixed_charge_index|
+            validate_fixed_charge_units(fixed_charge_override, index, fixed_charge_index)
+
             unless known_fixed_charge_add_on_codes.include?([plan_item["id"], fixed_charge_override["addOnCode"]])
               add_error(
                 field: plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.addOnCode"),
@@ -98,6 +100,19 @@ module QuoteVersions
               )
             end
           end
+        end
+
+        # units is forwarded verbatim to FixedCharges::OverrideService, and FixedCharge validates it
+        # with numericality: {greater_than_or_equal_to: 0}, the bound valid_amount? enforces.
+        def validate_fixed_charge_units(fixed_charge_override, index, fixed_charge_index)
+          units = fixed_charge_override["units"]
+          return if units.nil?
+          return if ::Validators::DecimalAmountService.valid_amount?(units)
+
+          add_error(
+            field: plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.units"),
+            error_code: "invalid_value"
+          )
         end
 
         def validate_coupons

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -60,13 +60,26 @@ module QuoteVersions
 
         def validate_plans
           plans.each_with_index do |plan_item, index|
-            unless known_plan_ids.include?(plan_item["id"])
+            plan = known_plans_by_id[plan_item["id"]]
+
+            if plan.nil?
               add_error(field: plan_field(index, "id"), error_code: "plan_not_found")
               next
             end
 
+            validate_plan_currency(plan, index)
             validate_charge_overrides(plan_item, index)
             validate_fixed_charge_overrides(plan_item, index)
+          end
+        end
+
+        # NOTE: overrides carry no plan-level currency, so the plan's own currency is the one
+        # billed: a EUR deal on a USD plan would invoice the customer in USD.
+        def validate_plan_currency(plan, index)
+          return if self.class.currency_list.exclude?(quote_version.currency)
+
+          if plan.amount_currency != quote_version.currency
+            add_error(field: plan_field(index, "id"), error_code: "currencies_does_not_match")
           end
         end
 
@@ -119,7 +132,15 @@ module QuoteVersions
           end
         end
 
+        # The snapshot type is required at approve while the amount checks below follow the live
+        # coupon, so a coupon retyped since the quote was drafted must be flagged rather than
+        # silently followed: it changes the negotiated discount.
         def validate_coupon_snapshot(coupon, coupon_item, index)
+          if coupon_item.dig("payload", "type") != coupon.coupon_type
+            add_error(field: coupon_field(index, "payload.type"), error_code: "coupon_type_does_not_match")
+            return
+          end
+
           if coupon.fixed_amount? && coupon_item.dig("payload", "amountCents").nil?
             add_error(field: coupon_field(index, "payload.amountCents"), error_code: "value_is_mandatory")
           end
@@ -134,8 +155,19 @@ module QuoteVersions
             payload = wallet_credit_item["payload"] || {}
 
             validate_wallet_credit_amounts(payload, index)
+            validate_expiration(payload["expirationAt"], wallet_credit_field(index, "payload.expirationAt"))
             validate_recurring_rules(payload, index)
           end
+        end
+
+        # NOTE: futureness is only guaranteed at approval time. An order scheduled far enough
+        # ahead can still reach execution with a past expiration, which Wallets::ValidateService
+        # rejects then.
+        def validate_expiration(expiration_at, field)
+          return unless scope == :approve
+          return if ::Validators::ExpirationDateValidator.valid?(expiration_at)
+
+          add_error(field:, error_code: "invalid_date")
         end
 
         def validate_wallet_credit_amounts(payload, index)
@@ -162,7 +194,9 @@ module QuoteVersions
           rules.each_with_index do |rule, rule_index|
             validate_rule_trigger(rule, wallet_credit_index, rule_index)
             validate_rule_method(rule, wallet_credit_index, rule_index)
+            validate_rule_grants_target_top_up(rule, wallet_credit_index, rule_index)
             validate_rule_credits(rule, wallet_credit_index, rule_index)
+            validate_expiration(rule["expirationAt"], rule_field(wallet_credit_index, rule_index, "expirationAt"))
           end
         end
 
@@ -203,6 +237,21 @@ module QuoteVersions
             BigDecimal(target) < BigDecimal(rule["thresholdCredits"])
         end
 
+        # Upstream only accepts the flag on a target rule, see
+        # Wallets::RecurringTransactionRules::ValidateService#valid_grants_target_top_up?
+        def validate_rule_grants_target_top_up(rule, wallet_credit_index, rule_index)
+          return if rule["grantsTargetTopUp"].nil?
+          return if rule["method"] == "target"
+
+          add_error(
+            field: rule_field(wallet_credit_index, rule_index, "grantsTargetTopUp"),
+            error_code: "invalid_value"
+          )
+        end
+
+        # NOTE: rule credits are deliberately sign-agnostic, mirroring upstream
+        # Wallets::RecurringTransactionRules::ValidateService#valid_credits?. The wallet-level
+        # amounts above use valid_amount? like Wallets::ValidateService, hence the difference.
         def validate_rule_credits(rule, wallet_credit_index, rule_index)
           %w[paidCredits grantedCredits].each do |key|
             value = rule[key]
@@ -246,21 +295,20 @@ module QuoteVersions
           wallet_credit_field(wallet_credit_index, "payload.recurringTransactionRules.#{rule_index}.#{suffix}")
         end
 
-        def known_plan_ids
-          @known_plan_ids ||= quote_version
+        def known_plans_by_id
+          @known_plans_by_id ||= quote_version
             .organization
             .plans
             .with_discarded
             .where(id: plans.map { |plan_item| plan_item["id"] })
-            .pluck(:id)
-            .to_set
+            .index_by(&:id)
         end
 
         def known_charge_metric_codes
           @known_charge_metric_codes ||= Charge
             .with_discarded
             .joins(:billable_metric)
-            .where(plan_id: known_plan_ids.to_a)
+            .where(plan_id: known_plans_by_id.keys)
             .pluck(:plan_id, "billable_metrics.code")
             .to_set
         end
@@ -269,7 +317,7 @@ module QuoteVersions
           @known_fixed_charge_add_on_codes ||= FixedCharge
             .with_discarded
             .joins(:add_on)
-            .where(plan_id: known_plan_ids.to_a)
+            .where(plan_id: known_plans_by_id.keys)
             .pluck(:plan_id, "add_ons.code")
             .to_set
         end

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -19,7 +19,7 @@ module QuoteVersions
           validate_dates
           validate_plans
           validate_coupons
-          validate_wallets
+          validate_wallet_credits
 
           if errors?
             result.validation_failure!(errors:)
@@ -71,12 +71,12 @@ module QuoteVersions
         end
 
         def validate_charge_overrides(plan_item, index)
-          charge_overrides = plan_item.dig("overrides", "charges") || []
+          charge_overrides = (plan_item["overrides"] || {})["charges"] || []
 
           charge_overrides.each_with_index do |charge_override, charge_index|
-            unless known_charge_keys.include?([plan_item["id"], charge_override["id"]])
+            unless known_charge_metric_codes.include?([plan_item["id"], charge_override["billableMetricCode"]])
               add_error(
-                field: plan_field(index, "overrides.charges.#{charge_index}.id"),
+                field: plan_field(index, "overrides.charges.#{charge_index}.billableMetricCode"),
                 error_code: "charge_not_found"
               )
             end
@@ -84,12 +84,12 @@ module QuoteVersions
         end
 
         def validate_fixed_charge_overrides(plan_item, index)
-          fixed_charge_overrides = plan_item.dig("overrides", "fixedCharges") || []
+          fixed_charge_overrides = (plan_item["overrides"] || {})["fixedCharges"] || []
 
           fixed_charge_overrides.each_with_index do |fixed_charge_override, fixed_charge_index|
-            unless known_fixed_charge_keys.include?([plan_item["id"], fixed_charge_override["id"]])
+            unless known_fixed_charge_add_on_codes.include?([plan_item["id"], fixed_charge_override["addOnCode"]])
               add_error(
-                field: plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.id"),
+                field: plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.addOnCode"),
                 error_code: "fixed_charge_not_found"
               )
             end
@@ -129,22 +129,22 @@ module QuoteVersions
           end
         end
 
-        def validate_wallets
-          wallets.each_with_index do |wallet_item, index|
-            payload = wallet_item["payload"] || {}
+        def validate_wallet_credits
+          wallet_credits.each_with_index do |wallet_credit_item, index|
+            payload = wallet_credit_item["payload"] || {}
 
-            validate_wallet_amounts(payload, index)
+            validate_wallet_credit_amounts(payload, index)
             validate_recurring_rules(payload, index)
           end
         end
 
-        def validate_wallet_amounts(payload, index)
+        def validate_wallet_credit_amounts(payload, index)
           %w[paidCredits grantedCredits].each do |key|
             value = payload[key]
             next if value.nil?
 
             unless ::Validators::DecimalAmountService.valid_amount?(value)
-              add_error(field: wallet_field(index, "payload.#{key}"), error_code: "invalid_value")
+              add_error(field: wallet_credit_field(index, "payload.#{key}"), error_code: "invalid_value")
             end
           end
 
@@ -152,48 +152,48 @@ module QuoteVersions
           return if rate_amount.nil?
 
           unless ::Validators::DecimalAmountService.valid_positive_amount?(rate_amount)
-            add_error(field: wallet_field(index, "payload.rateAmount"), error_code: "invalid_value")
+            add_error(field: wallet_credit_field(index, "payload.rateAmount"), error_code: "invalid_value")
           end
         end
 
-        def validate_recurring_rules(payload, wallet_index)
+        def validate_recurring_rules(payload, wallet_credit_index)
           rules = payload["recurringTransactionRules"] || []
 
           rules.each_with_index do |rule, rule_index|
-            validate_rule_trigger(rule, wallet_index, rule_index)
-            validate_rule_method(rule, wallet_index, rule_index)
-            validate_rule_credits(rule, wallet_index, rule_index)
+            validate_rule_trigger(rule, wallet_credit_index, rule_index)
+            validate_rule_method(rule, wallet_credit_index, rule_index)
+            validate_rule_credits(rule, wallet_credit_index, rule_index)
           end
         end
 
-        def validate_rule_trigger(rule, wallet_index, rule_index)
+        def validate_rule_trigger(rule, wallet_credit_index, rule_index)
           case rule["trigger"]
           when "interval"
             if rule["interval"].nil?
-              add_error(field: rule_field(wallet_index, rule_index, "interval"), error_code: "value_is_mandatory")
+              add_error(field: rule_field(wallet_credit_index, rule_index, "interval"), error_code: "value_is_mandatory")
             end
           when "threshold"
             threshold = rule["thresholdCredits"]
 
             if threshold.nil?
-              add_error(field: rule_field(wallet_index, rule_index, "thresholdCredits"), error_code: "value_is_mandatory")
+              add_error(field: rule_field(wallet_credit_index, rule_index, "thresholdCredits"), error_code: "value_is_mandatory")
             elsif !valid_decimal?(threshold)
-              add_error(field: rule_field(wallet_index, rule_index, "thresholdCredits"), error_code: "invalid_value")
+              add_error(field: rule_field(wallet_credit_index, rule_index, "thresholdCredits"), error_code: "invalid_value")
             end
           end
         end
 
-        def validate_rule_method(rule, wallet_index, rule_index)
+        def validate_rule_method(rule, wallet_credit_index, rule_index)
           return unless rule["method"] == "target"
 
           target = rule["targetOngoingBalance"]
 
           if target.nil?
-            add_error(field: rule_field(wallet_index, rule_index, "targetOngoingBalance"), error_code: "value_is_mandatory")
+            add_error(field: rule_field(wallet_credit_index, rule_index, "targetOngoingBalance"), error_code: "value_is_mandatory")
           elsif !valid_decimal?(target)
-            add_error(field: rule_field(wallet_index, rule_index, "targetOngoingBalance"), error_code: "invalid_value")
+            add_error(field: rule_field(wallet_credit_index, rule_index, "targetOngoingBalance"), error_code: "invalid_value")
           elsif target_below_threshold?(rule, target)
-            add_error(field: rule_field(wallet_index, rule_index, "targetOngoingBalance"), error_code: "invalid_value")
+            add_error(field: rule_field(wallet_credit_index, rule_index, "targetOngoingBalance"), error_code: "invalid_value")
           end
         end
 
@@ -203,13 +203,13 @@ module QuoteVersions
             BigDecimal(target) < BigDecimal(rule["thresholdCredits"])
         end
 
-        def validate_rule_credits(rule, wallet_index, rule_index)
+        def validate_rule_credits(rule, wallet_credit_index, rule_index)
           %w[paidCredits grantedCredits].each do |key|
             value = rule[key]
             next if value.nil?
 
             unless valid_decimal?(value)
-              add_error(field: rule_field(wallet_index, rule_index, key), error_code: "invalid_value")
+              add_error(field: rule_field(wallet_credit_index, rule_index, key), error_code: "invalid_value")
             end
           end
         end
@@ -226,8 +226,8 @@ module QuoteVersions
           billing_items["coupons"] || []
         end
 
-        def wallets
-          billing_items["wallets"] || []
+        def wallet_credits
+          billing_items["walletCredits"] || []
         end
 
         def plan_field(index, suffix)
@@ -238,12 +238,12 @@ module QuoteVersions
           :"billing_items.coupons.#{index}.#{suffix}"
         end
 
-        def wallet_field(index, suffix)
-          :"billing_items.wallets.#{index}.#{suffix}"
+        def wallet_credit_field(index, suffix)
+          :"billing_items.walletCredits.#{index}.#{suffix}"
         end
 
-        def rule_field(wallet_index, rule_index, suffix)
-          wallet_field(wallet_index, "payload.recurringTransactionRules.#{rule_index}.#{suffix}")
+        def rule_field(wallet_credit_index, rule_index, suffix)
+          wallet_credit_field(wallet_credit_index, "payload.recurringTransactionRules.#{rule_index}.#{suffix}")
         end
 
         def known_plan_ids
@@ -256,25 +256,21 @@ module QuoteVersions
             .to_set
         end
 
-        def known_charge_keys
-          @known_charge_keys ||= Charge
+        def known_charge_metric_codes
+          @known_charge_metric_codes ||= Charge
             .with_discarded
-            .where(
-              plan_id: known_plan_ids.to_a,
-              id: plans.flat_map { |plan_item| (plan_item.dig("overrides", "charges") || []).map { |charge_override| charge_override["id"] } }
-            )
-            .pluck(:plan_id, :id)
+            .joins(:billable_metric)
+            .where(plan_id: known_plan_ids.to_a)
+            .pluck(:plan_id, "billable_metrics.code")
             .to_set
         end
 
-        def known_fixed_charge_keys
-          @known_fixed_charge_keys ||= FixedCharge
+        def known_fixed_charge_add_on_codes
+          @known_fixed_charge_add_on_codes ||= FixedCharge
             .with_discarded
-            .where(
-              plan_id: known_plan_ids.to_a,
-              id: plans.flat_map { |plan_item| (plan_item.dig("overrides", "fixedCharges") || []).map { |fixed_charge_override| fixed_charge_override["id"] } }
-            )
-            .pluck(:plan_id, :id)
+            .joins(:add_on)
+            .where(plan_id: known_plan_ids.to_a)
+            .pluck(:plan_id, "add_ons.code")
             .to_set
         end
 

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -151,11 +151,11 @@ module QuoteVersions
             return
           end
 
-          if coupon.fixed_amount? && coupon_item.dig("payload", "amountCents").nil?
+          if coupon.fixed_amount? && quoted_coupon_value(coupon_item, "amountCents").nil?
             add_error(field: coupon_field(index, "payload.amountCents"), error_code: "value_is_mandatory")
           end
 
-          if coupon.percentage? && coupon_item.dig("payload", "percentageRate").nil?
+          if coupon.percentage? && quoted_coupon_value(coupon_item, "percentageRate").nil?
             add_error(field: coupon_field(index, "payload.percentageRate"), error_code: "value_is_mandatory")
           end
         end
@@ -173,10 +173,16 @@ module QuoteVersions
           add_error(field: coupon_field(index, "#{section}.frequencyDuration"), error_code: "value_is_mandatory")
         end
 
-        # Mirrors how the execution service resolves an overridden coupon value, then the fallback
-        # AppliedCoupons::CreateService applies on the live coupon.
+        # A negotiated value overrides the catalog snapshot it was drafted from, the way the
+        # execution services resolve a quoted value, see Orders::OneOff::ExecuteService.
+        def quoted_coupon_value(coupon_item, field)
+          coupon_item.dig("overrides", field) || coupon_item.dig("payload", field)
+        end
+
+        # Adds the fallback AppliedCoupons::CreateService applies on the live coupon, for the
+        # values it defaults rather than requires.
         def effective_coupon_value(coupon_item, field, coupon_value)
-          coupon_item.dig("overrides", field) || coupon_item.dig("payload", field) || coupon_value
+          quoted_coupon_value(coupon_item, field) || coupon_value
         end
 
         def validate_wallet_credits

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -39,11 +39,11 @@ module QuoteVersions
           start_date = quote_version.start_date
           end_date = quote_version.end_date
 
-          if scope == :approve
-            add_error(field: :start_date, error_code: "value_is_mandatory") if start_date.blank?
-            add_error(field: :end_date, error_code: "value_is_mandatory") if end_date.blank?
+          if scope == :approve && start_date.blank?
+            add_error(field: :start_date, error_code: "value_is_mandatory")
           end
 
+          # An open-ended deal is legitimate, the subscription simply carries no ending date, but
           # Subscriptions::ValidateService requires the ending date to be strictly after the
           # subscription date, and these are the dates a plan without its own falls back to, so a
           # zero-length range cannot produce a subscription.

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    module SubscriptionCreation
+      class BusinessValidator < ::BaseValidator
+        include Currencies
+
+        def initialize(result, quote_version:, billing_items:, scope:)
+          @quote_version = quote_version
+          @billing_items = billing_items
+          @scope = scope
+
+          super
+        end
+
+        def valid?
+          validate_currency
+          validate_dates
+          validate_plans
+          validate_coupons
+          validate_wallets
+
+          if errors?
+            result.validation_failure!(errors:)
+            return false
+          end
+
+          true
+        end
+
+        private
+
+        attr_reader :quote_version, :billing_items, :scope
+
+        def validate_currency
+          currency = quote_version.currency
+
+          if currency.blank?
+            add_error(field: :currency, error_code: "value_is_mandatory") if scope == :approve
+          elsif self.class.currency_list.exclude?(currency)
+            add_error(field: :currency, error_code: "invalid_currency")
+          end
+        end
+
+        # NOTE: payment terms are not validated yet, the quote-level field lands with LAGO-1529
+        def validate_dates
+          start_date = quote_version.start_date
+          end_date = quote_version.end_date
+
+          if scope == :approve
+            add_error(field: :start_date, error_code: "value_is_mandatory") if start_date.blank?
+            add_error(field: :end_date, error_code: "value_is_mandatory") if end_date.blank?
+          end
+
+          if start_date.present? && end_date.present? && end_date < start_date
+            add_error(field: :start_date, error_code: "invalid_date_range")
+          end
+        end
+
+        def validate_plans
+          plans.each_with_index do |plan_item, index|
+            unless known_plan_ids.include?(plan_item["id"])
+              add_error(field: plan_field(index, "id"), error_code: "plan_not_found")
+              next
+            end
+
+            validate_charge_overrides(plan_item, index)
+            validate_fixed_charge_overrides(plan_item, index)
+          end
+        end
+
+        def validate_charge_overrides(plan_item, index)
+          charge_overrides = plan_item.dig("overrides", "charges") || []
+
+          charge_overrides.each_with_index do |charge_override, charge_index|
+            unless known_charge_keys.include?([plan_item["id"], charge_override["id"]])
+              add_error(
+                field: plan_field(index, "overrides.charges.#{charge_index}.id"),
+                error_code: "charge_not_found"
+              )
+            end
+          end
+        end
+
+        def validate_fixed_charge_overrides(plan_item, index)
+          fixed_charge_overrides = plan_item.dig("overrides", "fixedCharges") || []
+
+          fixed_charge_overrides.each_with_index do |fixed_charge_override, fixed_charge_index|
+            unless known_fixed_charge_keys.include?([plan_item["id"], fixed_charge_override["id"]])
+              add_error(
+                field: plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.id"),
+                error_code: "fixed_charge_not_found"
+              )
+            end
+          end
+        end
+
+        def validate_coupons
+          coupons.each_with_index do |coupon_item, index|
+            coupon = known_coupons_by_id[coupon_item["id"]]
+
+            if coupon.nil?
+              add_error(field: coupon_field(index, "id"), error_code: "coupon_not_found")
+              next
+            end
+
+            validate_coupon_currency(coupon, index)
+            validate_coupon_snapshot(coupon, coupon_item, index) if scope == :approve
+          end
+        end
+
+        def validate_coupon_currency(coupon, index)
+          return unless coupon.fixed_amount?
+          return if self.class.currency_list.exclude?(quote_version.currency)
+
+          if coupon.amount_currency != quote_version.currency
+            add_error(field: coupon_field(index, "id"), error_code: "currencies_does_not_match")
+          end
+        end
+
+        def validate_coupon_snapshot(coupon, coupon_item, index)
+          if coupon.fixed_amount? && coupon_item.dig("payload", "amountCents").nil?
+            add_error(field: coupon_field(index, "payload.amountCents"), error_code: "value_is_mandatory")
+          end
+
+          if coupon.percentage? && coupon_item.dig("payload", "percentageRate").nil?
+            add_error(field: coupon_field(index, "payload.percentageRate"), error_code: "value_is_mandatory")
+          end
+        end
+
+        def validate_wallets
+          wallets.each_with_index do |wallet_item, index|
+            payload = wallet_item["payload"] || {}
+
+            validate_wallet_amounts(payload, index)
+            validate_recurring_rules(payload, index)
+          end
+        end
+
+        def validate_wallet_amounts(payload, index)
+          %w[paidCredits grantedCredits].each do |key|
+            value = payload[key]
+            next if value.nil?
+
+            unless ::Validators::DecimalAmountService.valid_amount?(value)
+              add_error(field: wallet_field(index, "payload.#{key}"), error_code: "invalid_value")
+            end
+          end
+
+          rate_amount = payload["rateAmount"]
+          return if rate_amount.nil?
+
+          unless ::Validators::DecimalAmountService.valid_positive_amount?(rate_amount)
+            add_error(field: wallet_field(index, "payload.rateAmount"), error_code: "invalid_value")
+          end
+        end
+
+        def validate_recurring_rules(payload, wallet_index)
+          rules = payload["recurringTransactionRules"] || []
+
+          rules.each_with_index do |rule, rule_index|
+            validate_rule_trigger(rule, wallet_index, rule_index)
+            validate_rule_method(rule, wallet_index, rule_index)
+            validate_rule_credits(rule, wallet_index, rule_index)
+          end
+        end
+
+        def validate_rule_trigger(rule, wallet_index, rule_index)
+          case rule["trigger"]
+          when "interval"
+            if rule["interval"].nil?
+              add_error(field: rule_field(wallet_index, rule_index, "interval"), error_code: "value_is_mandatory")
+            end
+          when "threshold"
+            threshold = rule["thresholdCredits"]
+
+            if threshold.nil?
+              add_error(field: rule_field(wallet_index, rule_index, "thresholdCredits"), error_code: "value_is_mandatory")
+            elsif !valid_decimal?(threshold)
+              add_error(field: rule_field(wallet_index, rule_index, "thresholdCredits"), error_code: "invalid_value")
+            end
+          end
+        end
+
+        def validate_rule_method(rule, wallet_index, rule_index)
+          return unless rule["method"] == "target"
+
+          target = rule["targetOngoingBalance"]
+
+          if target.nil?
+            add_error(field: rule_field(wallet_index, rule_index, "targetOngoingBalance"), error_code: "value_is_mandatory")
+          elsif !valid_decimal?(target)
+            add_error(field: rule_field(wallet_index, rule_index, "targetOngoingBalance"), error_code: "invalid_value")
+          elsif target_below_threshold?(rule, target)
+            add_error(field: rule_field(wallet_index, rule_index, "targetOngoingBalance"), error_code: "invalid_value")
+          end
+        end
+
+        def target_below_threshold?(rule, target)
+          rule["trigger"] == "threshold" &&
+            valid_decimal?(rule["thresholdCredits"]) &&
+            BigDecimal(target) < BigDecimal(rule["thresholdCredits"])
+        end
+
+        def validate_rule_credits(rule, wallet_index, rule_index)
+          %w[paidCredits grantedCredits].each do |key|
+            value = rule[key]
+            next if value.nil?
+
+            unless valid_decimal?(value)
+              add_error(field: rule_field(wallet_index, rule_index, key), error_code: "invalid_value")
+            end
+          end
+        end
+
+        def valid_decimal?(value)
+          ::Validators::DecimalAmountService.new(value).valid_decimal?
+        end
+
+        def plans
+          billing_items["plans"] || []
+        end
+
+        def coupons
+          billing_items["coupons"] || []
+        end
+
+        def wallets
+          billing_items["wallets"] || []
+        end
+
+        def plan_field(index, suffix)
+          :"billing_items.plans.#{index}.#{suffix}"
+        end
+
+        def coupon_field(index, suffix)
+          :"billing_items.coupons.#{index}.#{suffix}"
+        end
+
+        def wallet_field(index, suffix)
+          :"billing_items.wallets.#{index}.#{suffix}"
+        end
+
+        def rule_field(wallet_index, rule_index, suffix)
+          wallet_field(wallet_index, "payload.recurringTransactionRules.#{rule_index}.#{suffix}")
+        end
+
+        def known_plan_ids
+          @known_plan_ids ||= quote_version
+            .organization
+            .plans
+            .with_discarded
+            .where(id: plans.map { |plan_item| plan_item["id"] })
+            .pluck(:id)
+            .to_set
+        end
+
+        def known_charge_keys
+          @known_charge_keys ||= Charge
+            .with_discarded
+            .where(
+              plan_id: known_plan_ids.to_a,
+              id: plans.flat_map { |plan_item| (plan_item.dig("overrides", "charges") || []).map { |charge_override| charge_override["id"] } }
+            )
+            .pluck(:plan_id, :id)
+            .to_set
+        end
+
+        def known_fixed_charge_keys
+          @known_fixed_charge_keys ||= FixedCharge
+            .with_discarded
+            .where(
+              plan_id: known_plan_ids.to_a,
+              id: plans.flat_map { |plan_item| (plan_item.dig("overrides", "fixedCharges") || []).map { |fixed_charge_override| fixed_charge_override["id"] } }
+            )
+            .pluck(:plan_id, :id)
+            .to_set
+        end
+
+        def known_coupons_by_id
+          @known_coupons_by_id ||= quote_version
+            .organization
+            .coupons
+            .with_discarded
+            .where(id: coupons.map { |coupon_item| coupon_item["id"] })
+            .index_by(&:id)
+        end
+      end
+    end
+  end
+end

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -5,6 +5,7 @@ module QuoteVersions
     module SubscriptionCreation
       class BusinessValidator < ::BaseValidator
         include Currencies
+        include CurrencyValidation
 
         def initialize(result, quote_version:, billing_items:, scope:)
           @quote_version = quote_version
@@ -32,16 +33,6 @@ module QuoteVersions
         private
 
         attr_reader :quote_version, :billing_items, :scope
-
-        def validate_currency
-          currency = quote_version.currency
-
-          if currency.blank?
-            add_error(field: :currency, error_code: "value_is_mandatory") if scope == :approve
-          elsif self.class.currency_list.exclude?(currency)
-            add_error(field: :currency, error_code: "invalid_currency")
-          end
-        end
 
         # NOTE: payment terms are not validated yet, the quote-level field lands with LAGO-1529
         def validate_dates

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -62,6 +62,7 @@ module QuoteVersions
             end
 
             validate_plan_currency(plan, index)
+            validate_minimum_commitment(plan, plan_item, index)
             validate_charge_overrides(plan_item, index)
             validate_fixed_charge_overrides(plan_item, index)
           end
@@ -75,6 +76,23 @@ module QuoteVersions
           if plan.amount_currency != quote_version.currency
             add_error(field: plan_field(index, "id"), error_code: "currencies_does_not_match")
           end
+        end
+
+        # Plans::OverrideService builds a fresh Commitment rather than duplicating the plan's own,
+        # and Commitment rejects a nil amount, so the amount has to reach it from one side or the
+        # other. NOTE: the amount resolved here is the plan's, so the subscription_creation
+        # execution service must pass it down when the override omits it.
+        def validate_minimum_commitment(plan, plan_item, index)
+          return unless scope == :approve
+
+          minimum_commitment = plan_item.dig("overrides", "minimumCommitment")
+          return if minimum_commitment.nil?
+          return unless (minimum_commitment["amountCents"] || plan.minimum_commitment&.amount_cents).nil?
+
+          add_error(
+            field: plan_field(index, "overrides.minimumCommitment.amountCents"),
+            error_code: "value_is_mandatory"
+          )
         end
 
         def validate_charge_overrides(plan_item, index)
@@ -349,6 +367,7 @@ module QuoteVersions
             .organization
             .plans
             .with_discarded
+            .includes(:minimum_commitment)
             .where(id: plans.map { |plan_item| plan_item["id"] })
             .index_by(&:id)
         end

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -44,7 +44,10 @@ module QuoteVersions
             add_error(field: :end_date, error_code: "value_is_mandatory") if end_date.blank?
           end
 
-          if start_date.present? && end_date.present? && end_date < start_date
+          # Subscriptions::ValidateService requires the ending date to be strictly after the
+          # subscription date, and these are the dates a plan without its own falls back to, so a
+          # zero-length range cannot produce a subscription.
+          if start_date.present? && end_date.present? && end_date <= start_date
             add_error(field: :start_date, error_code: "invalid_date_range")
           end
         end

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -146,8 +146,22 @@ module QuoteVersions
             payload = wallet_credit_item["payload"] || {}
 
             validate_wallet_credit_amounts(payload, index)
+            validate_wallet_credit_currency(payload, index)
             validate_expiration(payload["expirationAt"], wallet_credit_field(index, "payload.expirationAt"))
             validate_recurring_rules(payload, index)
+          end
+        end
+
+        # Unless the multi_currency flag is on, Wallets::CreateService forces the customer currency
+        # onto the wallet, so a credit quoted in another currency is either silently ignored or
+        # funds a wallet the customer never agreed to.
+        def validate_wallet_credit_currency(payload, index)
+          currency = payload["currency"]
+          return if currency.nil?
+          return if self.class.currency_list.exclude?(quote_version.currency)
+
+          if currency != quote_version.currency
+            add_error(field: wallet_credit_field(index, "payload.currency"), error_code: "currencies_does_not_match")
           end
         end
 

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -125,6 +125,7 @@ module QuoteVersions
             end
 
             validate_coupon_currency(coupon, index)
+            validate_coupon_frequency(coupon, coupon_item, index)
             validate_coupon_snapshot(coupon, coupon_item, index) if scope == :approve
           end
         end
@@ -154,6 +155,25 @@ module QuoteVersions
           if coupon.percentage? && coupon_item.dig("payload", "percentageRate").nil?
             add_error(field: coupon_field(index, "payload.percentageRate"), error_code: "value_is_mandatory")
           end
+        end
+
+        # AppliedCoupon requires a positive frequency_duration when recurring, and
+        # AppliedCoupons::CreateService falls back to the live coupon's own frequency and duration,
+        # so overriding an already recurring coupon need not restate its duration. Only a coupon that
+        # is recurring nowhere but in the quote, with no duration anywhere, cannot be applied.
+        def validate_coupon_frequency(coupon, coupon_item, index)
+          return unless scope == :approve
+          return unless effective_coupon_value(coupon_item, "frequency", coupon.frequency) == "recurring"
+          return unless effective_coupon_value(coupon_item, "frequencyDuration", coupon.frequency_duration).nil?
+
+          section = (coupon_item.dig("overrides", "frequency") == "recurring") ? "overrides" : "payload"
+          add_error(field: coupon_field(index, "#{section}.frequencyDuration"), error_code: "value_is_mandatory")
+        end
+
+        # Mirrors how the execution service resolves an overridden coupon value, then the fallback
+        # AppliedCoupons::CreateService applies on the live coupon.
+        def effective_coupon_value(coupon_item, field, coupon_value)
+          coupon_item.dig("overrides", field) || coupon_item.dig("payload", field) || coupon_value
         end
 
         def validate_wallet_credits

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -6,6 +6,13 @@ module QuoteVersions
       module Schema
         CURRENCIES = Currencies::ACCEPTED_CURRENCIES.keys.map(&:to_s).freeze
 
+        COUPON_TYPES = Coupon::COUPON_TYPES.map(&:to_s).freeze
+        COUPON_FREQUENCIES = Coupon::FREQUENCIES.map(&:to_s).freeze
+
+        RULE_TRIGGERS = RecurringTransactionRule::TRIGGERS.map(&:to_s).freeze
+        RULE_INTERVALS = RecurringTransactionRule::INTERVALS.map(&:to_s).freeze
+        RULE_METHODS = RecurringTransactionRule::METHODS.map(&:to_s).freeze
+
         UPDATE_DEFINITION = {
           "type" => "object",
           "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
@@ -233,7 +240,7 @@ module QuoteVersions
                       },
                       "type" => {
                         "type" => "string",
-                        "enum" => %w[fixed_amount percentage],
+                        "enum" => COUPON_TYPES,
                         "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                       },
                       "amountCents" => {
@@ -253,7 +260,7 @@ module QuoteVersions
                       },
                       "frequency" => {
                         "type" => %w[string null],
-                        "enum" => ["once", "recurring", "forever", nil],
+                        "enum" => [*COUPON_FREQUENCIES, nil],
                         "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                       },
                       "frequencyDuration" => {
@@ -280,7 +287,7 @@ module QuoteVersions
                       },
                       "frequency" => {
                         "type" => %w[string null],
-                        "enum" => ["once", "recurring", "forever", nil],
+                        "enum" => [*COUPON_FREQUENCIES, nil],
                         "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                       },
                       "frequencyDuration" => {
@@ -349,17 +356,17 @@ module QuoteVersions
                           "properties" => {
                             "trigger" => {
                               "type" => %w[string null],
-                              "enum" => ["interval", "threshold", nil],
+                              "enum" => [*RULE_TRIGGERS, nil],
                               "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                             },
                             "interval" => {
                               "type" => %w[string null],
-                              "enum" => ["weekly", "monthly", "quarterly", "yearly", "semiannual", nil],
+                              "enum" => [*RULE_INTERVALS, nil],
                               "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                             },
                             "method" => {
                               "type" => %w[string null],
-                              "enum" => ["fixed", "target", nil],
+                              "enum" => [*RULE_METHODS, nil],
                               "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                             },
                             "thresholdCredits" => {
@@ -439,7 +446,7 @@ module QuoteVersions
           rules = wallet_credit_payload["properties"]["recurringTransactionRules"]["items"]
           rules["required"] = ["trigger"]
           rules["properties"]["trigger"]["type"] = "string"
-          rules["properties"]["trigger"]["enum"] = %w[interval threshold]
+          rules["properties"]["trigger"]["enum"] = RULE_TRIGGERS
         end.freeze
 
         SCHEMERS = {

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -1,0 +1,300 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    module SubscriptionCreation
+      module Schema
+        UPDATE_DEFINITION = {
+          "type" => "object",
+          "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+          "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+          "properties" => {
+            "plans" => {
+              "type" => "array",
+              "x-error" => {"type" => "invalid_type", "minItems" => "invalid_count"},
+              "items" => {
+                "type" => "object",
+                "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                "required" => %w[id localId type payload],
+                "properties" => {
+                  "id" => {
+                    "type" => "string",
+                    "format" => "uuid",
+                    "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                  },
+                  "localId" => {
+                    "type" => "string",
+                    "minLength" => 1,
+                    "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                  },
+                  "type" => {
+                    "type" => "string",
+                    "const" => "plan",
+                    "x-error" => {"type" => "invalid_type", "const" => "invalid_value"}
+                  },
+                  "payload" => {
+                    "type" => "object",
+                    "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                    "properties" => {
+                      "code" => {
+                        "type" => "string",
+                        "minLength" => 1,
+                        "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      }
+                    }
+                  },
+                  "overrides" => {
+                    "type" => "object",
+                    "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                    "x-error" => {"type" => "invalid_type"},
+                    "properties" => {
+                      "amountCents" => {
+                        "type" => "integer",
+                        "minimum" => 0,
+                        "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
+                      },
+                      "charges" => {
+                        "type" => "array",
+                        "x-error" => {"type" => "invalid_type"},
+                        "items" => {
+                          "type" => "object",
+                          "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                          "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                          "required" => ["id"],
+                          "properties" => {
+                            "id" => {
+                              "type" => "string",
+                              "format" => "uuid",
+                              "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                            },
+                            "properties" => {
+                              "type" => "object",
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "minAmountCents" => {
+                              "type" => "integer",
+                              "minimum" => 0,
+                              "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
+                            },
+                            "invoiceDisplayName" => {
+                              "type" => "string",
+                              "minLength" => 1,
+                              "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                            }
+                          }
+                        }
+                      },
+                      "fixedCharges" => {
+                        "type" => "array",
+                        "x-error" => {"type" => "invalid_type"},
+                        "items" => {
+                          "type" => "object",
+                          "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                          "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                          "required" => ["id"],
+                          "properties" => {
+                            "id" => {
+                              "type" => "string",
+                              "format" => "uuid",
+                              "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                            },
+                            "units" => {
+                              "type" => "string",
+                              "minLength" => 1,
+                              "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                            },
+                            "properties" => {
+                              "type" => "object",
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "invoiceDisplayName" => {
+                              "type" => "string",
+                              "minLength" => 1,
+                              "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "coupons" => {
+              "type" => "array",
+              "x-error" => {"type" => "invalid_type"},
+              "items" => {
+                "type" => "object",
+                "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                "required" => %w[id localId type payload],
+                "properties" => {
+                  "id" => {
+                    "type" => "string",
+                    "format" => "uuid",
+                    "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                  },
+                  "localId" => {
+                    "type" => "string",
+                    "minLength" => 1,
+                    "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                  },
+                  "type" => {
+                    "type" => "string",
+                    "const" => "coupon",
+                    "x-error" => {"type" => "invalid_type", "const" => "invalid_value"}
+                  },
+                  "payload" => {
+                    "type" => "object",
+                    "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                    "properties" => {
+                      "code" => {
+                        "type" => "string",
+                        "minLength" => 1,
+                        "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      },
+                      "couponType" => {
+                        "type" => "string",
+                        "enum" => %w[fixed_amount percentage],
+                        "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                      },
+                      "amountCents" => {
+                        "type" => "integer",
+                        "minimum" => 0,
+                        "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
+                      },
+                      "amountCurrency" => {
+                        "type" => "string",
+                        "x-error" => {"type" => "invalid_type"}
+                      },
+                      "percentageRate" => {
+                        "type" => "number",
+                        "exclusiveMinimum" => 0,
+                        "x-error" => {"type" => "invalid_type", "exclusiveMinimum" => "invalid_value"}
+                      },
+                      "frequency" => {
+                        "type" => "string",
+                        "enum" => %w[once recurring forever],
+                        "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                      },
+                      "frequencyDuration" => {
+                        "type" => "integer",
+                        "exclusiveMinimum" => 0,
+                        "x-error" => {"type" => "invalid_type", "exclusiveMinimum" => "invalid_value"}
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "wallets" => {
+              "type" => "array",
+              "x-error" => {"type" => "invalid_type"},
+              "items" => {
+                "type" => "object",
+                "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                "required" => %w[localId type payload],
+                "properties" => {
+                  "localId" => {
+                    "type" => "string",
+                    "minLength" => 1,
+                    "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                  },
+                  "type" => {
+                    "type" => "string",
+                    "const" => "wallet",
+                    "x-error" => {"type" => "invalid_type", "const" => "invalid_value"}
+                  },
+                  "payload" => {
+                    "type" => "object",
+                    "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                    "properties" => {
+                      "paidCredits" => {
+                        "type" => "string",
+                        "x-error" => {"type" => "invalid_type"}
+                      },
+                      "grantedCredits" => {
+                        "type" => "string",
+                        "x-error" => {"type" => "invalid_type"}
+                      },
+                      "rateAmount" => {
+                        "type" => "string",
+                        "x-error" => {"type" => "invalid_type"}
+                      },
+                      "recurringTransactionRules" => {
+                        "type" => "array",
+                        "x-error" => {"type" => "invalid_type"},
+                        "items" => {
+                          "type" => "object",
+                          "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                          "x-error" => {"type" => "invalid_type"},
+                          "properties" => {
+                            "trigger" => {
+                              "type" => "string",
+                              "enum" => %w[interval threshold],
+                              "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                            },
+                            "interval" => {
+                              "type" => "string",
+                              "enum" => %w[weekly monthly quarterly yearly semiannual],
+                              "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                            },
+                            "method" => {
+                              "type" => "string",
+                              "enum" => %w[fixed target],
+                              "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                            },
+                            "thresholdCredits" => {
+                              "type" => "string",
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "targetOngoingBalance" => {
+                              "type" => "string",
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "paidCredits" => {
+                              "type" => "string",
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "grantedCredits" => {
+                              "type" => "string",
+                              "x-error" => {"type" => "invalid_type"}
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }.freeze
+
+        APPROVE_DEFINITION = UPDATE_DEFINITION.deep_dup.tap do |schema|
+          schema["required"] = ["plans"]
+
+          plans = schema["properties"]["plans"]
+          plans["minItems"] = 1
+          plans["items"]["properties"]["payload"]["required"] = %w[code]
+
+          schema["properties"]["coupons"]["items"]["properties"]["payload"]["required"] =
+            %w[code couponType]
+          schema["properties"]["wallets"]["items"]["properties"]["payload"]["required"] =
+            %w[paidCredits grantedCredits rateAmount]
+        end.freeze
+
+        SCHEMERS = {
+          update: JSONSchemer.schema(UPDATE_DEFINITION),
+          approve: JSONSchemer.schema(APPROVE_DEFINITION)
+        }.freeze
+
+        def self.schemer(scope)
+          SCHEMERS.fetch(scope)
+        end
+      end
+    end
+  end
+end

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -83,8 +83,8 @@ module QuoteVersions
                         "properties" => {
                           "amountCents" => {
                             "type" => %w[integer null],
-                            "minimum" => 0,
-                            "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
+                            "exclusiveMinimum" => 0,
+                            "x-error" => {"type" => "invalid_type", "exclusiveMinimum" => "invalid_value"}
                           },
                           "invoiceDisplayName" => {
                             "type" => %w[string null],
@@ -104,8 +104,8 @@ module QuoteVersions
                           "properties" => {
                             "amountCents" => {
                               "type" => "integer",
-                              "minimum" => 0,
-                              "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
+                              "exclusiveMinimum" => 0,
+                              "x-error" => {"type" => "invalid_type", "exclusiveMinimum" => "invalid_value"}
                             },
                             "recurring" => {
                               "type" => %w[boolean null],
@@ -418,6 +418,14 @@ module QuoteVersions
           plans = schema["properties"]["plans"]
           plans["minItems"] = 1
           plans["items"]["properties"]["payload"]["required"] = %w[code]
+
+          # Commitments::OverrideService assigns amount_cents only when the key is given, and
+          # Commitment requires it present and positive. A commitment carrying just a display name
+          # would therefore approve something that cannot be created.
+          minimum_commitment = plans["items"]["properties"]["overrides"]["properties"]["minimumCommitment"]
+          minimum_commitment["required"] = ["amountCents"]
+          minimum_commitment["x-error"]["required"] = "value_is_mandatory"
+          minimum_commitment["properties"]["amountCents"]["type"] = "integer"
 
           schema["properties"]["coupons"]["items"]["properties"]["payload"]["required"] =
             %w[code type]

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -16,7 +16,7 @@ module QuoteVersions
                 "type" => "object",
                 "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
                 "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
-                "required" => %w[id localId type payload],
+                "required" => %w[id type payload],
                 "properties" => {
                   "id" => {
                     "type" => "string",
@@ -24,7 +24,7 @@ module QuoteVersions
                     "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
                   },
                   "localId" => {
-                    "type" => "string",
+                    "type" => %w[string null],
                     "minLength" => 1,
                     "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
                   },
@@ -45,40 +45,96 @@ module QuoteVersions
                     }
                   },
                   "overrides" => {
-                    "type" => "object",
+                    "type" => %w[object null],
                     "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
                     "x-error" => {"type" => "invalid_type"},
                     "properties" => {
                       "amountCents" => {
-                        "type" => "integer",
+                        "type" => %w[integer null],
                         "minimum" => 0,
                         "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
                       },
-                      "charges" => {
-                        "type" => "array",
+                      "invoiceDisplayName" => {
+                        "type" => %w[string null],
+                        "minLength" => 1,
+                        "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      },
+                      "minimumCommitment" => {
+                        "type" => %w[object null],
+                        "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                        "x-error" => {"type" => "invalid_type"},
+                        "properties" => {
+                          "amountCents" => {
+                            "type" => %w[integer null],
+                            "minimum" => 0,
+                            "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
+                          },
+                          "invoiceDisplayName" => {
+                            "type" => %w[string null],
+                            "minLength" => 1,
+                            "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                          }
+                        }
+                      },
+                      "usageThresholds" => {
+                        "type" => %w[array null],
                         "x-error" => {"type" => "invalid_type"},
                         "items" => {
                           "type" => "object",
                           "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
                           "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
-                          "required" => ["id"],
+                          "required" => ["amountCents"],
                           "properties" => {
-                            "id" => {
-                              "type" => "string",
-                              "format" => "uuid",
-                              "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
-                            },
-                            "properties" => {
-                              "type" => "object",
-                              "x-error" => {"type" => "invalid_type"}
-                            },
-                            "minAmountCents" => {
+                            "amountCents" => {
                               "type" => "integer",
                               "minimum" => 0,
                               "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
                             },
-                            "invoiceDisplayName" => {
+                            "recurring" => {
+                              "type" => %w[boolean null],
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "thresholdDisplayName" => {
+                              "type" => %w[string null],
+                              "minLength" => 1,
+                              "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                            }
+                          }
+                        }
+                      },
+                      "charges" => {
+                        "type" => %w[array null],
+                        "x-error" => {"type" => "invalid_type"},
+                        "items" => {
+                          "type" => "object",
+                          "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                          "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
+                          "required" => ["billableMetricCode"],
+                          "properties" => {
+                            "billableMetricCode" => {
                               "type" => "string",
+                              "minLength" => 1,
+                              "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                            },
+                            "chargeModel" => {
+                              "type" => %w[string null],
+                              "enum" => [
+                                "standard", "graduated", "package", "percentage",
+                                "volume", "graduated_percentage", "custom", "dynamic", nil
+                              ],
+                              "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                            },
+                            "properties" => {
+                              "type" => %w[object null],
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "minAmountCents" => {
+                              "type" => %w[integer null],
+                              "minimum" => 0,
+                              "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
+                            },
+                            "invoiceDisplayName" => {
+                              "type" => %w[string null],
                               "minLength" => 1,
                               "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
                             }
@@ -86,30 +142,30 @@ module QuoteVersions
                         }
                       },
                       "fixedCharges" => {
-                        "type" => "array",
+                        "type" => %w[array null],
                         "x-error" => {"type" => "invalid_type"},
                         "items" => {
                           "type" => "object",
                           "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
                           "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
-                          "required" => ["id"],
+                          "required" => ["addOnCode"],
                           "properties" => {
-                            "id" => {
-                              "type" => "string",
-                              "format" => "uuid",
-                              "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
-                            },
-                            "units" => {
+                            "addOnCode" => {
                               "type" => "string",
                               "minLength" => 1,
                               "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
                             },
+                            "units" => {
+                              "type" => %w[string null],
+                              "minLength" => 1,
+                              "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                            },
                             "properties" => {
-                              "type" => "object",
+                              "type" => %w[object null],
                               "x-error" => {"type" => "invalid_type"}
                             },
                             "invoiceDisplayName" => {
-                              "type" => "string",
+                              "type" => %w[string null],
                               "minLength" => 1,
                               "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
                             }
@@ -154,32 +210,59 @@ module QuoteVersions
                         "minLength" => 1,
                         "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
                       },
-                      "couponType" => {
+                      "type" => {
                         "type" => "string",
                         "enum" => %w[fixed_amount percentage],
                         "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                       },
                       "amountCents" => {
-                        "type" => "integer",
+                        "type" => %w[integer null],
                         "minimum" => 0,
                         "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
                       },
-                      "amountCurrency" => {
-                        "type" => "string",
+                      "currency" => {
+                        "type" => %w[string null],
                         "x-error" => {"type" => "invalid_type"}
                       },
                       "percentageRate" => {
-                        "type" => "number",
+                        "type" => %w[number null],
                         "exclusiveMinimum" => 0,
                         "x-error" => {"type" => "invalid_type", "exclusiveMinimum" => "invalid_value"}
                       },
                       "frequency" => {
-                        "type" => "string",
-                        "enum" => %w[once recurring forever],
+                        "type" => %w[string null],
+                        "enum" => ["once", "recurring", "forever", nil],
                         "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                       },
                       "frequencyDuration" => {
-                        "type" => "integer",
+                        "type" => %w[integer null],
+                        "exclusiveMinimum" => 0,
+                        "x-error" => {"type" => "invalid_type", "exclusiveMinimum" => "invalid_value"}
+                      }
+                    }
+                  },
+                  "overrides" => {
+                    "type" => %w[object null],
+                    "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
+                    "x-error" => {"type" => "invalid_type"},
+                    "properties" => {
+                      "amountCents" => {
+                        "type" => %w[integer null],
+                        "minimum" => 0,
+                        "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
+                      },
+                      "percentageRate" => {
+                        "type" => %w[number null],
+                        "exclusiveMinimum" => 0,
+                        "x-error" => {"type" => "invalid_type", "exclusiveMinimum" => "invalid_value"}
+                      },
+                      "frequency" => {
+                        "type" => %w[string null],
+                        "enum" => ["once", "recurring", "forever", nil],
+                        "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                      },
+                      "frequencyDuration" => {
+                        "type" => %w[integer null],
                         "exclusiveMinimum" => 0,
                         "x-error" => {"type" => "invalid_type", "exclusiveMinimum" => "invalid_value"}
                       }
@@ -188,7 +271,7 @@ module QuoteVersions
                 }
               }
             },
-            "wallets" => {
+            "walletCredits" => {
               "type" => "array",
               "x-error" => {"type" => "invalid_type"},
               "items" => {
@@ -204,7 +287,7 @@ module QuoteVersions
                   },
                   "type" => {
                     "type" => "string",
-                    "const" => "wallet",
+                    "const" => "wallet_credit",
                     "x-error" => {"type" => "invalid_type", "const" => "invalid_value"}
                   },
                   "payload" => {
@@ -224,7 +307,7 @@ module QuoteVersions
                         "x-error" => {"type" => "invalid_type"}
                       },
                       "recurringTransactionRules" => {
-                        "type" => "array",
+                        "type" => %w[array null],
                         "x-error" => {"type" => "invalid_type"},
                         "items" => {
                           "type" => "object",
@@ -232,34 +315,53 @@ module QuoteVersions
                           "x-error" => {"type" => "invalid_type"},
                           "properties" => {
                             "trigger" => {
-                              "type" => "string",
-                              "enum" => %w[interval threshold],
+                              "type" => %w[string null],
+                              "enum" => ["interval", "threshold", nil],
                               "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                             },
                             "interval" => {
-                              "type" => "string",
-                              "enum" => %w[weekly monthly quarterly yearly semiannual],
+                              "type" => %w[string null],
+                              "enum" => ["weekly", "monthly", "quarterly", "yearly", "semiannual", nil],
                               "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                             },
                             "method" => {
-                              "type" => "string",
-                              "enum" => %w[fixed target],
+                              "type" => %w[string null],
+                              "enum" => ["fixed", "target", nil],
                               "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                             },
                             "thresholdCredits" => {
-                              "type" => "string",
+                              "type" => %w[string null],
                               "x-error" => {"type" => "invalid_type"}
                             },
                             "targetOngoingBalance" => {
-                              "type" => "string",
+                              "type" => %w[string null],
                               "x-error" => {"type" => "invalid_type"}
                             },
                             "paidCredits" => {
-                              "type" => "string",
+                              "type" => %w[string null],
                               "x-error" => {"type" => "invalid_type"}
                             },
                             "grantedCredits" => {
-                              "type" => "string",
+                              "type" => %w[string null],
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "startedAt" => {
+                              "type" => %w[string null],
+                              "format" => "date-time",
+                              "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                            },
+                            "expirationAt" => {
+                              "type" => %w[string null],
+                              "format" => "date-time",
+                              "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                            },
+                            "transactionName" => {
+                              "type" => %w[string null],
+                              "minLength" => 1,
+                              "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                            },
+                            "invoiceRequiresSuccessfulPayment" => {
+                              "type" => %w[boolean null],
                               "x-error" => {"type" => "invalid_type"}
                             }
                           }
@@ -281,8 +383,8 @@ module QuoteVersions
           plans["items"]["properties"]["payload"]["required"] = %w[code]
 
           schema["properties"]["coupons"]["items"]["properties"]["payload"]["required"] =
-            %w[code couponType]
-          schema["properties"]["wallets"]["items"]["properties"]["payload"]["required"] =
+            %w[code type]
+          schema["properties"]["walletCredits"]["items"]["properties"]["payload"]["required"] =
             %w[paidCredits grantedCredits rateAmount]
         end.freeze
 

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -4,6 +4,8 @@ module QuoteVersions
   module Validators
     module SubscriptionCreation
       module Schema
+        CURRENCIES = Currencies::ACCEPTED_CURRENCIES.keys.map(&:to_s).freeze
+
         UPDATE_DEFINITION = {
           "type" => "object",
           "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
@@ -58,6 +60,21 @@ module QuoteVersions
                         "type" => %w[string null],
                         "minLength" => 1,
                         "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      },
+                      "name" => {
+                        "type" => %w[string null],
+                        "minLength" => 1,
+                        "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      },
+                      "description" => {
+                        "type" => %w[string null],
+                        "minLength" => 1,
+                        "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      },
+                      "trialPeriod" => {
+                        "type" => %w[number null],
+                        "minimum" => 0,
+                        "x-error" => {"type" => "invalid_type", "minimum" => "invalid_value"}
                       },
                       "minimumCommitment" => {
                         "type" => %w[object null],
@@ -222,7 +239,8 @@ module QuoteVersions
                       },
                       "currency" => {
                         "type" => %w[string null],
-                        "x-error" => {"type" => "invalid_type"}
+                        "enum" => CURRENCIES + [nil],
+                        "x-error" => {"type" => "invalid_type", "enum" => "invalid_currency"}
                       },
                       "percentageRate" => {
                         "type" => %w[number null],
@@ -295,24 +313,30 @@ module QuoteVersions
                     "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
                     "properties" => {
                       "paidCredits" => {
-                        "type" => "string",
+                        "type" => %w[string null],
                         "x-error" => {"type" => "invalid_type"}
                       },
                       "grantedCredits" => {
-                        "type" => "string",
+                        "type" => %w[string null],
                         "x-error" => {"type" => "invalid_type"}
                       },
                       "rateAmount" => {
-                        "type" => "string",
+                        "type" => %w[string null],
                         "x-error" => {"type" => "invalid_type"}
+                      },
+                      "expirationAt" => {
+                        "type" => %w[string null],
+                        "format" => "date-time",
+                        "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
                       },
                       "recurringTransactionRules" => {
                         "type" => %w[array null],
                         "x-error" => {"type" => "invalid_type"},
+                        # NOTE: rules live inside the free-form payload, so unknown keys are
+                        # accepted here too. Only the keys the validators act on are typed.
                         "items" => {
                           "type" => "object",
-                          "additionalProperties" => {"not" => {}, "x-error" => "unsupported_key"},
-                          "x-error" => {"type" => "invalid_type"},
+                          "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
                           "properties" => {
                             "trigger" => {
                               "type" => %w[string null],
@@ -335,6 +359,10 @@ module QuoteVersions
                             },
                             "targetOngoingBalance" => {
                               "type" => %w[string null],
+                              "x-error" => {"type" => "invalid_type"}
+                            },
+                            "grantsTargetTopUp" => {
+                              "type" => %w[boolean null],
                               "x-error" => {"type" => "invalid_type"}
                             },
                             "paidCredits" => {
@@ -384,8 +412,17 @@ module QuoteVersions
 
           schema["properties"]["coupons"]["items"]["properties"]["payload"]["required"] =
             %w[code type]
-          schema["properties"]["walletCredits"]["items"]["properties"]["payload"]["required"] =
-            %w[paidCredits grantedCredits rateAmount]
+
+          wallet_credit_payload = schema["properties"]["walletCredits"]["items"]["properties"]["payload"]
+          wallet_credit_payload["required"] = %w[paidCredits grantedCredits rateAmount]
+          wallet_credit_payload["required"].each do |key|
+            wallet_credit_payload["properties"][key]["type"] = "string"
+          end
+
+          rules = wallet_credit_payload["properties"]["recurringTransactionRules"]["items"]
+          rules["required"] = ["trigger"]
+          rules["properties"]["trigger"]["type"] = "string"
+          rules["properties"]["trigger"]["enum"] = %w[interval threshold]
         end.freeze
 
         SCHEMERS = {

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -328,6 +328,11 @@ module QuoteVersions
                         "type" => %w[string null],
                         "x-error" => {"type" => "invalid_type"}
                       },
+                      "currency" => {
+                        "type" => %w[string null],
+                        "enum" => CURRENCIES + [nil],
+                        "x-error" => {"type" => "invalid_type", "enum" => "invalid_currency"}
+                      },
                       "expirationAt" => {
                         "type" => %w[string null],
                         "format" => "date-time",

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -133,6 +133,10 @@ module QuoteVersions
                               "minLength" => 1,
                               "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
                             },
+                            # NOTE: chargeModel is stored for the execution flow to consume,
+                            # Charges::OverrideService cannot switch models yet. properties is
+                            # deliberately only type-checked: its shape per charge model is
+                            # validated where the override is applied, not here.
                             "chargeModel" => {
                               "type" => %w[string null],
                               "enum" => [

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -426,14 +426,6 @@ module QuoteVersions
           plans["minItems"] = 1
           plans["items"]["properties"]["payload"]["required"] = %w[code]
 
-          # Commitments::OverrideService assigns amount_cents only when the key is given, and
-          # Commitment requires it present and positive. A commitment carrying just a display name
-          # would therefore approve something that cannot be created.
-          minimum_commitment = plans["items"]["properties"]["overrides"]["properties"]["minimumCommitment"]
-          minimum_commitment["required"] = ["amountCents"]
-          minimum_commitment["x-error"]["required"] = "value_is_mandatory"
-          minimum_commitment["properties"]["amountCents"]["type"] = "integer"
-
           schema["properties"]["coupons"]["items"]["properties"]["payload"]["required"] =
             %w[code type]
 

--- a/app/services/quote_versions/validators/subscription_creation/structural_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/structural_validator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    module SubscriptionCreation
+      class StructuralValidator < ::BaseValidator
+        def initialize(result, billing_items:, scope:)
+          @billing_items = billing_items || {}
+          @scope = scope
+
+          super
+        end
+
+        def valid?
+          Schema.schemer(scope).validate(billing_items).each do |schema_error|
+            add_schema_error(schema_error)
+          end
+
+          if errors?
+            result.validation_failure!(errors:)
+            return false
+          end
+
+          true
+        end
+
+        private
+
+        attr_reader :billing_items, :scope
+
+        def add_schema_error(schema_error)
+          if schema_error["type"] == "required"
+            schema_error.dig("details", "missing_keys").each do |missing_key|
+              field = field_for("#{schema_error["data_pointer"]}/#{missing_key}")
+              add_error(field:, error_code: code_for(schema_error))
+            end
+          else
+            add_error(field: field_for(schema_error["data_pointer"]), error_code: code_for(schema_error))
+          end
+        end
+
+        def field_for(pointer)
+          ["billing_items", *pointer.split("/").reject(&:empty?)].join(".").to_sym
+        end
+
+        def code_for(schema_error)
+          if schema_error["x-error"]
+            schema_error["error"]
+          else
+            "is_invalid"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/quote_versions/validators/subscription_creation/structural_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/structural_validator.rb
@@ -3,52 +3,11 @@
 module QuoteVersions
   module Validators
     module SubscriptionCreation
-      class StructuralValidator < ::BaseValidator
-        def initialize(result, billing_items:, scope:)
-          @billing_items = billing_items || {}
-          @scope = scope
-
-          super
-        end
-
-        def valid?
-          Schema.schemer(scope).validate(billing_items).each do |schema_error|
-            add_schema_error(schema_error)
-          end
-
-          if errors?
-            result.validation_failure!(errors:)
-            return false
-          end
-
-          true
-        end
-
+      class StructuralValidator < BaseStructuralValidator
         private
 
-        attr_reader :billing_items, :scope
-
-        def add_schema_error(schema_error)
-          if schema_error["type"] == "required"
-            schema_error.dig("details", "missing_keys").each do |missing_key|
-              field = field_for("#{schema_error["data_pointer"]}/#{missing_key}")
-              add_error(field:, error_code: code_for(schema_error))
-            end
-          else
-            add_error(field: field_for(schema_error["data_pointer"]), error_code: code_for(schema_error))
-          end
-        end
-
-        def field_for(pointer)
-          ["billing_items", *pointer.split("/").reject(&:empty?)].join(".").to_sym
-        end
-
-        def code_for(schema_error)
-          if schema_error["x-error"]
-            schema_error["error"]
-          else
-            "is_invalid"
-          end
+        def schemer
+          Schema.schemer(scope)
         end
       end
     end

--- a/app/services/quote_versions/validators/subscription_creation_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation_validator.rb
@@ -2,37 +2,15 @@
 
 module QuoteVersions
   module Validators
-    class SubscriptionCreationValidator < ::BaseValidator
-      def initialize(result, quote_version:, scope:)
-        @quote_version = quote_version
-        @scope = scope
-
-        super
-      end
-
-      def valid?
-        structural = SubscriptionCreation::StructuralValidator.new(result, billing_items:, scope:)
-        return false unless structural.valid?
-
-        SubscriptionCreation::BusinessValidator.new(result, quote_version:, billing_items:, scope:).valid?
-      end
-
+    class SubscriptionCreationValidator < BaseOrderTypeValidator
       private
 
-      attr_reader :quote_version, :scope
-
-      def billing_items
-        @billing_items ||= normalized_billing_items
+      def structural_validator_class
+        SubscriptionCreation::StructuralValidator
       end
 
-      def normalized_billing_items
-        items = quote_version.billing_items || {}
-
-        if items.is_a?(Hash)
-          items.deep_stringify_keys
-        else
-          items
-        end
+      def business_validator_class
+        SubscriptionCreation::BusinessValidator
       end
     end
   end

--- a/app/services/quote_versions/validators/subscription_creation_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation_validator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    class SubscriptionCreationValidator < ::BaseValidator
+      def initialize(result, quote_version:, scope:)
+        @quote_version = quote_version
+        @scope = scope
+
+        super
+      end
+
+      def valid?
+        structural = SubscriptionCreation::StructuralValidator.new(result, billing_items:, scope:)
+        return false unless structural.valid?
+
+        SubscriptionCreation::BusinessValidator.new(result, quote_version:, billing_items:, scope:).valid?
+      end
+
+      private
+
+      attr_reader :quote_version, :scope
+
+      def billing_items
+        @billing_items ||= normalized_billing_items
+      end
+
+      def normalized_billing_items
+        items = quote_version.billing_items || {}
+
+        if items.is_a?(Hash)
+          items.deep_stringify_keys
+        else
+          items
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/quote_versions.rb
+++ b/spec/factories/quote_versions.rb
@@ -37,6 +37,26 @@ FactoryBot.define do
       end
     end
 
+    trait :with_subscription_creation_billing_items do
+      transient do
+        plan { create(:plan, organization: quote.organization) }
+      end
+
+      currency { "EUR" }
+      billing_items do
+        {
+          "plans" => [
+            {
+              "id" => plan.id,
+              "localId" => SecureRandom.uuid,
+              "type" => "plan",
+              "payload" => {"code" => plan.code}
+            }
+          ]
+        }
+      end
+    end
+
     trait :voided do
       status { :voided }
       voided_at { Time.current }

--- a/spec/graphql/mutations/quote_versions/approve_spec.rb
+++ b/spec/graphql/mutations/quote_versions/approve_spec.rb
@@ -5,7 +5,17 @@ require "rails_helper"
 RSpec.describe Mutations::QuoteVersions::Approve do
   let(:required_permission) { "quotes:approve" }
   let(:membership) { create(:membership) }
-  let(:quote_version) { create(:quote_version, organization: membership.organization) }
+  let(:quote) { create(:quote, organization: membership.organization) }
+  let(:quote_version) do
+    create(
+      :quote_version,
+      :with_subscription_creation_billing_items,
+      quote:,
+      organization: membership.organization,
+      start_date: Date.new(2026, 1, 1),
+      end_date: Date.new(2027, 1, 1)
+    )
+  end
 
   let(:input) do
     {

--- a/spec/requests/api/v1/quote_versions_controller_spec.rb
+++ b/spec/requests/api/v1/quote_versions_controller_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe Api::V1::QuoteVersionsController do
   describe "POST /api/v1/quote_versions/:id/approve" do
     subject { post_with_token(organization, "/api/v1/quote_versions/#{quote_version_id}/approve") }
 
+    let(:quote_version) do
+      create(
+        :quote_version,
+        :with_subscription_creation_billing_items,
+        quote:,
+        organization:,
+        start_date: Date.new(2026, 1, 1),
+        end_date: Date.new(2027, 1, 1)
+      )
+    end
     let(:quote_version_id) { quote_version.id }
 
     before { quote_version }

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -8,7 +8,14 @@ RSpec.describe QuoteVersions::ApproveService do
   let(:organization) { create(:organization, feature_flags: ["order_forms"]) }
   let(:quote) { create(:quote, organization:) }
   let(:quote_version) do
-    create(:quote_version, quote:, organization:, start_date: Date.new(2026, 1, 1), end_date: Date.new(2027, 1, 1))
+    create(
+      :quote_version,
+      :with_subscription_creation_billing_items,
+      quote:,
+      organization:,
+      start_date: Date.new(2026, 1, 1),
+      end_date: Date.new(2027, 1, 1)
+    )
   end
 
   describe ".call" do
@@ -87,6 +94,24 @@ RSpec.describe QuoteVersions::ApproveService do
         quote_version.reload
         expect(quote_version.approved?).to eq(false)
         expect(quote_version.approved_at).to eq(nil)
+      end
+
+      it "does not create an order form" do
+        expect { result }.not_to change(OrderForm, :count)
+      end
+    end
+
+    context "when the billing items are incomplete", :premium do
+      let(:quote_version) do
+        create(:quote_version, quote:, organization:, start_date: Date.new(2026, 1, 1), end_date: Date.new(2027, 1, 1))
+      end
+
+      it "does not approve the quote version" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({"billing_items.plans": ["value_is_mandatory"]})
+
+        expect(quote_version.reload.approved?).to eq(false)
       end
 
       it "does not create an order form" do

--- a/spec/services/quote_versions/validators/one_off/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/one_off/business_validator_spec.rb
@@ -31,9 +31,16 @@ RSpec.describe QuoteVersions::Validators::OneOff::BusinessValidator do
 
   describe "#valid?" do
     context "with a valid quote version" do
-      it "is valid for both scopes" do
-        expect(described_class.new(BaseService::Result.new, quote_version:, billing_items:, scope: :update)).to be_valid
-        expect(described_class.new(BaseService::Result.new, quote_version:, billing_items:, scope: :approve)).to be_valid
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
       end
     end
 

--- a/spec/services/quote_versions/validators/one_off/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/one_off/structural_validator_spec.rb
@@ -42,9 +42,16 @@ RSpec.describe QuoteVersions::Validators::OneOff::StructuralValidator do
 
   describe "#valid?" do
     context "with a full valid payload" do
-      it "is valid for both scopes" do
-        expect(described_class.new(BaseService::Result.new, billing_items:, scope: :update)).to be_valid
-        expect(described_class.new(BaseService::Result.new, billing_items:, scope: :approve)).to be_valid
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       "paidCredits" => "100.0",
       "grantedCredits" => "10.0",
       "rateAmount" => "1.0",
+      "currency" => "EUR",
       "recurringTransactionRules" => [recurring_rule]
     }
   end
@@ -528,6 +529,25 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
         expect(result.error.messages).to eq(
           {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.paidCredits": ["invalid_value"]}
         )
+      end
+    end
+
+    context "when the wallet credit currency differs from the version currency" do
+      let(:wallet_credit_payload) { super().merge("currency" => "USD") }
+
+      it "returns a currencies_does_not_match error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.walletCredits.0.payload.currency": ["currencies_does_not_match"]}
+        )
+      end
+    end
+
+    context "when the wallet credit carries no currency" do
+      let(:wallet_credit_payload) { super().except("currency") }
+
+      it "is valid" do
+        expect(validator).to be_valid
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -226,6 +226,15 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the plan currency differs from the version currency" do
+      let(:plan) { create(:plan, organization:, amount_currency: "USD") }
+
+      it "returns a currencies_does_not_match error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["currencies_does_not_match"]})
+      end
+    end
+
     context "when the charge override references a metric with no charge on the plan" do
       let(:charge_override) { super().merge("billableMetricCode" => "unknown_metric") }
 
@@ -381,6 +390,17 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
           )
         end
       end
+
+      context "when the coupon was retyped since the snapshot was taken" do
+        let(:coupon) { create(:coupon, organization:, coupon_type: "percentage", percentage_rate: 10) }
+
+        it "returns a coupon_type_does_not_match error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.coupons.0.payload.type": ["coupon_type_does_not_match"]}
+          )
+        end
+      end
     end
 
     context "when a fixed_amount coupon payload has no amountCents at update scope" do
@@ -508,6 +528,75 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
         expect(result.error.messages).to eq(
           {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.paidCredits": ["invalid_value"]}
         )
+      end
+    end
+
+    context "when the recurring rule grants a target top-up without the target method" do
+      let(:recurring_rule) do
+        {"trigger" => "interval", "interval" => "monthly", "method" => "fixed", "grantsTargetTopUp" => true}
+      end
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.grantsTargetTopUp": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the recurring rule grants a target top-up with the target method" do
+      let(:recurring_rule) do
+        {
+          "trigger" => "interval",
+          "interval" => "monthly",
+          "method" => "target",
+          "targetOngoingBalance" => "500",
+          "grantsTargetTopUp" => true
+        }
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the recurring rule expirationAt is in the past" do
+      let(:recurring_rule) { super().merge("expirationAt" => 1.day.ago.iso8601) }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "returns an invalid_date error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.expirationAt": ["invalid_date"]}
+          )
+        end
+      end
+    end
+
+    context "when the wallet credit expirationAt is in the past" do
+      let(:wallet_credit_payload) { super().merge("expirationAt" => 1.day.ago.iso8601) }
+      let(:scope) { :approve }
+
+      it "returns an invalid_date error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.walletCredits.0.payload.expirationAt": ["invalid_date"]}
+        )
+      end
+    end
+
+    context "when the wallet credit expirationAt is in the future" do
+      let(:wallet_credit_payload) { super().merge("expirationAt" => 1.year.from_now.iso8601) }
+      let(:scope) { :approve }
+
+      it "is valid" do
+        expect(validator).to be_valid
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -299,6 +299,44 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the fixed charge override units is negative" do
+      let(:fixed_charge_override) { super().merge("units" => "-1") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.units": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the fixed charge override units is not a decimal" do
+      let(:fixed_charge_override) { super().merge("units" => "abc") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.units": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the fixed charge override units is zero" do
+      let(:fixed_charge_override) { super().merge("units" => "0") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the fixed charge override carries no units" do
+      let(:fixed_charge_override) { super().except("units") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
     context "when the plan overrides is null" do
       let(:plan_overrides) { nil }
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -366,6 +366,48 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the minimum commitment override carries no amount" do
+      let(:plan_overrides) do
+        super().merge("minimumCommitment" => {"invoiceDisplayName" => "Min commitment"})
+      end
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "requires the amountCents" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.plans.0.overrides.minimumCommitment.amountCents": ["value_is_mandatory"]}
+          )
+        end
+
+        context "when the plan carries a minimum commitment" do
+          before { create(:commitment, plan:) }
+
+          it "is valid" do
+            expect(validator).to be_valid
+          end
+        end
+      end
+    end
+
+    context "when the minimum commitment override amount is null" do
+      let(:plan_overrides) do
+        super().merge("minimumCommitment" => {"amountCents" => nil, "invoiceDisplayName" => "Min commitment"})
+      end
+      let(:scope) { :approve }
+
+      before { create(:commitment, plan:) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
     context "when the coupon does not exist" do
       let(:coupon_item) { super().merge("id" => "11111111-2222-3333-4444-555555555555") }
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -439,6 +439,15 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
         end
       end
 
+      context "when a fixed_amount coupon carries its amountCents in the overrides" do
+        let(:coupon_payload) { {"code" => coupon.code, "type" => "fixed_amount"} }
+        let(:coupon_item) { super().merge("overrides" => {"amountCents" => 15_000}) }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
+      end
+
       context "when a percentage coupon payload has no percentageRate" do
         let(:coupon) { create(:coupon, organization:, coupon_type: "percentage", percentage_rate: 10) }
         let(:coupon_payload) { {"code" => coupon.code, "type" => "percentage", "percentageRate" => nil} }
@@ -448,6 +457,16 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
           expect(result.error.messages).to eq(
             {"billing_items.coupons.0.payload.percentageRate": ["value_is_mandatory"]}
           )
+        end
+      end
+
+      context "when a percentage coupon carries its percentageRate in the overrides" do
+        let(:coupon) { create(:coupon, organization:, coupon_type: "percentage", percentage_rate: 10) }
+        let(:coupon_payload) { {"code" => coupon.code, "type" => "percentage"} }
+        let(:coupon_item) { super().merge("overrides" => {"percentageRate" => 15.0}) }
+
+        it "is valid" do
+          expect(validator).to be_valid
         end
       end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
     )
   end
   let(:plan) { create(:plan, organization:) }
-  let(:charge) { create(:standard_charge, plan:) }
+  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:fixed_charge) { create(:fixed_charge, plan:) }
   let(:coupon) { create(:coupon, organization:) }
   let(:scope) { :update }
@@ -28,7 +29,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
   let(:plan_item) do
     {
       "id" => plan.id,
-      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "type" => "plan",
       "payload" => {"code" => plan.code},
       "overrides" => plan_overrides
     }
@@ -36,10 +37,18 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
   let(:plan_overrides) do
     {
       "amountCents" => 500_000,
-      "charges" => [{"id" => charge.id}],
-      "fixedCharges" => [{"id" => fixed_charge.id}]
+      "charges" => [charge_override],
+      "fixedCharges" => [fixed_charge_override]
     }
   end
+  let(:charge_override) do
+    {
+      "billableMetricCode" => charge.billable_metric.code,
+      "chargeModel" => "graduated",
+      "properties" => {"graduatedRanges" => []}
+    }
+  end
+  let(:fixed_charge_override) { {"addOnCode" => fixed_charge.add_on.code, "units" => "3"} }
 
   let(:coupon_item) do
     {
@@ -51,18 +60,18 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
   let(:coupon_payload) do
     {
       "code" => coupon.code,
-      "couponType" => "fixed_amount",
+      "type" => "fixed_amount",
       "amountCents" => 20_000
     }
   end
 
-  let(:wallet_item) do
+  let(:wallet_credit_item) do
     {
       "localId" => "d9169d94-b322-4d70-a2b1-9e6a58e3f74a",
-      "payload" => wallet_payload
+      "payload" => wallet_credit_payload
     }
   end
-  let(:wallet_payload) do
+  let(:wallet_credit_payload) do
     {
       "paidCredits" => "100.0",
       "grantedCredits" => "10.0",
@@ -76,7 +85,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
     {
       "plans" => [plan_item],
       "coupons" => [coupon_item],
-      "wallets" => [wallet_item]
+      "walletCredits" => [wallet_credit_item]
     }
   end
 
@@ -200,8 +209,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
     context "when the plan belongs to another organization" do
       let(:plan) { create(:plan) }
-      let(:charge) { create(:standard_charge) }
-      let(:fixed_charge) { create(:fixed_charge) }
+      let(:billable_metric) { create(:billable_metric, organization: plan.organization, code: "api_calls") }
+      let(:fixed_charge) { create(:fixed_charge, plan:) }
 
       it "returns a plan_not_found error" do
         expect(validator).not_to be_valid
@@ -217,12 +226,28 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
-    context "when the charge override points at another plan's charge" do
-      let(:charge) { create(:standard_charge, plan: create(:plan, organization:)) }
+    context "when the charge override references a metric with no charge on the plan" do
+      let(:charge_override) { super().merge("billableMetricCode" => "unknown_metric") }
 
       it "returns a charge_not_found error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.id": ["charge_not_found"]})
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.billableMetricCode": ["charge_not_found"]}
+        )
+      end
+    end
+
+    context "when the charge override references another plan's charge" do
+      let(:other_metric) { create(:billable_metric, organization:, code: "other_metric") }
+      let(:charge_override) { super().merge("billableMetricCode" => "other_metric") }
+
+      before { create(:standard_charge, plan: create(:plan, organization:), billable_metric: other_metric) }
+
+      it "returns a charge_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.billableMetricCode": ["charge_not_found"]}
+        )
       end
     end
 
@@ -234,19 +259,38 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
-    context "when the fixed charge override points at another plan's fixed charge" do
-      let(:fixed_charge) { create(:fixed_charge, plan: create(:plan, organization:)) }
+    context "when the billable metric is discarded" do
+      before do
+        charge
+        billable_metric.discard!
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the fixed charge override references an add-on with no fixed charge on the plan" do
+      let(:fixed_charge_override) { super().merge("addOnCode" => "unknown_add_on") }
 
       it "returns a fixed_charge_not_found error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.plans.0.overrides.fixedCharges.0.id": ["fixed_charge_not_found"]}
+          {"billing_items.plans.0.overrides.fixedCharges.0.addOnCode": ["fixed_charge_not_found"]}
         )
       end
     end
 
     context "when the fixed charge is discarded" do
       before { fixed_charge.discard! }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan overrides is null" do
+      let(:plan_overrides) { nil }
 
       it "is valid" do
         expect(validator).to be_valid
@@ -295,7 +339,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       let(:coupon_payload) do
         {
           "code" => coupon.code,
-          "couponType" => "percentage",
+          "type" => "percentage",
           "percentageRate" => 10.0
         }
       end
@@ -318,7 +362,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       let(:scope) { :approve }
 
       context "when a fixed_amount coupon payload has no amountCents" do
-        let(:coupon_payload) { {"code" => coupon.code, "couponType" => "fixed_amount"} }
+        let(:coupon_payload) { {"code" => coupon.code, "type" => "fixed_amount", "amountCents" => nil} }
 
         it "requires amountCents" do
           expect(validator).not_to be_valid
@@ -328,7 +372,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
       context "when a percentage coupon payload has no percentageRate" do
         let(:coupon) { create(:coupon, organization:, coupon_type: "percentage", percentage_rate: 10) }
-        let(:coupon_payload) { {"code" => coupon.code, "couponType" => "percentage"} }
+        let(:coupon_payload) { {"code" => coupon.code, "type" => "percentage", "percentageRate" => nil} }
 
         it "requires percentageRate" do
           expect(validator).not_to be_valid
@@ -340,58 +384,58 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
     end
 
     context "when a fixed_amount coupon payload has no amountCents at update scope" do
-      let(:coupon_payload) { {"code" => coupon.code, "couponType" => "fixed_amount"} }
+      let(:coupon_payload) { {"code" => coupon.code, "type" => "fixed_amount"} }
 
       it "is valid" do
         expect(validator).to be_valid
       end
     end
 
-    context "when the wallet paidCredits is not a decimal" do
-      let(:wallet_payload) { super().merge("paidCredits" => "abc") }
+    context "when the wallet credit paidCredits is not a decimal" do
+      let(:wallet_credit_payload) { super().merge("paidCredits" => "abc") }
 
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.wallets.0.payload.paidCredits": ["invalid_value"]})
+        expect(result.error.messages).to eq({"billing_items.walletCredits.0.payload.paidCredits": ["invalid_value"]})
       end
     end
 
-    context "when the wallet grantedCredits is negative" do
-      let(:wallet_payload) { super().merge("grantedCredits" => "-1") }
+    context "when the wallet credit grantedCredits is negative" do
+      let(:wallet_credit_payload) { super().merge("grantedCredits" => "-1") }
 
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.wallets.0.payload.grantedCredits": ["invalid_value"]})
+        expect(result.error.messages).to eq({"billing_items.walletCredits.0.payload.grantedCredits": ["invalid_value"]})
       end
     end
 
-    context "when the wallet rateAmount is zero" do
-      let(:wallet_payload) { super().merge("rateAmount" => "0") }
+    context "when the wallet credit rateAmount is zero" do
+      let(:wallet_credit_payload) { super().merge("rateAmount" => "0") }
 
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.wallets.0.payload.rateAmount": ["invalid_value"]})
+        expect(result.error.messages).to eq({"billing_items.walletCredits.0.payload.rateAmount": ["invalid_value"]})
       end
     end
 
     context "when the recurring rule trigger is interval without an interval" do
-      let(:recurring_rule) { {"trigger" => "interval", "method" => "fixed"} }
+      let(:recurring_rule) { {"trigger" => "interval", "interval" => nil, "method" => "fixed"} }
 
       it "requires the interval" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.interval": ["value_is_mandatory"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.interval": ["value_is_mandatory"]}
         )
       end
     end
 
     context "when the recurring rule trigger is threshold without thresholdCredits" do
-      let(:recurring_rule) { {"trigger" => "threshold", "method" => "fixed"} }
+      let(:recurring_rule) { {"trigger" => "threshold", "thresholdCredits" => nil, "method" => "fixed"} }
 
       it "requires thresholdCredits" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.thresholdCredits": ["value_is_mandatory"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.thresholdCredits": ["value_is_mandatory"]}
         )
       end
     end
@@ -402,18 +446,20 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.thresholdCredits": ["invalid_value"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.thresholdCredits": ["invalid_value"]}
         )
       end
     end
 
     context "when the recurring rule method is target without targetOngoingBalance" do
-      let(:recurring_rule) { {"trigger" => "interval", "interval" => "monthly", "method" => "target"} }
+      let(:recurring_rule) do
+        {"trigger" => "interval", "interval" => "monthly", "method" => "target", "targetOngoingBalance" => nil}
+      end
 
       it "requires targetOngoingBalance" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["value_is_mandatory"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["value_is_mandatory"]}
         )
       end
     end
@@ -426,7 +472,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["invalid_value"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["invalid_value"]}
         )
       end
     end
@@ -439,7 +485,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["invalid_value"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["invalid_value"]}
         )
       end
     end
@@ -460,7 +506,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.paidCredits": ["invalid_value"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.paidCredits": ["invalid_value"]}
         )
       end
     end

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -194,8 +194,9 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
         )
       end
 
-      it "is valid" do
-        expect(validator).to be_valid
+      it "returns an invalid_date_range error at update scope" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({start_date: ["invalid_date_range"]})
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -440,6 +440,65 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
           )
         end
       end
+
+      context "when the coupon is overridden to recurring without a duration" do
+        let(:coupon_item) { super().merge("overrides" => {"frequency" => "recurring"}) }
+
+        it "requires the frequencyDuration" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.coupons.0.overrides.frequencyDuration": ["value_is_mandatory"]}
+          )
+        end
+      end
+
+      context "when the coupon is overridden to recurring with a duration" do
+        let(:coupon_item) do
+          super().merge("overrides" => {"frequency" => "recurring", "frequencyDuration" => 3})
+        end
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
+      end
+
+      context "when the coupon payload is recurring without a duration" do
+        let(:coupon_payload) { super().merge("frequency" => "recurring") }
+
+        it "requires the frequencyDuration" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.coupons.0.payload.frequencyDuration": ["value_is_mandatory"]}
+          )
+        end
+      end
+
+      context "when an already recurring coupon is overridden to recurring without a duration" do
+        let(:coupon) do
+          create(:coupon, organization:, frequency: "recurring", frequency_duration: 3)
+        end
+        let(:coupon_item) { super().merge("overrides" => {"frequency" => "recurring"}) }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
+      end
+
+      context "when the coupon overrides only the duration" do
+        let(:coupon_item) { super().merge("overrides" => {"frequencyDuration" => 3}) }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
+      end
+    end
+
+    context "when the coupon payload is recurring without a duration at update scope" do
+      let(:coupon_payload) { super().merge("frequency" => "recurring") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
     end
 
     context "when a fixed_amount coupon payload has no amountCents at update scope" do

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -1,0 +1,484 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidator do
+  subject(:validator) { described_class.new(result, quote_version:, billing_items:, scope:) }
+
+  let(:result) { BaseService::Result.new }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+  let(:quote_version) do
+    create(
+      :quote_version,
+      quote:,
+      organization:,
+      currency: "EUR",
+      start_date: Date.parse("2026-01-01"),
+      end_date: Date.parse("2026-12-31")
+    )
+  end
+  let(:plan) { create(:plan, organization:) }
+  let(:charge) { create(:standard_charge, plan:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:scope) { :update }
+
+  let(:plan_item) do
+    {
+      "id" => plan.id,
+      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "payload" => {"code" => plan.code},
+      "overrides" => plan_overrides
+    }
+  end
+  let(:plan_overrides) do
+    {
+      "amountCents" => 500_000,
+      "charges" => [{"id" => charge.id}],
+      "fixedCharges" => [{"id" => fixed_charge.id}]
+    }
+  end
+
+  let(:coupon_item) do
+    {
+      "id" => coupon.id,
+      "localId" => "ba54903c-7bd5-4d40-8d51-45a5157005ff",
+      "payload" => coupon_payload
+    }
+  end
+  let(:coupon_payload) do
+    {
+      "code" => coupon.code,
+      "couponType" => "fixed_amount",
+      "amountCents" => 20_000
+    }
+  end
+
+  let(:wallet_item) do
+    {
+      "localId" => "d9169d94-b322-4d70-a2b1-9e6a58e3f74a",
+      "payload" => wallet_payload
+    }
+  end
+  let(:wallet_payload) do
+    {
+      "paidCredits" => "100.0",
+      "grantedCredits" => "10.0",
+      "rateAmount" => "1.0",
+      "recurringTransactionRules" => [recurring_rule]
+    }
+  end
+  let(:recurring_rule) { {"trigger" => "interval", "interval" => "monthly", "method" => "fixed"} }
+
+  let(:billing_items) do
+    {
+      "plans" => [plan_item],
+      "coupons" => [coupon_item],
+      "wallets" => [wallet_item]
+    }
+  end
+
+  describe "#valid?" do
+    context "with a valid quote version" do
+      it "is valid for both scopes" do
+        expect(described_class.new(BaseService::Result.new, quote_version:, billing_items:, scope: :update)).to be_valid
+        expect(described_class.new(BaseService::Result.new, quote_version:, billing_items:, scope: :approve)).to be_valid
+      end
+    end
+
+    context "when the currency is missing" do
+      let(:quote_version) do
+        create(
+          :quote_version,
+          quote:,
+          organization:,
+          currency: nil,
+          start_date: Date.parse("2026-01-01"),
+          end_date: Date.parse("2026-12-31")
+        )
+      end
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "requires the currency" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({currency: ["value_is_mandatory"]})
+        end
+      end
+    end
+
+    context "when the currency is not ISO 4217" do
+      let(:quote_version) do
+        create(
+          :quote_version,
+          quote:,
+          organization:,
+          currency: "DOUBLOON",
+          start_date: Date.parse("2026-01-01"),
+          end_date: Date.parse("2026-12-31")
+        )
+      end
+
+      it "returns an invalid_currency error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({currency: ["invalid_currency"]})
+      end
+    end
+
+    context "when the dates are missing" do
+      let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR") }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "requires both dates" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {
+              start_date: ["value_is_mandatory"],
+              end_date: ["value_is_mandatory"]
+            }
+          )
+        end
+      end
+    end
+
+    context "when the end date is before the start date" do
+      let(:quote_version) do
+        create(
+          :quote_version,
+          quote:,
+          organization:,
+          currency: "EUR",
+          start_date: Date.parse("2026-12-31"),
+          end_date: Date.parse("2026-01-01")
+        )
+      end
+
+      it "returns an invalid_date_range error at update scope" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({start_date: ["invalid_date_range"]})
+      end
+    end
+
+    context "when the end date equals the start date" do
+      let(:quote_version) do
+        create(
+          :quote_version,
+          quote:,
+          organization:,
+          currency: "EUR",
+          start_date: Date.parse("2026-01-01"),
+          end_date: Date.parse("2026-01-01")
+        )
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan does not exist" do
+      let(:plan_item) { super().merge("id" => "11111111-2222-3333-4444-555555555555") }
+
+      it "returns a plan_not_found error and skips the override checks" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["plan_not_found"]})
+      end
+    end
+
+    context "when the plan belongs to another organization" do
+      let(:plan) { create(:plan) }
+      let(:charge) { create(:standard_charge) }
+      let(:fixed_charge) { create(:fixed_charge) }
+
+      it "returns a plan_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["plan_not_found"]})
+      end
+    end
+
+    context "when the plan is discarded" do
+      before { plan.discard! }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the charge override points at another plan's charge" do
+      let(:charge) { create(:standard_charge, plan: create(:plan, organization:)) }
+
+      it "returns a charge_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.id": ["charge_not_found"]})
+      end
+    end
+
+    context "when the charge is discarded" do
+      before { charge.discard! }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the fixed charge override points at another plan's fixed charge" do
+      let(:fixed_charge) { create(:fixed_charge, plan: create(:plan, organization:)) }
+
+      it "returns a fixed_charge_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.id": ["fixed_charge_not_found"]}
+        )
+      end
+    end
+
+    context "when the fixed charge is discarded" do
+      before { fixed_charge.discard! }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the coupon does not exist" do
+      let(:coupon_item) { super().merge("id" => "11111111-2222-3333-4444-555555555555") }
+
+      it "returns a coupon_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.id": ["coupon_not_found"]})
+      end
+    end
+
+    context "when the coupon belongs to another organization" do
+      let(:coupon) { create(:coupon) }
+
+      it "returns a coupon_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.id": ["coupon_not_found"]})
+      end
+    end
+
+    context "when the coupon is discarded" do
+      before { coupon.discard! }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when a fixed_amount coupon currency differs from the version currency" do
+      let(:coupon) { create(:coupon, organization:, amount_currency: "USD") }
+
+      it "returns a currencies_does_not_match error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.id": ["currencies_does_not_match"]})
+      end
+    end
+
+    context "when a percentage coupon currency differs from the version currency" do
+      let(:coupon) do
+        create(:coupon, organization:, coupon_type: "percentage", percentage_rate: 10, amount_currency: "USD")
+      end
+      let(:coupon_payload) do
+        {
+          "code" => coupon.code,
+          "couponType" => "percentage",
+          "percentageRate" => 10.0
+        }
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the version currency is blank" do
+      let(:quote_version) { create(:quote_version, quote:, organization:, currency: nil) }
+      let(:coupon) { create(:coupon, organization:, amount_currency: "USD") }
+
+      it "does not check the coupon currency" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the scope is approve" do
+      let(:scope) { :approve }
+
+      context "when a fixed_amount coupon payload has no amountCents" do
+        let(:coupon_payload) { {"code" => coupon.code, "couponType" => "fixed_amount"} }
+
+        it "requires amountCents" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({"billing_items.coupons.0.payload.amountCents": ["value_is_mandatory"]})
+        end
+      end
+
+      context "when a percentage coupon payload has no percentageRate" do
+        let(:coupon) { create(:coupon, organization:, coupon_type: "percentage", percentage_rate: 10) }
+        let(:coupon_payload) { {"code" => coupon.code, "couponType" => "percentage"} }
+
+        it "requires percentageRate" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.coupons.0.payload.percentageRate": ["value_is_mandatory"]}
+          )
+        end
+      end
+    end
+
+    context "when a fixed_amount coupon payload has no amountCents at update scope" do
+      let(:coupon_payload) { {"code" => coupon.code, "couponType" => "fixed_amount"} }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the wallet paidCredits is not a decimal" do
+      let(:wallet_payload) { super().merge("paidCredits" => "abc") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.wallets.0.payload.paidCredits": ["invalid_value"]})
+      end
+    end
+
+    context "when the wallet grantedCredits is negative" do
+      let(:wallet_payload) { super().merge("grantedCredits" => "-1") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.wallets.0.payload.grantedCredits": ["invalid_value"]})
+      end
+    end
+
+    context "when the wallet rateAmount is zero" do
+      let(:wallet_payload) { super().merge("rateAmount" => "0") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.wallets.0.payload.rateAmount": ["invalid_value"]})
+      end
+    end
+
+    context "when the recurring rule trigger is interval without an interval" do
+      let(:recurring_rule) { {"trigger" => "interval", "method" => "fixed"} }
+
+      it "requires the interval" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.interval": ["value_is_mandatory"]}
+        )
+      end
+    end
+
+    context "when the recurring rule trigger is threshold without thresholdCredits" do
+      let(:recurring_rule) { {"trigger" => "threshold", "method" => "fixed"} }
+
+      it "requires thresholdCredits" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.thresholdCredits": ["value_is_mandatory"]}
+        )
+      end
+    end
+
+    context "when the recurring rule thresholdCredits is not a decimal" do
+      let(:recurring_rule) { {"trigger" => "threshold", "method" => "fixed", "thresholdCredits" => "abc"} }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.thresholdCredits": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the recurring rule method is target without targetOngoingBalance" do
+      let(:recurring_rule) { {"trigger" => "interval", "interval" => "monthly", "method" => "target"} }
+
+      it "requires targetOngoingBalance" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["value_is_mandatory"]}
+        )
+      end
+    end
+
+    context "when the recurring rule targetOngoingBalance is not a decimal" do
+      let(:recurring_rule) do
+        {"trigger" => "interval", "interval" => "monthly", "method" => "target", "targetOngoingBalance" => "abc"}
+      end
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the recurring rule target is below the threshold" do
+      let(:recurring_rule) do
+        {"trigger" => "threshold", "method" => "target", "thresholdCredits" => "100", "targetOngoingBalance" => "50"}
+      end
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.targetOngoingBalance": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the recurring rule target equals the threshold" do
+      let(:recurring_rule) do
+        {"trigger" => "threshold", "method" => "target", "thresholdCredits" => "100", "targetOngoingBalance" => "100"}
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the recurring rule paidCredits is not a decimal" do
+      let(:recurring_rule) { super().merge("paidCredits" => "abc") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.paidCredits": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "with errors on multiple coupons" do
+      let(:billing_items) do
+        super().merge(
+          "coupons" => [
+            coupon_item,
+            coupon_item.merge("id" => "11111111-2222-3333-4444-555555555555")
+          ]
+        )
+      end
+
+      it "keys each error with the coupon index" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.1.id": ["coupon_not_found"]})
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -92,9 +92,16 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
   describe "#valid?" do
     context "with a valid quote version" do
-      it "is valid for both scopes" do
-        expect(described_class.new(BaseService::Result.new, quote_version:, billing_items:, scope: :update)).to be_valid
-        expect(described_class.new(BaseService::Result.new, quote_version:, billing_items:, scope: :approve)).to be_valid
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -159,14 +159,27 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       context "when the scope is approve" do
         let(:scope) { :approve }
 
-        it "requires both dates" do
+        it "requires the start date" do
           expect(validator).not_to be_valid
-          expect(result.error.messages).to eq(
-            {
-              start_date: ["value_is_mandatory"],
-              end_date: ["value_is_mandatory"]
-            }
-          )
+          expect(result.error.messages).to eq({start_date: ["value_is_mandatory"]})
+        end
+      end
+    end
+
+    context "when the end date is missing" do
+      let(:quote_version) do
+        create(:quote_version, quote:, organization:, currency: "EUR", start_date: Date.parse("2026-01-01"))
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "is valid" do
+          expect(validator).to be_valid
         end
       end
     end

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -11,31 +11,50 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
   let(:plan_item) do
     {
       "id" => "48e59220-6722-49c1-8cdf-eacd040e2a56",
-      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
       "type" => "plan",
       "payload" => plan_payload,
       "overrides" => plan_overrides
     }
   end
-  let(:plan_payload) { {"code" => "enterprise"} }
+  let(:plan_payload) do
+    {
+      "code" => "base_plan",
+      "name" => "Base Plan",
+      "subscriptionExternalId" => "sub_ext_123",
+      "amountCents" => "10000",
+      "charges" => [{"billableMetric" => {"code" => "api_calls"}, "chargeModel" => "standard"}]
+    }
+  end
   let(:plan_overrides) do
     {
-      "amountCents" => 500_000,
+      "amountCents" => 25_000,
+      "invoiceDisplayName" => "Custom Enterprise fee",
       "charges" => [charge_override],
-      "fixedCharges" => [fixed_charge_override]
+      "fixedCharges" => [fixed_charge_override],
+      "minimumCommitment" => {"amountCents" => 50_000, "invoiceDisplayName" => "Min commitment"},
+      "usageThresholds" => [
+        {"amountCents" => 100_000, "recurring" => false, "thresholdDisplayName" => "First threshold"},
+        {"amountCents" => 200_000, "recurring" => true, "thresholdDisplayName" => "Recurring cap"}
+      ]
     }
   end
   let(:charge_override) do
     {
-      "id" => "9c4681ce-b915-486a-9d94-a294d444a89b",
-      "properties" => {"amount" => "0.30"},
+      "billableMetricCode" => "api_calls",
+      "chargeModel" => "graduated",
+      "properties" => {
+        "graduatedRanges" => [
+          {"fromValue" => 0, "toValue" => 1000, "perUnitAmount" => "0.005", "flatAmount" => "0"},
+          {"fromValue" => 1001, "toValue" => nil, "perUnitAmount" => "0.002", "flatAmount" => "0"}
+        ]
+      },
       "minAmountCents" => 10_000,
       "invoiceDisplayName" => "API calls"
     }
   end
   let(:fixed_charge_override) do
     {
-      "id" => "e447e942-e21a-40fb-9e75-4bbc2a68c46b",
+      "addOnCode" => "seats",
       "units" => "3",
       "properties" => {"amount" => "50"},
       "invoiceDisplayName" => "Seats"
@@ -47,41 +66,64 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       "id" => "5c1f47bb-fbf8-4be6-b1a4-b1a26a0a2b78",
       "localId" => "ba54903c-7bd5-4d40-8d51-45a5157005ff",
       "type" => "coupon",
-      "payload" => coupon_payload
+      "payload" => coupon_payload,
+      "overrides" => coupon_overrides
     }
   end
   let(:coupon_payload) do
     {
-      "code" => "ent_20",
-      "couponType" => "fixed_amount",
-      "amountCents" => 20_000,
-      "amountCurrency" => "EUR",
-      "frequency" => "once"
+      "code" => "SUMMER",
+      "type" => "fixed_amount",
+      "amountCents" => 5000,
+      "percentageRate" => nil,
+      "currency" => "USD",
+      "frequency" => "once",
+      "frequencyDuration" => nil,
+      "expirationAt" => nil
+    }
+  end
+  let(:coupon_overrides) do
+    {
+      "amountCents" => 9000,
+      "percentageRate" => nil,
+      "frequency" => "recurring",
+      "frequencyDuration" => 3
     }
   end
 
-  let(:wallet_item) do
+  let(:wallet_credit_item) do
     {
       "localId" => "d9169d94-b322-4d70-a2b1-9e6a58e3f74a",
-      "type" => "wallet",
-      "payload" => wallet_payload
+      "type" => "wallet_credit",
+      "payload" => wallet_credit_payload
     }
   end
-  let(:wallet_payload) do
+  let(:wallet_credit_payload) do
     {
-      "paidCredits" => "100.0",
-      "grantedCredits" => "10.0",
-      "rateAmount" => "1.0",
+      "name" => "Prepaid credits",
+      "currency" => "USD",
+      "rateAmount" => "1",
+      "paidCredits" => "1000",
+      "grantedCredits" => "200",
+      "expirationAt" => nil,
+      "purchaseOrderNumber" => "PO-123",
+      "appliesTo" => {"feeTypes" => ["charge"], "billableMetricCodes" => ["api_calls"]},
       "recurringTransactionRules" => [recurring_rule]
     }
   end
   let(:recurring_rule) do
     {
       "trigger" => "interval",
+      "method" => "target",
       "interval" => "monthly",
-      "method" => "fixed",
-      "paidCredits" => "50.0",
-      "grantedCredits" => "0"
+      "paidCredits" => "1000",
+      "grantedCredits" => "200",
+      "targetOngoingBalance" => "5000",
+      "thresholdCredits" => nil,
+      "startedAt" => "2026-08-01T00:00:00Z",
+      "transactionName" => "Monthly refill",
+      "invoiceRequiresSuccessfulPayment" => false,
+      "expirationAt" => nil
     }
   end
 
@@ -89,7 +131,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
     {
       "plans" => [plan_item],
       "coupons" => [coupon_item],
-      "wallets" => [wallet_item]
+      "walletCredits" => [wallet_credit_item]
     }
   end
 
@@ -128,12 +170,17 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
-    context "when billing_items contains an unknown root key" do
-      let(:billing_items) { super().merge("addOns" => []) }
+    context "when billing_items contains unknown root keys" do
+      let(:billing_items) { super().merge("addOns" => [], "wallets" => []) }
 
-      it "returns an unsupported_key error" do
+      it "returns unsupported_key errors" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.addOns": ["unsupported_key"]})
+        expect(result.error.messages).to eq(
+          {
+            "billing_items.addOns": ["unsupported_key"],
+            "billing_items.wallets": ["unsupported_key"]
+          }
+        )
       end
     end
 
@@ -146,17 +193,20 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
-    context "when the plan identity is missing" do
-      let(:plan_item) { super().except("id", "localId") }
+    context "when the plan localId is null" do
+      let(:plan_item) { super().merge("localId" => nil) }
 
-      it "requires id and localId at update scope" do
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan id is missing" do
+      let(:plan_item) { super().except("id") }
+
+      it "returns a value_is_mandatory error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq(
-          {
-            "billing_items.plans.0.id": ["value_is_mandatory"],
-            "billing_items.plans.0.localId": ["value_is_mandatory"]
-          }
-        )
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["value_is_mandatory"]})
       end
     end
 
@@ -166,24 +216,6 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       it "returns an invalid_format error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq({"billing_items.plans.0.id": ["invalid_format"]})
-      end
-    end
-
-    context "when the plan localId is empty" do
-      let(:plan_item) { super().merge("localId" => "") }
-
-      it "returns an invalid_value error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.localId": ["invalid_value"]})
-      end
-    end
-
-    context "when the plan type is not plan" do
-      let(:plan_item) { super().merge("type" => "add_on") }
-
-      it "returns an invalid_value error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.type": ["invalid_value"]})
       end
     end
 
@@ -205,29 +237,20 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
-    context "when the plan payload is not an object" do
-      let(:plan_payload) { "bogus" }
-
-      it "returns an invalid_type error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.payload": ["invalid_type"]})
-      end
-    end
-
-    context "when the plan payload contains unknown keys" do
-      let(:plan_payload) { super().merge("customField" => {"nested" => true}) }
-
-      it "is valid" do
-        expect(validator).to be_valid
-      end
-    end
-
     context "when the plan payload code is empty" do
       let(:plan_payload) { super().merge("code" => "") }
 
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq({"billing_items.plans.0.payload.code": ["invalid_value"]})
+      end
+    end
+
+    context "when the plan overrides is null" do
+      let(:plan_overrides) { nil }
+
+      it "is valid" do
+        expect(validator).to be_valid
       end
     end
 
@@ -249,64 +272,106 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
-    context "when the plan overrides amountCents is fractional" do
-      let(:plan_overrides) { super().merge("amountCents" => 10.5) }
+    context "when the plan overrides amountCents is null" do
+      let(:plan_overrides) { super().merge("amountCents" => nil) }
 
-      it "returns an invalid_type error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.amountCents": ["invalid_type"]})
+      it "is valid" do
+        expect(validator).to be_valid
       end
     end
 
-    context "when the plan overrides charges is not an array" do
-      let(:plan_overrides) { super().merge("charges" => {}) }
-
-      it "returns an invalid_type error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges": ["invalid_type"]})
-      end
-    end
-
-    context "when the charge override id is missing" do
-      let(:charge_override) { super().except("id") }
-
-      it "returns a value_is_mandatory error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.id": ["value_is_mandatory"]})
-      end
-    end
-
-    context "when the charge override id is not a uuid" do
-      let(:charge_override) { super().merge("id" => "not-a-uuid") }
-
-      it "returns an invalid_format error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.id": ["invalid_format"]})
-      end
-    end
-
-    context "when the charge override contains an unknown key" do
-      let(:charge_override) { super().merge("chargeModel" => "standard") }
-
-      it "returns an unsupported_key error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.chargeModel": ["unsupported_key"]})
-      end
-    end
-
-    context "when the charge override minAmountCents is negative" do
-      let(:charge_override) { super().merge("minAmountCents" => -1) }
+    context "when the plan overrides invoiceDisplayName is empty" do
+      let(:plan_overrides) { super().merge("invoiceDisplayName" => "") }
 
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.minAmountCents": ["invalid_value"]})
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.invoiceDisplayName": ["invalid_value"]}
+        )
       end
     end
 
-    context "when the charge override properties has model-specific keys" do
-      let(:charge_override) do
-        super().merge("properties" => {"graduatedRanges" => [{"fromValue" => 0, "toValue" => nil}]})
+    context "when the minimumCommitment contains an unknown key" do
+      let(:plan_overrides) do
+        super().merge("minimumCommitment" => {"amountCents" => 50_000, "taxCodes" => []})
       end
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.minimumCommitment.taxCodes": ["unsupported_key"]}
+        )
+      end
+    end
+
+    context "when the minimumCommitment amountCents is negative" do
+      let(:plan_overrides) { super().merge("minimumCommitment" => {"amountCents" => -1}) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.minimumCommitment.amountCents": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when a usage threshold has no amountCents" do
+      let(:plan_overrides) { super().merge("usageThresholds" => [{"recurring" => true}]) }
+
+      it "returns a value_is_mandatory error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.usageThresholds.0.amountCents": ["value_is_mandatory"]}
+        )
+      end
+    end
+
+    context "when a usage threshold recurring is not a boolean" do
+      let(:plan_overrides) do
+        super().merge("usageThresholds" => [{"amountCents" => 100, "recurring" => "yes"}])
+      end
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.usageThresholds.0.recurring": ["invalid_type"]}
+        )
+      end
+    end
+
+    context "when the charge override billableMetricCode is missing" do
+      let(:charge_override) { super().except("billableMetricCode") }
+
+      it "returns a value_is_mandatory error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.billableMetricCode": ["value_is_mandatory"]}
+        )
+      end
+    end
+
+    context "when the charge override contains an id" do
+      let(:charge_override) { super().merge("id" => "9c4681ce-b915-486a-9d94-a294d444a89b") }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.id": ["unsupported_key"]})
+      end
+    end
+
+    context "when the charge override chargeModel is not in the enum" do
+      let(:charge_override) { super().merge("chargeModel" => "flat") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.chargeModel": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the charge override chargeModel is null" do
+      let(:charge_override) { super().merge("chargeModel" => nil) }
 
       it "is valid" do
         expect(validator).to be_valid
@@ -318,16 +383,31 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
 
       it "returns an invalid_type error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.properties": ["invalid_type"]})
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.properties": ["invalid_type"]}
+        )
       end
     end
 
-    context "when the fixed charge override id is missing" do
-      let(:fixed_charge_override) { super().except("id") }
+    context "when the charge override minAmountCents is negative" do
+      let(:charge_override) { super().merge("minAmountCents" => -1) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.minAmountCents": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the fixed charge override addOnCode is missing" do
+      let(:fixed_charge_override) { super().except("addOnCode") }
 
       it "returns a value_is_mandatory error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.fixedCharges.0.id": ["value_is_mandatory"]})
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.addOnCode": ["value_is_mandatory"]}
+        )
       end
     end
 
@@ -340,12 +420,11 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
-    context "when the fixed charge override units is empty" do
-      let(:fixed_charge_override) { super().merge("units" => "") }
+    context "when the fixed charge override units is null" do
+      let(:fixed_charge_override) { super().merge("units" => nil) }
 
-      it "returns an invalid_value error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.fixedCharges.0.units": ["invalid_value"]})
+      it "is valid" do
+        expect(validator).to be_valid
       end
     end
 
@@ -357,15 +436,6 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
         expect(result.error.messages).to eq(
           {"billing_items.plans.0.overrides.fixedCharges.0.applyUnitsImmediately": ["unsupported_key"]}
         )
-      end
-    end
-
-    context "when the coupon type is not coupon" do
-      let(:coupon_item) { super().merge("type" => "plan") }
-
-      it "returns an invalid_value error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.coupons.0.type": ["invalid_value"]})
       end
     end
 
@@ -384,29 +454,29 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
     end
 
     context "when the coupon payload contains unknown keys" do
-      let(:coupon_payload) { super().merge("customField" => true) }
+      let(:coupon_payload) { super().merge("catalogSnapshot" => nil, "planCodes" => []) }
 
       it "is valid" do
         expect(validator).to be_valid
       end
     end
 
-    context "when the couponType is not in the enum" do
-      let(:coupon_payload) { super().merge("couponType" => "bogus") }
+    context "when the coupon payload type is not in the enum" do
+      let(:coupon_payload) { super().merge("type" => "bogus") }
 
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.couponType": ["invalid_value"]})
+        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.type": ["invalid_value"]})
       end
     end
 
-    context "when the couponType has a wrong JSON type" do
-      let(:coupon_payload) { super().merge("couponType" => 123) }
+    context "when the coupon payload type has a wrong JSON type" do
+      let(:coupon_payload) { super().merge("type" => 123) }
 
       it "returns invalid_type and invalid_value errors" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.coupons.0.payload.couponType": ["invalid_type", "invalid_value"]}
+          {"billing_items.coupons.0.payload.type": ["invalid_type", "invalid_value"]}
         )
       end
     end
@@ -421,7 +491,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
     end
 
     context "when the coupon percentageRate is a string" do
-      let(:coupon_payload) { super().merge("couponType" => "percentage", "percentageRate" => "10.0") }
+      let(:coupon_payload) { super().merge("type" => "percentage", "percentageRate" => "10.0") }
 
       it "returns an invalid_type error" do
         expect(validator).not_to be_valid
@@ -430,20 +500,11 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
     end
 
     context "when the coupon percentageRate is zero" do
-      let(:coupon_payload) { super().merge("couponType" => "percentage", "percentageRate" => 0) }
+      let(:coupon_payload) { super().merge("type" => "percentage", "percentageRate" => 0) }
 
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq({"billing_items.coupons.0.payload.percentageRate": ["invalid_value"]})
-      end
-    end
-
-    context "when the coupon frequency is not in the enum" do
-      let(:coupon_payload) { super().merge("frequency" => "daily") }
-
-      it "returns an invalid_value error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.frequency": ["invalid_value"]})
       end
     end
 
@@ -456,53 +517,82 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
-    context "when the wallet contains an id" do
-      let(:wallet_item) { super().merge("id" => "48e59220-6722-49c1-8cdf-eacd040e2a56") }
-
-      it "returns an unsupported_key error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.wallets.0.id": ["unsupported_key"]})
-      end
-    end
-
-    context "when the wallet identity is missing" do
-      let(:wallet_item) { super().except("localId", "payload") }
-
-      it "requires localId and payload at update scope" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq(
-          {
-            "billing_items.wallets.0.localId": ["value_is_mandatory"],
-            "billing_items.wallets.0.payload": ["value_is_mandatory"]
-          }
-        )
-      end
-    end
-
-    context "when the wallet paidCredits is a number" do
-      let(:wallet_payload) { super().merge("paidCredits" => 100) }
-
-      it "returns an invalid_type error" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.wallets.0.payload.paidCredits": ["invalid_type"]})
-      end
-    end
-
-    context "when the wallet payload contains unknown keys" do
-      let(:wallet_payload) { super().merge("name" => "Prepaid credits") }
+    context "when the coupon overrides is null" do
+      let(:coupon_overrides) { nil }
 
       it "is valid" do
         expect(validator).to be_valid
       end
     end
 
+    context "when the coupon overrides contains an unknown key" do
+      let(:coupon_overrides) { super().merge("expirationAt" => nil) }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.overrides.expirationAt": ["unsupported_key"]})
+      end
+    end
+
+    context "when the coupon overrides frequencyDuration is zero" do
+      let(:coupon_overrides) { super().merge("frequencyDuration" => 0) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.coupons.0.overrides.frequencyDuration": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the wallet credit contains an id" do
+      let(:wallet_credit_item) { super().merge("id" => "48e59220-6722-49c1-8cdf-eacd040e2a56") }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.walletCredits.0.id": ["unsupported_key"]})
+      end
+    end
+
+    context "when the wallet credit type is wallet" do
+      let(:wallet_credit_item) { super().merge("type" => "wallet") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.walletCredits.0.type": ["invalid_value"]})
+      end
+    end
+
+    context "when the wallet credit identity is missing" do
+      let(:wallet_credit_item) { super().except("localId", "payload") }
+
+      it "requires localId and payload at update scope" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {
+            "billing_items.walletCredits.0.localId": ["value_is_mandatory"],
+            "billing_items.walletCredits.0.payload": ["value_is_mandatory"]
+          }
+        )
+      end
+    end
+
+    context "when the wallet credit paidCredits is a number" do
+      let(:wallet_credit_payload) { super().merge("paidCredits" => 100) }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.walletCredits.0.payload.paidCredits": ["invalid_type"]})
+      end
+    end
+
     context "when the recurring rule contains an unknown key" do
-      let(:recurring_rule) { super().merge("startedAt" => "2026-01-01") }
+      let(:recurring_rule) { super().merge("purchaseOrderNumber" => "PO-123") }
 
       it "returns an unsupported_key error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.startedAt": ["unsupported_key"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.purchaseOrderNumber": ["unsupported_key"]}
         )
       end
     end
@@ -513,7 +603,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.trigger": ["invalid_value"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.trigger": ["invalid_value"]}
         )
       end
     end
@@ -524,29 +614,40 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.interval": ["invalid_value"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.interval": ["invalid_value"]}
         )
       end
     end
 
-    context "when the recurring rule method is not in the enum" do
-      let(:recurring_rule) { super().merge("method" => "bogus") }
+    context "when the recurring rule startedAt is not an ISO 8601 date-time" do
+      let(:recurring_rule) { super().merge("startedAt" => "not-a-date") }
 
-      it "returns an invalid_value error" do
+      it "returns an invalid_format error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.method": ["invalid_value"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.startedAt": ["invalid_format"]}
+        )
+      end
+    end
+
+    context "when the recurring rule invoiceRequiresSuccessfulPayment is a string" do
+      let(:recurring_rule) { super().merge("invoiceRequiresSuccessfulPayment" => "false") }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.invoiceRequiresSuccessfulPayment": ["invalid_type"]}
         )
       end
     end
 
     context "when the recurring rule thresholdCredits is a number" do
-      let(:recurring_rule) { super().merge("trigger" => "threshold", "thresholdCredits" => 100) }
+      let(:recurring_rule) { super().merge("thresholdCredits" => 100) }
 
       it "returns an invalid_type error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.wallets.0.payload.recurringTransactionRules.0.thresholdCredits": ["invalid_type"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.thresholdCredits": ["invalid_type"]}
         )
       end
     end
@@ -564,7 +665,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
 
       context "when the plan payload is incomplete" do
-        let(:plan_payload) { {"customField" => true} }
+        let(:plan_payload) { {"name" => "Base Plan"} }
 
         it "requires the snapshot fields" do
           expect(validator).not_to be_valid
@@ -573,29 +674,29 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
 
       context "when the coupon payload is incomplete" do
-        let(:coupon_payload) { {"amountCents" => 20_000} }
+        let(:coupon_payload) { {"amountCents" => 5000} }
 
         it "requires the snapshot fields" do
           expect(validator).not_to be_valid
           expect(result.error.messages).to eq(
             {
               "billing_items.coupons.0.payload.code": ["value_is_mandatory"],
-              "billing_items.coupons.0.payload.couponType": ["value_is_mandatory"]
+              "billing_items.coupons.0.payload.type": ["value_is_mandatory"]
             }
           )
         end
       end
 
-      context "when the wallet payload is incomplete" do
-        let(:wallet_payload) { {} }
+      context "when the wallet credit payload is incomplete" do
+        let(:wallet_credit_payload) { {} }
 
         it "requires the snapshot fields" do
           expect(validator).not_to be_valid
           expect(result.error.messages).to eq(
             {
-              "billing_items.wallets.0.payload.paidCredits": ["value_is_mandatory"],
-              "billing_items.wallets.0.payload.grantedCredits": ["value_is_mandatory"],
-              "billing_items.wallets.0.payload.rateAmount": ["value_is_mandatory"]
+              "billing_items.walletCredits.0.payload.paidCredits": ["value_is_mandatory"],
+              "billing_items.walletCredits.0.payload.grantedCredits": ["value_is_mandatory"],
+              "billing_items.walletCredits.0.payload.rateAmount": ["value_is_mandatory"]
             }
           )
         end
@@ -605,7 +706,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
     context "when the payloads are incomplete at update scope" do
       let(:plan_payload) { {} }
       let(:coupon_payload) { {} }
-      let(:wallet_payload) { {} }
+      let(:wallet_credit_payload) { {} }
 
       it "is valid" do
         expect(validator).to be_valid
@@ -635,16 +736,16 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
 
     context "with errors across item types" do
       let(:plan_item) { super().merge("id" => "not-a-uuid") }
-      let(:coupon_payload) { super().merge("couponType" => "bogus") }
-      let(:wallet_payload) { super().merge("rateAmount" => 1) }
+      let(:coupon_payload) { super().merge("type" => "bogus") }
+      let(:wallet_credit_payload) { super().merge("rateAmount" => 1) }
 
       it "keys each error with its item type and index" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
           {
             "billing_items.plans.0.id": ["invalid_format"],
-            "billing_items.coupons.0.payload.couponType": ["invalid_value"],
-            "billing_items.wallets.0.payload.rateAmount": ["invalid_type"]
+            "billing_items.coupons.0.payload.type": ["invalid_value"],
+            "billing_items.walletCredits.0.payload.rateAmount": ["invalid_type"]
           }
         )
       end

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -1,0 +1,653 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValidator do
+  subject(:validator) { described_class.new(result, billing_items:, scope:) }
+
+  let(:result) { BaseService::Result.new }
+  let(:scope) { :update }
+
+  let(:plan_item) do
+    {
+      "id" => "48e59220-6722-49c1-8cdf-eacd040e2a56",
+      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "type" => "plan",
+      "payload" => plan_payload,
+      "overrides" => plan_overrides
+    }
+  end
+  let(:plan_payload) { {"code" => "enterprise"} }
+  let(:plan_overrides) do
+    {
+      "amountCents" => 500_000,
+      "charges" => [charge_override],
+      "fixedCharges" => [fixed_charge_override]
+    }
+  end
+  let(:charge_override) do
+    {
+      "id" => "9c4681ce-b915-486a-9d94-a294d444a89b",
+      "properties" => {"amount" => "0.30"},
+      "minAmountCents" => 10_000,
+      "invoiceDisplayName" => "API calls"
+    }
+  end
+  let(:fixed_charge_override) do
+    {
+      "id" => "e447e942-e21a-40fb-9e75-4bbc2a68c46b",
+      "units" => "3",
+      "properties" => {"amount" => "50"},
+      "invoiceDisplayName" => "Seats"
+    }
+  end
+
+  let(:coupon_item) do
+    {
+      "id" => "5c1f47bb-fbf8-4be6-b1a4-b1a26a0a2b78",
+      "localId" => "ba54903c-7bd5-4d40-8d51-45a5157005ff",
+      "type" => "coupon",
+      "payload" => coupon_payload
+    }
+  end
+  let(:coupon_payload) do
+    {
+      "code" => "ent_20",
+      "couponType" => "fixed_amount",
+      "amountCents" => 20_000,
+      "amountCurrency" => "EUR",
+      "frequency" => "once"
+    }
+  end
+
+  let(:wallet_item) do
+    {
+      "localId" => "d9169d94-b322-4d70-a2b1-9e6a58e3f74a",
+      "type" => "wallet",
+      "payload" => wallet_payload
+    }
+  end
+  let(:wallet_payload) do
+    {
+      "paidCredits" => "100.0",
+      "grantedCredits" => "10.0",
+      "rateAmount" => "1.0",
+      "recurringTransactionRules" => [recurring_rule]
+    }
+  end
+  let(:recurring_rule) do
+    {
+      "trigger" => "interval",
+      "interval" => "monthly",
+      "method" => "fixed",
+      "paidCredits" => "50.0",
+      "grantedCredits" => "0"
+    }
+  end
+
+  let(:billing_items) do
+    {
+      "plans" => [plan_item],
+      "coupons" => [coupon_item],
+      "wallets" => [wallet_item]
+    }
+  end
+
+  describe "#valid?" do
+    context "with a full valid payload" do
+      it "is valid for both scopes" do
+        expect(described_class.new(BaseService::Result.new, billing_items:, scope: :update)).to be_valid
+        expect(described_class.new(BaseService::Result.new, billing_items:, scope: :approve)).to be_valid
+      end
+    end
+
+    context "when billing_items is nil" do
+      let(:billing_items) { nil }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+        expect(result).to be_success
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "requires the plans list" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({"billing_items.plans": ["value_is_mandatory"]})
+        end
+      end
+    end
+
+    context "when billing_items is not an object" do
+      let(:billing_items) { "bogus" }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({billing_items: ["invalid_type"]})
+      end
+    end
+
+    context "when billing_items contains an unknown root key" do
+      let(:billing_items) { super().merge("addOns" => []) }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.addOns": ["unsupported_key"]})
+      end
+    end
+
+    context "when the plan contains an unknown key" do
+      let(:plan_item) { super().merge("entitlementsOverrides" => []) }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.entitlementsOverrides": ["unsupported_key"]})
+      end
+    end
+
+    context "when the plan identity is missing" do
+      let(:plan_item) { super().except("id", "localId") }
+
+      it "requires id and localId at update scope" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {
+            "billing_items.plans.0.id": ["value_is_mandatory"],
+            "billing_items.plans.0.localId": ["value_is_mandatory"]
+          }
+        )
+      end
+    end
+
+    context "when the plan id is not a uuid" do
+      let(:plan_item) { super().merge("id" => "not-a-uuid") }
+
+      it "returns an invalid_format error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["invalid_format"]})
+      end
+    end
+
+    context "when the plan localId is empty" do
+      let(:plan_item) { super().merge("localId" => "") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.localId": ["invalid_value"]})
+      end
+    end
+
+    context "when the plan type is not plan" do
+      let(:plan_item) { super().merge("type" => "add_on") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.type": ["invalid_value"]})
+      end
+    end
+
+    context "when the plan type has a wrong JSON type" do
+      let(:plan_item) { super().merge("type" => 123) }
+
+      it "returns invalid_type and invalid_value errors" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.type": ["invalid_type", "invalid_value"]})
+      end
+    end
+
+    context "when the plan payload is missing" do
+      let(:plan_item) { super().except("payload") }
+
+      it "returns a value_is_mandatory error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload": ["value_is_mandatory"]})
+      end
+    end
+
+    context "when the plan payload is not an object" do
+      let(:plan_payload) { "bogus" }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload": ["invalid_type"]})
+      end
+    end
+
+    context "when the plan payload contains unknown keys" do
+      let(:plan_payload) { super().merge("customField" => {"nested" => true}) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan payload code is empty" do
+      let(:plan_payload) { super().merge("code" => "") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.code": ["invalid_value"]})
+      end
+    end
+
+    context "when the plan overrides contains an unknown key" do
+      let(:plan_overrides) { super().merge("taxCodes" => ["vat_20"]) }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.taxCodes": ["unsupported_key"]})
+      end
+    end
+
+    context "when the plan overrides amountCents is negative" do
+      let(:plan_overrides) { super().merge("amountCents" => -1) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.amountCents": ["invalid_value"]})
+      end
+    end
+
+    context "when the plan overrides amountCents is fractional" do
+      let(:plan_overrides) { super().merge("amountCents" => 10.5) }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.amountCents": ["invalid_type"]})
+      end
+    end
+
+    context "when the plan overrides charges is not an array" do
+      let(:plan_overrides) { super().merge("charges" => {}) }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges": ["invalid_type"]})
+      end
+    end
+
+    context "when the charge override id is missing" do
+      let(:charge_override) { super().except("id") }
+
+      it "returns a value_is_mandatory error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.id": ["value_is_mandatory"]})
+      end
+    end
+
+    context "when the charge override id is not a uuid" do
+      let(:charge_override) { super().merge("id" => "not-a-uuid") }
+
+      it "returns an invalid_format error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.id": ["invalid_format"]})
+      end
+    end
+
+    context "when the charge override contains an unknown key" do
+      let(:charge_override) { super().merge("chargeModel" => "standard") }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.chargeModel": ["unsupported_key"]})
+      end
+    end
+
+    context "when the charge override minAmountCents is negative" do
+      let(:charge_override) { super().merge("minAmountCents" => -1) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.minAmountCents": ["invalid_value"]})
+      end
+    end
+
+    context "when the charge override properties has model-specific keys" do
+      let(:charge_override) do
+        super().merge("properties" => {"graduatedRanges" => [{"fromValue" => 0, "toValue" => nil}]})
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the charge override properties is not an object" do
+      let(:charge_override) { super().merge("properties" => "bogus") }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.charges.0.properties": ["invalid_type"]})
+      end
+    end
+
+    context "when the fixed charge override id is missing" do
+      let(:fixed_charge_override) { super().except("id") }
+
+      it "returns a value_is_mandatory error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.fixedCharges.0.id": ["value_is_mandatory"]})
+      end
+    end
+
+    context "when the fixed charge override units is a number" do
+      let(:fixed_charge_override) { super().merge("units" => 3) }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.fixedCharges.0.units": ["invalid_type"]})
+      end
+    end
+
+    context "when the fixed charge override units is empty" do
+      let(:fixed_charge_override) { super().merge("units" => "") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.fixedCharges.0.units": ["invalid_value"]})
+      end
+    end
+
+    context "when the fixed charge override contains an unknown key" do
+      let(:fixed_charge_override) { super().merge("applyUnitsImmediately" => true) }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.applyUnitsImmediately": ["unsupported_key"]}
+        )
+      end
+    end
+
+    context "when the coupon type is not coupon" do
+      let(:coupon_item) { super().merge("type" => "plan") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.type": ["invalid_value"]})
+      end
+    end
+
+    context "when the coupon identity is missing" do
+      let(:coupon_item) { super().except("id", "localId") }
+
+      it "requires id and localId at update scope" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {
+            "billing_items.coupons.0.id": ["value_is_mandatory"],
+            "billing_items.coupons.0.localId": ["value_is_mandatory"]
+          }
+        )
+      end
+    end
+
+    context "when the coupon payload contains unknown keys" do
+      let(:coupon_payload) { super().merge("customField" => true) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the couponType is not in the enum" do
+      let(:coupon_payload) { super().merge("couponType" => "bogus") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.couponType": ["invalid_value"]})
+      end
+    end
+
+    context "when the couponType has a wrong JSON type" do
+      let(:coupon_payload) { super().merge("couponType" => 123) }
+
+      it "returns invalid_type and invalid_value errors" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.coupons.0.payload.couponType": ["invalid_type", "invalid_value"]}
+        )
+      end
+    end
+
+    context "when the coupon amountCents is negative" do
+      let(:coupon_payload) { super().merge("amountCents" => -1) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.amountCents": ["invalid_value"]})
+      end
+    end
+
+    context "when the coupon percentageRate is a string" do
+      let(:coupon_payload) { super().merge("couponType" => "percentage", "percentageRate" => "10.0") }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.percentageRate": ["invalid_type"]})
+      end
+    end
+
+    context "when the coupon percentageRate is zero" do
+      let(:coupon_payload) { super().merge("couponType" => "percentage", "percentageRate" => 0) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.percentageRate": ["invalid_value"]})
+      end
+    end
+
+    context "when the coupon frequency is not in the enum" do
+      let(:coupon_payload) { super().merge("frequency" => "daily") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.frequency": ["invalid_value"]})
+      end
+    end
+
+    context "when the coupon frequencyDuration is zero" do
+      let(:coupon_payload) { super().merge("frequency" => "recurring", "frequencyDuration" => 0) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.frequencyDuration": ["invalid_value"]})
+      end
+    end
+
+    context "when the wallet contains an id" do
+      let(:wallet_item) { super().merge("id" => "48e59220-6722-49c1-8cdf-eacd040e2a56") }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.wallets.0.id": ["unsupported_key"]})
+      end
+    end
+
+    context "when the wallet identity is missing" do
+      let(:wallet_item) { super().except("localId", "payload") }
+
+      it "requires localId and payload at update scope" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {
+            "billing_items.wallets.0.localId": ["value_is_mandatory"],
+            "billing_items.wallets.0.payload": ["value_is_mandatory"]
+          }
+        )
+      end
+    end
+
+    context "when the wallet paidCredits is a number" do
+      let(:wallet_payload) { super().merge("paidCredits" => 100) }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.wallets.0.payload.paidCredits": ["invalid_type"]})
+      end
+    end
+
+    context "when the wallet payload contains unknown keys" do
+      let(:wallet_payload) { super().merge("name" => "Prepaid credits") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the recurring rule contains an unknown key" do
+      let(:recurring_rule) { super().merge("startedAt" => "2026-01-01") }
+
+      it "returns an unsupported_key error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.startedAt": ["unsupported_key"]}
+        )
+      end
+    end
+
+    context "when the recurring rule trigger is not in the enum" do
+      let(:recurring_rule) { super().merge("trigger" => "bogus") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.trigger": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the recurring rule interval is not in the enum" do
+      let(:recurring_rule) { super().merge("interval" => "daily") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.interval": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the recurring rule method is not in the enum" do
+      let(:recurring_rule) { super().merge("method" => "bogus") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.method": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the recurring rule thresholdCredits is a number" do
+      let(:recurring_rule) { super().merge("trigger" => "threshold", "thresholdCredits" => 100) }
+
+      it "returns an invalid_type error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.wallets.0.payload.recurringTransactionRules.0.thresholdCredits": ["invalid_type"]}
+        )
+      end
+    end
+
+    context "when the scope is approve" do
+      let(:scope) { :approve }
+
+      context "when the plans list is empty" do
+        let(:billing_items) { super().merge("plans" => []) }
+
+        it "returns an invalid_count error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({"billing_items.plans": ["invalid_count"]})
+        end
+      end
+
+      context "when the plan payload is incomplete" do
+        let(:plan_payload) { {"customField" => true} }
+
+        it "requires the snapshot fields" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({"billing_items.plans.0.payload.code": ["value_is_mandatory"]})
+        end
+      end
+
+      context "when the coupon payload is incomplete" do
+        let(:coupon_payload) { {"amountCents" => 20_000} }
+
+        it "requires the snapshot fields" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {
+              "billing_items.coupons.0.payload.code": ["value_is_mandatory"],
+              "billing_items.coupons.0.payload.couponType": ["value_is_mandatory"]
+            }
+          )
+        end
+      end
+
+      context "when the wallet payload is incomplete" do
+        let(:wallet_payload) { {} }
+
+        it "requires the snapshot fields" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {
+              "billing_items.wallets.0.payload.paidCredits": ["value_is_mandatory"],
+              "billing_items.wallets.0.payload.grantedCredits": ["value_is_mandatory"],
+              "billing_items.wallets.0.payload.rateAmount": ["value_is_mandatory"]
+            }
+          )
+        end
+      end
+    end
+
+    context "when the payloads are incomplete at update scope" do
+      let(:plan_payload) { {} }
+      let(:coupon_payload) { {} }
+      let(:wallet_payload) { {} }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "with errors on multiple plans" do
+      let(:billing_items) do
+        super().merge(
+          "plans" => [
+            plan_item.merge("id" => "not-a-uuid"),
+            plan_item.merge("payload" => plan_payload.merge("code" => ""))
+          ]
+        )
+      end
+
+      it "keys each error with the plan index" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {
+            "billing_items.plans.0.id": ["invalid_format"],
+            "billing_items.plans.1.payload.code": ["invalid_value"]
+          }
+        )
+      end
+    end
+
+    context "with errors across item types" do
+      let(:plan_item) { super().merge("id" => "not-a-uuid") }
+      let(:coupon_payload) { super().merge("couponType" => "bogus") }
+      let(:wallet_payload) { super().merge("rateAmount" => 1) }
+
+      it "keys each error with its item type and index" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {
+            "billing_items.plans.0.id": ["invalid_format"],
+            "billing_items.coupons.0.payload.couponType": ["invalid_value"],
+            "billing_items.wallets.0.payload.rateAmount": ["invalid_type"]
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -335,6 +335,73 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
+    context "when the minimumCommitment amountCents is zero" do
+      let(:plan_overrides) { super().merge("minimumCommitment" => {"amountCents" => 0}) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.minimumCommitment.amountCents": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the minimumCommitment carries only an invoiceDisplayName" do
+      let(:plan_overrides) do
+        super().merge("minimumCommitment" => {"invoiceDisplayName" => "Min commitment"})
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "returns a value_is_mandatory error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.plans.0.overrides.minimumCommitment.amountCents": ["value_is_mandatory"]}
+          )
+        end
+      end
+    end
+
+    context "when the minimumCommitment amountCents is null" do
+      let(:plan_overrides) { super().merge("minimumCommitment" => {"amountCents" => nil}) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "returns an invalid_type error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.plans.0.overrides.minimumCommitment.amountCents": ["invalid_type"]}
+          )
+        end
+      end
+    end
+
+    context "when the minimumCommitment is null" do
+      let(:plan_overrides) { super().merge("minimumCommitment" => nil) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
+      end
+    end
+
     context "when a usage threshold has no amountCents" do
       let(:plan_overrides) { super().merge("usageThresholds" => [{"recurring" => true}]) }
 
@@ -342,6 +409,17 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
           {"billing_items.plans.0.overrides.usageThresholds.0.amountCents": ["value_is_mandatory"]}
+        )
+      end
+    end
+
+    context "when a usage threshold amountCents is zero" do
+      let(:plan_overrides) { super().merge("usageThresholds" => [{"amountCents" => 0}]) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.usageThresholds.0.amountCents": ["invalid_value"]}
         )
       end
     end

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -623,6 +623,15 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
+    context "when the wallet credit currency is not a known currency" do
+      let(:wallet_credit_payload) { super().merge("currency" => "EURO") }
+
+      it "returns an invalid_currency error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.walletCredits.0.payload.currency": ["invalid_currency"]})
+      end
+    end
+
     context "when the wallet credit expirationAt is not an ISO 8601 date-time" do
       let(:wallet_credit_payload) { super().merge("expirationAt" => "not-a-date") }
 

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -138,9 +138,16 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
 
   describe "#valid?" do
     context "with a full valid payload" do
-      it "is valid for both scopes" do
-        expect(described_class.new(BaseService::Result.new, billing_items:, scope: :update)).to be_valid
-        expect(described_class.new(BaseService::Result.new, billing_items:, scope: :approve)).to be_valid
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       "paidCredits" => "1000",
       "grantedCredits" => "200",
       "targetOngoingBalance" => "5000",
+      "grantsTargetTopUp" => true,
       "thresholdCredits" => nil,
       "startedAt" => "2026-08-01T00:00:00Z",
       "transactionName" => "Monthly refill",
@@ -288,6 +289,25 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
         expect(result.error.messages).to eq(
           {"billing_items.plans.0.overrides.invoiceDisplayName": ["invalid_value"]}
         )
+      end
+    end
+
+    context "when the plan overrides carries trialPeriod, name and description" do
+      let(:plan_overrides) do
+        super().merge("trialPeriod" => 14.0, "name" => "Enterprise", "description" => "Negotiated wording")
+      end
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan overrides trialPeriod is negative" do
+      let(:plan_overrides) { super().merge("trialPeriod" => -1) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.trialPeriod": ["invalid_value"]})
       end
     end
 
@@ -481,6 +501,15 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
+    context "when the coupon payload currency is not a known currency" do
+      let(:coupon_payload) { super().merge("currency" => "EURO") }
+
+      it "returns an invalid_currency error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.0.payload.currency": ["invalid_currency"]})
+      end
+    end
+
     context "when the coupon amountCents is negative" do
       let(:coupon_payload) { super().merge("amountCents" => -1) }
 
@@ -586,14 +615,47 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
+    context "when the wallet credit paidCredits is null" do
+      let(:wallet_credit_payload) { super().merge("paidCredits" => nil) }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the wallet credit expirationAt is not an ISO 8601 date-time" do
+      let(:wallet_credit_payload) { super().merge("expirationAt" => "not-a-date") }
+
+      it "returns an invalid_format error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.walletCredits.0.payload.expirationAt": ["invalid_format"]})
+      end
+    end
+
     context "when the recurring rule contains an unknown key" do
       let(:recurring_rule) { super().merge("purchaseOrderNumber" => "PO-123") }
 
-      it "returns an unsupported_key error" do
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the recurring rule grantsTargetTopUp is a string" do
+      let(:recurring_rule) { super().merge("grantsTargetTopUp" => "true") }
+
+      it "returns an invalid_type error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
-          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.purchaseOrderNumber": ["unsupported_key"]}
+          {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.grantsTargetTopUp": ["invalid_type"]}
         )
+      end
+    end
+
+    context "when the recurring rule trigger is null" do
+      let(:recurring_rule) { super().merge("trigger" => nil) }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
       end
     end
 
@@ -697,6 +759,41 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
               "billing_items.walletCredits.0.payload.paidCredits": ["value_is_mandatory"],
               "billing_items.walletCredits.0.payload.grantedCredits": ["value_is_mandatory"],
               "billing_items.walletCredits.0.payload.rateAmount": ["value_is_mandatory"]
+            }
+          )
+        end
+      end
+
+      context "when the wallet credit paidCredits is null" do
+        let(:wallet_credit_payload) { super().merge("paidCredits" => nil) }
+
+        it "returns an invalid_type error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({"billing_items.walletCredits.0.payload.paidCredits": ["invalid_type"]})
+        end
+      end
+
+      context "when the recurring rule has no trigger" do
+        let(:recurring_rule) { super().except("trigger") }
+
+        it "requires the trigger" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.walletCredits.0.payload.recurringTransactionRules.0.trigger": ["value_is_mandatory"]}
+          )
+        end
+      end
+
+      context "when the recurring rule trigger is null" do
+        let(:recurring_rule) { super().merge("trigger" => nil) }
+
+        it "returns invalid_type and invalid_value errors" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {
+              "billing_items.walletCredits.0.payload.recurringTransactionRules.0.trigger": [
+                "invalid_type", "invalid_value"
+              ]
             }
           )
         end

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -362,14 +362,13 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
         expect(validator).to be_valid
       end
 
+      # The business validator decides whether the amount is mandatory, it can fall back to the
+      # plan's own commitment.
       context "when the scope is approve" do
         let(:scope) { :approve }
 
-        it "returns a value_is_mandatory error" do
-          expect(validator).not_to be_valid
-          expect(result.error.messages).to eq(
-            {"billing_items.plans.0.overrides.minimumCommitment.amountCents": ["value_is_mandatory"]}
-          )
+        it "is valid" do
+          expect(validator).to be_valid
         end
       end
     end
@@ -384,11 +383,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       context "when the scope is approve" do
         let(:scope) { :approve }
 
-        it "returns an invalid_type error" do
-          expect(validator).not_to be_valid
-          expect(result.error.messages).to eq(
-            {"billing_items.plans.0.overrides.minimumCommitment.amountCents": ["invalid_type"]}
-          )
+        it "is valid" do
+          expect(validator).to be_valid
         end
       end
     end

--- a/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
       "id" => coupon.id,
       "localId" => "ba54903c-7bd5-4d40-8d51-45a5157005ff",
       "type" => "coupon",
-      "payload" => {"code" => coupon.code, "couponType" => "fixed_amount", "amountCents" => 20_000}
+      "payload" => {"code" => coupon.code, "type" => "fixed_amount", "amountCents" => 20_000}
     }
   end
-  let(:wallet_item) do
+  let(:wallet_credit_item) do
     {
       "localId" => "d9169d94-b322-4d70-a2b1-9e6a58e3f74a",
-      "type" => "wallet",
+      "type" => "wallet_credit",
       "payload" => {"paidCredits" => "100.0", "grantedCredits" => "10.0", "rateAmount" => "1.0"}
     }
   end
@@ -51,7 +51,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
     {
       "plans" => [plan_item],
       "coupons" => [coupon_item],
-      "wallets" => [wallet_item]
+      "walletCredits" => [wallet_credit_item]
     }
   end
 

--- a/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
+  subject(:validator) { described_class.new(result, quote_version:, scope:) }
+
+  let(:result) { BaseService::Result.new }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+  let(:quote_version) do
+    create(
+      :quote_version,
+      quote:,
+      organization:,
+      currency: "EUR",
+      start_date: Date.parse("2026-01-01"),
+      end_date: Date.parse("2026-12-31"),
+      billing_items:
+    )
+  end
+  let(:plan) { create(:plan, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:scope) { :approve }
+
+  let(:plan_item) do
+    {
+      "id" => plan.id,
+      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "type" => "plan",
+      "payload" => {"code" => plan.code}
+    }
+  end
+  let(:coupon_item) do
+    {
+      "id" => coupon.id,
+      "localId" => "ba54903c-7bd5-4d40-8d51-45a5157005ff",
+      "type" => "coupon",
+      "payload" => {"code" => coupon.code, "couponType" => "fixed_amount", "amountCents" => 20_000}
+    }
+  end
+  let(:wallet_item) do
+    {
+      "localId" => "d9169d94-b322-4d70-a2b1-9e6a58e3f74a",
+      "type" => "wallet",
+      "payload" => {"paidCredits" => "100.0", "grantedCredits" => "10.0", "rateAmount" => "1.0"}
+    }
+  end
+  let(:billing_items) do
+    {
+      "plans" => [plan_item],
+      "coupons" => [coupon_item],
+      "wallets" => [wallet_item]
+    }
+  end
+
+  describe "#valid?" do
+    context "with a complete valid quote version" do
+      it "is valid and leaves the result untouched" do
+        expect(validator).to be_valid
+        expect(result).to be_success
+      end
+    end
+
+    context "with both structural and business errors" do
+      let(:plan_item) { super().merge("overrides" => {"amountCents" => -1}) }
+      let(:quote_version) do
+        create(
+          :quote_version,
+          quote:,
+          organization:,
+          currency: "DOUBLOON",
+          start_date: Date.parse("2026-01-01"),
+          end_date: Date.parse("2026-12-31"),
+          billing_items:
+        )
+      end
+
+      it "returns the structural errors first" do
+        expect(validator).not_to be_valid
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.amountCents": ["invalid_value"]})
+      end
+    end
+
+    context "with a valid structure and an unknown plan" do
+      let(:plan_item) { super().merge("id" => "11111111-2222-3333-4444-555555555555") }
+
+      it "reports the business error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["plan_not_found"]})
+      end
+    end
+
+    context "when the structure is invalid" do
+      let(:plan_item) do
+        super().merge("entitlementsOverrides" => [], "id" => "11111111-2222-3333-4444-555555555555")
+      end
+
+      it "returns only structural errors and skips business validation" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.entitlementsOverrides": ["unsupported_key"]}
+        )
+      end
+    end
+
+    context "when billing_items has symbol keys" do
+      let(:billing_items) do
+        {
+          plans: [
+            {
+              id: plan.id,
+              localId: "3d08b2df-4e4c-4d58-b415-a525c1663735",
+              type: "plan",
+              payload: {code: plan.code}
+            }
+          ]
+        }
+      end
+
+      it "normalizes them before validating" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when billing_items is nil at update scope" do
+      let(:scope) { :update }
+      let(:billing_items) { nil }
+
+      it "is valid" do
+        expect(validator).to be_valid
+        expect(result).to be_success
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/validators_spec.rb
+++ b/spec/services/quote_versions/validators_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe QuoteVersions::Validators do
     context "when the quote is subscription_creation" do
       let(:order_type) { :subscription_creation }
 
-      it "returns no validator" do
-        expect(validator).to be_nil
+      it "returns a subscription_creation validator" do
+        expect(validator).to be_a(QuoteVersions::Validators::SubscriptionCreationValidator)
       end
     end
 


### PR DESCRIPTION
## Context

`QuoteVersions::Validators.for` only knew about `one_off`, so it returned `nil` for
`subscription_creation` and both `UpdateService` and `ApproveService` let those payloads
through untouched. Anything the front end sent was accepted, and the first thing to look at
the payload was the execution flow, well after the quote had been approved and signed.

That is the wrong place to find out. A signed order that cannot execute rolls the whole
thing back and lands as failed, with no editable draft left to fix. So the validation stack
has to reject, at approval time, anything the downstream services would refuse:
`Subscriptions::CreateService`, `Commitments`/`Charges`/`FixedCharges::OverrideService`,
`AppliedCoupons::CreateService` and `Wallets::CreateService`.

## Description

**Shared scaffolding.** `OneOffValidator` and `OneOff::StructuralValidator` carried logic
that is not order-type specific: the structural-then-business ordering, `billing_items`
normalisation, and the JSON schema error to `billing_items.<pointer> => [error_code]`
flattening the API surfaces. Both move up into `BaseOrderTypeValidator` and
`BaseStructuralValidator`, leaving subclasses to name their two passes and their schemer.
The currency check moves into a `CurrencyValidation` concern that pulls `Currencies` in from
its own `included` hook, since `currency_list` is only ever defined on an includer and an
includer that forgot the line would lose the check to a `NoMethodError`.

**`subscription_creation` schema.** Two scopes over one literal document: `UPDATE_DEFINITION`
stays lenient so a draft can be saved half-filled, `APPROVE_DEFINITION` is derived from it and
narrows what a signable payload must carry. Keys are camelCase to match the FE payload,
unknown keys are rejected with `unsupported_key`, and the coupon type, coupon frequency and
recurring transaction rule trigger/interval/method enums are interpolated from `Coupon` and
`RecurringTransactionRule` rather than hand-copied, so adding an interval upstream does not
silently get rejected here.

Approve scope adds: at least one plan, `payload.code` on plans, `code` and `type` on coupons,
`amountCents` on a minimum commitment (a commitment carrying only a display name cannot be
created, so "no commitment" now means sending `null`), `paidCredits`/`grantedCredits`/
`rateAmount` on wallet credits, and a non-null `trigger` on each recurring rule. Commitment
and usage threshold amounts reject zero, matching the model validations.

**Business validator.** Everything the schema cannot express, one DB round trip per resource
kind:

- currency mandatory at approve, ISO 4217 when set
- start/end date mandatory at approve, end date strictly after start (`Subscriptions::ValidateService`
  requires it, and the quote dates are what a plan without its own falls back to)
- plan existence, plan currency against the deal currency, charge override `billableMetricCode`
  and fixed charge override `addOnCode` existence, fixed charge `units` against the same
  non-negative bound `FixedCharge` enforces
- coupon existence, fixed-amount coupon currency, snapshot `type` and matching amount field at
  approve (a coupon retyped since drafting changes the negotiated discount and should be
  flagged, not followed), and a duration on any coupon that ends up recurring. The effective
  frequency resolves through overrides, then payload, then the live coupon, mirroring how
  `AppliedCoupons::CreateService` falls back, so this cannot live in the schema
- wallet credit amounts, currency against the deal (`Wallets::CreateService` forces the customer
  currency unless `multi_currency` is on, so a mismatched credit is either dropped or funds a
  wallet nobody agreed to), expiration futureness, and per-rule `interval`/`thresholdCredits`/
  `targetOngoingBalance`/`grantsTargetTopUp`/credits, sign conventions matching
  `Wallets::RecurringTransactionRules::ValidateService`

Lookups use `with_discarded` so a soft-deleted plan or coupon quoted before deletion still
resolves.

### Dependencies

Stacked under #6075 (`feat(orders): execute subscription_creation orders`), which consumes the
payload this validates.