### PR TITLE
feat(products): add rate card services

### DIFF
--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -22,7 +22,7 @@ module Clickhouse
     belongs_to :user, optional: true
     belongs_to :api_key, optional: true
 
-    RESOURCE_TYPES_WITH_DISCARDED = %w[BillableMetric Plan Customer BillingEntity Coupon ProductCategory Product ProductFilter].freeze
+    RESOURCE_TYPES_WITH_DISCARDED = %w[BillableMetric Plan Customer BillingEntity Coupon ProductCategory Product ProductFilter RateCard].freeze
 
     RESOURCE_TYPES = {
       billable_metric: "BillableMetric",
@@ -39,7 +39,8 @@ module Clickhouse
       feature: "Entitlement::Feature",
       product_category: "ProductCategory",
       product: "Product",
-      product_filter: "ProductFilter"
+      product_filter: "ProductFilter",
+      rate_card: "RateCard"
     }.freeze
 
     ACTIVITY_TYPES = {
@@ -102,7 +103,10 @@ module Clickhouse
       product_deleted: "product.deleted",
       product_filter_created: "product_filter.created",
       product_filter_updated: "product_filter.updated",
-      product_filter_deleted: "product_filter.deleted"
+      product_filter_deleted: "product_filter.deleted",
+      rate_card_created: "rate_card.created",
+      rate_card_updated: "rate_card.updated",
+      rate_card_deleted: "rate_card.deleted"
     }
 
     before_save :ensure_activity_id

--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -87,8 +87,9 @@ class RateCard < ApplicationRecord
   end
 
   # The card bills someone once it belongs to a plan that has subscriptions or
-  # is attached directly to a subscription. From that point its pricing is
-  # immutable: any price change goes through a new card and a plan migration.
+  # is attached directly to a subscription. From that point the billed
+  # timeline freezes — card fields, active and past rates — and price changes
+  # go through appended rates.
   def attached_to_subscriptions?
     subscription_applied_rate_cards.exists? ||
       Subscription.where(plan_id: plan_applied_rate_cards.select(:plan_id)).exists?

--- a/app/queries/rate_cards_query.rb
+++ b/app/queries/rate_cards_query.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class RateCardsQuery < BaseQuery
+  Result = BaseResult[:rate_cards]
+  Filters = BaseFilters[:product_id, :product_filter_id]
+
+  def call
+    rate_cards = base_scope.result
+    rate_cards = paginate(rate_cards)
+    rate_cards = apply_consistent_ordering(rate_cards)
+
+    rate_cards = with_product(rate_cards) if filters.product_id.present?
+    rate_cards = with_product_filter(rate_cards) if filters.product_filter_id.present?
+
+    result.rate_cards = rate_cards
+    result
+  end
+
+  private
+
+  def base_scope
+    RateCard.where(organization:).ransack(search_params)
+  end
+
+  def search_params
+    return if search_term.blank?
+
+    {
+      m: "or",
+      name_cont: search_term,
+      code_cont: search_term
+    }
+  end
+
+  def with_product(scope)
+    scope.where(product_id: filters.product_id)
+  end
+
+  def with_product_filter(scope)
+    scope.where(product_filter_id: filters.product_filter_id)
+  end
+end

--- a/app/serializers/v1/rate_card_rate_serializer.rb
+++ b/app/serializers/v1/rate_card_rate_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V1
+  class RateCardRateSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        effective_datetime: model.effective_datetime.iso8601,
+        status: model.status,
+        rate_model: model.rate_model,
+        rate_properties: model.rate_properties,
+        min_amount_cents: model.min_amount_cents,
+        billing_interval_count: model.billing_interval_count,
+        billing_interval_unit: model.billing_interval_unit,
+        applied_pricing_unit_conversion_rate: model.applied_pricing_unit_conversion_rate,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+    end
+  end
+end

