### PR TITLE
Chore(optimisation): rewrite BillableMetricFilters::RefreshDraftInvocies query to get rid of the joins

### DIFF
--- a/app/jobs/billable_metric_filters/refresh_draft_invoices_job.rb
+++ b/app/jobs/billable_metric_filters/refresh_draft_invoices_job.rb
@@ -7,12 +7,13 @@ module BillableMetricFilters
     def perform(billable_metric_id)
       billable_metric = BillableMetric.find_by(id: billable_metric_id)
       return unless billable_metric
+      plan_ids = billable_metric.plans.distinct.ids
+      return if plan_ids.empty?
 
       Invoice.draft
-        .joins(plans: [:billable_metrics])
-        .where(billable_metrics: {id: billable_metric.id})
-        .distinct
-        .in_batches do |batch|
+        .where(id: InvoiceSubscription
+                     .where(subscription_id: Subscription.where(plan_id: plan_ids).select(:id))
+                     .select(:invoice_id).in_batches do |batch|
           batch.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
         end
     end


### PR DESCRIPTION
## Context

The job of refreshing invoices fails with timeout, having a separate query + subquery will help us not to join all the tables together
