### PR TITLE
feat(orders): execute subscription_creation orders

### DIFF
--- a/app/graphql/types/orders/execution_record.rb
+++ b/app/graphql/types/orders/execution_record.rb
@@ -10,8 +10,26 @@ module Types
       field :execution_mode, Types::Orders::ExecutionModeEnum, null: true
       field :invoice_id, ID, null: true
 
+      field :applied_coupon_ids, [ID], null: false
+      field :subscription_ids, [ID], null: false
+      field :wallet_ids, [ID], null: false
+
       def errors
         object["errors"] || []
+      end
+
+      # Order types that create none of these, and records written before they existed, have no
+      # such key at all.
+      def applied_coupon_ids
+        object["applied_coupon_ids"] || []
+      end
+
+      def subscription_ids
+        object["subscription_ids"] || []
+      end
+
+      def wallet_ids
+        object["wallet_ids"] || []
       end
     end
   end

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -12,7 +12,7 @@ module Types
       field :status, Types::Orders::StatusEnum, null: false
 
       field :billing_snapshot, GraphQL::Types::JSON, null: false
-      field :currency, String, null: true
+      field :currency, Types::CurrencyEnum, null: true
       field :execute_at, GraphQL::Types::ISO8601DateTime, null: true
       field :executed_at, GraphQL::Types::ISO8601DateTime, null: true
       field :execution_record, Types::Orders::ExecutionRecord, null: false

--- a/app/graphql/types/quote_versions/object.rb
+++ b/app/graphql/types/quote_versions/object.rb
@@ -9,7 +9,7 @@ module Types
       field :billing_items, GraphQL::Types::JSON, null: true
       field :content, String, null: true
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-      field :currency, String, null: true
+      field :currency, Types::CurrencyEnum, null: true
       field :end_date, GraphQL::Types::ISO8601Date, null: true
       field :id, ID, null: false
       field :mention_variables, GraphQL::Types::JSON, null: false

--- a/app/graphql/types/quote_versions/update_input.rb
+++ b/app/graphql/types/quote_versions/update_input.rb
@@ -7,7 +7,7 @@ module Types
 
       argument :billing_items, GraphQL::Types::JSON, required: false
       argument :content, String, required: false
-      argument :currency, String, required: false
+      argument :currency, Types::CurrencyEnum, required: false
       argument :end_date, GraphQL::Types::ISO8601Date, required: false
       argument :id, ID, required: true
       argument :start_date, GraphQL::Types::ISO8601Date, required: false

--- a/app/graphql/types/quotes/create_input.rb
+++ b/app/graphql/types/quotes/create_input.rb
@@ -7,7 +7,6 @@ module Types
 
       argument :billing_items, GraphQL::Types::JSON, required: false
       argument :content, String, required: false
-      argument :currency, String, required: false
       argument :customer_id, ID, required: true
       argument :end_date, GraphQL::Types::ISO8601Date, required: false
       argument :order_type, Types::Quotes::OrderTypeEnum, required: true

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -14,6 +14,19 @@ class Order < ApplicationRecord
     order_only: "order_only"
   }.freeze
 
+  # Every order type writes the same keys, whether or not it can create such a record, so a reader
+  # never has to tell a missing key from an empty one. Records written before a key existed are
+  # merged onto these defaults when read, see V1::OrderSerializer.
+  EXECUTION_RECORD_DEFAULTS = {
+    "executed_at" => nil,
+    "execution_mode" => nil,
+    "invoice_id" => nil,
+    "subscription_ids" => [],
+    "applied_coupon_ids" => [],
+    "wallet_ids" => [],
+    "errors" => []
+  }.freeze
+
   before_save :ensure_number
 
   belongs_to :organization

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class QuoteVersion < ApplicationRecord
+  include Currencies
   include Sequenced
 
   STATUSES = {
@@ -34,6 +35,8 @@ class QuoteVersion < ApplicationRecord
   enum :void_reason, VOID_REASONS,
     instance_methods: false,
     validate: {allow_nil: true}
+
+  validates :currency, inclusion: {in: currency_list}, allow_nil: true
 
   validates :void_reason, :voided_at,
     presence: true,

--- a/app/serializers/v1/order_serializer.rb
+++ b/app/serializers/v1/order_serializer.rb
@@ -12,13 +12,21 @@ module V1
         billing_snapshot: model.billing_snapshot,
         currency: model.currency,
         executed_at: model.executed_at&.iso8601,
-        execution_record: model.execution_record,
+        execution_record:,
         lago_organization_id: model.organization_id,
         lago_customer_id: model.customer_id,
         lago_order_form_id: model.order_form_id,
         created_at: model.created_at.iso8601,
         updated_at: model.updated_at.iso8601
       }
+    end
+
+    private
+
+    # A record written before a key existed carries no such key at all, so the shape is completed
+    # here. Types::Orders::ExecutionRecord does the same for GraphQL.
+    def execution_record
+      Order::EXECUTION_RECORD_DEFAULTS.merge(model.execution_record || {})
     end
   end
 end

--- a/app/services/orders/base_execute_service.rb
+++ b/app/services/orders/base_execute_service.rb
@@ -61,7 +61,7 @@ module Orders
       order.update!(
         status: :executed,
         executed_at:,
-        execution_record: execution_record(executed_at: executed_at.iso8601).merge(created)
+        execution_record: execution_record(executed_at: executed_at.iso8601, **created)
       )
     end
 
@@ -78,18 +78,10 @@ module Orders
       failed_result
     end
 
-    # Every order type writes the same keys, whether or not it can create such a record, so a
-    # reader never has to tell a missing key from an empty one.
     def execution_record(**written)
-      {
-        executed_at: nil,
-        execution_mode: order.execution_mode,
-        invoice_id: nil,
-        subscription_ids: [],
-        applied_coupon_ids: [],
-        wallet_ids: [],
-        errors: []
-      }.merge(written)
+      Order::EXECUTION_RECORD_DEFAULTS
+        .merge("execution_mode" => order.execution_mode)
+        .merge(written.stringify_keys)
     end
 
     def billing_items

--- a/app/services/orders/base_execute_service.rb
+++ b/app/services/orders/base_execute_service.rb
@@ -92,6 +92,15 @@ module Orders
       }.merge(written)
     end
 
+    def billing_items
+      @billing_items ||= order.billing_snapshot || {}
+    end
+
+    # A negotiated value overrides the catalog snapshot it was drafted from.
+    def effective_value(item, field)
+      item.dig("overrides", field) || item.dig("payload", field)
+    end
+
     def execution_errors(error)
       if error.respond_to?(:messages)
         error.messages.values.flatten

--- a/app/services/orders/base_execute_service.rb
+++ b/app/services/orders/base_execute_service.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Orders
+  # Internal: premium/feature-flag gates live in Orders::ExecuteService, always call through it.
+  # Subclasses implement create_records, returning the ids of what they created for the execution
+  # record.
+  class BaseExecuteService < BaseService
+    Result = BaseResult[:order]
+
+    def initialize(order:)
+      @order = order
+
+      super
+    end
+
+    def call
+      return success_result if order.executed?
+
+      if order.execution_mode.blank?
+        return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
+      end
+
+      Order.transaction do
+        Quotes::LockService.call(quote: order.quote) do
+          order.reload
+          next success_result if order.executed?
+
+          mark_executed!(execute_in_lago? ? create_records : {})
+
+          result.order = order
+        end
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      record_execution_failure!(result.record_validation_failure!(record: e.record))
+    rescue BaseService::FailedResult => e
+      record_execution_failure!(e.result)
+    end
+
+    private
+
+    attr_reader :order
+
+    def create_records
+      raise NotImplementedError
+    end
+
+    def success_result
+      result.order = order
+      result
+    end
+
+    def execute_in_lago?
+      order.execution_mode == Order::EXECUTION_MODES[:execute_in_lago]
+    end
+
+    def mark_executed!(created)
+      executed_at = Time.current
+
+      order.update!(
+        status: :executed,
+        executed_at:,
+        execution_record: execution_record(executed_at: executed_at.iso8601).merge(created)
+      )
+    end
+
+    # The transaction has already rolled back, so this trace is the only durable outcome of the
+    # attempt. Recording it moves the order to failed, excluding it from the executable scope;
+    # retrying is a deliberate manual action.
+    def record_execution_failure!(failed_result)
+      order.update!(
+        status: :failed,
+        executed_at: nil,
+        execution_record: execution_record(errors: execution_errors(failed_result.error))
+      )
+
+      failed_result
+    end
+
+    # Every order type writes the same keys, whether or not it can create such a record, so a
+    # reader never has to tell a missing key from an empty one.
+    def execution_record(**written)
+      {
+        executed_at: nil,
+        execution_mode: order.execution_mode,
+        invoice_id: nil,
+        subscription_ids: [],
+        applied_coupon_ids: [],
+        wallet_ids: [],
+        errors: []
+      }.merge(written)
+    end
+
+    def execution_errors(error)
+      if error.respond_to?(:messages)
+        error.messages.values.flatten
+      elsif error.respond_to?(:code)
+        [error.code]
+      else
+        [error.message]
+      end
+    end
+  end
+end

--- a/app/services/orders/execute_service.rb
+++ b/app/services/orders/execute_service.rb
@@ -2,7 +2,7 @@
 
 module Orders
   # Dispatches execution to the concrete service for the order's order_type.
-  # Only one_off is supported for now.
+  # subscription_amendment is not supported yet.
   class ExecuteService < BaseService
     include OrderForms::Premium
 
@@ -20,6 +20,8 @@ module Orders
       case order.order_type
       when Quote::ORDER_TYPES[:one_off]
         Orders::OneOff::ExecuteService.call(order:)
+      when Quote::ORDER_TYPES[:subscription_creation]
+        Orders::SubscriptionCreation::ExecuteService.call(order:)
       else
         result.single_validation_failure!(field: :order_type, error_code: "unsupported_order_type")
       end

--- a/app/services/orders/one_off/execute_service.rb
+++ b/app/services/orders/one_off/execute_service.rb
@@ -2,96 +2,11 @@
 
 module Orders
   module OneOff
-    # Internal: premium/feature-flag gates live in Orders::ExecuteService, always call through it.
-    class ExecuteService < BaseService
-      Result = BaseResult[:order]
-
-      def initialize(order:)
-        @order = order
-
-        super
-      end
-
-      def call
-        return success_result if order.executed?
-
-        if order.execution_mode.blank?
-          return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
-        end
-
-        Order.transaction do
-          Quotes::LockService.call(quote: order.quote) do
-            order.reload
-            next success_result if order.executed?
-
-            invoice = execute_in_lago? ? bill_one_off : nil
-            mark_executed!(invoice)
-
-            result.order = order
-          end
-        end
-
-        result
-      rescue ActiveRecord::RecordInvalid => e
-        record_execution_failure!(result.record_validation_failure!(record: e.record))
-      rescue BaseService::FailedResult => e
-        record_execution_failure!(e.result)
-      end
-
+    class ExecuteService < Orders::BaseExecuteService
       private
 
-      attr_reader :order
-
-      def success_result
-        result.order = order
-        result
-      end
-
-      def execute_in_lago?
-        order.execution_mode == Order::EXECUTION_MODES[:execute_in_lago]
-      end
-
-      def mark_executed!(invoice)
-        executed_at = Time.current
-
-        order.update!(
-          status: :executed,
-          executed_at:,
-          execution_record: {
-            executed_at: executed_at.iso8601,
-            execution_mode: order.execution_mode,
-            invoice_id: invoice&.id,
-            errors: []
-          }
-        )
-      end
-
-      # The transaction has already rolled back, so this trace is the only durable outcome
-      # of the attempt. Recording it moves the order to failed, excluding it from the
-      # executable scope; retrying is a deliberate manual action.
-      def record_execution_failure!(failed_result)
-        order.update!(
-          status: :failed,
-          executed_at: nil,
-          execution_record: {
-            executed_at: nil,
-            execution_mode: order.execution_mode,
-            invoice_id: nil,
-            errors: execution_errors(failed_result.error)
-          }
-        )
-
-        failed_result
-      end
-
-      def execution_errors(error)
-        if error.respond_to?(:messages)
-          error.messages.values.flatten
-        elsif error.respond_to?(:code)
-          [error.code]
-        else
-          [error.message]
-        end
+      def create_records
+        {invoice_id: bill_one_off&.id}
       end
 
       def bill_one_off

--- a/app/services/orders/one_off/execute_service.rb
+++ b/app/services/orders/one_off/execute_service.rb
@@ -36,16 +36,8 @@ module Orders
         end
       end
 
-      def effective_value(item, field)
-        item.dig("overrides", field) || item.dig("payload", field)
-      end
-
       def add_on_items
-        Array((quote_version.billing_items || {})["addOns"])
-      end
-
-      def quote_version
-        order.quote_version
+        Array(billing_items["addOns"])
       end
     end
   end

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -135,7 +135,9 @@ module Orders
         payload = item["payload"] || {}
 
         {
-          external_id: payload["subscriptionExternalId"].presence || SecureRandom.uuid,
+          # localId is the quote line's own id, so a retry after a failed execution reuses the same
+          # external id instead of minting a new one.
+          external_id: payload["subscriptionExternalId"].presence || item["localId"].presence || SecureRandom.uuid,
           name: payload["subscriptionName"],
           billing_time: payload["billingTime"],
           subscription_at: subscription_datetime(payload["startDate"], quote_version.start_date),

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -6,6 +6,8 @@ module Orders
     class ExecuteService < BaseService
       Result = BaseResult[:order]
 
+      CALENDAR_DATE = /\A\d{4}-\d{2}-\d{2}\z/
+
       def initialize(order:)
         @order = order
 
@@ -136,12 +138,33 @@ module Orders
           external_id: payload["subscriptionExternalId"].presence || SecureRandom.uuid,
           name: payload["subscriptionName"],
           billing_time: payload["billingTime"],
-          subscription_at: payload["startDate"] || quote_version.start_date,
-          ending_at: payload["endDate"] || quote_version.end_date,
+          subscription_at: subscription_datetime(payload["startDate"], quote_version.start_date),
+          ending_at: subscription_datetime(payload["endDate"], quote_version.end_date),
           payment_method: payment_method_params(payload),
           plan_overrides: plan_overrides(item, plan).presence,
           usage_thresholds: usage_thresholds(item).presence
         }.compact
+      end
+
+      # quote_versions.start_date and end_date are date columns, and the payload may carry a bare
+      # date too. A date reaches a datetime attribute as midnight UTC, which is the previous day for
+      # a customer west of UTC: Subscriptions::CreateService would then take its past subscription
+      # path and anniversary date. A calendar date means that day for the customer, so it is read in
+      # their timezone.
+      def subscription_datetime(payload_value, version_value)
+        value = payload_value.presence || version_value
+        return value unless calendar_date?(value)
+
+        Utils::Datetime.parse_iso8601_date(value).in_time_zone(order.customer.applicable_timezone)
+      end
+
+      # A string that only looks like a date is left alone for Subscriptions::ValidateService to
+      # reject.
+      def calendar_date?(value)
+        return true if value.is_a?(Date)
+        return false unless value.is_a?(String) && CALENDAR_DATE.match?(value)
+
+        Utils::Datetime.parse_iso8601_date(value).present?
       end
 
       # PaymentMethods::ValidateService refuses an id without its type.

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -51,8 +51,9 @@ module Orders
         payload = item["payload"] || {}
 
         {
-          # localId is the quote line's own id, so a retry after a failed execution reuses the same
-          # external id instead of minting a new one.
+          # Both quoted ids are stable, so a retry after a failed execution reuses the same external
+          # id. NOTE: localId is optional on plan items, so an item carrying neither mints a new
+          # external id on every attempt.
           external_id: payload["subscriptionExternalId"].presence || item["localId"].presence || SecureRandom.uuid,
           name: payload["subscriptionName"],
           billing_time: payload["billingTime"],
@@ -71,18 +72,19 @@ module Orders
       # their timezone.
       def subscription_datetime(payload_value, version_value)
         value = payload_value.presence || version_value
-        return value unless calendar_date?(value)
+        date = calendar_date(value)
+        return value if date.nil?
 
-        Utils::Datetime.parse_iso8601_date(value).in_time_zone(order.customer.applicable_timezone)
+        date.in_time_zone(order.customer.applicable_timezone)
       end
 
       # A string that only looks like a date is left alone for Subscriptions::ValidateService to
       # reject.
-      def calendar_date?(value)
-        return true if value.is_a?(Date)
-        return false unless value.is_a?(String) && CALENDAR_DATE.match?(value)
+      def calendar_date(value)
+        return value.to_date if value.is_a?(Date)
+        return nil unless value.is_a?(String) && CALENDAR_DATE.match?(value)
 
-        Utils::Datetime.parse_iso8601_date(value).present?
+        Utils::Datetime.parse_iso8601_date(value)
       end
 
       # PaymentMethods::ValidateService refuses an id without its type.
@@ -276,10 +278,6 @@ module Orders
         rules.presence
       end
 
-      def effective_value(item, field)
-        item.dig("overrides", field) || item.dig("payload", field)
-      end
-
       def plan_items
         Array(billing_items["plans"])
       end
@@ -308,10 +306,6 @@ module Orders
           .coupons
           .where(id: coupon_items.map { |item| item["id"] })
           .index_by(&:id)
-      end
-
-      def billing_items
-        @billing_items ||= quote_version.billing_items || {}
       end
 
       def quote_version

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -102,18 +102,21 @@ module Orders
           name: overrides["name"],
           description: overrides["description"],
           trial_period: overrides["trialPeriod"],
-          minimum_commitment: minimum_commitment(overrides),
+          minimum_commitment: minimum_commitment(overrides, plan),
           charges: charge_overrides(item, plan).presence,
           fixed_charges: fixed_charge_overrides(item, plan).presence
         }.compact
       end
 
