### PR TITLE
feat(charge_filters): add code to identify filters

### DIFF
--- a/app/jobs/charge_filters/cascade_job.rb
+++ b/app/jobs/charge_filters/cascade_job.rb
@@ -4,7 +4,7 @@ module ChargeFilters
   class CascadeJob < ApplicationJob
     queue_as :default
 
-    def perform(charge_id, action, filter_values, old_properties, new_properties, invoice_display_name)
+    def perform(charge_id, action, filter_values, old_properties, new_properties, invoice_display_name, parent_code = nil)
       charge = Charge.find_by(id: charge_id)
       return unless charge
 
@@ -14,7 +14,8 @@ module ChargeFilters
         filter_values:,
         old_properties:,
         new_properties:,
-        invoice_display_name:
+        invoice_display_name:,
+        parent_code:
       )
     end
   end

--- a/app/jobs/database_migrations/backfill_charge_filter_codes_job.rb
+++ b/app/jobs/database_migrations/backfill_charge_filter_codes_job.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillChargeFilterCodesJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed, on_conflict: :log, lock_ttl: 6.hours
+
+    def perform(charge_id)
+      charge = Charge.kept.includes(:plan).find_by(id: charge_id)
+
+      return if charge.nil?
+      return unless charge.parent_id.nil? && charge.plan.parent_id.nil?
+
+      filters = charge.filters.includes(values: :billable_metric_filter).to_a
+      taken = filters.filter_map(&:code).to_set
+
+      # Grouped by the code the values derive rather than by the values, since the code is what can
+      # collide: it sorts, so `{region: [us, eu]}` and `{region: [eu, us]}` are the same
+      filters.group_by { ChargeFilter.generate_code(it.to_h) }.each do |code, group|
+        next unless group.one?       # skip duplicates
+        next if group.sole.code      # already have code
+        next if taken.include?(code) # already taken ( would generate duplicate )
+
+        group.sole.update_column(:code, code) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      return unless filters.any?(&:code)
+
+      BackfillChildChargeFilterCodesJob.perform_later(charge.id)
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/jobs/database_migrations/backfill_child_charge_filter_codes_job.rb
+++ b/app/jobs/database_migrations/backfill_child_charge_filter_codes_job.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillChildChargeFilterCodesJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed, on_conflict: :log, lock_ttl: 6.hours
+
+    CHARGES_PER_BATCH = 1_000
+    IDS_PER_UPDATE = 10_000
+
+    # One row per charge filter. The fields are positional: they follow the `pluck` in `filters_of`,
+    Filter = Struct.new(:charge_id, :id, :code, :signature)
+
+    SIGNATURE_SQL = <<~SQL.squish
+      COALESCE(
+        jsonb_object_agg(
+          cfv.billable_metric_filter_id,
+          to_jsonb(ARRAY(SELECT unnest(cfv.values) ORDER BY 1))
+        ) FILTER (WHERE cfv.id IS NOT NULL),
+        '{}'::jsonb
+      )::text
+    SQL
+
+    def perform(parent_charge_id)
+      parent = Charge.kept.includes(:plan).find_by(id: parent_charge_id)
+      return if parent.nil?
+
+      return unless parent.parent_id.nil? && parent.plan.parent_id.nil?
+
+      to_copy = codes_to_copy(parent)
+      return if to_copy.empty?
+
+      parent.children.in_batches(of: CHARGES_PER_BATCH) do |children|
+        backfill(children, to_copy)
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+
+    private
+
+    # The codes this parent can hand down (without duplicates)
+    def codes_to_copy(parent)
+      codes = {}
+
+      filters_of(parent.id).group_by(&:signature).each do |signature, filters|
+        next unless filters.one?
+        next if filters.sole.code.nil? # no code yet: nothing to hand down
+
+        codes[signature] = filters.sole.code
+      end
+
+      codes
+    end
+
+    # Walks what the parent has to hand down rather than the override's filters, so one the override
+    # has and the plan does not is never visited, and keeps no code.
+    def backfill(children, to_copy)
+      ids_by_code = Hash.new { |ids, code| ids[code] = [] }
+
+      filters_of(children).group_by(&:charge_id).each_value do |filters|
+        by_signature = filters.group_by(&:signature)
+        taken = filters.filter_map(&:code).to_set
+
+        to_copy.each do |signature, code|
+          next if taken.include?(code) # a filter here already holds it, from when its values were these
+
+          matching = by_signature[signature]
+          next unless matching&.one? # held twice here: neither can say which one is the copy
+          next if matching.sole.code # frozen at creation, and that is the one it keeps
+
+          ids_by_code[code] << matching.sole.id
+        end
+      end
+
+      write_codes(ids_by_code)
+    end
+
+    # One query for a whole batch of charges, filters and values and all
+    def filters_of(charge_scope)
+      ChargeFilter
+        .where(charge_id: charge_scope)
+        .joins("LEFT JOIN charge_filter_values cfv ON cfv.charge_filter_id = charge_filters.id AND cfv.deleted_at IS NULL")
+        .group("charge_filters.id")
+        .pluck(:charge_id, :id, :code, Arel.sql(SIGNATURE_SQL))
+        .map { Filter.new(*it) }
+    end
+
+    # One statement per code
+    def write_codes(ids_by_code)
+      ids_by_code.each do |code, ids|
+        ids.each_slice(IDS_PER_UPDATE) do |slice|
+          ChargeFilter.where(id: slice, code: nil).update_all(code:) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/database_migrations/backfill_child_charge_filter_codes_job.rb
+++ b/app/jobs/database_migrations/backfill_child_charge_filter_codes_job.rb
@@ -8,8 +8,8 @@ module DatabaseMigrations
     CHARGES_PER_BATCH = 1_000
     IDS_PER_UPDATE = 10_000
 