--- a/app/serializers/v1/rate_card_rate_serializer.rb
+++ b/app/serializers/v1/rate_card_rate_serializer.rb
@@ -5,6 +5,7 @@ module V1
     def serialize
       {
         lago_id: model.id,
+        code: model.code,
         effective_from: model.effective_from.iso8601,
         status: model.status,
         rate_model: model.rate_model,

--- a/app/serializers/v1/rate_card_rate_serializer.rb
+++ b/app/serializers/v1/rate_card_rate_serializer.rb
@@ -5,7 +5,7 @@ module V1
     def serialize
       {
         lago_id: model.id,
-        effective_datetime: model.effective_datetime.iso8601,
+        effective_from: model.effective_from.iso8601,
         status: model.status,
         rate_model: model.rate_model,
         rate_properties: model.rate_properties,

--- a/app/serializers/v1/rate_card_serializer.rb
+++ b/app/serializers/v1/rate_card_serializer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module V1
+  class RateCardSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        product_code: model.product.code,
+        product_filter_code: model.product_filter&.code,
+        name: model.name,
+        code: model.code,
+        description: model.description,
+        currency: model.currency,
+        billing_timing: model.billing_timing,
+        proration: model.proration,
+        display_on_invoice: model.display_on_invoice,
+        regroup_paid_fees: model.regroup_paid_fees,
+        applied_pricing_unit_code: model.applied_pricing_unit_code,
+        wallet_targetable: model.wallet_targetable,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+
+      payload.merge!(rates) if include?(:rates)
+      payload
+    end
+
+    private
+
+    def rates
+      ::CollectionSerializer.new(
+        model.rates,
+        ::V1::RateCardRateSerializer,
+        collection_name: "rates"
+      ).serialize
+    end
+  end
+end

--- a/app/services/rate_card_rates/create_service.rb
+++ b/app/services/rate_card_rates/create_service.rb
@@ -20,10 +20,6 @@ module RateCardRates
     def call
       return result.not_found_failure!(resource: "rate_card") unless rate_card
 
-      if rate_card.attached_to_subscriptions?
-        return result.single_validation_failure!(field: :rate_card, error_code: "attached_to_subscriptions")
-      end
-
       rate = rate_card.rates.create!(
         organization_id: rate_card.organization_id,
         code: params[:code].presence,

--- a/app/services/rate_card_rates/create_service.rb
+++ b/app/services/rate_card_rates/create_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module RateCardRates
+  class CreateService < BaseService
+    Result = BaseResult[:rate_card_rate]
+
+    def initialize(rate_card:, params:, emit_activity_log: true)
+      @rate_card = rate_card
+      @params = params.to_h.with_indifferent_access
+      @emit_activity_log = emit_activity_log
+      super
+    end
+
+    activity_loggable(
+      action: "rate_card.updated",
+      record: -> { rate_card },
+      condition: -> { emit_activity_log }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "rate_card") unless rate_card
+
+      if rate_card.attached_to_subscriptions?
+        return result.single_validation_failure!(field: :rate_card, error_code: "attached_to_subscriptions")
+      end
+
+      rate = rate_card.rates.create!(
+        organization_id: rate_card.organization_id,
+        code: params[:code].presence,
+        effective_datetime: params[:effective_datetime],
+        rate_model: params[:rate_model],
+        rate_properties: params[:rate_properties] || {},
+        min_amount_cents: params[:min_amount_cents] || 0,
+        billing_interval_count: params[:billing_interval_count] || 1,
+        billing_interval_unit: params[:billing_interval_unit],
+        applied_pricing_unit_conversion_rate: params[:applied_pricing_unit_conversion_rate]
+      )
+
+      result.rate_card_rate = rate
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :rate_card, :params, :emit_activity_log
+  end
+end

--- a/app/services/rate_card_rates/create_service.rb
+++ b/app/services/rate_card_rates/create_service.rb
@@ -27,7 +27,7 @@ module RateCardRates
       rate = rate_card.rates.create!(
         organization_id: rate_card.organization_id,
         code: params[:code].presence,
-        effective_datetime: params[:effective_datetime],
+        effective_from: params[:effective_from],
         rate_model: params[:rate_model],
         rate_properties: params[:rate_properties] || {},
         min_amount_cents: params[:min_amount_cents] || 0,

--- a/app/services/rate_card_rates/destroy_service.rb
+++ b/app/services/rate_card_rates/destroy_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RateCardRates
+  class DestroyService < BaseService
+    Result = BaseResult[:rate_card_rate]
+
+    def initialize(rate_card_rate:)
+      @rate_card_rate = rate_card_rate
+      super
+    end
+
+    activity_loggable(
+      action: "rate_card.updated",
+      record: -> { rate_card_rate&.rate_card }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "rate_card_rate") unless rate_card_rate
+
+      if rate_card_rate.rate_card.attached_to_subscriptions?
+        return result.single_validation_failure!(field: :rate_card, error_code: "attached_to_subscriptions")
+      end
+
+      # Active and terminated rates are kept for audit: the timeline only moves
+      # forward by appending new rates.
+      unless rate_card_rate.pending?
+        return result.single_validation_failure!(field: :status, error_code: "only_pending_rates_can_be_deleted")
+      end
+
+      rate_card_rate.discard!
+
+      result.rate_card_rate = rate_card_rate
+      result
+    end
+
+    private
+
+    attr_reader :rate_card_rate
+  end
+end

--- a/app/services/rate_card_rates/destroy_service.rb
+++ b/app/services/rate_card_rates/destroy_service.rb
@@ -21,8 +21,7 @@ module RateCardRates
         return result.single_validation_failure!(field: :rate_card, error_code: "attached_to_subscriptions")
       end
 
-      # Active and terminated rates are kept for audit: the timeline only moves
-      # forward by appending new rates.
+      # Active and terminated rates are kept for audit.
       unless rate_card_rate.pending?
         return result.single_validation_failure!(field: :status, error_code: "only_pending_rates_can_be_deleted")
       end

--- a/app/services/rate_card_rates/destroy_service.rb
+++ b/app/services/rate_card_rates/destroy_service.rb
@@ -17,10 +17,6 @@ module RateCardRates
     def call
       return result.not_found_failure!(resource: "rate_card_rate") unless rate_card_rate
 
-      if rate_card_rate.rate_card.attached_to_subscriptions?
-        return result.single_validation_failure!(field: :rate_card, error_code: "attached_to_subscriptions")
-      end
-
       # Active and terminated rates are kept for audit.
       unless rate_card_rate.pending?
         return result.single_validation_failure!(field: :status, error_code: "only_pending_rates_can_be_deleted")

--- a/app/services/rate_card_rates/update_service.rb
+++ b/app/services/rate_card_rates/update_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module RateCardRates
+  class UpdateService < BaseService
+    Result = BaseResult[:rate_card_rate]
+
+    # Per the editability matrix: a terminated rate is frozen, an active rate only
+    # accepts new pricing values, a pending rate is fully editable.
+    FROZEN_ON_ACTIVE = %i[effective_datetime rate_model min_amount_cents billing_interval_count billing_interval_unit].freeze
+
+    def initialize(rate_card_rate:, params:)
+      @rate_card_rate = rate_card_rate
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    activity_loggable(
+      action: "rate_card.updated",
+      record: -> { rate_card_rate&.rate_card }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "rate_card_rate") unless rate_card_rate
+
+      if rate_card_rate.rate_card.attached_to_subscriptions?
+        return result.single_validation_failure!(field: :rate_card, error_code: "attached_to_subscriptions")
+      end
+
+      if rate_card_rate.terminated?
+        return result.single_validation_failure!(field: :status, error_code: "terminated_rate_not_editable")
+      end
+
+      if rate_card_rate.active?
+        frozen_field = FROZEN_ON_ACTIVE.find { params.key?(it) }
+        if frozen_field
+          return result.single_validation_failure!(field: frozen_field, error_code: "not_editable_on_active_rate")
+        end
+      end
+
+      assign_attributes
+      rate_card_rate.save!
+
+      result.rate_card_rate = rate_card_rate
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :rate_card_rate, :params
+
+    def assign_attributes
+      rate_card_rate.effective_datetime = params[:effective_datetime] if params.key?(:effective_datetime)
+      rate_card_rate.rate_model = params[:rate_model] if params.key?(:rate_model)
+      rate_card_rate.rate_properties = params[:rate_properties] if params.key?(:rate_properties)
+      rate_card_rate.min_amount_cents = params[:min_amount_cents] if params.key?(:min_amount_cents)
+      rate_card_rate.billing_interval_count = params[:billing_interval_count] if params.key?(:billing_interval_count)
+      rate_card_rate.billing_interval_unit = params[:billing_interval_unit] if params.key?(:billing_interval_unit)
+
+      if params.key?(:applied_pricing_unit_conversion_rate)
+        rate_card_rate.applied_pricing_unit_conversion_rate = params[:applied_pricing_unit_conversion_rate]
+      end
+    end
+  end
+end

--- a/app/services/rate_card_rates/update_service.rb
+++ b/app/services/rate_card_rates/update_service.rb
@@ -23,7 +23,9 @@ module RateCardRates
     def call
       return result.not_found_failure!(resource: "rate_card_rate") unless rate_card_rate
 
-      if rate_card_rate.rate_card.attached_to_subscriptions?
+      # On a card billed by subscriptions only pending rates stay editable:
+      # the active rate prices live subscriptions, changes go through appends.
+      if rate_card_rate.rate_card.attached_to_subscriptions? && !rate_card_rate.pending?
         return result.single_validation_failure!(field: :rate_card, error_code: "attached_to_subscriptions")
       end
 

--- a/app/services/rate_card_rates/update_service.rb
+++ b/app/services/rate_card_rates/update_service.rb
@@ -4,8 +4,9 @@ module RateCardRates
   class UpdateService < BaseService
     Result = BaseResult[:rate_card_rate]
 
-    # Per the editability matrix: a terminated rate is frozen, an active rate only
-    # accepts new pricing values, a pending rate is fully editable.
+    # Terminated rates are frozen, active rates only accept new pricing values,
+    # pending rates are fully editable. Frozen fields are rejected on presence:
+    # sending one on an active rate is an error even with an unchanged value.
     FROZEN_ON_ACTIVE = %i[effective_from rate_model min_amount_cents billing_interval_count billing_interval_unit].freeze
 
     def initialize(rate_card_rate:, params:)

--- a/app/services/rate_card_rates/update_service.rb
+++ b/app/services/rate_card_rates/update_service.rb
@@ -6,7 +6,7 @@ module RateCardRates
 
     # Per the editability matrix: a terminated rate is frozen, an active rate only
     # accepts new pricing values, a pending rate is fully editable.
-    FROZEN_ON_ACTIVE = %i[effective_datetime rate_model min_amount_cents billing_interval_count billing_interval_unit].freeze
+    FROZEN_ON_ACTIVE = %i[effective_from rate_model min_amount_cents billing_interval_count billing_interval_unit].freeze
 
     def initialize(rate_card_rate:, params:)
       @rate_card_rate = rate_card_rate
@@ -51,7 +51,7 @@ module RateCardRates
     attr_reader :rate_card_rate, :params
 
     def assign_attributes
-      rate_card_rate.effective_datetime = params[:effective_datetime] if params.key?(:effective_datetime)
+      rate_card_rate.effective_from = params[:effective_from] if params.key?(:effective_from)
       rate_card_rate.rate_model = params[:rate_model] if params.key?(:rate_model)
       rate_card_rate.rate_properties = params[:rate_properties] if params.key?(:rate_properties)
       rate_card_rate.min_amount_cents = params[:min_amount_cents] if params.key?(:min_amount_cents)

--- a/app/services/rate_cards/create_service.rb
+++ b/app/services/rate_cards/create_service.rb
@@ -45,7 +45,6 @@ module RateCards
         description: params[:description],
         currency: params[:currency],
         billing_timing: params[:billing_timing] || "arrears",
-        regroup_paid_fees: params[:regroup_paid_fees],
         applied_pricing_unit_code: params[:applied_pricing_unit_code],
         wallet_targetable: params[:wallet_targetable]
       }
@@ -54,6 +53,7 @@ module RateCards
       # to the column default instead of inserting NULL.
       attributes[:proration] = params[:proration] unless params[:proration].nil?
       attributes[:display_on_invoice] = params[:display_on_invoice] unless params[:display_on_invoice].nil?
+      attributes[:regroup_paid_fees] = params[:regroup_paid_fees] unless params[:regroup_paid_fees].nil?
 
       ActiveRecord::Base.transaction do
         rate_card = product.rate_cards.create!(**attributes)

--- a/app/services/rate_cards/create_service.rb
+++ b/app/services/rate_cards/create_service.rb
@@ -48,9 +48,7 @@ module RateCards
         applied_pricing_unit_code: params[:applied_pricing_unit_code],
         wallet_targetable: params[:wallet_targetable]
       }
-      # proration and display_on_invoice are NOT NULL with a DB default; only set
-      # them when a value is given so a missing key OR an explicit null falls back
-      # to the column default instead of inserting NULL.
+      # NOT NULL columns with DB defaults: only set when a value is given.
       attributes[:proration] = params[:proration] unless params[:proration].nil?
       attributes[:display_on_invoice] = params[:display_on_invoice] unless params[:display_on_invoice].nil?
       attributes[:regroup_paid_fees] = params[:regroup_paid_fees] unless params[:regroup_paid_fees].nil?

--- a/app/services/rate_cards/create_service.rb
+++ b/app/services/rate_cards/create_service.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module RateCards
+  class CreateService < BaseService
+    include ValidatesBooleanParams
+
+    Result = BaseResult[:rate_card]
+
+    def initialize(product:, params:)
+      @product = product
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    activity_loggable(
+      action: "rate_card.created",
+      record: -> { result.rate_card }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "product") unless product
+
+      boolean_failure = boolean_params_failure
+      return boolean_failure if boolean_failure
+
+      product_filter = nil
+      if params[:product_filter_id].present?
+        product_filter = product.filters.find_by(id: params[:product_filter_id])
+        return result.not_found_failure!(resource: "product_filter") unless product_filter
+      end
+
+      if params[:wallet_targetable] && !organization.events_targeting_wallets_enabled?
+        return result.single_validation_failure!(field: :wallet_targetable, error_code: "feature_unavailable")
+      end
+
+      if params[:applied_pricing_unit_code].present? && !organization.pricing_units.exists?(code: params[:applied_pricing_unit_code])
+        return result.single_validation_failure!(field: :applied_pricing_unit_code, error_code: "value_is_invalid")
+      end
+
+      attributes = {
+        organization:,
+        product_filter:,
+        name: params[:name],
+        code: params[:code]&.strip,
+        description: params[:description],
+        currency: params[:currency],
+        billing_timing: params[:billing_timing] || "arrears",
+        regroup_paid_fees: params[:regroup_paid_fees],
+        applied_pricing_unit_code: params[:applied_pricing_unit_code],
+        wallet_targetable: params[:wallet_targetable]
+      }
+      # proration and display_on_invoice are NOT NULL with a DB default; only set
+      # them when a value is given so a missing key OR an explicit null falls back
+      # to the column default instead of inserting NULL.
+      attributes[:proration] = params[:proration] unless params[:proration].nil?
+      attributes[:display_on_invoice] = params[:display_on_invoice] unless params[:display_on_invoice].nil?
+
+      ActiveRecord::Base.transaction do
+        rate_card = product.rate_cards.create!(**attributes)
+
+        create_rates(rate_card)
+
+        result.rate_card = rate_card
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      # Only the nested rate creations are called with call! here.
+      if e.result.error.is_a?(BaseService::ValidationFailure)
+        errors = e.result.error.messages.transform_keys { |key| :"rates.#{key}" }
+        result.validation_failure!(errors:)
+      else
+        e.result
+      end
+    end
+
+    private
+
+    attr_reader :product, :params
+
+    def organization
+      product.organization
+    end
+
+    def create_rates(rate_card)
+      (params[:rates] || []).each do |rate_params|
+        RateCardRates::CreateService.call!(rate_card:, params: rate_params, emit_activity_log: false)
+      end
+    end
+  end
+end

--- a/app/services/rate_cards/destroy_service.rb
+++ b/app/services/rate_cards/destroy_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RateCards
+  class DestroyService < BaseService
+    Result = BaseResult[:rate_card]
+
+    def initialize(rate_card:)
+      @rate_card = rate_card
+      super
+    end
+
+    activity_loggable(
+      action: "rate_card.deleted",
+      record: -> { result.rate_card }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "rate_card") unless rate_card
+
+      if rate_card.attached_to_plan_or_subscription?
+        return result.single_validation_failure!(field: :rate_card, error_code: "attached_to_plan_or_subscription")
+      end
+
+      ActiveRecord::Base.transaction do
+        rate_card.rates.discard_all!
+        rate_card.discard!
+      end
+
+      result.rate_card = rate_card
+      result
+    end
+
+    private
+
+    attr_reader :rate_card
+  end
+end

--- a/app/services/rate_cards/update_service.rb
+++ b/app/services/rate_cards/update_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module RateCards
+  class UpdateService < BaseService
+    include ValidatesBooleanParams
+
+    Result = BaseResult[:rate_card]
+
+    # The billing-semantic fields are locked once any rate exists on the card —
+    # changing them would silently alter what the existing rates mean (currency
+    # of the amounts, advance/arrears validity of the rate models, proration of
+    # partial periods, pricing-unit conversions, invoicing and wallet
+    # eligibility of the fees): create a new card instead. Only name and
+    # description stay editable.
+    LOCKED_WITH_RATES = %i[currency applied_pricing_unit_code billing_timing proration regroup_paid_fees display_on_invoice wallet_targetable].freeze
+
+    def initialize(rate_card:, params:)
+      @rate_card = rate_card
+      @params = params.to_h.with_indifferent_access
+      super
+    end
+
+    activity_loggable(
+      action: "rate_card.updated",
+      record: -> { rate_card }
+    )
+
+    def call
+      return result.not_found_failure!(resource: "rate_card") unless rate_card
+
+      boolean_failure = boolean_params_failure
+      return boolean_failure if boolean_failure
+
+      if rate_card.rates.exists?
+        locked_field = LOCKED_WITH_RATES.find { params.key?(it) && params[it] != rate_card[it] }
+        if locked_field
+          return result.single_validation_failure!(field: locked_field, error_code: "not_editable_with_rates")
+        end
+      end
+
+      assign_attributes
+      rate_card.save!
+
+      result.rate_card = rate_card
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :rate_card, :params
+
+    def assign_attributes
+      rate_card.name = params[:name] if params.key?(:name)
+      rate_card.description = params[:description] if params.key?(:description)
+      rate_card.currency = params[:currency] if params.key?(:currency)
+      rate_card.billing_timing = params[:billing_timing] if params.key?(:billing_timing)
+      rate_card.proration = params[:proration] if params.key?(:proration)
+      rate_card.display_on_invoice = params[:display_on_invoice] if params.key?(:display_on_invoice)
+      rate_card.regroup_paid_fees = params[:regroup_paid_fees] if params.key?(:regroup_paid_fees)
+      rate_card.applied_pricing_unit_code = params[:applied_pricing_unit_code] if params.key?(:applied_pricing_unit_code)
+      rate_card.wallet_targetable = params[:wallet_targetable] if params.key?(:wallet_targetable)
+    end
+  end
+end

--- a/app/services/rate_cards/update_service.rb
+++ b/app/services/rate_cards/update_service.rb
@@ -6,12 +6,8 @@ module RateCards
 
     Result = BaseResult[:rate_card]
 
-    # The billing-semantic fields are locked once any rate exists on the card —
-    # changing them would silently alter what the existing rates mean (currency
-    # of the amounts, advance/arrears validity of the rate models, proration of
-    # partial periods, pricing-unit conversions, invoicing and wallet
-    # eligibility of the fees): create a new card instead. Only name and
-    # description stay editable.
+    # Billing-semantic fields freeze once a rate exists — changing them would
+    # alter what the existing rates mean; create a new card instead.
     LOCKED_WITH_RATES = %i[currency applied_pricing_unit_code billing_timing proration regroup_paid_fees display_on_invoice wallet_targetable].freeze
 
     def initialize(rate_card:, params:)
@@ -28,9 +24,7 @@ module RateCards
     def call
       return result.not_found_failure!(resource: "rate_card") unless rate_card
 
-      # An explicit null resets regroup_paid_fees to none — the column is NOT
-      # NULL, absence of regrouping is a real value. Normalised here so the
-      # locked-field comparison below doesn't read null as a phantom change.
+      # An explicit null means none — the column is NOT NULL.
       if params.key?(:regroup_paid_fees) && params[:regroup_paid_fees].nil?
         params[:regroup_paid_fees] = "none"
       end

--- a/app/services/rate_cards/update_service.rb
+++ b/app/services/rate_cards/update_service.rb
@@ -32,6 +32,14 @@ module RateCards
       boolean_failure = boolean_params_failure
       return boolean_failure if boolean_failure
 
+      if params[:wallet_targetable] && !rate_card.organization.events_targeting_wallets_enabled?
+        return result.single_validation_failure!(field: :wallet_targetable, error_code: "feature_unavailable")
+      end
+
+      if params[:applied_pricing_unit_code].present? && !rate_card.organization.pricing_units.exists?(code: params[:applied_pricing_unit_code])
+        return result.single_validation_failure!(field: :applied_pricing_unit_code, error_code: "value_is_invalid")
+      end
+
       if rate_card.rates.exists?
         locked_field = LOCKED_WITH_RATES.find { params.key?(it) && params[it] != rate_card[it] }
         if locked_field

--- a/app/services/rate_cards/update_service.rb
+++ b/app/services/rate_cards/update_service.rb
@@ -28,6 +28,13 @@ module RateCards
     def call
       return result.not_found_failure!(resource: "rate_card") unless rate_card
 
+      # An explicit null resets regroup_paid_fees to none — the column is NOT
+      # NULL, absence of regrouping is a real value. Normalised here so the
+      # locked-field comparison below doesn't read null as a phantom change.
+      if params.key?(:regroup_paid_fees) && params[:regroup_paid_fees].nil?
+        params[:regroup_paid_fees] = "none"
+      end
+
       boolean_failure = boolean_params_failure
       return boolean_failure if boolean_failure
 

--- a/app/services/rate_cards/validates_boolean_params.rb
+++ b/app/services/rate_cards/validates_boolean_params.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RateCards
+  # Rails casts any non-falsey value to true on a boolean column, so a garbage
+  # string like "hello" would silently become `true`. Reject non-boolean input
+  # with a 422 instead. nil is allowed (missing key or explicit null falls back
+  # to the column default). GraphQL is already protected by its Boolean arg type;
+  # this guards the permissive JSON REST layer.
+  module ValidatesBooleanParams
+    BOOLEAN_FIELDS = %i[proration display_on_invoice wallet_targetable].freeze
+
+    private
+
+    def boolean_params_failure
+      invalid = BOOLEAN_FIELDS.select do |field|
+        params.key?(field) && !params[field].nil? && ![true, false].include?(params[field])
+      end
+      return if invalid.empty?
+
+      result.validation_failure!(errors: invalid.index_with { ["value_is_invalid"] })
+    end
+  end
+end

--- a/app/services/rate_cards/validates_boolean_params.rb
+++ b/app/services/rate_cards/validates_boolean_params.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 module RateCards
-  # Rails casts any non-falsey value to true on a boolean column, so a garbage
-  # string like "hello" would silently become `true`. Reject non-boolean input
-  # with a 422 instead. nil is allowed (missing key or explicit null falls back
-  # to the column default). GraphQL is already protected by its Boolean arg type;
-  # this guards the permissive JSON REST layer.
+  # Rails casts any non-falsey value to true on boolean columns; reject
+  # non-boolean input from the permissive REST layer instead. nil is allowed.
   module ValidatesBooleanParams
     BOOLEAN_FIELDS = %i[proration display_on_invoice wallet_targetable].freeze
 

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -3,13 +3,14 @@
 module Utils
   class ActivityLog
     IGNORED_FIELDS = %i[updated_at].freeze
-    IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES = %w[BillableMetric Coupon Plan BillingEntity Entitlement::Feature ProductCategory Product ProductFilter].freeze
+    IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES = %w[BillableMetric Coupon Plan BillingEntity Entitlement::Feature ProductCategory Product ProductFilter RateCard].freeze
     MAX_SERIALIZED_FEES = 25
     MAX_SERIALIZED_CHARGES = 50
     MAX_SERIALIZED_CHARGE_FILTERS = 100
 
     SERIALIZED_INCLUDED_OBJECTS = {
       billing_entity: %i[taxes],
+      rate_card: %i[rates],
       credit_note: %i[items applied_taxes error_details],
       customer: %i[taxes integration_customers applicable_invoice_custom_sections],
       invoice: %i[customer integration_customers billing_periods subscriptions fees credits metadata applied_taxes error_details applied_invoice_custom_sections],

--- a/schema.graphql
+++ b/schema.graphql
@@ -338,6 +338,21 @@ enum ActivityTypeEnum {
   product_updated
 
   """
+  rate_card.created
+  """
+  rate_card_created
+
+  """
+  rate_card.deleted
+  """
+  rate_card_deleted
+
+  """
+  rate_card.updated
+  """
+  rate_card_updated
+
+  """
   subscription.canceled
   """
   subscription_canceled
@@ -12274,6 +12289,11 @@ enum ResourceTypeEnum {
   ProductFilter
   """
   product_filter
+
+  """
+  RateCard
+  """
+  rate_card
 
   """
   Subscription

--- a/schema.json
+++ b/schema.json
@@ -872,6 +872,24 @@
               "description": "product_filter.deleted",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "rate_card_created",
+              "description": "rate_card.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rate_card_updated",
+              "description": "rate_card.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rate_card_deleted",
+              "description": "rate_card.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -66628,6 +66646,12 @@
             {
               "name": "product_filter",
               "description": "ProductFilter",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rate_card",
+              "description": "RateCard",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
@@ -65,6 +65,9 @@ RSpec.describe Types::ActivityLogs::ActivityTypeEnum do
         product_filter_created
         product_filter_updated
         product_filter_deleted
+        rate_card_created
+        rate_card_updated
+        rate_card_deleted
         email_sent
       ]
     )

--- a/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Types::ActivityLogs::ResourceTypeEnum do
         product_category
         product
         product_filter
+        rate_card
       ]
     )
   end

--- a/spec/queries/rate_cards_query_spec.rb
+++ b/spec/queries/rate_cards_query_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCardsQuery do
+  subject(:result) { described_class.call(organization:, search_term:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:search_term) { nil }
+  let(:pagination) { nil }
+  let(:filters) { {} }
+
+  let(:product) { create(:product, organization:) }
+  let!(:card_one) { create(:rate_card, organization:, product:, name: "Growth USD", code: "growth_usd") }
+  let!(:card_two) { create(:rate_card, organization:, name: "Standard EUR", code: "standard_eur") }
+
+  it "returns all rate cards of the organization" do
+    expect(result.rate_cards).to match_array([card_one, card_two])
+  end
+
+  it "does not return rate cards from other organizations" do
+    create(:rate_card)
+    expect(result.rate_cards).to match_array([card_one, card_two])
+  end
+
+  context "with a product filter" do
+    let(:filters) { {product_id: product.id} }
+
+    it "returns only the cards of that product" do
+      expect(result.rate_cards).to eq([card_one])
+    end
+  end
+
+  context "with a search term" do
+    let(:search_term) { "growth" }
+
+    it "returns matching cards" do
+      expect(result.rate_cards).to eq([card_one])
+    end
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 1, limit: 1} }
+
+    it "paginates the results" do
+      expect(result.rate_cards.count).to eq(1)
+      expect(result.rate_cards.total_count).to eq(2)
+    end
+  end
+end

--- a/spec/serializers/v1/rate_card_rate_serializer_spec.rb
+++ b/spec/serializers/v1/rate_card_rate_serializer_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe V1::RateCardRateSerializer do
+  subject(:serializer) { described_class.new(rate, root_name: "rate") }
+
+  let(:rate) { create(:rate_card_rate) }
+
+  it "serializes the rate" do
+    payload = serializer.serialize
+
+    expect(payload[:lago_id]).to eq(rate.id)
+    expect(payload[:code]).to eq(rate.code)
+    expect(payload[:effective_from]).to eq(rate.effective_from.iso8601)
+    expect(payload[:status]).to eq("active")
+    expect(payload[:rate_model]).to eq(rate.rate_model)
+  end
+end

--- a/spec/services/rate_card_rates/create_service_spec.rb
+++ b/spec/services/rate_card_rates/create_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RateCardRates::CreateService do
   let(:params) do
     {
       code: "standard_price",
-      effective_datetime: Time.current.iso8601,
+      effective_from: Time.current.beginning_of_day.iso8601,
       rate_model: "standard",
       rate_properties: {"amount" => "10"},
       billing_interval_count: 1,
@@ -42,8 +42,8 @@ RSpec.describe RateCardRates::CreateService do
     expect(Utils::ActivityLog).to have_produced("rate_card.updated").after_commit.with(rate_card)
   end
 
-  context "when effective_datetime is in the future" do
-    before { params[:effective_datetime] = 1.month.from_now.iso8601 }
+  context "when effective_from is in the future" do
+    before { params[:effective_from] = 1.month.from_now.beginning_of_day.iso8601 }
 
     it "creates a pending rate" do
       expect(result.rate_card_rate.status).to eq("pending")
@@ -51,7 +51,7 @@ RSpec.describe RateCardRates::CreateService do
   end
 
   context "when a rate is already active" do
-    let!(:previous_rate) { create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.ago) }
+    let!(:previous_rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day) }
 
     it "terminates the previous rate and activates the new one" do
       expect(result.rate_card_rate.status).to eq("active")
