### PR TITLE
feat(products): add product filter services

### DIFF
--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -22,7 +22,7 @@ module Clickhouse
     belongs_to :user, optional: true
     belongs_to :api_key, optional: true
 
-    RESOURCE_TYPES_WITH_DISCARDED = %w[BillableMetric Plan Customer BillingEntity Coupon].freeze
+    RESOURCE_TYPES_WITH_DISCARDED = %w[BillableMetric Plan Customer BillingEntity Coupon ProductFilter].freeze
 
     RESOURCE_TYPES = {
       billable_metric: "BillableMetric",
@@ -36,7 +36,8 @@ module Clickhouse
       coupon: "Coupon",
       payment_receipt: "PaymentReceipt",
       payment_request: "PaymentRequest",
-      feature: "Entitlement::Feature"
+      feature: "Entitlement::Feature",
+      product_filter: "ProductFilter"
     }.freeze
 
     ACTIVITY_TYPES = {
@@ -90,7 +91,10 @@ module Clickhouse
       email_sent: "email.sent",
       feature_created: "feature.created",
       feature_deleted: "feature.deleted",
-      feature_updated: "feature.updated"
+      feature_updated: "feature.updated",
+      product_filter_created: "product_filter.created",
+      product_filter_updated: "product_filter.updated",
+      product_filter_deleted: "product_filter.deleted"
     }
 
     before_save :ensure_activity_id

--- a/app/queries/product_filters_query.rb
+++ b/app/queries/product_filters_query.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ProductFiltersQuery < BaseQuery
+  Result = BaseResult[:product_filters]
+  Filters = BaseFilters[:product_id, :product_category_ids, :without_product_category]
+
+  def call
+    product_filters = base_scope.result
+    product_filters = paginate(product_filters)
+    product_filters = apply_consistent_ordering(product_filters)
+
+    product_filters = with_product(product_filters) if filters.product_id.present?
+    if filters.product_category_ids.present? || filters.without_product_category.present?
+      product_filters = with_product_category(product_filters)
+    end
+
+    result.product_filters = product_filters
+    result
+  end
+
+  private
+
+  def base_scope
+    ProductFilter.where(organization:).ransack(search_params)
+  end
+
+  def search_params
+    return if search_term.blank?
+
+    {
+      m: "or",
+      name_cont: search_term,
+      code_cont: search_term
+    }
+  end
+
+  def with_product(scope)
+    scope.where(product_id: filters.product_id)
+  end
+
+  # The product_category dimension is a multi-select: chosen product_categories OR "no product_category".
+  # A filter's product_category is its parent item's product_category.
+  def with_product_category(scope)
+    scope = scope.joins(:product)
+    if filters.product_category_ids.present? && filters.without_product_category.present?
+      scope.where(products: {product_category_id: filters.product_category_ids})
+        .or(scope.where(products: {product_category_id: nil}))
+    elsif filters.without_product_category.present?
+      scope.where(products: {product_category_id: nil})
+    else
+      scope.where(products: {product_category_id: filters.product_category_ids})
+    end
+  end
+end

--- a/app/serializers/v1/product_filter_serializer.rb
+++ b/app/serializers/v1/product_filter_serializer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module V1
+  class ProductFilterSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        name: model.name,
+        code: model.code,
+        description: model.description,
+        invoice_display_name: model.invoice_display_name,
+        values: values,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+    end
+
+    private
+
+    def values
+      model.values.map do |value|
+        {
+          billable_metric_filter_id: value.billable_metric_filter_id,
+          key: value.key,
+          value: value.value
+        }
+      end
+    end
+  end
+end

