### PR TITLE
feat(netsuite-integration): Add functionality to void invoice on Netsuite

### DIFF
--- a/app/jobs/concerns/integrations/aggregator/provider_delayed_retry.rb
+++ b/app/jobs/concerns/integrations/aggregator/provider_delayed_retry.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module ProviderDelayedRetry
+      extend ActiveSupport::Concern
+
+      READ_TIMEOUT_ATTEMPTS = 6
+
+      # NOTE: NetSuite waits longer to avoid racing in-flight Nango calls; others use polynomial backoff.
+      # 6 minutes covers Nango's 5-minute upstream NetSuite action timeout with a safety margin.
+      DELAY_BY_PROVIDER_KEY = {
+        "netsuite" => 6.minutes
+      }.freeze
+
+      included do
+        # NOTE: `executions_for` and `determine_delay` are ActiveJob internals used by `retry_on`,
+        # not part of its public API. We reuse them so the per-exception execution counter and jitter
+        # behave identically to a normal `retry_on`. Revisit this block on Rails upgrades.
+        rescue_from(Net::ReadTimeout) do |error|
+          executions_count = executions_for([Net::ReadTimeout])
+
+          if executions_count >= READ_TIMEOUT_ATTEMPTS
+            instrument :retry_stopped, error:
+            raise
+          end
+
+          wait_strategy = DELAY_BY_PROVIDER_KEY.fetch(integration_provider_key, :polynomially_longer)
+
+          retry_job(
+            wait: determine_delay(seconds_or_duration_or_algorithm: wait_strategy, executions: executions_count),
+            error: error
+          )
+        end
+      end
+
+      private
+
+      def integration_provider_key
+        invoice = arguments.first[:invoice]
+        invoice&.customer&.integration_customers&.accounting_kind&.first&.integration&.provider_key
+      end
+    end
+  end
+end

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -5,12 +5,7 @@ module Integrations
     module Invoices
       class CreateJob < ApplicationJob
         include ConcurrencyThrottlable
-
-        # NOTE: NetSuite waits longer to avoid racing in-flight Nango calls; others use polynomial backoff.
-        # 6 minutes covers Nango's 5-minute upstream NetSuite action timeout with a safety margin.
-        DELAY_BY_PROVIDER_KEY = {
-          "netsuite" => 6.minutes
-        }.freeze
+        include Integrations::Aggregator::ProviderDelayedRetry
 
         queue_as "integrations"
 
@@ -20,26 +15,6 @@ module Integrations
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
         retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
         discard_on BaseService::NonRetryableFailure
-
-        # NOTE: `executions_for` and `determine_delay` are ActiveJob internals used by `retry_on`,
-        # not part of its public API. We reuse them so the per-exception execution counter and jitter
-        # behave identically to a normal `retry_on`. Revisit this block on Rails upgrades.
-        rescue_from(Net::ReadTimeout) do |error|
-          attempts = 6
-          executions_count = executions_for([Net::ReadTimeout])
-
-          if executions_count >= attempts
-            instrument :retry_stopped, error:
-            raise
-          end
-
-          wait_strategy = DELAY_BY_PROVIDER_KEY.fetch(integration_provider_key, :polynomially_longer)
-
-          retry_job(
-            wait: determine_delay(seconds_or_duration_or_algorithm: wait_strategy, executions: executions_count),
-            error: error
-          )
-        end
 
         def perform(invoice:, find_first: false)
           # Note: Look upstream before posting in two cases:
@@ -56,13 +31,6 @@ module Integrations
           end
 
           Integrations::Aggregator::Invoices::CreateService.call!(invoice:)
-        end
-
-        private
-
-        def integration_provider_key
-          invoice = arguments.first[:invoice]
-          invoice&.customer&.integration_customers&.accounting_kind&.first&.integration&.provider_key
         end
       end
     end

--- a/app/jobs/integrations/aggregator/invoices/void_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/void_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Invoices
+      class VoidJob < ApplicationJob
+        include ConcurrencyThrottlable
+        include Integrations::Aggregator::ProviderDelayedRetry
+
+        queue_as "integrations"
+
+        unique :until_executed, on_conflict: :log
+
+        retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
+        retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
+        discard_on BaseService::NonRetryableFailure
+
+        def perform(invoice:)
+          Integrations::Aggregator::Invoices::VoidService.call!(invoice:)
+        end
+      end
+    end
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -535,6 +535,10 @@ class Invoice < ApplicationRecord
     !self_billed && finalized? && customer.integration_customers.accounting_kind.any? { |c| c.integration.sync_invoices }
   end
 