@@ -59,23 +59,23 @@ RSpec.describe RateCardRates::CreateService do
     end
   end
 
-  context "when the effective_datetime is at or before the active rate" do
+  context "when the effective_from is at or before the active rate" do
     before do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.day.ago)
-      params[:effective_datetime] = 2.days.ago.iso8601
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.day.ago.beginning_of_day)
+      params[:effective_from] = 2.days.ago.beginning_of_day.iso8601
     end
 
     it "returns a validation failure" do
       expect(result).not_to be_success
-      expect(result.error.messages[:effective_datetime]).to eq(["must_be_after_active_rate"])
+      expect(result.error.messages[:effective_from]).to eq(["must_be_after_active_rate"])
     end
   end
 
-  context "when the effective_datetime falls between the active rate and a pending rate" do
+  context "when the effective_from falls between the active rate and a pending rate" do
     before do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.day.ago)
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 30.days.from_now)
-      params[:effective_datetime] = 10.days.from_now.iso8601
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.day.ago.beginning_of_day)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 30.days.from_now.beginning_of_day)
+      params[:effective_from] = 10.days.from_now.beginning_of_day.iso8601
     end
 
     it "creates the rate in the pending sequence" do

--- a/spec/services/rate_card_rates/create_service_spec.rb
+++ b/spec/services/rate_card_rates/create_service_spec.rb
@@ -50,6 +50,49 @@ RSpec.describe RateCardRates::CreateService do
     end
   end
 
