### PR TITLE
fix: timeout in TerminateEndedSubscriptionsJob

### DIFF
--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -2,16 +2,26 @@
 
 module Clock
   class TerminateEndedSubscriptionsJob < ClockJob
+    ENDING_AT_PREFILTER = 3.days
+
     unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
 
     def perform
+      now = Time.current
+
+      # Optimization: the DATE comparison below reads the timezone from a joined
+      # row, so no index can help it and Postgres checks every active subscription
+      # one by one. The separate ending_at range is plain UTC, so it is indexed and
+      # runs first. It does not change the result: every row the DATE comparison
+      # matches fits in it, with room to spare for any timezone.
       Subscription
         .joins(customer: :billing_entity)
         .active
+        .where(ending_at: (now - ENDING_AT_PREFILTER)..(now + ENDING_AT_PREFILTER))
         .where(
           "DATE(subscriptions.ending_at#{Utils::Timezone.at_time_zone_sql}) = " \
           "DATE(?#{Utils::Timezone.at_time_zone_sql})",
-          Time.current
+          now
         )
         .find_each do |subscription|
           Subscriptions::TerminateEndedSubscriptionJob.perform_later(subscription)

--- a/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
@@ -30,6 +30,22 @@ describe Clock::TerminateEndedSubscriptionsJob, job: true do
       end
     end
 
+    context "with subscriptions ending on a nearby day" do
+      let!(:subscription_ending_the_day_before) { create(:subscription, ending_at: ending_at - 1.day) }
+      let!(:subscription_ending_the_day_after) { create(:subscription, ending_at: ending_at + 1.day) }
+
+      it "does not enqueue them" do
+        travel_to(ending_at) do
+          described_class.perform_now
+
+          expect(Subscriptions::TerminateEndedSubscriptionJob)
+            .not_to have_been_enqueued.with(subscription_ending_the_day_before)
+          expect(Subscriptions::TerminateEndedSubscriptionJob)
+            .not_to have_been_enqueued.with(subscription_ending_the_day_after)
+        end
+      end
+    end
+
     context "with customer timezone" do
       let(:ending_at) { DateTime.parse("2022-10-21 00:30:00") }
 
@@ -49,6 +65,36 @@ describe Clock::TerminateEndedSubscriptionsJob, job: true do
             .not_to have_been_enqueued.with(subscription2)
           expect(Subscriptions::TerminateEndedSubscriptionJob)
             .not_to have_been_enqueued.with(subscription3)
+        end
+      end
+    end
+
+    context "with a customer timezone far ahead of UTC" do
+      let(:ending_at) { DateTime.parse("2022-10-20 12:00:00") }
+
+      before { subscription1.customer.update!(timezone: "Pacific/Auckland") }
+
+      it "enqueues subscriptions ending on the same local day but hours apart in UTC" do
+        travel_to(DateTime.parse("2022-10-21 00:30:00")) do
+          described_class.perform_now
+
+          expect(Subscriptions::TerminateEndedSubscriptionJob)
+            .to have_been_enqueued.with(subscription1)
+        end
+      end
+    end
+
+    context "with a customer timezone far behind UTC" do
+      let(:ending_at) { DateTime.parse("2022-10-21 00:30:00") }
+
+      before { subscription1.customer.update!(timezone: "Pacific/Midway") }
+
+      it "enqueues subscriptions ending on the same local day but on the next UTC day" do
+        travel_to(DateTime.parse("2022-10-20 12:00:00")) do
+          described_class.perform_now
+
+          expect(Subscriptions::TerminateEndedSubscriptionJob)
+            .to have_been_enqueued.with(subscription1)
         end
       end
     end


### PR DESCRIPTION
## Context

`Clock::TerminateEndedSubscriptionsJob` times out in production.

The job finds subscriptions ending today. "Today" depends on each subscription's timezone.

This timezone comes from either the customer or the billing entity. Postgres joins those tables and checks every active subscription one by one without using any index.

The result is a full scan every hour which leads to a timeout when the table is large enough.

The query condition looks like:
```sql
DATE(subscriptions.ending_at::timestamptz AT TIME ZONE COALESCE(customers.timezone, billing_entities.timezone, 'UTC'))
  = DATE(now()::timestamptz               AT TIME ZONE COALESCE(customers.timezone, billing_entities.timezone, 'UTC'))
```

## Description

Added a separate range check on `ending_at`, before the timezone comparison.

```sql
 subscriptions.ending_at BETWEEN (now() AT TIME ZONE 'UTC') - interval '3 days'
                                  AND (now() AT TIME ZONE 'UTC') + interval '3 days'
  AND DATE(subscriptions.ending_at::timestamptz AT TIME ZONE COALESCE(customers.timezone, billing_entities.timezone, 'UTC'))
    = DATE(now()::timestamptz               AT TIME ZONE COALESCE(customers.timezone, billing_entities.timezone, 'UTC'))
```

`ending_at` is indexed (`index_subscriptions_on_ending_at_active`) => **postgres reads a smaller slice instead of the whole table** => **fewer rows reach the slow timezone check**.

The range is 3 days either side of now which is _too safe_ but still lets the index cut out most rows. The old timezone comparison is unchanged and still decides what gets terminated.

Why 3 days is safe: UTC offsets go from -12:00 to +14:00. So a subscription ending "today" in its own timezone is never more than ~50 hours from now.