--- a/app/services/product_filters/create_service.rb
+++ b/app/services/product_filters/create_service.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module ProductFilters
+  class CreateService < BaseService
+    Result = BaseResult[:product_filter]
+
+    def initialize(product:, params:)
+      @product = product
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    activity_loggable(
+      action: "product_filter.created",
+      record: -> { result.product_filter }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "product") unless product
+
+      unless product.usage?
+        return result.single_validation_failure!(field: :product, error_code: "invalid_product_type")
+      end
+
+      return resolved_values unless resolved_values.success?
+
+      values_validation = ProductFilters::ValidateValuesService.call(product:, values_params: resolved_values.values_params)
+      return values_validation unless values_validation.success?
+
+      ActiveRecord::Base.transaction do
+        product_filter = product.filters.create!(
+          organization_id: product.organization_id,
+          name: params[:name],
+          code: params[:code]&.strip,
+          description: params[:description],
+          invoice_display_name: params[:invoice_display_name]
+        )
+
+        create_values(product_filter)
+
+        result.product_filter = product_filter
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      if e.record.is_a?(ProductFilterValue)
+        errors = e.record.errors.messages.transform_keys { |key| :"values.#{key}" }
+        result.validation_failure!(errors:)
+      else
+        result.record_validation_failure!(record: e.record)
+      end
+    end
+
+    private
+
+    attr_reader :product, :params
+
+    def resolved_values
+      @resolved_values ||= ProductFilters::ResolveValuesService.call(product:, values_params: params[:values])
+    end
+
+    def create_values(product_filter)
+      resolved_values.values_params.each do |value_params|
+        product_filter.values.create!(
+          organization_id: product.organization_id,
+          billable_metric_filter_id: value_params[:billable_metric_filter_id],
+          value: value_params[:value]
+        )
+      end
+    end
+  end
+end

--- a/app/services/product_filters/destroy_service.rb
+++ b/app/services/product_filters/destroy_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ProductFilters
+  class DestroyService < BaseService
+    Result = BaseResult[:product_filter]
+
+    def initialize(product_filter:)
+      @product_filter = product_filter
+      super
+    end
+
+    activity_loggable(
+      action: "product_filter.deleted",
+      record: -> { result.product_filter }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "product_filter") unless product_filter
+
+      # Same rule as product_categories and items: a catalog object cannot be deleted while
+      # its item is attached to a plan or subscription. Detach first, then delete.
+      if product_filter.attached_to_plan_or_subscription?
+        return result.single_validation_failure!(field: :product_filter, error_code: "attached_to_plan_or_subscription")
+      end
+
+      ActiveRecord::Base.transaction do
+        # Rate cards scoped to this filter lose their scope when it is deleted, so
+        # discard them too (all unattached, guaranteed by the guard above) — mirrors
+        # the product destroy cascade and avoids orphaned rate cards.
+        scoped_cards = product_filter.product.rate_cards.where(product_filter_id: product_filter.id)
+        RateCardRate.where(rate_card_id: scoped_cards.ids).discard_all!
+        scoped_cards.discard_all!
+
+        product_filter.values.discard_all!
+        product_filter.discard!
+      end
+
+      result.product_filter = product_filter
+      result
+    end
+
+    private
+
+    attr_reader :product_filter
+  end
+end

--- a/app/services/product_filters/resolve_values_service.rb
+++ b/app/services/product_filters/resolve_values_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ProductFilters
+  # The public API references billable metric filters by key — their ids are
+  # not exposed on the billable metric payload. Resolve each value entry's
+  # `key` to the matching filter of the item's metric; entries already carrying
+  # a `billable_metric_filter_id` pass through. An unknown key fails on the
+  # `values.key` field — the field the caller actually sent.
+  class ResolveValuesService < BaseService
+    Result = BaseResult[:values_params]
+
+    def initialize(product:, values_params:)
+      @product = product
+      @values_params = values_params
+      super
+    end
+
+    def call
+      resolved = Array.wrap(values_params).map do |value_params|
+        value_params = value_params.to_h.with_indifferent_access
+        next value_params if value_params[:billable_metric_filter_id].present? || value_params[:key].blank?
+
+        metric_filter = product.billable_metric&.filters&.find_by(key: value_params[:key])
+        unless metric_filter
+          return result.single_validation_failure!(field: :"values.key", error_code: "value_is_invalid")
+        end
+
+        value_params.except(:key).merge(billable_metric_filter_id: metric_filter.id)
+      end
+
+      result.values_params = resolved
+      result
+    end
+
+    private
+
+    attr_reader :product, :values_params
+  end
+end