-      def minimum_commitment(overrides)
+      # Plans::OverrideService builds a fresh Commitment rather than duplicating the plan's own, and
+      # Commitment rejects a nil amount, so an override renaming the commitment without repricing it
+      # only reaches a valid record if the plan's own amount is forwarded here.
+      def minimum_commitment(overrides, plan)
         commitment = overrides["minimumCommitment"]
         return nil if commitment.blank?
 
         {
-          amount_cents: commitment["amountCents"],
+          amount_cents: commitment["amountCents"] || plan.minimum_commitment&.amount_cents,
           invoice_display_name: commitment["invoiceDisplayName"]
         }.compact.presence
       end
@@ -293,7 +296,7 @@ module Orders
       # Plans::OverrideService dups it, so two items on the same plan get their own instance
       # instead of inheriting each other's amount.
       def find_plan!(plan_id)
-        plan = order.organization.plans.includes(:charges, :fixed_charges).find_by(id: plan_id)
+        plan = order.organization.plans.includes(:charges, :fixed_charges, :minimum_commitment).find_by(id: plan_id)
         result.not_found_failure!(resource: "plan").raise_if_error! if plan.nil?
 
         plan

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -55,15 +55,26 @@ module Orders
       # Subscriptions come first: they settle the customer currency the coupons and wallets
       # then reuse.
       def create_deal
-        subscriptions = create_subscriptions
-        applied_coupons = apply_coupons
-        wallets = create_wallets
+        with_coupon_lock do
+          subscriptions = create_subscriptions
+          applied_coupons = apply_coupons
+          wallets = create_wallets
 
-        {
-          subscription_ids: subscriptions.map(&:id),
-          applied_coupon_ids: applied_coupons.map(&:id),
-          wallet_ids: wallets.map(&:id)
-        }
+          {
+            subscription_ids: subscriptions.map(&:id),
+            applied_coupon_ids: applied_coupons.map(&:id),
+            wallet_ids: wallets.map(&:id)
+          }
+        end
+      end
+
+      # AppliedCoupons::CreateService takes this lock and then writes the customer row, while
+      # Subscriptions::CreateService locks the row first. Taking it up front keeps one ordering for
+      # the whole deal; the lock is transaction scoped, so the inner acquisition is then a no-op.
+      def with_coupon_lock(&block)
+        return yield if coupon_items.empty?
+
+        ::Customers::LockService.call(customer: order.customer, scope: :coupon, &block).value
       end
 
       # invoice_id stays nil: a subscription is invoiced later by BillSubscriptionJob, and only

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -1,0 +1,378 @@
+# frozen_string_literal: true
+
+module Orders
+  module SubscriptionCreation
+    # Internal: premium/feature-flag gates live in Orders::ExecuteService, always call through it.
+    class ExecuteService < BaseService
+      Result = BaseResult[:order]
+
+      def initialize(order:)
+        @order = order
+
+        super
+      end
+
+      def call
+        return success_result if order.executed?
+
+        if order.execution_mode.blank?
+          return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
+        end
+
+        Order.transaction do
+          Quotes::LockService.call(quote: order.quote) do
+            order.reload
+            next success_result if order.executed?
+
+            mark_executed!(execute_in_lago? ? create_deal : {})
+
+            result.order = order
+          end
+        end
+
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        record_execution_failure!(result.record_validation_failure!(record: e.record))
+      rescue BaseService::FailedResult => e
+        record_execution_failure!(e.result)
+      end
+
+      private
+
+      attr_reader :order
+
+      def success_result
+        result.order = order
+        result
+      end
+
+      def execute_in_lago?
+        order.execution_mode == Order::EXECUTION_MODES[:execute_in_lago]
+      end
+
+      # Subscriptions come first: they settle the customer currency the coupons and wallets
+      # then reuse.
+      def create_deal
+        subscriptions = create_subscriptions
+        applied_coupons = apply_coupons
+        wallets = create_wallets
+
+        {
+          subscription_ids: subscriptions.map(&:id),
+          applied_coupon_ids: applied_coupons.map(&:id),
+          wallet_ids: wallets.map(&:id)
+        }
+      end
+
+      # invoice_id stays nil: a subscription is invoiced later by BillSubscriptionJob, and only
+      # when the plan is paid in advance.
+      def mark_executed!(created)
+        executed_at = Time.current
+
+        order.update!(
+          status: :executed,
+          executed_at:,
+          execution_record: {
+            executed_at: executed_at.iso8601,
+            execution_mode: order.execution_mode,
+            invoice_id: nil,
+            subscription_ids: [],
+            applied_coupon_ids: [],
+            wallet_ids: [],
+            errors: []
+          }.merge(created)
+        )
+      end
+
+      # The transaction has already rolled back, so this trace is the only durable outcome
+      # of the attempt. Recording it moves the order to failed, excluding it from the
+      # executable scope; retrying is a deliberate manual action.
+      def record_execution_failure!(failed_result)
+        order.update!(
+          status: :failed,
+          executed_at: nil,
+          execution_record: {
+            executed_at: nil,
+            execution_mode: order.execution_mode,
+            invoice_id: nil,
+            subscription_ids: [],
+            applied_coupon_ids: [],
+            wallet_ids: [],
+            errors: execution_errors(failed_result.error)
+          }
+        )
+
+        failed_result
+      end
+
+      def execution_errors(error)
+        if error.respond_to?(:messages)
+          error.messages.values.flatten
+        elsif error.respond_to?(:code)
+          [error.code]
+        else
+          [error.message]
+        end
+      end
+
+      # NOTE: an external id matching a live subscription of this customer makes
+      # Subscriptions::CreateService reuse, upgrade or downgrade it instead of creating one.
+      def create_subscriptions
+        plan_items.map do |item|
+          plan = plans_by_id[item["id"]]
+          result.not_found_failure!(resource: "plan").raise_if_error! if plan.nil?
+
+          ::Subscriptions::CreateService.call!(
+            customer: order.customer,
+            plan:,
+            params: subscription_params(item, plan)
+          ).subscription
+        end
+      end
+
+      def subscription_params(item, plan)
+        payload = item["payload"] || {}
+
+        {
+          external_id: payload["subscriptionExternalId"].presence || SecureRandom.uuid,
+          name: payload["subscriptionName"],
+          billing_time: payload["billingTime"],
+          subscription_at: payload["startDate"] || quote_version.start_date,
+          ending_at: payload["endDate"] || quote_version.end_date,
+          payment_method: payment_method_params(payload),
+          plan_overrides: plan_overrides(item, plan).presence,
+          usage_thresholds: usage_thresholds(item).presence
+        }.compact
+      end
+
+      # PaymentMethods::ValidateService refuses an id without its type.
+      def payment_method_params(payload)
+        payment_method_id = payload["paymentMethodId"]
+        return nil if payment_method_id.nil?
+
+        {payment_method_type: "provider", payment_method_id:}
+      end
+
+      def plan_overrides(item, plan)
+        overrides = item["overrides"] || {}
+
+        {
+          amount_cents: overrides["amountCents"],
+          invoice_display_name: overrides["invoiceDisplayName"],
+          name: overrides["name"],
+          description: overrides["description"],
+          trial_period: overrides["trialPeriod"],
+          minimum_commitment: minimum_commitment(overrides),
+          charges: charge_overrides(item, plan).presence,
+          fixed_charges: fixed_charge_overrides(item, plan).presence
+        }.compact
+      end
+
+      def minimum_commitment(overrides)
+        commitment = overrides["minimumCommitment"]
+        return nil if commitment.blank?
+
+        {
+          amount_cents: commitment["amountCents"],
+          invoice_display_name: commitment["invoiceDisplayName"]
+        }.compact.presence
+      end
+
+      # chargeModel is not forwarded: Charges::OverrideService cannot switch models and ignores it.
+      def charge_overrides(item, plan)
+        Array(item.dig("overrides", "charges")).map do |override|
+          {
+            id: charge_id!(item, plan, override["billableMetricCode"]),
+            properties: override["properties"],
+            min_amount_cents: override["minAmountCents"],
+            invoice_display_name: override["invoiceDisplayName"]
+          }.compact
+        end
+      end
+
+      def fixed_charge_overrides(item, plan)
+        Array(item.dig("overrides", "fixedCharges")).map do |override|
+          {
+            id: fixed_charge_id!(item, plan, override["addOnCode"]),
+            units: override["units"],
+            properties: override["properties"],
+            invoice_display_name: override["invoiceDisplayName"]
+          }.compact
+        end
+      end
+
+      # Plans::OverrideService matches by id and silently ignores one it cannot find, which would
+      # bill the catalog price. The charge must still be on the plan, whatever happened to the
+      # catalog since the quote was approved.
+      def charge_id!(item, plan, metric_code)
+        snapshot = Array(item.dig("payload", "charges")).find do |charge|
+          charge.dig("billableMetric", "code") == metric_code
+        end
+        charge_id = snapshot&.dig("id")
+
+        unless plan.charges.any? { |charge| charge.id == charge_id }
+          result.not_found_failure!(resource: "charge").raise_if_error!
+        end
+
+        charge_id
+      end
+
+      def fixed_charge_id!(item, plan, add_on_code)
+        snapshot = Array(item.dig("payload", "fixedCharges")).find do |fixed_charge|
+          fixed_charge.dig("addOn", "code") == add_on_code
+        end
+        fixed_charge_id = snapshot&.dig("id")
+
+        unless plan.fixed_charges.any? { |fixed_charge| fixed_charge.id == fixed_charge_id }
+          result.not_found_failure!(resource: "fixed_charge").raise_if_error!
+        end
+
+        fixed_charge_id
+      end
+
+      # Thresholds ride on the subscription, not on the overridden plan: plan_overrides
+      # .usage_thresholds is the deprecated path and combining both is refused upstream.
+      def usage_thresholds(item)
+        Array(item.dig("overrides", "usageThresholds")).map do |threshold|
+          {
+            amount_cents: threshold["amountCents"],
+            recurring: threshold["recurring"],
+            threshold_display_name: threshold["thresholdDisplayName"]
+          }.compact
+        end
+      end
+
+      def apply_coupons
+        coupon_items.map do |item|
+          coupon = coupons_by_id[item["id"]]
+          result.not_found_failure!(resource: "coupon").raise_if_error! if coupon.nil?
+
+          ::AppliedCoupons::CreateService.call!(
+            customer: order.customer,
+            coupon:,
+            params: coupon_params(item)
+          ).applied_coupon
+        end
+      end
+
+      # amount_currency is left out on purpose so it falls back to the coupon's own currency,
+      # which approve validation pins to the deal currency.
+      def coupon_params(item)
+        {
+          amount_cents: effective_value(item, "amountCents"),
+          percentage_rate: effective_value(item, "percentageRate"),
+          frequency: effective_value(item, "frequency"),
+          frequency_duration: effective_value(item, "frequencyDuration")
+        }.compact
+      end
+
+      def create_wallets
+        wallet_credit_items.map do |item|
+          ::Wallets::CreateService.call!(params: wallet_params(item)).wallet
+        end
+      end
+
+      def wallet_params(item)
+        payload = item["payload"] || {}
+
+        {
+          organization_id: order.organization_id,
+          customer: order.customer,
+          currency: payload["currency"] || order.currency,
+          name: payload["name"],
+          rate_amount: payload["rateAmount"],
+          paid_credits: payload["paidCredits"],
+          granted_credits: payload["grantedCredits"],
+          expiration_at: payload["expirationAt"],
+          purchase_order_number: payload["purchaseOrderNumber"],
+          invoice_requires_successful_payment: payload["invoiceRequiresSuccessfulPayment"],
+          applies_to: applies_to(payload),
+          recurring_transaction_rules: recurring_transaction_rules(payload)
+        }.compact
+      end
+
+      def applies_to(payload)
+        applies_to = payload["appliesTo"]
+        return nil if applies_to.blank?
+
+        {
+          fee_types: applies_to["feeTypes"].presence,
+          billable_metric_ids: billable_metric_ids!(applies_to["billableMetricCodes"])
+        }.compact.presence
+      end
+
+      # Outside api context Wallets::CreateService resolves the limitation by id, so a code that
+      # no longer exists would create a wallet without its limitation.
+      def billable_metric_ids!(codes)
+        return nil if codes.blank?
+
+        ids = order.organization.billable_metrics.where(code: codes).pluck(:id)
+        result.not_found_failure!(resource: "billable_metric").raise_if_error! if ids.count != codes.uniq.count
+
+        ids
+      end
+
+      def recurring_transaction_rules(payload)
+        rules = Array(payload["recurringTransactionRules"]).map do |rule|
+          {
+            trigger: rule["trigger"],
+            interval: rule["interval"],
+            method: rule["method"],
+            threshold_credits: rule["thresholdCredits"],
+            target_ongoing_balance: rule["targetOngoingBalance"],
+            grants_target_top_up: rule["grantsTargetTopUp"],
+            paid_credits: rule["paidCredits"],
+            granted_credits: rule["grantedCredits"],
+            started_at: rule["startedAt"],
+            expiration_at: rule["expirationAt"],
+            transaction_name: rule["transactionName"],
+            invoice_requires_successful_payment: rule["invoiceRequiresSuccessfulPayment"]
+          }.compact
+        end
+
+        rules.presence
+      end
+
+      def effective_value(item, field)
+        item.dig("overrides", field) || item.dig("payload", field)
+      end
+
+      def plan_items
+        Array(billing_items["plans"])
+      end
+
+      def coupon_items
+        Array(billing_items["coupons"])
+      end
+
+      def wallet_credit_items
+        Array(billing_items["walletCredits"])
+      end
+
+      def plans_by_id
+        @plans_by_id ||= order
+          .organization
+          .plans
+          .includes(:charges, :fixed_charges)
+          .where(id: plan_items.map { |item| item["id"] })
+          .index_by(&:id)
+      end
+
+      def coupons_by_id
+        @coupons_by_id ||= order
+          .organization
+          .coupons
+          .where(id: coupon_items.map { |item| item["id"] })
+          .index_by(&:id)
+      end
+
+      def billing_items
+        @billing_items ||= quote_version.billing_items || {}
+      end
+
+      def quote_version
+        order.quote_version
+      end
+    end
+  end
+end

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -119,8 +119,7 @@ module Orders
       # Subscriptions::CreateService reuse, upgrade or downgrade it instead of creating one.
       def create_subscriptions
         plan_items.map do |item|
-          plan = plans_by_id[item["id"]]
-          result.not_found_failure!(resource: "plan").raise_if_error! if plan.nil?
+          plan = find_plan!(item["id"])
 
           ::Subscriptions::CreateService.call!(
             customer: order.customer,
@@ -349,13 +348,14 @@ module Orders
         Array(billing_items["walletCredits"])
       end
 
-      def plans_by_id
-        @plans_by_id ||= order
-          .organization
-          .plans
-          .includes(:charges, :fixed_charges)
-          .where(id: plan_items.map { |item| item["id"] })
-          .index_by(&:id)
+      # Subscriptions::CreateService assigns the negotiated amount onto the plan it is given and
+      # Plans::OverrideService dups it, so two items on the same plan get their own instance
+      # instead of inheriting each other's amount.
+      def find_plan!(plan_id)
+        plan = order.organization.plans.includes(:charges, :fixed_charges).find_by(id: plan_id)
+        result.not_found_failure!(resource: "plan").raise_if_error! if plan.nil?
+
+        plan
       end
 
       def coupons_by_id

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -2,59 +2,15 @@
 
 module Orders
   module SubscriptionCreation
-    # Internal: premium/feature-flag gates live in Orders::ExecuteService, always call through it.
-    class ExecuteService < BaseService
-      Result = BaseResult[:order]
-
+    class ExecuteService < Orders::BaseExecuteService
       CALENDAR_DATE = /\A\d{4}-\d{2}-\d{2}\z/
-
-      def initialize(order:)
-        @order = order
-
-        super
-      end
-
-      def call
-        return success_result if order.executed?
-
-        if order.execution_mode.blank?
-          return result.single_validation_failure!(field: :execution_mode, error_code: "value_is_mandatory")
-        end
-
-        Order.transaction do
-          Quotes::LockService.call(quote: order.quote) do
-            order.reload
-            next success_result if order.executed?
-
-            mark_executed!(execute_in_lago? ? create_deal : {})
-
-            result.order = order
-          end
-        end
-
-        result
-      rescue ActiveRecord::RecordInvalid => e
-        record_execution_failure!(result.record_validation_failure!(record: e.record))
-      rescue BaseService::FailedResult => e
-        record_execution_failure!(e.result)
-      end
 
       private
 
-      attr_reader :order
-
-      def success_result
-        result.order = order
-        result
-      end
-
-      def execute_in_lago?
-        order.execution_mode == Order::EXECUTION_MODES[:execute_in_lago]
-      end
-
       # Subscriptions come first: they settle the customer currency the coupons and wallets
-      # then reuse.
-      def create_deal
+      # then reuse. No invoice_id: a subscription is invoiced later by BillSubscriptionJob, and only
+      # when the plan is paid in advance.
+      def create_records
         with_coupon_lock do
           subscriptions = create_subscriptions
           applied_coupons = apply_coupons
@@ -75,57 +31,6 @@ module Orders
         return yield if coupon_items.empty?
 
         ::Customers::LockService.call(customer: order.customer, scope: :coupon, &block).value
-      end
-
-      # invoice_id stays nil: a subscription is invoiced later by BillSubscriptionJob, and only
-      # when the plan is paid in advance.
-      def mark_executed!(created)
-        executed_at = Time.current
-
-        order.update!(
-          status: :executed,
-          executed_at:,
-          execution_record: {
-            executed_at: executed_at.iso8601,
-            execution_mode: order.execution_mode,
-            invoice_id: nil,
-            subscription_ids: [],
-            applied_coupon_ids: [],
-            wallet_ids: [],
-            errors: []
-          }.merge(created)
-        )
-      end
-
-      # The transaction has already rolled back, so this trace is the only durable outcome
-      # of the attempt. Recording it moves the order to failed, excluding it from the
-      # executable scope; retrying is a deliberate manual action.
-      def record_execution_failure!(failed_result)
-        order.update!(
-          status: :failed,
-          executed_at: nil,
-          execution_record: {
-            executed_at: nil,
-            execution_mode: order.execution_mode,
-            invoice_id: nil,
-            subscription_ids: [],
-            applied_coupon_ids: [],
-            wallet_ids: [],
-            errors: execution_errors(failed_result.error)
-          }
-        )
-
-        failed_result
-      end
-
-      def execution_errors(error)
-        if error.respond_to?(:messages)
-          error.messages.values.flatten
-        elsif error.respond_to?(:code)
-          [error.code]
-        else
-          [error.message]
-        end
       end
 
       # NOTE: an external id matching a live subscription of this customer makes

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -154,9 +154,12 @@ module Orders
           charge.dig("billableMetric", "code") == metric_code
         end
         charge_id = snapshot&.dig("id")
+        charge = plan.charges.find { |plan_charge| plan_charge.id == charge_id }
 
-        unless plan.charges.any? { |charge| charge.id == charge_id }
-          result.not_found_failure!(resource: "charge").raise_if_error!
+        result.not_found_failure!(resource: "charge").raise_if_error! if charge.nil?
+
+        if charge_model_changed?(snapshot, charge)
+          result.single_validation_failure!(field: :charge_model, error_code: "charge_model_changed").raise_if_error!
         end
 
         charge_id
@@ -167,12 +170,28 @@ module Orders
           fixed_charge.dig("addOn", "code") == add_on_code
         end
         fixed_charge_id = snapshot&.dig("id")
+        fixed_charge = plan.fixed_charges.find { |plan_fixed_charge| plan_fixed_charge.id == fixed_charge_id }
 
-        unless plan.fixed_charges.any? { |fixed_charge| fixed_charge.id == fixed_charge_id }
-          result.not_found_failure!(resource: "fixed_charge").raise_if_error!
+        result.not_found_failure!(resource: "fixed_charge").raise_if_error! if fixed_charge.nil?
+
+        if charge_model_changed?(snapshot, fixed_charge)
+          result
+            .single_validation_failure!(field: :fixed_charge_model, error_code: "fixed_charge_model_changed")
+            .raise_if_error!
         end
 
         fixed_charge_id
+      end
+
+      # The negotiated properties were approved against the model the snapshot pinned. A catalog
+      # model change since then makes them invalid for the charge they now land on, and the override
+      # services fail on that inside Plans::OverrideService, which ignores their result: the charge
+      # would be dropped and the subscription would bill nothing for it.
+      def charge_model_changed?(snapshot, chargeable)
+        charge_model = snapshot["chargeModel"]
+        return false if charge_model.nil?
+
+        charge_model != chargeable.charge_model
       end
 
       # Thresholds ride on the subscription, not on the overridden plan: plan_overrides

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -163,6 +163,10 @@ module QuoteVersions
           )
         end
 
