### PR TITLE
Chore(delete-bm): do not destroy events when discarding a billable metric

### DIFF
--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -32,8 +32,6 @@ module BillableMetrics
         # rubocop:enable Rails/SkipsModelValidations
       end
 
-      # NOTE: Discard all related events asynchronously.
-      BillableMetrics::DeleteEventsJob.perform_later(metric)
       BillableMetricFilters::DestroyAllJob.perform_later(metric.id)
 
       SendWebhookJob.perform_after_commit("billable_metric.deleted", metric)

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -43,12 +43,6 @@ RSpec.describe BillableMetrics::DestroyService do
         .to have_enqueued_job(BillableMetricFilters::DestroyAllJob).with(billable_metric.id)
     end
 
-    it "enqueues a BillableMetrics::DeleteEventsJob" do
-      expect do
-        destroy_service.call
-      end.to have_enqueued_job(BillableMetrics::DeleteEventsJob).with(billable_metric)
-    end
-
     it "enqueues a billable_metric.deleted webhook" do
       destroy_service.call
 


### PR DESCRIPTION
## Context

This job was introduced in 2023, however now it makes more sense to keep the events