### PR TITLE
feat(multi-currency): make it generally available / Phase 1

### DIFF
--- a/app/services/customers/update_currency_service.rb
+++ b/app/services/customers/update_currency_service.rb
@@ -17,28 +17,7 @@ module Customers
       return result if customer.currency == currency
 
       # Multi-currency: customer.currency becomes a default preference, not a constraint.
-      if customer.organization.feature_flag_enabled?(:multi_currency)
-        customer.update!(currency:) if customer_update || customer.currency.blank?
-        return result
-      end
-
-      if customer_update
-        # NOTE: direct update of the customer currency
-        unless customer.editable?
-          return result.single_validation_failure!(
-            field: :currency,
-            error_code: "currencies_does_not_match"
-          )
-        end
-      elsif customer.currency.present? || !customer.editable?
-        # NOTE: Assign currency from another resource
-        return result.single_validation_failure!(
-          field: :currency,
-          error_code: "currencies_does_not_match"
-        )
-      end
-
-      customer.update!(currency:)
+      customer.update!(currency:) if customer_update || customer.currency.blank?
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -101,13 +101,6 @@ module Invoices
         return false
       end
 
-      if customer.currency && customer.currency != subscription_currencies.first
-        unless organization.feature_flag_enabled?(:multi_currency)
-          result.single_validation_failure!(error_code: "customer_currency_does_not_match")
-          return false
-        end
-      end
-
       true
     end
 

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -530,8 +530,6 @@ module Subscriptions
     end
 
     def group_by_currency(subscription_groups)
-      return subscription_groups unless organization.feature_flag_enabled?(:multi_currency)
-
       subscription_groups.flat_map do |subscriptions|
         subscriptions.group_by { |sub| sub.plan.amount_currency }.values
       end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -69,11 +69,11 @@ module Wallets
       recurring_transaction_rule = nil
 
       ActiveRecord::Base.transaction do
-        if currency.present? && (!organization_flag_enabled?(:multi_currency) || customer.currency.blank?)
+        if currency.present? && customer.currency.blank?
           Customers::UpdateCurrencyService.call!(customer: customer, currency:)
         end
 
-        wallet.currency = organization_flag_enabled?(:multi_currency) ? (currency || wallet.customer.currency) : wallet.customer.currency
+        wallet.currency = currency || wallet.customer.currency
         wallet.save!
 
         validate_wallet_initial_amount! wallet

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -105,11 +105,10 @@ RSpec.describe AppliedCoupons::CreateService do
 
         before { customer.update!(currency: "EUR") }
 
-        it "fails" do
-          expect(create_result).not_to be_success
-          expect(create_result.error).to be_a(BaseService::ValidationFailure)
-          expect(create_result.error.messages.keys).to include(:currency)
-          expect(create_result.error.messages[:currency]).to include("currencies_does_not_match")
+        it "applies the coupon (currency is a default preference)" do
+          expect(create_result).to be_success
+          expect(create_result.applied_coupon.amount_currency).to eq("NOK")
+          expect(customer.reload.currency).to eq("EUR")
         end
       end
     end
@@ -224,11 +223,10 @@ RSpec.describe AppliedCoupons::CreateService do
 
       before { customer.update!(currency: "EUR") }
 
-      it "fails" do
-        expect(create_result).not_to be_success
-        expect(create_result.error).to be_a(BaseService::ValidationFailure)
-        expect(create_result.error.messages.keys).to include(:currency)
-        expect(create_result.error.messages[:currency]).to include("currencies_does_not_match")
+      it "applies the coupon (currency is a default preference)" do
+        expect(create_result).to be_success
+        expect(create_result.applied_coupon.amount_currency).to eq("NOK")
+        expect(customer.reload.currency).to eq("EUR")
       end
     end
 

--- a/spec/services/customers/update_currency_service_spec.rb
+++ b/spec/services/customers/update_currency_service_spec.rb
@@ -40,53 +40,6 @@ RSpec.describe Customers::UpdateCurrencyService do
       end
     end
 