+        # The execution flow resolves each date on its own, falling back to the quote's, and
+        # Subscriptions::ValidateService then requires the pair, compared as dates, to be strictly
+        # increasing. Both fallbacks are applied here so a plan overriding one side only is still
+        # checked against the quote's other side.
         def validate_plan_dates(plan_item, index)
           start_date = plan_item.dig("payload", "startDate")
           end_date = plan_item.dig("payload", "endDate")
@@ -170,11 +174,18 @@ module QuoteVersions
           valid_start = validate_plan_date(start_date, plan_field(index, "payload.startDate"))
           valid_end = validate_plan_date(end_date, plan_field(index, "payload.endDate"))
           return unless valid_start && valid_end
-          return if start_date.nil? || end_date.nil?
+          # A plan carrying neither date bills the quote pair, which validate_dates already checked.
+          return if start_date.nil? && end_date.nil?
 
-          if Time.zone.parse(end_date) < Time.zone.parse(start_date)
-            add_error(field: plan_field(index, "payload.startDate"), error_code: "invalid_date_range")
-          end
+          effective_start = effective_date(start_date, quote_version.start_date)
+          effective_end = effective_date(end_date, quote_version.end_date)
+          return if effective_start.nil? || effective_end.nil?
+          return if effective_end > effective_start
+
+          add_error(
+            field: plan_field(index, start_date.nil? ? "payload.endDate" : "payload.startDate"),
+            error_code: "invalid_date_range"
+          )
         end
 
         # Same ISO 8601 check as Subscriptions::ValidateService, the service these dates feed.
@@ -184,6 +195,12 @@ module QuoteVersions
 
           add_error(field:, error_code: "invalid_date")
           false
+        end
+
+        # Same parsing as Subscriptions::ValidateService: the payload carries ISO 8601 strings while
+        # the quote carries date columns, and the service compares both as dates.
+        def effective_date(payload_value, quote_value)
+          Utils::Datetime.parse_iso8601(payload_value || quote_value)&.to_date
         end
 
         # Subscriptions::CreateService resolves the payment method by id and organization only, so

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -39,10 +39,6 @@ module QuoteVersions
           start_date = quote_version.start_date
           end_date = quote_version.end_date
 
-          if scope == :approve && start_date.blank?
-            add_error(field: :start_date, error_code: "value_is_mandatory")
-          end
-
           # An open-ended deal is legitimate, the subscription simply carries no ending date, but
           # Subscriptions::ValidateService requires the ending date to be strictly after the
           # subscription date, and these are the dates a plan without its own falls back to, so a
@@ -79,6 +75,7 @@ module QuoteVersions
 
             validate_plan_currency(plan, index)
             validate_minimum_commitment(plan, plan_item, index)
+            validate_plan_start_date_presence(plan_item, index)
             validate_plan_dates(plan_item, index)
             validate_plan_payment_method(plan_item, index)
             validate_charge_overrides(plan_item, plan, index)
@@ -286,6 +283,13 @@ module QuoteVersions
           )
         end
 
+        def validate_plan_start_date_presence(plan_item, index)
+          return unless scope == :approve
+          return unless (plan_item.dig("payload", "startDate") || quote_version.start_date).nil?
+
+          add_error(field: plan_field(index, "payload.startDate"), error_code: "value_is_mandatory")
+        end
+
         # The execution flow resolves each date on its own, falling back to the quote's, and
         # Subscriptions::ValidateService then requires the pair, compared as dates, to be strictly
         # increasing. Both fallbacks are applied here so a plan overriding one side only is still
@@ -297,7 +301,7 @@ module QuoteVersions
           valid_start = validate_plan_date(start_date, plan_field(index, "payload.startDate"))
           valid_end = validate_plan_date(end_date, plan_field(index, "payload.endDate"))
           return unless valid_start && valid_end
-          # A plan carrying neither date bills the quote pair, which validate_dates already checked.
+          # A plan carrying neither date bills the quote pair.
           return if start_date.nil? && end_date.nil?
 
           # The quote's own ending date is checked by validate_dates, so only a payload one is

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -138,6 +138,13 @@ module QuoteVersions
               charge,
               plan_field(index, "payload.charges.#{snapshot_index}.chargeModel")
             )
+            # The negotiated properties only mean something against the model they were drafted
+            # for, and a model that moved is already reported above.
+            next if model_changed?(charge_override["chargeModel"], charge) ||
+              model_changed?(snapshot["chargeModel"], charge)
+
+            validate_charge_properties(charge_override, charge, index, charge_index)
+            validate_charge_min_amount(charge_override, charge, index, charge_index)
           end
         end
 
@@ -145,9 +152,7 @@ module QuoteVersions
         # chargeModel would otherwise let the catalog drift away from it unnoticed, landing the
         # negotiated properties on another model.
         def validate_snapshot_charge_model(snapshot, charge, field)
-          charge_model = snapshot["chargeModel"]
-          return if charge_model.nil?
-          return if charge_model == charge.charge_model
+          return unless model_changed?(snapshot["chargeModel"], charge)
 
           add_error(field:, error_code: "charge_model_changed")
         end
@@ -155,13 +160,42 @@ module QuoteVersions
         # Charges::OverrideService cannot switch a charge model and ignores the key, so properties
         # negotiated for another model would land on the catalog one.
         def validate_charge_model(charge_override, charge, index, charge_index)
-          charge_model = charge_override["chargeModel"]
-          return if charge_model.nil?
-          return if charge_model == charge.charge_model
+          return unless model_changed?(charge_override["chargeModel"], charge)
 
           add_error(
             field: plan_field(index, "overrides.charges.#{charge_index}.chargeModel"),
             error_code: "cannot_override_charge_model"
+          )
+        end
+
+        # A quote that pinned no model follows whatever the catalog holds.
+        def model_changed?(quoted_charge_model, chargeable)
+          return false if quoted_charge_model.nil?
+
+          quoted_charge_model != chargeable.charge_model
+        end
+
+        def validate_charge_properties(charge_override, charge, index, charge_index)
+          properties = charge_override["properties"]
+          return if properties.nil?
+
+          field = plan_field(index, "overrides.charges.#{charge_index}.properties")
+          validate_properties(charge, properties, field)
+        # The model validators below assume a hash shaped for their charge model and raise on
+        # anything else, while a quoted payload is free-form.
+        rescue
+          add_error(field:, error_code: "invalid_value")
+        end
+
+        # Charge#validate_min_amount_cents refuses a minimum on a charge billed in advance, and
+        # Plans::OverrideService swallows that failure the same way.
+        def validate_charge_min_amount(charge_override, charge, index, charge_index)
+          return unless charge.pay_in_advance?
+          return unless charge_override["minAmountCents"].to_i.positive?
+
+          add_error(
+            field: plan_field(index, "overrides.charges.#{charge_index}.minAmountCents"),
+            error_code: "not_compatible_with_pay_in_advance"
           )
         end
 
@@ -187,6 +221,9 @@ module QuoteVersions
               fixed_charge,
               plan_field(index, "payload.fixedCharges.#{snapshot_index}.chargeModel")
             )
+            next if model_changed?(snapshot["chargeModel"], fixed_charge)
+
+            validate_fixed_charge_properties(fixed_charge_override, fixed_charge, index, fixed_charge_index)
           end
         end
 
@@ -194,11 +231,46 @@ module QuoteVersions
         # checks its result and the override carries no model of its own, so the snapshot is the only
         # place the approved model survives.
         def validate_snapshot_fixed_charge_model(snapshot, fixed_charge, field)
-          charge_model = snapshot["chargeModel"]
-          return if charge_model.nil?
-          return if charge_model == fixed_charge.charge_model
+          return unless model_changed?(snapshot["chargeModel"], fixed_charge)
 
           add_error(field:, error_code: "fixed_charge_model_changed")
+        end
+
+        # FixedCharges::OverrideService slices the properties down to the keys its charge model knows
+        # before saving, and FixedCharge requires them to be present, so an override drafted for
+        # another model filters down to nothing and takes the fixed charge with it.
+        def validate_fixed_charge_properties(fixed_charge_override, fixed_charge, index, fixed_charge_index)
+          properties = fixed_charge_override["properties"]
+          return if properties.nil?
+
+          field = plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.properties")
+          filtered = ChargeModels::FilterPropertiesService
+            .call(chargeable: fixed_charge, properties: properties.presence)
+            .properties
+
+          return add_error(field:, error_code: "invalid_value") if filtered.blank?
+
+          validate_properties(fixed_charge, filtered, field)
+        # Neither the filter nor the model validators tolerate a hash shaped for something else,
+        # while a quoted payload is free-form.
+        rescue
+          add_error(field:, error_code: "invalid_value")
+        end
+
+        # Plans::OverrideService calls the two override services without raise_if_error! and both
+        # rescue RecordInvalid, so properties the charge model rejects drop the charge from the
+        # override plan instead of failing execution: the subscription would then bill nothing at all
+        # for it. These are the validators the models themselves run.
+        def validate_properties(chargeable, properties, field)
+          validator = ChargePropertiesValidation::PROPERTIES_VALIDATORS
+            .fetch(chargeable.charge_model.to_sym, ::Charges::Validators::BaseService)
+            .new(charge: chargeable, properties:)
+
+          return if validator.valid?
+
+          validator.result.error.messages.each do |key, error_codes|
+            error_codes.each { add_error(field: :"#{field}.#{key}", error_code: it) }
+          end
         end
 
         # units is forwarded verbatim to FixedCharges::OverrideService, and FixedCharge validates it

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -269,6 +269,8 @@ module QuoteVersions
         end
 
         def validate_coupons
+          earlier_coupons = []
+
           coupons.each_with_index do |coupon_item, index|
             coupon = known_coupons_by_id[coupon_item["id"]]
 
@@ -279,8 +281,61 @@ module QuoteVersions
 
             validate_coupon_currency(coupon, index)
             validate_coupon_frequency(coupon, coupon_item, index)
+            validate_coupon_preconditions(coupon, earlier_coupons, index)
             validate_coupon_snapshot(coupon, coupon_item, index) if scope == :approve
+
+            earlier_coupons << coupon
           end
+        end
+
+        # AppliedCoupons::CreateService refuses a non-reusable coupon the customer already carries and
+        # a limited coupon overlapping one already applied. The deal applies its coupons one by one,
+        # so the first application is what makes a second one fail, halfway through execution.
+        # NOTE: the customer's own applied coupons are deliberately not checked here, that state can
+        # change between approval and execution.
+        def validate_coupon_preconditions(coupon, earlier_coupons, index)
+          if !coupon.reusable? && earlier_coupons.any? { |earlier| earlier.id == coupon.id }
+            add_error(field: coupon_field(index, "id"), error_code: "coupon_is_not_reusable")
+          end
+
+          return unless limited?(coupon)
+          return if earlier_coupons.none? { |earlier| overlapping_limitations?(coupon, earlier) }
+
+          add_error(field: coupon_field(index, "id"), error_code: "plan_overlapping")
+        end
+
+        def limited?(coupon)
+          coupon.limited_plans? || coupon.limited_billable_metrics?
+        end
+
+        # The four comparisons AppliedCoupons::CreateService makes: plans against plans, metrics
+        # against metrics, and each against the other through the charges connecting them.
+        def overlapping_limitations?(coupon, earlier)
+          plan_ids = target_ids(coupon, :plan_id)
+          metric_ids = target_ids(coupon, :billable_metric_id)
+          earlier_plan_ids = target_ids(earlier, :plan_id)
+          earlier_metric_ids = target_ids(earlier, :billable_metric_id)
+
+          plan_ids.intersect?(earlier_plan_ids) ||
+            metric_ids.intersect?(earlier_metric_ids) ||
+            earlier_plan_ids.intersect?(plans_charging(metric_ids)) ||
+            earlier_metric_ids.intersect?(metrics_charged_by(plan_ids))
+        end
+
+        def target_ids(coupon, attribute)
+          coupon.coupon_targets.filter_map(&attribute)
+        end
+
+        def plans_charging(metric_ids)
+          return [] if metric_ids.empty?
+
+          Charge.joins(:billable_metric).where(billable_metric: {id: metric_ids}).pluck(:plan_id)
+        end
+
+        def metrics_charged_by(plan_ids)
+          return [] if plan_ids.empty?
+
+          Charge.joins(:plan).where(plan: {id: plan_ids}).pluck(:billable_metric_id)
         end
 
         def validate_coupon_currency(coupon, index)
@@ -558,6 +613,7 @@ module QuoteVersions
             .organization
             .coupons
             .with_discarded
+            .includes(:coupon_targets)
             .where(id: coupons.map { |coupon_item| coupon_item["id"] })
             .index_by(&:id)
         end

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -63,8 +63,10 @@ module QuoteVersions
 
             validate_plan_currency(plan, index)
             validate_minimum_commitment(plan, plan_item, index)
-            validate_charge_overrides(plan_item, index)
-            validate_fixed_charge_overrides(plan_item, index)
+            validate_plan_dates(plan_item, index)
+            validate_plan_payment_method(plan_item, index)
+            validate_charge_overrides(plan_item, plan, index)
+            validate_fixed_charge_overrides(plan_item, plan, index)
           end
         end
 
@@ -95,30 +97,55 @@ module QuoteVersions
           )
         end
 
-        def validate_charge_overrides(plan_item, index)
-          charge_overrides = (plan_item["overrides"] || {})["charges"] || []
-
-          charge_overrides.each_with_index do |charge_override, charge_index|
-            unless known_charge_metric_codes.include?([plan_item["id"], charge_override["billableMetricCode"]])
-              add_error(
-                field: plan_field(index, "overrides.charges.#{charge_index}.billableMetricCode"),
-                error_code: "charge_not_found"
-              )
+        # Plans::OverrideService matches overrides by charge id and silently ignores an id it
+        # cannot find, which would bill the catalog price instead of the negotiated one. So the
+        # id the execution flow will use is resolved here, from the payload snapshot, and must
+        # still exist on the plan.
+        def validate_charge_overrides(plan_item, plan, index)
+          charge_overrides(plan_item).each_with_index do |charge_override, charge_index|
+            field = plan_field(index, "overrides.charges.#{charge_index}.billableMetricCode")
+            snapshots = snapshot_charges(plan_item).select do |snapshot|
+              snapshot.dig("billableMetric", "code") == charge_override["billableMetricCode"]
             end
+
+            next add_error(field:, error_code: "charge_not_found") if snapshots.empty?
+            next add_error(field:, error_code: "ambiguous_charge_override") if snapshots.count > 1
+
+            charge = plan.charges.find { |plan_charge| plan_charge.id == snapshots.first["id"] }
+
+            next add_error(field:, error_code: "charge_not_found") if charge.nil?
+
+            validate_charge_model(charge_override, charge, index, charge_index)
           end
         end
 
-        def validate_fixed_charge_overrides(plan_item, index)
-          fixed_charge_overrides = (plan_item["overrides"] || {})["fixedCharges"] || []
+        # Charges::OverrideService cannot switch a charge model and ignores the key, so properties
+        # negotiated for another model would land on the catalog one.
+        def validate_charge_model(charge_override, charge, index, charge_index)
+          charge_model = charge_override["chargeModel"]
+          return if charge_model.nil?
+          return if charge_model == charge.charge_model
 