--- a/app/services/product_filters/update_service.rb
+++ b/app/services/product_filters/update_service.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module ProductFilters
+  class UpdateService < BaseService
+    Result = BaseResult[:product_filter]
+
+    def initialize(product_filter:, params:)
+      @product_filter = product_filter
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    activity_loggable(
+      action: "product_filter.updated",
+      record: -> { product_filter }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "product_filter") unless product_filter
+
+      if params.key?(:values)
+        return resolved_values unless resolved_values.success?
+
+        values_validation = ProductFilters::ValidateValuesService.call(
+          product: product_filter.product,
+          values_params: resolved_values.values_params
+        )
+        return values_validation unless values_validation.success?
+      end
+
+      ActiveRecord::Base.transaction do
+        product_filter.name = params[:name] if params.key?(:name)
+        product_filter.description = params[:description] if params.key?(:description)
+        product_filter.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+        product_filter.save!
+
+        replace_values if params.key?(:values)
+
+        result.product_filter = product_filter
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      if e.record.is_a?(ProductFilterValue)
+        errors = e.record.errors.messages.transform_keys { |key| :"values.#{key}" }
+        result.validation_failure!(errors:)
+      else
+        result.record_validation_failure!(record: e.record)
+      end
+    end
+
+    private
+
+    attr_reader :product_filter, :params
+
+    def resolved_values
+      @resolved_values ||= ProductFilters::ResolveValuesService.call(
+        product: product_filter.product,
+        values_params: params[:values]
+      )
+    end
+
+    def replace_values
+      product_filter.values.discard_all!
+
+      resolved_values.values_params.each do |value_params|
+        product_filter.values.create!(
+          organization_id: product_filter.organization_id,
+          billable_metric_filter_id: value_params[:billable_metric_filter_id],
+          value: value_params[:value]
+        )
+      end
+    end
+  end
+end

--- a/app/services/product_filters/validate_values_service.rb
+++ b/app/services/product_filters/validate_values_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ProductFilters
+  class ValidateValuesService < BaseService
+    Result = BaseResult
+
+    def initialize(product:, values_params:)
+      @product = product
+      @values_params = values_params
+      super
+    end
+
+    def call
+      if values_params.blank?
+        return result.single_validation_failure!(field: :values, error_code: "value_is_mandatory")
+      end
+
+      requested_ids = values_params.map { it[:billable_metric_filter_id].to_s }.uniq
+      known_ids = product.billable_metric.filters.where(id: requested_ids).ids
+      if known_ids.map(&:to_s).sort != requested_ids.sort
+        return result.single_validation_failure!(field: :"values.billable_metric_filter", error_code: "value_is_invalid")
+      end
+
+      # A key-only entry (no value) matches any value of the key, so combining
+      # it with specific values for the same key is contradictory — the
+      # wildcard subsumes them.
+      key_only_ids = values_params.select { it[:value].nil? }.map { it[:billable_metric_filter_id].to_s }
+      specific_ids = values_params.reject { it[:value].nil? }.map { it[:billable_metric_filter_id].to_s }
+      if key_only_ids.intersect?(specific_ids)
+        return result.single_validation_failure!(field: :values, error_code: "key_only_conflicts_with_values")
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :product, :values_params
+  end
+end

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -3,7 +3,7 @@
 module Utils
   class ActivityLog
     IGNORED_FIELDS = %i[updated_at].freeze
-    IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES = %w[BillableMetric Coupon Plan BillingEntity Entitlement::Feature].freeze
+    IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES = %w[BillableMetric Coupon Plan BillingEntity Entitlement::Feature ProductFilter].freeze
     MAX_SERIALIZED_FEES = 25
     MAX_SERIALIZED_CHARGES = 50
     MAX_SERIALIZED_CHARGE_FILTERS = 100

--- a/schema.graphql
+++ b/schema.graphql
@@ -293,6 +293,21 @@ enum ActivityTypeEnum {
   plan_updated
 
   """
+  product_filter.created
+  """
+  product_filter_created
+
+  """
+  product_filter.deleted
+  """
+  product_filter_deleted
+
+  """
+  product_filter.updated
+  """
+  product_filter_updated
+
+  """
   subscription.canceled
   """
   subscription_canceled
@@ -11821,6 +11836,11 @@ enum ResourceTypeEnum {
   Plan
   """
   plan
+
+  """
+  ProductFilter
+  """
+  product_filter
 
   """
   Subscription

--- a/schema.json
+++ b/schema.json
@@ -803,6 +803,24 @@
               "description": "feature.updated",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "product_filter_created",
+              "description": "product_filter.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "product_filter_updated",
+              "description": "product_filter.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "product_filter_deleted",
+              "description": "product_filter.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -64304,6 +64322,12 @@
             {
               "name": "feature",
               "description": "Entitlement::Feature",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "product_filter",
+              "description": "ProductFilter",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
@@ -56,6 +56,9 @@ RSpec.describe Types::ActivityLogs::ActivityTypeEnum do
         feature_created
         feature_deleted
         feature_updated
+        product_filter_created
+        product_filter_updated
+        product_filter_deleted
         email_sent
       ]
     )

--- a/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Types::ActivityLogs::ResourceTypeEnum do
         payment_request
         feature
         payment_receipt
+        product_filter
       ]
     )
   end