+  context "with an arrears card" do
+    it "canonicalizes a datetime to its day's midnight" do
+      params[:effective_from] = 1.month.from_now.change(hour: 17).iso8601
+
+      expect(result).to be_success
+      expect(result.rate_card_rate.effective_from).to eq(1.month.from_now.beginning_of_day)
+    end
+
+    it "accepts a bare date" do
+      params[:effective_from] = 1.month.from_now.to_date.iso8601
+
+      expect(result).to be_success
+      expect(result.rate_card_rate.effective_from).to eq(1.month.from_now.beginning_of_day)
+    end
+
+    it "refuses a second rate on the same day whatever its time" do
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
+      params[:effective_from] = 1.month.from_now.change(hour: 17).iso8601
+
+      expect(result).not_to be_success
+      expect(result.error.messages[:effective_from]).to eq(["value_already_exist"])
+    end
+  end
+
+  context "with an advance card" do
+    let(:rate_card) { create(:rate_card, organization:, billing_timing: "advance") }
+
+    it "keeps the full instant" do
+      effective_at = 1.month.from_now.change(hour: 17)
+      params[:effective_from] = effective_at.iso8601
+
+      expect(result).to be_success
+      expect(result.rate_card_rate.effective_from).to eq(effective_at)
+    end
+
+    it "converts a bare date to midnight" do
+      params[:effective_from] = 1.month.from_now.to_date.iso8601
+
+      expect(result).to be_success
+      expect(result.rate_card_rate.effective_from).to eq(1.month.from_now.beginning_of_day)
+    end
+  end
+
   context "when a rate is already active" do
     let!(:previous_rate) { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day) }
 