-          fixed_charge_overrides.each_with_index do |fixed_charge_override, fixed_charge_index|
+          add_error(
+            field: plan_field(index, "overrides.charges.#{charge_index}.chargeModel"),
+            error_code: "cannot_override_charge_model"
+          )
+        end
+
+        def validate_fixed_charge_overrides(plan_item, plan, index)
+          fixed_charge_overrides(plan_item).each_with_index do |fixed_charge_override, fixed_charge_index|
             validate_fixed_charge_units(fixed_charge_override, index, fixed_charge_index)
 
-            unless known_fixed_charge_add_on_codes.include?([plan_item["id"], fixed_charge_override["addOnCode"]])
-              add_error(
-                field: plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.addOnCode"),
-                error_code: "fixed_charge_not_found"
-              )
+            field = plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.addOnCode")
+            snapshots = snapshot_fixed_charges(plan_item).select do |snapshot|
+              snapshot.dig("addOn", "code") == fixed_charge_override["addOnCode"]
+            end
+
+            next add_error(field:, error_code: "fixed_charge_not_found") if snapshots.empty?
+            next add_error(field:, error_code: "ambiguous_fixed_charge_override") if snapshots.count > 1
+
+            unless plan.fixed_charges.any? { |fixed_charge| fixed_charge.id == snapshots.first["id"] }
+              add_error(field:, error_code: "fixed_charge_not_found")
             end
           end
         end
@@ -134,6 +161,39 @@ module QuoteVersions
             field: plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.units"),
             error_code: "invalid_value"
           )
+        end
+
+        def validate_plan_dates(plan_item, index)
+          start_date = plan_item.dig("payload", "startDate")
+          end_date = plan_item.dig("payload", "endDate")
+
+          valid_start = validate_plan_date(start_date, plan_field(index, "payload.startDate"))
+          valid_end = validate_plan_date(end_date, plan_field(index, "payload.endDate"))
+          return unless valid_start && valid_end
+          return if start_date.nil? || end_date.nil?
+
+          if Time.zone.parse(end_date) < Time.zone.parse(start_date)
+            add_error(field: plan_field(index, "payload.startDate"), error_code: "invalid_date_range")
+          end
+        end
+
+        # Same ISO 8601 check as Subscriptions::ValidateService, the service these dates feed.
+        def validate_plan_date(value, field)
+          return true if value.nil?
+          return true if Utils::Datetime.valid_format?(value)
+
+          add_error(field:, error_code: "invalid_date")
+          false
+        end
+
+        # Subscriptions::CreateService resolves the payment method by id and organization only, so
+        # ownership is checked here: another customer's method would otherwise be attached.
+        def validate_plan_payment_method(plan_item, index)
+          payment_method_id = plan_item.dig("payload", "paymentMethodId")
+          return if payment_method_id.nil?
+          return if known_payment_method_ids.include?(payment_method_id)
+
+          add_error(field: plan_field(index, "payload.paymentMethodId"), error_code: "payment_method_not_found")
         end
 
         def validate_coupons
@@ -209,9 +269,24 @@ module QuoteVersions
 
             validate_wallet_credit_amounts(payload, index)
             validate_wallet_credit_currency(payload, index)
+            validate_wallet_credit_applies_to(payload, index)
             validate_expiration(payload["expirationAt"], wallet_credit_field(index, "payload.expirationAt"))
             validate_recurring_rules(payload, index)
           end
+        end
+
+        # Outside api context Wallets::CreateService resolves metric limitations by id, so a code
+        # that does not resolve means the wallet is created without its limitation instead of
+        # failing.
+        def validate_wallet_credit_applies_to(payload, index)
+          codes = Array(payload.dig("appliesTo", "billableMetricCodes"))
+          return if codes.empty?
+          return if (codes - known_billable_metric_codes).empty?
+
+          add_error(
+            field: wallet_credit_field(index, "payload.appliesTo.billableMetricCodes"),
+            error_code: "billable_metric_not_found"
+          )
         end
 
         # Unless the multi_currency flag is on, Wallets::CreateService forces the customer currency
@@ -346,6 +421,22 @@ module QuoteVersions
           billing_items["walletCredits"] || []
         end
 
+        def charge_overrides(plan_item)
+          Array(plan_item.dig("overrides", "charges"))
+        end
+
+        def fixed_charge_overrides(plan_item)
+          Array(plan_item.dig("overrides", "fixedCharges"))
+        end
+
+        def snapshot_charges(plan_item)
+          Array(plan_item.dig("payload", "charges"))
+        end
+
+        def snapshot_fixed_charges(plan_item)
+          Array(plan_item.dig("payload", "fixedCharges"))
+        end
+
         def plan_field(index, suffix)
           :"billing_items.plans.#{index}.#{suffix}"
         end
@@ -367,27 +458,27 @@ module QuoteVersions
             .organization
             .plans
             .with_discarded
-            .includes(:minimum_commitment)
+            .includes(:charges, :fixed_charges, :minimum_commitment)
             .where(id: plans.map { |plan_item| plan_item["id"] })
             .index_by(&:id)
         end
 
-        def known_charge_metric_codes
-          @known_charge_metric_codes ||= Charge
-            .with_discarded
-            .joins(:billable_metric)
-            .where(plan_id: known_plans_by_id.keys)
-            .pluck(:plan_id, "billable_metrics.code")
+        def known_payment_method_ids
+          @known_payment_method_ids ||= quote_version
+            .quote
+            .customer
+            .payment_methods
+            .where(id: plans.filter_map { |plan_item| plan_item.dig("payload", "paymentMethodId") })
+            .pluck(:id)
             .to_set
         end
 
-        def known_fixed_charge_add_on_codes
-          @known_fixed_charge_add_on_codes ||= FixedCharge
-            .with_discarded
-            .joins(:add_on)
-            .where(plan_id: known_plans_by_id.keys)
-            .pluck(:plan_id, "add_ons.code")
-            .to_set
+        def known_billable_metric_codes
+          @known_billable_metric_codes ||= quote_version
+            .organization
+            .billable_metrics
+            .where(code: wallet_credits.flat_map { |item| Array(item.dig("payload", "appliesTo", "billableMetricCodes")) })
+            .pluck(:code)
         end
 
         def known_coupons_by_id

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -120,19 +120,36 @@ module QuoteVersions
         def validate_charge_overrides(plan_item, plan, index)
           charge_overrides(plan_item).each_with_index do |charge_override, charge_index|
             field = plan_field(index, "overrides.charges.#{charge_index}.billableMetricCode")
-            snapshots = snapshot_charges(plan_item).select do |snapshot|
+            snapshots = snapshot_charges(plan_item).each_with_index.select do |snapshot, _|
               snapshot.dig("billableMetric", "code") == charge_override["billableMetricCode"]
             end
 
             next add_error(field:, error_code: "charge_not_found") if snapshots.empty?
             next add_error(field:, error_code: "ambiguous_charge_override") if snapshots.count > 1
 
-            charge = plan.charges.find { |plan_charge| plan_charge.id == snapshots.first["id"] }
+            snapshot, snapshot_index = snapshots.first
+            charge = plan.charges.find { |plan_charge| plan_charge.id == snapshot["id"] }
 
             next add_error(field:, error_code: "charge_not_found") if charge.nil?
 
             validate_charge_model(charge_override, charge, index, charge_index)
+            validate_snapshot_charge_model(
+              snapshot,
+              charge,
+              plan_field(index, "payload.charges.#{snapshot_index}.chargeModel")
+            )
           end
+        end
+
+        # The snapshot pins the charge model the approver was looking at, and an override omitting
+        # chargeModel would otherwise let the catalog drift away from it unnoticed, landing the
+        # negotiated properties on another model.
+        def validate_snapshot_charge_model(snapshot, charge, field)
+          charge_model = snapshot["chargeModel"]
+          return if charge_model.nil?
+          return if charge_model == charge.charge_model
+
+          add_error(field:, error_code: "charge_model_changed")
         end
 
         # Charges::OverrideService cannot switch a charge model and ignores the key, so properties
@@ -153,17 +170,35 @@ module QuoteVersions
             validate_fixed_charge_units(fixed_charge_override, index, fixed_charge_index)
 
             field = plan_field(index, "overrides.fixedCharges.#{fixed_charge_index}.addOnCode")
-            snapshots = snapshot_fixed_charges(plan_item).select do |snapshot|
+            snapshots = snapshot_fixed_charges(plan_item).each_with_index.select do |snapshot, _|
               snapshot.dig("addOn", "code") == fixed_charge_override["addOnCode"]
             end
 
             next add_error(field:, error_code: "fixed_charge_not_found") if snapshots.empty?
             next add_error(field:, error_code: "ambiguous_fixed_charge_override") if snapshots.count > 1
 
-            unless plan.fixed_charges.any? { |fixed_charge| fixed_charge.id == snapshots.first["id"] }
-              add_error(field:, error_code: "fixed_charge_not_found")
-            end
+            snapshot, snapshot_index = snapshots.first
+            fixed_charge = plan.fixed_charges.find { |plan_fixed_charge| plan_fixed_charge.id == snapshot["id"] }
+
+            next add_error(field:, error_code: "fixed_charge_not_found") if fixed_charge.nil?
+
+            validate_snapshot_fixed_charge_model(
+              snapshot,
+              fixed_charge,
+              plan_field(index, "payload.fixedCharges.#{snapshot_index}.chargeModel")
+            )
           end
+        end
+
+        # FixedCharges::OverrideService does refuse a model switch, but Plans::OverrideService never
+        # checks its result and the override carries no model of its own, so the snapshot is the only
+        # place the approved model survives.
+        def validate_snapshot_fixed_charge_model(snapshot, fixed_charge, field)
+          charge_model = snapshot["chargeModel"]
+          return if charge_model.nil?
+          return if charge_model == fixed_charge.charge_model
+
+          add_error(field:, error_code: "fixed_charge_model_changed")
         end
 
         # units is forwarded verbatim to FixedCharges::OverrideService, and FixedCharge validates it

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -50,6 +50,22 @@ module QuoteVersions
           if start_date.present? && end_date.present? && end_date <= start_date
             add_error(field: :start_date, error_code: "invalid_date_range")
           end
+
+          validate_future_end_date(end_date, :end_date)
+        end
+
+        # Subscriptions::ValidateService also requires the ending date to be after today, and the
+        # quote pair is what a plan without its own dates falls back to. NOTE: futureness is only
+        # guaranteed at approval time. An order scheduled far enough ahead can still reach execution
+        # with a past ending date, which that service rejects then.
+        def validate_future_end_date(value, field)
+          return unless scope == :approve
+
+          end_date = Utils::Datetime.parse_iso8601(value)&.to_date
+          return if end_date.nil?
+          return if end_date > Time.current.to_date
+
+          add_error(field:, error_code: "invalid_date")
         end
 
         def validate_plans
@@ -177,13 +193,17 @@ module QuoteVersions
           # A plan carrying neither date bills the quote pair, which validate_dates already checked.
           return if start_date.nil? && end_date.nil?
 
+          # The quote's own ending date is checked by validate_dates, so only a payload one is
+          # reported here.
+          validate_future_end_date(end_date, plan_field(index, "payload.endDate"))
+
           effective_start = effective_date(start_date, quote_version.start_date)
           effective_end = effective_date(end_date, quote_version.end_date)
           return if effective_start.nil? || effective_end.nil?
           return if effective_end > effective_start
 
           add_error(
-            field: plan_field(index, start_date.nil? ? "payload.endDate" : "payload.startDate"),
+            field: plan_field(index, end_date.nil? ? "payload.startDate" : "payload.endDate"),
             error_code: "invalid_date_range"
           )
         end

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -399,15 +399,35 @@ module QuoteVersions
         end
 
         def plans_charging(metric_ids)
-          return [] if metric_ids.empty?
-
-          Charge.joins(:billable_metric).where(billable_metric: {id: metric_ids}).pluck(:plan_id)
+          metric_ids.flat_map { plans_by_metric_id[it] || [] }
         end
 
         def metrics_charged_by(plan_ids)
-          return [] if plan_ids.empty?
+          plan_ids.flat_map { metrics_by_plan_id[it] || [] }
+        end
 
-          Charge.joins(:plan).where(plan: {id: plan_ids}).pluck(:billable_metric_id)
+        # The charges connecting the two limitation kinds, resolved once for every coupon the quote
+        # carries rather than once per pair compared.
+        def plans_by_metric_id
+          @plans_by_metric_id ||= Charge
+            .joins(:billable_metric)
+            .where(billable_metric: {id: quoted_target_ids(:billable_metric_id)})
+            .pluck(:billable_metric_id, :plan_id)
+            .group_by(&:first)
+            .transform_values { |rows| rows.map(&:last) }
+        end
+
+        def metrics_by_plan_id
+          @metrics_by_plan_id ||= Charge
+            .joins(:plan)
+            .where(plan: {id: quoted_target_ids(:plan_id)})
+            .pluck(:plan_id, :billable_metric_id)
+            .group_by(&:first)
+            .transform_values { |rows| rows.map(&:last) }
+        end
+
+        def quoted_target_ids(attribute)
+          known_coupons_by_id.each_value.flat_map { |coupon| target_ids(coupon, attribute) }.uniq
         end
 
         def validate_coupon_currency(coupon, index)

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -547,6 +547,21 @@ module QuoteVersions
           plans["minItems"] = 1
           plans["items"]["properties"]["payload"]["required"] = %w[code]
 
+          # An override is resolved through its snapshot entry, by code then by id, so an approved
+          # entry must carry both. Without the id the business validator can only report
+          # charge_not_found against the override, pointing the approver at the wrong key.
+          charge_snapshot = plans["items"]["properties"]["payload"]["properties"]["charges"]["items"]
+          charge_snapshot["required"] = ["id"]
+          charge_snapshot["x-error"]["required"] = "value_is_mandatory"
+          charge_snapshot["properties"]["billableMetric"]["required"] = ["code"]
+          charge_snapshot["properties"]["billableMetric"]["x-error"]["required"] = "value_is_mandatory"
+
+          fixed_charge_snapshot = plans["items"]["properties"]["payload"]["properties"]["fixedCharges"]["items"]
+          fixed_charge_snapshot["required"] = ["id"]
+          fixed_charge_snapshot["x-error"]["required"] = "value_is_mandatory"
+          fixed_charge_snapshot["properties"]["addOn"]["required"] = ["code"]
+          fixed_charge_snapshot["properties"]["addOn"]["x-error"]["required"] = "value_is_mandatory"
+
           schema["properties"]["coupons"]["items"]["properties"]["payload"]["required"] =
             %w[code type]
 

--- a/app/services/quote_versions/validators/subscription_creation/schema.rb
+++ b/app/services/quote_versions/validators/subscription_creation/schema.rb
@@ -6,6 +6,9 @@ module QuoteVersions
       module Schema
         CURRENCIES = Currencies::ACCEPTED_CURRENCIES.keys.map(&:to_s).freeze
 
+        CHARGE_MODELS = Charge::CHARGE_MODELS.map(&:to_s).freeze
+        FIXED_CHARGE_MODELS = FixedCharge::CHARGE_MODELS.keys.map(&:to_s).freeze
+
         COUPON_TYPES = Coupon::COUPON_TYPES.map(&:to_s).freeze
         COUPON_FREQUENCIES = Coupon::FREQUENCIES.map(&:to_s).freeze
 
@@ -42,6 +45,10 @@ module QuoteVersions
                     "const" => "plan",
                     "x-error" => {"type" => "invalid_type", "const" => "invalid_value"}
                   },
