### PR TITLE
feat(products): add rate card timeline rules

### DIFF
--- a/app/models/rate_card.rb
+++ b/app/models/rate_card.rb
@@ -43,6 +43,7 @@ class RateCard < ApplicationRecord
   validate :validate_filter_belongs_to_item
   validate :validate_display_on_invoice
   validate :validate_proration
+  validate :validate_regroup_paid_fees
 
   default_scope -> { kept }
 
@@ -73,8 +74,30 @@ class RateCard < ApplicationRecord
     errors.add(:proration, :not_allowed_for_aggregation_type) if metric.weighted_sum_agg?
   end
 
+  # Paid-fee regrouping only exists for advance fees kept off the invoice
+  def validate_regroup_paid_fees
+    return if regroup_paid_fees_none?
+
+    errors.add(:regroup_paid_fees, :not_allowed_for_billing_timing) unless advance?
+    errors.add(:regroup_paid_fees, :not_allowed_with_display_on_invoice) if display_on_invoice?
+  end
+
   def self.ransackable_attributes(_auth_object = nil)
     %w[name code]
+  end
+
+  # The card bills someone once it belongs to a plan that has subscriptions or
+  # is attached directly to a subscription. From that point its pricing is
+  # immutable: any price change goes through a new card and a plan migration.
+  def attached_to_subscriptions?
+    subscription_applied_rate_cards.exists? ||
+      Subscription.where(plan_id: plan_applied_rate_cards.select(:plan_id)).exists?
+  end
+
+  # The active rate is the latest effective rate; later rates are pending and
+  # earlier ones have been superseded (terminated).
+  def active_rate
+    rates.effective.order(effective_from: :desc).first
   end
 end
 

--- a/app/models/rate_card_rate.rb
+++ b/app/models/rate_card_rate.rb
@@ -2,6 +2,7 @@
 
 class RateCardRate < ApplicationRecord
   include PaperTrailTraceable
+  include ChargePropertiesValidation
   include Discard::Model
 
   self.discard_column = :deleted_at
@@ -54,8 +55,51 @@ class RateCardRate < ApplicationRecord
   validate :validate_effective_from_parseable
   validate :validate_effective_from_is_appended
   validate :validate_pricing_unit_conversion_rate
+  validate :validate_rate_model_compatibility
+  validate :validate_min_amount_timing
+  validate :validate_properties
 
   default_scope -> { kept }
+
+  scope :pending, -> { where("effective_from > ?", Time.current) }
+  scope :effective, -> { where(effective_from: ..Time.current) }
+
+  # The charge validators read pricing data from a `properties` attribute.
+  def properties
+    rate_properties
+  end
+
+  # Status is derived from the card's append-only timeline rather than stored:
+  # the latest effective rate is active, future rates are pending, and earlier
+  # effective rates have been superseded and are terminated.
+  def status
+    return STATUSES[:pending] if effective_from > Time.current
+
+    superseded = rate_card.rates
+      .where("effective_from > ?", effective_from)
+      .where(effective_from: ..Time.current)
+      .exists?
+
+    superseded ? STATUSES[:terminated] : STATUSES[:active]
+  end
+
+  def pending?
+    status == STATUSES[:pending]
+  end
+
+  def active?
+    status == STATUSES[:active]
+  end
+
+  def terminated?
+    status == STATUSES[:terminated]
+  end
+
+  # The property validators are shared with v1 charges and read the metric
+  # from the record; expose the card's item metric under the same name.
+  def billable_metric
+    rate_card&.product&.billable_metric
+  end
 
   private
 
@@ -75,12 +119,27 @@ class RateCardRate < ApplicationRecord
     errors.add(:effective_from, :invalid)
   end
 
