### PR TITLE
feat(payment_terms) Add the new payment_term and payment_term_source columns

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -210,6 +210,7 @@ end
 #  logo                                         :string
 #  name                                         :string           not null
 #  net_payment_term                             :integer          default(0), not null
+#  payment_term                                 :jsonb
 #  phone                                        :string
 #  state                                        :string
 #  subscription_invoice_issuing_date_adjustment :enum             default("align_with_finalization_date"), not null

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -443,6 +443,7 @@ end
 #  payment_provider                             :string
 #  payment_provider_code                        :string
 #  payment_receipt_counter                      :bigint           default(0), not null
+#  payment_term                                 :jsonb
 #  phone                                        :string
 #  shipping_address_line1                       :string
 #  shipping_address_line2                       :string

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -775,6 +775,8 @@ end
 #  payment_due_date                        :date
 #  payment_overdue                         :boolean          default(FALSE)
 #  payment_status                          :integer          default("pending"), not null
+#  payment_term                            :jsonb
+#  payment_term_source                     :string
 #  prepaid_credit_amount_cents             :bigint           default(0), not null
 #  prepaid_granted_credit_amount_cents     :bigint
 #  prepaid_purchased_credit_amount_cents   :bigint

--- a/db/migrate/20260810135202_add_payment_terms.rb
+++ b/db/migrate/20260810135202_add_payment_terms.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddPaymentTerms < ActiveRecord::Migration[8.0]
+  def change
+    add_column :customers, :payment_term, :jsonb
+    add_column :billing_entities, :payment_term, :jsonb
+    add_column :invoices, :payment_term, :jsonb
+    add_column :invoices, :payment_term_source, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2299,7 +2299,8 @@ CREATE TABLE public.billing_entities (
     einvoicing boolean DEFAULT false NOT NULL,
     subscription_invoice_issuing_date_anchor public.subscription_invoice_issuing_date_anchors DEFAULT 'next_period_start'::public.subscription_invoice_issuing_date_anchors NOT NULL,
     subscription_invoice_issuing_date_adjustment public.subscription_invoice_issuing_date_adjustments DEFAULT 'align_with_finalization_date'::public.subscription_invoice_issuing_date_adjustments NOT NULL,
-    phone character varying
+    phone character varying,
+    payment_term jsonb
 );
 
 
@@ -2694,6 +2695,7 @@ CREATE TABLE public.customers (
     subscription_invoice_issuing_date_adjustment public.subscription_invoice_issuing_date_adjustments,
     awaiting_wallet_refresh boolean DEFAULT false NOT NULL,
     dunning_currency_attempts jsonb DEFAULT '{}'::jsonb NOT NULL,
+    payment_term jsonb,
     CONSTRAINT check_customers_on_invoice_grace_period CHECK ((invoice_grace_period >= 0)),
     CONSTRAINT check_customers_on_net_payment_term CHECK ((net_payment_term >= 0))
 );
@@ -3642,6 +3644,8 @@ CREATE TABLE public.invoices (
     payment_method_id uuid,
     skip_automatic_payment boolean,
     purchase_order_number character varying,
+    payment_term jsonb,
+    payment_term_source character varying,
     CONSTRAINT check_organizations_on_net_payment_term CHECK ((net_payment_term >= 0))
 );
 
@@ -14187,6 +14191,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260817175013'),
 ('20260817175012'),
+('20260810135202'),
 ('20260805201143'),
 ('20260805110509'),
 ('20260805110508'),


### PR DESCRIPTION
## Context

We're replacing the legacy `net_payment_term` integer with a structured `payment_term` object supporting six new types.

`net_payment_term` remains as a backward-compatible alias: it contains a value for Net and due-on-receipt terms and is null for types it cannot represent accurately

## Description

- The new `jsonb` column is added to `customers`, `billing_entities`, and `invoices`.
- An additional `payment_term_source` column is added to the `invoices` table to show from which object the payment term was derived.

Examples of content stored in the new field:

`{ "term_type": "due_on_receipt" }; `
`{ "term_type": "net", "days": 10 };`
`{ "term_type": "net_end_of_month", "days": 10 };`
`{ "term_type": "days_end_of_month",  "days": 10 };`
`{ "term_type": "days_end_of_month",  "day_of_month": 31, "month_offset": 3 };` (month_offset is optional, default: 1)


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>