### PR TITLE
feat(payment_terms): Add value object and date math

### DIFF
--- a/app/models/payment_term.rb
+++ b/app/models/payment_term.rb
@@ -2,7 +2,14 @@
 
 # Value object for a structured payment term, stored as jsonb tagged by term_type
 class PaymentTerm
-  TERM_TYPES = %w[due_on_receipt net end_of_month net_end_of_month days_end_of_month day_of_month].freeze
+  FIELDS_BY_TERM_TYPE = {
+    "due_on_receipt" => [],
+    "net" => ["days"],
+    "end_of_month" => [],
+    "net_end_of_month" => ["days"],
+    "days_end_of_month" => ["days"],
+    "day_of_month" => ["day_of_month", "month_offset"]
+  }.freeze
 
   attr_reader :term_type, :days, :day_of_month, :month_offset
 
@@ -19,8 +26,8 @@ class PaymentTerm
 
   def initialize(term_type:, days: nil, day_of_month: nil, month_offset: nil)
     @term_type = term_type.to_s
-    @days = days&.to_i
-    @day_of_month = day_of_month&.to_i
+    @days = days&.to_i if carries?("days")
+    @day_of_month = day_of_month&.to_i if carries?("day_of_month")
     @month_offset = normalized_month_offset(month_offset)
   end
 
@@ -42,6 +49,8 @@ class PaymentTerm
   end
 
   def due_date_for(issuing_date)
+    issuing_date = issuing_date.to_date
+
     case term_type
     when "due_on_receipt" then issuing_date
     when "net" then issuing_date + days
@@ -49,15 +58,20 @@ class PaymentTerm
     when "net_end_of_month" then issuing_date.end_of_month + days # US: EOM, then +N
     when "days_end_of_month" then (issuing_date + days).end_of_month # EU: +N, then EOM
     when "day_of_month" then day_of_month_due_date(issuing_date)
+    else raise ArgumentError, "unknown term_type: #{term_type}"
     end
   end
 
   private
 
+  def carries?(field)
+    FIELDS_BY_TERM_TYPE.fetch(term_type, []).include?(field)
+  end
+
   # Only day_of_month terms carry a month_offset.
   # If absent - next month (1) by default.
   def normalized_month_offset(month_offset)
-    if term_type == "day_of_month"
+    if carries?("month_offset")
       (month_offset || 1).to_i
     end
   end
@@ -75,6 +89,6 @@ class PaymentTerm
 
   # Clamp the configured day to the target month: day 31 → Sep 30 / Feb 28 (29 on leap years)
   def clamped_day_in_month(date)
-    Date.new(date.year, date.month, [day_of_month, date.end_of_month.day].min)
+    date.change(day: [day_of_month, date.end_of_month.day].min)
   end
 end