+  def validate_rate_model_compatibility
+    code = RateCardRates::ModelCompatibility.error_code(rate_model:, rate_card:)
+    errors.add(:rate_model, code.to_sym) if code
+  end
+
+  # Minimum spending true-ups against a closed period, so it only exists on
+  # arrears cards.
+  def validate_min_amount_timing
+    return unless min_amount_cents&.positive?
+    return unless rate_card&.advance?
+
+    errors.add(:min_amount_cents, :not_allowed_for_billing_timing)
+  end
+
   # Append-only timeline: a new rate's effective_from must be strictly greater
   # than the latest existing rate on the same card. No insertion between rates.
   # The past is immutable, the future is editable
   def validate_effective_from_is_appended
     return if effective_from.blank?
     return if rate_card.blank?
+    return unless new_record? || effective_from_changed?
 
     others = rate_card.rates.where.not(id:)
     if others.where(effective_from:).exists?
@@ -100,6 +159,19 @@ class RateCardRate < ApplicationRecord
     return if applied_pricing_unit_conversion_rate.present?
 
     errors.add(:applied_pricing_unit_conversion_rate, :blank)
+  end
+
+  def validate_properties
+    return unless rate_model
+    return if errors[:rate_model].any?
+
+    validator = ChargePropertiesValidation::PROPERTIES_VALIDATORS[rate_model.to_sym]
+    validator ||= Charges::Validators::BaseService
+
+    instance = validator.new(charge: self)
+    return if instance.valid?
+
+    instance.result.error.messages.values.flatten.each { errors.add(:rate_properties, it) }
   end
 end
 

--- a/app/services/charges/validators/graduated_percentage_service.rb
+++ b/app/services/charges/validators/graduated_percentage_service.rb
@@ -30,7 +30,7 @@ module Charges
       private
 
       def validate_billable_metric
-        return unless charge.billable_metric.latest_agg?
+        return unless charge.billable_metric&.latest_agg?
 
         add_error(field: :billable_metric, error_code: "invalid_value")
       end

--- a/app/services/charges/validators/percentage_service.rb
+++ b/app/services/charges/validators/percentage_service.rb
@@ -21,7 +21,7 @@ module Charges
       end
 
       def validate_billable_metric
-        return unless charge.billable_metric.latest_agg?
+        return unless charge.billable_metric&.latest_agg?
 
         add_error(field: :billable_metric, error_code: "invalid_value")
       end

--- a/app/services/rate_card_rates/model_compatibility.rb
+++ b/app/services/rate_card_rates/model_compatibility.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module RateCardRates
+  # v1-parity compatibility matrix between a rate model and the card pricing
+  # it (product type, billing timing, proration). Returns the error code
+  # to surface on :rate_model, or nil when the combination is billable.
+  module ModelCompatibility
+    # Mirrors FixedCharge::CHARGE_MODELS.
+    FIXED_ITEM_RATE_MODELS = %w[standard graduated volume].freeze
+    # Mirrors Charge#validate_prorated.
+    PRORATION_ARREARS_MODELS = %w[standard volume graduated].freeze
+    PRORATION_ADVANCE_MODELS = %w[standard].freeze
+
+    module_function
+
+    def error_code(rate_model:, rate_card:)
+      item = rate_card&.product
+      return nil unless rate_model && item
+
+      if item.fixed? && !FIXED_ITEM_RATE_MODELS.include?(rate_model)
+        return "not_allowed_for_product"
+      end
+
+      metric = item.billable_metric
+
+      # Dynamic pricing only works on sum aggregation.
+      if rate_model == "dynamic" && !metric&.sum_agg?
+        return "not_allowed_for_aggregation_type"
+      end
+
+      # Percentage models price a monetary amount; a latest aggregation keeps
+      # a point-in-time value, not an amount to take a percentage of.
+      if %w[percentage graduated_percentage].include?(rate_model) && metric&.latest_agg?
+        return "not_allowed_for_aggregation_type"
+      end
+
+      if rate_card.advance?
+        # Volume needs the full period...
+        return "not_allowed_for_billing_timing" if rate_model == "volume"
+        # ...and advance billing needs an aggregation that can be priced per
+        # event.
+        return "not_allowed_for_aggregation_type" if metric && !metric.payable_in_advance?
+      end
+
+      if rate_card.proration
+        return "not_allowed_with_proration" unless proration_models(rate_card, metric).include?(rate_model)
+      end
+
+      nil
+    end
+
+    def proration_models(rate_card, metric)
+      # Usage proration needs a recurring, non-weighted metric; fixed items
+      # prorate by calendar time and follow the same model lists.
+      if metric
+        return [] if metric.weighted_sum_agg? || !metric.recurring?
+      end
+
+      rate_card.advance? ? PRORATION_ADVANCE_MODELS : PRORATION_ARREARS_MODELS
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,10 +48,16 @@ en:
         missing_graduated_ranges: missing_graduated_ranges
         missing_volume_ranges: missing_volume_ranges
         modification_not_allowed: modification_not_allowed