+  def should_sync_voided_invoice?
+    !self_billed && voided? && customer.integration_customers.accounting_kind.any? { |c| c.integration.sync_invoices }
+  end
+
   def should_sync_hubspot_invoice?
     finalized? && should_update_hubspot_invoice?
   end

--- a/app/services/integrations/aggregator/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/invoices/base_service.rb
@@ -4,6 +4,8 @@ module Integrations
   module Aggregator
     module Invoices
       class BaseService < Integrations::Aggregator::BaseService
+        INVALID_LOGIN_ATTEMPT = "INVALID_LOGIN_ATTEMPT"
+
         def initialize(invoice:)
           @invoice = invoice
 
@@ -39,6 +41,15 @@ module Integrations
             integration_customer:,
             invoice:
           )
+        end
+
+        def retryable_error?(http_error)
+          server_error = http_error.error_code.to_i >= 500 || http_error.error_code.to_i == 424
+          server_error && !invalid_login_attempt_error?(http_error)
+        end
+
+        def invalid_login_attempt_error?(http_error)
+          http_error.error_body.include?(INVALID_LOGIN_ATTEMPT)
         end
       end
     end

--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -6,8 +6,6 @@ module Integrations
       class CreateService < BaseService
         Result = BaseResult[:invoice_id, :external_id]
 
-        INVALID_LOGIN_ATTEMPT = "INVALID_LOGIN_ATTEMPT"
-
         def initialize(invoice:, find_first: false)
           @find_first = find_first
           super(invoice:)
@@ -97,15 +95,6 @@ module Integrations
 
         def process_string_result(body)
           result.external_id = body
-        end
-
-        def retryable_error?(http_error)
-          server_error = http_error.error_code.to_i >= 500 || http_error.error_code.to_i == 424
-          server_error && !invalid_login_attempt_error?(http_error)
-        end
-
-        def invalid_login_attempt_error?(http_error)
-          http_error.error_body.include?(INVALID_LOGIN_ATTEMPT)
         end
       end
     end

--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -22,11 +22,7 @@ module Integrations
               "options" => {
                 "ignoreMandatoryFields" => false,
                 "fullInvoicePayload" => {
-                  "invoice_payload" => ::V1::InvoiceSerializer.new(
-                    invoice,
-                    root_name: "invoice",
-                    includes: %i[customer integration_customers billing_periods subscriptions fees credits metadata applied_taxes]
-                  ).serialize
+                  "invoice_payload" => invoice_payload
                 }
               }
             }
@@ -43,7 +39,26 @@ module Integrations
             result
           end
 
+          def void_body
+            unless integration_invoice
+              raise Integrations::Aggregator::BasePayload::Failure.new(nil, code: "invoice_missing")
+            end
+
+            {
+              "type" => "void-invoice",
+              "payload" => invoice_payload
+            }
+          end
+
           private
