### PR TITLE
[ING-502] feat(alerts): add alert resolution columns

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -88,7 +88,7 @@ class Organization < ApplicationRecord
 
   has_many :subscription_activities, class_name: "UsageMonitoring::SubscriptionActivity"
   has_many :alerts, class_name: "UsageMonitoring::Alert"
-  has_many :triggered_alerts, class_name: "UsageMonitoring::TriggeredAlert"
+  has_many :triggered_alerts, -> { triggered }, class_name: "UsageMonitoring::TriggeredAlert"
   has_many :pending_vies_checks
 
   has_many :stripe_payment_providers, class_name: "PaymentProviders::StripeProvider"

--- a/app/models/usage_monitoring/alert.rb
+++ b/app/models/usage_monitoring/alert.rb
@@ -39,6 +39,11 @@ module UsageMonitoring
       dependent: :delete_all
 
     has_many :triggered_alerts,
+      -> { triggered },
+      foreign_key: :usage_monitoring_alert_id,
+      class_name: "UsageMonitoring::TriggeredAlert"
+
+    has_many :all_triggered_alerts,
       foreign_key: :usage_monitoring_alert_id,
       class_name: "UsageMonitoring::TriggeredAlert"
 

--- a/app/models/usage_monitoring/alert_threshold.rb
+++ b/app/models/usage_monitoring/alert_threshold.rb
@@ -2,11 +2,16 @@
 
 class UsageMonitoring::AlertThreshold < ApplicationRecord
   SOFT_LIMIT = 20
+  NOTIFY_ON_RESOLVED = "resolved"
 
   belongs_to :organization
   belongs_to :alert,
     foreign_key: "usage_monitoring_alert_id",
     class_name: "UsageMonitoring::Alert"
+
+  def notify_on_resolved?
+    notify_on.include?(NOTIFY_ON_RESOLVED)
+  end
 end
 
 # == Schema Information
@@ -16,6 +21,7 @@ end
 #
 #  id                        :uuid             not null, primary key
 #  code                      :string
+#  notify_on                 :string           default(["triggered"]), not null, is an Array
 #  recurring                 :boolean          default(FALSE), not null
 #  value                     :decimal(30, 5)   not null
 #  created_at                :datetime         not null

--- a/app/models/usage_monitoring/triggered_alert.rb
+++ b/app/models/usage_monitoring/triggered_alert.rb
@@ -2,6 +2,8 @@
 
 module UsageMonitoring
   class TriggeredAlert < ApplicationRecord
+    KINDS = {triggered: "triggered", resolved: "resolved", seeded: "seeded"}.freeze
+
     belongs_to :organization
     belongs_to :subscription, optional: true
     belongs_to :wallet, optional: true
@@ -9,6 +11,8 @@ module UsageMonitoring
       -> { with_discarded },
       foreign_key: "usage_monitoring_alert_id",
       class_name: "UsageMonitoring::Alert"
+
+    enum :kind, KINDS, validate: true
   end
 end
 
@@ -20,6 +24,9 @@ end
 #  id                        :uuid             not null, primary key
 #  crossed_thresholds        :jsonb
 #  current_value             :decimal(30, 5)   not null
+#  fully_resolved            :boolean
+#  in_alarm_thresholds       :jsonb
+#  kind                      :enum             default("triggered"), not null
 #  previous_value            :decimal(30, 5)   not null
 #  triggered_at              :datetime         not null
 #  created_at                :datetime         not null

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -17,7 +17,7 @@ class Wallet < ApplicationRecord
   has_many :billable_metrics, through: :wallet_targets
 
   has_many :alerts, class_name: "UsageMonitoring::Alert"
-  has_many :triggered_alerts, class_name: "UsageMonitoring::TriggeredAlert"
+  has_many :triggered_alerts, -> { triggered }, class_name: "UsageMonitoring::TriggeredAlert"
 
   has_many :activity_logs,
     -> { order(logged_at: :desc) },

