### PR TITLE
feat(graphql): array-based customer payment connections

### DIFF
--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -38,8 +38,8 @@ module Types
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :payment_provider_code, String, required: false
-      argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
       argument :payment_provider_customers, [Types::PaymentProviderCustomers::CustomerInput], required: false
+      argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
 
       argument :integration_customers, [Types::IntegrationCustomers::Input], required: false
 

--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -39,6 +39,7 @@ module Types
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :payment_provider_code, String, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
+      argument :payment_provider_customers, [Types::PaymentProviderCustomers::CustomerInput], required: false
 
       argument :integration_customers, [Types::IntegrationCustomers::Input], required: false
 

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -158,26 +158,6 @@ module Types
         object.active_subscriptions.count
       end
 
-      # The payment list always surfaces a "manual" option so the UI can select it. When the
-      # customer has no persisted manual connection, a non-persisted placeholder is prepended.
-      def payment_provider_customers
-        connections = object.payment_provider_customers.to_a
-        return connections if connections.any?(&:manual?)
-
-        [manual_connection_placeholder, *connections]
-      end
-
-      def manual_connection_placeholder
-        {
-          id: "#{object.id}-manual",
-          code: ::PaymentProviderCustomers::BaseCustomer::MANUAL_CODE,
-          is_default: false,
-          provider_customer_id: nil,
-          provider_payment_methods: nil,
-          sync_with_provider: nil
-        }
-      end
-
       def provider_customer # rubocop:disable GraphQL/ResolverMethodLength
         case object&.payment_provider&.to_sym
         when :stripe

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -158,6 +158,26 @@ module Types
         object.active_subscriptions.count
       end
 
+      # The payment list always surfaces a "manual" option so the UI can select it. When the
+      # customer has no persisted manual connection, a non-persisted placeholder is prepended.
+      def payment_provider_customers
+        connections = object.payment_provider_customers.to_a
+        return connections if connections.any?(&:manual?)
+
+        [manual_connection_placeholder, *connections]
+      end
+
+      def manual_connection_placeholder
+        {
+          id: "#{object.id}-manual",
+          code: ::PaymentProviderCustomers::BaseCustomer::MANUAL_CODE,
+          is_default: false,
+          provider_customer_id: nil,
+          provider_payment_methods: nil,
+          sync_with_provider: nil
+        }
+      end
+
       def provider_customer # rubocop:disable GraphQL/ResolverMethodLength
         case object&.payment_provider&.to_sym
         when :stripe

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -45,15 +45,31 @@ module Types
 
       field :billing_configuration, Types::Customers::BillingConfiguration, null: true
 
-      field :provider_customer, Types::PaymentProviderCustomers::Provider, null: true
+      field :payment_provider_customers, [Types::PaymentProviderCustomers::Provider], null: false
+      field :connection_status,
+        Types::PaymentProviderCustomers::ConnectionStatusEnum,
+        null: false,
+        method: :payment_connection_status,
+        description: "Payment connection status derived from the customer's default payment connection"
       field :subscriptions, [Types::Subscriptions::Object], resolver: Resolvers::Customers::SubscriptionsResolver
 
-      field :anrok_customer, Types::IntegrationCustomers::Anrok, null: true
-      field :avalara_customer, Types::IntegrationCustomers::Avalara, null: true
-      field :hubspot_customer, Types::IntegrationCustomers::Hubspot, null: true
-      field :netsuite_customer, Types::IntegrationCustomers::Netsuite, null: true
-      field :salesforce_customer, Types::IntegrationCustomers::Salesforce, null: true
-      field :xero_customer, Types::IntegrationCustomers::Xero, null: true
+      field :integration_customers, [Types::IntegrationCustomers::Object], null: false
+
+      field :provider_customer, Types::PaymentProviderCustomers::Provider, null: true,
+        deprecation_reason: "Use paymentProviderCustomers instead"
+
+      field :anrok_customer, Types::IntegrationCustomers::Anrok, null: true,
+        deprecation_reason: "Use integrationCustomers instead"
+      field :avalara_customer, Types::IntegrationCustomers::Avalara, null: true,
+        deprecation_reason: "Use integrationCustomers instead"
+      field :hubspot_customer, Types::IntegrationCustomers::Hubspot, null: true,
+        deprecation_reason: "Use integrationCustomers instead"
+      field :netsuite_customer, Types::IntegrationCustomers::Netsuite, null: true,
+        deprecation_reason: "Use integrationCustomers instead"
+      field :salesforce_customer, Types::IntegrationCustomers::Salesforce, null: true,
+        deprecation_reason: "Use integrationCustomers instead"
+      field :xero_customer, Types::IntegrationCustomers::Xero, null: true,
+        deprecation_reason: "Use integrationCustomers instead"
 
       field :billing_entity, Types::BillingEntities::Object, null: false
       field :invoices, [Types::Invoices::Object]

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -45,12 +45,12 @@ module Types
 
       field :billing_configuration, Types::Customers::BillingConfiguration, null: true
 
-      field :payment_provider_customers, [Types::PaymentProviderCustomers::Provider], null: false
       field :connection_status,
         Types::PaymentProviderCustomers::ConnectionStatusEnum,
         null: false,
         method: :payment_connection_status,
         description: "Payment connection status derived from the customer's default payment connection"
+      field :payment_provider_customers, [Types::PaymentProviderCustomers::Provider], null: false
       field :subscriptions, [Types::Subscriptions::Object], resolver: Resolvers::Customers::SubscriptionsResolver
 
       field :integration_customers, [Types::IntegrationCustomers::Object], null: false

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -37,8 +37,8 @@ module Types
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false, permission: "customers:update"
       argument :payment_provider_code, String, required: false, permission: "customers:update"
-      argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false, permission: "customers:update"
       argument :payment_provider_customers, [Types::PaymentProviderCustomers::CustomerInput], required: false, permission: "customers:update"
+      argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false, permission: "customers:update"
 
       argument :integration_customers, [Types::IntegrationCustomers::Input], required: false, permission: "customers:update"
 

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -38,6 +38,7 @@ module Types
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false, permission: "customers:update"
       argument :payment_provider_code, String, required: false, permission: "customers:update"
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false, permission: "customers:update"
+      argument :payment_provider_customers, [Types::PaymentProviderCustomers::CustomerInput], required: false, permission: "customers:update"
 
       argument :integration_customers, [Types::IntegrationCustomers::Input], required: false, permission: "customers:update"
 

--- a/app/graphql/types/payment_provider_customers/connection_status_enum.rb
+++ b/app/graphql/types/payment_provider_customers/connection_status_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentProviderCustomers
+    class ConnectionStatusEnum < Types::BaseEnum
+      graphql_name "PaymentProviderConnectionStatusEnum"
+
+      ::PaymentProviderCustomers::BaseCustomer::CONNECTION_STATUSES.each_value do |status|
+        value status
+      end
+    end
+  end
+end

--- a/app/graphql/types/payment_provider_customers/customer_input.rb
+++ b/app/graphql/types/payment_provider_customers/customer_input.rb
@@ -7,9 +7,9 @@ module Types
 
       argument :id, ID, required: false
 
+      # NOTE: code "lago_manual" flags the reserved null-provider connection; provider connections
+      # carry their own code and payment provider.
       argument :code, String, required: false
-      # NOTE: "lago_manual" flags the reserved null-provider connection; omit for provider connections.
-      argument :type, String, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :payment_provider_code, String, required: false

--- a/app/graphql/types/payment_provider_customers/customer_input.rb
+++ b/app/graphql/types/payment_provider_customers/customer_input.rb
@@ -8,8 +8,7 @@ module Types
       argument :id, ID, required: false
 
       argument :code, String, required: false
-      argument :is_default, Boolean, required: false
-      # NOTE: "manual" flags the reserved null-provider connection; omit for provider connections.
+      # NOTE: "lago_manual" flags the reserved null-provider connection; omit for provider connections.
       argument :type, String, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false