+        must_be_after_active_rate: must_be_after_active_rate
         must_be_array: must_be_array
         must_be_greater_than_or_equal_min: must_be_greater_than_or_equal_min
         must_be_greater_than_or_equal_threshold: must_be_greater_than_or_equal_threshold
         must_be_true_unless_pay_in_advance: must_be_true_unless_pay_in_advance
+        not_allowed_for_aggregation_type: not_allowed_for_aggregation_type
+        not_allowed_for_billing_timing: not_allowed_for_billing_timing
+        not_allowed_for_product: not_allowed_for_product
+        not_allowed_with_display_on_invoice: not_allowed_with_display_on_invoice
+        not_allowed_with_proration: not_allowed_with_proration
         not_compatible_with_aggregation_type: not_compatible_with_aggregation_type
         not_compatible_with_pay_in_advance: not_compatible_with_pay_in_advance
         one_of_plan_or_subscription_required: one_of_plan_or_subscription_required

--- a/spec/models/rate_card_rate_spec.rb
+++ b/spec/models/rate_card_rate_spec.rb
@@ -37,6 +37,37 @@ RSpec.describe RateCardRate do
     end
   end
 
+  describe "#status" do
+    let(:rate_card) { create(:rate_card) }
+    let(:organization) { rate_card.organization }
+
+    it "derives the status from the card timeline" do
+      terminated = create(:rate_card_rate, organization:, rate_card:, effective_from: 2.months.ago.beginning_of_day)
+      active = create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.ago.beginning_of_day)
+      pending = create(:rate_card_rate, organization:, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
+
+      expect(terminated.status).to eq("terminated")
+      expect(terminated).to be_terminated
+      expect(active.status).to eq("active")
+      expect(active).to be_active
+      expect(pending.status).to eq("pending")
+      expect(pending).to be_pending
+    end
+  end
+
+  describe "Scopes" do
+    describe ".pending and .effective" do
+      it "splits rates around the current time" do
+        rate_card = create(:rate_card)
+        effective = create(:rate_card_rate, organization: rate_card.organization, rate_card:, effective_from: 1.month.ago.beginning_of_day)
+        pending = create(:rate_card_rate, organization: rate_card.organization, rate_card:, effective_from: 1.month.from_now.beginning_of_day)
+
+        expect(described_class.pending).to eq([pending])
+        expect(described_class.effective).to eq([effective])
+      end
+    end
+  end
+
   describe "validations" do
     describe "effective_from normalization" do
       it "canonicalizes a time component to midnight on an arrears card" do
@@ -95,6 +126,108 @@ RSpec.describe RateCardRate do
       end
     end
 
+    describe "rate_model compatibility" do
+      let(:organization) { create(:organization) }
+
+      def rate_for(product_type:, rate_model:, billing_timing: "arrears", proration: false, metric: nil)
+        item = create(:product, organization:, product_type:, billable_metric: metric)
+        rate_card = create(:rate_card, organization:, product: item, billing_timing:, proration:)
+        build(:rate_card_rate, organization:, rate_card:, rate_model:)
+      end
+
+      it "rejects models outside standard/graduated/volume on fixed items" do
+        %w[package percentage graduated_percentage custom dynamic].each do |model|
+          rate = rate_for(product_type: "fixed", rate_model: model)
+          rate.valid?
+          expect(rate.errors.where(:rate_model)).to be_present, "expected #{model} to be rejected"
+          expect(rate.errors.first.type.to_s).to eq("not_allowed_for_product")
+        end
+
+        %w[standard graduated volume].each do |model|
+          rate = rate_for(product_type: "fixed", rate_model: model)
+          rate.valid?
+          expect(rate.errors.where(:rate_model)).to be_empty, "expected #{model} to be allowed"
+        end
+      end
+
+      it "rejects volume on an advance card" do
+        rate = rate_for(product_type: "fixed", billing_timing: "advance", rate_model: "volume")
+        rate.valid?
+        expect(rate.errors.where(:rate_model, :not_allowed_for_billing_timing)).to be_present
+      end
+
+      it "rejects advance rates on a non-payable-in-advance aggregation" do
+        metric = create(:billable_metric, organization:, aggregation_type: "max_agg", field_name: "amount")
+        rate = rate_for(product_type: "usage", billing_timing: "advance", metric:, rate_model: "standard")
+        rate.valid?
+        expect(rate.errors.where(:rate_model, :not_allowed_for_aggregation_type)).to be_present
+      end
+
+      it "applies the v1 proration matrix" do
+        recurring = create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
+        rate = rate_for(product_type: "usage", proration: true, metric: recurring, rate_model: "percentage")
+        rate.valid?
+        expect(rate.errors.where(:rate_model, :not_allowed_with_proration)).to be_present
+
+        allowed = rate_for(product_type: "usage", proration: true, metric: recurring, rate_model: "standard")
+        allowed.valid?
+        expect(allowed.errors.where(:rate_model)).to be_empty
+      end
+
+      it "rejects percentage models on latest aggregation as a compatibility error" do
+        latest = create(:billable_metric, organization:, aggregation_type: "latest_agg", field_name: "amount")
+
+        %w[percentage graduated_percentage].each do |model|
+          rate = rate_for(product_type: "usage", metric: latest, rate_model: model)
+          rate.valid?
+          expect(rate.errors.where(:rate_model, :not_allowed_for_aggregation_type)).to be_present, "expected #{model} rejected"
+          expect(rate.errors.where(:rate_properties)).to be_empty
+        end
+      end
+
+      it "restricts dynamic to sum aggregation" do
+        sum = create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "amount")
+        count = create(:billable_metric, organization:, aggregation_type: "count_agg")
+
+        allowed = rate_for(product_type: "usage", metric: sum, rate_model: "dynamic")
+        allowed.valid?
+        expect(allowed.errors.where(:rate_model)).to be_empty
+
+        rejected = rate_for(product_type: "usage", metric: count, rate_model: "dynamic")
+        rejected.valid?
+        expect(rejected.errors.where(:rate_model, :not_allowed_for_aggregation_type)).to be_present
+      end
+
+      it "applies the proration matrix to fixed items" do
+        allowed = rate_for(product_type: "fixed", proration: true, rate_model: "graduated")
+        allowed.valid?
+        expect(allowed.errors.where(:rate_model)).to be_empty
+
+        rejected = rate_for(product_type: "fixed", proration: true, billing_timing: "advance", rate_model: "graduated")
+        rejected.valid?
+        expect(rejected.errors.where(:rate_model, :not_allowed_with_proration)).to be_present
+      end
+
+      it "rejects a minimum spending on advance cards" do
+        rate = rate_for(product_type: "fixed", billing_timing: "advance", rate_model: "standard")
+        rate.min_amount_cents = 100
+        rate.valid?
+        expect(rate.errors.where(:min_amount_cents, :not_allowed_for_billing_timing)).to be_present
+
+        arrears = rate_for(product_type: "fixed", rate_model: "standard")
+        arrears.min_amount_cents = 100
+        arrears.valid?
+        expect(arrears.errors.where(:min_amount_cents)).to be_empty
+      end
+
+      it "validates percentage properties on usage items without crashing" do
+        metric = create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "amount")
+        rate = rate_for(product_type: "usage", metric:, rate_model: "percentage")
+        rate.rate_properties = {"rate" => "1"}
+        expect(rate).to be_valid
+      end
+    end
+
     it { is_expected.to validate_presence_of(:rate_model) }
     it { is_expected.to validate_presence_of(:billing_interval_unit) }
 