--- a/db/migrate/20260804131008_add_alert_resolution_columns.rb
+++ b/db/migrate/20260804131008_add_alert_resolution_columns.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddAlertResolutionColumns < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :usage_monitoring_triggered_alert_kinds, %w[triggered resolved seeded]
+
+    add_column :usage_monitoring_alert_thresholds, :notify_on, :string, array: true, default: ["triggered"], null: false
+
+    add_column :usage_monitoring_triggered_alerts, :kind, :enum,
+      enum_type: :usage_monitoring_triggered_alert_kinds,
+      default: "triggered",
+      null: false
+    add_column :usage_monitoring_triggered_alerts, :in_alarm_thresholds, :jsonb
+    add_column :usage_monitoring_triggered_alerts, :fully_resolved, :boolean
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1310,6 +1310,7 @@ DROP TABLE IF EXISTS public.active_storage_attachments;
 DROP TABLE IF EXISTS partman.template_public_enriched_events;
 DROP FUNCTION IF EXISTS public.set_payment_receipt_number();
 DROP FUNCTION IF EXISTS public.ensure_role_consistency();
+DROP TYPE IF EXISTS public.usage_monitoring_triggered_alert_kinds;
 DROP TYPE IF EXISTS public.usage_monitoring_alert_types;
 DROP TYPE IF EXISTS public.usage_monitoring_alert_direction;
 DROP TYPE IF EXISTS public.tax_status;
@@ -1860,6 +1861,17 @@ CREATE TYPE public.usage_monitoring_alert_types AS ENUM (
     'wallet_ongoing_balance_amount',
     'wallet_credits_ongoing_balance',
     'billable_metric_lifetime_usage_units'
+);
+
+
+--
+-- Name: usage_monitoring_triggered_alert_kinds; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.usage_monitoring_triggered_alert_kinds AS ENUM (
+    'triggered',
+    'resolved',
+    'seeded'
 );
 
 
@@ -4356,7 +4368,8 @@ CREATE TABLE public.usage_monitoring_alert_thresholds (
     code character varying,
     recurring boolean DEFAULT false NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    notify_on character varying[] DEFAULT '{triggered}'::character varying[] NOT NULL
 );
 
 
@@ -4392,6 +4405,9 @@ CREATE TABLE public.usage_monitoring_triggered_alerts (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     wallet_id uuid,
+    kind public.usage_monitoring_triggered_alert_kinds DEFAULT 'triggered'::public.usage_monitoring_triggered_alert_kinds NOT NULL,
+    in_alarm_thresholds jsonb,
+    fully_resolved boolean,
     CONSTRAINT chk_triggered_alerts_subscription_xor_wallet CHECK (((subscription_id IS NOT NULL) <> (wallet_id IS NOT NULL)))
 );
 
@@ -14146,6 +14162,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260804131008'),
 ('20260803162623'),
 ('20260724094543'),
 ('20260724094542'),

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe Organization do
       expect(subject).to have_many(:pending_vies_checks)
       expect(subject).to have_many(:order_forms)
       expect(subject).to have_many(:orders)
+      expect(subject).to have_many(:triggered_alerts).class_name("UsageMonitoring::TriggeredAlert")
+        .conditions(kind: "triggered")
     end
   end
 

--- a/spec/models/usage_monitoring/alert_spec.rb
+++ b/spec/models/usage_monitoring/alert_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe UsageMonitoring::Alert do
       expect(subject).to have_many(:thresholds).class_name("UsageMonitoring::AlertThreshold")
         .with_foreign_key(:usage_monitoring_alert_id).dependent(:delete_all)
       expect(subject).to have_many(:triggered_alerts).class_name("UsageMonitoring::TriggeredAlert")
+        .with_foreign_key(:usage_monitoring_alert_id).conditions(kind: "triggered")
+      expect(subject).to have_many(:all_triggered_alerts).class_name("UsageMonitoring::TriggeredAlert")
         .with_foreign_key(:usage_monitoring_alert_id)
     end
   end