+                  # Catalog snapshot: free-form, except the keys the execution flow consumes.
+                  # startDate/endDate carry no format on purpose, the business validator applies
+                  # the same ISO 8601 check as Subscriptions::ValidateService so an approved quote
+                  # is never stricter than the service it feeds.
                   "payload" => {
                     "type" => "object",
                     "x-error" => {"type" => "invalid_type", "required" => "value_is_mandatory"},
@@ -50,6 +57,99 @@ module QuoteVersions
                         "type" => "string",
                         "minLength" => 1,
                         "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      },
+                      "subscriptionExternalId" => {
+                        "type" => %w[string null],
+                        "minLength" => 1,
+                        "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      },
+                      "subscriptionName" => {
+                        "type" => %w[string null],
+                        "minLength" => 1,
+                        "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                      },
+                      "billingTime" => {
+                        "type" => %w[string null],
+                        "enum" => [*Subscription::BILLING_TIME.map(&:to_s), nil],
+                        "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                      },
+                      "startDate" => {
+                        "type" => %w[string null],
+                        "x-error" => {"type" => "invalid_type"}
+                      },
+                      "endDate" => {
+                        "type" => %w[string null],
+                        "x-error" => {"type" => "invalid_type"}
+                      },
+                      "paymentMethodId" => {
+                        "type" => %w[string null],
+                        "format" => "uuid",
+                        "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                      },
+                      # Charge overrides are keyed by billableMetricCode while
+                      # Plans::OverrideService keys by charge id, so the id is resolved through
+                      # this snapshot: it pins the charge the approver was looking at.
+                      "charges" => {
+                        "type" => %w[array null],
+                        "x-error" => {"type" => "invalid_type"},
+                        "items" => {
+                          "type" => "object",
+                          "x-error" => {"type" => "invalid_type"},
+                          "properties" => {
+                            "id" => {
+                              "type" => "string",
+                              "format" => "uuid",
+                              "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                            },
+                            "billableMetric" => {
+                              "type" => "object",
+                              "x-error" => {"type" => "invalid_type"},
+                              "properties" => {
+                                "code" => {
+                                  "type" => "string",
+                                  "minLength" => 1,
+                                  "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                                }
+                              }
+                            },
+                            "chargeModel" => {
+                              "type" => %w[string null],
+                              "enum" => [*CHARGE_MODELS, nil],
+                              "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                            }
+                          }
+                        }
+                      },
+                      "fixedCharges" => {
+                        "type" => %w[array null],
+                        "x-error" => {"type" => "invalid_type"},
+                        "items" => {
+                          "type" => "object",
+                          "x-error" => {"type" => "invalid_type"},
+                          "properties" => {
+                            "id" => {
+                              "type" => "string",
+                              "format" => "uuid",
+                              "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
+                            },
+                            "addOn" => {
+                              "type" => "object",
+                              "x-error" => {"type" => "invalid_type"},
+                              "properties" => {
+                                "code" => {
+                                  "type" => "string",
+                                  "minLength" => 1,
+                                  "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                                }
+                              }
+                            },
+                            "chargeModel" => {
+                              "type" => %w[string null],
+                              "enum" => [*FIXED_CHARGE_MODELS, nil],
+                              "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                            }
+                          }
+                        }
                       }
                     }
                   },
@@ -146,10 +246,7 @@ module QuoteVersions
                             # validated where the override is applied, not here.
                             "chargeModel" => {
                               "type" => %w[string null],
-                              "enum" => [
-                                "standard", "graduated", "package", "percentage",
-                                "volume", "graduated_percentage", "custom", "dynamic", nil
-                              ],
+                              "enum" => [*CHARGE_MODELS, nil],
                               "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
                             },
                             "properties" => {
@@ -345,6 +442,30 @@ module QuoteVersions
                         "format" => "date-time",
                         "x-error" => {"type" => "invalid_type", "format" => "invalid_format"}
                       },
+                      "appliesTo" => {
+                        "type" => %w[object null],
+                        "x-error" => {"type" => "invalid_type"},
+                        "properties" => {
+                          "feeTypes" => {
+                            "type" => %w[array null],
+                            "x-error" => {"type" => "invalid_type"},
+                            "items" => {
+                              "type" => "string",
+                              "enum" => Fee::FEE_TYPES.map(&:to_s),
+                              "x-error" => {"type" => "invalid_type", "enum" => "invalid_value"}
+                            }
+                          },
+                          "billableMetricCodes" => {
+                            "type" => %w[array null],
+                            "x-error" => {"type" => "invalid_type"},
+                            "items" => {
+                              "type" => "string",
+                              "minLength" => 1,
+                              "x-error" => {"type" => "invalid_type", "minLength" => "invalid_value"}
+                            }
+                          }
+                        }
+                      },
                       "recurringTransactionRules" => {
                         "type" => %w[array null],
                         "x-error" => {"type" => "invalid_type"},
@@ -435,7 +556,13 @@ module QuoteVersions
             wallet_credit_payload["properties"][key]["type"] = "string"
           end
 
-          rules = wallet_credit_payload["properties"]["recurringTransactionRules"]["items"]
+          # Wallets::ValidateService rejects more than one rule per wallet, so approving two is
+          # approving something that cannot be created.
+          recurring_rules = wallet_credit_payload["properties"]["recurringTransactionRules"]
+          recurring_rules["maxItems"] = 1
+          recurring_rules["x-error"]["maxItems"] = "invalid_count"
+
+          rules = recurring_rules["items"]
           rules["required"] = ["trigger"]
           rules["properties"]["trigger"]["type"] = "string"
           rules["properties"]["trigger"]["enum"] = RULE_TRIGGERS

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -69,11 +69,18 @@ module Quotes
         params: params.slice(
           :billing_items,
           :content,
-          :currency,
           :start_date,
           :end_date
-        )
+        ).merge(currency: deal_currency)
       )
+    end
+
+    # The deal currency follows the billing object when there is one, and only then the customer's
+    # own default. It stays editable on the draft through QuoteVersions::UpdateService.
+    def deal_currency
+      return subscription.plan_amount_currency if subscription
+
+      customer.currency.presence || customer.billing_entity.default_currency
     end
 
     def add_owners!(quote:)

--- a/schema.graphql
+++ b/schema.graphql
@@ -3468,7 +3468,6 @@ input CreateQuoteInput {
   """
   clientMutationId: String
   content: String
-  currency: String
   customerId: ID!
   endDate: ISO8601Date
   orderType: OrderTypeEnum!

--- a/schema.graphql
+++ b/schema.graphql
@@ -9809,7 +9809,7 @@ enum OnTerminationInvoiceEnum {
 type Order {
   billingSnapshot: JSON!
   createdAt: ISO8601DateTime!
-  currency: String
+  currency: CurrencyEnum
   customer: Customer!
   executeAt: ISO8601DateTime
   executedAt: ISO8601DateTime
@@ -11945,7 +11945,7 @@ type QuoteVersion {
   billingItems: JSON
   content: String
   createdAt: ISO8601DateTime!
-  currency: String
+  currency: CurrencyEnum
   endDate: ISO8601Date
   id: ID!
   mentionVariables: JSON!
@@ -14477,7 +14477,7 @@ input UpdateQuoteVersionInput {
   """
   clientMutationId: String
   content: String
-  currency: String
+  currency: CurrencyEnum
   endDate: ISO8601Date
   id: ID!
   startDate: ISO8601Date

--- a/schema.graphql
+++ b/schema.graphql
@@ -9851,10 +9851,13 @@ enum OrderExecutionModeEnum {
 }
 
 type OrderExecutionRecord {
+  appliedCouponIds: [ID!]!
   errors: [String!]!
   executedAt: ISO8601DateTime
   executionMode: OrderExecutionModeEnum
   invoiceId: ID
+  subscriptionIds: [ID!]!
+  walletIds: [ID!]!
 }
 
 type OrderForm {

--- a/schema.json
+++ b/schema.json
@@ -46773,8 +46773,8 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -65118,8 +65118,8 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -77367,8 +77367,8 @@
               "name": "currency",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
                 "ofType": null
               },
               "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -15954,18 +15954,6 @@
               "deprecationReason": null
             },
             {
-              "name": "currency",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "customerId",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -47081,6 +47081,30 @@
           "description": null,
           "fields": [
             {
+              "name": "appliedCouponIds",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "errors",
               "description": null,
               "args": [],
@@ -47136,6 +47160,54 @@
                 "kind": "SCALAR",
                 "name": "ID",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionIds",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "walletIds",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/mutations/quote_versions/update_spec.rb
+++ b/spec/graphql/mutations/quote_versions/update_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Mutations::QuoteVersions::Update do
     {
       id: quote_version.id,
       billingItems: {},
-      content: "Test content"
+      content: "Test content",
+      currency: "EUR"
     }
   end
 
@@ -24,7 +25,8 @@ RSpec.describe Mutations::QuoteVersions::Update do
           version,
           status,
           billingItems,
-          content
+          content,
+          currency
         }
       }
     GQL
@@ -57,7 +59,8 @@ RSpec.describe Mutations::QuoteVersions::Update do
         "version" => quote_version.version,
         "status" => quote_version.status,
         "billingItems" => {},
-        "content" => "Test content"
+        "content" => "Test content",
+        "currency" => "EUR"
       )
     end
   end
@@ -67,7 +70,8 @@ RSpec.describe Mutations::QuoteVersions::Update do
       {
         id: "00000000-0000-0000-0000-000000000000",
         billingItems: {},
-        content: "Test content"
+        content: "Test content",
+        currency: "EUR"
       }
     end
 

--- a/spec/graphql/mutations/quotes/create_spec.rb
+++ b/spec/graphql/mutations/quotes/create_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Mutations::Quotes::Create do
           organization { id },
           number,
           orderType
-          currentVersion { id version status content billingItems }
-          versions { id version status content billingItems }
+          currentVersion { id version status content billingItems currency }
+          versions { id version status content billingItems currency }
         }
       }
     GQL
@@ -60,7 +60,8 @@ RSpec.describe Mutations::Quotes::Create do
           "status" => "draft",
           "version" => 1,
           "content" => "Test content",
-          "billingItems" => {}
+          "billingItems" => {},
+          "currency" => customer.currency
         }
       )
       expect(quote["versions"].size).to eq(1)

--- a/spec/graphql/types/orders/execution_record_spec.rb
+++ b/spec/graphql/types/orders/execution_record_spec.rb
@@ -10,5 +10,8 @@ RSpec.describe Types::Orders::ExecutionRecord do
     expect(subject).to have_field(:executed_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:execution_mode).of_type("OrderExecutionModeEnum")
     expect(subject).to have_field(:invoice_id).of_type("ID")
+    expect(subject).to have_field(:applied_coupon_ids).of_type("[ID!]!")
+    expect(subject).to have_field(:subscription_ids).of_type("[ID!]!")
+    expect(subject).to have_field(:wallet_ids).of_type("[ID!]!")
   end
 end

--- a/spec/graphql/types/orders/object_spec.rb
+++ b/spec/graphql/types/orders/object_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Types::Orders::Object do
     expect(subject).to have_field(:status).of_type("OrderStatusEnum!")
 
     expect(subject).to have_field(:billing_snapshot).of_type("JSON!")
-    expect(subject).to have_field(:currency).of_type("String")
+    expect(subject).to have_field(:currency).of_type("CurrencyEnum")
     expect(subject).to have_field(:execute_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:executed_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:execution_record).of_type("OrderExecutionRecord!")

--- a/spec/graphql/types/quote_versions/object_spec.rb
+++ b/spec/graphql/types/quote_versions/object_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Types::QuoteVersions::Object do
     expect(subject).to have_field(:voided_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
-    expect(subject).to have_field(:currency).of_type("String")
+    expect(subject).to have_field(:currency).of_type("CurrencyEnum")
     expect(subject).to have_field(:start_date).of_type("ISO8601Date")
     expect(subject).to have_field(:end_date).of_type("ISO8601Date")
   end

--- a/spec/graphql/types/quote_versions/update_input_spec.rb
+++ b/spec/graphql/types/quote_versions/update_input_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::QuoteVersions::UpdateInput do
+  subject { described_class }
+
+  it "has the expected arguments with correct types" do
+    expect(subject).to accept_argument(:billing_items).of_type("JSON")
+    expect(subject).to accept_argument(:content).of_type("String")
+    expect(subject).to accept_argument(:currency).of_type("CurrencyEnum")
+    expect(subject).to accept_argument(:end_date).of_type("ISO8601Date")
+    expect(subject).to accept_argument(:id).of_type("ID!")
+    expect(subject).to accept_argument(:start_date).of_type("ISO8601Date")
+  end
+end

--- a/spec/graphql/types/quotes/create_input_spec.rb
+++ b/spec/graphql/types/quotes/create_input_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Quotes::CreateInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:billing_items).of_type("JSON")
+    expect(subject).to accept_argument(:content).of_type("String")
+    expect(subject).to accept_argument(:customer_id).of_type("ID!")
+    expect(subject).to accept_argument(:end_date).of_type("ISO8601Date")
+    expect(subject).to accept_argument(:order_type).of_type("OrderTypeEnum!")
+    expect(subject).to accept_argument(:owners).of_type("[ID!]")
+    expect(subject).to accept_argument(:start_date).of_type("ISO8601Date")
+    expect(subject).to accept_argument(:subscription_id).of_type("ID")
+  end
+
+  it "does not accept a currency: the deal currency is derived at creation" do
+    expect(subject).not_to accept_argument(:currency)
+  end
+end

--- a/spec/models/quote_version_spec.rb
+++ b/spec/models/quote_version_spec.rb
@@ -61,6 +61,17 @@ RSpec.describe QuoteVersion do
         expect(quote_version).to be_valid
       end
     end
+
+    describe "currency" do
+      it "must be an ISO 4217 code when set" do
+        expect(build(:quote_version, currency: "EUR")).to be_valid
+        expect(build(:quote_version, currency: "DOUBLOON")).not_to be_valid
+      end
+
+      it "is allowed to be nil while the deal is not approved yet" do
+        expect(build(:quote_version, currency: nil)).to be_valid
+      end
+    end
   end
 
   describe "sequencing" do

--- a/spec/serializers/v1/order_serializer_spec.rb
+++ b/spec/serializers/v1/order_serializer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ::V1::OrderSerializer do
       "billing_snapshot" => order.billing_snapshot,
       "currency" => "EUR",
       "executed_at" => nil,
-      "execution_record" => order.execution_record,
+      "execution_record" => Order::EXECUTION_RECORD_DEFAULTS,
       "lago_organization_id" => order.organization_id,
       "lago_customer_id" => order.customer_id,
       "lago_order_form_id" => order.order_form_id,
@@ -36,7 +36,9 @@ RSpec.describe ::V1::OrderSerializer do
   context "when the order failed" do
     let(:order) { create(:order, :failed, organization:, customer:, order_form:) }
 
-    it "serializes the execution record trace" do
+    # The trace this factory writes predates the record id keys, so it stands in for a record
+    # written before this deploy.
+    it "completes the execution record shape" do
       result = JSON.parse(serializer.to_json)
 
       expect(result["order"]["status"]).to eq("failed")
@@ -44,6 +46,9 @@ RSpec.describe ::V1::OrderSerializer do
         "executed_at" => nil,
         "execution_mode" => "execute_in_lago",
         "invoice_id" => nil,
+        "subscription_ids" => [],
+        "applied_coupon_ids" => [],
+        "wallet_ids" => [],
         "errors" => ["currencies_does_not_match"]
       )
     end

--- a/spec/services/orders/execute_service_spec.rb
+++ b/spec/services/orders/execute_service_spec.rb
@@ -58,8 +58,29 @@ RSpec.describe Orders::ExecuteService do
         end
       end
 
-      context "when the order type is not supported yet" do
+      context "when the order is a subscription_creation" do
         let(:order_type) { :subscription_creation }
+
+        it "delegates to the subscription_creation execute service" do
+          allow(Orders::SubscriptionCreation::ExecuteService).to receive(:call).and_call_original
+
+          execute_service.call
+
+          expect(Orders::SubscriptionCreation::ExecuteService).to have_received(:call).with(order:)
+        end
+      end
+
+      context "when the order type is not supported yet" do
+        let(:order_type) { :subscription_amendment }
+        let(:quote) do
+          create(
+            :quote,
+            organization:,
+            customer:,
+            order_type:,
+            subscription: create(:subscription, organization:, customer:)
+          )
+        end
 
         it "returns a validation failure" do
           result = execute_service.call

--- a/spec/services/orders/one_off/execute_service_spec.rb
+++ b/spec/services/orders/one_off/execute_service_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe Orders::OneOff::ExecuteService do
         expect(order.execution_record["errors"]).to eq([])
       end
 
+      it "records the keys a one-off order creates nothing for" do
+        execute_service.call
+
+        order.reload
+        expect(order.execution_record["subscription_ids"]).to eq([])
+        expect(order.execution_record["applied_coupon_ids"]).to eq([])
+        expect(order.execution_record["wallet_ids"]).to eq([])
+      end
+
       it "bills the payload values" do
         execute_service.call
 

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -167,6 +167,20 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
           expect(commitment.amount_cents).to eq(50_000)
           expect(commitment.invoice_display_name).to eq("Yearly floor")
         end
+
+        context "when the override only renames the commitment" do
+          let(:plan_overrides) { super().merge("minimumCommitment" => {"invoiceDisplayName" => "Yearly floor"}) }
+
+          before { create(:commitment, plan:, amount_cents: 30_000) }
+
+          it "falls back to the plan's own amount" do
+            execute_service.call
+
+            commitment = customer.subscriptions.sole.plan.minimum_commitment
+            expect(commitment.amount_cents).to eq(30_000)
+            expect(commitment.invoice_display_name).to eq("Yearly floor")
+          end
+        end
       end
 
       context "with usage thresholds" do

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -153,6 +153,50 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
           expect(overridden.units).to eq(5)
           expect(overridden.properties["amount"]).to eq("80")
         end
+
+        context "when the catalog switched the fixed charge model since approval" do
+          # The snapshot keeps the model the approver was looking at.
+          let(:plan_payload) do
+            super().merge("fixedCharges" => [super()["fixedCharges"].sole.merge("chargeModel" => "standard")])
+          end
+          let(:graduated_properties) do
+            {"graduated_ranges" => [{"from_value" => 0, "to_value" => nil, "per_unit_amount" => "1", "flat_amount" => "0"}]}
+          end
+
+          before { fixed_charge.update!(charge_model: :graduated, properties: graduated_properties) }
+
+          it "records the failure and marks the order failed" do
+            result = nil
+            expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+            expect(result).not_to be_success
+
+            order.reload
+            expect(order.failed?).to eq(true)
+            expect(order.execution_record["errors"]).to eq(["fixed_charge_model_changed"])
+          end
+        end
+      end
+
+      context "when the catalog switched the charge model since approval" do
+        # The snapshot keeps the model the approver was looking at.
+        let(:plan_payload) do
+          super().merge("charges" => [super()["charges"].sole.merge("chargeModel" => "standard")])
+        end
+        let(:package_properties) { {"amount" => "50", "package_size" => 10, "free_units" => 0} }
+
+        before { charge.update!(charge_model: :package, properties: package_properties) }
+
+        it "records the failure and marks the order failed" do
+          result = nil
+          expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+          expect(result).not_to be_success
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["charge_model_changed"])
+        end
       end
 
       context "with a minimum commitment" do
@@ -505,6 +549,28 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
             expect(rule.target_ongoing_balance).to eq(500)
             expect(rule.grants_target_top_up).to eq(true)
             expect(rule.transaction_name).to eq("Monthly refill")
+          end
+        end
+
+        context "with a second wallet credit" do
+          let(:billing_items) do
+            super().merge(
+              "walletCredits" => super()["walletCredits"] + [
+                {
+                  "localId" => "3fd9b5cb-1a1e-4f8e-9ad6-8f6f45f9bd6c",
+                  "type" => "wallet_credit",
+                  "payload" => {"name" => "Overage credits", "rateAmount" => "2", "paidCredits" => "50", "grantedCredits" => "0"}
+                }
+              ]
+            )
+          end
+
+          it "creates both wallets and records both ids" do
+            expect { execute_service.call }.to change(Wallet, :count).by(2)
+
+            order.reload
+            expect(order.execution_record["wallet_ids"]).to match_array(customer.wallets.pluck(:id))
+            expect(customer.wallets.pluck(:code)).to match_array(%w[prepaid_credits overage_credits])
           end
         end
 

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -143,6 +143,39 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
         end
       end
 
+      context "when the customer is west of UTC" do
+        let(:customer) do
+          create(:customer, organization:, billing_entity:, currency: "EUR", timezone: "America/New_York")
+        end
+
+        it "reads the version dates as calendar dates in the customer timezone" do
+          execute_service.call
+
+          subscription = customer.subscriptions.sole
+          timezone = customer.applicable_timezone
+          expect(subscription.subscription_at.in_time_zone(timezone).to_date).to eq(quote_version.start_date)
+          expect(subscription.ending_at.in_time_zone(timezone).to_date).to eq(quote_version.end_date)
+        end
+
+        context "when the payload carries bare dates" do
+          let(:plan_payload) do
+            super().merge(
+              "startDate" => 3.days.from_now.to_date.iso8601,
+              "endDate" => 1.year.from_now.to_date.iso8601
+            )
+          end
+
+          it "reads them in the customer timezone too" do
+            execute_service.call
+
+            subscription = customer.subscriptions.sole
+            timezone = customer.applicable_timezone
+            expect(subscription.subscription_at.in_time_zone(timezone).to_date).to eq(3.days.from_now.to_date)
+            expect(subscription.ending_at.in_time_zone(timezone).to_date).to eq(1.year.from_now.to_date)
+          end
+        end
+      end
+
       context "when the payload carries a payment method" do
         let(:payment_method) { create(:payment_method, organization:, customer:) }
         let(:plan_payload) { super().merge("paymentMethodId" => payment_method.id) }

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -1,0 +1,407 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Orders::ExecuteService only dispatches here on a premium license, and plan overrides plus
+# recurring rules are premium-gated downstream.
+RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
+  subject(:execute_service) { described_class.new(order:) }
+
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
+  let(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
+  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {"amount" => "50"}) }
+
+  let(:plan_item) do
+    {
+      "id" => plan.id,
+      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "type" => "plan",
+      "payload" => plan_payload,
+      "overrides" => plan_overrides
+    }.compact
+  end
+  let(:plan_payload) do
+    {
+      "code" => plan.code,
+      "subscriptionExternalId" => "sub_ext_42",
+      "subscriptionName" => "Enterprise deal",
+      "billingTime" => "anniversary",
+      "charges" => [
+        {
+          "id" => charge.id,
+          "billableMetric" => {"code" => billable_metric.code},
+          "chargeModel" => charge.charge_model
+        }
+      ]
+    }
+  end
+  let(:plan_overrides) do
+    {
+      "amountCents" => 80_000,
+      "charges" => [
+        {
+          "billableMetricCode" => billable_metric.code,
+          "chargeModel" => charge.charge_model,
+          "properties" => {"amount" => "30"}
+        }
+      ]
+    }
+  end
+
+  let(:billing_items) { {"plans" => [plan_item]} }
+  let(:quote) { create(:quote, organization:, customer:, order_type: :subscription_creation) }
+  let(:quote_version) do
+    create(
+      :quote_version,
+      :approved,
+      quote:,
+      organization:,
+      currency: "EUR",
+      start_date: Date.current,
+      end_date: 1.year.from_now.to_date,
+      billing_items:
+    )
+  end
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+  let(:order) { create(:order, organization:, customer:, order_form:, execution_mode:) }
+  let(:execution_mode) { :execute_in_lago }
+
+  # Records are resolved by id only outside api context, and CurrentContext leaks across spec
+  # files (no global reset), so pin it.
+  before do
+    CurrentContext.source = nil
+    charge
+  end
+
+  describe "#call" do
+    context "with execute_in_lago mode" do
+      it "creates the subscription and marks the order executed" do
+        result = nil
+        expect { result = execute_service.call }.to change(Subscription, :count).by(1)
+
+        expect(result).to be_success
+
+        subscription = customer.subscriptions.sole
+        expect(subscription.external_id).to eq("sub_ext_42")
+        expect(subscription.name).to eq("Enterprise deal")
+        expect(subscription.billing_time).to eq("anniversary")
+        expect(subscription.ending_at.to_date).to eq(quote_version.end_date)
+
+        order.reload
+        expect(order.executed?).to eq(true)
+        expect(order.executed_at).to be_present
+        expect(order.execution_record["executed_at"]).to be_present
+        expect(order.execution_record["execution_mode"]).to eq("execute_in_lago")
+        expect(order.execution_record["invoice_id"]).to be_nil
+        expect(order.execution_record["subscription_ids"]).to eq([subscription.id])
+        expect(order.execution_record["errors"]).to eq([])
+      end
+
+      it "bills the negotiated plan through an override plan" do
+        execute_service.call
+
+        overridden_plan = customer.subscriptions.sole.plan
+        expect(overridden_plan.parent_id).to eq(plan.id)
+        expect(overridden_plan.amount_cents).to eq(80_000)
+        expect(overridden_plan.charges.sole.properties["amount"]).to eq("30")
+      end
+
+      context "without overrides" do
+        let(:plan_overrides) { nil }
+
+        it "subscribes to the catalog plan" do
+          execute_service.call
+
+          expect(customer.subscriptions.sole.plan).to eq(plan)
+        end
+      end
+
+      context "when the payload carries no external id" do
+        let(:plan_payload) { super().except("subscriptionExternalId") }
+
+        it "generates one" do
+          execute_service.call
+
+          expect(customer.subscriptions.sole.external_id).to be_present
+        end
+      end
+
+      context "when the payload carries dates" do
+        let(:plan_payload) do
+          super().merge("startDate" => 2.days.from_now.iso8601, "endDate" => 2.years.from_now.iso8601)
+        end
+
+        it "uses them over the version dates" do
+          execute_service.call
+
+          subscription = customer.subscriptions.sole
+          expect(subscription.subscription_at.to_date).to eq(2.days.from_now.to_date)
+          expect(subscription.ending_at.to_date).to eq(2.years.from_now.to_date)
+        end
+      end
+
+      context "when the payload carries a payment method" do
+        let(:payment_method) { create(:payment_method, organization:, customer:) }
+        let(:plan_payload) { super().merge("paymentMethodId" => payment_method.id) }
+
+        it "attaches it to the subscription" do
+          execute_service.call
+
+          expect(customer.subscriptions.sole.payment_method_id).to eq(payment_method.id)
+        end
+      end
+
+      context "with several plans" do
+        let(:other_plan) { create(:plan, organization:, amount_currency: "EUR") }
+        let(:billing_items) do
+          {
+            "plans" => [
+              plan_item,
+              {
+                "id" => other_plan.id,
+                "type" => "plan",
+                "payload" => {"code" => other_plan.code, "subscriptionExternalId" => "sub_ext_43"}
+              }
+            ]
+          }
+        end
+
+        it "creates one subscription per plan" do
+          expect { execute_service.call }.to change(Subscription, :count).by(2)
+
+          order.reload
+          expect(order.execution_record["subscription_ids"].count).to eq(2)
+        end
+      end
+
+      context "when the overridden charge is gone from the plan" do
+        before { charge.discard! }
+
+        it "records the failure and marks the order failed" do
+          result = nil
+          expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+          expect(result).not_to be_success
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["charge_not_found"])
+        end
+      end
+
+      context "when the plan is gone" do
+        before { plan.discard! }
+
+        it "records the failure and marks the order failed" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["plan_not_found"])
+        end
+      end
+
+      context "when the subscription creation fails" do
+        let(:failed_result) do
+          Subscriptions::CreateService::Result.new.tap do |failed|
+            failed.single_validation_failure!(field: :currency, error_code: "currencies_does_not_match")
+          end
+        end
+
+        before do
+          allow(Subscriptions::CreateService).to receive(:call!).and_raise(failed_result.error)
+        end
+
+        it "records the failure and marks the order failed" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["executed_at"]).to be_nil
+          expect(order.execution_record["subscription_ids"]).to eq([])
+          expect(order.execution_record["errors"]).to eq(["currencies_does_not_match"])
+        end
+      end
+
+      context "with a coupon" do
+        let(:coupon) { create(:coupon, organization:, amount_cents: 20_000, amount_currency: "EUR") }
+        let(:billing_items) do
+          super().merge(
+            "coupons" => [
+              {
+                "id" => coupon.id,
+                "localId" => "ba54903c-7bd5-4d40-8d51-45a5157005ff",
+                "type" => "coupon",
+                "payload" => {"code" => coupon.code, "type" => "fixed_amount", "amountCents" => 20_000},
+                "overrides" => {"amountCents" => 15_000}
+              }
+            ]
+          )
+        end
+
+        it "applies the negotiated amount" do
+          expect { execute_service.call }.to change(AppliedCoupon, :count).by(1)
+
+          applied_coupon = customer.applied_coupons.sole
+          expect(applied_coupon.coupon).to eq(coupon)
+          expect(applied_coupon.amount_cents).to eq(15_000)
+
+          order.reload
+          expect(order.execution_record["applied_coupon_ids"]).to eq([applied_coupon.id])
+        end
+
+        context "when the coupon is discarded" do
+          before { coupon.discard! }
+
+          it "records the failure and marks the order failed" do
+            result = nil
+            expect { result = execute_service.call }.not_to change(AppliedCoupon, :count)
+
+            expect(result).not_to be_success
+
+            order.reload
+            expect(order.failed?).to eq(true)
+            expect(order.execution_record["errors"]).to eq(["coupon_not_found"])
+          end
+        end
+      end
+
+      context "with a wallet credit" do
+        let(:billing_items) do
+          super().merge(
+            "walletCredits" => [
+              {
+                "localId" => "d9169d94-b322-4d70-a2b1-9e6a58e3f74a",
+                "type" => "wallet_credit",
+                "payload" => wallet_credit_payload
+              }
+            ]
+          )
+        end
+        let(:wallet_credit_payload) do
+          {
+            "name" => "Prepaid credits",
+            "currency" => "EUR",
+            "rateAmount" => "1",
+            "paidCredits" => "100",
+            "grantedCredits" => "10",
+            "appliesTo" => {"feeTypes" => ["charge"], "billableMetricCodes" => [billable_metric.code]}
+          }
+        end
+
+        it "creates the wallet with its limitation" do
+          expect { execute_service.call }.to change(Wallet, :count).by(1)
+
+          wallet = customer.wallets.sole
+          expect(wallet.name).to eq("Prepaid credits")
+          expect(wallet.rate_amount).to eq(1)
+          expect(wallet.allowed_fee_types).to eq(["charge"])
+          expect(wallet.billable_metrics).to eq([billable_metric])
+
+          order.reload
+          expect(order.execution_record["wallet_ids"]).to eq([wallet.id])
+        end
+
+        context "with a recurring rule" do
+          let(:wallet_credit_payload) do
+            super().merge(
+              "recurringTransactionRules" => [
+                {
+                  "trigger" => "interval",
+                  "interval" => "monthly",
+                  "method" => "target",
+                  "targetOngoingBalance" => "500",
+                  "grantsTargetTopUp" => true,
+                  "transactionName" => "Monthly refill"
+                }
+              ]
+            )
+          end
+
+          it "creates the rule" do
+            expect { execute_service.call }.to change(RecurringTransactionRule, :count).by(1)
+
+            rule = customer.wallets.sole.recurring_transaction_rules.sole
+            expect(rule.trigger).to eq("interval")
+            expect(rule.interval).to eq("monthly")
+            expect(rule.method).to eq("target")
+            expect(rule.target_ongoing_balance).to eq(500)
+            expect(rule.grants_target_top_up).to eq(true)
+            expect(rule.transaction_name).to eq("Monthly refill")
+          end
+        end
+
+        context "when a limitation metric no longer exists" do
+          let(:wallet_credit_payload) do
+            super().merge("appliesTo" => {"billableMetricCodes" => ["gone_metric"]})
+          end
+
+          it "records the failure and marks the order failed" do
+            result = nil
+            expect { result = execute_service.call }.not_to change(Wallet, :count)
+
+            expect(result).not_to be_success
+
+            order.reload
+            expect(order.failed?).to eq(true)
+            expect(order.execution_record["errors"]).to eq(["billable_metric_not_found"])
+          end
+        end
+      end
+    end
+
+    context "with order_only mode" do
+      let(:execution_mode) { :order_only }
+
+      it "marks the order executed without creating anything" do
+        result = nil
+        expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+        expect(result).to be_success
+
+        order.reload
+        expect(order.executed?).to eq(true)
+        expect(order.execution_record["execution_mode"]).to eq("order_only")
+        expect(order.execution_record["subscription_ids"]).to eq([])
+        expect(order.execution_record["errors"]).to eq([])
+      end
+    end
+
+    context "when the order is already executed" do
+      let(:order) { create(:order, :executed_in_lago, organization:, customer:, order_form:) }
+
+      it "is idempotent and does nothing" do
+        result = nil
+        expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+        expect(result).to be_success
+        expect(result.order).to eq(order)
+      end
+    end
+
+    context "when the order has no execution_mode" do
+      let(:order) { create(:order, organization:, customer:, order_form:, execution_mode: nil) }
+
+      it "returns a validation failure without touching the order" do
+        result = nil
+        expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:execution_mode]).to eq(["value_is_mandatory"])
+
+        order.reload
+        expect(order.executed?).to eq(false)
+        expect(order.execution_record).to eq({})
+      end
+    end
+  end
+end

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -122,10 +122,20 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
       context "when the payload carries no external id" do
         let(:plan_payload) { super().except("subscriptionExternalId") }
 