--- a/app/graphql/types/payment_provider_customers/customer_input.rb
+++ b/app/graphql/types/payment_provider_customers/customer_input.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentProviderCustomers
+    class CustomerInput < Types::BaseInputObject
+      graphql_name "PaymentProviderCustomerInput"
+
+      argument :id, ID, required: false
+
+      argument :code, String, required: false
+      argument :is_default, Boolean, required: false
+      # NOTE: "manual" flags the reserved null-provider connection; omit for provider connections.
+      argument :type, String, required: false
+
+      argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
+      argument :payment_provider_code, String, required: false
+      argument :provider_customer_id, ID, required: false
+      argument :provider_payment_methods, [Types::PaymentProviderCustomers::ProviderPaymentMethodsEnum], required: false
+      argument :sync_with_provider, Boolean, required: false
+    end
+  end
+end

--- a/app/models/concerns/connection_resolvable.rb
+++ b/app/models/concerns/connection_resolvable.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Resolves the effective connection of each category (payment / tax / accounting / crm) for a
+# billing object, cascading an explicit per-object override to the customer default:
+#
+#   * an override row (billing_object_connections) with behavior "specific" pins its connection
+#   * an override row with behavior "skip" resolves to nil (no connection for that category)
+#   * no override row means "inherit": fall back to the customer's default connection
+#
+# For a single-connection customer with no overrides this returns that connection, so behaviour
+# is unchanged.
+module ConnectionResolvable
+  extend ActiveSupport::Concern
+
+  CATEGORIES = BillingObjectConnection::CATEGORIES
+
+  def effective_payment_connection
+    effective_connection(CATEGORIES[:payment])
+  end
+
+  def effective_tax_connection
+    effective_connection(CATEGORIES[:tax])
+  end
+
+  def effective_accounting_connection
+    effective_connection(CATEGORIES[:accounting])
+  end
+
+  def effective_crm_connection
+    effective_connection(CATEGORIES[:crm])
+  end
+
+  private
+
+  def effective_connection(category)
+    override = billing_object_connections.find_by(category:)
+
+    if override
+      return nil if override.skip?
+
+      return override_connection(override, category)
+    end
+
+    customer_default_connection(category)
+  end
+
+  def override_connection(override, category)
+    if category == CATEGORIES[:payment]
+      override.payment_provider_customer
+    else
+      override.integration_customer
+    end
+  end
+
+  def customer_default_connection(category)
+    return unless customer
+
+    if category == CATEGORIES[:payment]
+      customer.payment_connection
+    else
+      customer.integration_connection(category)
+    end
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -384,6 +384,11 @@ class Customer < ApplicationRecord
     payment_provider_customers.find_by(is_default: true)
   end
 
+  # The customer's default integration connection for a category (tax / accounting / crm).
+  def integration_connection(category)
+    integration_customers.where(category:).find_by(is_default: true)
+  end
+
   def payment_connection_status
     connection = payment_connection
 

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -27,6 +27,8 @@ module PaymentProviderCustomers
     has_many :payment_methods, foreign_key: :payment_provider_customer_id
     has_many :refunds, foreign_key: :payment_provider_customer_id
 
+    before_validation :set_code
+
     validates :customer_id, uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :type}
     validates :code, uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :customer_id}, allow_nil: true
     validate :code_is_not_reserved
@@ -58,6 +60,11 @@ module PaymentProviderCustomers
     end
 
     private
+
+    # A connection's code defaults to its payment provider's code when none is provided.
+    def set_code
+      self.code ||= payment_provider&.code
+    end
 
     # The "lago_manual" code is reserved for the null-provider manual connection; a provider-backed
     # connection cannot use it.

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -40,12 +40,6 @@ module PaymentProviderCustomers
         .where(provider_customer_id: provider_id)
     end
 
-    # A manual payment row is a reserved null-provider connection (code "manual"). It is the
-    # implicit payment default when no provider connection is set.
-    def manual?
-      payment_provider_id.nil? && code == MANUAL_CODE
-    end
-
     def provider_payment_methods
       nil
     end

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -40,6 +40,12 @@ module PaymentProviderCustomers
         .where(provider_customer_id: provider_id)
     end
 
+    # A manual payment row is a reserved null-provider connection (code "manual"). It is the
+    # implicit payment default when no provider connection is set.
+    def manual?
+      payment_provider_id.nil? && code == MANUAL_CODE
+    end
+
     def provider_payment_methods
       nil
     end

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -3,10 +3,13 @@
 class RecurringTransactionRule < ApplicationRecord
   include HasPurchaseOrderNumber
   include PaperTrailTraceable
+  include ConnectionResolvable
 
   belongs_to :wallet
   belongs_to :organization
   belongs_to :payment_method, optional: true
+
+  delegate :customer, to: :wallet
 
   has_many :billing_object_connections, as: :owner, dependent: :destroy
   has_many :applied_invoice_custom_sections,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,6 +4,7 @@ class Subscription < ApplicationRecord
   include HasPurchaseOrderNumber
   include PaperTrailTraceable
   include RansackUuidSearch
+  include ConnectionResolvable
 
   self.ignored_columns += %w[incompleted_at cancelation_reason]
 

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -4,6 +4,7 @@ class Wallet < ApplicationRecord
   include HasPurchaseOrderNumber
   include PaperTrailTraceable
   include Currencies
+  include ConnectionResolvable
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :organization

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -114,8 +114,7 @@ module Customers
       if args.key?(:payment_provider_customers)
         PaymentProviderCustomers::CreateOrUpdateBatchService.call(
           payment_provider_customers: args[:payment_provider_customers],
-          customer:,
-          new_customer: true
+          customer:
         ).raise_if_error!
       end
 

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -99,14 +99,25 @@ module Customers
         args[:metadata].each { |m| create_metadata(customer:, args: m) } if args[:metadata].present?
       end
 
-      # NOTE: handle configuration for configured payment providers
-      billing_configuration = args[:provider_customer]&.to_h&.merge(
-        payment_provider: args[:payment_provider],
-        payment_provider_code: args[:payment_provider_code]
-      )
-      create_billing_configuration(customer, billing_configuration)
+      # NOTE: the payment_provider_customers array (new shape) takes precedence over the singular
+      # provider_customer (deprecated). Only fall back to the legacy path when the array is absent.
+      unless args.key?(:payment_provider_customers)
+        billing_configuration = args[:provider_customer]&.to_h&.merge(
+          payment_provider: args[:payment_provider],
+          payment_provider_code: args[:payment_provider_code]
+        )
+        create_billing_configuration(customer, billing_configuration)
+      end
 
       result.customer = customer