--- a/spec/queries/product_filters_query_spec.rb
+++ b/spec/queries/product_filters_query_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductFiltersQuery do
+  subject(:result) { described_class.call(organization:, search_term:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:search_term) { nil }
+  let(:pagination) { nil }
+  let(:filters) { {} }
+
+  let(:product) { create(:product, organization:) }
+  let!(:filter_one) { create(:product_filter, organization:, product:, name: "US cards", code: "us_cards") }
+  let!(:filter_two) { create(:product_filter, organization:, name: "EU cards", code: "eu_cards") }
+
+  it "returns all filters of the organization" do
+    expect(result.product_filters).to match_array([filter_one, filter_two])
+  end
+
+  it "does not return filters from other organizations" do
+    create(:product_filter)
+    expect(result.product_filters).to match_array([filter_one, filter_two])
+  end
+
+  context "with a product filter" do
+    let(:filters) { {product_id: product.id} }
+
+    it "returns only the filters of that product" do
+      expect(result.product_filters).to eq([filter_one])
+    end
+  end
+
+  context "with a product_category filter" do
+    let(:filters) { {product_category_ids: [product.product_category_id]} }
+
+    it "returns only the filters of items belonging to those product_categories" do
+      expect(result.product_filters).to eq([filter_one])
+    end
+  end
+
+  context "with a without_product_category filter" do
+    let(:standalone_item) { create(:product, :standalone, organization:) }
+    let!(:orphan_filter) { create(:product_filter, organization:, product: standalone_item) }
+    let(:filters) { {without_product_category: true} }
+
+    it "returns only the filters of items not attached to any product_category" do
+      expect(result.product_filters).to eq([orphan_filter])
+    end
+  end
+
+  context "with product_category and without_product_category filters combined" do
+    let(:standalone_item) { create(:product, :standalone, organization:) }
+    let!(:orphan_filter) { create(:product_filter, organization:, product: standalone_item) }
+    let(:filters) { {product_category_ids: [product.product_category_id], without_product_category: true} }
+
+    it "returns the union of both" do
+      expect(result.product_filters).to match_array([filter_one, orphan_filter])
+    end
+  end
+
+  context "with a search term on name" do
+    let(:search_term) { "US" }
+
+    it "returns matching filters" do
+      expect(result.product_filters).to eq([filter_one])
+    end
+  end
+
+  context "with a search term on code" do
+    let(:search_term) { "eu_" }
+
+    it "returns matching filters" do
+      expect(result.product_filters).to eq([filter_two])
+    end
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 1, limit: 1} }
+
+    it "paginates the results" do
+      expect(result.product_filters.count).to eq(1)
+      expect(result.product_filters.total_count).to eq(2)
+    end
+  end
+end

