### PR TITLE
fix(invoice): display zero-unit flat fees in pdf

### DIFF
--- a/app/views/helpers/invoice_subscriptions_helper.rb
+++ b/app/views/helpers/invoice_subscriptions_helper.rb
@@ -9,12 +9,13 @@ class InvoiceSubscriptionsHelper
       # Group all fees by their billing period (with eager loading and DB-level filtering to avoid N+1 queries)
       base_fees = invoice.subscription_fees(subscription.id)
         .includes(:true_up_parent_fee, :true_up_fee, :charge_filter, :presentation_breakdowns, charge: :billable_metric, fixed_charge: :add_on)
-      # Include: subscription, commitment, fixed_charge with positive units, charge with positive units (excluding true_up fees),
-      # and charge fees that are parents of true_up fees (even with zero units)
+      # Always include subscription and commitment fees. Include fixed-charge and top-level charge fees
+      # when their units or amount is positive. Also include zero-value charge fees that have a true-up child.
+      displayable_fees = base_fees.where("fees.units > ? OR fees.amount_cents > ?", 0, 0)
       filtered_fees = base_fees
         .where(fee_type: [:subscription, :commitment])
-        .or(base_fees.fixed_charge.positive_units)
-        .or(base_fees.charge.positive_units.where(true_up_parent_fee: nil))
+        .or(displayable_fees.fixed_charge)
+        .or(displayable_fees.charge.where(true_up_parent_fee: nil))
         .or(base_fees.charge.where(id: base_fees.charge.select(:true_up_parent_fee_id).where.not(true_up_parent_fee_id: nil)))
       grouped_fees = FeeBoundariesHelper.group_fees_by_billing_period(filtered_fees, invoice_subscription:)
 

--- a/spec/views/app/views/templates/invoices/v4.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4.slim_spec.rb
@@ -636,6 +636,22 @@ RSpec.describe "templates/invoices/v4.slim" do
     it "renders correctly" do
       expect(rendered_template).to match_html_snapshot
     end
+
+    context "when a fixed charge fee has zero units and a positive amount" do
+      before do
+        arrears_fixed_charge_fee.update!(units: 0, unit_amount_cents: 0, precise_unit_amount: 0)
+      end
+
+      it "renders the fee line" do
+        fee_row = Nokogiri::HTML.fragment(rendered_template).css("tr.fee").find do |row|
+          row.text.include?("Standard Pay in Arrears Fixed Charge Fee")
+        end
+
+        expect(fee_row.css("td").map { |cell| cell.text.squish }).to eq(
+          ["Standard Pay in Arrears Fixed Charge Fee", "0", "$0.00", "0.0%", "$85.00"]
+        )
+      end
+    end
   end
 
   context "when invoice has different boundaries for fixed charges" do

--- a/spec/views/helpers/invoice_subscriptions_helper_spec.rb
+++ b/spec/views/helpers/invoice_subscriptions_helper_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe InvoiceSubscriptionsHelper do
     end
 
     describe "filtered_fees" do
-      subject(:filtered_fees) { result.first.filtered_fees }
+      subject(:filtered_fees) { result.first.filtered_fees.to_a }
 
       context "when there is a subscription fee" do
         let!(:subscription_fee) { create(:fee, fee_type: "subscription", subscription:, invoice:) }
@@ -62,10 +62,18 @@ RSpec.describe InvoiceSubscriptionsHelper do
           it { is_expected.to include(fixed_charge_fee) }
         end
 
-        context "with zero units" do
-          let!(:fixed_charge_fee) { create(:fixed_charge_fee, subscription:, invoice:, units: 0) }
+        context "with zero units and a positive amount" do
+          let!(:fixed_charge_fee) { create(:fixed_charge_fee, subscription:, invoice:, units: 0, amount_cents: 200) }
 
-          it { is_expected.not_to include(fixed_charge_fee) }
+          it { is_expected.to eq([fixed_charge_fee]) }
+        end
+
+        context "with zero units and zero amount" do
+          before do
+            create(:fixed_charge_fee, subscription:, invoice:, units: 0, amount_cents: 0, precise_amount_cents: 0)
+          end
+
+          it { is_expected.to eq([]) }
         end
       end
 
@@ -76,22 +84,47 @@ RSpec.describe InvoiceSubscriptionsHelper do
           it { is_expected.to include(charge_fee) }
         end
 
-        context "with zero units and no true_up_parent_fee" do
-          let!(:charge_fee) { create(:charge_fee, subscription:, invoice:, units: 0, total_aggregated_units: 0) }
+        context "with zero units, a positive amount, and no true_up_parent_fee" do
+          let!(:charge_fee) { create(:charge_fee, subscription:, invoice:, units: 0, amount_cents: 200, total_aggregated_units: 0) }
 
-          it { is_expected.not_to include(charge_fee) }
+          it { is_expected.to eq([charge_fee]) }
+        end
+
+        context "with zero units, zero amount, and no true_up_parent_fee" do
+          before do
+            create(
+              :charge_fee,
+              subscription:,
+              invoice:,
+              units: 0,
+              amount_cents: 0,
+              precise_amount_cents: 0,
+              total_aggregated_units: 0
+            )
+          end
+
+          it { is_expected.to eq([]) }
         end
 
         context "with zero units but is the parent of a true_up fee" do
-          let!(:parent_fee) { create(:charge_fee, subscription:, invoice:, units: 0, total_aggregated_units: 0) }
-          let!(:true_up_fee) { create(:charge_fee, subscription:, invoice:, units: 5, total_aggregated_units: 5, true_up_parent_fee: parent_fee) }
-
-          it "includes the parent fee" do
-            expect(filtered_fees).to include(parent_fee)
+          let!(:parent_fee) do
+            create(
+              :charge_fee,
+              subscription:,
+              invoice:,
+              units: 0,
+              amount_cents: 0,
+              precise_amount_cents: 0,
+              total_aggregated_units: 0
+            )
           end
 
-          it "excludes the true_up fee itself" do
-            expect(filtered_fees).not_to include(true_up_fee)
+          before do
+            create(:charge_fee, subscription:, invoice:, units: 5, total_aggregated_units: 5, true_up_parent_fee: parent_fee)
+          end
+
+          it "includes only the parent fee" do
+            expect(filtered_fees).to eq([parent_fee])
           end
         end
       end


### PR DESCRIPTION
## Context

Invoice PDFs were hiding charge and fixed-charge lines when their units were zero, even if they had a positive flat amount. The amount was still included in the invoice total, so the visible lines did not add up to the total.

This became more visible after [PR #5760](https://github.com/getlago/lago-api/pull/5760), which applies first-tier flat fees even when usage is zero. Those fees were calculated correctly but were still missing from the PDF.

## Description

Update the PDF fee filtering to include fees when either their units or amount is positive.
Fees with zero units and zero amount remain hidden.

Add tests for charge fees, fixed-charge fees, true-up fees, and the final PDF rendering.

### Visual comparison

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td>

<img width="544" height="705" alt="Screenshot 2026-08-06 at 16 05 05" src="https://github.com/user-attachments/assets/0e21c527-69b8-42be-a68a-b74bcba648e7" />

</td>

<td>

<img width="543" height="701" alt="Screenshot 2026-08-06 at 16 08 52" src="https://github.com/user-attachments/assets/d5120bd0-5358-4a2b-9425-2be70cf7b8be" />

</td>
</tr>
</table>