### PR TITLE
fix(payments): allow 3DS retry on activation payments

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -86,7 +86,7 @@ class Payment < ApplicationRecord
   end
 
   def gated_subscription_activation?
-    payable.is_a?(Invoice) && payable.subscription_payment_gated?
+    payable.subscription_payment_gated?
   end
 
   def method_display_name

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -85,6 +85,10 @@ class Payment < ApplicationRecord
     payment_provider&.payment_type
   end
 
+  def gated_subscription_activation?
+    payable.is_a?(Invoice) && payable.subscription_payment_gated?
+  end
+
   def method_display_name
     return nil if provider_payment_method_data.blank?
 

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -37,7 +37,7 @@ module PaymentProviders
       payment_status
     end
 
-    def retriable_authentication_failure?(_error_code)
+    def retriable_authentication_failure?(_error_code, payment: nil)
       false
     end
   end

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -43,8 +43,10 @@ module PaymentProviders
       "stripe"
     end
 
-    def retriable_authentication_failure?(error_code)
-      error_code == NEED_3DS_ERROR_CODE && supports_3ds.present?
+    def retriable_authentication_failure?(error_code, payment:)
+      return false unless error_code == NEED_3DS_ERROR_CODE
+
+      supports_3ds.present? || payment.gated_subscription_activation?
     end
   end
 end

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -40,6 +40,10 @@ class PaymentRequest < ApplicationRecord
     invoices
   end
 
+  def subscription_payment_gated?
+    false
+  end
+
   def invoice_ids
     applied_invoices.pluck(:invoice_id)
   end

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -63,7 +63,7 @@ module Invoices
       def authentication_retry_pending?(payment, status)
         return false unless status.to_s == "failed"
 
-        payment.payment_provider&.retriable_authentication_failure?(payment.error_code) ||
+        payment.payment_provider&.retriable_authentication_failure?(payment.error_code, payment:) ||
           payment.payable.payments.excluding(payment).where(status: :requires_action).any?
       end
 

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -41,7 +41,7 @@ module PaymentProviders
             #       For now we keep it as pending, the user can still update it manually
             prepare_failed_result(e, payable_payment_status: :pending)
           when StripeProvider::NEED_3DS_ERROR_CODE
-            prepare_failed_result(e, should_retry: payment_provider.supports_3ds)
+            prepare_failed_result(e, should_retry: payment_provider.retriable_authentication_failure?(e.code, payment:))
           else
             prepare_failed_result(e)
           end

--- a/spec/models/payment_providers/stripe_provider_spec.rb
+++ b/spec/models/payment_providers/stripe_provider_spec.rb
@@ -47,6 +47,45 @@ RSpec.describe PaymentProviders::StripeProvider do
     end
   end
 
+  describe "#retriable_authentication_failure?" do
+    subject(:method_call) { stripe_provider.retriable_authentication_failure?(error_code, payment:) }
+
+    let(:error_code) { described_class::NEED_3DS_ERROR_CODE }
+    let(:payment) { create(:payment, payable: create(:invoice)) }
+
+    context "when the error is not an authentication failure" do
+      let(:error_code) { "card_declined" }
+
+      before { stripe_provider.supports_3ds = true }
+
+      it "returns false" do
+        expect(method_call).to eq(false)
+      end
+    end
+
+    context "when the connection supports 3DS" do
+      before { stripe_provider.supports_3ds = true }
+
+      it "returns true" do
+        expect(method_call).to eq(true)
+      end
+    end
+
+    context "when the connection does not support 3DS" do
+      it "returns false" do
+        expect(method_call).to eq(false)
+      end
+
+      context "when the payment activates a payment-gated subscription" do
+        before { allow(payment).to receive(:gated_subscription_activation?).and_return(true) }
+
+        it "returns true" do
+          expect(method_call).to eq(true)
+        end
+      end
+    end
+  end
+
   describe "require_terms_of_service_consent" do
     it "assigns and retrieve a setting" do
       stripe_provider.require_terms_of_service_consent = true

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe PaymentRequest do
     end
   end
 
+  describe "#subscription_payment_gated?" do
+    it "returns false because a payment request settles finalized invoices" do
+      expect(payment_request.subscription_payment_gated?).to eq(false)
+    end
+  end
+
   describe "#increment_payment_attempts!" do
     let(:payment_request) { create :payment_request }
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -605,6 +605,48 @@ RSpec.describe Payment do
     end
   end
 
+  describe "#gated_subscription_activation?" do
+    subject(:method_call) { payment.gated_subscription_activation? }
+
+    let(:payment) { create(:payment, payable:) }
+    let(:subscription) { create(:subscription, :incomplete) }
+
+    context "when the payable is the activation invoice of a payment-gated subscription" do
+      let(:payable) do
+        create(
+          :invoice,
+          :open,
+          :with_subscriptions,
+          subscriptions: [subscription],
+          organization: subscription.organization,
+          customer: subscription.customer
+        )
+      end
+
+      before { create(:subscription_activation_rule, subscription:, status: "pending") }
+
+      it "returns true" do
+        expect(method_call).to eq(true)
+      end
+    end
+
+    context "when the payable is a regular invoice" do
+      let(:payable) { create(:invoice) }
+
+      it "returns false" do
+        expect(method_call).to eq(false)
+      end
+    end
+
+    context "when the payable is a payment request" do
+      let(:payable) { create(:payment_request) }
+
+      it "returns false" do
+        expect(method_call).to eq(false)
+      end
+    end
+  end
+
   describe ".for_organization" do
     subject(:result) { described_class.for_organization(organization) }
 