--- a/app/models/payment_term.rb
+++ b/app/models/payment_term.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Value object for a structured payment term, stored as jsonb tagged by term_type
+class PaymentTerm
+  TERM_TYPES = %w[due_on_receipt net end_of_month net_end_of_month days_end_of_month day_of_month].freeze
+
+  attr_reader :term_type, :days, :day_of_month, :month_offset
+
+  def self.from_h(hash)
+    hash = hash.to_h.with_indifferent_access
+
+    new(
+      term_type: hash[:term_type],
+      days: hash[:days],
+      day_of_month: hash[:day_of_month],
+      month_offset: hash[:month_offset]
+    )
+  end
+
+  def initialize(term_type:, days: nil, day_of_month: nil, month_offset: nil)
+    @term_type = term_type.to_s
+    @days = days&.to_i
+    @day_of_month = day_of_month&.to_i
+    @month_offset = normalized_month_offset(month_offset)
+  end
+
+  def to_h
+    {
+      "term_type" => term_type,
+      "days" => days,
+      "day_of_month" => day_of_month,
+      "month_offset" => month_offset
+    }.compact
+  end
+
+  # N for net, 0 for due_on_receipt, nil for the four types the integer cannot represent.
+  def net_payment_term_alias
+    case term_type
+    when "net" then days
+    when "due_on_receipt" then 0
+    end
+  end
+
+  def due_date_for(issuing_date)
+    case term_type
+    when "due_on_receipt" then issuing_date
+    when "net" then issuing_date + days
+    when "end_of_month" then issuing_date.end_of_month
+    when "net_end_of_month" then issuing_date.end_of_month + days # US: EOM, then +N
+    when "days_end_of_month" then (issuing_date + days).end_of_month # EU: +N, then EOM
+    when "day_of_month" then day_of_month_due_date(issuing_date)
+    end
+  end
+
+  private
+
+  # Only day_of_month terms carry a month_offset.
+  # If absent - next month (1) by default.
+  def normalized_month_offset(month_offset)
+    if term_type == "day_of_month"
+      (month_offset || 1).to_i
+    end
+  end
+
+  # month_offset → clamp → roll forward (only reachable with offset 0) → re-clamp
+  def day_of_month_due_date(issuing_date)
+    due_date = clamped_day_in_month(issuing_date >> month_offset)
+
+    if due_date < issuing_date
+      clamped_day_in_month(due_date >> 1)
+    else
+      due_date
+    end
+  end
+
+  # Clamp the configured day to the target month: day 31 → Sep 30 / Feb 28 (29 on leap years)
+  def clamped_day_in_month(date)
+    Date.new(date.year, date.month, [day_of_month, date.end_of_month.day].min)
+  end
+end

