### PR TITLE
fix(payment-methods): Handle scenario where associated customer is discarded

### DIFF
--- a/app/services/payment_provider_customers/stripe/check_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/check_payment_method_service.rb
@@ -23,7 +23,10 @@ module PaymentProviderCustomers
         # NOTE: The payment method is no longer valid
         stripe_customer.update!(payment_method_id: nil)
 
-        payment_method = customer.payment_methods.find_by(provider_method_id: payment_method_id)
+        payment_method = PaymentMethod.find_by(
+          customer_id: stripe_customer.customer_id,
+          provider_method_id: payment_method_id
+        )
         PaymentMethods::DestroyService.call(payment_method:)
 
         result.single_validation_failure!(field: :payment_method_id, error_code: "value_is_invalid")
@@ -35,10 +38,6 @@ module PaymentProviderCustomers
 
       def api_key
         stripe_customer.payment_provider.secret_key
-      end
-
-      def customer
-        @customer ||= stripe_customer.customer
       end
     end
   end

--- a/app/services/payment_provider_customers/stripe/check_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/check_payment_method_service.rb
@@ -23,10 +23,7 @@ module PaymentProviderCustomers
         # NOTE: The payment method is no longer valid
         stripe_customer.update!(payment_method_id: nil)
 
-        payment_method = PaymentMethod.find_by(
-          customer_id: stripe_customer.customer_id,
-          provider_method_id: payment_method_id
-        )
+        payment_method = stripe_customer.payment_methods.find_by(provider_method_id: payment_method_id)
         PaymentMethods::DestroyService.call(payment_method:)
 
         result.single_validation_failure!(field: :payment_method_id, error_code: "value_is_invalid")

--- a/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
@@ -73,6 +73,17 @@ RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService do
           expect(stripe_api_customer).to have_received(:retrieve_payment_method)
           expect(default_payment_method.reload.deleted_at).to be_present
         end
+
+        context "when customer is deleted" do
+          let(:customer) { create(:customer, :deleted, organization:) }
+
+          it "returns a failed result and discards payment method" do
+            result = check_service.call
+
+            expect(result).not_to be_success
+            expect(default_payment_method.reload.deleted_at).to be_present
+          end
+        end
       end
     end
 

--- a/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
@@ -77,10 +77,15 @@ RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService do
         context "when customer is deleted" do
           let(:customer) { create(:customer, :deleted, organization:) }
 
+          before { stripe_customer.reload }
+
           it "returns a failed result and discards payment method" do
             result = check_service.call
 
             expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:payment_method_id]).to eq(["value_is_invalid"])
+            expect(stripe_customer.reload.payment_method_id).to be_nil
             expect(default_payment_method.reload.deleted_at).to be_present
           end
         end
@@ -89,6 +94,8 @@ RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService do
 
     context "when customer is deleted" do
       let(:customer) { create(:customer, :deleted, organization:) }
+
+      before { stripe_customer.reload }
 
       it "checks for the existence of the payment method" do
         allow(stripe_api_customer)

--- a/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService do
       end
 
       context "when a payment method exists" do
-        let(:default_payment_method) { create(:payment_method, customer:, provider_method_id: payment_method_id) }
+        let(:default_payment_method) do
+          create(:payment_method, customer:, payment_provider_customer: stripe_customer, provider_method_id: payment_method_id)
+        end
 
         before { default_payment_method }
 


### PR DESCRIPTION
## Context

When a customer is deleted in Lago, the collection of its termination invoice can still run. If Stripe then reports the stored payment method as invalid, `PaymentProviderCustomers::Stripe::CheckPaymentMethodService` crashed with `NoMethodError: undefined method 'payment_methods' for nil` on `Invoices::Payments::CreateJob`: the rescue path resolves the payment method through `stripe_customer.customer`, which returns `nil` for discarded customers. This service was originally introduced in #3196 to rely only on the `stripe_customer` for this exact reason, and #4861 reintroduced the customer dependency.

## Description

Look up the stale `PaymentMethod` by the `customer_id` foreign key instead of going through the `customer` association. The lookup semantics are unchanged for kept customers, and for discarded ones the invalid payment method is now properly discarded and the payment fails with `value_is_invalid` instead of crash-looping the job.