--- a/spec/services/product_filters/create_service_spec.rb
+++ b/spec/services/product_filters/create_service_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductFilters::CreateService do
+  subject(:result) { described_class.call(product:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:product) { create(:product, organization:, billable_metric:) }
+  let(:region_filter) { create(:billable_metric_filter, organization:, billable_metric:, key: "region", values: %w[us eu]) }
+  let(:scheme_filter) { create(:billable_metric_filter, organization:, billable_metric:, key: "scheme", values: %w[visa mastercard]) }
+
+  let(:params) do
+    {
+      name: "US Visa",
+      code: "us_visa",
+      description: "US visa transactions",
+      invoice_display_name: "US · Visa",
+      values: [
+        {billable_metric_filter_id: region_filter.id, value: "us"},
+        {billable_metric_filter_id: scheme_filter.id, value: "visa"}
+      ]
+    }
+  end
+
+  it "creates a product filter with its values" do
+    expect { result }.to change(ProductFilter, :count).by(1)
+      .and change(ProductFilterValue, :count).by(2)
+
+    filter = result.product_filter
+    expect(filter.name).to eq("US Visa")
+    expect(filter.code).to eq("us_visa")
+    expect(filter.description).to eq("US visa transactions")
+    expect(filter.invoice_display_name).to eq("US · Visa")
+    expect(filter.to_h).to eq("region" => %w[us], "scheme" => %w[visa])
+  end
+
+  context "when values reference metric filters by key" do
+    let(:params) do
+      {
+        name: "US Visa",
+        code: "us_visa_by_key",
+        values: [
+          {key: region_filter.key, value: "us"},
+          {key: scheme_filter.key, value: "visa"}
+        ]
+      }
+    end
+
+    it "resolves the keys to the metric's filters" do
+      expect { result }.to change(ProductFilterValue, :count).by(2)
+      expect(result.product_filter.to_h).to eq("region" => %w[us], "scheme" => %w[visa])
+    end
+
+    context "with an unknown key" do
+      let(:params) { {name: "Broken", code: "broken", values: [{key: "unknown", value: "us"}]} }
+
+      it "returns a validation failure on the key" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:"values.key"]).to eq(["value_is_invalid"])
+      end
+    end
+  end
+
+  context "with a key-only value selection" do
+    let(:params) do
+      {
+        name: "Any region",
+        code: "any_region",
+        values: [{key: region_filter.key}]
+      }
+    end
+
+    it "creates the filter matching any value of the key" do
+      expect { result }.to change(ProductFilterValue, :count).by(1)
+
+      value = result.product_filter.values.sole
+      expect(value.billable_metric_filter).to eq(region_filter)
+      expect(value.value).to be_nil
+    end
+  end
+
+  context "when a key-only entry is combined with specific values for the same key" do
+    let(:params) do
+      {
+        name: "Contradiction",
+        code: "contradiction",
+        values: [
+          {key: region_filter.key},
+          {key: region_filter.key, value: "eu"}
+        ]
+      }
+    end
+
+    it "returns a validation failure" do
+      expect { result }.not_to change(ProductFilter, :count)
+
+      expect(result).not_to be_success
+      expect(result.error.messages[:values]).to eq(["key_only_conflicts_with_values"])
+    end
+  end
+
+  context "when product is nil" do
+    let(:product) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("product")
+    end
+  end
+
+  context "when product is a fixed item" do
+    let(:product) { create(:product, :fixed, organization:) }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:product]).to eq(["invalid_product_type"])
+    end
+  end
+
+  context "when values are missing" do
+    before { params[:values] = [] }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:values]).to eq(["value_is_mandatory"])
+    end
+  end
+
+  context "when a billable metric filter belongs to another metric" do
+    let(:other_metric_filter) { create(:billable_metric_filter, organization:) }
+
+    before { params[:values] = [{billable_metric_filter_id: other_metric_filter.id, value: "anything"}] }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:"values.billable_metric_filter"]).to eq(["value_is_invalid"])
+    end
+  end
+
+  context "when the combination is already used on the product" do
+    before do
+      described_class.call(
+        product:,
+        params: params.merge(name: "Existing", code: "existing")
+      )
+    end
+
+    it "creates the filter anyway" do
+      expect(result).to be_success
+      expect(result.product_filter.to_h).to eq("region" => %w[us], "scheme" => %w[visa])
+    end
+  end
+
+  context "when a value does not belong to the metric filter values" do
+    before { params[:values] = [{billable_metric_filter_id: region_filter.id, value: "mars"}] }
+
+    it "returns a validation failure on the value" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:"values.value"]).to be_present
+    end
+  end
+
+  context "when the code is already used on the product" do
+    before { create(:product_filter, organization:, product:, code: "us_visa") }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:code]).to be_present
+    end
+  end
+
+  it "produces an activity log" do
+    filter = result.product_filter
+    expect(Utils::ActivityLog).to have_produced("product_filter.created").after_commit.with(filter)
+  end
+end

