### PR TITLE
[BIL-507] fix(billing): keep fixed charge on draft refresh

### DIFF
--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -61,6 +61,8 @@ module Fees
       fixed_charge
         .fees
         .where(subscription:)
+        # A fee with no units and no amount billed nothing, so it is not proof of billing.
+        .where("fees.units > 0 OR fees.amount_cents > 0")
         .joins(:invoice).where.not(invoices: {status: %i[voided deleted]})
         .where(
           "date_trunc('second', (properties->>'fixed_charges_from_datetime')::timestamptz) = date_trunc('second', ?::timestamptz)",

--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -61,7 +61,6 @@ module Fees
       fixed_charge
         .fees
         .where(subscription:)
-        # A fee with no units and no amount billed nothing, so it is not proof of billing.
         .where("fees.units > 0 OR fees.amount_cents > 0")
         .joins(:invoice).where.not(invoices: {status: %i[voided deleted]})
         .where(

--- a/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
+++ b/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
@@ -44,12 +44,20 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
 
     # Repeating units that are already billed leaves the pay in advance run with nothing
     # to bill, so it writes a fee of zero units on a second invoice.
-    travel_to subscription_date + 1.second do
+    travel_to subscription_date + 1.hour do
       update_subscription(
         subscription,
         {plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 2, apply_units_immediately: true}]}}
       )
     end
+  end
+
+  # Pins the setup itself: without this fee on a second invoice there is nothing for the
+  # guard to misread, and the example below would pass whether or not the bug exists.
+  it "leaves a fee that billed nothing on a second invoice" do
+    placeholder = subscription.invoices.where.not(id: draft.id).sole
+
+    expect(placeholder.fees.fixed_charge.sole).to have_attributes(units: 0, amount_cents: 0)
   end
 
   # A refresh destroys the fees and builds them again. The zero-unit fee on the other

--- a/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
+++ b/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
@@ -8,12 +8,13 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
   let(:add_on) { create(:add_on, organization:) }
   let(:plan) { create(:plan, organization:, amount_cents: 0, interval: "monthly", pay_in_advance: true) }
 
+  # The plan carries no units; the subscription brings them as an override.
   let(:fixed_charge) do
     create(
       :fixed_charge,
       plan:,
       add_on:,
-      units: 2,
+      units: 0,
       properties: {amount: "239.9"},
       prorated: true,
       pay_in_advance: true
@@ -34,9 +35,11 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
           external_customer_id: customer.external_id,
           external_id: "sub_#{customer.external_id}",
           plan_code: plan.code,
-          billing_time: "calendar"
+          billing_time: "calendar",
+          plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 2}]}
         }
       )
+      perform_all_enqueued_jobs
     end
 
     # Repeating units that are already billed leaves the pay in advance run with nothing

--- a/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
+++ b/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :premium do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, invoice_grace_period: 3, timezone: "UTC") }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:plan) { create(:plan, organization:, amount_cents: 0, interval: "monthly", pay_in_advance: true) }
+
+  let(:fixed_charge) do
+    create(
+      :fixed_charge,
+      plan:,
+      add_on:,
+      units: 2,
+      properties: {amount: "239.9"},
+      prorated: true,
+      pay_in_advance: true
+    )
+  end
+
+  let(:subscription_date) { DateTime.new(2024, 3, 1) }
+  let(:subscription) { customer.subscriptions.sole }
+  let(:draft) { subscription.invoices.order(:created_at).first }
+
+  before do
+    fixed_charge
+
+    travel_to subscription_date do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: "sub_#{customer.external_id}",
+          plan_code: plan.code,
+          billing_time: "calendar"
+        }
+      )
+    end
+
+    # The units are already billed on the subscription invoice, so this second run
+    # writes a fee of zero units.
+    travel_to subscription_date + 1.second do
+      Invoices::CreatePayInAdvanceFixedChargesService.call(subscription:, timestamp: Time.current.to_i)
+    end
+  end
+
+  it "keeps the fee and the invoice total when the draft is refreshed" do
+    # 2 units x 239.90, a full calendar month so proration is a no-op
+    expect(draft.fees.fixed_charge.sum(:amount_cents)).to eq(47_980)
+
+    travel_to subscription_date + 1.day do
+      refresh_invoice(draft)
+    end
+
+    draft.reload
+    expect(draft.fees.fixed_charge.sum(:amount_cents)).to eq(47_980)
+    expect(draft.total_amount_cents).to eq(47_980)
+  end
+end

--- a/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
+++ b/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
@@ -22,6 +22,7 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
 
   let(:subscription_date) { DateTime.new(2024, 3, 1) }
   let(:subscription) { customer.subscriptions.sole }