-        it "generates one" do
+        it "falls back to the quote line id" do
           execute_service.call
 
-          expect(customer.subscriptions.sole.external_id).to be_present
+          expect(customer.subscriptions.sole.external_id).to eq("3d08b2df-4e4c-4d58-b415-a525c1663735")
+        end
+
+        context "when the item carries no local id either" do
+          let(:plan_item) { super().except("localId") }
+
+          it "generates one" do
+            execute_service.call
+
+            expect(customer.subscriptions.sole.external_id).to be_present
+          end
         end
       end
 

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -177,6 +177,30 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
         end
       end
 
+      context "with two entries on the same plan" do
+        let(:billing_items) do
+          {
+            "plans" => [
+              plan_item,
+              {
+                "id" => plan.id,
+                "type" => "plan",
+                "payload" => {"code" => plan.code, "subscriptionExternalId" => "sub_ext_43"},
+                "overrides" => {"invoiceDisplayName" => "Second seat"}
+              }
+            ]
+          }
+        end
+
+        it "does not carry the first negotiated amount over to the second" do
+          expect { execute_service.call }.to change(Subscription, :count).by(2)
+
+          second_plan = customer.subscriptions.find_by(external_id: "sub_ext_43").plan
+          expect(second_plan.invoice_display_name).to eq("Second seat")
+          expect(second_plan.amount_cents).to eq(100_000)
+        end
+      end
+
       context "when the overridden charge is gone from the plan" do
         before { charge.discard! }
 

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -343,6 +343,24 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
         end
       end
 
+      # This is why QuoteVersions::Validators::SubscriptionCreation::BusinessValidator checks the
+      # negotiated properties at approve: Plans::OverrideService calls Charges::OverrideService
+      # without raise_if_error!, so the charge is dropped and the subscription bills nothing for the
+      # metric. Should this example ever fail, that service now surfaces the error and the executor
+      # can stop relying on approve alone.
+      context "when the negotiated properties are invalid for the charge model" do
+        let(:plan_overrides) do
+          super().merge("charges" => [super()["charges"].sole.merge("properties" => {"amount" => "not a number"})])
+        end
+
+        it "executes with the charge silently dropped from the override plan" do
+          result = execute_service.call
+
+          expect(result).to be_success
+          expect(customer.subscriptions.sole.plan.charges).to be_empty
+        end
+      end
+
       context "when the plan is gone" do
         before { plan.discard! }
 

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -119,6 +119,76 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
         end
       end
 
+      context "with a fixed charge override" do
+        let(:add_on) { create(:add_on, organization:, code: "seats") }
+        let(:fixed_charge) do
+          create(:fixed_charge, plan:, add_on:, units: 1, properties: {"amount" => "100"})
+        end
+        let(:plan_payload) do
+          super().merge(
+            "fixedCharges" => [
+              {
+                "id" => fixed_charge.id,
+                "addOn" => {"code" => add_on.code},
+                "chargeModel" => fixed_charge.charge_model
+              }
+            ]
+          )
+        end
+        let(:plan_overrides) do
+          super().merge(
+            "fixedCharges" => [
+              {"addOnCode" => add_on.code, "units" => "5", "properties" => {"amount" => "80"}}
+            ]
+          )
+        end
+
+        before { fixed_charge }
+
+        it "bills the negotiated fixed charge" do
+          execute_service.call
+
+          overridden = customer.subscriptions.sole.plan.fixed_charges.sole
+          expect(overridden.parent_id).to eq(fixed_charge.id)
+          expect(overridden.units).to eq(5)
+          expect(overridden.properties["amount"]).to eq("80")
+        end
+      end
+
+      context "with a minimum commitment" do
+        let(:plan_overrides) do
+          super().merge("minimumCommitment" => {"amountCents" => 50_000, "invoiceDisplayName" => "Yearly floor"})
+        end
+
+        it "creates it on the overridden plan" do
+          execute_service.call
+
+          commitment = customer.subscriptions.sole.plan.minimum_commitment
+          expect(commitment.amount_cents).to eq(50_000)
+          expect(commitment.invoice_display_name).to eq("Yearly floor")
+        end
+      end
+
+      context "with usage thresholds" do
+        let(:organization) { create(:organization, premium_integrations: ["progressive_billing"]) }
+        let(:plan_overrides) do
+          super().merge(
+            "usageThresholds" => [
+              {"amountCents" => 100_000, "recurring" => false, "thresholdDisplayName" => "First"},
+              {"amountCents" => 200_000, "recurring" => true, "thresholdDisplayName" => "Recurring cap"}
+            ]
+          )
+        end
+
+        it "creates them on the subscription, not on the overridden plan" do
+          execute_service.call
+
+          subscription = customer.subscriptions.sole
+          expect(subscription.usage_thresholds.pluck(:amount_cents)).to match_array([100_000, 200_000])
+          expect(subscription.plan.usage_thresholds).to be_empty
+        end
+      end
+
       context "when the payload carries no external id" do
         let(:plan_payload) { super().except("subscriptionExternalId") }
 