-    # One row per charge filter. The fields are positional: they follow the `pluck` in `filters_of`,
-    Filter = Struct.new(:charge_id, :id, :code, :signature)
+    # One row per charge filter, filled positionally from the `pluck` in `filters_of`
+    Filter = Data.define(:charge_id, :id, :code, :signature)
 
     SIGNATURE_SQL = <<~SQL.squish
       COALESCE(

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -21,6 +21,38 @@ class ChargeFilter < ApplicationRecord
   # NOTE: Ensure filters are keeping the initial ordering
   default_scope -> { kept.order(updated_at: :asc) }
 
+  CODE_SLUG_LIMIT = 200
+
+  # A name for a filter. Removing a value from a billable metric trims it out of every filter using it,
+  # so two filters can collapse onto the same values and stop being distinguishable:
+  #
+  #   {region: [us], tier: [gold]}    @0.02     ->  {region: [us]}  @0.02
+  #   {region: [us], tier: [silver]}  @0.015    ->  {region: [us]}  @0.015
+  # The code is derived at creation and never again, which is why the
+  # backfill keeps an existing one instead of recomputing it.
+  def self.generate_code(values_hash)
+    canonical = values_hash.sort.map { |key, values| "#{key}:#{Array(values).sort.join("+")}" }.join("|")
+    "#{canonical.parameterize(separator: "_").first(CODE_SLUG_LIMIT)}_#{Digest::SHA256.hexdigest(canonical).first(8)}"
+  end
+
+  # Add a suffix if duplicated, only for new ones
+  def self.unique_code_for(charge_id, base_code)
+    return base_code if charge_id.nil?
+
+    next_free_code(base_code, where(charge_id:).unscope(:order).pluck(:code).compact.to_set)
+  end
+
+  # Callers that create several filters at once hold their own set, since the codes they hand out
+  # are not in the table yet
+  def self.next_free_code(base_code, taken)
+    return base_code unless taken.include?(base_code)
+
+    suffix = 2
+    suffix += 1 while taken.include?("#{base_code}_#{suffix}")
+
+    "#{base_code}_#{suffix}"
+  end
+
   def display_name(separator: ", ")
     invoice_display_name.presence || (values.map do |value|
       next value.billable_metric_filter.key if value.values == [ChargeFilterValue::ALL_FILTER_VALUES]
@@ -30,15 +62,11 @@ class ChargeFilter < ApplicationRecord
   end
 
   def to_h
-    @to_h ||= values.each_with_object({}) do |filter_value, result|
-      result[filter_value.billable_metric_filter.key] = filter_value.values
-    end.freeze
+    @to_h ||= values_by_key(values)
   end
 
   def to_h_with_discarded
-    @to_h_with_discarded ||= values.with_discarded.each_with_object({}) do |filter_value, result|
-      result[filter_value.billable_metric_filter.key] = filter_value.values
-    end.freeze
+    @to_h_with_discarded ||= values_by_key(values.with_discarded)
   end
 
   def to_h_with_all_values
@@ -50,11 +78,24 @@ class ChargeFilter < ApplicationRecord
     end.freeze
   end
 
+  def assign_code!
+    return if code.present?
+    base_code = self.class.generate_code(values_by_key(values.reload))
+
+    update_column(:code, self.class.unique_code_for(charge_id, base_code)) # rubocop:disable Rails/SkipsModelValidations
+  end
+
   def pricing_group_keys
     properties["pricing_group_keys"].presence || properties["grouped_by"]
   end
 
   private
+
+  def values_by_key(scope)
+    scope.each_with_object({}) do |filter_value, result|
+      result[filter_value.billable_metric_filter.key] = filter_value.values
+    end.freeze
+  end
 
   def validate_properties
     validate_charge_model_properties(charge&.charge_model)
@@ -67,6 +108,7 @@ end
 # Database name: primary
 #
 #  id                   :uuid             not null, primary key
+#  code                 :string
 #  deleted_at           :datetime
 #  invoice_display_name :string
 #  properties           :jsonb            not null
@@ -77,10 +119,11 @@ end
 #
 # Indexes
 #
-#  index_active_charge_filters              (charge_id) WHERE (deleted_at IS NULL)
-#  index_charge_filters_on_charge_id        (charge_id)
-#  index_charge_filters_on_deleted_at       (deleted_at)
-#  index_charge_filters_on_organization_id  (organization_id)
+#  index_active_charge_filters                 (charge_id) WHERE (deleted_at IS NULL)
+#  index_charge_filters_on_charge_id           (charge_id)
+#  index_charge_filters_on_charge_id_and_code  (charge_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#  index_charge_filters_on_deleted_at          (deleted_at)
+#  index_charge_filters_on_organization_id     (organization_id)
 #
 # Foreign Keys
 #

--- a/app/services/charge_filters/cascade_dispatcher.rb
+++ b/app/services/charge_filters/cascade_dispatcher.rb
@@ -6,7 +6,8 @@ module ChargeFilters
 
     # Diffs `before` against `after` and enqueues one ChargeFilters::CascadeJob
     # per change. `before` and `after` are arrays of:
-    #   { values: {"key" => [...]}, properties: {...} | nil, invoice_display_name: "..." }
+    #   { values: {"key" => [...]}, properties: {...} | nil, invoice_display_name: "...",
+    #     code: "..." | nil }
     # `values` and `properties` must be string-keyed.
     def call(charge:, before:, after:)
       before_by_values = before.index_by { |f| f[:values] }
@@ -24,7 +25,8 @@ module ChargeFilters
           new_filter[:values],
           existing&.dig(:properties),
           new_filter[:properties],
-          new_filter[:invoice_display_name]
+          new_filter[:invoice_display_name],
+          new_filter[:code]
         )
       end
 
@@ -35,7 +37,8 @@ module ChargeFilters
           old[:values],
           old[:properties],
           nil,
-          old[:invoice_display_name]
+          old[:invoice_display_name],
+          old[:code]
         )
       end
     end

--- a/app/services/charge_filters/cascade_service.rb
+++ b/app/services/charge_filters/cascade_service.rb
@@ -4,13 +4,14 @@ module ChargeFilters
   class CascadeService < BaseService
     Result = BaseResult
 
-    def initialize(charge:, action:, filter_values:, old_properties: nil, new_properties: nil, invoice_display_name: nil)
+    def initialize(charge:, action:, filter_values:, old_properties: nil, new_properties: nil, invoice_display_name: nil, parent_code: nil)
       @charge = charge
       @action = action
       @filter_values = filter_values
       @old_properties = old_properties
       @new_properties = new_properties
       @invoice_display_name = invoice_display_name
+      @parent_code = parent_code
 
       super
     end
@@ -45,7 +46,7 @@ module ChargeFilters
 
     private
 
-    attr_reader :charge, :action, :filter_values, :old_properties, :new_properties, :invoice_display_name
+    attr_reader :charge, :action, :filter_values, :old_properties, :new_properties, :invoice_display_name, :parent_code
 
     def child_ids
       @child_ids ||= charge.children
@@ -105,6 +106,7 @@ module ChargeFilters
       ActiveRecord::Base.transaction do
         child_filter = child_charge.filters.new(
           organization_id: child_charge.organization_id,
+          code: parent_code,
           invoice_display_name:,
           properties: ChargeModels::FilterPropertiesService.call(
             chargeable: child_charge,

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -8,9 +8,6 @@ module ChargeFilters
       @charge = charge
       @filters_params = filters_params
       @organization = charge.organization
-      @new_filter_rows = []
-      @new_filter_value_rows = []
-      @new_filter_ids = []
 
       # We only care about order when you have less than 100 filters.
       @should_touch = filters_params.size < 100
@@ -28,6 +25,32 @@ module ChargeFilters
       end
 
       return result.single_validation_failure!(field: :values, error_code: "value_is_mandatory") if empty_filter_values?
+
+      retrying_on_code_collision { create_or_update_filters }
+
+      result
+    end
+
+    private
+
+    # Codes are read before the insert, so two concurrent requests creating filters with the same
+    # values on one charge can pick the same one. The index is what rejects it; retrying recomputes
+    # against the row that won, rather than failing a request nobody got wrong.
+    def retrying_on_code_collision
+      attempted = false
+
+      begin
+        yield
+      rescue ActiveRecord::RecordNotUnique
+        raise if attempted
+
+        attempted = true
+        retry
+      end
+    end
+
+    def create_or_update_filters
+      start_attempt
 
       ActiveRecord::Base.transaction do
         filters_params.each do |filter_param|
@@ -56,11 +79,21 @@ module ChargeFilters
           remove_filter(it)
         end
       end
-
-      result
     end
 
-    private
+    # Everything an attempt accumulates is built here rather than in the constructor, so a retry
+    # starts clean without a second list of things to undo
+    def start_attempt
+      @new_filter_rows = []
+      @new_filter_value_rows = []
+      @new_filter_ids = []
+      @taken_filter_codes = nil
+      @filters = nil
+      @filters_by_values_key = nil
+
+      result.filters = []
+      charge.filters.reset
+    end
 
     attr_reader :charge, :filters_params, :organization, :should_touch, :new_filter_rows, :new_filter_value_rows, :new_filter_ids
 
@@ -119,12 +152,14 @@ module ChargeFilters
       )
       filter_instance.validate!
 
+      # insert_all! skips callbacks, so the code the model would assign is built here
       new_filter_rows << {
         id: filter_id,
         charge_id: charge.id,
         organization_id: organization.id,
         invoice_display_name: filter_param[:invoice_display_name],
-        properties: properties
+        properties: properties,
+        code: claim_filter_code(values_params)
       }
       new_filter_ids << filter_id
 
@@ -146,6 +181,20 @@ module ChargeFilters
           values: values
         }
       end
+    end
+
+    def claim_filter_code(values_params)
+      code = ChargeFilter.next_free_code(ChargeFilter.generate_code(values_params), taken_filter_codes)
+      taken_filter_codes << code
+
+      code
+    end
+
+    # Read once rather than per filter: this runs inside a loop that then bulk inserts, so a
+    # query per filter would undo what insert_all! is here for. Codes assigned during the run
+    # are added as they go, since they are not in the table yet.
+    def taken_filter_codes
+      @taken_filter_codes ||= charge.filters.unscope(:order).pluck(:code).compact.to_set
     end
 
     def bulk_insert_new_filters

--- a/app/services/charge_filters/create_service.rb
+++ b/app/services/charge_filters/create_service.rb
@@ -26,6 +26,7 @@ module ChargeFilters
         )
 
         create_filter_values(charge_filter)
+        charge_filter.assign_code!
 
         result.charge_filter = charge_filter
       end

--- a/app/services/charges/cascade_updatable.rb
+++ b/app/services/charges/cascade_updatable.rb
@@ -24,7 +24,8 @@ module Charges
         {
           values: f[:values].deep_stringify_keys,
           properties: f[:properties]&.deep_stringify_keys,
-          invoice_display_name: f[:invoice_display_name]
+          invoice_display_name: f[:invoice_display_name],
+          code: f[:code]
         }
       end
 
@@ -33,7 +34,8 @@ module Charges
         {
           values: filter.to_h.deep_stringify_keys,
           properties: filter.properties.deep_stringify_keys,
-          invoice_display_name: filter.invoice_display_name
+          invoice_display_name: filter.invoice_display_name,
+          code: filter.code
         }
       end
 
@@ -50,7 +52,7 @@ module Charges
 
     def capture_old_filters_attrs
       charge.filters.includes(values: :billable_metric_filter).map do |f|