--- a/spec/models/usage_monitoring/alert_threshold_spec.rb
+++ b/spec/models/usage_monitoring/alert_threshold_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsageMonitoring::AlertThreshold do
+  describe "associations" do
+    it do
+      expect(subject).to belong_to(:organization)
+      expect(subject).to belong_to(:alert).class_name("UsageMonitoring::Alert")
+        .with_foreign_key(:usage_monitoring_alert_id)
+    end
+  end
+
+  describe "notify_on" do
+    it "notifies on trigger only by default" do
+      expect(create(:alert_threshold).notify_on).to eq(["triggered"])
+    end
+  end
+
+  describe "#notify_on_resolved?" do
+    it "is false when the threshold notifies on trigger only" do
+      expect(create(:alert_threshold)).not_to be_notify_on_resolved
+    end
+
+    it "is true when the threshold opted in to resolution" do
+      expect(create(:alert_threshold, notify_on: %w[triggered resolved])).to be_notify_on_resolved
+    end
+  end
+end

--- a/spec/models/usage_monitoring/triggered_alert_spec.rb
+++ b/spec/models/usage_monitoring/triggered_alert_spec.rb
@@ -5,6 +5,15 @@ require "rails_helper"
 RSpec.describe UsageMonitoring::TriggeredAlert do
   let(:triggered_alert) { create(:triggered_alert) }
 
+  describe "enums" do
+    it do
+      expect(subject).to define_enum_for(:kind)
+        .backed_by_column_of_type(:enum)
+        .validating
+        .with_values(triggered: "triggered", resolved: "resolved", seeded: "seeded")
+    end
+  end
+
   describe "associations" do
     it do
       expect(subject).to belong_to(:organization)
@@ -12,6 +21,20 @@ RSpec.describe UsageMonitoring::TriggeredAlert do
       expect(subject).to belong_to(:wallet).optional
       expect(subject).to belong_to(:alert).class_name("UsageMonitoring::Alert")
         .with_foreign_key(:usage_monitoring_alert_id)
+    end
+  end
+
+  describe "kind" do
+    it "records a trigger by default" do
+      expect(triggered_alert).to be_triggered
+    end
+  end
+
+  describe "resolution columns" do
+    it "records which codes remain in alarm and whether the alert is fully resolved" do
+      resolved = create(:triggered_alert, kind: :resolved, in_alarm_thresholds: ["warn"], fully_resolved: false)
+
+      expect(resolved.reload).to have_attributes(in_alarm_thresholds: ["warn"], fully_resolved: false)
     end
   end
 end

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Wallet do
       expect(subject).to have_one(:metadata).class_name("Metadata::ItemMetadata").dependent(:destroy)
       expect(subject).to have_many(:alerts).class_name("UsageMonitoring::Alert")
       expect(subject).to have_many(:triggered_alerts).class_name("UsageMonitoring::TriggeredAlert")
+        .conditions(kind: "triggered")
     end
   end
 


### PR DESCRIPTION
## Context

Lago alerts only fire when usage or a wallet balance crosses a limit; they never signal the return to normal. A customer who automatically blocks something on an alert has no automatic way to release that block. This adds the schema for a new `alert.resolved` webhook that a threshold can opt into.

Nothing here is reachable yet. The feature stays inactive until the API opt-in ships, so this is groundwork.

## Changes

- `notify_on` on alert thresholds. It defaults to notifying on trigger only, so existing alerts behave exactly as today.
- `kind` on alert events, distinguishing a real trigger from a recovery, and from a silent record written when a threshold already sits past its line at opt-in time.
- `in_alarm_thresholds` and `fully_resolved` on alert events, populated only on recovery rows.
- The three `triggered_alerts` associations are scoped to triggers, so readers whose name already promises triggers keep meaning that once recoveries exist. `Alert` also gains `all_triggered_alerts` for the full event stream, mirroring `billing_entities` and `all_billing_entities` on `Organization`.

Every column is added with a constant default, so these are metadata-only changes on PostgreSQL 15: no table rewrite, no long lock, and no back-fill.

Both alert serializers, the GraphQL threshold type and the export view all enumerate their fields explicitly, so none of the new columns reaches a customer-visible surface.
