### PR TITLE
Fix(progressive-billing): rewrite source of charges for PB credits

### DIFF
--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -24,9 +24,15 @@ module Credits
         next unless progressive_billing_invoice
 
         progressive_billed_charge_ids = progressive_billing_invoice.fees.charge.pluck(:charge_id)
+        # A plan override creates a child charge, so a fee on this invoice can point at the child
+        # while the progressive billing invoice was billed on its parent. Both are matched, as the
+        # override can also predate the progressive billing invoices.
         invoice_charge_fees = invoice.fees.charge.where(subscription:).joins(:charge)
         total_charges_amount = invoice_charge_fees
-          .where("COALESCE(charges.parent_id, charges.id) IN (?)", progressive_billed_charge_ids)
+          .where(
+            "fees.charge_id IN (:ids) OR charges.parent_id IN (:ids)",
+            ids: progressive_billed_charge_ids
+          )
           .sum(:amount_cents)
 
         # Don't be tempted to calculate the credit amount yourself, you have to use the result from this service.
@@ -67,9 +73,11 @@ module Credits
     def apply_credit_to_fees(progressive_billing_invoice)
       # Use the loaded association so the credit stays visible to the caller's in-memory fees.
       invoice_fees = invoice.fees.select(&:charge?)
+      parent_charge_ids = parent_charge_ids_for(invoice_fees)
+
       progressive_billing_invoice.fees.charge.each do |progressive_fee|
         fee = invoice_fees.find { |f|
-          f.charge_id == progressive_fee.charge_id &&
+          matching_charge?(f, progressive_fee, parent_charge_ids) &&
             f.charge_filter_id == progressive_fee.charge_filter_id &&
             f.grouped_by == progressive_fee.grouped_by
         }
@@ -79,6 +87,20 @@ module Credits
         fee.precise_coupons_amount_cents = fee.amount_cents if fee.amount_cents < fee.precise_coupons_amount_cents
         fee.save!
       end
+    end
+
+    # Mirrors the charge matching used for total_charges_amount: a fee on an overridden (child)
+    # charge belongs to the progressive billing fee booked on its parent.
+    def matching_charge?(fee, progressive_fee, parent_charge_ids)
+      fee.charge_id == progressive_fee.charge_id ||
+        parent_charge_ids[fee.charge_id] == progressive_fee.charge_id
+    end
+
+    def parent_charge_ids_for(fees)
+      charge_ids = fees.filter_map(&:charge_id).uniq
+      return {} if charge_ids.empty?
+
+      Charge.with_discarded.where(id: charge_ids).pluck(:id, :parent_id).to_h
     end
   end
 end

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -72,7 +72,7 @@ module Credits
 
     def apply_credit_to_fees(progressive_billing_invoice)
       # Use the loaded association so the credit stays visible to the caller's in-memory fees.