--- a/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
+++ b/spec/scenarios/subscriptions/payment_gated_activation_spec.rb
@@ -249,6 +249,36 @@ describe "Payment Gated Subscription Activation Scenarios" do
         expect(invoice.payment_status).not_to eq("failed")
       end
     end
+
+    context "when the Stripe connection does not support 3DS" do
+      before { stub_off_session_rejection_then_on_session_retry }
+
+      it "keeps the subscription incomplete so the customer can still authenticate" do
+        # Stage 1: the off-session charge is rejected, the authentication retry takes over
+        create_subscription(subscription_params)
+        perform_all_enqueued_jobs
+
+        subscription = customer.subscriptions.sole
+        invoice = subscription.invoices.sole
+        rejected_payment = invoice.payments.find_by(error_code: "authentication_required")
+
+        expect(rejected_payment).to be_present
+        expect(subscription).to be_incomplete
+        expect(subscription.cancellation_reason).to be_nil
+        expect(subscription.activation_rules.sole).to be_pending
+        expect(invoice.reload).to be_open
+        expect(invoice.payment_status).not_to eq("failed")
+
+        # Stage 2: Stripe reports the rejected off-session intent as failed
+        simulate_rejected_intent_failure_webhook(rejected_payment)
+
+        expect(subscription.reload).to be_incomplete
+        expect(subscription.cancellation_reason).to be_nil
+        expect(subscription.activation_rules.sole).to be_pending
+        expect(invoice.reload).to be_open
+        expect(invoice.payment_status).not_to eq("failed")
+      end
+    end
   end
 
   describe "payment failure: subscription canceled" do

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -343,6 +343,44 @@ RSpec.describe Invoices::Payments::StripeService do
             ready_for_payment_processing: true
           )
         end
+
+        context "when the invoice activates a payment-gated subscription" do
+          let(:subscription) { create(:subscription, :incomplete, organization:, customer:) }
+          let(:invoice) do
+            create(
+              :invoice,
+              :open,
+              :with_subscriptions,
+              subscriptions: [subscription],
+              organization:,
+              customer:,
+              total_amount_cents: 200,
+              currency: "EUR",
+              ready_for_payment_processing: true
+            )
+          end
+
+          before { create(:subscription_activation_rule, subscription:, status: "pending") }
+
+          # The activation payment always gets the on-session retry, so the failure of the
+          # rejected off-session intent is not terminal and must not cancel the subscription.
+          it "updates the payment status but not the invoice status" do
+            result = described_class.call(
+              :update_payment_status,
+              organization_id: organization.id,
+              status: "failed",
+              stripe_payment:
+            )
+
+            expect(result).to be_success
+            expect(result.payment.status).to eq("failed")
+            expect(result.payment.error_code).to eq("authentication_required")
+            expect(result.invoice.reload).to have_attributes(
+              payment_status: "pending",
+              ready_for_payment_processing: true
+            )
+          end
+        end
       end
 
       context "when there is another payment in requires_action state for the invoice" do

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -496,6 +496,39 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
           end
         end
       end
+
+      context "when the payment activates a payment-gated subscription without 3ds support" do
+        let(:subscription) { create(:subscription, :incomplete, organization:, customer:) }
+        let(:invoice) do
+          create(
+            :invoice,
+            :open,
+            :with_subscriptions,
+            subscriptions: [subscription],
+            organization:,
+            customer:,
+            total_amount_cents: 200,
+            currency:,
+            ready_for_payment_processing: true
+          )
+        end
+
+        before { create(:subscription_activation_rule, subscription:, status: "pending") }
+
+        it "retries the payment to offer the authentication challenge" do
+          WebMock.stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+            .to_return(
+              status: 400,
+              body: get_stripe_fixtures("payment_intent_authentication_required_response.json", version: "2025-04-30.basil")
+            )
+
+          result = create_service.call
+
+          expect(result).to be_failure
+          expect(result.error_code).to eq "authentication_required"
+          expect(result.should_retry).to eq true
+        end
+      end
     end
 
     context "when invoice amount is too big to pay with Boleto" do


### PR DESCRIPTION
Part of INT-210

## Context

A payment-gated subscription activates only once its first invoice is paid. When the customer's card requires 3D Secure, Stripe rejects the off-session charge with `authentication_required`, and the payment can only succeed if it is retried on-session so the customer can complete the challenge.

That retry was governed by the Stripe connection's `supports_3ds` setting, which is off by default. With it off, the rejection was terminal: the invoice was marked as failed and the subscription was canceled seconds after creation — indistinguishable from a real decline, and with no path for the customer to authenticate or to subscribe with that card at all.

## Description

The activation payment of a payment-gated subscription now always gets the on-session retry, regardless of the connection setting, so the customer is offered the authentication challenge and the subscription stays incomplete while it is pending. The setting keeps governing recurring invoices, where escalating a silent off-session charge to an interactive one stays an opt-in.

The scoping lever is `Invoice#subscription_payment_gated?` (open invoice + incomplete gated subscription), so no new column or plan-level flag is needed: a recurring invoice of an active subscription can never match.

Both decision points now read the same policy, which matters because they race each other: the synchronous charge attempt (which drives the retry) and the `payment_intent.payment_failed` webhook for the rejected off-session intent (which would otherwise settle the invoice as failed and cancel the subscription before the retry runs).

## Behavior change to be aware of

Organizations that never enabled `supports_3ds` now receive `payment.requires_action` with the Stripe-hosted challenge URL for activation payments, and must pass it to their customer. If they ignore that webhook, the subscription sits incomplete until the activation timeout instead of being canceled immediately — a better failure mode, but a change for orgs that never opted in. Note `timeout_hours` defaults to `0`, which means no deadline.