-        {id: f.id, properties: f.properties, invoice_display_name: f.invoice_display_name, values: f.to_h}
+        {id: f.id, code: f.code, properties: f.properties, invoice_display_name: f.invoice_display_name, values: f.to_h}
       end
     end
 

--- a/app/services/database_migrations/enqueue_charge_filter_code_backfill_service.rb
+++ b/app/services/database_migrations/enqueue_charge_filter_code_backfill_service.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "sidekiq/api"
+
+module DatabaseMigrations
+  class EnqueueChargeFilterCodeBackfillService < BaseService
+    Result = BaseResult
+
+    BATCH_SIZE = 100
+    MAX_QUEUE_SIZE = 1_000
+    POLL_INTERVAL = 5
+
+    def initialize(batch_size: BATCH_SIZE, max_queue_size: MAX_QUEUE_SIZE, poll_interval: POLL_INTERVAL)
+      @batch_size = batch_size
+      @max_queue_size = max_queue_size
+      @poll_interval = poll_interval
+
+      super
+    end
+
+    def call
+      cursor = nil
+
+      loop do
+        wait_for_room
+
+        charge_ids = next_charge_ids(cursor)
+        break if charge_ids.empty?
+
+        cursor = charge_ids.last
+
+        charge_ids.each { BackfillChargeFilterCodesJob.perform_later(it) }
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :batch_size, :max_queue_size, :poll_interval
+
+    def wait_for_room
+      sleep(poll_interval) while queue.size > max_queue_size
+    end
+
+    # The whole queue, not just this job's share of it — the overrides pass lands here too, and so
+    # does everything else on low_priority. Burying that is what the limit exists to prevent.
+    def queue
+      Sidekiq::Queue.new(BackfillChargeFilterCodesJob.queue_name)
+    end
+
+    # Both conditions, as the job checks again before it writes. `charges.parent_id` goes back to
+    # NULL when the parent charge is deleted (has_many :children, dependent: :nullify), so on its
+    # own it cannot tell a plan's own charge from an override that lost its parent
+    def next_charge_ids(cursor)
+      pending = ChargeFilter.unscope(:order)
+        .where(code: nil)
+        .where("charge_filters.charge_id = charges.id")
+
+      scope = Charge.kept
+        .joins(:plan)
+        .where(parent_id: nil, organization_id: billing_organization_ids)
+        .where(plans: {parent_id: nil, deleted_at: nil})
+        .where(pending.arel.exists)
+        .order(:id)
+        .limit(batch_size)
+
+      scope = scope.where("charges.id > ?", cursor) if cursor
+
+      scope.pluck(:id)
+    end
+
+    # An organization with nothing active or pending should be skipped.
+    def billing_organization_ids
+      @billing_organization_ids ||= Subscription
+        .where(status: %i[active pending])
+        .distinct
+        .pluck(:organization_id)
+    end
+  end
+end

--- a/app/services/database_migrations/enqueue_charge_filter_code_backfill_service.rb
+++ b/app/services/database_migrations/enqueue_charge_filter_code_backfill_service.rb
@@ -19,18 +19,7 @@ module DatabaseMigrations
     end
 
     def call
-      cursor = nil
-
-      loop do
-        wait_for_room
-
-        charge_ids = next_charge_ids(cursor)
-        break if charge_ids.empty?
-
-        cursor = charge_ids.last
-
-        charge_ids.each { BackfillChargeFilterCodesJob.perform_later(it) }
-      end
+      billing_organization_ids.each { enqueue_charges_of(it) }
 
       result
     end
@@ -38,6 +27,24 @@ module DatabaseMigrations
     private
 
     attr_reader :batch_size, :max_queue_size, :poll_interval
+
+    # One organization at a time, each with its own cursor, rather than one walk over every charge
+    # with the organizations as an `IN` list: that list is as long as the number of organizations
+    # billing anything and would be repeated in every batch query.
+    def enqueue_charges_of(organization_id)
+      cursor = nil
+
+      loop do
+        wait_for_room
+
+        charge_ids = next_charge_ids(organization_id, cursor)
+        break if charge_ids.empty?
+
+        cursor = charge_ids.last
+
+        charge_ids.each { BackfillChargeFilterCodesJob.perform_later(it) }
+      end
+    end
 
     def wait_for_room
       sleep(poll_interval) while queue.size > max_queue_size
@@ -52,14 +59,14 @@ module DatabaseMigrations
     # Both conditions, as the job checks again before it writes. `charges.parent_id` goes back to
     # NULL when the parent charge is deleted (has_many :children, dependent: :nullify), so on its
     # own it cannot tell a plan's own charge from an override that lost its parent
-    def next_charge_ids(cursor)
+    def next_charge_ids(organization_id, cursor)
       pending = ChargeFilter.unscope(:order)
         .where(code: nil)
         .where("charge_filters.charge_id = charges.id")
 
       scope = Charge.kept
         .joins(:plan)
-        .where(parent_id: nil, organization_id: billing_organization_ids)
+        .where(parent_id: nil, organization_id:)
         .where(plans: {parent_id: nil, deleted_at: nil})
         .where(pending.arel.exists)
         .order(:id)
@@ -72,10 +79,7 @@ module DatabaseMigrations
 
     # An organization with nothing active or pending should be skipped.
     def billing_organization_ids
-      @billing_organization_ids ||= Subscription
-        .where(status: %i[active pending])
-        .distinct
-        .pluck(:organization_id)
+      Subscription.where(status: %i[active pending]).distinct.pluck(:organization_id)
     end
   end
 end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -154,7 +154,7 @@ module Plans
           old_parent_applied_pricing_unit_attrs:
         )
 
-        cascade_filter_changes(charge, before_filters, payload_charge[:filters]) if before_filters
+        cascade_filter_changes(charge, before_filters) if before_filters
       end
     end
 
@@ -163,21 +163,18 @@ module Plans
         {
           values: f.to_h.deep_stringify_keys,
           properties: f.properties,
-          invoice_display_name: f.invoice_display_name
+          invoice_display_name: f.invoice_display_name,
+          code: f.code
         }
       end
     end
 
-    def cascade_filter_changes(charge, before, payload_filters)
-      after = (payload_filters || []).map do |fp|
-        {
-          values: (fp[:values] || {}).deep_stringify_keys,
-          properties: fp[:properties]&.deep_stringify_keys,
-          invoice_display_name: fp[:invoice_display_name]
-        }
-      end
+    # Read back rather than reuse the payload: the codes are assigned while saving, and a child
+    # filter has to be created with the code of the parent filter it copies
+    def cascade_filter_changes(charge, before)
+      charge.filters.reset
 
-      ChargeFilters::CascadeDispatcher.call(charge:, before:, after:)
+      ChargeFilters::CascadeDispatcher.call(charge:, before:, after: capture_filters(charge))
     end
 
     def cascade_fixed_charge_removal(fixed_charge)

--- a/db/migrate/20260805110508_add_code_to_charge_filters.rb
+++ b/db/migrate/20260805110508_add_code_to_charge_filters.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCodeToChargeFilters < ActiveRecord::Migration[8.0]
+  def change
+    add_column :charge_filters, :code, :string
+  end
+end

--- a/db/migrate/20260805110509_add_charge_filters_charge_code_index.rb
+++ b/db/migrate/20260805110509_add_charge_filters_charge_code_index.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddChargeFiltersChargeCodeIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # NOTE: repeated NULLs are allowed, so rows still waiting on the backfill do not trip this
+    add_index :charge_filters,
+      %i[charge_id code],
+      unique: true,
+      where: "deleted_at IS NULL",
+      algorithm: :concurrently,
+      if_not_exists: true,
+      name: "index_charge_filters_on_charge_id_and_code"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -847,6 +847,7 @@ DROP INDEX IF EXISTS public.index_charges_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_charges_on_accepts_target_wallet;
 DROP INDEX IF EXISTS public.index_charge_filters_on_organization_id;
 DROP INDEX IF EXISTS public.index_charge_filters_on_deleted_at;
+DROP INDEX IF EXISTS public.index_charge_filters_on_charge_id_and_code;
 DROP INDEX IF EXISTS public.index_charge_filters_on_charge_id;
 DROP INDEX IF EXISTS public.index_charge_filter_values_on_organization_id;
 DROP INDEX IF EXISTS public.index_charge_filter_values_on_deleted_at;
@@ -2389,7 +2390,8 @@ CREATE TABLE public.charge_filters (
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
     invoice_display_name character varying,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    code character varying
 );
 
 
@@ -8040,6 +8042,13 @@ CREATE INDEX index_charge_filter_values_on_organization_id ON public.charge_filt
 --
 
 CREATE INDEX index_charge_filters_on_charge_id ON public.charge_filters USING btree (charge_id);