-      invoice_fees = invoice.fees.joins(charge: :parent).select(&:charge?)
+      invoice_fees = invoice.fees.select(&:charge?)
 
       progressive_billing_invoice.fees.charge.each do |progressive_fee|
         fee = invoice_fees.find { |f|

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -72,12 +72,12 @@ module Credits
 
     def apply_credit_to_fees(progressive_billing_invoice)
       # Use the loaded association so the credit stays visible to the caller's in-memory fees.
-      invoice_fees = invoice.fees.select(&:charge?)
-      parent_charge_ids = parent_charge_ids_for(invoice_fees)
+      invoice_fees = invoice.fees.joins(charge: :parent).select(&:charge?)
 
       progressive_billing_invoice.fees.charge.each do |progressive_fee|
         fee = invoice_fees.find { |f|
-          matching_charge?(f, progressive_fee, parent_charge_ids) &&
+          matching_charge?(f, progressive_fee) &&
+            matching_charge_filter?(f, progressive_fee) &&
             f.charge_filter_id == progressive_fee.charge_filter_id &&
             f.grouped_by == progressive_fee.grouped_by
         }
@@ -89,18 +89,14 @@ module Credits
       end
     end
 
-    # Mirrors the charge matching used for total_charges_amount: a fee on an overridden (child)
-    # charge belongs to the progressive billing fee booked on its parent.
-    def matching_charge?(fee, progressive_fee, parent_charge_ids)
+    def matching_charge?(fee, progressive_fee)
       fee.charge_id == progressive_fee.charge_id ||
-        parent_charge_ids[fee.charge_id] == progressive_fee.charge_id
+        fee.charge&.parent_id == progressive_fee.charge_id
     end
 
-    def parent_charge_ids_for(fees)
-      charge_ids = fees.filter_map(&:charge_id).uniq
-      return {} if charge_ids.empty?
-
-      Charge.with_discarded.where(id: charge_ids).pluck(:id, :parent_id).to_h
+    def matching_charge_filter?(fee, progressive_fee)
+      fee.charge_filter_id == progressive_fee.charge_filter_id ||
+        fee.charge_filter&.code == progressive_fee.charge_filter&.code
     end
   end
 end

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -22,22 +22,12 @@ module Credits
         progressive_billing_invoice = progressive_billed_result.progressive_billing_invoice
 
         next unless progressive_billing_invoice
-        #
-        # total_charges_amount = invoice
-        #   .fees
-        #   .charge
-        #   .where(subscription:)
-        #   .where(charge_id: progressive_billing_invoice.fees.charge.pluck(:charge_id))
-        #   .sum(:amount_cents)
-        #
 
-        parent_charge_ids = invoice.fees.charge.map { it.charge.parent_id }.compact.uniq
-        total_charges_amount = progressive_billing_invoice
-         .fees
-         .charge
-         .where(subscription:)
-         .where(charge_id: invoice.fees.charge.pluck(:charge_id).merge(parent_charge_ids.present? ? parent_charge_ids : [nil]))
-         .sum(:amount_cents)
+        progressive_billed_charge_ids = progressive_billing_invoice.fees.charge.pluck(:charge_id)
+        invoice_charge_fees = invoice.fees.charge.where(subscription:).joins(:charge)
+        total_charges_amount = invoice_charge_fees
+          .where("COALESCE(charges.parent_id, charges.id) IN (?)", progressive_billed_charge_ids)
+          .sum(:amount_cents)
 
         # Don't be tempted to calculate the credit amount yourself, you have to use the result from this service.
         amount_to_credit = progressive_billed_result.to_credit_amount

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -22,13 +22,22 @@ module Credits
         progressive_billing_invoice = progressive_billed_result.progressive_billing_invoice
 
         next unless progressive_billing_invoice
+        #
+        # total_charges_amount = invoice
+        #   .fees
+        #   .charge
+        #   .where(subscription:)
+        #   .where(charge_id: progressive_billing_invoice.fees.charge.pluck(:charge_id))
+        #   .sum(:amount_cents)
+        #
 
-        total_charges_amount = invoice
-          .fees
-          .charge
-          .where(subscription:)
-          .where(charge_id: progressive_billing_invoice.fees.charge.pluck(:charge_id))
-          .sum(:amount_cents)
+        parent_charge_ids = invoice.fees.charge.map { it.charge.parent_id }.compact.uniq
+        total_charges_amount = progressive_billing_invoice
+         .fees
+         .charge
+         .where(subscription:)
+         .where(charge_id: invoice.fees.charge.pluck(:charge_id).merge(parent_charge_ids.present? ? parent_charge_ids : [nil]))
+         .sum(:amount_cents)
 
         # Don't be tempted to calculate the credit amount yourself, you have to use the result from this service.
         amount_to_credit = progressive_billed_result.to_credit_amount

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -505,6 +505,170 @@ Rspec.describe Credits::ProgressiveBillingService do
     end
   end
 
+  context "when the subscription plan is overridden" do
+    # An override creates a child charge (charges.parent_id -> parent charge). Depending on when it
+    # happened, the progressive billing fees sit on the parent while the final invoice's fees sit on
+    # the child, or both sit on the child. Both have to be credited.
+    let(:plan) { create(:plan, organization: customer.organization) }
+    let(:overridden_plan) { create(:plan, organization: customer.organization, parent_id: plan.id) }
+    let(:billable_metric) { create(:billable_metric, organization: customer.organization) }
+
+    let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+    let(:overridden_charge) do
+      create(:standard_charge, plan: overridden_plan, billable_metric:, parent_id: charge.id)
+    end
+
+    let(:subscription) { create(:subscription, customer_id: customer.id, plan: overridden_plan) }
+
+    let(:invoice) do
+      create(:invoice,
+        :subscription,
+        customer:,
+        organization:,
+        sub_total_excluding_taxes_amount_cents: 35_000,
+        subscriptions: subscriptions)
+    end
+
+    # $350 of charges, billed on the overridden (child) charge
+    let(:subscription_fees) { [overridden_fee] }
+    let(:overridden_fee) do
+      create(:charge_fee, invoice:, subscription:, charge: overridden_charge, amount_cents: 35_000)
+    end
+
+    # $100 / $200 / $300 progressive billing invoices, all billed on the parent charge
+    let(:progressive_billing_invoice) do
+      create(
+        :invoice,
+        :with_subscriptions,
+        organization:,
+        customer:,
+        status: "finalized",
+        invoice_type: :progressive_billing,
+        subscriptions: [subscription],
+        issuing_date: invoice.issuing_date - 3.days,
+        created_at: invoice.issuing_date - 3.days,
+        fees_amount_cents: 10_000
+      )
+    end
+
+    let(:progressive_billing_invoice2) do
+      create(
+        :invoice,
+        :with_subscriptions,
+        organization:,
+        customer:,
+        status: "finalized",
+        invoice_type: :progressive_billing,
+        subscriptions: [subscription],
+        issuing_date: invoice.issuing_date - 2.days,
+        created_at: invoice.issuing_date - 2.days,
+        fees_amount_cents: 20_000
+      )
+    end
+
+    let(:progressive_billing_invoice3) do
+      create(
+        :invoice,
+        :with_subscriptions,
+        organization:,
+        customer:,
+        status: "finalized",
+        invoice_type: :progressive_billing,
+        subscriptions: [subscription],
+        issuing_date: invoice.issuing_date - 1.day,
+        created_at: invoice.issuing_date - 1.day,
+        fees_amount_cents: 30_000
+      )
+    end
+
+    let(:progressive_billing_fee) do
+      create(:charge_fee, amount_cents: 10_000, charge:, invoice: progressive_billing_invoice)
+    end
+    let(:progressive_billing_fee2) do
+      create(:charge_fee, amount_cents: 20_000, charge:, invoice: progressive_billing_invoice2)
+    end
+    let(:progressive_billing_fee3) do
+      create(:charge_fee, amount_cents: 30_000, charge:, invoice: progressive_billing_invoice3)
+    end
+
+    before do
+      progressive_billing_fee
+      progressive_billing_fee2
+      progressive_billing_fee3
+
+      [progressive_billing_invoice, progressive_billing_invoice2, progressive_billing_invoice3].each do |pb_invoice|
+        pb_invoice.invoice_subscriptions.first.update!(
+          charges_from_datetime: pb_invoice.issuing_date - 1.month,
+          charges_to_datetime: pb_invoice.issuing_date,
+          timestamp: pb_invoice.issuing_date
+        )
+      end
+    end
+
+    # The progressive billing invoices were issued before the override, so their fees are booked on
+    # the parent charge while the final invoice's fees are on the child.
+    describe "#call" do
+      it "credits the progressively billed amount against the overridden charge" do
+        result = credit_service.call
+
+        expect(result.credits.size).to eq(1)
+        credit = result.credits.sole
+        expect(credit.progressive_billing_invoice).to eq(progressive_billing_invoice3)
+        expect(credit.amount_cents).to eq(30_000)
+        expect(invoice.progressive_billing_credit_amount_cents).to eq(30_000)
+      end
+
+      it "does not create a credit note for the progressively billed amount" do
+        # The $350 of charges fully absorb the $300 already billed, so nothing is left to refund.
+        expect { credit_service.call }.not_to change(CreditNote, :count)
+        expect(progressive_billing_invoice3.credit_notes).to be_empty
+      end
+
+      it "applies the credit to the overridden charge fee" do
+        credit_service.call
+
+        expect(overridden_fee.reload.precise_coupons_amount_cents).to eq(30_000)
+      end
+    end
+
+    context "when the progressive billing invoices were issued after the override" do
+      # The subscription was already overridden, so every fee - progressive billing and final alike -
+      # is booked on the child charge and nothing points at the parent.
+      let(:progressive_billing_fee) do
+        create(:charge_fee, amount_cents: 10_000, charge: overridden_charge, invoice: progressive_billing_invoice)
+      end
+      let(:progressive_billing_fee2) do
+        create(:charge_fee, amount_cents: 20_000, charge: overridden_charge, invoice: progressive_billing_invoice2)
+      end
+      let(:progressive_billing_fee3) do
+        create(:charge_fee, amount_cents: 30_000, charge: overridden_charge, invoice: progressive_billing_invoice3)
+      end
+
+      describe "#call" do
+        it "credits the progressively billed amount" do
+          result = credit_service.call
+
+          expect(result.credits.size).to eq(1)
+          credit = result.credits.sole
+          expect(credit.progressive_billing_invoice).to eq(progressive_billing_invoice3)
+          expect(credit.amount_cents).to eq(30_000)
+          expect(invoice.progressive_billing_credit_amount_cents).to eq(30_000)
+        end
+
+        it "does not create a credit note for the progressively billed amount" do
+          expect { credit_service.call }.not_to change(CreditNote, :count)
+          expect(progressive_billing_invoice3.credit_notes).to be_empty
+        end
+
+        it "applies the credit to the overridden charge fee" do
+          credit_service.call
+
+          expect(overridden_fee.reload.precise_coupons_amount_cents).to eq(30_000)
+        end
+      end
+    end
+  end
+
   context "with a spy on Subscriptions::ProgressiveBilledAmount" do
     let(:progressive_billing_invoice) do
       create(


### PR DESCRIPTION
## Context

When subscription is created, it can follow the original plan
if the original plan has progressive billing, it might get some progressive billing invoices
then subscription gets overridden, 
final subscription invoices is issued for new (children) charges
when we try to apply progressive billing credits, we're looking in the subscription invoices fees, matching charges of the progressive billing invoice
since charge_ids are not matching, we're not finding any matches and trying to create credit notes for all amount on the latest progressive billing invoice
but if there were multiple progressive billing invoices, final total progressively_billed amount can be higher than the latest progressive_billing invoice and we'll fail to issue the credit notes

## Description

when matching the invoice's fees to the progressive billing fees, not only check their charge_id, but also join them with charge and check charge.parent_id