### PR TITLE
fix: timeout in sidekiq job for invoice refresh

### DIFF
--- a/app/jobs/billable_metric_filters/refresh_draft_invoices_job.rb
+++ b/app/jobs/billable_metric_filters/refresh_draft_invoices_job.rb
@@ -8,7 +8,10 @@ module BillableMetricFilters
       billable_metric = BillableMetric.find_by(id: billable_metric_id)
       return unless billable_metric
 
+      # The organization_id is redundant with the plans join but added as an optimisation:
+      # it avoids a full scan of the invoices table by using the idx_invoices_organization_id_status index.
       Invoice.draft
+        .where(organization_id: billable_metric.organization_id)
         .joins(plans: [:billable_metrics])
         .where(billable_metrics: {id: billable_metric.id})
         .distinct


### PR DESCRIPTION
## Context

The `BillableMetricFilters::RefreshDraftInvoicesJob` sidekiq job marks draft invoices as `ready_to_be_refreshed` when a billable metric's filters change.

When this job is launched for organizations that have a lot of invoices the query times out with:
```
PG::QueryCanceled: ERROR: canceling statement due to statement timeout (ActiveRecord::QueryCanceled)
```

## Description

The old query joined draft invoices to plans and billable metrics with no organization filter.
There's no index on just the `invoices.status` column, so postgres had to scan the whole invoices table.

This PR adds **just one line**:
```
  .where(organization_id: billable_metric.organization_id)
```

Filtering by organization_id might seem redundant but **it avoids a full scan of the invoices table** by using the `idx_invoices_organization_id_status` index.

The result of the query stays the same.