+
+
+--
+-- Name: index_charge_filters_on_charge_id_and_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_charge_filters_on_charge_id_and_code ON public.charge_filters USING btree (charge_id, code) WHERE (deleted_at IS NULL);
 
 
 --
@@ -14162,6 +14171,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260805110509'),
+('20260805110508'),
 ('20260804131008'),
 ('20260803162623'),
 ('20260724094543'),

--- a/lib/tasks/filters.rake
+++ b/lib/tasks/filters.rake
@@ -23,4 +23,34 @@ namespace :filters do
       end
     end
   end
+
+  # Charge filters the backfill deliberately left alone. Two situations produce them, and neither
+  # is a failure:
+  #
+  #   - two filters on one charge hold the same values, because removing a value from a billable
+  #     metric trimmed them onto the same predicate. Whichever kept the code would be the one that
+  #     bills from then on, and that is not a migration's call.
+  #
+  #   - an override kept a filter its plan no longer has. There is nothing left to link it to —
+  #     the plan's filter is gone, or the parent charge was deleted and `dependent: :nullify` cut
+  #     the link. This is damage already done and no backfill undoes it.
+  #
+  # Cleaning up the first kind and running upgrade:perform_required_jobs again converges.
+  desc "Report the charge filters left without a code"
+  task report_codes: :environment do
+    scope = ChargeFilter.where(code: nil, deleted_at: nil)
+
+    puts "##################################"
+    puts "Charge filters without a code: #{scope.count}"
+    puts ""
+    puts "They are either two filters sharing one predicate on the same charge — where picking"
+    puts "which keeps the code would decide which one bills — or an override holding a filter its"
+    puts "plan no longer has, which has nothing left to link to."
+    puts ""
+    puts "The charges to look at first:"
+
+    scope.group(:charge_id).order(Arel.sql("count(*) DESC")).limit(25).count.each do |charge_id, filters|
+      pp "- charge #{charge_id}: #{filters} filters"
+    end
+  end
 end

--- a/lib/tasks/upgrade_verification.rake
+++ b/lib/tasks/upgrade_verification.rake
@@ -33,19 +33,6 @@ namespace :upgrade do
       end
     end
 
-    pp "- Checking Subscription#last_received_event_on: 🔎"
-    backfill_org_ids = Organization
-      .joins(:subscriptions)
-      .where(subscriptions: {status: :active, last_received_event_on: nil})
-      .distinct
-      .pluck(:id)
-
-    if backfill_org_ids.any?
-      pp "  -> #{backfill_org_ids.size} organizations to process 🧮"
-    else
-      pp "  -> Nothing to do ✅"
-    end
-
     if to_fill.any?
       puts "\n#### Enqueue jobs in the low_priority queue ####"
       to_fill.each do |resource|
@@ -54,15 +41,7 @@ namespace :upgrade do
       end
     end
 
-    if backfill_org_ids.any?
-      puts "\n#### Enqueue BackfillLastReceivedEventOnJob per organization ####"
-      backfill_org_ids.each do |organization_id|
-        pp "- Enqueuing BackfillLastReceivedEventOnJob for org #{organization_id}"
-        DatabaseMigrations::BackfillLastReceivedEventOnJob.perform_later(organization_id)
-      end
-    end
-
-    while to_fill.present? || backfill_org_ids.any?
+    while to_fill.present?
       sleep 5
       puts "\n#### Checking status ####"
 
@@ -80,18 +59,42 @@ namespace :upgrade do
         end
       end
       to_delete.each { to_fill.delete(it) }
-
-      if backfill_org_ids.any?
-        pp "- Checking BackfillLastReceivedEventOnJob: 🔎"
-        still_running = backfill_last_received_event_on_jobs_running?
-        if still_running
-          pp "  -> Jobs still running 🧮"
-        else
-          backfill_org_ids = []
-          pp "  -> Done ✅"
-        end
-      end
     end
+
+    # One walk. Each plan charge hands its own overrides on as it finishes, so the ordering the two
+    # passes need is the order those two jobs run in — there is no barrier here to get wrong, and
+    # no second pass to trigger. A charge cleaned up by hand later is picked up the same way, since
+    # it goes back to having filters without a code and the walk selects it again.
+    #
+    # So waiting below is about not telling the operator they are ready while work is in flight,
+    # not about correctness. Sidekiq reports busy workers from a heartbeat that lags a few seconds,
+    # so this can call it done a moment early; the cost of that is nothing.
+    puts "\n#### Backfilling charge filter codes ####"
+
+    DatabaseMigrations::EnqueueChargeFilterCodeBackfillService.call
+
+    codeless = -> { ChargeFilter.unscoped.where(code: nil, deleted_at: nil).count }
+    jobs = [DatabaseMigrations::BackfillChargeFilterCodesJob, DatabaseMigrations::BackfillChildChargeFilterCodesJob]
+    remaining = codeless.call
+
+    room = DatabaseMigrations::EnqueueChargeFilterCodeBackfillService::MAX_QUEUE_SIZE
+    queue = Sidekiq::Queue.new(DatabaseMigrations::BackfillChargeFilterCodesJob.queue_name)
+
+    loop do
+      sleep 10
+      next if queue.size > room
+
+      next if jobs.any? { backfill_jobs_running?(it) }
+
+      still = codeless.call
+      break if still == remaining
+
+      remaining = still
+      pp "  -> #{remaining} filters still without a code 🧮"
+    end
+
+    pp "  -> Done ✅"
+    pp "   #{remaining} filters were left without one on purpose: rake filters:report_codes"
 
     puts "\n#### All good, ready to Upgrade! ✅ ####"
   end
@@ -216,14 +219,15 @@ namespace :upgrade do
     queue.size == 0
   end
 
-  def backfill_last_received_event_on_jobs_running?
-    job_class = "DatabaseMigrations::BackfillLastReceivedEventOnJob"
-
-    queued = Sidekiq::Queue.new("low_priority").any? { |job| job.klass == job_class }
-    return true if queued
+  # Sidekiq stores ActiveJob entries under the adapter's wrapper class, so `klass` reads
+  # "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper" and never matches a job name. The
+  # job's own name lives in `wrapped`, which `display_class` reads back off a queue entry.
+  def backfill_jobs_running?(job_class)
+    return true if Sidekiq::Queue.new(job_class.queue_name).any? { |job| job.display_class == job_class.name }
+    return true if Sidekiq::ScheduledSet.new.any? { |job| job.display_class == job_class.name }
 
     Sidekiq::Workers.new.any? do |_process_id, _thread_id, work|
-      work.dig("payload", "class") == job_class
+      work.payload["wrapped"] == job_class.name
     end
   end
 end

--- a/spec/jobs/charge_filters/cascade_job_spec.rb
+++ b/spec/jobs/charge_filters/cascade_job_spec.rb
@@ -22,7 +22,16 @@ RSpec.describe ChargeFilters::CascadeJob do
       filter_values:,
       old_properties:,
       new_properties:,
-      invoice_display_name:
+      invoice_display_name:,
+      parent_code: nil
+    )
+  end
+
+  it "passes the parent code through when it is given" do
+    described_class.perform_now(charge.id, "create", filter_values, nil, new_properties, invoice_display_name, "a-parent-code")
+
+    expect(ChargeFilters::CascadeService).to have_received(:call!).with(
+      hash_including(parent_code: "a-parent-code")
     )
   end
 

