### PR TITLE
fix(exports): include date range for add-on fees

### DIFF
--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -116,8 +116,8 @@ module DataExports
       def fee_period_dates(fee, billing_period, timezone)
         datetimes = [billing_period&.from_datetime, billing_period&.to_datetime]
 
-        # Add-on dates always use UTC start and end of day, regardless of the customer timezone.
-        # Keep the stored dates instead of converting them to the customer timezone.
+        # Add-on periods use the UTC date of each timestamp.
+        # Unlike other fees, do not convert them to the customer timezone.
         if fee.add_on?
           return datetimes.map { |datetime| datetime&.to_date }
         end

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -77,6 +77,7 @@ module DataExports
             billing_period = if invoice_subscription || fee.add_on?
               DataExports::Csv::ResolveFeeBillingPeriodService.call!(fee:, invoice_subscription:)
             end
+            fee_from_date, fee_to_date = fee_period_dates(fee, billing_period, timezone)
 
             serialized_subscription = {
               external_id: fee.subscription&.external_id,
@@ -97,8 +98,8 @@ module DataExports
               serialized_fee.dig(:item, :grouped_by),
               serialized_subscription[:external_id],
               serialized_subscription[:plan_code],
-              period_date(billing_period&.from_datetime, timezone),
-              period_date(billing_period&.to_datetime, timezone),
+              fee_from_date,
+              fee_to_date,
               serialized_fee[:total_amount_currency],
               serialized_fee[:units],
               serialized_fee[:precise_unit_amount],
@@ -110,6 +111,18 @@ module DataExports
 
       def period_date(datetime, timezone)
         datetime&.in_time_zone(timezone)&.to_date
+      end
+
+      def fee_period_dates(fee, billing_period, timezone)
+        datetimes = [billing_period&.from_datetime, billing_period&.to_datetime]
+
+        # Add-on dates always use UTC start and end of day, regardless of the customer timezone.
+        # Keep the stored dates instead of converting them to the customer timezone.
+        if fee.add_on?
+          return datetimes.map { |datetime| datetime&.to_date }
+        end
+
+        datetimes.map { |datetime| period_date(datetime, timezone) }
       end
 
       def collection

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -74,7 +74,7 @@ module DataExports
             serialized_fee = fee_serializer_klass.new(fee).serialize
             invoice_subscription = invoice_subscriptions[fee.subscription_id]
 
-            billing_period = if invoice_subscription
+            billing_period = if invoice_subscription || fee.add_on?
               DataExports::Csv::ResolveFeeBillingPeriodService.call!(fee:, invoice_subscription:)
             end
 

--- a/app/services/data_exports/csv/resolve_fee_billing_period_service.rb
+++ b/app/services/data_exports/csv/resolve_fee_billing_period_service.rb
@@ -34,6 +34,8 @@ module DataExports
           properties_period("from_datetime", "to_datetime") || commitment_period
         when :charge
           charge_period
+        when :add_on
+          properties_period("from_datetime", "to_datetime")
         else
           charges_period
         end

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -328,11 +328,10 @@ RSpec.describe DataExports::Csv::InvoiceFees do
       end
 
       context "with an add-on fee" do
-        let(:timezone) { "America/New_York" }
         let(:add_on_boundaries) do
           {
-            "from_datetime" => "2026-06-22T04:00:00Z",
-            "to_datetime" => "2026-07-22T03:59:59Z"
+            "from_datetime" => "2026-08-04T00:00:00Z",
+            "to_datetime" => "2026-08-04T23:59:59Z"
           }
         end
         let(:exported_fee) { add_on_fee }
@@ -340,8 +339,24 @@ RSpec.describe DataExports::Csv::InvoiceFees do
         shared_examples "exports the stored add-on period" do
           before { add_on_fee }
 
-          it "exports the fee's stored period in the customer timezone" do
-            expect(exported_period).to eq(%w[2026-06-22 2026-07-21])
+          it "exports the stored calendar dates in UTC" do
+            expect(exported_period).to eq(%w[2026-08-04 2026-08-04])
+          end
+
+          context "when the customer has a negative UTC offset" do
+            let(:timezone) { "America/New_York" }
+
+            it "does not move the start date back one day" do
+              expect(exported_period).to eq(%w[2026-08-04 2026-08-04])
+            end
+          end
+
+          context "when the customer has a positive UTC offset" do
+            let(:timezone) { "Asia/Tokyo" }
+
+            it "does not move the end date forward one day" do
+              expect(exported_period).to eq(%w[2026-08-04 2026-08-04])
+            end
           end
         end
 

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -326,6 +326,24 @@ RSpec.describe DataExports::Csv::InvoiceFees do
           expect(exported_period).to eq(%w[2026-06-22 2026-07-21])
         end
       end
+
+      context "with a one-off add-on fee" do
+        let(:advance_fee) do
+          create(:add_on_fee,
+            invoice:,
+            organization: customer.organization,
+            properties: {
+              "from_datetime" => "2026-06-22T00:00:00Z",
+              "to_datetime" => "2026-07-21T23:59:59Z"
+            })
+        end
+
+        before { advance_fee }
+
+        it "exports the fee's stored period" do
+          expect(exported_period).to eq(%w[2026-06-22 2026-07-21])
+        end
+      end
     end
   end
 end

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -327,21 +327,44 @@ RSpec.describe DataExports::Csv::InvoiceFees do
         end
       end
 
-      context "with a one-off add-on fee" do
-        let(:advance_fee) do
-          create(:add_on_fee,
-            invoice:,
-            organization: customer.organization,
-            properties: {
-              "from_datetime" => "2026-06-22T00:00:00Z",
-              "to_datetime" => "2026-07-21T23:59:59Z"
-            })
+      context "with an add-on fee" do
+        let(:timezone) { "America/New_York" }
+        let(:add_on_boundaries) do
+          {
+            "from_datetime" => "2026-06-22T04:00:00Z",
+            "to_datetime" => "2026-07-22T03:59:59Z"
+          }
+        end
+        let(:exported_fee) { add_on_fee }
+
+        shared_examples "exports the stored add-on period" do
+          before { add_on_fee }
+
+          it "exports the fee's stored period in the customer timezone" do
+            expect(exported_period).to eq(%w[2026-06-22 2026-07-21])
+          end
         end
 
-        before { advance_fee }
+        context "with a one-off fee" do
+          let(:add_on_fee) do
+            create(:one_off_fee,
+              invoice:,
+              organization: customer.organization,
+              properties: add_on_boundaries)
+          end
 
-        it "exports the fee's stored period" do
-          expect(exported_period).to eq(%w[2026-06-22 2026-07-21])
+          it_behaves_like "exports the stored add-on period"
+        end
+
+        context "with a legacy applied add-on fee" do
+          let(:add_on_fee) do
+            create(:add_on_fee,
+              invoice:,
+              organization: customer.organization,
+              properties: add_on_boundaries)
+          end
+
+          it_behaves_like "exports the stored add-on period"
         end
       end
     end

--- a/spec/services/data_exports/csv/resolve_fee_billing_period_service_spec.rb
+++ b/spec/services/data_exports/csv/resolve_fee_billing_period_service_spec.rb
@@ -182,5 +182,21 @@ RSpec.describe DataExports::Csv::ResolveFeeBillingPeriodService do
         end
       end
     end
+
+    context "with an add-on fee" do
+      let(:fee_type) { "add_on" }
+      let(:invoice_subscription) { nil }
+      let(:properties) do
+        {
+          "from_datetime" => "2026-06-22T00:00:00Z",
+          "to_datetime" => "2026-07-21T23:59:59Z"
+        }
+      end
+
+      it "returns the stored fee boundaries" do
+        expect(result.from_datetime).to eq(Time.zone.parse("2026-06-22 00:00:00 UTC"))
+        expect(result.to_datetime).to eq(Time.zone.parse("2026-07-21 23:59:59 UTC"))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

The advanced invoice export (CSV) left the date range empty for one-off add-on fees.

These fees are not linked to a subscription, but they have their own stored date range.

## Changes

- Add-on fee rows now use their stored billing period.
- The dates are converted to the customer's timezone, following the existing CSV behavior.