-    context "when customer already has a currency" do
-      let(:customer) { create(:customer, currency: "EUR") }
-
-      it "returns a failure" do
-        result = currency_service.call
-
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:currency]).to eq(["currencies_does_not_match"])
-      end
-
-      context "when in customer update" do
-        let(:customer_update) { true }
-
-        it "assigns the currency to the customer" do
-          result = currency_service.call
-
-          expect(result).to be_success
-          expect(customer.reload.currency).to eq(currency)
-        end
-
-        context "when customer is not editable" do
-          before { create(:subscription, customer:) }
-
-          it "returns a failure" do
-            result = currency_service.call
-
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages[:currency]).to eq(["currencies_does_not_match"])
-          end
-        end
-      end
-    end
-
-    context "when customer is not editable" do
-      before { create(:subscription, customer:) }
-
-      it "returns a failure" do
-        result = currency_service.call
-
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:currency]).to eq(["currencies_does_not_match"])
-      end
-    end
-
     context "when providing an invalid currency" do
       let(:currency) { "INVALID" }
 
@@ -99,9 +52,7 @@ RSpec.describe Customers::UpdateCurrencyService do
       end
     end
 
-    context "when multi_currency flag is enabled" do
-      before { customer.organization.enable_feature_flag!(:multi_currency) }
-
+    context "when the customer currency is a default preference" do
       context "when customer_update is false (billing object creation)" do
         let(:customer_update) { false }
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -324,13 +324,11 @@ RSpec.describe Customers::UpdateService do
           }
         end
 
-        it "fails" do
+        it "updates the currency" do
           result = customers_service.call
 
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to include(:currency)
-          expect(result.error.messages[:currency]).to include("currencies_does_not_match")
+          expect(result).to be_success
+          expect(result.customer.currency).to eq("CAD")
         end
       end
     end

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -842,11 +842,9 @@ RSpec.describe Customers::UpsertFromApiService do
         customer.update!(currency: subscription.plan.amount_currency)
       end
 
-      it "fails is we change the subscription" do
-        expect(result).to be_failure
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages.keys).to include(:currency)
-        expect(result.error.messages[:currency]).to include("currencies_does_not_match")
+      it "updates the customer currency (it is now a default preference)" do
+        expect(result).to be_success
+        expect(customer.reload.currency).to eq("CAD")
       end
     end
 

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -353,13 +353,11 @@ RSpec.describe Invoices::CreateOneOffService do
     context "when currency does not match" do
       let(:currency) { "NOK" }
 
-      it "fails" do
+      it "creates the invoice (currency is a default preference)" do
         result = described_class.call(**args)
 
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages.keys).to include(:currency)
-        expect(result.error.messages[:currency]).to include("currencies_does_not_match")
+        expect(result).to be_success
+        expect(result.invoice.currency).to eq("NOK")
       end
     end
 

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -62,26 +62,15 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
         end
       end
 
-      context "when currencies do not match" do
+      context "when the customer currency differs from the subscription" do
         let(:customer) { build(:customer, organization:, billing_entity:, currency: "USD") }
 
-        it "returns an error" do
-          result = preview_service.call
+        it "allows the preview" do
+          travel_to(timestamp) do
+            result = preview_service.call
 
-          expect(result).not_to be_success
-          expect(result.error.messages[:base]).to include("customer_currency_does_not_match")
-        end
-
-        context "when multi_currency flag is enabled" do
-          before { organization.enable_feature_flag!(:multi_currency) }
-
-          it "allows the preview" do
-            travel_to(timestamp) do
-              result = preview_service.call
-
-              expect(result).to be_success
-              expect(result.invoice).to be_present
-            end
+            expect(result).to be_success
+            expect(result.invoice).to be_present
           end
         end
       end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1028,13 +1028,11 @@ RSpec.describe Subscriptions::CreateService do
       context "when new plan has different currency than the old plan" do
         let(:plan) { create(:plan, amount_cents: 200, organization:, amount_currency: "USD") }
 