+
+      if args.key?(:payment_provider_customers)
+        PaymentProviderCustomers::CreateOrUpdateBatchService.call(
+          payment_provider_customers: args[:payment_provider_customers],
+          customer:,
+          new_customer: true
+        ).raise_if_error!
+      end
 
       IntegrationCustomers::CreateOrUpdateBatchService.call(
         integration_customers: args[:integration_customers],

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -191,8 +191,7 @@ module Customers
       if args.key?(:payment_provider_customers)
         PaymentProviderCustomers::CreateOrUpdateBatchService.call(
           payment_provider_customers: args[:payment_provider_customers],
-          customer:,
-          new_customer: false
+          customer:
         ).raise_if_error!
       else
         if args.key?(:provider_customer) || args.key?(:payment_provider)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -186,15 +186,24 @@ module Customers
         Customers::Metadata::UpdateService.call(customer:, params: args[:metadata]) if args[:metadata]
       end
 
-      # NOTE: if payment provider is updated, we need to create/update the provider customer
-      if args.key?(:provider_customer) || args.key?(:payment_provider)
-        payment_provider = old_payment_provider || customer.payment_provider
-        create_or_update_provider_customer(customer, payment_provider, args[:provider_customer])
-      end
+      # NOTE: the payment_provider_customers array (new shape) takes precedence over the singular
+      # provider_customer (deprecated). Only fall back to the legacy path when the array is absent.
+      if args.key?(:payment_provider_customers)
+        PaymentProviderCustomers::CreateOrUpdateBatchService.call(
+          payment_provider_customers: args[:payment_provider_customers],
+          customer:,
+          new_customer: false
+        ).raise_if_error!
+      else
+        if args.key?(:provider_customer) || args.key?(:payment_provider)
+          payment_provider = old_payment_provider || customer.payment_provider
+          create_or_update_provider_customer(customer, payment_provider, args[:provider_customer])
+        end
 
-      if args.dig(:provider_customer, :provider_customer_id)
-        update_result = PaymentProviderCustomers::UpdateService.call(customer)
-        update_result.raise_if_error!
+        if args.dig(:provider_customer, :provider_customer_id)
+          update_result = PaymentProviderCustomers::UpdateService.call(customer)
+          update_result.raise_if_error!
+        end
       end
 
       result.customer = customer

--- a/app/services/payment_provider_customers/create_connection_service.rb
+++ b/app/services/payment_provider_customers/create_connection_service.rb
@@ -22,7 +22,7 @@ module PaymentProviderCustomers
       ActiveRecord::Base.transaction do
         @payment_provider_customer = create_provider_customer(payment_provider)
 
-        payment_provider_customer.code = params[:code] || payment_provider.code
+        payment_provider_customer.code = params[:code] if params[:code].present?
         payment_provider_customer.is_default = true if first_connection
         payment_provider_customer.save!
 

--- a/app/services/payment_provider_customers/create_or_update_batch_service.rb
+++ b/app/services/payment_provider_customers/create_or_update_batch_service.rb
@@ -10,16 +10,24 @@ module PaymentProviderCustomers
 
     MANUAL_CODE = PaymentProviderCustomers::BaseCustomer::MANUAL_CODE
 
-    def initialize(customer:, payment_provider_customers:, new_customer:)
+    def initialize(customer:, payment_provider_customers:)
       @customer = customer
       @params_list = payment_provider_customers&.map { |c| c.to_h.deep_symbolize_keys }
-      @new_customer = new_customer
 
       super
     end
 
     def call
       return result if params_list.nil? || customer.nil?
+
+      # TEMPORARY: the array carries a single connection until multi-connection support ships;
+      # reject more than one so the feature is consumed incrementally.
+      if params_list.size > 1
+        return result.single_validation_failure!(
+          field: :payment_provider_customers,
+          error_code: "only_one_connection_allowed"
+        )
+      end
 
       ActiveRecord::Base.transaction do
         discard_removed_connections
@@ -36,7 +44,7 @@ module PaymentProviderCustomers
 
     private
 
-    attr_reader :customer, :params_list, :new_customer
+    attr_reader :customer, :params_list
 
     def discard_removed_connections
       kept_ids = params_list.filter_map { |params| params[:id] }
@@ -60,7 +68,7 @@ module PaymentProviderCustomers
     end
 
     def manual?(params)
-      params[:type] == MANUAL_CODE
+      params[:code] == MANUAL_CODE
     end
 
     def upsert_manual

--- a/app/services/payment_provider_customers/create_or_update_batch_service.rb
+++ b/app/services/payment_provider_customers/create_or_update_batch_service.rb
@@ -3,8 +3,8 @@
 module PaymentProviderCustomers
   # Declaratively reconciles a customer's payment provider connections from the GraphQL array:
   # connections absent from the array (matched by id) are discarded, provider connections are
-  # created/updated, the reserved manual connection is created on demand, and the element flagged
-  # is_default becomes the customer default.
+  # created/updated, and the reserved manual connection is created on demand. The customer default
+  # is managed through the dedicated set-as-default mutation, not this array.
   class CreateOrUpdateBatchService < BaseService
     Result = BaseResult[:payment_provider_customers]
 
@@ -24,7 +24,6 @@ module PaymentProviderCustomers
       ActiveRecord::Base.transaction do
         discard_removed_connections
         params_list.each { |params| upsert_connection(params) }
-        apply_default
       end
 
       result.payment_provider_customers = customer.payment_provider_customers.reload
@@ -83,17 +82,6 @@ module PaymentProviderCustomers
         :provider_payment_methods,
         :sync_with_provider
       )
-    end
-
-    # The element explicitly flagged as default wins; later flags override earlier ones.
-    def apply_default
-      default_params = params_list.rfind { |params| params[:is_default] }
-      return unless default_params
-
-      connection = customer.payment_provider_customers.by_code(default_params[:code]).first
-      return unless connection
-
-      PaymentProviderCustomers::SetAsDefaultService.call!(payment_provider_customer: connection)
     end
   end
 end

--- a/app/services/payment_provider_customers/create_or_update_batch_service.rb
+++ b/app/services/payment_provider_customers/create_or_update_batch_service.rb
@@ -23,7 +23,7 @@ module PaymentProviderCustomers
 
       ActiveRecord::Base.transaction do
         discard_removed_connections
-        params_list.each { |params| upsert(params) }
+        params_list.each { |params| upsert_connection(params) }
         apply_default
       end
 
@@ -47,7 +47,7 @@ module PaymentProviderCustomers
       end
     end
 
-    def upsert(params)
+    def upsert_connection(params)
       if manual?(params)
         upsert_manual
       elsif params[:id]
@@ -87,7 +87,7 @@ module PaymentProviderCustomers
 
     # The element explicitly flagged as default wins; later flags override earlier ones.
     def apply_default
-      default_params = params_list.reverse.find { |params| params[:is_default] }
+      default_params = params_list.rfind { |params| params[:is_default] }
       return unless default_params
 
       connection = customer.payment_provider_customers.by_code(default_params[:code]).first

