### PR TITLE
[ING-555] fix(payment): clear customer provider on connection destroy

### DIFF
--- a/app/services/payment_provider_customers/destroy_service.rb
+++ b/app/services/payment_provider_customers/destroy_service.rb
@@ -20,6 +20,8 @@ module PaymentProviderCustomers
         payment_provider_customer.payment_methods.find_each do |payment_method|
           PaymentMethods::DestroyService.call!(payment_method:)
         end
+
+        clear_customer_payment_provider
       end
 
       result.payment_provider_customer = payment_provider_customer
@@ -29,5 +31,19 @@ module PaymentProviderCustomers
     private
 
     attr_reader :payment_provider_customer
+
+    # Keep the customer in the same end state as removing the provider through
+    # Customers::UpdateService: when the destroyed connection is the customer's active provider,
+    # clear the pointers so nothing references a connection that no longer exists.
+    def clear_customer_payment_provider
+      customer = payment_provider_customer.customer
+      return unless customer.payment_provider == provider_type
+
+      customer.update!(payment_provider: nil, payment_provider_code: nil)
+    end
+
+    def provider_type
+      payment_provider_customer.type.demodulize.underscore.delete_suffix("_customer")
+    end
   end
 end

--- a/spec/services/payment_provider_customers/destroy_service_spec.rb
+++ b/spec/services/payment_provider_customers/destroy_service_spec.rb
@@ -58,6 +58,32 @@ RSpec.describe PaymentProviderCustomers::DestroyService do
             .to change { payment_method.reload.deleted_at }.from(nil)
         end
       end
+
+      context "when the connection is the customer's active provider" do
+        let(:customer) do
+          create(:customer, organization:, payment_provider: "stripe", payment_provider_code: "stripe_1")
+        end
+
+        it "clears the customer's payment provider and code" do
+          destroy_service.call
+
+          expect(customer.reload.payment_provider).to be_nil
+          expect(customer.payment_provider_code).to be_nil
+        end
+      end
+
+      context "when the connection is not the customer's active provider" do
+        let(:customer) do
+          create(:customer, organization:, payment_provider: "gocardless", payment_provider_code: "gc_1")
+        end
+
+        it "leaves the customer's payment provider untouched" do
+          destroy_service.call
+
+          expect(customer.reload.payment_provider).to eq("gocardless")
+          expect(customer.payment_provider_code).to eq("gc_1")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Destroying a payment provider customer through
destroyPaymentProviderCustomer discarded the connection and its payment methods but left customer.payment_provider and payment_provider_code pointing at a connection that no longer exists. The customer-level path (Customers::UpdateService with payment_provider: nil) clears both, so the two removal routes ended in different states and clients still listed the deleted connection.

## Description

PaymentProviderCustomers::DestroyService now clears the customer's payment_provider and payment_provider_code inside the same transaction, but only when the destroyed connection is the customer's active provider (its provider type matches customer.payment_provider), so removing a non-active connection leaves the active pointer intact. This mirrors the end state of removing the provider through Customers::UpdateService.