@@ -110,7 +243,7 @@ RSpec.describe RateCardRate do
           :rate_card_rate,
           rate_card: rate.rate_card,
           organization: rate.organization,
-          effective_from: 1.month.from_now,
+          effective_from: 1.month.from_now.beginning_of_day,
           code: "launch_price"
         )
         duplicate.valid?

--- a/spec/models/rate_card_spec.rb
+++ b/spec/models/rate_card_spec.rb
@@ -100,6 +100,26 @@ RSpec.describe RateCard do
       end
     end
 
+    describe "regroup_paid_fees compatibility" do
+      it "names the field that actually conflicts" do
+        arrears = build(:rate_card, regroup_paid_fees: "invoice", billing_timing: "arrears", display_on_invoice: false)
+        arrears.valid?
+        expect(arrears.errors.where(:regroup_paid_fees).map(&:type)).to eq([:not_allowed_for_billing_timing])
+
+        displayed = build(:rate_card, regroup_paid_fees: "invoice", billing_timing: "advance", display_on_invoice: true)
+        displayed.valid?
+        expect(displayed.errors.where(:regroup_paid_fees).map(&:type)).to eq([:not_allowed_with_display_on_invoice])
+
+        both = build(:rate_card, regroup_paid_fees: "invoice", billing_timing: "arrears", display_on_invoice: true)
+        both.valid?
+        expect(both.errors.where(:regroup_paid_fees).map(&:type))
+          .to match_array(%i[not_allowed_for_billing_timing not_allowed_with_display_on_invoice])
+
+        valid = build(:rate_card, regroup_paid_fees: "invoice", billing_timing: "advance", display_on_invoice: false)
+        expect(valid).to be_valid
+      end
+    end
+
     describe "currency inclusion" do
       it "is valid with an accepted currency" do
         expect(build(:rate_card, currency: "USD")).to be_valid