--- a/spec/models/payment_term_spec.rb
+++ b/spec/models/payment_term_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentTerm do
+  let(:issuing_date) { Date.new(2026, 7, 15) }
+
+  describe ".from_h" do
+    it "builds a term from a jsonb-style hash with string keys" do
+      term = described_class.from_h("term_type" => "net", "days" => 30)
+
+      expect(term.term_type).to eq("net")
+      expect(term.days).to eq(30)
+    end
+
+    it "builds a term from a hash with symbol keys" do
+      term = described_class.from_h(term_type: "day_of_month", day_of_month: 15, month_offset: 2)
+
+      expect(term.term_type).to eq("day_of_month")
+      expect(term.day_of_month).to eq(15)
+      expect(term.month_offset).to eq(2)
+    end
+
+    it "defaults month_offset to 1 for day_of_month" do
+      term = described_class.from_h(term_type: "day_of_month", day_of_month: 15)
+
+      expect(term.month_offset).to eq(1)
+    end
+  end
+
+  describe "#to_h" do
+    it "serializes only the fields carried by the term type" do
+      expect(described_class.from_h(term_type: "due_on_receipt").to_h)
+        .to eq("term_type" => "due_on_receipt")
+      expect(described_class.from_h(term_type: "net", days: 30).to_h)
+        .to eq("term_type" => "net", "days" => 30)
+      expect(described_class.from_h(term_type: "end_of_month").to_h)
+        .to eq("term_type" => "end_of_month")
+      expect(described_class.from_h(term_type: "day_of_month", day_of_month: 31).to_h)
+        .to eq("term_type" => "day_of_month", "day_of_month" => 31, "month_offset" => 1)
+    end
+
+    it "round-trips through from_h" do
+      hash = {"term_type" => "days_end_of_month", "days" => 30}
+
+      expect(described_class.from_h(hash).to_h).to eq(hash)
+    end
+  end
+
+  describe "#net_payment_term_alias" do
+    it "returns N for net, 0 for due_on_receipt and nil for the four new types" do
+      expect(described_class.from_h(term_type: "net", days: 30).net_payment_term_alias).to eq(30)
+      expect(described_class.from_h(term_type: "due_on_receipt").net_payment_term_alias).to eq(0)
+      expect(described_class.from_h(term_type: "end_of_month").net_payment_term_alias).to be_nil
+      expect(described_class.from_h(term_type: "net_end_of_month", days: 30).net_payment_term_alias).to be_nil
+      expect(described_class.from_h(term_type: "days_end_of_month", days: 30).net_payment_term_alias).to be_nil
+      expect(described_class.from_h(term_type: "day_of_month", day_of_month: 15).net_payment_term_alias).to be_nil
+    end
+  end
+
+  describe "#due_date_for" do
+    context "when due_on_receipt" do
+      it "returns the issuing date" do
+        term = described_class.from_h(term_type: "due_on_receipt")
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 7, 15))
+      end
+    end
+
+    context "when net" do
+      it "adds N days to the issuing date" do
+        term = described_class.from_h(term_type: "net", days: 30)
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 8, 14))
+      end
+
+      it "equals due_on_receipt when days is 0" do
+        term = described_class.from_h(term_type: "net", days: 0)
+
+        expect(term.due_date_for(issuing_date)).to eq(issuing_date)
+      end
+    end
+
+    context "when end_of_month" do
+      it "returns the last day of the issuing month" do
+        term = described_class.from_h(term_type: "end_of_month")
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 7, 31))
+      end
+
+      it "handles February in a leap year" do
+        term = described_class.from_h(term_type: "end_of_month")
+
+        expect(term.due_date_for(Date.new(2028, 2, 10))).to eq(Date.new(2028, 2, 29))
+      end
+    end
+
+    context "when net_end_of_month (US)" do
+      it "goes to end of month, then adds N days" do
+        term = described_class.from_h(term_type: "net_end_of_month", days: 30)
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 8, 30))
+      end
+
+      it "equals end_of_month when days is 0" do
+        term = described_class.from_h(term_type: "net_end_of_month", days: 0)
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 7, 31))
+      end
+    end
+
+    context "when days_end_of_month (EU)" do
+      it "adds N days, then goes to end of month" do
+        term = described_class.from_h(term_type: "days_end_of_month", days: 30)
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 8, 31))
+      end
+
+      it "equals end_of_month when days is 0" do
+        term = described_class.from_h(term_type: "days_end_of_month", days: 0)
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 7, 31))
+      end
+    end
+
+    context "when the two end-of-month types share the same days value" do
+      it "produces diverging due dates because the order of operations differs" do
+        us = described_class.from_h(term_type: "net_end_of_month", days: 30)
+        eu = described_class.from_h(term_type: "days_end_of_month", days: 30)
+
+        expect(us.due_date_for(issuing_date)).to eq(Date.new(2026, 8, 30))
+        expect(eu.due_date_for(issuing_date)).to eq(Date.new(2026, 8, 31))
+      end
+    end
+
+    context "when day_of_month" do
+      it "returns the Dth day of the month after month_offset" do
+        term = described_class.from_h(term_type: "day_of_month", day_of_month: 15)
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 8, 15))
+      end
+
+      it "supports a month_offset greater than 1" do
+        term = described_class.from_h(term_type: "day_of_month", day_of_month: 15, month_offset: 2)
+
+        expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 9, 15))
+      end
+
+      it "clamps the day to the last day of a shorter month" do
+        term = described_class.from_h(term_type: "day_of_month", day_of_month: 31)
+
+        expect(term.due_date_for(Date.new(2026, 8, 15))).to eq(Date.new(2026, 9, 30))
+      end
+
+      it "clamps to February 28 in a non-leap year" do
+        term = described_class.from_h(term_type: "day_of_month", day_of_month: 31)
+
+        expect(term.due_date_for(Date.new(2026, 1, 15))).to eq(Date.new(2026, 2, 28))
+      end
+
+      it "clamps to February 29 in a leap year" do
+        term = described_class.from_h(term_type: "day_of_month", day_of_month: 31)
+
+        expect(term.due_date_for(Date.new(2028, 1, 15))).to eq(Date.new(2028, 2, 29))
+      end
+
+      context "with month_offset 0" do
+        it "rolls forward to the next month when the day is before the issuing date" do
+          term = described_class.from_h(term_type: "day_of_month", day_of_month: 10, month_offset: 0)
+
+          expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 8, 10))
+        end
+
+        it "does not roll when the day equals the issuing date" do
+          term = described_class.from_h(term_type: "day_of_month", day_of_month: 15, month_offset: 0)
+
+          expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 7, 15))
+        end
+
+        it "does not roll when the day is after the issuing date" do
+          term = described_class.from_h(term_type: "day_of_month", day_of_month: 20, month_offset: 0)
+
+          expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 7, 20))
+        end
+
+        it "re-clamps when the roll lands on a shorter month" do
+          # issued Jan 31, day 30 → Jan 30 is in the past → roll → Feb 28
+          term = described_class.from_h(term_type: "day_of_month", day_of_month: 30, month_offset: 0)
+
+          expect(term.due_date_for(Date.new(2026, 1, 31))).to eq(Date.new(2026, 2, 28))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/payment_term_spec.rb
+++ b/spec/models/payment_term_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe PaymentTerm do
 
       expect(described_class.from_h(hash).to_h).to eq(hash)
     end