--- a/spec/services/product_filters/destroy_service_spec.rb
+++ b/spec/services/product_filters/destroy_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductFilters::DestroyService do
+  subject(:result) { described_class.call(product_filter:) }
+
+  let(:organization) { create(:organization) }
+  let(:product_filter) { create(:product_filter, :with_values, organization:) }
+
+  it "soft deletes the filter and its values" do
+    value_ids = product_filter.values.ids
+    expect(result).to be_success
+    expect(product_filter.reload).to be_discarded
+    expect(ProductFilterValue.with_discarded.where(id: value_ids).map(&:discarded?)).to all(be(true))
+  end
+
+  it "produces an activity log" do
+    result
+    expect(Utils::ActivityLog).to have_produced("product_filter.deleted").after_commit.with(product_filter)
+  end
+
+  context "when a scoped rate card exists" do
+    let(:product) { product_filter.product }
+    let!(:scoped_card) { create(:rate_card, organization:, product:, product_filter:) }
+
+    it "discards the scoped rate card alongside the filter" do
+      expect(result).to be_success
+      expect(scoped_card.reload).to be_discarded
+    end
+  end
+
+  context "when the item is attached to a plan" do
+    before do
+      rate_card = create(:rate_card, organization:, product: product_filter.product)
+      create(:plan_rate_card, organization:, rate_card:)
+    end
+
+    it "returns a validation failure and discards nothing" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:product_filter]).to eq(["attached_to_plan_or_subscription"])
+      expect(product_filter.reload).not_to be_discarded
+    end
+  end
+
+  context "when product_filter is nil" do
+    let(:product_filter) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("product_filter")
+    end
+  end
+end

--- a/spec/services/product_filters/update_service_spec.rb
+++ b/spec/services/product_filters/update_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProductFilters::UpdateService do
+  subject(:result) { described_class.call(product_filter:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:product) { create(:product, organization:, billable_metric:) }
+  let(:region_filter) { create(:billable_metric_filter, organization:, billable_metric:, key: "region", values: %w[us eu]) }
+
+  let(:product_filter) do
+    filter = create(:product_filter, organization:, product:, name: "Before", description: "old")
+    create(:product_filter_value, organization:, product_filter: filter, billable_metric_filter: region_filter, value: "us")
+    filter
+  end
+
+  let(:params) { {name: "After", description: "new", invoice_display_name: "Display"} }
+
+  it "updates the filter attributes" do
+    expect(result).to be_success
+    expect(result.product_filter.name).to eq("After")
+    expect(result.product_filter.description).to eq("new")
+    expect(result.product_filter.invoice_display_name).to eq("Display")
+  end
+
+  it "does not change the values when none are provided" do
+    expect { result }.not_to change { product_filter.reload.values.count }
+  end
+
+  it "produces an activity log" do
+    result
+    expect(Utils::ActivityLog).to have_produced("product_filter.updated").after_commit.with(product_filter)
+  end
+
+  context "when product_filter is nil" do
+    let(:product_filter) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("product_filter")
+    end
+  end
+
+  context "when values are provided" do
+    let(:params) { {values: [{billable_metric_filter_id: region_filter.id, value: "eu"}]} }
+
+    it "replaces the existing values" do
+      expect(result).to be_success
+      expect(result.product_filter.reload.to_h).to eq("region" => %w[eu])
+    end
+
+    context "when the new combination matches another filter on the item" do
+      before do
+        other = create(:product_filter, organization:, product:)
+        create(:product_filter_value, organization:, product_filter: other, billable_metric_filter: region_filter, value: "eu")
+      end
+
+      it "is allowed" do
+        expect(result).to be_success
+        expect(result.product_filter.reload.to_h).to eq("region" => %w[eu])
+      end
+    end
+
+    context "when values are empty" do
+      let(:params) { {values: []} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:values]).to eq(["value_is_mandatory"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Service layer for `ProductFilter`, the first of the three catalog authoring entities introduced in #5652. Every write goes through a dedicated service so the REST and GraphQL surfaces (later slices) share identical behaviour and validation.

## Description

- Create/update/destroy services for `ProductFilter`, with a query object and V1 serializer.
- Filter values are resolved by metric-filter key (`ResolveValuesService`) and validated (`ValidateValuesService`): values must belong to the product's metric, key-only wildcards cannot mix with specific values for the same key, and an empty values list is rejected.
- Filters are only allowed on metered products (`not_allowed_for_product_type` on fixed items).