--- a/app/services/payment_provider_customers/create_or_update_batch_service.rb
+++ b/app/services/payment_provider_customers/create_or_update_batch_service.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  # Declaratively reconciles a customer's payment provider connections from the GraphQL array:
+  # connections absent from the array (matched by id) are discarded, provider connections are
+  # created/updated, the reserved manual connection is created on demand, and the element flagged
+  # is_default becomes the customer default.
+  class CreateOrUpdateBatchService < BaseService
+    Result = BaseResult[:payment_provider_customers]
+
+    MANUAL_CODE = PaymentProviderCustomers::BaseCustomer::MANUAL_CODE
+
+    def initialize(customer:, payment_provider_customers:, new_customer:)
+      @customer = customer
+      @params_list = payment_provider_customers&.map { |c| c.to_h.deep_symbolize_keys }
+      @new_customer = new_customer
+
+      super
+    end
+
+    def call
+      return result if params_list.nil? || customer.nil?
+
+      ActiveRecord::Base.transaction do
+        discard_removed_connections
+        params_list.each { |params| upsert(params) }
+        apply_default
+      end
+
+      result.payment_provider_customers = customer.payment_provider_customers.reload
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      result.fail_with_error!(e)
+    end
+
+    private
+
+    attr_reader :customer, :params_list, :new_customer
+
+    def discard_removed_connections
+      kept_ids = params_list.filter_map { |params| params[:id] }
+
+      customer.payment_provider_customers.where.not(id: kept_ids).find_each do |connection|
+        PaymentProviderCustomers::DestroyService.call!(payment_provider_customer: connection)
+      end
+    end
+
+    def upsert(params)
+      if manual?(params)
+        upsert_manual
+      elsif params[:id]
+        PaymentProviderCustomers::UpdateConnectionService.call!(
+          payment_provider_customer: customer.payment_provider_customers.find(params[:id]),
+          params: connection_params(params)
+        )
+      else
+        PaymentProviderCustomers::CreateConnectionService.call!(customer:, params: connection_params(params))
+      end
+    end
+
+    def manual?(params)
+      params[:type] == MANUAL_CODE
+    end
+
+    def upsert_manual
+      return if customer.payment_provider_customers.by_code(MANUAL_CODE).exists?
+
+      customer.payment_provider_customers.create!(
+        organization_id: customer.organization_id,
+        type: "PaymentProviderCustomers::BaseCustomer",
+        code: MANUAL_CODE
+      )
+    end
+
+    def connection_params(params)
+      params.slice(
+        :code,
+        :payment_provider,
+        :payment_provider_code,
+        :provider_customer_id,
+        :provider_payment_methods,
+        :sync_with_provider
+      )
+    end
+
+    # The element explicitly flagged as default wins; later flags override earlier ones.
+    def apply_default
+      default_params = params_list.reverse.find { |params| params[:is_default] }
+      return unless default_params
+
+      connection = customer.payment_provider_customers.by_code(default_params[:code]).first
+      return unless connection
+
+      PaymentProviderCustomers::SetAsDefaultService.call!(payment_provider_customer: connection)
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -10606,7 +10606,6 @@ input PaymentProviderCustomerInput {
   providerCustomerId: ID
   providerPaymentMethods: [ProviderPaymentMethodsEnum!]
   syncWithProvider: Boolean
-  type: String
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -10601,7 +10601,6 @@ enum PaymentProviderConnectionStatusEnum {
 input PaymentProviderCustomerInput {
   code: String
   id: ID
-  isDefault: Boolean
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
   providerCustomerId: ID

--- a/schema.graphql
+++ b/schema.graphql
@@ -3134,6 +3134,7 @@ input CreateCustomerInput {
   netPaymentTerm: Int
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
+  paymentProviderCustomers: [PaymentProviderCustomerInput!]
   phone: String
   providerCustomer: ProviderCustomerInput
   shippingAddress: CustomerAddressInput
@@ -10597,6 +10598,18 @@ enum PaymentProviderConnectionStatusEnum {
   not_connected
 }
 
+input PaymentProviderCustomerInput {
+  code: String
+  id: ID
+  isDefault: Boolean
+  paymentProvider: ProviderTypeEnum
+  paymentProviderCode: String
+  providerCustomerId: ID
+  providerPaymentMethods: [ProviderPaymentMethodsEnum!]
+  syncWithProvider: Boolean
+  type: String
+}
+
 """
 PaymentReceipt
 """
@@ -14769,6 +14782,7 @@ input UpdateCustomerInput {
   netPaymentTerm: Int
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
+  paymentProviderCustomers: [PaymentProviderCustomerInput!]
   phone: String
   providerCustomer: ProviderCustomerInput
   shippingAddress: CustomerAddressInput

--- a/schema.graphql
+++ b/schema.graphql
@@ -4802,12 +4802,12 @@ type Customer {
   activityLogs: [ActivityLog!]
   addressLine1: String
   addressLine2: String
-  anrokCustomer: AnrokCustomer
+  anrokCustomer: AnrokCustomer @deprecated(reason: "Use integrationCustomers instead")
   applicableTimezone: TimezoneEnum!
   appliedAddOns: [AppliedAddOn!]
   appliedCoupons: [AppliedCoupon!]
   appliedDunningCampaign: DunningCampaign
-  avalaraCustomer: AvalaraCustomer
+  avalaraCustomer: AvalaraCustomer @deprecated(reason: "Use integrationCustomers instead")
   billingConfiguration: CustomerBillingConfiguration
   billingEntity: BillingEntity!
 
@@ -4821,6 +4821,11 @@ type Customer {
   Invoice custom sections manually configured for the customer
   """
   configurableInvoiceCustomSections: [InvoiceCustomSection!]
+
+  """
+  Payment connection status derived from the customer's default payment connection
+  """
+  connectionStatus: PaymentProviderConnectionStatusEnum!
   country: CountryCode
   createdAt: ISO8601DateTime!
   creditNotes: [CreditNote!]
@@ -4874,8 +4879,9 @@ type Customer {
   Define if the customer has custom invoice custom sections selection
   """
   hasOverwrittenInvoiceCustomSectionsSelection: Boolean
-  hubspotCustomer: HubspotCustomer
+  hubspotCustomer: HubspotCustomer @deprecated(reason: "Use integrationCustomers instead")
   id: ID!
+  integrationCustomers: [IntegrationCustomer!]!
   invoiceGracePeriod: Int
   invoices: [Invoice!]
   lastDunningCampaignAttempt: Int!
@@ -4887,7 +4893,7 @@ type Customer {
   metadata: [CustomerMetadata!]
   name: String
   netPaymentTerm: Int
-  netsuiteCustomer: NetsuiteCustomer
+  netsuiteCustomer: NetsuiteCustomer @deprecated(reason: "Use integrationCustomers instead")
 
   """
   Overdue balance per currency
@@ -4895,9 +4901,10 @@ type Customer {
   overdueBalances: [CustomerOverdueBalance!]!
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
+  paymentProviderCustomers: [ProviderCustomer!]!
   phone: String
-  providerCustomer: ProviderCustomer
-  salesforceCustomer: SalesforceCustomer
+  providerCustomer: ProviderCustomer @deprecated(reason: "Use paymentProviderCustomers instead")
+  salesforceCustomer: SalesforceCustomer @deprecated(reason: "Use integrationCustomers instead")
   sequentialId: String!
   shippingAddress: CustomerAddress
 
@@ -4922,7 +4929,7 @@ type Customer {
   timezone: TimezoneEnum
   updatedAt: ISO8601DateTime!
   url: String
-  xeroCustomer: XeroCustomer
+  xeroCustomer: XeroCustomer @deprecated(reason: "Use integrationCustomers instead")
   zipcode: String
 }
 
@@ -10582,6 +10589,12 @@ type PaymentProviderCollection {
   Pagination Metadata for navigating the Pagination
   """
   metadata: CollectionMetadata!
+}
+
+enum PaymentProviderConnectionStatusEnum {
+  connected
+  manual
+  not_connected
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -13428,18 +13428,6 @@
               "deprecationReason": null
             },
             {
-              "name": "providerCustomer",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ProviderCustomerInput",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "paymentProviderCustomers",
               "description": null,
               "type": {
@@ -13454,6 +13442,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "providerCustomer",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProviderCustomerInput",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -78639,18 +78639,6 @@
               "deprecationReason": null
             },
             {
-              "name": "providerCustomer",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ProviderCustomerInput",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "paymentProviderCustomers",
               "description": null,
               "type": {
@@ -78665,6 +78653,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "providerCustomer",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProviderCustomerInput",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -51282,18 +51282,6 @@
               "deprecationReason": null
             },
             {
-              "name": "type",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "paymentProvider",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -21768,8 +21768,8 @@
                 "name": "AnrokCustomer",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use integrationCustomers instead"
             },
             {
               "name": "applicableTimezone",
@@ -21848,8 +21848,8 @@
                 "name": "AvalaraCustomer",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use integrationCustomers instead"
             },
             {
               "name": "billingConfiguration",
@@ -21922,6 +21922,22 @@
                     "name": "InvoiceCustomSection",
                     "ofType": null
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "connectionStatus",
+              "description": "Payment connection status derived from the customer's default payment connection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PaymentProviderConnectionStatusEnum",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -22252,8 +22268,8 @@
                 "name": "HubspotCustomer",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use integrationCustomers instead"
             },
             {
               "name": "id",
@@ -22266,6 +22282,30 @@
                   "kind": "SCALAR",
                   "name": "ID",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "integrationCustomers",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "IntegrationCustomer",
+                      "ofType": null
+                    }
+                  }
                 }
               },
               "isDeprecated": false,
@@ -22432,8 +22472,8 @@
                 "name": "NetsuiteCustomer",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use integrationCustomers instead"
             },
             {
               "name": "overdueBalances",
@@ -22484,6 +22524,30 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentProviderCustomers",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProviderCustomer",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "phone",
               "description": null,
               "args": [],
@@ -22504,8 +22568,8 @@
                 "name": "ProviderCustomer",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use paymentProviderCustomers instead"
             },
             {
               "name": "salesforceCustomer",
@@ -22516,8 +22580,8 @@
                 "name": "SalesforceCustomer",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use integrationCustomers instead"
             },
             {
               "name": "sequentialId",
@@ -22713,8 +22777,8 @@
                 "name": "XeroCustomer",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use integrationCustomers instead"
             },
             {
               "name": "zipcode",
@@ -51136,6 +51200,35 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "PaymentProviderConnectionStatusEnum",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "not_connected",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "manual",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "connected",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {

--- a/schema.json
+++ b/schema.json
@@ -13440,6 +13440,26 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentProviderCustomers",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "PaymentProviderCustomerInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "integrationCustomers",
               "description": null,
               "type": {
@@ -51232,6 +51252,133 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "PaymentProviderCustomerInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDefault",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentProvider",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "ProviderTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentProviderCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "providerCustomerId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "providerPaymentMethods",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ProviderPaymentMethodsEnum",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "syncWithProvider",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "PaymentReceipt",
           "description": "PaymentReceipt",
@@ -78498,6 +78645,26 @@
                 "kind": "INPUT_OBJECT",
                 "name": "ProviderCustomerInput",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentProviderCustomers",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "PaymentProviderCustomerInput",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -51282,18 +51282,6 @@
               "deprecationReason": null
             },
             {
-              "name": "isDefault",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "type",
               "description": null,
               "type": {

--- a/spec/factories/payment_provider_customers.rb
+++ b/spec/factories/payment_provider_customers.rb
@@ -9,6 +9,16 @@ FactoryBot.define do
     provider_payment_methods { %w[card sepa_debit] }
   end
 
+  # The reserved manual connection: a null-provider row keyed by code "manual" (no dedicated STI
+  # class; the base type is stamped explicitly since the column is NOT NULL).
+  factory :manual_payment_provider_customer, class: "PaymentProviderCustomers::BaseCustomer" do
+    customer
+    organization { customer.organization }
+
+    type { "PaymentProviderCustomers::BaseCustomer" }
+    code { "manual" }
+  end
+
   factory :gocardless_customer, class: "PaymentProviderCustomers::GocardlessCustomer" do
     customer
     organization { customer.organization }

--- a/spec/factories/payment_provider_customers.rb
+++ b/spec/factories/payment_provider_customers.rb
@@ -9,14 +9,14 @@ FactoryBot.define do
     provider_payment_methods { %w[card sepa_debit] }
   end
 
-  # The reserved manual connection: a null-provider row keyed by code "manual" (no dedicated STI
+  # The reserved manual connection: a null-provider row keyed by code "lago_manual" (no dedicated STI
   # class; the base type is stamped explicitly since the column is NOT NULL).
   factory :manual_payment_provider_customer, class: "PaymentProviderCustomers::BaseCustomer" do
     customer
     organization { customer.organization }
 
     type { "PaymentProviderCustomers::BaseCustomer" }
-    code { "manual" }
+    code { "lago_manual" }
   end
 
   factory :gocardless_customer, class: "PaymentProviderCustomers::GocardlessCustomer" do

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Mutations::Customers::Create do
       GQL
     end
 
-    it "creates the connections declaratively" do
+    it "creates the connection declaratively" do
       stripe_provider
 
       result = execute_graphql(
@@ -240,16 +240,16 @@ RSpec.describe Mutations::Customers::Create do
             name: "Array Inc",
             externalId: "array_inc",
             paymentProviderCustomers: [
-              {type: "lago_manual", code: "lago_manual"},
               {code: "stripe_eu", paymentProvider: "stripe", providerCustomerId: "cu_12345", providerPaymentMethods: ["card"]}
             ]
           }
         }
       )
 
-      result_data = result["data"]["createCustomer"]
+      expect(result["data"]["createCustomer"]).to be_present
 
-      expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to match_array(%w[lago_manual stripe_eu])
+      created = organization.customers.find_by(external_id: "array_inc")
+      expect(created.payment_provider_customers.pluck(:code)).to eq(["stripe_eu"])
     end
   end
 

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -214,6 +214,48 @@ RSpec.describe Mutations::Customers::Create do
     end
   end
 
+  context "with the payment_provider_customers array" do
+    let(:array_mutation) do
+      <<~GQL
+        mutation($input: CreateCustomerInput!) {
+          createCustomer(input: $input) {
+            id
+            connectionStatus
+            paymentProviderCustomers { id code isDefault }
+          }
+        }
+      GQL
+    end
+
+    it "creates the connections and marks the flagged one as default" do
+      stripe_provider
+
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permissions,
+        query: array_mutation,
+        variables: {
+          input: {
+            name: "Array Inc",
+            externalId: "array_inc",
+            paymentProviderCustomers: [
+              {type: "manual", code: "manual", isDefault: true},
+              {code: "stripe_eu", paymentProvider: "stripe", providerCustomerId: "cu_12345", providerPaymentMethods: ["card"]}
+            ]
+          }
+        }
+      )
+
+      result_data = result["data"]["createCustomer"]
+
+      expect(result_data["connectionStatus"]).to eq("manual")
+      expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to match_array(%w[manual stripe_eu])
+      manual = result_data["paymentProviderCustomers"].find { |c| c["code"] == "manual" }
+      expect(manual["isDefault"]).to be(true)
+    end
+  end
+
   context "with validation errors" do
     it "returns an error with validation messages" do
       result = execute_graphql(

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Mutations::Customers::Create do
       GQL
     end
 
-    it "creates the connections and marks the flagged one as default" do
+    it "creates the connections declaratively" do
       stripe_provider
 
       result = execute_graphql(
@@ -240,7 +240,7 @@ RSpec.describe Mutations::Customers::Create do
             name: "Array Inc",
             externalId: "array_inc",
             paymentProviderCustomers: [
-              {type: "lago_manual", code: "lago_manual", isDefault: true},
+              {type: "lago_manual", code: "lago_manual"},
               {code: "stripe_eu", paymentProvider: "stripe", providerCustomerId: "cu_12345", providerPaymentMethods: ["card"]}
             ]
           }
@@ -249,10 +249,7 @@ RSpec.describe Mutations::Customers::Create do
 
       result_data = result["data"]["createCustomer"]
 
-      expect(result_data["connectionStatus"]).to eq("manual")
       expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to match_array(%w[lago_manual stripe_eu])
-      manual = result_data["paymentProviderCustomers"].find { |c| c["code"] == "lago_manual" }
-      expect(manual["isDefault"]).to be(true)
     end
   end
 

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Mutations::Customers::Create do
             name: "Array Inc",
             externalId: "array_inc",
             paymentProviderCustomers: [
-              {type: "manual", code: "manual", isDefault: true},
+              {type: "lago_manual", code: "lago_manual", isDefault: true},
               {code: "stripe_eu", paymentProvider: "stripe", providerCustomerId: "cu_12345", providerPaymentMethods: ["card"]}
             ]
           }
@@ -250,8 +250,8 @@ RSpec.describe Mutations::Customers::Create do
       result_data = result["data"]["createCustomer"]
 
       expect(result_data["connectionStatus"]).to eq("manual")
-      expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to match_array(%w[manual stripe_eu])
-      manual = result_data["paymentProviderCustomers"].find { |c| c["code"] == "manual" }
+      expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to match_array(%w[lago_manual stripe_eu])
+      manual = result_data["paymentProviderCustomers"].find { |c| c["code"] == "lago_manual" }
       expect(manual["isDefault"]).to be(true)
     end
   end

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Mutations::Customers::Update do
           id: customer.id,
           externalId: customer.external_id,
           paymentProviderCustomers: [
-            {type: "lago_manual", code: "lago_manual"}
+            {code: "lago_manual"}
           ]
         }
       )

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Mutations::Customers::Update do
           id: customer.id,
           externalId: customer.external_id,
           paymentProviderCustomers: [
-            {type: "manual", code: "manual", isDefault: true}
+            {type: "lago_manual", code: "lago_manual", isDefault: true}
           ]
         }
       )
@@ -238,7 +238,7 @@ RSpec.describe Mutations::Customers::Update do
       result_data = result["data"]["updateCustomer"]
 
       expect(result_data["connectionStatus"]).to eq("manual")
-      expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["manual"])
+      expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["lago_manual"])
       expect(existing_connection.reload).to be_discarded
     end
   end

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -207,4 +207,39 @@ RSpec.describe Mutations::Customers::Update do
       expect(result_data["metadata"]).to be_present
     end
   end
