### PR TITLE
[ING-431] fix(graphql): apply connection edits without provider id

### DIFF
--- a/app/services/payment_provider_customers/update_connection_service.rb
+++ b/app/services/payment_provider_customers/update_connection_service.rb
@@ -53,10 +53,6 @@ module PaymentProviderCustomers
     end
 
     def update_provider_customer
-      handle_provider_customer = provider_customer_params[:provider_customer_id].present?
-      handle_provider_customer ||= payment_provider_customer&.provider_customer_id.present?
-      return unless handle_provider_customer
-
       PaymentProviders::CreateCustomerFactory.new_instance(
         provider:,
         customer:,

--- a/spec/services/payment_provider_customers/update_connection_service_spec.rb
+++ b/spec/services/payment_provider_customers/update_connection_service_spec.rb
@@ -115,15 +115,16 @@ RSpec.describe PaymentProviderCustomers::UpdateConnectionService do
         end
       end
 
-      context "when provider_customer does not exist and is not provided" do
+      context "when the connection has no provider_customer_id and none is provided" do
         let(:payment_provider_customer) do
           create(:stripe_customer, organization:, customer:, provider_customer_id: nil, provider_payment_methods: %w[card])
         end
         let(:params) { {provider_payment_methods: %w[card sepa_debit]} }
 
-        it "does not update the provider payment methods" do
+        it "applies the provider payment methods" do
           expect { update_service.call }
-            .not_to change { payment_provider_customer.reload.provider_payment_methods }
+            .to change { payment_provider_customer.reload.provider_payment_methods }
+            .from(%w[card]).to(%w[card sepa_debit])
         end
       end
     end


### PR DESCRIPTION
## Context

Editing a payment connection's providerPaymentMethods or syncWithProvider through updatePaymentProviderCustomer silently did nothing when the connection had no stored provider_customer_id and none was sent: the mutation succeeded, no error, nothing persisted. This is a normal state — a sync-on Stripe connection without a manual external id, or Cashfree/Flutterwave which have no provider-side customer. The legacy updateCustomer path worked because its guard also passes whenever the customer already has a payment provider.

## Description

UpdateConnectionService#update_provider_customer returned early unless a provider_customer_id was present on the record or in the params, so the provider field edit was never applied. Remove that guard: the service already fails with not_found when the connection is missing, and the upsert only runs when a provider field is actually being edited, so an existing connection is enough to apply the change.