@@ -154,6 +174,34 @@ RSpec.describe RateCard do
       create(:subscription_rate_card, organization: rate_card.organization, rate_card:)
 
       expect(rate_card.attached_to_plan_or_subscription?).to be(true)
+    end
+  end
+
+  describe "#attached_to_subscriptions?" do
+    subject(:rate_card) { create(:rate_card) }
+
+    it "is false without any subscription linkage" do
+      expect(rate_card.attached_to_subscriptions?).to be(false)
+    end
+
+    it "is false when on a plan without subscriptions" do
+      create(:plan_rate_card, organization: rate_card.organization, rate_card:)
+
+      expect(rate_card.attached_to_subscriptions?).to be(false)
+    end
+
+    it "is true when on a plan that has subscriptions" do
+      plan = create(:plan, organization: rate_card.organization)
+      create(:plan_rate_card, organization: rate_card.organization, plan:, rate_card:)
+      create(:subscription, plan:, organization: rate_card.organization)
+
+      expect(rate_card.attached_to_subscriptions?).to be(true)
+    end
+
+    it "is true when attached directly to a subscription" do
+      create(:subscription_rate_card, organization: rate_card.organization, rate_card:)
+
+      expect(rate_card.attached_to_subscriptions?).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Context

Rate cards price a product through an effective-dated timeline of rates: a price change is an append, never an edit. The rules that keep that timeline coherent live on the models so every surface shares them.

## Description

- `RateCardRate`: arrears `effective_from` canonicalized to midnight (one rate per day via the uniqueness rule), appends only after the active rate, per-card code rules, pricing-unit conversion requirement, rate_properties validated against the rate model.
- `RateCard`: `regroup_paid_fees` compatibility (none = no regrouping), proration requirements, filter ownership, `active_rate`.
- `RateCardRates::ModelCompatibility` rides along — it is pure validation machinery the model calls.
- Model specs + locale entries. No services, no API surface, no schema change.