+
+  context "with the payment_provider_customers array" do
+    let(:array_mutation) do
+      <<~GQL
+        mutation($input: UpdateCustomerInput!) {
+          updateCustomer(input: $input) {
+            id
+            connectionStatus
+            paymentProviderCustomers { id code isDefault }
+          }
+        }
+      GQL
+    end
+
+    let!(:existing_connection) { create(:stripe_customer, customer:, code: "stripe_eu", is_default: true) }
+
+    it "reconciles the connections declaratively and discards the omitted one" do
+      result = execute_query(
+        query: array_mutation,
+        input: {
+          id: customer.id,
+          externalId: customer.external_id,
+          paymentProviderCustomers: [
+            {type: "manual", code: "manual", isDefault: true}
+          ]
+        }
+      )
+
+      result_data = result["data"]["updateCustomer"]
+
+      expect(result_data["connectionStatus"]).to eq("manual")
+      expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["manual"])
+      expect(existing_connection.reload).to be_discarded
+    end
+  end
 end

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -230,14 +230,13 @@ RSpec.describe Mutations::Customers::Update do
           id: customer.id,
           externalId: customer.external_id,
           paymentProviderCustomers: [
-            {type: "lago_manual", code: "lago_manual", isDefault: true}
+            {type: "lago_manual", code: "lago_manual"}
           ]
         }
       )
 
       result_data = result["data"]["updateCustomer"]
 