-        it "fails" do
+        it "creates the subscription (currency is a default preference)" do
           result = create_service.call
 
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to include(:currency)
-          expect(result.error.messages[:currency]).to include("currencies_does_not_match")
+          expect(result).to be_success
+          expect(result.subscription).to be_present
         end
       end
 

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
     end
 
     context "when grouping subscriptions by currency" do
-      let(:organization) { create(:organization, feature_flags: ["multi_currency"]) }
+      let(:organization) { create(:organization) }
       let(:interval) { :monthly }
       let(:billing_time) { :anniversary }
       let(:current_date) { subscription_at.next_month }
@@ -494,21 +494,6 @@ RSpec.describe Subscriptions::OrganizationBillingService do
           expect(BillNonInvoiceableFeesJob).to have_been_enqueued
             .with([eur_subscription], current_date)
         end
-
-        context "without feature flag" do
-          let(:organization) { create(:organization) }
-
-          it "groups them into a single billing job" do
-            billing_service.call
-
-            expect(BillSubscriptionJob).to have_been_enqueued
-              .with(
-                contain_exactly(usd_subscription, eur_subscription),
-                current_date.to_i,
-                invoicing_reason: :subscription_periodic
-              )
-          end
-        end
       end
 
       context "when subscriptions share the same currency" do
@@ -556,7 +541,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
       end
 
       context "when combined with payment method grouping" do
-        let(:organization) { create(:organization, feature_flags: %w[multi_currency]) }
+        let(:organization) { create(:organization) }
         let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }
         let(:eur_plan) { create(:plan, organization:, interval:, amount_currency: "EUR") }
 
@@ -1213,7 +1198,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
       end
 
       context "when combined with currency grouping" do
-        let(:organization) { create(:organization, feature_flags: ["multi_currency"]) }
+        let(:organization) { create(:organization) }
         let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }
         let(:eur_plan) { create(:plan, organization:, interval:, amount_currency: "EUR") }
 
@@ -1433,7 +1418,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
 
       context "when combined with payment method, currency and billing entity grouping" do
         let(:organization) do
-          create(:organization, feature_flags: %w[multi_currency multi_entity_billing])
+          create(:organization, feature_flags: %w[multi_entity_billing])
         end
         let(:other_billing_entity) { create(:billing_entity, organization:) }
         let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -362,20 +362,6 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
-    context "when customer already has a different currency" do
-      let(:customer_currency) { "USD" }
-
-      it "returns a currency mismatch error" do
-        expect(service_result).not_to be_success
-        expect(service_result.error.messages[:currency]).to eq(["currencies_does_not_match"])
-      end
-
-      it "does not update the customer currency" do
-        service_result
-        expect(customer.reload.currency).to eq("USD")
-      end
-    end
-
     context "when customer already has the same currency" do
       let(:customer_currency) { "EUR" }
 
@@ -392,9 +378,7 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
-    context "when multi currency is enabled" do
-      before { organization.update!(feature_flags: ["multi_currency"]) }
-
+    context "when the wallet currency can differ from the customer currency" do
       context "when customer does not have a currency" do
         let(:customer_currency) { nil }
 


### PR DESCRIPTION
## Context

Phase 1 of making multi-currency generally available, following the feature-flag removal runbook: remove all gating first, keeping the enabled behavior, before the flag definition and org values are dropped in later phases. The flag stays in feature_flags.yaml for now.

## Description

- update_currency_service: the customer currency is a default preference rather than a constraint; drop the mismatch/editability failures.
- preview_service: a customer/subscription currency mismatch no longer blocks the preview.
- organization_billing_service: always group subscriptions by their plan currency.
- wallets create_service: take the wallet currency from the param (falling back to the customer) and only set the customer currency when it is blank.
- Update the specs and drop the now-invalid disabled-behavior cases.