+
+          def invoice_payload
+            ::V1::InvoiceSerializer.new(
+              invoice,
+              root_name: "invoice",
+              includes: %i[customer integration_customers billing_periods subscriptions fees credits metadata applied_taxes]
+            ).serialize
+          end
 
           def columns
             result = {

--- a/app/services/integrations/aggregator/invoices/void_service.rb
+++ b/app/services/integrations/aggregator/invoices/void_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Invoices
+      class VoidService < BaseService
+        Result = BaseResult[:invoice_id]
+
+        def action_path
+          "v1/#{provider}/invoices/void"
+        end
+
+        def call
+          return result unless integration
+          return result unless integration.sync_invoices
+          return result unless provider == "netsuite"
+          return result unless invoice.voided?
+
+          throttle!(:netsuite)
+
+          http_client.put_with_response(payload.void_body, headers)
+
+          result.invoice_id = invoice.id
+          result
+        rescue LagoHttpClient::HttpError => e
+          raise RequestLimitError.new(e) if request_limit_error?(e)
+
+          code = code(e)
+          message = message(e)
+
+          deliver_error_webhook(customer:, code:, message:)
+
+          raise e if retryable_error?(e)
+
+          result.non_retryable_failure!(code:, message:)
+        end
+      end
+    end
+  end
+end

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -56,6 +56,7 @@ module Invoices
       result.invoice = invoice
       SendWebhookJob.perform_later("invoice.voided", result.invoice)
       Invoices::ProviderTaxes::VoidJob.perform_later(invoice:)
+      Integrations::Aggregator::Invoices::VoidJob.perform_later(invoice:) if invoice.should_sync_voided_invoice?
       Integrations::Aggregator::Invoices::Hubspot::UpdateJob.perform_later(invoice:) if invoice.should_update_hubspot_invoice?
 
       result

--- a/spec/jobs/integrations/aggregator/invoices/void_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/void_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Invoices::VoidJob do
+describe Integrations::Aggregator::Invoices::VoidJob do
   subject(:void_job) { described_class }
 
   let(:organization) { create(:organization) }

--- a/spec/jobs/integrations/aggregator/invoices/void_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/void_job_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Integrations::Aggregator::Invoices::VoidJob do
+  subject(:void_job) { described_class }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:, status: :voided) }
+  let(:result) { Integrations::Aggregator::Invoices::VoidService::Result.new }
+
+  before do
+    allow(Integrations::Aggregator::Invoices::VoidService).to receive(:call).and_return(result)
+  end
+
+  it "calls the void service" do
+    described_class.perform_now(invoice:)
+
+    expect(Integrations::Aggregator::Invoices::VoidService).to have_received(:call).with(invoice:)
+  end
+
+  context "when the service fails with an invoice missing failure" do
+    let(:failure) { Integrations::Aggregator::BasePayload::Failure.new(nil, code: "invoice_missing") }
+
+    before do
+      allow(Integrations::Aggregator::Invoices::VoidService).to receive(:call).and_raise(failure)
+    end
+
+    it "re-enqueues the job" do
+      expect { described_class.perform_now(invoice:) }.to have_enqueued_job(described_class)
+    end
+  end
+
+  context "when the service fails with a non-retryable failure" do
+    before { result.non_retryable_failure!(code: "client_error", message: "bad request") }
+
+    it "discards the job" do
+      expect { described_class.perform_now(invoice:) }.not_to raise_error
+    end
+  end
+
+  describe "Net::ReadTimeout retry" do
+    before do
+      allow(Integrations::Aggregator::Invoices::VoidService).to receive(:call).and_raise(Net::ReadTimeout.new)
+    end
+
+    context "when the invoice is for a NetSuite integration" do
+      let(:integration) { create(:netsuite_integration, organization:) }
+
+      before { create(:netsuite_customer, integration:, customer:) }
+
+      it "schedules the next attempt at least 6 minutes later" do
+        freeze_time do
+          described_class.perform_now(invoice:)
+
+          retry_at = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:at]
+          # NOTE: ActiveJob applies up to 15% positive jitter on top of the configured wait,
+          # so the retry lands in [6 minutes, 6 minutes + 15%] from now.
+          expect(retry_at).to be_between(6.minutes.from_now.to_f, 7.minutes.from_now.to_f)
+        end
+      end
+    end
+
+    context "when the invoice is for a non-NetSuite integration" do
+      let(:integration) { create(:xero_integration, organization:) }
+
+      before { create(:xero_customer, integration:, customer:) }
+
+      it "schedules the next attempt with polynomial backoff" do
+        freeze_time do
+          described_class.perform_now(invoice:)
+
+          retry_at = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:at]
+          # NOTE: First polynomial retry is ~3s (1**4 + 2) plus up to 15% jitter; well under a minute.
+          expect(retry_at).to be < 1.minute.from_now.to_f
+        end
+      end
+    end
+  end
+end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -438,6 +438,81 @@ RSpec.describe Invoice do
     end
   end
 