-      expect(result_data["connectionStatus"]).to eq("manual")
       expect(result_data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["lago_manual"])
       expect(existing_connection.reload).to be_discarded
     end

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -255,23 +255,22 @@ RSpec.describe Types::Customers::Object do
     end
 
     context "when the customer has no payment connection" do
-      it "returns a placeholder manual element and not_connected status" do
+      it "returns an empty list and not_connected status" do
         data = execute
 
         expect(data["connectionStatus"]).to eq("not_connected")
-        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["lago_manual"])
-        expect(data["paymentProviderCustomers"].first["isDefault"]).to be(false)
+        expect(data["paymentProviderCustomers"]).to be_empty
       end
     end
 
     context "when the customer has a default provider connection" do
       before { create(:stripe_customer, customer:, code: "stripe_eu", is_default: true) }
 
-      it "prepends the manual placeholder to the real connections" do
+      it "returns the real connection" do
         data = execute
 
         expect(data["connectionStatus"]).to eq("connected")
-        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(%w[lago_manual stripe_eu])
+        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["stripe_eu"])
       end
     end
 

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Types::Customers::Object do
         data = execute
 
         expect(data["connectionStatus"]).to eq("not_connected")
-        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["manual"])
+        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["lago_manual"])
         expect(data["paymentProviderCustomers"].first["isDefault"]).to be(false)
       end
     end
@@ -271,7 +271,7 @@ RSpec.describe Types::Customers::Object do
         data = execute
 
         expect(data["connectionStatus"]).to eq("connected")
-        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(%w[manual stripe_eu])
+        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(%w[lago_manual stripe_eu])
       end
     end
 
@@ -282,7 +282,7 @@ RSpec.describe Types::Customers::Object do
         data = execute
 
         expect(data["connectionStatus"]).to eq("manual")
-        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["manual"])
+        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["lago_manual"])
         expect(data["paymentProviderCustomers"].first["isDefault"]).to be(true)
       end
     end

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -226,4 +226,65 @@ RSpec.describe Types::Customers::Object do
       end
     end
   end
+
+  describe "paymentProviderCustomers list" do
+    let(:required_permission) { "customers:view" }
+    let(:membership) { create(:membership) }
+    let(:organization) { membership.organization }
+    let(:customer) { create(:customer, organization:) }
+
+    let(:query) do
+      <<~GQL
+        query($customerId: ID!) {
+          customer(id: $customerId) {
+            connectionStatus
+            paymentProviderCustomers { id code isDefault }
+          }
+        }
+      GQL
+    end
+
+    def execute
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {customerId: customer.id}
+      ).dig("data", "customer")
+    end
+
+    context "when the customer has no payment connection" do
+      it "returns a placeholder manual element and not_connected status" do
+        data = execute
+
+        expect(data["connectionStatus"]).to eq("not_connected")
+        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["manual"])
+        expect(data["paymentProviderCustomers"].first["isDefault"]).to be(false)
+      end
+    end
+
+    context "when the customer has a default provider connection" do
+      before { create(:stripe_customer, customer:, code: "stripe_eu", is_default: true) }
+
+      it "prepends the manual placeholder to the real connections" do
+        data = execute
+
+        expect(data["connectionStatus"]).to eq("connected")
+        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(%w[manual stripe_eu])
+      end
+    end
+
+    context "when the customer has a persisted manual connection" do
+      before { create(:manual_payment_provider_customer, customer:, is_default: true) }
+
+      it "returns the persisted manual row without duplicating it" do
+        data = execute
+
+        expect(data["connectionStatus"]).to eq("manual")
+        expect(data["paymentProviderCustomers"].map { |c| c["code"] }).to eq(["manual"])
+        expect(data["paymentProviderCustomers"].first["isDefault"]).to be(true)
+      end
+    end
+  end
 end

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -54,6 +54,9 @@ RSpec.describe Types::Customers::Object do
     expect(subject).to have_field(:netsuite_customer).of_type("NetsuiteCustomer")
     expect(subject).to have_field(:salesforce_customer).of_type("SalesforceCustomer")
     expect(subject).to have_field(:provider_customer).of_type("ProviderCustomer")
+    expect(subject).to have_field(:payment_provider_customers).of_type("[ProviderCustomer!]!")
+    expect(subject).to have_field(:connection_status).of_type("PaymentProviderConnectionStatusEnum!")
+    expect(subject).to have_field(:integration_customers).of_type("[IntegrationCustomer!]!")
     expect(subject).to have_field(:subscriptions).of_type("[Subscription!]!")
     expect(subject).to have_field(:xero_customer).of_type("XeroCustomer")
 

--- a/spec/graphql/types/payment_provider_customers/connection_status_enum_spec.rb
+++ b/spec/graphql/types/payment_provider_customers/connection_status_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::PaymentProviderCustomers::ConnectionStatusEnum do
+  it "enumerates the correct values" do
+    expect(described_class.values.keys).to match_array(%w[not_connected manual connected])
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1472,6 +1472,19 @@ RSpec.describe Customer do
     end
   end
 
+  describe "#integration_connection" do
+    let(:customer) { create(:customer) }
+    let!(:default_connection) { create(:netsuite_customer, customer:, is_default: true) }
+
+    it "returns the default connection of the category" do
+      expect(customer.integration_connection("accounting")).to eq(default_connection)
+    end
+
+    it "returns nil when no connection is default in the category" do
+      expect(customer.integration_connection("crm")).to be_nil
+    end
+  end
+
   describe "#address_changed?" do
     context "when a billing address field changes" do
       it "returns true" do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -672,6 +672,32 @@ RSpec.describe Customer do
     end
   end
 
+  describe "#payment_connection_status" do
+    subject { customer.payment_connection_status }
+
+    let(:customer) { create(:customer, organization:) }
+
+    context "when no payment connection is default" do
+      before { create(:stripe_customer, customer:, is_default: false) }
+
+      it { is_expected.to eq("not_connected") }
+    end
+
+    context "when a provider connection is default" do
+      before { create(:stripe_customer, customer:, is_default: true) }
+
+      it { is_expected.to eq("connected") }
+    end
+
+    context "when the manual connection is default" do
+      before do
+        create(:stripe_customer, customer:, payment_provider: nil, provider_customer_id: nil, code: "manual", is_default: true)
+      end
+
+      it { is_expected.to eq("manual") }
+    end
+  end
+
   describe "#applicable_timezone" do
     subject(:customer) do
       described_class.new(billing_entity:, timezone: "Europe/Paris")

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -690,9 +690,7 @@ RSpec.describe Customer do
     end
 
     context "when the manual connection is default" do
-      before do
-        create(:stripe_customer, customer:, payment_provider: nil, provider_customer_id: nil, code: "manual", is_default: true)
-      end
+      before { create(:manual_payment_provider_customer, customer:, is_default: true) }
 
       it { is_expected.to eq("manual") }
     end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -677,6 +677,10 @@ RSpec.describe Customer do
 
     let(:customer) { create(:customer, organization:) }
 
+    context "when the customer has no payment connection" do
+      it { is_expected.to eq("not_connected") }
+    end
+
     context "when no payment connection is default" do
       before { create(:stripe_customer, customer:, is_default: false) }
 
@@ -1465,40 +1469,6 @@ RSpec.describe Customer do
 
     it "returns nil for an unknown code" do
       expect(customer.payment_connection("unknown")).to be_nil
-    end
-  end
-
-  describe "#payment_connection_status" do
-    let(:customer) { create(:customer) }
-
-    context "when no connection is the default" do
-      it "returns not_connected" do
-        expect(customer.payment_connection_status).to eq("not_connected")
-      end
-    end
-
-    context "when the default is a provider connection" do
-      before { create(:stripe_customer, customer:, is_default: true) }
-
-      it "returns connected" do
-        expect(customer.payment_connection_status).to eq("connected")
-      end
-    end
-
-    context "when the default is the manual row" do
-      before do
-        PaymentProviderCustomers::BaseCustomer.create!(
-          customer:,
-          organization: customer.organization,
-          type: "PaymentProviderCustomers::BaseCustomer",
-          code: "lago_manual",
-          is_default: true
-        )
-      end
-
-      it "returns manual" do
-        expect(customer.payment_connection_status).to eq("manual")
-      end
     end
   end
 

