### PR TITLE
chore(multi-currency): drop the feature flag / Phase 2

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -10,10 +10,6 @@ wallet_traceability:
   description: "Enable wallet traceability on newly created wallets"
   owners: ["@groyoh", "@D1353L"]
 
-multi_currency:
-  description: "Allow customers to have billing objects in multiple currencies"
-  owners: ["@feliperodrigues", "@mariohd", "@lovrocolic"]
-
 payment_gated_subscriptions:
   description: "Enable payment-gated subscription activation rules"
   owners: ["@osmarluz", "@ancorcruz"]

--- a/schema.graphql
+++ b/schema.graphql
@@ -6238,7 +6238,6 @@ enum FeatureFlagEnum {
   lazy_charge_usage_cache
   meilisearch
   multi_connection
-  multi_currency
   multi_entity_billing
   order_forms
   payment_gated_subscriptions

--- a/schema.json
+++ b/schema.json
@@ -30310,12 +30310,6 @@
               "deprecationReason": null
             },
             {
-              "name": "multi_currency",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "payment_gated_subscriptions",
               "description": null,
               "isDeprecated": false,


### PR DESCRIPTION
> ⚠️ **Do not merge before #6089 (Phase 1).** This must ship only after Phase 1 is merged and released, and after the front has stopped referencing the `multiCurrency` enum member — otherwise front codegen breaks when the schema drops it, and any remaining `feature_flag_enabled?(:multi_currency)` call would raise once the definition is gone (Phase 1 removes them all).

## Context

Phase 2 of making multi-currency generally available, following the feature-flag removal runbook. Phase 1 (#6089) removes all gating while keeping the enabled behavior; this PR drops the flag definition and regenerates the schema so `FeatureFlagEnum` no longer advertises the member.

## Changes

Removes `multi_currency` from `feature_flags.yaml` and regenerates `schema.graphql` / `schema.json`, which drops the member from `FeatureFlagEnum`.

## Follow-up

Phase 3 is a data step, not code: `FeatureFlag.sanitize!` strips the now-unknown `multi_currency` value from every organization's `feature_flags` array (once the definition is gone, that's the only way to remove it).