--- a/spec/services/rate_card_rates/create_service_spec.rb
+++ b/spec/services/rate_card_rates/create_service_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCardRates::CreateService do
+  subject(:result) { described_class.call(rate_card:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  let(:params) do
+    {
+      code: "standard_price",
+      effective_datetime: Time.current.iso8601,
+      rate_model: "standard",
+      rate_properties: {"amount" => "10"},
+      billing_interval_count: 1,
+      billing_interval_unit: "month"
+    }
+  end
+
+  it "creates an active rate when effective now" do
+    expect { result }.to change(RateCardRate, :count).by(1)
+
+    rate = result.rate_card_rate
+    expect(rate.rate_model).to eq("standard")
+    expect(rate.status).to eq("active")
+    expect(rate.code).to eq("standard_price")
+  end
+
+  context "when the code is missing" do
+    before { params.delete(:code) }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:code]).to be_present
+    end
+  end
+
+  it "produces a rate_card.updated activity log" do
+    result
+    expect(Utils::ActivityLog).to have_produced("rate_card.updated").after_commit.with(rate_card)
+  end
+
+  context "when effective_datetime is in the future" do
+    before { params[:effective_datetime] = 1.month.from_now.iso8601 }
+
+    it "creates a pending rate" do
+      expect(result.rate_card_rate.status).to eq("pending")
+    end
+  end
+
+  context "when a rate is already active" do
+    let!(:previous_rate) { create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.ago) }
+
+    it "terminates the previous rate and activates the new one" do
+      expect(result.rate_card_rate.status).to eq("active")
+      expect(previous_rate.reload.status).to eq("terminated")
+    end
+  end
+
+  context "when the effective_datetime is at or before the active rate" do
+    before do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.day.ago)
+      params[:effective_datetime] = 2.days.ago.iso8601
+    end
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:effective_datetime]).to eq(["must_be_after_active_rate"])
+    end
+  end
+
+  context "when the effective_datetime falls between the active rate and a pending rate" do
+    before do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.day.ago)
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 30.days.from_now)
+      params[:effective_datetime] = 10.days.from_now.iso8601
+    end
+
+    it "creates the rate in the pending sequence" do
+      expect(result).to be_success
+      expect(result.rate_card_rate.status).to eq("pending")
+    end
+  end
+
+  context "when rate_properties do not match the rate model" do
+    before { params[:rate_properties] = {} }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_properties]).to be_present
+    end
+  end
+
+  context "when the card has a pricing unit and no conversion rate is given" do
+    let(:rate_card) { create(:rate_card, organization:, applied_pricing_unit_code: "credits") }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:applied_pricing_unit_conversion_rate]).to be_present
+    end
+  end
+
+  context "when rate_card is nil" do
+    let(:rate_card) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("rate_card")
+    end
+  end
+
+  context "when the card is attached to a subscription" do
+    before { create(:subscription_rate_card, organization:, rate_card:) }
+
+    it "forbids appending a rate" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+    end
+  end
+
+  context "when the card is on a plan that has subscriptions" do
+    before do
+      plan = create(:plan, organization:)
+      create(:plan_rate_card, organization:, plan:, rate_card:)
+      create(:subscription, plan:, organization:)
+    end
+
+    it "forbids appending a rate" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+    end
+  end
+end

