### PR TITLE
[ING-550] fix(exports): keep recoveries out of the alert events export view

### DIFF
--- a/db/migrate/20260805201143_update_exports_usage_monitoring_triggered_alerts_to_version_2.rb
+++ b/db/migrate/20260805201143_update_exports_usage_monitoring_triggered_alerts_to_version_2.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateExportsUsageMonitoringTriggeredAlertsToVersion2 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :exports_usage_monitoring_triggered_alerts, version: 2, revert_to_version: 1
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4430,7 +4430,8 @@ CREATE VIEW public.exports_usage_monitoring_triggered_alerts AS
     ta.triggered_at,
     ta.created_at,
     ta.updated_at
-   FROM public.usage_monitoring_triggered_alerts ta;
+   FROM public.usage_monitoring_triggered_alerts ta
+  WHERE (ta.kind = 'triggered'::public.usage_monitoring_triggered_alert_kinds);
 
 
 --
@@ -14171,6 +14172,7 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260805201143'),
 ('20260805110509'),
 ('20260805110508'),
 ('20260804131008'),

--- a/db/views/exports_usage_monitoring_triggered_alerts_v02.sql
+++ b/db/views/exports_usage_monitoring_triggered_alerts_v02.sql
@@ -1,0 +1,14 @@
+SELECT
+  ta.id AS lago_id,
+  ta.organization_id,
+  ta.usage_monitoring_alert_id AS lago_alert_id,
+  ta.subscription_id AS lago_subscription_id,
+  ta.wallet_id AS lago_wallet_id,
+  ta.current_value,
+  ta.previous_value,
+  ta.crossed_thresholds,
+  ta.triggered_at,
+  ta.created_at,
+  ta.updated_at
+FROM usage_monitoring_triggered_alerts AS ta
+WHERE ta.kind = 'triggered';

--- a/spec/db/views/exports_usage_monitoring_triggered_alerts_spec.rb
+++ b/spec/db/views/exports_usage_monitoring_triggered_alerts_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "exports_usage_monitoring_triggered_alerts view" do # rubocop:disable RSpec/DescribeClass
+  def row_for(id)
+    ActiveRecord::Base.connection.select_one(
+      "SELECT * FROM exports_usage_monitoring_triggered_alerts WHERE lago_id = #{ActiveRecord::Base.connection.quote(id)}"
+    )
+  end
+
+  describe "alert event kinds" do
+    it "exports triggers only" do
+      triggered = create(:triggered_alert)
+      resolved = create(:triggered_alert, kind: :resolved)
+      seeded = create(:triggered_alert, kind: :seeded)
+
+      expect(row_for(triggered.id)).to be_present
+      expect(row_for(resolved.id)).to be_nil
+      expect(row_for(seeded.id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
> Stacked on #6080, which adds the column this filters on. GitHub will retarget this to `main` once that merges.

## Context

The alert events export view selects every row of the events table with no filter. That table now also holds recovery events and silent seed records, and the view exposes no column that would let a consumer tell them apart, so without a filter they arrive downstream indistinguishable from alerts that actually fired:

```mermaid
graph LR
    T["kind: triggered<br/>a real alert firing"] --> V1["view v01<br/>no filter"]
    R["kind: resolved<br/>a recovery"] --> V1
    S["kind: seeded<br/>silent record, no webhook"] --> V1
    V1 --> W1["consumer sees all three,<br/>indistinguishable"]

    T2["kind: triggered"] --> V2["view v02<br/>WHERE kind = triggered"]
    R2["kind: resolved"] -.blocked.-> V2
    S2["kind: seeded"] -.blocked.-> V2
    V2 --> W2["consumer sees<br/>real firings only"]
```

## Changes

Ships a new version of the view restricted to real triggers. The column list is unchanged, so nothing a consumer already reads moves or disappears; only rows that were never meant to be there are excluded. An export of recovery events can follow separately if anyone needs one.

Plain equality is used rather than `IS DISTINCT FROM`. #5905 needed the latter on `exports_fees_v03`, because that view joins to invoices so the column is NULL for legitimate rows, but here the discriminator is NOT NULL on the base table and the view has no join.

Adds the view's first spec: a trigger is exported, a recovery and a seed record are not.

## Note for consumers of this view

This removes rows that would otherwise be emitted, so anything counting rows from this view will see real firings only. Worth agreeing with the people reading it before this merges rather than after.