--- a/spec/jobs/database_migrations/backfill_charge_filter_codes_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_charge_filter_codes_job_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabaseMigrations::BackfillChargeFilterCodesJob do
+  subject(:perform) { described_class.perform_now(charge.id) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:bm_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+
+  let(:us_code) { ChargeFilter.generate_code({"region" => ["us"]}) }
+  let(:eu_code) { ChargeFilter.generate_code({"region" => ["eu"]}) }
+
+  def build_filter(on, values, **attrs)
+    filter = create(:charge_filter, charge: on, **attrs)
+    create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values:)
+    filter
+  end
+
+  it "assigns every filter the code derived from its values" do
+    filter = build_filter(charge, ["us"])
+
+    perform
+
+    expect(filter.reload.code).to eq(us_code)
+  end
+
+  it "leaves a filter that already has a code untouched" do
+    filter = build_filter(charge, ["us"])
+    filter.update_column(:code, "assigned_at_creation") # rubocop:disable Rails/SkipsModelValidations
+
+    perform
+
+    expect(filter.reload.code).to eq("assigned_at_creation")
+  end
+
+  # Both derive the same code from these values, so they are two filters on one predicate: whichever
+  # kept it would be the one that bills, and that is not a migration's call
+  it "leaves both filters holding the same values in a different order without a code" do
+    first = build_filter(charge, %w[us eu])
+    second = build_filter(charge, %w[eu us])
+
+    perform
+
+    expect([first.reload.code, second.reload.code]).to eq([nil, nil])
+  end
+
+  it "does nothing when the charge is gone" do
+    expect { described_class.perform_now(SecureRandom.uuid) }.not_to raise_error
+  end
+
+  # Handed one directly it must still refuse: an override's code comes from the filter it was
+  # copied from, and deriving one here would claim a link that was never checked.
+  context "when the charge sits on a plan that overrides another" do
+    let(:child_plan) { create(:plan, organization:, parent: plan) }
+
+    it "does nothing" do
+      child_charge = create(:standard_charge, plan: child_plan, billable_metric:, parent: charge)
+      child_filter = build_filter(child_charge, ["us"])
+
+      described_class.perform_now(child_charge.id)
+
+      expect(child_filter.reload.code).to be_nil
+    end
+
+    # dependent: :nullify puts parent_id back to NULL when the parent charge is deleted, so an
+    # override that lost its parent looks exactly like a plan's own charge by that column.
+    it "does nothing even once the charge has lost its parent" do
+      orphan = create(:standard_charge, plan: child_plan, billable_metric:, parent: nil)
+      orphan_filter = build_filter(orphan, ["us"])
+
+      described_class.perform_now(orphan.id)
+
+      expect(orphan_filter.reload.code).to be_nil
+    end
+  end
+
+  it "does nothing when the charge was discarded" do
+    filter = build_filter(charge, ["us"])
+    charge.discard!
+
+    perform
+
+    expect(filter.reload.code).to be_nil
+  end
+
+  # Suffixing one of them would decide which is "the" filter from then on, and where the prices
+  # differ that is a billing decision.
+  context "when two filters on the charge hold the same values" do
+    let!(:first) { build_filter(charge, ["us"], properties: {"amount" => "10"}) }
+    let!(:second) { build_filter(charge, ["us"], properties: {"amount" => "20"}) }
+
+    it "leaves both of them without codes" do
+      perform
+
+      expect([first.reload.code, second.reload.code]).to eq([nil, nil])
+    end
+
+    # The pair is the billing decision; a filter on its own predicate is not, and its copies on
+    # overrides need its code to link back.
+    it "still fills the filters on the charge that are unambiguous" do
+      unaffected = build_filter(charge, ["eu"])
+
+      perform
+
+      expect(unaffected.reload.code).to eq(eu_code)
+    end
+  end
+
+  # Handing the overrides on from here is what makes the ordering unlosable: by the time this
+  # runs, the codes it passes down are written.
+  describe "handing on to the overrides" do
+    it "enqueues the overrides pass for the charge it just filled" do
+      build_filter(charge, ["us"])
+
+      expect { perform }.to have_enqueued_job(DatabaseMigrations::BackfillChildChargeFilterCodesJob)
+        .with(charge.id)
+    end
+
+    it "does not when the charge ended up with nothing to hand down" do
+      build_filter(charge, ["us"], properties: {"amount" => "10"})
+      build_filter(charge, ["us"], properties: {"amount" => "20"})
+
+      expect { perform }.not_to have_enqueued_job(DatabaseMigrations::BackfillChildChargeFilterCodesJob)
+    end
+
+    # A re-run over a charge already filled still has to hand on, since a previous overrides pass
+    # may have been the part that failed
+    it "still hands on when the codes were already there" do
+      build_filter(charge, ["us"]).update_column(:code, us_code) # rubocop:disable Rails/SkipsModelValidations
+
+      expect { perform }.to have_enqueued_job(DatabaseMigrations::BackfillChildChargeFilterCodesJob)
+        .with(charge.id)
+    end
+  end
+
+  # A code already on the charge is the one that filter was created with, so a filter whose
+  # values have since collapsed onto it cannot take it.
+  it "leaves the charge alone when a derived code is already taken by a sibling" do
+    build_filter(charge, ["eu"]).update_column(:code, us_code) # rubocop:disable Rails/SkipsModelValidations
+    collapsing = build_filter(charge, ["us"])
+
+    perform
+
+    expect(collapsing.reload.code).to be_nil
+  end
+
+  # The upgrade task cannot tell a filter still waiting for a code from one this pass refuses to
+  # decide, so it hands the charge out again on every run. That has to be free of consequence.
+  it "writes nothing a second time" do
+    filter = build_filter(charge, ["us"])
+    perform
+
+    expect { described_class.perform_now(charge.id) }.not_to change { filter.reload.code }
+  end
+end

