### PR TITLE
[ING-506] fix(alerts): stop evaluating alerts for inactive subscriptions

### DIFF
--- a/app/services/usage_monitoring/process_lifetime_usage_alert_service.rb
+++ b/app/services/usage_monitoring/process_lifetime_usage_alert_service.rb
@@ -13,6 +13,7 @@ module UsageMonitoring
     def call
       return result unless alert.alert_type == "billable_metric_lifetime_usage_units"
       return result unless subscription
+      return result unless subscription.active?
 
       charge_ids = subscription.plan.charges.where(billable_metric_id: alert.billable_metric_id).ids
       return result if charge_ids.empty?

--- a/app/services/usage_monitoring/process_subscription_activity_service.rb
+++ b/app/services/usage_monitoring/process_subscription_activity_service.rb
@@ -11,6 +11,11 @@ module UsageMonitoring
     end
 
     def call
+      unless subscription.active?
+        subscription_activity.delete
+        return result
+      end
+
       exception_to_raise = nil
       lifetime_usage = find_or_create_lifetime_usage
 

--- a/spec/services/usage_monitoring/process_lifetime_usage_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/process_lifetime_usage_alert_service_spec.rb
@@ -101,6 +101,19 @@ RSpec.describe UsageMonitoring::ProcessLifetimeUsageAlertService, :premium do
     end
   end
 
+  context "when the subscription is no longer active" do
+    let(:premium_integrations) { %w[lifetime_usage] }
+
+    before { subscription.mark_as_terminated! }
+
+    it "does not call CustomerUsageService or process the alert" do
+      service.call
+
+      expect(::Invoices::CustomerUsageService).not_to have_received(:call!)
+      expect(::UsageMonitoring::ProcessAlertService).not_to have_received(:call)
+    end
+  end
+
   context "when CustomerUsageService fails" do
     let(:premium_integrations) { %w[lifetime_usage] }
     let(:usage_error) { BaseService::ServiceFailure.new(nil, code: "test_error", error_message: "something went wrong") }

--- a/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
@@ -222,4 +222,23 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, :premium do
       end
     end
   end
+
+  context "when the subscription is no longer active" do
+    let(:premium_integrations) { ["lifetime_usage"] }
+    let(:alert) { create(:alert, organization:, subscription_external_id: subscription.external_id, thresholds: [10]) }
+
+    before do
+      alert
+      allow(UsageMonitoring::ProcessAlertService).to receive(:call)
+      subscription.mark_as_terminated!
+    end
+
+    it "does not evaluate alerts and drops the stale activity" do
+      service.call
+
+      expect(UsageMonitoring::ProcessAlertService).not_to have_received(:call)
+      expect(::Invoices::CustomerUsageService).not_to have_received(:call)
+      expect { subscription_activity.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Alerts are keyed by a subscription's external id, and a plan upgrade carries that id over to the new subscription while terminating the old one. The queue that drives alert evaluation only ever accepts an active subscription, but nothing checked again by the time the work actually ran. So a queued item belonging to a subscription that had since been upgraded away was still evaluated, and the alert it resolved by external id was the one now owned by the replacement.

```mermaid
sequenceDiagram
    participant Q as Activity queue
    participant A as Subscription A
    participant B as Subscription B (same external_id)
    participant AL as Alert (keyed by external_id)

    A->>Q: usage event, A is active, item queued
    Note over A,B: plan upgrade
    A->>A: terminated, final usage 900
    B->>B: created, usage starts at 0
    Q->>A: job runs, loads A and computes A's usage (900)
    Q->>AL: resolve alert by external_id, finds B's alert
    AL->>AL: baseline overwritten, 0 becomes 900
    B->>AL: later crosses 500
    AL--xB: nothing fires, 500 is below the 900 baseline
```

Two things went wrong. A notification could be sent naming a subscription the customer had already left. Worse, the alert's stored baseline was overwritten with the old subscription's final usage, which is high where the replacement starts from nothing, so genuine crossings afterwards were measured against the wrong number and went unreported. The stray notification is the visible symptom; the silence is the damaging one.

This is a live bug on its own, independent of the alert resolution work it was found alongside.

## Changes

Evaluation now stops when the subscription is no longer active, and the queued item is dropped rather than left behind. The check sits ahead of the usage calculation, so nothing expensive runs for work that cannot produce a valid answer.

The same omission existed on the delayed path used by billable metric lifetime alerts. That one waits before running, so its window for the subscription to disappear underneath it is wider. It now makes the same check.

Dropping the queued item at termination time was considered instead. Subscriptions are terminated from around ten call sites, including the pending-upgrade activation path most relevant here, so a single-service delete would have looked complete while missing the main case. This guard covers every path and clears the item itself.

This deliberately ends evaluation for every inactive subscription, not only those replaced by an upgrade. Alerts outlive the subscriptions they watch and are found by external id, so any evaluation against a subscription that is gone can only spoil the baseline for whatever takes that id next. The rest of the pipeline already refuses inactive subscriptions.