--- a/spec/services/rate_card_rates/create_service_spec.rb
+++ b/spec/services/rate_card_rates/create_service_spec.rb
@@ -157,9 +157,20 @@ RSpec.describe RateCardRates::CreateService do
   context "when the card is attached to a subscription" do
     before { create(:subscription_rate_card, organization:, rate_card:) }
 
-    it "forbids appending a rate" do
-      expect(result).not_to be_success
-      expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+    it "appends the rate" do
+      expect(result).to be_success
+      expect(result.rate_card_rate).to be_persisted
+    end
+
+    context "when the rate is not after the active rate" do
+      before { create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day) }
+
+      it "still enforces the timeline placement" do
+        params[:effective_from] = 2.months.ago.beginning_of_day.iso8601
+
+        expect(result).not_to be_success
+        expect(result.error.messages[:effective_from]).to eq(["must_be_after_active_rate"])
+      end
     end
   end
 
@@ -170,9 +181,9 @@ RSpec.describe RateCardRates::CreateService do
       create(:subscription, plan:, organization:)
     end
 
-    it "forbids appending a rate" do
-      expect(result).not_to be_success
-      expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+    it "appends the rate" do
+      expect(result).to be_success
+      expect(result.rate_card_rate).to be_persisted
     end
   end
 end

--- a/spec/services/rate_card_rates/destroy_service_spec.rb
+++ b/spec/services/rate_card_rates/destroy_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCardRates::DestroyService do
+  subject(:result) { described_class.call(rate_card_rate:) }
+
+  let(:organization) { create(:organization) }
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  context "with a pending rate" do
+    let(:rate_card_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.from_now)
+    end
+
+    it "soft deletes the rate" do
+      expect(result).to be_success
+      expect(rate_card_rate.reload).to be_discarded
+    end
+
+    it "produces a rate_card.updated activity log" do
+      result
+      expect(Utils::ActivityLog).to have_produced("rate_card.updated").after_commit.with(rate_card)
+    end
+  end
+
+  context "with an active rate" do
+    let(:rate_card_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.ago)
+    end
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:status]).to eq(["only_pending_rates_can_be_deleted"])
+    end
+  end
+
+  context "when rate_card_rate is nil" do
+    let(:rate_card_rate) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("rate_card_rate")
+    end
+  end
+
+  context "when the card is attached to a subscription" do
+    let(:rate_card_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.from_now)
+    end
+
+    before { create(:subscription_rate_card, organization:, rate_card:) }
+
+    it "forbids deleting the rate" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+    end
+  end
+end

--- a/spec/services/rate_card_rates/destroy_service_spec.rb
+++ b/spec/services/rate_card_rates/destroy_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RateCardRates::DestroyService do
 
   context "with a pending rate" do
     let(:rate_card_rate) do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.from_now)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
     end
 
     it "soft deletes the rate" do
@@ -26,7 +26,7 @@ RSpec.describe RateCardRates::DestroyService do
 
   context "with an active rate" do
     let(:rate_card_rate) do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.ago)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day)
     end
 
     it "returns a validation failure" do
@@ -46,7 +46,7 @@ RSpec.describe RateCardRates::DestroyService do
 
   context "when the card is attached to a subscription" do
     let(:rate_card_rate) do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.from_now)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
     end
 
     before { create(:subscription_rate_card, organization:, rate_card:) }

--- a/spec/services/rate_card_rates/destroy_service_spec.rb
+++ b/spec/services/rate_card_rates/destroy_service_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe RateCardRates::DestroyService do
 
     before { create(:subscription_rate_card, organization:, rate_card:) }
 
-    it "forbids deleting the rate" do
-      expect(result).not_to be_success
-      expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+    it "deletes the pending rate" do
+      expect(result).to be_success
+      expect(rate_card_rate.reload).to be_discarded
     end
   end
 end

--- a/spec/services/rate_card_rates/update_service_spec.rb
+++ b/spec/services/rate_card_rates/update_service_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCardRates::UpdateService do
+  subject(:result) { described_class.call(rate_card_rate:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  context "with a pending rate" do
+    let(:rate_card_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.from_now)
+    end
+
+    let(:params) { {rate_model: "standard", rate_properties: {"amount" => "25"}, billing_interval_count: 3} }
+
+    it "updates all fields" do
+      expect(result).to be_success
+      expect(result.rate_card_rate.rate_properties).to eq("amount" => "25")
+      expect(result.rate_card_rate.billing_interval_count).to eq(3)
+    end
+
+    it "produces a rate_card.updated activity log" do
+      result
+      expect(Utils::ActivityLog).to have_produced("rate_card.updated").after_commit.with(rate_card)
+    end
+
+    context "when the effective_datetime is moved to the past" do
+      let(:params) { {effective_datetime: Time.current.iso8601} }
+
+      it "activates the rate" do
+        expect(result).to be_success
+        expect(result.rate_card_rate.status).to eq("active")
+      end
+    end
+  end
+
+  context "with an active rate" do
+    let(:rate_card_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.ago)
+    end
+
+    context "when updating rate_properties" do
+      let(:params) { {rate_properties: {"amount" => "42"}} }
+
+      it "updates the properties" do
+        expect(result).to be_success
+        expect(result.rate_card_rate.rate_properties).to eq("amount" => "42")
+      end
+    end
+
+    context "when updating a frozen field" do
+      let(:params) { {billing_interval_count: 6} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_interval_count]).to eq(["not_editable_on_active_rate"])
+      end
+    end
+  end
+
+  context "with a terminated rate" do
+    let(:rate_card_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 2.months.ago)
+    end
+
+    let(:params) { {rate_properties: {"amount" => "42"}} }
+
+    before do
+      rate_card_rate
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.ago)
+    end
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:status]).to eq(["terminated_rate_not_editable"])
+    end
+  end
+
+  context "when rate_card_rate is nil" do
+    let(:rate_card_rate) { nil }
+    let(:params) { {} }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("rate_card_rate")
+    end
+  end
+
+  context "when the card is attached to a subscription" do
+    let(:rate_card_rate) do
+      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.from_now)
+    end
+    let(:params) { {rate_properties: {"amount" => "25"}} }
+
+    before { create(:subscription_rate_card, organization:, rate_card:) }
+
+    it "forbids updating the rate" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+    end
+  end
+end

--- a/spec/services/rate_card_rates/update_service_spec.rb
+++ b/spec/services/rate_card_rates/update_service_spec.rb
@@ -98,16 +98,30 @@ RSpec.describe RateCardRates::UpdateService do
   end
 
   context "when the card is attached to a subscription" do
-    let(:rate_card_rate) do
-      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
-    end
     let(:params) { {rate_properties: {"amount" => "25"}} }
 
     before { create(:subscription_rate_card, organization:, rate_card:) }
 
-    it "forbids updating the rate" do
-      expect(result).not_to be_success
-      expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+    context "with a pending rate" do
+      let(:rate_card_rate) do
+        create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
+      end
+
+      it "updates the rate" do
+        expect(result).to be_success
+        expect(result.rate_card_rate.rate_properties).to eq("amount" => "25")
+      end
+    end
+
+    context "with an active rate" do
+      let(:rate_card_rate) do
+        create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day)
+      end
+
+      it "forbids updating the rate" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:rate_card]).to include("attached_to_subscriptions")
+      end
     end
   end
 end

--- a/spec/services/rate_card_rates/update_service_spec.rb
+++ b/spec/services/rate_card_rates/update_service_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe RateCardRates::UpdateService do
         expect(result.rate_card_rate.status).to eq("active")
       end
     end
+
+    context "when the effective_from carries a time component on an arrears card" do
+      let(:params) { {effective_from: 2.months.from_now.change(hour: 17).iso8601} }
+
+      it "canonicalizes the value to its day's midnight" do
+        expect(result).to be_success
+        expect(result.rate_card_rate.effective_from).to eq(2.months.from_now.beginning_of_day)
+      end
+    end
   end
 
   context "with an active rate" do