--- a/spec/services/quote_versions/validators/one_off/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/one_off/business_validator_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe QuoteVersions::Validators::OneOff::BusinessValidator do
     end
 
     context "when the currency is not ISO 4217" do
-      let(:quote_version) { create(:quote_version, quote:, organization:, currency: "DOUBLOON") }
+      let(:quote_version) { build(:quote_version, quote:, organization:, currency: "DOUBLOON") }
 
       it "returns an invalid_currency error" do
         expect(validator).not_to be_valid

--- a/spec/services/quote_versions/validators/one_off_validator_spec.rb
+++ b/spec/services/quote_versions/validators/one_off_validator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe QuoteVersions::Validators::OneOffValidator do
 
     context "with both structural and business errors" do
       let(:payload) { super().merge("units" => 0) }
-      let(:quote_version) { create(:quote_version, quote:, organization:, currency: "DOUBLOON", billing_items:) }
+      let(:quote_version) { build(:quote_version, quote:, organization:, currency: "DOUBLOON", billing_items:) }
 
       it "returns the structural errors first" do
         expect(validator).not_to be_valid

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
-    context "when the dates are missing" do
+    context "when the quote carries no dates" do
       let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR") }
 
       it "is valid at update scope" do
@@ -180,9 +180,11 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       context "when the scope is approve" do
         let(:scope) { :approve }
 
-        it "requires the start date" do
+        it "requires a start date on the plan" do
           expect(validator).not_to be_valid
-          expect(result.error.messages).to eq({start_date: ["value_is_mandatory"]})
+          expect(result.error.messages).to eq(
+            {"billing_items.plans.0.payload.startDate": ["value_is_mandatory"]}
+          )
         end
       end
     end
@@ -805,6 +807,43 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
       it "is valid" do
         expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
+      end
+    end
+
+    context "when the quote carries no dates and the plan start date is blank" do
+      let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR") }
+      let(:plan_payload) { super().merge("startDate" => "") }
+      let(:scope) { :approve }
+
+      it "returns an invalid_date error only" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.startDate": ["invalid_date"]})
+      end
+    end
+
+    context "when the quote carries no dates and only one plan carries its own" do
+      let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR") }
+      let(:plan_payload) { super().merge("startDate" => 6.months.from_now.iso8601) }
+      let(:other_plan) { create(:plan, organization:) }
+      let(:undated_plan_item) do
+        {"id" => other_plan.id, "type" => "plan", "payload" => {"code" => other_plan.code}}
+      end
+      let(:billing_items) { {"plans" => [plan_item, undated_plan_item]} }
+      let(:scope) { :approve }
+
+      it "reports only the plan carrying none" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.1.payload.startDate": ["value_is_mandatory"]}
+        )
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -930,6 +930,22 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
           expect(validator).not_to be_valid
           expect(result.error.messages).to eq({"billing_items.coupons.1.id": ["plan_overlapping"]})
         end
+
+        # overlapping_limitations? transcribes plan_limitation_overlapping? from the service below,
+        # and nothing else would fail if that one changed. Running the same pair through it keeps the
+        # two verdicts in step.
+        context "when the same pair reaches AppliedCoupons::CreateService" do
+          before { charge }
+
+          it "is refused there too" do
+            AppliedCoupons::CreateService.call!(customer:, coupon:, params: {})
+
+            applied = AppliedCoupons::CreateService.call(customer:, coupon: other_coupon, params: {})
+
+            expect(applied).not_to be_success
+            expect(applied.error.code).to eq("plan_overlapping")
+          end
+        end
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -406,6 +406,103 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the negotiated charge properties are invalid for the charge model" do
+      let(:charge_override) { super().merge("properties" => {"amount" => "not a number"}) }
+
+      it "returns the error the charge model itself raises" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.properties.amount": ["invalid_amount"]}
+        )
+      end
+    end
+
+    context "when the negotiated charge properties are empty" do
+      let(:charge_override) { super().merge("properties" => {}) }
+
+      it "returns an invalid_amount error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.properties.amount": ["invalid_amount"]}
+        )
+      end
+    end
+
+    context "when the negotiated charge properties were drafted for another charge model" do
+      let(:charge) { create(:graduated_charge, plan:, billable_metric:) }
+      let(:charge_override) { super().merge("chargeModel" => nil, "properties" => {"amount" => "100"}) }
+
+      it "returns a missing_graduated_ranges error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.properties.graduated_ranges": ["missing_graduated_ranges"]}
+        )
+      end
+    end
+
+    context "when the negotiated charge properties are not shaped for any charge model" do
+      let(:charge) { create(:graduated_charge, plan:, billable_metric:) }
+      let(:charge_override) do
+        super().merge("chargeModel" => nil, "properties" => {"graduated_ranges" => "one to ten"})
+      end
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.properties": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the charge override carries no properties" do
+      let(:charge_override) { super().except("properties") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the charge model moved and the properties no longer fit it" do
+      let(:charge_snapshot) { super().merge("chargeModel" => "graduated") }
+      let(:charge_override) { super().merge("chargeModel" => nil, "properties" => {"amount" => "100"}) }
+
+      it "only reports the charge model" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.payload.charges.0.chargeModel": ["charge_model_changed"]}
+        )
+      end
+    end
+
+    context "when the negotiated minimum lands on a charge billed in advance" do
+      let(:charge) { create(:standard_charge, plan:, billable_metric:, pay_in_advance: true) }
+      let(:charge_override) { super().merge("minAmountCents" => 1_000) }
+
+      it "returns a not_compatible_with_pay_in_advance error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.minAmountCents": ["not_compatible_with_pay_in_advance"]}
+        )
+      end
+    end
+
+    context "when the negotiated minimum is zero on a charge billed in advance" do
+      let(:charge) { create(:standard_charge, plan:, billable_metric:, pay_in_advance: true) }
+      let(:charge_override) { super().merge("minAmountCents" => 0) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the negotiated minimum lands on a charge billed in arrears" do
+      let(:charge_override) { super().merge("minAmountCents" => 1_000) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
     context "when the billable metric is discarded" do
       before do
         charge
@@ -467,6 +564,50 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
     context "when the snapshot fixed charge carries no charge model" do
       let(:fixed_charge_snapshot) { super().except("chargeModel") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the negotiated fixed charge properties are invalid for the charge model" do
+      let(:fixed_charge_override) { super().merge("properties" => {"amount" => "not a number"}) }
+
+      it "returns the error the charge model itself raises" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.properties.amount": ["invalid_amount"]}
+        )
+      end
+    end
+
+    # FixedCharges::OverrideService slices these away and FixedCharge then refuses blank properties.
+    context "when the negotiated fixed charge properties were drafted for another charge model" do
+      let(:fixed_charge_override) do
+        super().merge("properties" => {"graduated_ranges" => [{"from_value" => 0, "per_unit_amount" => "1"}]})
+      end
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.properties": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the negotiated fixed charge properties are empty" do
+      let(:fixed_charge_override) { super().merge("properties" => {}) }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.properties": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the negotiated fixed charge properties are valid" do
+      let(:fixed_charge_override) { super().merge("properties" => {"amount" => "42"}) }
 
       it "is valid" do
         expect(validator).to be_valid

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -30,8 +30,29 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
     {
       "id" => plan.id,
       "type" => "plan",
-      "payload" => {"code" => plan.code},
+      "payload" => plan_payload,
       "overrides" => plan_overrides
+    }
+  end
+  let(:plan_payload) do
+    {
+      "code" => plan.code,
+      "charges" => [charge_snapshot],
+      "fixedCharges" => [fixed_charge_snapshot]
+    }
+  end
+  let(:charge_snapshot) do
+    {
+      "id" => charge.id,
+      "billableMetric" => {"code" => billable_metric.code},
+      "chargeModel" => charge.charge_model
+    }
+  end
+  let(:fixed_charge_snapshot) do
+    {
+      "id" => fixed_charge.id,
+      "addOn" => {"code" => fixed_charge.add_on.code},
+      "chargeModel" => fixed_charge.charge_model
     }
   end
   let(:plan_overrides) do
@@ -44,8 +65,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
   let(:charge_override) do
     {
       "billableMetricCode" => charge.billable_metric.code,
-      "chargeModel" => "graduated",
-      "properties" => {"graduatedRanges" => []}
+      "chargeModel" => charge.charge_model,
+      "properties" => {"amount" => "100"}
     }
   end
   let(:fixed_charge_override) { {"addOnCode" => fixed_charge.add_on.code, "units" => "3"} }
@@ -285,8 +306,58 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
     context "when the charge is discarded" do
       before { charge.discard! }
 
-      it "is valid" do
-        expect(validator).to be_valid
+      it "returns a charge_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.billableMetricCode": ["charge_not_found"]}
+        )
+      end
+    end
+
+    context "when the plan has two charges on the overridden metric" do
+      before { create(:standard_charge, plan:, billable_metric:) }
+
+      let(:plan_payload) { super().merge("charges" => [charge_snapshot, charge_snapshot.merge("id" => plan.charges.last.id)]) }
+
+      it "returns an ambiguous_charge_override error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.billableMetricCode": ["ambiguous_charge_override"]}
+        )
+      end
+    end
+
+    context "when the snapshot carries no charges" do
+      let(:plan_payload) { super().except("charges") }
+
+      it "returns a charge_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.billableMetricCode": ["charge_not_found"]}
+        )
+      end
+    end
+
+    context "when the snapshot charge belongs to another plan" do
+      let(:other_charge) { create(:standard_charge, plan: create(:plan, organization:), billable_metric:) }
+      let(:charge_snapshot) { super().merge("id" => other_charge.id) }
+
+      it "returns a charge_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.billableMetricCode": ["charge_not_found"]}
+        )
+      end
+    end
+
+    context "when the override charge model differs from the charge" do
+      let(:charge_override) { super().merge("chargeModel" => "graduated") }
+
+      it "returns a cannot_override_charge_model error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.charges.0.chargeModel": ["cannot_override_charge_model"]}
+        )
       end
     end
 
@@ -315,8 +386,26 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
     context "when the fixed charge is discarded" do
       before { fixed_charge.discard! }
 
-      it "is valid" do
-        expect(validator).to be_valid
+      it "returns a fixed_charge_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.addOnCode": ["fixed_charge_not_found"]}
+        )
+      end
+    end
+
+    context "when the plan has two fixed charges on the overridden add-on" do
+      before { create(:fixed_charge, plan:, add_on: fixed_charge.add_on) }
+
+      let(:plan_payload) do
+        super().merge("fixedCharges" => [fixed_charge_snapshot, fixed_charge_snapshot.merge("id" => plan.fixed_charges.last.id)])
+      end
+
+      it "returns an ambiguous_fixed_charge_override error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.overrides.fixedCharges.0.addOnCode": ["ambiguous_fixed_charge_override"]}
+        )
       end
     end
 
@@ -405,6 +494,55 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
       it "is valid" do
         expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan payload dates are not ISO 8601" do
+      let(:plan_payload) { super().merge("startDate" => "not-a-date") }
+
+      it "returns an invalid_date error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.startDate": ["invalid_date"]})
+      end
+    end
+
+    context "when the plan payload endDate is before its startDate" do
+      let(:plan_payload) do
+        super().merge("startDate" => "2026-06-01T00:00:00Z", "endDate" => "2026-01-01T00:00:00Z")
+      end
+
+      it "returns an invalid_date_range error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.startDate": ["invalid_date_range"]})
+      end
+    end
+
+    context "when the plan payload dates are date-only" do
+      let(:plan_payload) { super().merge("startDate" => "2026-01-01", "endDate" => "2026-12-31") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan payload payment method belongs to the customer" do
+      let(:payment_method) { create(:payment_method, organization:, customer:) }
+      let(:plan_payload) { super().merge("paymentMethodId" => payment_method.id) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan payload payment method belongs to another customer" do
+      let(:payment_method) { create(:payment_method, organization:, customer: create(:customer, organization:)) }
+      let(:plan_payload) { super().merge("paymentMethodId" => payment_method.id) }
+
+      it "returns a payment_method_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.payload.paymentMethodId": ["payment_method_not_found"]}
+        )
       end
     end
 
@@ -718,6 +856,31 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq(
           {"billing_items.walletCredits.0.payload.currency": ["currencies_does_not_match"]}
+        )
+      end
+    end
+
+    context "when the wallet credit limits itself to a known billable metric" do
+      let(:wallet_credit_payload) do
+        super().merge("appliesTo" => {"feeTypes" => ["charge"], "billableMetricCodes" => [billable_metric.code]})
+      end
+
+      before { billable_metric }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the wallet credit limits itself to an unknown billable metric" do
+      let(:wallet_credit_payload) do
+        super().merge("appliesTo" => {"billableMetricCodes" => ["unknown_metric"]})
+      end
+
+      it "returns a billable_metric_not_found error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.walletCredits.0.payload.appliesTo.billableMetricCodes": ["billable_metric_not_found"]}
         )
       end
     end

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -525,6 +525,52 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the plan payload dates fall on the same day" do
+      let(:plan_payload) do
+        super().merge("startDate" => "2026-06-01T08:00:00Z", "endDate" => "2026-06-01T18:00:00Z")
+      end
+
+      it "returns an invalid_date_range error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.startDate": ["invalid_date_range"]})
+      end
+    end
+
+    context "when the plan payload only overrides the start date, past the quote end date" do
+      let(:plan_payload) { super().merge("startDate" => "2027-01-01T00:00:00Z") }
+
+      it "returns an invalid_date_range error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.startDate": ["invalid_date_range"]})
+      end
+    end
+
+    context "when the plan payload only overrides the end date, before the quote start date" do
+      let(:plan_payload) { super().merge("endDate" => "2025-12-31T00:00:00Z") }
+
+      it "returns an invalid_date_range error on the end date" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.endDate": ["invalid_date_range"]})
+      end
+    end
+
+    context "when the plan payload only overrides the start date, inside the quote range" do
+      let(:plan_payload) { super().merge("startDate" => "2026-06-01T00:00:00Z") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the quote carries no dates and the plan overrides one" do
+      let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR") }
+      let(:plan_payload) { super().merge("startDate" => "2026-06-01T00:00:00Z") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
     context "when the plan payload payment method belongs to the customer" do
       let(:payment_method) { create(:payment_method, organization:, customer:) }
       let(:plan_payload) { super().merge("paymentMethodId" => payment_method.id) }

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -387,6 +387,25 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the snapshot charge model differs from the charge" do
+      let(:charge_snapshot) { super().merge("chargeModel" => "graduated") }
+
+      it "returns a charge_model_changed error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.payload.charges.0.chargeModel": ["charge_model_changed"]}
+        )
+      end
+    end
+
+    context "when the snapshot charge carries no charge model" do
+      let(:charge_snapshot) { super().except("chargeModel") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
     context "when the billable metric is discarded" do
       before do
         charge
@@ -432,6 +451,25 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
         expect(result.error.messages).to eq(
           {"billing_items.plans.0.overrides.fixedCharges.0.addOnCode": ["ambiguous_fixed_charge_override"]}
         )
+      end
+    end
+
+    context "when the snapshot fixed charge model differs from the fixed charge" do
+      let(:fixed_charge_snapshot) { super().merge("chargeModel" => "graduated") }
+
+      it "returns a fixed_charge_model_changed error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.payload.fixedCharges.0.chargeModel": ["fixed_charge_model_changed"]}
+        )
+      end
+    end
+
+    context "when the snapshot fixed charge carries no charge model" do
+      let(:fixed_charge_snapshot) { super().except("chargeModel") }
+
+      it "is valid" do
+        expect(validator).to be_valid
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
     context "when the currency is not ISO 4217" do
       let(:quote_version) do
-        create(
+        build(
           :quote_version,
           quote:,
           organization:,

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       quote:,
       organization:,
       currency: "EUR",
-      start_date: Date.parse("2026-01-01"),
-      end_date: Date.parse("2026-12-31")
+      start_date: Date.current,
+      end_date: 1.year.from_now.to_date
     )
   end
   let(:plan) { create(:plan, organization:) }
@@ -133,8 +133,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
           quote:,
           organization:,
           currency: nil,
-          start_date: Date.parse("2026-01-01"),
-          end_date: Date.parse("2026-12-31")
+          start_date: Date.current,
+          end_date: 1.year.from_now.to_date
         )
       end
 
@@ -159,8 +159,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
           quote:,
           organization:,
           currency: "DOUBLOON",
-          start_date: Date.parse("2026-01-01"),
-          end_date: Date.parse("2026-12-31")
+          start_date: Date.current,
+          end_date: 1.year.from_now.to_date
         )
       end
 
@@ -212,8 +212,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
           quote:,
           organization:,
           currency: "EUR",
-          start_date: Date.parse("2026-12-31"),
-          end_date: Date.parse("2026-01-01")
+          start_date: 1.year.from_now.to_date,
+          end_date: 1.month.from_now.to_date
         )
       end
 
@@ -230,14 +230,40 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
           quote:,
           organization:,
           currency: "EUR",
-          start_date: Date.parse("2026-01-01"),
-          end_date: Date.parse("2026-01-01")
+          start_date: 1.month.from_now.to_date,
+          end_date: 1.month.from_now.to_date
         )
       end
 
       it "returns an invalid_date_range error at update scope" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq({start_date: ["invalid_date_range"]})