+  # The grace period keeps this one as a draft, so it is the invoice the refresh rebuilds.
   let(:draft) { subscription.invoices.order(:created_at).first }
 
   before do
@@ -45,6 +46,8 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
     end
   end
 
+  # A refresh destroys the fees and builds them again. The zero-unit fee on the other
+  # invoice billed nothing, so it is not proof of billing and must not stop the rebuild.
   it "keeps the fee and the invoice total when the draft is refreshed" do
     # 2 units x 239.90, a full calendar month so proration is a no-op
     expect(draft.fees.fixed_charge.sum(:amount_cents)).to eq(47_980)

--- a/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
+++ b/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
@@ -39,10 +39,14 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
       )
     end
 
-    # The units are already billed on the subscription invoice, so this second run
-    # writes a fee of zero units.
+    # Repeating units that are already billed leaves the pay in advance run with nothing
+    # to bill, so it writes a fee of zero units on a second invoice.
     travel_to subscription_date + 1.second do
-      Invoices::CreatePayInAdvanceFixedChargesService.call(subscription:, timestamp: Time.current.to_i)
+      update_subscription(
+        subscription,
+        {plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 2, apply_units_immediately: true}]}}
+      )
+      perform_all_enqueued_jobs
     end
   end
 

--- a/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
+++ b/spec/scenarios/fixed_charges/refresh_draft_keeps_pay_in_advance_fee_spec.rb
@@ -23,8 +23,9 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
 
   let(:subscription_date) { DateTime.new(2024, 3, 1) }
   let(:subscription) { customer.subscriptions.sole }
-  # The grace period keeps this one as a draft, so it is the invoice the refresh rebuilds.
-  let(:draft) { subscription.invoices.order(:created_at).first }
+  let(:draft) { subscription.invoices.draft.sole }
+  # 2 units x 239.90, a full calendar month so proration is a no-op
+  let(:fee_amount_cents) { 47_980 }
 
   before do
     fixed_charge
@@ -39,7 +40,6 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
           plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 2}]}
         }
       )
-      perform_all_enqueued_jobs
     end
 
     # Repeating units that are already billed leaves the pay in advance run with nothing
@@ -49,22 +49,20 @@ describe "Refreshing a draft invoice keeps its pay in advance fixed charge", :pr
         subscription,
         {plan_overrides: {fixed_charges: [{id: fixed_charge.id, units: 2, apply_units_immediately: true}]}}
       )
-      perform_all_enqueued_jobs
     end
   end
 
   # A refresh destroys the fees and builds them again. The zero-unit fee on the other
   # invoice billed nothing, so it is not proof of billing and must not stop the rebuild.
   it "keeps the fee and the invoice total when the draft is refreshed" do
-    # 2 units x 239.90, a full calendar month so proration is a no-op
-    expect(draft.fees.fixed_charge.sum(:amount_cents)).to eq(47_980)
+    expect(draft.fees.fixed_charge.sole.amount_cents).to eq(fee_amount_cents)
 
     travel_to subscription_date + 1.day do
       refresh_invoice(draft)
     end
 
     draft.reload
-    expect(draft.fees.fixed_charge.sum(:amount_cents)).to eq(47_980)
-    expect(draft.total_amount_cents).to eq(47_980)
+    expect(draft.fees.fixed_charge.sum(:amount_cents)).to eq(fee_amount_cents)
+    expect(draft.total_amount_cents).to eq(fee_amount_cents)
   end
 end