--- a/spec/models/payment_provider_customers/base_customer_spec.rb
+++ b/spec/models/payment_provider_customers/base_customer_spec.rb
@@ -63,30 +63,6 @@ RSpec.describe PaymentProviderCustomers::BaseCustomer do
     end
   end
 
-  describe "#manual?" do
-    subject { payment_provider_customer.manual? }
-
-    context "when the row has no payment provider and the reserved manual code" do
-      let(:payment_provider_customer) { build(:stripe_customer, payment_provider: nil, code: "manual") }
-
-      it { is_expected.to be(true) }
-    end
-
-    context "when the row is backed by a payment provider" do
-      let(:payment_provider_customer) do
-        build(:stripe_customer, payment_provider: create(:stripe_provider), code: "manual")
-      end
-
-      it { is_expected.to be(false) }
-    end
-
-    context "when the row has no provider but a different code" do
-      let(:payment_provider_customer) { build(:stripe_customer, payment_provider: nil, code: "stripe_eu") }
-
-      it { is_expected.to be(false) }
-    end
-  end
-
   describe "#legacy_provider_method_id" do
     subject { customer.legacy_provider_method_id }
 

--- a/spec/models/payment_provider_customers/base_customer_spec.rb
+++ b/spec/models/payment_provider_customers/base_customer_spec.rb
@@ -63,6 +63,30 @@ RSpec.describe PaymentProviderCustomers::BaseCustomer do
     end
   end
 
+  describe "#manual?" do
+    subject { payment_provider_customer.manual? }
+
+    context "when the row has no payment provider and the reserved manual code" do
+      let(:payment_provider_customer) { build(:stripe_customer, payment_provider: nil, code: "manual") }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the row is backed by a payment provider" do
+      let(:payment_provider_customer) do
+        build(:stripe_customer, payment_provider: create(:stripe_provider), code: "manual")
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when the row has no provider but a different code" do
+      let(:payment_provider_customer) { build(:stripe_customer, payment_provider: nil, code: "stripe_eu") }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
   describe "#legacy_provider_method_id" do
     subject { customer.legacy_provider_method_id }
 

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe RecurringTransactionRule do
   it_behaves_like "a model with a purchase order number"
 
+  it_behaves_like "a connection-resolvable billing object" do
+    let(:resolvable) { create(:recurring_transaction_rule) }
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }
     it { is_expected.to belong_to(:organization) }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Subscription do
   it_behaves_like "paper_trail traceable"
   it_behaves_like "a model with a purchase order number"
 
+  it_behaves_like "a connection-resolvable billing object" do
+    let(:resolvable) { create(:subscription) }
+  end
+
   describe "enums" do
     it do
       expect(subject).to define_enum_for(:status).with_values(

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Wallet do
   it_behaves_like "paper_trail traceable"
   it_behaves_like "a model with a purchase order number"
 
+  it_behaves_like "a connection-resolvable billing object" do
+    let(:resolvable) { create(:wallet) }
+  end
+
   describe "associations" do
     it do
       expect(subject).to belong_to(:organization)

--- a/spec/services/multi_customer_connections/backfill_connections_service_spec.rb
+++ b/spec/services/multi_customer_connections/backfill_connections_service_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe MultiCustomerConnections::BackfillConnectionsService do
   describe "#call" do
     context "with a payment_provider_customer missing a code" do
       let(:provider) { create(:stripe_provider, organization:, code: "stripe_eu") }
-      let(:pp_customer) { create(:stripe_customer, customer:, organization:, payment_provider: provider, code: nil) }
+      let(:pp_customer) do
+        # Simulate a legacy row: the model now derives code on save, so null it directly.
+        create(:stripe_customer, customer:, organization:, payment_provider: provider).tap do |pp|
+          pp.update_columns(code: nil) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
 
       before { pp_customer }
 
@@ -106,7 +111,12 @@ RSpec.describe MultiCustomerConnections::BackfillConnectionsService do
     context "with dry_run: true" do
       let(:dry_run) { true }
       let(:provider) { create(:stripe_provider, organization:, code: "stripe_eu") }
-      let(:pp_customer) { create(:stripe_customer, customer:, organization:, payment_provider: provider, code: nil) }
+      let(:pp_customer) do
+        # Simulate a legacy row: the model now derives code on save, so null it directly.
+        create(:stripe_customer, customer:, organization:, payment_provider: provider).tap do |pp|
+          pp.update_columns(code: nil) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
 
       before { pp_customer }
 

--- a/spec/services/payment_provider_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_or_update_batch_service_spec.rb
@@ -4,12 +4,11 @@ require "rails_helper"
 
 RSpec.describe PaymentProviderCustomers::CreateOrUpdateBatchService do
   subject(:service) do
-    described_class.call(customer:, payment_provider_customers:, new_customer:)
+    described_class.call(customer:, payment_provider_customers:)
   end
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:new_customer) { false }
 
   describe "#call" do
     context "when the array is nil" do
@@ -22,8 +21,23 @@ RSpec.describe PaymentProviderCustomers::CreateOrUpdateBatchService do
       end
     end
 
+    context "when the array carries more than one connection" do
+      let(:payment_provider_customers) { [{code: "lago_manual"}, {code: "stripe_eu", payment_provider: "stripe"}] }
+
+      it "fails as only one connection is allowed for now" do
+        result = service
+
+        expect(result).not_to be_success
+        expect(result.error.messages[:payment_provider_customers]).to include("only_one_connection_allowed")
+      end
+
+      it "does not create any connection" do
+        expect { service }.not_to change(PaymentProviderCustomers::BaseCustomer, :count)
+      end
+    end
+
     context "when creating the manual connection" do
-      let(:payment_provider_customers) { [{type: "lago_manual", code: "lago_manual"}] }
+      let(:payment_provider_customers) { [{code: "lago_manual"}] }
 
       it "creates the reserved manual connection" do
         result = service
@@ -37,7 +51,7 @@ RSpec.describe PaymentProviderCustomers::CreateOrUpdateBatchService do
 
     context "when a connection is omitted from the array" do
       let!(:existing) { create(:stripe_customer, customer:, is_default: true) }
-      let(:payment_provider_customers) { [{type: "lago_manual", code: "lago_manual"}] }
+      let(:payment_provider_customers) { [{code: "lago_manual"}] }
 
       it "discards the omitted connection" do
         service

--- a/spec/services/payment_provider_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_or_update_batch_service_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviderCustomers::CreateOrUpdateBatchService do
+  subject(:service) do
+    described_class.call(customer:, payment_provider_customers:, new_customer:)
+  end
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:new_customer) { false }
+
+  describe "#call" do
+    context "when the array is nil" do
+      let(:payment_provider_customers) { nil }
+
+      before { create(:stripe_customer, customer:, is_default: true) }
+
+      it "does not change the connections" do
+        expect { service }.not_to change { customer.payment_provider_customers.count }
+      end
+    end
+
+    context "when creating the manual connection as default" do
+      let(:payment_provider_customers) { [{type: "manual", code: "manual", is_default: true}] }
+
+      it "creates the reserved manual connection and marks it default" do
+        result = service
+
+        expect(result).to be_success
+        manual = customer.payment_provider_customers.by_code("manual").first
+        expect(manual.payment_provider_id).to be_nil
+        expect(manual).to be_manual
+        expect(manual).to be_is_default
+        expect(customer.payment_connection_status).to eq("manual")
+      end
+    end
+
+    context "when a connection is omitted from the array" do
+      let!(:existing) { create(:stripe_customer, customer:, is_default: true) }
+      let(:payment_provider_customers) { [{type: "manual", code: "manual", is_default: true}] }
+
+      it "discards the omitted connection" do
+        service
+
+        expect(existing.reload).to be_discarded
+        expect(customer.payment_provider_customers.by_code("manual").first).to be_present
+      end
+    end
+
+    context "when an existing connection is referenced by id" do
+      let!(:existing) { create(:stripe_customer, customer:, code: "stripe_eu", is_default: true) }
+      let(:payment_provider_customers) { [{id: existing.id, code: "stripe_renamed"}] }
+
+      it "updates it instead of discarding it" do
+        service
+
+        expect(existing.reload).not_to be_discarded
+        expect(existing.code).to eq("stripe_renamed")
+      end
+    end
+
+    context "when creating a provider connection" do
+      let(:stripe_provider) { create(:stripe_provider, organization:, code: "stripe_eu_account") }
+      let(:payment_provider_customers) do
+        [
+          {
+            code: "stripe_eu",
+            payment_provider: "stripe",
+            payment_provider_code: "stripe_eu_account",
+            provider_customer_id: "cus_123",
+            provider_payment_methods: ["card"]
+          }
+        ]
+      end
+
+      before { stripe_provider }
+
+      it "creates the provider connection" do
+        result = service
+
+        expect(result).to be_success
+        connection = customer.payment_provider_customers.by_code("stripe_eu").first
+        expect(connection).to be_a(PaymentProviderCustomers::StripeCustomer)
+        expect(connection.provider_customer_id).to eq("cus_123")
+      end
+    end
+  end
+end