--- a/spec/jobs/database_migrations/backfill_child_charge_filter_codes_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_child_charge_filter_codes_job_spec.rb
@@ -1,0 +1,354 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabaseMigrations::BackfillChildChargeFilterCodesJob do
+  subject(:perform) { described_class.perform_now(parent_charge.id) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:bm_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:parent_charge) { create(:standard_charge, plan:, billable_metric:) }
+
+  let(:child_plan) { create(:plan, organization:, parent: plan) }
+  let(:child_charge) { create(:standard_charge, plan: child_plan, billable_metric:, parent: parent_charge) }
+
+  let(:us_code) { ChargeFilter.generate_code({"region" => ["us"]}) }
+  let(:eu_code) { ChargeFilter.generate_code({"region" => ["eu"]}) }
+
+  def build_filter(on, values, code: nil, **attrs)
+    filter = create(:charge_filter, charge: on, **attrs)
+    create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values:)
+    filter.update_column(:code, code) if code # rubocop:disable Rails/SkipsModelValidations
+    filter
+  end
+
+  it "gives the override's filter the code its parent holds" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    child_filter = build_filter(child_charge, ["us"], properties: {"amount" => "1"})
+
+    perform
+
+    expect(child_filter.reload.code).to eq(us_code)
+  end
+
+  # The override kept a filter its plan no longer has, so there is no link left to record
+  it "leaves a filter the parent does not hold without a code" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    orphan = build_filter(child_charge, ["eu"])
+
+    perform
+
+    expect(orphan.reload.code).to be_nil
+  end
+
+  it "does nothing when the parent has no codes yet" do
+    build_filter(parent_charge, ["us"])
+    child_filter = build_filter(child_charge, ["us"])
+
+    perform
+
+    expect(child_filter.reload.code).to be_nil
+  end
+
+  it "leaves a filter that already has a code untouched" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    child_filter = build_filter(child_charge, ["us"], code: "inherited_on_propagation")
+
+    perform
+
+    expect(child_filter.reload.code).to eq("inherited_on_propagation")
+  end
+
+  # Same rule as the parents pass: choosing which of them keeps the code decides which one bills
+  it "leaves both of two filters sharing a code without one" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    first = build_filter(child_charge, ["us"], properties: {"amount" => "1"})
+    second = build_filter(child_charge, ["us"], properties: {"amount" => "2"})
+
+    perform
+
+    expect([first.reload.code, second.reload.code]).to eq([nil, nil])
+  end
+
+  it "still fills the filters on the override that are unambiguous" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    build_filter(parent_charge, ["eu"], code: eu_code)
+    build_filter(child_charge, ["us"], properties: {"amount" => "1"})
+    build_filter(child_charge, ["us"], properties: {"amount" => "2"})
+    unaffected = build_filter(child_charge, ["eu"])
+
+    perform
+
+    expect(unaffected.reload.code).to eq(eu_code)
+  end
+
+  it "reaches every override of the parent" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    other_child_plan = create(:plan, organization:, parent: plan)
+    other_child = create(:standard_charge, plan: other_child_plan, billable_metric:, parent: parent_charge)
+    filters = [build_filter(child_charge, ["us"]), build_filter(other_child, ["us"])]
+
+    perform
+
+    expect(filters.map { it.reload.code }).to eq([us_code, us_code])
+  end
+
+  # The parent's code was frozen at creation and its values moved afterwards, so it no longer
+  # matches what those values produce today. The override is still a copy of it.
+  it "copies a parent code its own values no longer derive" do
+    build_filter(parent_charge, ["us"], code: "frozen_before_the_values_moved")
+    child_filter = build_filter(child_charge, ["us"])
+
+    perform
+
+    expect(child_filter.reload.code).to eq("frozen_before_the_values_moved")
+  end
+
+  # The override is a copy of that filter, and both sides derive the same code from these values.
+  # Reading the two as different would leave a link that exists unrecorded.
+  it "copies the parent code when the two hold the values in a different order" do
+    build_filter(parent_charge, %w[us eu], code: "frozen_us_eu")
+    child_filter = build_filter(child_charge, %w[eu us])
+
+    perform
+
+    expect(child_filter.reload.code).to eq("frozen_us_eu")
+  end
+
+  # It cannot say which of the two the override was copied from
+  it "copies nothing for a predicate the parent holds twice" do
+    build_filter(parent_charge, ["us"], code: us_code, properties: {"amount" => "1"})
+    build_filter(parent_charge, ["us"], code: "#{us_code}_2", properties: {"amount" => "2"})
+    child_filter = build_filter(child_charge, ["us"])
+
+    perform
+
+    expect(child_filter.reload.code).to be_nil
+  end
+
+  it "gives every override of the parent the codes it holds" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    build_filter(parent_charge, ["eu"], code: eu_code)
+
+    filters = Array.new(3) do
+      other_plan = create(:plan, organization:, parent: plan)
+      other_child = create(:standard_charge, plan: other_plan, billable_metric:, parent: parent_charge)
+      [build_filter(other_child, ["us"]), build_filter(other_child, ["eu"])]
+    end.flatten
+
+    perform
+
+    expect(filters.map { it.reload.code }).to eq([us_code, eu_code] * 3)
+  end
+
+  # The walk reads an override, then writes minutes later. A propagation or an API edit in between
+  # assigns a code of its own, and that one was assigned at creation.
+  it "leaves a code that appeared between reading the override and writing to it" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    child_filter = build_filter(child_charge, ["us"])
+
+    # Hooked on the write itself, which is the only place the window can be reproduced: the batch has
+    # been read and matched by now, and the code appears before the statement runs
+    allow_any_instance_of(described_class).to receive(:write_codes).and_wrap_original do |original, *args| # rubocop:disable RSpec/AnyInstance
+      child_filter.update_column(:code, "assigned_while_the_walk_was_running") # rubocop:disable Rails/SkipsModelValidations
+      original.call(*args)
+    end
+
+    perform
+
+    expect(child_filter.reload.code).to eq("assigned_while_the_walk_was_running")
+  end
+
+  it "does nothing when the charge is gone" do
+    expect { described_class.perform_now(SecureRandom.uuid) }.not_to raise_error
+  end
+
+  it "does nothing when handed an override rather than a plan's charge" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    grandchild_plan = create(:plan, organization:, parent: child_plan)
+    grandchild = create(:standard_charge, plan: grandchild_plan, billable_metric:, parent: child_charge)
+    filter = build_filter(grandchild, ["us"])
+
+    described_class.perform_now(child_charge.id)
+
+    expect(filter.reload.code).to be_nil
+  end
+
+  # The sibling froze this code when its own values were these. Writing it again would break the
+  # unique index on (charge_id, code), and take every other filter in the same statement with it.
+  it "leaves the filter without a code when a sibling on the override already holds it" do
+    build_filter(parent_charge, ["us"], code: us_code)
+    build_filter(child_charge, ["eu"], code: us_code)
+    filter = build_filter(child_charge, ["us"])
+
+    perform
+
+    expect(filter.reload.code).to be_nil
+  end
+
+  # A filter is known by its values, so what counts as the same values is what the pairing rests on
+  describe "what counts as the same filter" do
+    let(:bm_filter) do
+      create(:billable_metric_filter, billable_metric:, key: "region",
+        values: %w[us eu US usa a+b a b ação acao x1 x2 x10])
+    end
+
+    it "pairs mixed case held in a different order" do
+      build_filter(parent_charge, %w[US us], code: "frozen_on_the_plan")
+      filter = build_filter(child_charge, %w[us US])
+
+      perform
+
+      expect(filter.reload.code).to eq("frozen_on_the_plan")
+    end
+
+    it "pairs values that look numeric, which sort as text" do
+      build_filter(parent_charge, %w[x1 x2 x10], code: "frozen_on_the_plan")
+      filter = build_filter(child_charge, %w[x10 x2 x1])
+
+      perform
+
+      expect(filter.reload.code).to eq("frozen_on_the_plan")
+    end
+
+    it "pairs a value holding the separator the code derives with" do
+      build_filter(parent_charge, ["a+b"], code: "frozen_on_the_plan")
+      filter = build_filter(child_charge, ["a+b"])
+
+      perform
+
+      expect(filter.reload.code).to eq("frozen_on_the_plan")
+    end
+
+    it "does not pair values differing only in case" do
+      build_filter(parent_charge, %w[us], code: "frozen_on_the_plan")
+      filter = build_filter(child_charge, %w[US])
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+
+    # Otherwise a filter could take the code of the one whose values the separator makes it look like
+    it "does not pair a joined value with the two values it looks like" do
+      build_filter(parent_charge, ["a+b"], code: "frozen_on_the_plan")
+      filter = build_filter(child_charge, %w[a b])
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+
+    it "does not pair an accented value with its plain form" do
+      build_filter(parent_charge, %w[ação], code: "frozen_on_the_plan")
+      filter = build_filter(child_charge, %w[acao])
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+
+    it "does not pair a value with one that is a prefix of it" do
+      build_filter(parent_charge, %w[us], code: "frozen_on_the_plan")
+      filter = build_filter(child_charge, %w[us usa])
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+  end
+
+  describe "filters naming more than one key, or none" do
+    let(:tier_filter) { create(:billable_metric_filter, billable_metric:, key: "tier", values: %w[gold silver]) }
+
+    # Several keys, or none at all, which `build_filter` cannot express
+    def build_filter_with(charge, values_by_metric_filter, code: nil)
+      filter = create(:charge_filter, charge:)
+      values_by_metric_filter.each do |metric_filter, values|
+        create(:charge_filter_value, charge_filter: filter, billable_metric_filter: metric_filter, values:)
+      end
+      filter.update_column(:code, code) if code # rubocop:disable Rails/SkipsModelValidations
+      filter
+    end
+
+    it "pairs when both name the same two keys" do
+      build_filter_with(parent_charge, {bm_filter => %w[us], tier_filter => %w[gold]}, code: "two_keys")
+      filter = build_filter_with(child_charge, {bm_filter => %w[us], tier_filter => %w[gold]})
+
+      perform
+
+      expect(filter.reload.code).to eq("two_keys")
+    end
+
+    it "does not pair when the override names a key the plan does not" do
+      build_filter_with(parent_charge, {bm_filter => %w[us]}, code: "one_key")
+      filter = build_filter_with(child_charge, {bm_filter => %w[us], tier_filter => %w[gold]})
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+
+    it "does not pair when the override is missing a key the plan names" do
+      build_filter_with(parent_charge, {bm_filter => %w[us], tier_filter => %w[gold]}, code: "two_keys")
+      filter = build_filter_with(child_charge, {bm_filter => %w[us]})
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+
+    it "pairs two filters that hold no values at all" do
+      build_filter_with(parent_charge, {}, code: "no_values")
+      filter = build_filter_with(child_charge, {})
+
+      perform
+
+      expect(filter.reload.code).to eq("no_values")
+    end
+
+    it "does not pair one holding no values with one that holds some" do
+      build_filter_with(parent_charge, {}, code: "no_values")
+      filter = build_filter_with(child_charge, {bm_filter => %w[us]})
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+  end
+
+  # The pairing reads live values on both sides, and the two sides have to agree on that
+  describe "discarded rows" do
+    it "does not pair an override filter whose values are discarded" do
+      build_filter(parent_charge, ["us"], code: us_code)
+      filter = build_filter(child_charge, ["us"])
+      filter.values.each(&:discard!)
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+
+    it "does not hand down a code from a plan filter whose values are discarded" do
+      build_filter(parent_charge, ["us"], code: us_code).values.each(&:discard!)
+      filter = build_filter(child_charge, ["us"])
+
+      perform
+
+      expect(filter.reload.code).to be_nil
+    end
+
+    it "does not read a discarded duplicate as ambiguous" do
+      build_filter(parent_charge, ["us"], code: us_code)
+      build_filter(child_charge, ["us"]).discard!
+      filter = build_filter(child_charge, ["us"])
+
+      perform
+
+      expect(filter.reload.code).to eq(us_code)
+    end
+  end
+end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -456,4 +456,82 @@ RSpec.describe ChargeFilter do
       end
     end
   end