### PR DESCRIPTION
Linear: [BIL-507](https://linear.app/getlago/issue/BIL-507/refreshing-a-draft-invoice-deletes-its-pay-in-advance-fixed-charge)

## Context

Refreshing a draft invoice deletes all of its fees and rebuilds them. During the rebuild, `already_billed?` looks for a fee that already exists for this fixed charge, subscription and period. It finds the zero-unit fee that a pay-in-advance run writes when it has no units left to bill, decides the charge was already billed, and skips it. The invoice then closes at zero, the customer is never billed, and the original fee cannot be recovered because the refresh deletes fees permanently.

The check was written when a fee always meant that something had been charged. Since pay-in-advance fixed charges started always writing a zero fee, that is no longer true. This has already cost real revenue for customers who had an invoice grace period, since a grace period is what keeps invoices as drafts long enough to be refreshed.

## Steps to reproduce

The placeholder only appears when a pay-in-advance run has nothing left to bill, so the same units must already be billed when it runs. Everything below is an API call, and the scenario spec in this PR does exactly this.

1. Customer with an `invoice_grace_period`, so the subscription invoice stays a draft.
2. Plan `pay_in_advance`, with a `prorated` `pay_in_advance` fixed charge carrying **2 units on the plan**.
3. Create the subscription, no overrides. The draft invoice carries 2 units.
4. Update the subscription with the **same** units and `apply_units_immediately`:

```
PUT /api/v1/subscriptions/:external_id
{"subscription": {"plan_overrides": {"fixed_charges": [
  {"id": "<fixed_charge_id>", "units": 2, "apply_units_immediately": true}
]}}}
```

5. Refresh the **first** invoice, the draft one.

Observed on main:

```
after create   draft      total=47980  fixed_charge_fees=1
after update   draft      total=47980  fixed_charge_fees=1
               finalized  total=0      fixed_charge_fees=1   <- the placeholder
after refresh  draft      total=0      fixed_charge_fees=0
```

Two things that make this easy to get wrong by hand. The units must already be billed: updating from 0 to 2 bills a real delta and produces an ordinary fee, not the placeholder. And the invoice to refresh is the subscription invoice, not the one the update just created, which is finalised rather than draft.

Production reached the same state with 0 units on the plan and a create-time units override instead. Either route bills the units before the pay-in-advance run.

### Via the dashboard

The same thing with clicks only, confirmed on a local stack.

1. **Plans**, Create plan. Open **Subscription fee** and choose "At the start of each billing period and on event (in advance)", then Save edits.
2. **Add a fixed charge**: pick an add-on, Amount `239.9`, Units `2`, keep "in advance", turn **Prorate amount** on. Add charge, then Create plan.
3. **Customers**, create one, open its **Settings** tab, **Grace period**, Add, `3` days.
4. On the customer, assign the plan. A draft invoice appears with one fixed charge fee of 2 units.
5. Open the subscription, **Subscription plan** tab, the fixed charge, Actions, **Edit**. Leave Units at **2** and turn on **Apply unit changes now**, then Save edits. A second invoice is created, finalised, at zero, holding the zero-unit fee.
6. Open the **draft** invoice, click **Refresh invoice**, then reload the page. On main the total falls to zero and the fee is gone.

Step 6 needs the reload: the invoice page keeps showing the old total after the mutation, so the change is invisible until the page is re-read. That alone can look like the bug not reproducing.

## Changes

The guard now requires a fee that actually billed something, by units or by amount. The placeholder has neither, so it stops counting, while a fee that took money still counts whatever its units are.

This makes the read side agree with the write side: `should_persist_fee?` in the same file already refuses to persist a fee with no units and no amount, using the same predicate inverted. The same predicate exists elsewhere for the same reason: `invoice_subscriptions_helper.rb` filters display lines with `fees.units > ? OR fees.amount_cents > ?`, commented "Fees with zero units and zero amount remain hidden".

## Behaviour, before and after

| Case | Before | After | Pinned by |
| --- | --- | --- | --- |
| Draft refresh, the placeholder is the only fee for the period | charge dropped, invoice closes at zero | charge rebuilt | the new scenario spec, which fails without this change |
| Trial ends, period already billed by a fee carrying an amount and no units | blocks the re-bill | blocks the re-bill | `subscription_service_spec.rb`, "does not create a duplicate fixed charge fee for the same billing period" |
| Units decreased mid-period, placeholder sits beside the original positive fee | blocks the re-bill | blocks the re-bill | `pay_in_advance_units_change_spec.rb` |
| Plan override, real fee on the parent charge, placeholder on the child | blocks the re-bill | does not block | not covered |
| Operator adjusts a fee down to zero units and zero amount | blocks the re-bill | does not block | not covered |

Row two is why the predicate is not units-only: that fixture carries an amount and no units, because the factory never sets units and the column defaults to zero, so a units-only filter lets it through and the charge is billed twice.

## For reviewers

The last two rows are the behaviour changes beyond the bug, and neither is covered by a spec.

`already_billed?` scopes to `fixed_charge.fees`, while its sibling `find_already_paid_units` scopes to `[fixed_charge, fixed_charge.parent]`. When a plan override creates a child fixed charge, the period's real fee can sit on the parent while the child holds only the placeholder. That placeholder used to block a re-bill and no longer does. Making the guard symmetric with the sibling would close it, but that is a behaviour decision for this team rather than something to slip into this fix.

An adjusted fee that an operator sets to zero units and zero amount is a deliberate "do not bill" record. It used to block and now does not. Adjusted fees only exist on drafts and only for pay-in-advance fixed charges, so the reach is small.

There is also a third case this fix does not cover and does not make worse. During a refresh the invoice's own fees are destroyed before the guard runs, so the guard cannot tell "billed on another invoice" from "billed on this one, which I just deleted". When the other invoice holds a non-zero delta fee for the same period, for example after a mid-period units increase, refreshing the draft still drops its fee. That is pre-existing and untested: `pay_in_advance_units_change_spec.rb` never calls `refresh_invoice`.