+
+    it "drops fields not carried by the term type" do
+      term = described_class.from_h(term_type: "end_of_month", days: 5, day_of_month: 10, month_offset: 2)
+
+      expect(term.to_h).to eq("term_type" => "end_of_month")
+    end
   end
 
   describe "#net_payment_term_alias" do
@@ -64,6 +70,26 @@ RSpec.describe PaymentTerm do
         term = described_class.from_h(term_type: "due_on_receipt")
 
         expect(term.due_date_for(issuing_date)).to eq(Date.new(2026, 7, 15))
+      end
+    end
+
+    context "when the issuing date is a Time" do
+      it "coerces to a Date so days are added as days, not seconds" do
+        term = described_class.from_h(term_type: "net", days: 30)
+
+        due_date = term.due_date_for(Time.zone.parse("2026-07-15 10:30:00"))
+
+        expect(due_date).to eq(Date.new(2026, 8, 14))
+        expect(due_date).to be_a(Date)
+      end
+    end
+
+    context "when the term type is unknown" do
+      it "raises an ArgumentError" do
+        term = described_class.from_h(term_type: "fortnightly")
+
+        expect { term.due_date_for(issuing_date) }
+          .to raise_error(ArgumentError, "unknown term_type: fortnightly")
       end
     end
 


### PR DESCRIPTION
## Context

We're replacing the legacy net_payment_term integer with a structured payment_term object supporting six new types:

term_type | Fields | Rule | Due date (invoice issued 2026‑07‑15)
-- | -- | -- | --
due_on_receipt | — | issue day | 2026‑07‑15
net | days | +N days | 2026‑08‑14
end_of_month | — | last day of month | 2026‑07‑31
net_end_of_month (US) | days | EOM then +N | 2026‑08‑30
days_end_of_month (EU) | days | +N then EOM | 2026‑08‑31
day_of_month | day_of_month (1–31), month_offset (default 1) | Dth of month+offset | 2026‑08‑15

## Description

- Added `PaymentTerm` value object with `due_date` calculations based on `payment_term` rule
- The `net_payment_term_alias` is applicable only for `due_on_receipt` and `net` terms. For all others it will be `nil`.

- For the `day_of_month` (MFI) term, 2 normalizations are introduced:
  - If `day_of_month` number is beyond the month's total days, set it to the last day of the month.
  _Example_: `day_of_month`: 31 -> in February, it will be 28 or 29.
  - If the date is in the past, move it to the next month.
  _Example_: current date 13/08, `day_of_month`: 3, `offset`: 0 -> move to the next month (03/09). Otherwise, because offset is 0, it would be a past date (03/08).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>