--- a/spec/services/rate_card_rates/update_service_spec.rb
+++ b/spec/services/rate_card_rates/update_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RateCardRates::UpdateService do
 
   context "with a pending rate" do
     let(:rate_card_rate) do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.from_now)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
     end
 
     let(:params) { {rate_model: "standard", rate_properties: {"amount" => "25"}, billing_interval_count: 3} }
@@ -26,8 +26,8 @@ RSpec.describe RateCardRates::UpdateService do
       expect(Utils::ActivityLog).to have_produced("rate_card.updated").after_commit.with(rate_card)
     end
 
-    context "when the effective_datetime is moved to the past" do
-      let(:params) { {effective_datetime: Time.current.iso8601} }
+    context "when the effective_from is moved to the past" do
+      let(:params) { {effective_from: Time.current.beginning_of_day.iso8601} }
 
       it "activates the rate" do
         expect(result).to be_success
@@ -38,7 +38,7 @@ RSpec.describe RateCardRates::UpdateService do
 
   context "with an active rate" do
     let(:rate_card_rate) do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.ago)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day)
     end
 
     context "when updating rate_properties" do
@@ -62,14 +62,14 @@ RSpec.describe RateCardRates::UpdateService do
 
   context "with a terminated rate" do
     let(:rate_card_rate) do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 2.months.ago)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 2.months.ago.beginning_of_day)
     end
 
     let(:params) { {rate_properties: {"amount" => "42"}} }
 
     before do
       rate_card_rate
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.ago)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day)
     end
 
     it "returns a validation failure" do
@@ -90,7 +90,7 @@ RSpec.describe RateCardRates::UpdateService do
 
   context "when the card is attached to a subscription" do
     let(:rate_card_rate) do
-      create(:rate_card_rate, organization:, rate_card:, effective_datetime: 1.month.from_now)
+      create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
     end
     let(:params) { {rate_properties: {"amount" => "25"}} }
 

--- a/spec/services/rate_cards/create_service_spec.rb
+++ b/spec/services/rate_cards/create_service_spec.rb
@@ -84,14 +84,14 @@ RSpec.describe RateCards::CreateService do
       params[:rates] = [
         {
           code: "launch_price",
-          effective_datetime: 1.minute.ago.iso8601,
+          effective_from: 1.minute.ago.beginning_of_day.iso8601,
           rate_model: "standard",
           rate_properties: {"amount" => "10"},
           billing_interval_unit: "month"
         },
         {
           code: "standard_price",
-          effective_datetime: 1.month.from_now.iso8601,
+          effective_from: 1.month.from_now.beginning_of_day.iso8601,
           rate_model: "standard",
           rate_properties: {"amount" => "12"},
           billing_interval_unit: "month"
@@ -102,7 +102,7 @@ RSpec.describe RateCards::CreateService do
     it "creates the card with its rates in one call" do
       expect { result }.to change(RateCardRate, :count).by(2)
 
-      rates = result.rate_card.rates.order(:effective_datetime)
+      rates = result.rate_card.rates.order(:effective_from)
       expect(rates.first.status).to eq("active")
       expect(rates.last.status).to eq("pending")
     end
@@ -113,7 +113,7 @@ RSpec.describe RateCards::CreateService do
     end
 
     context "when a nested rate is invalid" do
-      before { params[:rates] = [{code: "bad", rate_model: "standard", rate_properties: {}, billing_interval_unit: "month", effective_datetime: Time.current.iso8601}] }
+      before { params[:rates] = [{code: "bad", rate_model: "standard", rate_properties: {}, billing_interval_unit: "month", effective_from: Time.current.beginning_of_day.iso8601}] }
 
       it "returns a validation failure with prefixed keys and creates nothing" do
         expect { result }.not_to change(RateCard, :count)

--- a/spec/services/rate_cards/create_service_spec.rb
+++ b/spec/services/rate_cards/create_service_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe RateCards::CreateService do
     expect(rate_card.currency).to eq("USD")
     expect(rate_card.billing_timing).to eq("arrears")
     expect(rate_card.display_on_invoice).to be(true)
+    expect(rate_card.regroup_paid_fees).to eq("none")
+  end
+
+  context "when regroup_paid_fees is explicitly null" do
+    before { params[:regroup_paid_fees] = nil }
+
+    it "falls back to none instead of inserting NULL" do
+      expect(result.rate_card.regroup_paid_fees).to eq("none")
+    end
   end
 
   context "when proration is omitted" do

--- a/spec/services/rate_cards/create_service_spec.rb
+++ b/spec/services/rate_cards/create_service_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe RateCards::CreateService do
   subject(:result) { described_class.call(product:, params:) }
 
   let(:organization) { create(:organization) }
-  let(:product) { create(:product, organization:) }
+  # The shared params set proration: true, which requires a recurring metric.
+  let(:metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount") }
+  let(:product) { create(:product, organization:, billable_metric: metric) }
 
   let(:params) do
     {

--- a/spec/services/rate_cards/create_service_spec.rb
+++ b/spec/services/rate_cards/create_service_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCards::CreateService do
+  subject(:result) { described_class.call(product:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:product) { create(:product, organization:) }
+
+  let(:params) do
+    {
+      name: "Growth USD",
+      code: "growth_usd",
+      description: "Growth tier pricing in USD",
+      currency: "USD",
+      billing_timing: "arrears",
+      proration: true
+    }
+  end
+
+  it "creates a rate card" do
+    expect { result }.to change(RateCard, :count).by(1)
+
+    rate_card = result.rate_card
+    expect(rate_card.product).to eq(product)
+    expect(rate_card.name).to eq("Growth USD")
+    expect(rate_card.code).to eq("growth_usd")
+    expect(rate_card.currency).to eq("USD")
+    expect(rate_card.billing_timing).to eq("arrears")
+    expect(rate_card.display_on_invoice).to be(true)
+  end
+
+  context "when proration is omitted" do
+    let(:params) { {name: "No proration", code: "no_proration", currency: "USD"} }
+
+    it "falls back to the column default" do
+      expect(result.rate_card.proration).to be(false)
+    end
+  end
+
+  context "when proration is explicitly null" do
+    before { params[:proration] = nil }
+
+    it "falls back to the column default instead of inserting NULL" do
+      expect(result).to be_success
+      expect(result.rate_card.proration).to be(false)
+    end
+  end
+
+  context "when proration is not a boolean" do
+    before { params[:proration] = "hello" }
+
+    it "returns a validation failure instead of coercing to true" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:proration]).to eq(["value_is_invalid"])
+    end
+  end
+
+  it "produces an activity log" do
+    rate_card = result.rate_card
+    expect(Utils::ActivityLog).to have_produced("rate_card.created").after_commit.with(rate_card)
+  end
+
+  context "with nested rates" do
+    # A prorated card requires a recurring metric for its rates to be valid.
+    let(:product) do
+      metric = create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
+      create(:product, organization:, billable_metric: metric)
+    end
+
+    before do
+      params[:rates] = [
+        {
+          code: "launch_price",
+          effective_datetime: 1.minute.ago.iso8601,
+          rate_model: "standard",
+          rate_properties: {"amount" => "10"},
+          billing_interval_unit: "month"
+        },
+        {
+          code: "standard_price",
+          effective_datetime: 1.month.from_now.iso8601,
+          rate_model: "standard",
+          rate_properties: {"amount" => "12"},
+          billing_interval_unit: "month"
+        }
+      ]
+    end
+
+    it "creates the card with its rates in one call" do
+      expect { result }.to change(RateCardRate, :count).by(2)
+
+      rates = result.rate_card.rates.order(:effective_datetime)
+      expect(rates.first.status).to eq("active")
+      expect(rates.last.status).to eq("pending")
+    end
+
+    it "does not produce per-rate activity logs" do
+      result
+      expect(Utils::ActivityLog).not_to have_produced("rate_card.updated")
+    end
+
+    context "when a nested rate is invalid" do
+      before { params[:rates] = [{code: "bad", rate_model: "standard", rate_properties: {}, billing_interval_unit: "month", effective_datetime: Time.current.iso8601}] }
+
+      it "returns a validation failure with prefixed keys and creates nothing" do
+        expect { result }.not_to change(RateCard, :count)
+        expect(result).not_to be_success
+        expect(result.error.messages[:"rates.rate_properties"]).to be_present
+      end
+    end
+  end
+
+  context "with a product filter" do
+    let(:filter) { create(:product_filter, organization:, product:) }
+
+    before { params[:product_filter_id] = filter.id }
+
+    it "scopes the card to the filter" do
+      expect(result.rate_card.product_filter).to eq(filter)
+    end
+
+    context "when the filter belongs to another product" do
+      let(:filter) { create(:product_filter, organization:) }
+
+      it "returns a not found failure" do
+        expect(result).not_to be_success
+        expect(result.error.resource).to eq("product_filter")
+      end
+    end
+  end
+
+  context "when wallet_targetable is set without the organization feature" do
+    before { params[:wallet_targetable] = true }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:wallet_targetable]).to eq(["feature_unavailable"])
+    end
+  end
+
+  context "when applied_pricing_unit_code is unknown" do
+    before { params[:applied_pricing_unit_code] = "unknown" }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:applied_pricing_unit_code]).to eq(["value_is_invalid"])
+    end
+  end
+
+  context "when the code is already used on the product" do
+    before { create(:rate_card, organization:, product:, code: "growth_usd") }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:code]).to be_present
+    end
+  end
+
+  context "when product is nil" do
+    let(:product) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("product")
+    end
+  end
+end