+      end
+    end
+
+    context "when the end date is today" do
+      let(:quote_version) do
+        create(
+          :quote_version,
+          quote:,
+          organization:,
+          currency: "EUR",
+          start_date: 1.month.ago.to_date,
+          end_date: Date.current
+        )
+      end
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "returns an invalid_date error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({end_date: ["invalid_date"]})
+        end
       end
     end
 
@@ -508,17 +534,19 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
     context "when the plan payload endDate is before its startDate" do
       let(:plan_payload) do
-        super().merge("startDate" => "2026-06-01T00:00:00Z", "endDate" => "2026-01-01T00:00:00Z")
+        super().merge("startDate" => 6.months.from_now.iso8601, "endDate" => 3.months.from_now.iso8601)
       end
 
-      it "returns an invalid_date_range error" do
+      it "returns an invalid_date_range error on the end date" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.payload.startDate": ["invalid_date_range"]})
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.endDate": ["invalid_date_range"]})
       end
     end
 
     context "when the plan payload dates are date-only" do
-      let(:plan_payload) { super().merge("startDate" => "2026-01-01", "endDate" => "2026-12-31") }
+      let(:plan_payload) do
+        super().merge("startDate" => Date.current.iso8601, "endDate" => 1.year.from_now.to_date.iso8601)
+      end
 
       it "is valid" do
         expect(validator).to be_valid
@@ -527,17 +555,20 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
     context "when the plan payload dates fall on the same day" do
       let(:plan_payload) do
-        super().merge("startDate" => "2026-06-01T08:00:00Z", "endDate" => "2026-06-01T18:00:00Z")
+        super().merge(
+          "startDate" => 6.months.from_now.beginning_of_day.iso8601,
+          "endDate" => 6.months.from_now.end_of_day.iso8601
+        )
       end
 
-      it "returns an invalid_date_range error" do
+      it "returns an invalid_date_range error on the end date" do
         expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.payload.startDate": ["invalid_date_range"]})
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.endDate": ["invalid_date_range"]})
       end
     end
 
     context "when the plan payload only overrides the start date, past the quote end date" do
-      let(:plan_payload) { super().merge("startDate" => "2027-01-01T00:00:00Z") }
+      let(:plan_payload) { super().merge("startDate" => 2.years.from_now.iso8601) }
 
       it "returns an invalid_date_range error" do
         expect(validator).not_to be_valid
@@ -546,7 +577,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
     end
 
     context "when the plan payload only overrides the end date, before the quote start date" do
-      let(:plan_payload) { super().merge("endDate" => "2025-12-31T00:00:00Z") }
+      let(:plan_payload) { super().merge("endDate" => 1.day.ago.iso8601) }
 
       it "returns an invalid_date_range error on the end date" do
         expect(validator).not_to be_valid
@@ -554,8 +585,35 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the plan payload endDate is today" do
+      let(:quote_version) do
+        create(
+          :quote_version,
+          quote:,
+          organization:,
+          currency: "EUR",
+          start_date: 1.month.ago.to_date,
+          end_date: 1.year.from_now.to_date
+        )
+      end
+      let(:plan_payload) { super().merge("endDate" => Time.current.iso8601) }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "returns an invalid_date error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({"billing_items.plans.0.payload.endDate": ["invalid_date"]})
+        end
+      end
+    end
+
     context "when the plan payload only overrides the start date, inside the quote range" do
-      let(:plan_payload) { super().merge("startDate" => "2026-06-01T00:00:00Z") }
+      let(:plan_payload) { super().merge("startDate" => 6.months.from_now.iso8601) }
 
       it "is valid" do
         expect(validator).to be_valid
@@ -564,7 +622,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
 
     context "when the quote carries no dates and the plan overrides one" do
       let(:quote_version) { create(:quote_version, quote:, organization:, currency: "EUR") }
-      let(:plan_payload) { super().merge("startDate" => "2026-06-01T00:00:00Z") }
+      let(:plan_payload) { super().merge("startDate" => 6.months.from_now.iso8601) }
 
       it "is valid" do
         expect(validator).to be_valid

--- a/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/business_validator_spec.rb
@@ -714,6 +714,84 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::BusinessValidato
       end
     end
 
+    context "when the same non-reusable coupon is applied twice" do
+      let(:coupon) { create(:coupon, organization:, reusable: false) }
+      let(:billing_items) { super().merge("coupons" => [coupon_item, coupon_item]) }
+
+      it "returns a coupon_is_not_reusable error on the second one" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.coupons.1.id": ["coupon_is_not_reusable"]})
+      end
+    end
+
+    context "when the same reusable coupon is applied twice" do
+      let(:billing_items) { super().merge("coupons" => [coupon_item, coupon_item]) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "with a second coupon" do
+      let(:other_coupon) { create(:coupon, organization:) }
+      let(:other_coupon_item) do
+        {
+          "id" => other_coupon.id,
+          "localId" => "4c0e5e21-9f38-4a2b-8c7d-6e5f4a3b2c1d",
+          "payload" => {"code" => other_coupon.code, "type" => "fixed_amount", "amountCents" => 10_000}
+        }
+      end
+      let(:billing_items) { super().merge("coupons" => [coupon_item, other_coupon_item]) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      context "when both are limited to the same plan" do
+        let(:coupon) { create(:coupon, organization:, limited_plans: true) }
+        let(:other_coupon) { create(:coupon, organization:, limited_plans: true) }
+
+        before do
+          create(:coupon_plan, coupon:, plan:)
+          create(:coupon_plan, coupon: other_coupon, plan:)
+        end
+
+        it "returns a plan_overlapping error on the second one" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({"billing_items.coupons.1.id": ["plan_overlapping"]})
+        end
+      end
+
+      context "when they are limited to different plans" do
+        let(:coupon) { create(:coupon, organization:, limited_plans: true) }
+        let(:other_coupon) { create(:coupon, organization:, limited_plans: true) }
+
+        before do
+          create(:coupon_plan, coupon:, plan:)
+          create(:coupon_plan, coupon: other_coupon, plan: create(:plan, organization:))
+        end
+
+        it "is valid" do
+          expect(validator).to be_valid
+        end
+      end
+
+      context "when one is limited to a plan and the other to a metric that plan charges" do
+        let(:coupon) { create(:coupon, organization:, limited_plans: true) }
+        let(:other_coupon) { create(:coupon, organization:, limited_billable_metrics: true) }
+
+        before do
+          create(:coupon_plan, coupon:, plan:)
+          create(:coupon_billable_metric, coupon: other_coupon, billable_metric:)
+        end
+
+        it "returns a plan_overlapping error on the second one" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq({"billing_items.coupons.1.id": ["plan_overlapping"]})
+        end
+      end
+    end
+
     context "when a fixed_amount coupon currency differs from the version currency" do
       let(:coupon) { create(:coupon, organization:, amount_currency: "USD") }
 

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -21,8 +21,28 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       "code" => "base_plan",
       "name" => "Base Plan",
       "subscriptionExternalId" => "sub_ext_123",
+      "subscriptionName" => "Main subscription",
+      "billingTime" => "anniversary",
+      "startDate" => "2026-01-01T00:00:00Z",
+      "endDate" => "2026-12-31T00:00:00Z",
+      "paymentMethodId" => "b1a1d0dc-3e2a-4e12-8f2a-16f0d5b7a0c1",
       "amountCents" => "10000",
-      "charges" => [{"billableMetric" => {"code" => "api_calls"}, "chargeModel" => "standard"}]
+      "charges" => [charge_snapshot],
+      "fixedCharges" => [fixed_charge_snapshot]
+    }
+  end
+  let(:charge_snapshot) do
+    {
+      "id" => "9c4681ce-b915-486a-9d94-a294d444a89b",
+      "billableMetric" => {"code" => "api_calls", "name" => "API calls"},
+      "chargeModel" => "standard"
+    }
+  end
+  let(:fixed_charge_snapshot) do
+    {
+      "id" => "2f3a1b8c-5d6e-4f70-8a91-b2c3d4e5f607",
+      "addOn" => {"code" => "seats", "name" => "Seats"},
+      "chargeModel" => "standard"
     }
   end
   let(:plan_overrides) do
@@ -251,6 +271,63 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       it "returns an invalid_value error" do
         expect(validator).not_to be_valid
         expect(result.error.messages).to eq({"billing_items.plans.0.payload.code": ["invalid_value"]})
+      end
+    end
+
+    context "when the plan payload billingTime is not in the enum" do
+      let(:plan_payload) { super().merge("billingTime" => "monthly") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.billingTime": ["invalid_value"]})
+      end
+    end
+
+    context "when the plan payload paymentMethodId is not a uuid" do
+      let(:plan_payload) { super().merge("paymentMethodId" => "not-a-uuid") }
+
+      it "returns an invalid_format error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.paymentMethodId": ["invalid_format"]})
+      end
+    end
+
+    context "when the plan payload dates are date-only" do
+      let(:plan_payload) { super().merge("startDate" => "2026-01-01", "endDate" => "2026-12-31") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when a snapshot charge id is not a uuid" do
+      let(:charge_snapshot) { super().merge("id" => "not-a-uuid") }
+
+      it "returns an invalid_format error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.charges.0.id": ["invalid_format"]})
+      end
+    end
+
+    context "when a snapshot charge chargeModel is not in the enum" do
+      let(:charge_snapshot) { super().merge("chargeModel" => "flat") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.payload.charges.0.chargeModel": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when a snapshot fixed charge chargeModel is not a fixed charge model" do
+      let(:fixed_charge_snapshot) { super().merge("chargeModel" => "package") }
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.plans.0.payload.fixedCharges.0.chargeModel": ["invalid_value"]}
+        )
       end
     end
 
@@ -701,6 +778,38 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
 
       it "is valid at update scope" do
         expect(validator).to be_valid
+      end
+    end
+
+    context "when the wallet credit appliesTo carries an unknown fee type" do
+      let(:wallet_credit_payload) do
+        super().merge("appliesTo" => {"feeTypes" => ["bogus"], "billableMetricCodes" => []})
+      end
+
+      it "returns an invalid_value error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq(
+          {"billing_items.walletCredits.0.payload.appliesTo.feeTypes.0": ["invalid_value"]}
+        )
+      end
+    end
+
+    context "when the wallet credit carries two recurring rules" do
+      let(:wallet_credit_payload) { super().merge("recurringTransactionRules" => [recurring_rule, recurring_rule]) }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "returns an invalid_count error" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.walletCredits.0.payload.recurringTransactionRules": ["invalid_count"]}
+          )
+        end
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation/structural_validator_spec.rb
@@ -331,6 +331,82 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreation::StructuralValida
       end
     end
 
+    context "when a snapshot charge carries no id" do
+      let(:charge_snapshot) { super().except("id") }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "requires the id the override is resolved through" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.plans.0.payload.charges.0.id": ["value_is_mandatory"]}
+          )
+        end
+      end
+    end
+
+    context "when a snapshot charge billable metric carries no code" do
+      let(:charge_snapshot) { super().merge("billableMetric" => {"name" => "API calls"}) }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "requires the code the override is matched on" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.plans.0.payload.charges.0.billableMetric.code": ["value_is_mandatory"]}
+          )
+        end
+      end
+    end
+
+    context "when a snapshot fixed charge carries no id" do
+      let(:fixed_charge_snapshot) { super().except("id") }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "requires the id the override is resolved through" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.plans.0.payload.fixedCharges.0.id": ["value_is_mandatory"]}
+          )
+        end
+      end
+    end
+
+    context "when a snapshot fixed charge add-on carries no code" do
+      let(:fixed_charge_snapshot) { super().merge("addOn" => {"name" => "Seats"}) }
+
+      it "is valid at update scope" do
+        expect(validator).to be_valid
+      end
+
+      context "when the scope is approve" do
+        let(:scope) { :approve }
+
+        it "requires the code the override is matched on" do
+          expect(validator).not_to be_valid
+          expect(result.error.messages).to eq(
+            {"billing_items.plans.0.payload.fixedCharges.0.addOn.code": ["value_is_mandatory"]}
+          )
+        end
+      end
+    end
+
     context "when the plan overrides is null" do
       let(:plan_overrides) { nil }
 

--- a/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_creation_validator_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe QuoteVersions::Validators::SubscriptionCreationValidator do
     context "with both structural and business errors" do
       let(:plan_item) { super().merge("overrides" => {"amountCents" => -1}) }
       let(:quote_version) do
-        create(
+        build(
           :quote_version,
           quote:,
           organization:,

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Quotes::CreateService do
       content: "Test content",
       order_type: :subscription_creation,
       owners: [owner.id],
-      currency: "USD",
       start_date:,
       end_date:
     }
@@ -50,10 +49,20 @@ RSpec.describe Quotes::CreateService do
           expect(result.quote.current_version.draft?).to eq(true)
           expect(result.quote.current_version.content).to eq("Test content")
           expect(result.quote.current_version.billing_items).to eq({})
-          expect(result.quote.current_version.currency).to eq("USD")
+          expect(result.quote.current_version.currency).to eq("EUR")
           expect(result.quote.current_version.start_date).to eq(start_date)
           expect(result.quote.current_version.end_date).to eq(end_date)
         end
+      end
+    end
+
+    context "when the customer has no currency", :premium do
+      let(:customer) { create(:customer, organization:, currency: nil) }
+
+      it "falls back to the billing entity default currency" do
+        expect(result).to be_success
+        expect(customer.billing_entity.default_currency).to eq("USD")
+        expect(result.quote.current_version.currency).to eq("USD")
       end
     end
 
@@ -62,7 +71,6 @@ RSpec.describe Quotes::CreateService do
       let(:create_params) do
         {
           order_type: :one_off,
-          currency: "EUR",
           billing_items: {
             "addOns" => [
               {
@@ -91,7 +99,6 @@ RSpec.describe Quotes::CreateService do
         let(:create_params) do
           {
             order_type: :one_off,
-            currency: "EUR",
             billing_items: {
               "addOns" => [{"id" => "not-a-uuid", "localId" => "l1", "type" => "add_on", "payload" => {}}]
             }
@@ -108,7 +115,8 @@ RSpec.describe Quotes::CreateService do
     end
 
     context "when subscription is required and provided correctly", :premium do
-      let(:subscription) { create(:subscription, organization:, customer:) }
+      let(:plan) { create(:plan, organization:, amount_currency: "USD") }
+      let(:subscription) { create(:subscription, organization:, customer:, plan:) }
       let(:create_params) do
         {
           billing_items: {},
@@ -122,6 +130,11 @@ RSpec.describe Quotes::CreateService do
         expect(result).to be_success
         expect(result.quote.subscription_id).to eq(subscription.id)
         expect(result.quote.order_type).to eq("subscription_amendment")
+      end
+
+      it "takes the currency from the subscription plan" do
+        expect(customer.currency).to eq("EUR")
+        expect(result.quote.current_version.currency).to eq("USD")
       end
     end
 


### PR DESCRIPTION
## Why

`Orders::ExecuteService` dispatched `one_off` only, so a `subscription_creation` quote could be drafted, approved, signed and turned into an order, then stopped with `order_type: ["unsupported_order_type"]`. This is the execution half of the spec whose validation half is #6069, mirroring how one_off shipped as #5860 then #5953.

Executing such an order means turning the frozen `billing_items` snapshot into real records: a subscription per `plans` entry with its negotiated overrides, an applied coupon per `coupons` entry, and a wallet per `walletCredits` entry.

## What

**Make the contract executable.** `Subscriptions::CreateService` needs fields the contract did not declare, `external_id` above all, which it does not generate outside a controller. The frontend already sends them inside the free-form plan `payload`, where nothing validated them, so `billingTime: "monthly"` or a stale `paymentMethodId` would only surface at execution and leave the order failed. They are now declared and checked at approve, along with the payment method belonging to the quote's customer, per-plan date coherence, wallet metric limitations resolving, and a single recurring rule per wallet since `Wallets::ValidateService` refuses more.

**Resolve charge overrides through the snapshot.** `billing_items` references charges by `billableMetricCode` while `Plans::OverrideService` keys on charge UUID, and the payload already carries both side by side. Resolving there pins the charge the approver was looking at rather than whatever the catalog holds at execution time. Approval now refuses a code with no snapshot entry, a code matching several, an id no longer on the plan, and a charge model that drifted, because `Plans::OverrideService` silently ignores an id it cannot find and `Charges::OverrideService` cannot switch models: either case would bill catalog pricing instead of the negotiated price. The executor re-checks the id against the live plan for the same reason.

**Add the executor.** `Orders::SubscriptionCreation::ExecuteService` creates subscriptions, then applied coupons, then wallets in one transaction under the quote's advisory lock, reusing the one_off executor's idempotency, `execution_mode` guard and durable failure trace. Subscriptions come first so the customer currency they settle is the one coupons and wallets reuse.

**Record what an execution produced.** `execution_record` gains `subscription_ids`, `applied_coupon_ids` and `wallet_ids`, exposed on `OrderExecutionRecord`. Nothing else linked an order to its output: `quotes.subscription_id` is only populated for amendments, and `invoice_id` stays null here because a subscription is invoiced later by `BillSubscriptionJob`, and only when the plan is paid in advance.

## Notes for the reviewer

- A charge or fixed charge discarded since the quote was approved now fails validation instead of passing. That is a behaviour change to the validator merged in #6069, and it is deliberate: the override would otherwise vanish silently.
- `ending_at` falls back to the quote's `end_date`, so every subscription created from a quote terminates at the contract end. If a quote's end date means the offer's validity rather than the contract term, this mapping should drop `ending_at` instead.
- Known gaps carried, not fixed: a discarded coupon or plan fails at execution rather than at approve, the customer currency mismatch still surfaces in `Customers::UpdateCurrencyService`, and an `subscriptionExternalId` colliding with a live subscription makes `Subscriptions::CreateService` reuse or upgrade it rather than create one.

## Stacked on

#6069, review and merge that first.