--- a/spec/services/payment_provider_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_or_update_batch_service_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe PaymentProviderCustomers::CreateOrUpdateBatchService do
     end
 
     context "when creating the manual connection as default" do
-      let(:payment_provider_customers) { [{type: "manual", code: "manual", is_default: true}] }
+      let(:payment_provider_customers) { [{type: "lago_manual", code: "lago_manual", is_default: true}] }
 
       it "creates the reserved manual connection and marks it default" do
         result = service
 
         expect(result).to be_success
-        manual = customer.payment_provider_customers.by_code("manual").first
+        manual = customer.payment_provider_customers.by_code("lago_manual").first
         expect(manual.payment_provider_id).to be_nil
         expect(manual).to be_manual
         expect(manual).to be_is_default
@@ -39,13 +39,13 @@ RSpec.describe PaymentProviderCustomers::CreateOrUpdateBatchService do
 
     context "when a connection is omitted from the array" do
       let!(:existing) { create(:stripe_customer, customer:, is_default: true) }
-      let(:payment_provider_customers) { [{type: "manual", code: "manual", is_default: true}] }
+      let(:payment_provider_customers) { [{type: "lago_manual", code: "lago_manual", is_default: true}] }
 
       it "discards the omitted connection" do
         service
 
         expect(existing.reload).to be_discarded
-        expect(customer.payment_provider_customers.by_code("manual").first).to be_present
+        expect(customer.payment_provider_customers.by_code("lago_manual").first).to be_present
       end
     end
 

--- a/spec/services/payment_provider_customers/create_or_update_batch_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_or_update_batch_service_spec.rb
@@ -22,24 +22,22 @@ RSpec.describe PaymentProviderCustomers::CreateOrUpdateBatchService do
       end
     end
 
-    context "when creating the manual connection as default" do
-      let(:payment_provider_customers) { [{type: "lago_manual", code: "lago_manual", is_default: true}] }
+    context "when creating the manual connection" do
+      let(:payment_provider_customers) { [{type: "lago_manual", code: "lago_manual"}] }
 
-      it "creates the reserved manual connection and marks it default" do
+      it "creates the reserved manual connection" do
         result = service
 
         expect(result).to be_success
         manual = customer.payment_provider_customers.by_code("lago_manual").first
         expect(manual.payment_provider_id).to be_nil
         expect(manual).to be_manual
-        expect(manual).to be_is_default
-        expect(customer.payment_connection_status).to eq("manual")
       end
     end
 
     context "when a connection is omitted from the array" do
       let!(:existing) { create(:stripe_customer, customer:, is_default: true) }
-      let(:payment_provider_customers) { [{type: "lago_manual", code: "lago_manual", is_default: true}] }
+      let(:payment_provider_customers) { [{type: "lago_manual", code: "lago_manual"}] }
 
       it "discards the omitted connection" do
         service

--- a/spec/support/shared_examples/connection_resolvable.rb
+++ b/spec/support/shared_examples/connection_resolvable.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Shared coverage for ConnectionResolvable. The including spec must define `let(:resolvable)`,
+# a billing object whose customer's default connections are inherited.
+RSpec.shared_examples "a connection-resolvable billing object" do
+  let(:resolution_customer) { resolvable.customer }
+  let(:organization) { resolution_customer.organization }
+
+  describe "#effective_payment_connection" do
+    context "when the customer has a default payment connection" do
+      let!(:default_connection) do
+        create(:stripe_customer, customer: resolution_customer, organization:, is_default: true)
+      end
+
+      it "returns the customer default" do
+        expect(resolvable.effective_payment_connection).to eq(default_connection)
+      end
+
+      context "when the object pins a specific connection" do
+        let(:override_connection) { create(:gocardless_customer, customer: resolution_customer, organization:) }
+
+        before do
+          create(:billing_object_connection, owner: resolvable, organization:, category: :payment,
+            behavior: :specific, payment_provider_customer: override_connection)
+        end
+
+        it "returns the override connection" do
+          expect(resolvable.effective_payment_connection).to eq(override_connection)
+        end
+      end
+
+      context "when the object skips the category" do
+        before do
+          create(:billing_object_connection, owner: resolvable, organization:, category: :payment, behavior: :skip)
+        end
+
+        it "returns nil" do
+          expect(resolvable.effective_payment_connection).to be_nil
+        end
+      end
+    end
+
+    context "when the customer has no default payment connection" do
+      it "returns nil" do
+        expect(resolvable.effective_payment_connection).to be_nil
+      end
+    end
+  end
+
+  describe "#effective_accounting_connection" do
+    context "when the customer has a default accounting connection" do
+      let!(:default_connection) do
+        create(:netsuite_customer, customer: resolution_customer, organization:, is_default: true)
+      end
+
+      it "returns the customer default" do
+        expect(resolvable.effective_accounting_connection).to eq(default_connection)
+      end
+
+      context "when the object pins a specific connection" do
+        let(:override_connection) { create(:xero_customer, customer: resolution_customer, organization:) }
+
+        before do
+          create(:billing_object_connection, owner: resolvable, organization:, category: :accounting,
+            behavior: :specific, integration_customer: override_connection)
+        end
+
+        it "returns the override connection" do
+          expect(resolvable.effective_accounting_connection).to eq(override_connection)
+        end
+      end
+
+      context "when the object skips the category" do
+        before do
+          create(:billing_object_connection, owner: resolvable, organization:, category: :accounting, behavior: :skip)
+        end
+
+        it "returns nil" do
+          expect(resolvable.effective_accounting_connection).to be_nil
+        end
+      end
+    end
+  end
+
+  describe "#effective_tax_connection" do
+    let!(:default_connection) do
+      create(:anrok_customer, customer: resolution_customer, organization:, is_default: true)
+    end
+
+    it "returns the customer default tax connection" do
+      expect(resolvable.effective_tax_connection).to eq(default_connection)
+    end
+  end
+
+  describe "#effective_crm_connection" do
+    let!(:default_connection) do
+      create(:hubspot_customer, customer: resolution_customer, organization:, is_default: true)
+    end
+
+    it "returns the customer default crm connection" do
+      expect(resolvable.effective_crm_connection).to eq(default_connection)
+    end
+  end
+end


### PR DESCRIPTION
## Context

The customer connections UI is moving to an array-based shape as groundwork for multi-connection support, while behaviour stays one connection per type. Until now the GraphQL customer type only exposed singular connection fields (`providerCustomer`, `anrokCustomer`, …), which the new UI cannot consume. This delivers the GraphQL side only — the REST API is handled separately.

## Read side

The customer type now exposes `paymentProviderCustomers` and `integrationCustomers` lists, plus a customer-level `connectionStatus` (`not_connected | manual | connected`) derived from the default payment connection. The payment list always surfaces a "manual" option, synthesizing a placeholder when the customer has no persisted manual connection. The singular fields stay as deprecated shims returning the default.

## Write side

`Create`/`UpdateCustomerInput` accept a declarative `paymentProviderCustomers` array. A new `PaymentProviderCustomers::CreateOrUpdateBatchService` reconciles the customer's connections: connections omitted from the array (matched by `id`) are discarded, provider connections are created/updated, the reserved manual connection (null provider, `code "manual"`) is created on demand, and the element flagged `isDefault` becomes the customer default. The singular `providerCustomer` input still works; the array takes precedence when present.

## Notes

Ungated and backward-compatible, at most one connection per type for now. No migrations — the `code` / `is_default` columns already exist. The REST array and the integration-input fields (`code` / `is_default` / `category`) are out of scope and tracked separately.