--- a/spec/services/rate_cards/destroy_service_spec.rb
+++ b/spec/services/rate_cards/destroy_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCards::DestroyService do
+  subject(:result) { described_class.call(rate_card:) }
+
+  let(:organization) { create(:organization) }
+  let(:rate_card) { create(:rate_card, organization:) }
+
+  before do
+    create(:rate_card_rate, organization:, rate_card:) if rate_card
+  end
+
+  it "soft deletes the card and its rates" do
+    rate_ids = rate_card.rates.ids
+
+    expect(result).to be_success
+    expect(rate_card.reload).to be_discarded
+    expect(RateCardRate.with_discarded.where(id: rate_ids).map(&:discarded?)).to all(be(true))
+  end
+
+  it "produces an activity log" do
+    result
+    expect(Utils::ActivityLog).to have_produced("rate_card.deleted").after_commit.with(rate_card)
+  end
+
+  context "when rate_card is nil" do
+    let(:rate_card) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("rate_card")
+    end
+  end
+
+  context "when the card is attached to a plan" do
+    before { create(:plan_rate_card, organization:, rate_card:) }
+
+    it "returns a validation failure and discards nothing" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:rate_card]).to eq(["attached_to_plan_or_subscription"])
+      expect(rate_card.reload).not_to be_discarded
+    end
+  end
+end

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateCards::UpdateService do
+  subject(:result) { described_class.call(rate_card:, params:) }
+
+  let(:organization) { create(:organization) }
+  let(:rate_card) { create(:rate_card, organization:, name: "Before", currency: "EUR") }
+
+  let(:params) { {name: "After", description: "new", billing_timing: "advance"} }
+
+  it "updates the attributes" do
+    expect(result).to be_success
+    expect(result.rate_card.name).to eq("After")
+    expect(result.rate_card.description).to eq("new")
+    expect(result.rate_card.billing_timing).to eq("advance")
+  end
+
+  it "does not change the code" do
+    expect { result }.not_to change { rate_card.reload.code }
+  end
+
+  it "produces an activity log" do
+    result
+    expect(Utils::ActivityLog).to have_produced("rate_card.updated").after_commit.with(rate_card)
+  end
+
+  context "when a boolean field is not a boolean" do
+    let(:params) { {display_on_invoice: "hello"} }
+
+    it "returns a validation failure instead of coercing" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:display_on_invoice]).to eq(["value_is_invalid"])
+    end
+  end
+
+  context "when the card has no rates" do
+    let(:params) { {currency: "USD"} }
+
+    it "allows changing the currency" do
+      expect(result).to be_success
+      expect(result.rate_card.currency).to eq("USD")
+    end
+  end
+
+  context "when the card has rates" do
+    before { create(:rate_card_rate, organization:, rate_card:) }
+
+    context "when changing the currency" do
+      let(:params) { {currency: "USD"} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:currency]).to eq(["not_editable_with_rates"])
+      end
+    end
+
+    context "when sending the unchanged currency" do
+      let(:params) { {currency: "EUR", name: "After"} }
+
+      it "is allowed" do
+        expect(result).to be_success
+        expect(result.rate_card.name).to eq("After")
+      end
+    end
+
+    context "when changing the billing_timing" do
+      let(:params) { {billing_timing: "advance"} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:billing_timing]).to eq(["not_editable_with_rates"])
+      end
+    end
+
+    context "when changing the proration" do
+      let(:params) { {proration: true} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:proration]).to eq(["not_editable_with_rates"])
+      end
+    end
+
+    context "when changing regroup_paid_fees" do
+      let(:params) { {regroup_paid_fees: "invoice"} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:regroup_paid_fees]).to eq(["not_editable_with_rates"])
+      end
+    end
+
+    context "when resending all unchanged billing fields" do
+      let(:params) do
+        {
+          currency: rate_card.currency,
+          billing_timing: rate_card.billing_timing,
+          proration: rate_card.proration,
+          regroup_paid_fees: rate_card.regroup_paid_fees,
+          name: "After"
+        }
+      end
+
+      it "is allowed" do
+        expect(result).to be_success
+        expect(result.rate_card.name).to eq("After")
+      end
+    end
+
+    context "when changing display_on_invoice" do
+      let(:params) { {display_on_invoice: false} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:display_on_invoice]).to eq(["not_editable_with_rates"])
+      end
+    end
+
+    context "when changing wallet_targetable" do
+      let(:params) { {wallet_targetable: false} }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:wallet_targetable]).to eq(["not_editable_with_rates"])
+      end
+    end
+
+    context "when editing presentation fields" do
+      let(:params) { {name: "After", description: "new"} }
+
+      it "is allowed" do
+        expect(result).to be_success
+        expect(result.rate_card.name).to eq("After")
+      end
+    end
+  end
+
+  context "when rate_card is nil" do
+    let(:rate_card) { nil }
+
+    it "returns a not found failure" do
+      expect(result).not_to be_success
+      expect(result.error.resource).to eq("rate_card")
+    end
+  end
+end

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe RateCards::UpdateService do
       end
     end
 
+    context "when sending an explicit null regroup_paid_fees" do
+      let(:params) { {regroup_paid_fees: nil, name: "After"} }
+
+      it "reads as none, not as a locked-field change" do
+        expect(result).to be_success
+        expect(result.rate_card.name).to eq("After")
+        expect(result.rate_card.regroup_paid_fees).to eq("none")
+      end
+    end
+
     context "when resending all unchanged billing fields" do
       let(:params) do
         {

--- a/spec/services/rate_cards/update_service_spec.rb
+++ b/spec/services/rate_cards/update_service_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe RateCards::UpdateService do
     end
   end
 
+  context "when wallet_targetable is set without the organization feature" do
+    let(:params) { {wallet_targetable: true} }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:wallet_targetable]).to eq(["feature_unavailable"])
+    end
+  end
+
+  context "when applied_pricing_unit_code is unknown" do
+    let(:params) { {applied_pricing_unit_code: "unknown"} }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:applied_pricing_unit_code]).to eq(["value_is_invalid"])
+    end
+  end
+
   context "when the card has rates" do
     before { create(:rate_card_rate, organization:, rate_card:) }
 


### PR DESCRIPTION
## Context

Service layer for rate cards and their rates, the pricing objects attached to products. Every write goes through a dedicated service so the GraphQL surface (#5707) and REST (later in the stack) share identical behaviour and validation.

## Description

- Create/update/destroy services for `RateCard`, with a query object and V1 serializer.
- Append/update/destroy services for `RateCardRate` with the effective_from timeline rules: arrears canonicalized to midnight, one rate per day, appends only after the active rate.
- Rate card activity-log types (`rate_card.created/updated/deleted`) and the regenerated schema dumps that carry the new activity enum values.