+  describe "#should_sync_voided_invoice?" do
+    subject(:method_call) { invoice.should_sync_voided_invoice? }
+
+    let(:invoice) { create(:invoice, customer:, organization:, status:) }
+
+    context "when invoice is not voided" do
+      let(:status) { %i[draft generating finalized].sample }
+
+      context "without integration customer" do
+        let(:customer) { create(:customer, organization:) }
+
+        it "returns false" do
+          expect(method_call).to eq(false)
+        end
+      end
+
+      context "with integration customer" do
+        let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+        let(:integration) { create(:netsuite_integration, organization:, sync_invoices: true) }
+        let(:customer) { create(:customer, organization:) }
+
+        before { integration_customer }
+
+        it "returns false" do
+          expect(method_call).to eq(false)
+        end
+      end
+    end
+
+    context "when invoice is voided" do
+      let(:status) { :voided }
+
+      context "without integration customer" do
+        let(:customer) { create(:customer, organization:) }
+
+        it "returns false" do
+          expect(method_call).to eq(false)
+        end
+      end
+
+      context "with integration customer" do
+        let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+        let(:integration) { create(:netsuite_integration, organization:, sync_invoices:) }
+        let(:customer) { create(:customer, organization:) }
+
+        before { integration_customer }
+
+        context "when sync invoices is true" do
+          let(:sync_invoices) { true }
+
+          it "returns true" do
+            expect(method_call).to eq(true)
+          end
+        end
+
+        context "when sync invoices is false" do
+          let(:sync_invoices) { false }
+
+          it "returns false" do
+            expect(method_call).to eq(false)
+          end
+        end
+
+        context "when the invoice is self_billed" do
+          let(:invoice) { create(:invoice, customer:, organization:, status:, self_billed: true) }
+          let(:sync_invoices) { true }
+
+          it "returns false" do
+            expect(method_call).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
   describe "#should_sync_salesforce_invoice?" do
     subject(:method_call) { invoice.should_sync_salesforce_invoice? }
 

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -737,6 +737,35 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
     end
   end
 
+  describe "#void_body" do
+    subject(:void_body_call) { payload.void_body }
+
+    context "when integration invoice exists" do
+      before { create(:integration_resource, integration:, syncable: invoice, resource_type: :invoice) }
+
+      it "returns the void payload" do
+        expect(void_body_call).to eq(
+          {
+            "type" => "void-invoice",
+            "payload" => ::V1::InvoiceSerializer.new(
+              invoice,
+              root_name: "invoice",
+              includes: %i[customer integration_customers billing_periods subscriptions fees credits metadata applied_taxes]
+            ).serialize
+          }
+        )
+      end
+    end
+
+    context "when integration invoice does not exist" do
+      it "raises an invoice missing failure" do
+        expect { void_body_call }.to raise_error(Integrations::Aggregator::BasePayload::Failure) do |error|
+          expect(error.code).to eq("invoice_missing")
+        end
+      end
+    end
+  end
+
   describe "#tax_item_complete?" do
     subject(:tax_item_complete_call) { payload.__send__(:tax_item_complete?) }
 

--- a/spec/services/integrations/aggregator/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/void_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Invoices::VoidService do
+describe Integrations::Aggregator::Invoices::VoidService do
   subject(:service_call) { described_class.call(invoice:) }
 
   let(:service) { described_class.new(invoice:) }