+
+  describe ".generate_code" do
+    it "is independent of key and value order" do
+      a = described_class.generate_code({"type" => %w[pages], "model" => %w[b a]})
+      b = described_class.generate_code({"model" => %w[a b], "type" => %w[pages]})
+
+      expect(a).to eq(b)
+    end
+
+    it "differs for different values" do
+      a = described_class.generate_code({"model" => %w[ocr-2411]})
+      b = described_class.generate_code({"model" => %w[ocr-2503]})
+
+      expect(a).not_to eq(b)
+    end
+
+    it "stays readable and bounded" do
+      code = described_class.generate_code({"type" => %w[pages], "model" => %w[ocr-2411]})
+
+      expect(code).to start_with("model_ocr-2411_type_pages_")
+      expect(code.length).to be <= described_class::CODE_SLUG_LIMIT + 9
+    end
+
+    it "keeps long values distinct once the readable part is truncated" do
+      long = "m" * 200
+      a = described_class.generate_code({"model" => ["#{long}a"]})
+      b = described_class.generate_code({"model" => ["#{long}b"]})
+
+      expect(a).not_to eq(b)
+    end
+  end
+
+  describe "#assign_code!" do
+    let(:charge) { create(:standard_charge) }
+    let(:bm_filter) { create(:billable_metric_filter, billable_metric: charge.billable_metric, key: "model", values: %w[a b]) }
+
+    def filter_with(values)
+      filter = create(:charge_filter, charge:)
+      create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values:)
+      filter.assign_code!
+      filter
+    end
+
+    it "derives the code from the values" do
+      expect(filter_with(%w[a]).code).to eq(described_class.generate_code({"model" => %w[a]}))
+    end
+
+    it "suffixes a code already taken on the charge" do
+      first = filter_with(%w[a])
+      second = filter_with(%w[a])
+
+      expect(second.code).to eq("#{first.code}_2")
+    end
+
+    it "leaves an existing code alone, so a copied filter keeps the one it came with" do
+      filter = filter_with(%w[a])
+
+      expect { filter.assign_code! }.not_to change { filter.reload.code }
+    end
+
+    # updated_at orders a charge's filters, and the cascade pairs plan and override by it
+    it "does not touch updated_at" do
+      filter = create(:charge_filter, charge:)
+      create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: %w[a])
+
+      expect { filter.assign_code! }.not_to change { filter.reload.updated_at }
+    end
+
+    # The code freezes the values the filter was born with: a later metric edit that trims a
+    # value must not change it, or two filters collapsing onto one predicate would collide
+    it "survives a value being discarded" do
+      filter = filter_with(%w[a])
+
+      filter.values.each(&:discard!)
+
+      expect { filter.assign_code! }.not_to change { filter.reload.code }
+    end
+  end
 end

--- a/spec/services/charge_filters/cascade_dispatcher_spec.rb
+++ b/spec/services/charge_filters/cascade_dispatcher_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
         expect {
           described_class.call(charge:, before:, after:)
         }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
-          charge.id, "create", us_values, nil, {"amount" => "10"}, "US"
+          charge.id, "create", us_values, nil, {"amount" => "10"}, "US", nil
         )
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
         expect {
           described_class.call(charge:, before:, after:)
         }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
-          charge.id, "destroy", us_values, {"amount" => "10"}, nil, "US"
+          charge.id, "destroy", us_values, {"amount" => "10"}, nil, "US", nil
         )
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
         expect {
           described_class.call(charge:, before:, after:)
         }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
-          charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "15"}, "US"
+          charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "15"}, "US", nil
         )
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
         expect {
           described_class.call(charge:, before:, after:)
         }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
-          charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "10"}, "US region"
+          charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "10"}, "US region", nil
         )
       end
     end
@@ -119,7 +119,7 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
         expect {
           described_class.call(charge:, before:, after:)
         }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
-          charge.id, "update", eu_values, {"amount" => "20"}, {"amount" => "25"}, "EU"
+          charge.id, "update", eu_values, {"amount" => "20"}, {"amount" => "25"}, "EU", nil
         )
       end
 
@@ -127,7 +127,7 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
         expect {
           described_class.call(charge:, before:, after:)
         }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
-          charge.id, "create", ca_values, nil, {"amount" => "40"}, "CA"
+          charge.id, "create", ca_values, nil, {"amount" => "40"}, "CA", nil
         )
       end
 
@@ -135,7 +135,7 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
         expect {
           described_class.call(charge:, before:, after:)
         }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
-          charge.id, "destroy", asia_values, {"amount" => "30"}, nil, "Asia"
+          charge.id, "destroy", asia_values, {"amount" => "30"}, nil, "Asia", nil
         )
       end
     end

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -175,6 +175,30 @@ RSpec.describe ChargeFilters::CascadeService do
         expect(new_filter.to_h).to eq({"region" => ["eu"]})
       end
 
+      # The code links a plan's filter to the copies on its overrides, so the child has to take
+      # the parent's rather than derive one from its own values
+      it "gives the new child filter the parent's code" do
+        described_class.call(
+          charge: parent_charge,
+          action: "create",
+          filter_values: {"region" => ["eu"]},
+          new_properties: {"amount" => "20"},
+          invoice_display_name: "EU region",
+          parent_code: "a-code-only-the-parent-could-have"
+        )
+
+        expect(child_charge.filters.find_by(invoice_display_name: "EU region").code)
+          .to eq("a-code-only-the-parent-could-have")
+      end
+
+      # The parent is still waiting on the backfill. Deriving a code here would hand the child
+      # one the parent never gets, and the backfill would then never pair them.
+      it "leaves the code nil when the parent has none yet" do
+        service
+
+        expect(child_charge.filters.find_by(invoice_display_name: "EU region").code).to be_nil
+      end
+
       context "when child already has the filter" do
         before do
           existing = create(:charge_filter, charge: child_charge, properties: {amount: "20"})

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -444,4 +444,70 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
       expect(new_filter.values.pluck(:values).flatten).to eq(["visa"])
     end
   end
+
+  describe "filter codes" do
+    let(:charge) { create(:standard_charge) }
+    let(:bm_filter) { create(:billable_metric_filter, billable_metric: charge.billable_metric, key: "model", values: %w[a b]) }
+
+    before { bm_filter }
+
+    # The rows go in through insert_all!, which skips model callbacks, so the code has to be
+    # built while the row hash is assembled
+    it "assigns a code to every filter it inserts" do
+      result = described_class.call(charge:, filters_params: [
+        {values: {"model" => %w[a]}, properties: {amount: "10"}},
+        {values: {"model" => %w[b]}, properties: {amount: "20"}}
+      ])
+
+      expect(result.filters.map(&:code)).to eq([
+        ChargeFilter.generate_code({"model" => %w[a]}),
+        ChargeFilter.generate_code({"model" => %w[b]})
+      ])
+    end
+
+    it "suffixes the second of two filters holding the same values" do
+      result = described_class.call(charge:, filters_params: [
+        {values: {"model" => %w[a]}, properties: {amount: "10"}},
+        {values: {"model" => %w[a]}, properties: {amount: "20"}}
+      ])
+
+      base_code = ChargeFilter.generate_code({"model" => %w[a]})
+
+      expect(result.filters.map(&:code)).to eq([base_code, "#{base_code}_2"])
+    end
+
+    # Codes are read before the insert, so a concurrent request can take the one this call
+    # picked. A real race commits in another transaction; here we only raise what the index
+    # would raise, and check the call recovers instead of surfacing a 500.
+    it "recovers when the insert hits the unique index" do
+      base_code = ChargeFilter.generate_code({"model" => %w[a]})
+      attempts = 0
+
+      allow(ChargeFilter).to receive(:insert_all!).and_wrap_original do |original, *args, **kwargs|
+        attempts += 1
+        raise ActiveRecord::RecordNotUnique.new("index_charge_filters_on_charge_id_and_code") if attempts == 1
+
+        original.call(*args, **kwargs)
+      end
+
+      result = described_class.call(charge:, filters_params: [
+        {values: {"model" => %w[a]}, properties: {amount: "10"}}
+      ])
+
+      expect(result).to be_success
+      expect(attempts).to eq(2)
+      expect(charge.filters.reload.map(&:code)).to eq([base_code])
+    end
+
+    it "gives up when the retry collides too" do
+      allow(ChargeFilter).to receive(:insert_all!)
+        .and_raise(ActiveRecord::RecordNotUnique.new("index_charge_filters_on_charge_id_and_code"))
+
+      expect {
+        described_class.call(charge:, filters_params: [
+          {values: {"model" => %w[a]}, properties: {amount: "10"}}
+        ])
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
 end

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -202,5 +202,40 @@ RSpec.describe Charges::OverrideService do
         end
       end
     end
+
+    # The code is the link between a plan's filter and the copy on an override: the copy must
+    # carry the same one, never a freshly generated one.
+    context "with filter codes", :premium do
+      let(:params) { {id: charge.id, plan:, properties: {amount: "200"}} }
+
+      let(:bm_filter) do
+        create(:billable_metric_filter, billable_metric:, key: "model", values: %w[a b])
+      end
+
+      before do
+        %w[a b].each do |value|
+          filter = create(:charge_filter, charge:)
+          create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: [value])
+          filter.assign_code!
+        end
+      end
+
+      it "copies the parent codes onto the override" do
+        result = override_service.call
+
+        expect(result).to be_success
+        expect(result.charge.filters.map(&:code).sort).to eq(charge.filters.reload.map(&:code).sort)
+      end
+
+      it "gives the copies the code of the filter they came from" do
+        result = override_service.call
+
+        parent_codes = charge.filters.reload.to_h { |f| [f.to_h, f.code] }
+
+        result.charge.filters.each do |child_filter|
+          expect(child_filter.code).to eq(parent_codes[child_filter.to_h])
+        end
+      end
+    end
   end
 end

--- a/spec/services/database_migrations/enqueue_charge_filter_code_backfill_service_spec.rb
+++ b/spec/services/database_migrations/enqueue_charge_filter_code_backfill_service_spec.rb
@@ -43,6 +43,23 @@ RSpec.describe DatabaseMigrations::EnqueueChargeFilterCodeBackfillService do
         .once
     end
 
+    # The walk is one cursor per organization, so it has to carry on into the next one
+    it "hands out charges from every organization that is billing" do
+      build_filter(charge, ["us"])
+
+      other_organization = create(:organization)
+      create(:subscription, organization: other_organization, status: :active)
+      other_metric = create(:billable_metric, organization: other_organization)
+      other_charge = create(:standard_charge, plan: create(:plan, organization: other_organization), billable_metric: other_metric)
+      other_bm_filter = create(:billable_metric_filter, billable_metric: other_metric, key: "region", values: %w[us])
+      create(:charge_filter_value, charge_filter: create(:charge_filter, charge: other_charge),
+        billable_metric_filter: other_bm_filter, values: %w[us])
+
+      expect { service }
+        .to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob).with(charge.id).once
+        .and have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob).with(other_charge.id).once
+    end
+
     it "hands out every charge that needs one" do
       other = create(:standard_charge, plan:, billable_metric:)
       build_filter(charge, ["us"])

--- a/spec/services/database_migrations/enqueue_charge_filter_code_backfill_service_spec.rb
+++ b/spec/services/database_migrations/enqueue_charge_filter_code_backfill_service_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabaseMigrations::EnqueueChargeFilterCodeBackfillService do
+  subject(:service) { described_class.call(poll_interval: 0) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:bm_filter) { create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu]) }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+
+  def build_filter(on, values, **attrs)
+    filter = create(:charge_filter, charge: on, **attrs)
+    create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values:)
+    filter
+  end
+
+  # An organization with nothing active is not billing, so its filters are not worth the work
+  before { create(:subscription, organization:, status: :active) }
+
+  describe "#call" do
+    it "skips organizations with nothing active" do
+      dormant = create(:organization)
+      dormant_plan = create(:plan, organization: dormant)
+      dormant_metric = create(:billable_metric, organization: dormant)
+      dormant_charge = create(:standard_charge, plan: dormant_plan, billable_metric: dormant_metric)
+      dormant_filter = create(:charge_filter, charge: dormant_charge)
+      dormant_bm_filter = create(:billable_metric_filter, billable_metric: dormant_metric, key: "region", values: %w[us])
+      create(:charge_filter_value, charge_filter: dormant_filter, billable_metric_filter: dormant_bm_filter, values: %w[us])
+
+      expect { service }.not_to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob)
+        .with(dormant_charge.id)
+    end
+
+    it "enqueues one job for a plan charge still missing a code" do
+      build_filter(charge, ["us"])
+
+      expect { service }.to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob)
+        .with(charge.id)
+        .once
+    end
+
+    it "hands out every charge that needs one" do
+      other = create(:standard_charge, plan:, billable_metric:)
+      build_filter(charge, ["us"])
+      build_filter(other, ["eu"])
+
+      expect { service }.to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob).twice
+    end
+
+    # An override can only take a code its plan already holds, so it is a later pass.
+    it "ignores charges that override another" do
+      child_plan = create(:plan, organization:, parent: plan)
+      child_charge = create(:standard_charge, plan: child_plan, billable_metric:, parent: charge)
+      build_filter(child_charge, ["us"])
+
+      expect { service }.not_to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob)
+    end
+
+    it "ignores a charge whose filters already have codes" do
+      build_filter(charge, ["us"]).update_column(:code, "already_set") # rubocop:disable Rails/SkipsModelValidations
+
+      expect { service }.not_to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob)
+    end
+
+    it "ignores a charge with no filters at all" do
+      create(:standard_charge, plan:, billable_metric:)
+
+      expect { service }.not_to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob)
+    end
+
+    it "ignores discarded charges" do
+      build_filter(charge, ["us"])
+      charge.discard!
+
+      expect { service }.not_to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob)
+    end
+
+    # A deleted plan is not billing anything, so its filters are not worth the work — and the
+    # plan association is `with_discarded`, so without this they would come through
+    it "ignores charges on a discarded plan" do
+      build_filter(charge, ["us"])
+      plan.discard!
+
+      expect { service }.not_to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob)
+    end
+
+    it "walks past the end of a batch" do
+      3.times { build_filter(create(:standard_charge, plan:, billable_metric:), ["us"]) }
+
+      expect { described_class.call(batch_size: 2, poll_interval: 0) }
+        .to have_enqueued_job(DatabaseMigrations::BackfillChargeFilterCodesJob).exactly(3).times
+    end
+
+    # The cursor is on charges, so the batch bounds what is read as well as what is handed out.
+    # One plan holds 51,914 of them in production, and reading those in one go was what the
+    # earlier plan-driven walk could not avoid.
+    it "reads no more than a batch at a time" do
+      3.times { build_filter(create(:standard_charge, plan:, billable_metric:), ["us"]) }
+      queue = instance_double(Sidekiq::Queue, size: 0)
+      allow(Sidekiq::Queue).to receive(:new).and_return(queue)
+
+      described_class.call(batch_size: 1, poll_interval: 0)
+
+      # one check per batch, and a batch is one charge
+      expect(queue).to have_received(:size).at_least(3).times
+    end
+
+    # The queue is shared, so the walk has to stop pushing rather than bury everything else.
+    it "waits for the queue to drop below the limit before handing out more" do
+      build_filter(charge, ["us"])
+      queue = instance_double(Sidekiq::Queue)
+      allow(Sidekiq::Queue).to receive(:new).and_return(queue)
+      allow(queue).to receive(:size).and_return(5_000, 0)
+
+      described_class.call(max_queue_size: 10, poll_interval: 0)
+
+      expect(queue).to have_received(:size).at_least(:twice)
+    end
+  end
+end


### PR DESCRIPTION
## Context

A charge filter has no stable identity. It is known by its values, and those move: removing a value
from a billable metric trims it out of every filter using it, so two filters that were distinct can
collapse onto the same values and stop being distinguishable.

```
{region: [us], tier: [gold]}    @0.02     ->  {region: [us]}  @0.02
{region: [us], tier: [silver]}  @0.015    ->  {region: [us]}  @0.015
```

Propagating a plan's charge to its overrides pairs filters by those values, so once that happens it
can reprice the wrong one.

## Description

Charge filters get a `code`, derived from the values a filter is created with and frozen from then
on, so a filter keeps its identity even when its values move. An override inherits the code of the
filter it was copied from rather than deriving its own — that inheritance is what records the link
between the two.

A filter that exists **only** on the override, because the customer negotiated a segment the plan
does not price, derives its own code: there is nothing to inherit from, and it is not orphaned
either. If the plan later gains that predicate it derives the same code, so the two line up by
construction rather than by luck.

### Backfilling existing rows

One walk, over the charges belonging to a plan, a job per charge. Each job derives the codes for its
own filters and then hands its overrides on to a second job 

The unit of work is a charge on the way in and a parent on the way out, because every override of a
charge answers to the same set of codes.

### What stays NULL, on purpose

- **a charge holding two filters on one predicate** — whichever kept the code would be the one that
  bills from then on, and that is not a migration's call. Only the colliding filters are skipped;
  their siblings are still filled.
- **an override holding a filter its plan no longer has** — nothing left to link it to, either
  because the plan dropped it or because the parent charge was deleted and `dependent: :nullify` cut
  the link. Damage already done; no backfill undoes it.
- **a filter whose code a sibling already holds**, frozen when that sibling's own values were these —
  writing it again would break the unique index on `(charge_id, code)`.
- **organizations with nothing active or pending, and deleted plans** — not billing, not worth the work.

`rake filters:report_codes` reports what is left and why. Cleaning up the first kind and running the
upgrade task again converges, since a cleaned charge goes back to having filters without a code and
the walk selects it again.