--- a/spec/services/integrations/aggregator/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/void_service_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Integrations::Aggregator::Invoices::VoidService do
+  subject(:service_call) { described_class.call(invoice:) }
+
+  let(:service) { described_class.new(invoice:) }
+  let(:integration) { create(:netsuite_integration, organization:, sync_invoices: true) }
+  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:lago_client) { instance_double(LagoHttpClient::Client) }
+  let(:endpoint) { "https://api.nango.dev/v1/netsuite/invoices/void" }
+  let(:invoice) { create(:invoice, customer:, organization:, status: :voided) }
+
+  let(:headers) do
+    {
+      "Connection-Id" => integration.connection_id,
+      "Authorization" => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
+      "Provider-Config-Key" => "netsuite-tba"
+    }
+  end
+
+  let(:params) do
+    {
+      "type" => "void-invoice",
+      "payload" => anything
+    }
+  end
+
+  before do
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
+
+    integration_customer
+  end
+
+  describe "#call" do
+    context "when integration invoice exists" do
+      let(:response) { instance_double(Net::HTTPOK) }
+
+      before do
+        create(:integration_resource, integration:, syncable: invoice, resource_type: :invoice)
+        allow(lago_client).to receive(:put_with_response).with(params, headers).and_return(response)
+      end
+
+      it "voids the invoice on the provider" do
+        result = service_call
+
+        expect(result).to be_success
+        expect(result.invoice_id).to eq(invoice.id)
+        expect(lago_client).to have_received(:put_with_response).with(params, headers)
+      end
+
+      it_behaves_like "throttles!", :netsuite
+    end
+
+    context "when integration invoice does not exist" do
+      it "raises an invoice missing failure" do
+        expect { service_call }.to raise_error(Integrations::Aggregator::BasePayload::Failure) do |error|
+          expect(error.code).to eq("invoice_missing")
+        end
+      end
+    end
+
+    context "when there is no integration customer" do
+      let(:integration_customer) { nil }
+
+      it "returns result without making an API call" do
+        result = service_call
+
+        expect(result).to be_success
+        expect(LagoHttpClient::Client).not_to have_received(:new)
+      end
+    end
+
+    context "when sync invoices is disabled" do
+      let(:integration) { create(:netsuite_integration, organization:, sync_invoices: false) }
+
+      it "returns result without making an API call" do
+        result = service_call
+
+        expect(result).to be_success
+        expect(LagoHttpClient::Client).not_to have_received(:new)
+      end
+    end
+
+    context "when the provider is not netsuite" do
+      let(:integration) { create(:xero_integration, organization:, sync_invoices: true) }
+      let(:integration_customer) { create(:xero_customer, integration:, customer:) }
+
+      it "returns result without making an API call" do
+        result = service_call
+
+        expect(result).to be_success
+        expect(LagoHttpClient::Client).not_to have_received(:new)
+      end
+    end
+
+    context "when the invoice is not voided" do
+      let(:invoice) { create(:invoice, customer:, organization:, status: :finalized) }
+
+      it "returns result without making an API call" do
+        result = service_call
+
+        expect(result).to be_success
+        expect(LagoHttpClient::Client).not_to have_received(:new)
+      end
+    end
+
+    context "when the http call fails" do
+      let(:body) do
+        path = Rails.root.join("spec/fixtures/integration_aggregator/error_response.json")
+        File.read(path)
+      end
+
+      let(:http_error) { LagoHttpClient::HttpError.new(error_code, body, nil) }
+
+      before do
+        create(:integration_resource, integration:, syncable: invoice, resource_type: :invoice)
+        allow(lago_client).to receive(:put_with_response).with(params, headers).and_raise(http_error)
+      end
+
+      context "when it is a server error" do
+        let(:error_code) { 500 }
+
+        it "returns an error" do
+          expect do
+            service_call
+          end.to raise_error(http_error)
+        end
+
+        it "enqueues a SendWebhookJob" do
+          expect { service_call }.to have_enqueued_job(SendWebhookJob).and raise_error(http_error)
+        end
+      end
+
+      context "when it is a client error" do
+        let(:error_code) { 400 }
+
+        it "does not raise an error" do
+          expect { service_call }.not_to raise_error
+        end
+
+        it "returns a failure result" do
+          result = service_call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NonRetryableFailure)
+        end
+
+        it "enqueues a SendWebhookJob" do
+          expect { service_call }.to have_enqueued_job(SendWebhookJob)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -90,6 +90,24 @@ RSpec.describe Invoices::VoidService do
           end.to have_enqueued_job(Invoices::ProviderTaxes::VoidJob).with(invoice:)
         end
 
+        it "does not enqueue an accounting void invoice job" do
+          expect do
+            void_service.call
+          end.not_to have_enqueued_job(Integrations::Aggregator::Invoices::VoidJob)
+        end
+
+        context "when the invoice syncs with an accounting integration" do
+          let(:integration) { create(:netsuite_integration, organization: invoice.organization, sync_invoices: true) }
+
+          before { create(:netsuite_customer, integration:, customer: invoice.customer) }
+
+          it "enqueues an accounting void invoice job" do
+            expect do
+              void_service.call
+            end.to have_enqueued_job(Integrations::Aggregator::Invoices::VoidJob).with(invoice:)
+          end
+        end
+
         it "marks the invoice's payment overdue as false" do
           expect { void_service.call }.to change(invoice, :payment_overdue).from(true).to(false)
         end


### PR DESCRIPTION
## Context

When an invoice already synced to NetSuite is voided in Lago, the void never reaches NetSuite. The two systems drift apart and the invoice has to be voided manually in NetSuite.

## Description

Void the invoice in NetSuite when it is voided in Lago. `Invoices::VoidService` now enqueues a new `Integrations::Aggregator::Invoices::VoidJob` / `VoidService` pair that calls Nango's `void-invoice` action. The sync only runs when the invoice is voided, not self-billed, and belongs to a NetSuite integration with invoice sync enabled (`Invoice#should_sync_voided_invoice?`). If the invoice was never synced to NetSuite, the payload raises `BasePayload::Failure`, which the job retries with polynomial backoff before dead-queueing.

The void path reuses the error handling built for invoice creation:
- `retryable_error?` / `invalid_login_attempt_error?` move from `CreateService` to the shared invoices `BaseService`.
- The `Net::ReadTimeout` handling (6-minute delay for NetSuite to cover Nango's 5-minute upstream timeout, polynomial backoff for other providers) is extracted from `CreateJob` into a `ProviderDelayedRetry` concern included by both jobs.
