### PR TITLE
feat(payment_terms): Add Resolve and Validate services

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -96,7 +96,7 @@ class BillingEntity < ApplicationRecord
   validates :document_number_prefix, length: {minimum: 1, maximum: 10}, allow_nil: true, on: :create
   validates :document_number_prefix, length: {minimum: 1, maximum: 10}, on: :update
   validates :invoice_grace_period, numericality: {greater_than_or_equal_to: 0}
-  validates :net_payment_term, numericality: {greater_than_or_equal_to: 0}
+  validates :net_payment_term, numericality: {greater_than_or_equal_to: 0, only_integer: true}
   validates :logo,
     image: {authorized_content_type: %w[image/png image/jpg image/jpeg], max_size: 800.kilobytes},
     if: :logo?

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -165,7 +165,7 @@ class Customer < ApplicationRecord
     uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :organization_id},
     unless: :deleted_at
   validates :invoice_grace_period, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
-  validates :net_payment_term, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
+  validates :net_payment_term, numericality: {greater_than_or_equal_to: 0, only_integer: true}, allow_nil: true
   validates :payment_provider, inclusion: {in: PAYMENT_PROVIDERS}, allow_nil: true
   validates :timezone, timezone: true, allow_nil: true
   validates :email, email: true, if: -> { email? && will_save_change_to_email? }

--- a/app/services/payment_terms/resolve_service.rb
+++ b/app/services/payment_terms/resolve_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PaymentTerms
+  class ResolveService < BaseService
+    Result = BaseResult[:payment_term, :source]
+
+    DEFAULT_TERM = {"term_type" => "due_on_receipt"}.freeze
+
+    def initialize(customer:)
+      @customer = customer
+      super
+    end
+
+    def call
+      if customer.payment_term.present?
+        result.payment_term = PaymentTerm.from_h(customer.payment_term)
+        result.source = "customer"
+      elsif customer.billing_entity.payment_term.present?
+        result.payment_term = PaymentTerm.from_h(customer.billing_entity.payment_term)
+        result.source = "billing_entity"
+      else
+        result.payment_term = PaymentTerm.from_h(DEFAULT_TERM)
+        result.source = "default"
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :customer
+  end
+end

--- a/app/services/payment_terms/validate_service.rb
+++ b/app/services/payment_terms/validate_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module PaymentTerms
+  class ValidateService < BaseValidator
+    DAY_OF_MONTH_RANGE = (1..31)
+    MONTH_OFFSET_RANGE = (0..12)
+
+    def valid?
+      if payment_term.nil?
+        return true
+      end
+
+      if !payment_term.is_a?(Hash)
+        add_error(field: :payment_term, error_code: "invalid_format")
+      elsif !PaymentTerm::FIELDS_BY_TERM_TYPE.key?(term_type)
+        add_error(field: :payment_term, error_code: "invalid_term_type")
+      else
+        valid_fields?
+        valid_days?
+        valid_day_of_month?
+        valid_month_offset?
+      end
+
+      if errors?
+        result.validation_failure!(errors:)
+        return false
+      end
+
+      true
+    end
+
+    private
+
+    def payment_term
+      args[:payment_term]
+    end
+
+    def term_type
+      payment_term[:term_type]
+    end
+
+    def valid_fields?
+      unexpected = payment_term.keys.map(&:to_s) - ["term_type"] - PaymentTerm::FIELDS_BY_TERM_TYPE.fetch(term_type)
+      return true if unexpected.empty?
+
+      add_error(field: :payment_term, error_code: "unexpected_fields")
+    end
+
+    def valid_days?
+      return true unless PaymentTerm::FIELDS_BY_TERM_TYPE.fetch(term_type).include?("days")
+
+      days = payment_term[:days]
+
+      return true if days.is_a?(Integer) && days >= 0
+
+      add_error(field: :payment_term, error_code: "invalid_days")
+    end
+
+    def valid_day_of_month?
+      return true unless term_type == "day_of_month"
+
+      day = payment_term[:day_of_month]
+      return true if day.is_a?(Integer) && DAY_OF_MONTH_RANGE.cover?(day)
+
+      add_error(field: :payment_term, error_code: "invalid_day_of_month")
+    end
+
+    def valid_month_offset?
+      return true unless term_type == "day_of_month"
+
+      offset = payment_term[:month_offset]
+      # Absent is fine: PaymentTerm.from_h fills the default (1).
+      return true if offset.nil?
+      return true if offset.is_a?(Integer) && MONTH_OFFSET_RANGE.cover?(offset)
+
+      add_error(field: :payment_term, error_code: "invalid_month_offset")
+    end
+  end
+end

--- a/app/services/payment_terms/validate_service.rb
+++ b/app/services/payment_terms/validate_service.rb
@@ -6,20 +6,8 @@ module PaymentTerms
     MONTH_OFFSET_RANGE = (0..12)
 
     def valid?
-      if payment_term.nil?
-        return true
-      end
-
-      if !payment_term.is_a?(Hash)
-        add_error(field: :payment_term, error_code: "invalid_format")
-      elsif !PaymentTerm::FIELDS_BY_TERM_TYPE.key?(term_type)
-        add_error(field: :payment_term, error_code: "invalid_term_type")
-      else
-        valid_fields?
-        valid_days?
-        valid_day_of_month?
-        valid_month_offset?
-      end
+      valid_net_payment_term?
+      valid_payment_term?
 
       if errors?
         result.validation_failure!(errors:)
@@ -30,6 +18,36 @@ module PaymentTerms
     end
 
     private
+
+    def valid_net_payment_term?
+      value = args[:net_payment_term]
+      if value.nil?
+        true
+      elsif !value.is_a?(Integer)
+        add_error(field: :net_payment_term, error_code: "invalid_format")
+      elsif value.negative?
+        add_error(field: :net_payment_term, error_code: "value_is_out_of_range")
+      else
+        true
+      end
+    end
+
+    def valid_payment_term?
+      return true if payment_term.nil?
+
+      if !payment_term.is_a?(Hash)
+        return add_error(field: :payment_term, error_code: "invalid_format")
+      end
+
+      unless PaymentTerm::FIELDS_BY_TERM_TYPE.key?(term_type)
+        return add_error(field: :payment_term, error_code: "invalid_term_type")
+      end
+
+      valid_fields?
+      valid_days?
+      valid_day_of_month?
+      valid_month_offset?
+    end
 
     def payment_term
       args[:payment_term]

--- a/spec/services/payment_terms/resolve_service_spec.rb
+++ b/spec/services/payment_terms/resolve_service_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentTerms::ResolveService do
+  subject(:result) { described_class.call(customer:) }
+
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:customer) { create(:customer, organization:, billing_entity:) }
+
+  context "when the customer has a payment term" do
+    before do
+      customer.update!(payment_term: {term_type: "net", days: 45})
+      billing_entity.update!(payment_term: {term_type: "end_of_month"})
+    end
+
+    it "returns the customer term with source customer" do
+      expect(result).to be_success
+      expect(result.payment_term).to be_a(PaymentTerm)
+      expect(result.payment_term.term_type).to eq("net")
+      expect(result.payment_term.days).to eq(45)
+      expect(result.source).to eq("customer")
+    end
+  end
+
+  context "when only the billing entity has a payment term" do
+    before do
+      billing_entity.update!(payment_term: {term_type: "day_of_month", day_of_month: 15})
+    end
+
+    it "returns the billing entity term with source billing_entity" do
+      expect(result).to be_success
+      expect(result.payment_term.term_type).to eq("day_of_month")
+      expect(result.payment_term.day_of_month).to eq(15)
+      expect(result.payment_term.month_offset).to eq(1)
+      expect(result.source).to eq("billing_entity")
+    end
+  end
+
+  context "when no level has a payment term" do
+    it "falls back to due_on_receipt with source default" do
+      expect(result).to be_success
+      expect(result.payment_term.term_type).to eq("due_on_receipt")
+      expect(result.source).to eq("default")
+    end
+  end
+end

--- a/spec/services/payment_terms/validate_service_spec.rb
+++ b/spec/services/payment_terms/validate_service_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe PaymentTerms::ValidateService do
 
   let(:result) { BaseResult.new }
 
-  shared_examples "a term type carrying days" do |term_type|
-    context "when days is valid" do
-      [0, 30, 400].each do |days|
-        context "with #{days}" do
-          let(:payment_term) { {term_type:, days:} }
+  describe "net_payment_term validation" do
+    subject(:validate_service) { described_class.new(result, net_payment_term:) }
+
+    context "with an integer >= 0 or null" do
+      [30, 0, nil].each do |value|
+        context "with #{value.inspect}" do
+          let(:net_payment_term) { value }
 
           it "returns true" do
             expect(validate_service).to be_valid
@@ -21,128 +23,43 @@ RSpec.describe PaymentTerms::ValidateService do
       end
     end
 
-    context "when days is missing" do
-      let(:payment_term) { {term_type:} }
+    context "with a negative integer" do
+      let(:net_payment_term) { -1 }
 
-      it "fails with invalid_days" do
+      it "fails with value_is_out_of_range" do
         expect(validate_service).not_to be_valid
-        expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
+        expect(result.error.messages[:net_payment_term]).to eq(["value_is_out_of_range"])
       end
     end
 
-    context "when days is negative" do
-      let(:payment_term) { {term_type:, days: -1} }
+    context "with a non-integer value" do
+      [30.5, 30.0, "30", "abc", "", true, {}, []].each do |value|
+        context "with #{value.inspect}" do
+          let(:net_payment_term) { value }
 
-      it "fails with invalid_days" do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
-      end
-    end
-
-    context "when days is not an integer" do
-      let(:payment_term) { {term_type:, days: "30"} }
-
-      it "fails with invalid_days" do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
-      end
-    end
-  end
-
-  shared_examples "a term type carrying no fields" do |term_type, unexpected_field|
-    context "when no other field is sent" do
-      let(:payment_term) { {term_type:} }
-
-      it "returns true" do
-        expect(validate_service).to be_valid
-        expect(result).to be_success
-      end
-    end
-
-    context "when #{unexpected_field.keys.first} is sent" do
-      let(:payment_term) { {term_type:}.merge(unexpected_field) }
-
-      it "fails with unexpected_fields" do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:payment_term]).to include("unexpected_fields")
-      end
-    end
-  end
-
-  describe "#valid?" do
-    context "when payment_term is not provided" do
-      let(:payment_term) { nil }
-
-      it "returns true" do
-        expect(validate_service).to be_valid
-      end
-    end
-
-    context "when payment_term is not a hash" do
-      let(:payment_term) { "net 30" }
-
-      it "fails with invalid_format" do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:payment_term]).to eq(["invalid_format"])
-      end
-    end
-
-    context "when term_type is missing" do
-      let(:payment_term) { {days: 20} }
-
-      it "fails with invalid_term_type" do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:payment_term]).to eq(["invalid_term_type"])
-      end
-    end
-
-    context "when term_type is unknown" do
-      let(:payment_term) { {term_type: "net_15_eom"} }
-
-      it "fails with invalid_term_type" do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:payment_term]).to eq(["invalid_term_type"])
-      end
-    end
-
-    context "with due_on_receipt" do
-      it_behaves_like "a term type carrying no fields", "due_on_receipt", {days: 0}
-    end
-
-    context "with net" do
-      it_behaves_like "a term type carrying days", "net"
-
-      context "when day_of_month is sent" do
-        let(:payment_term) { {term_type: "net", days: 30, day_of_month: 5} }
-
-        it "fails with unexpected_fields" do
-          expect(validate_service).not_to be_valid
-          expect(result.error.messages[:payment_term]).to include("unexpected_fields")
+          it "fails with invalid_format" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:net_payment_term]).to eq(["invalid_format"])
+          end
         end
       end
     end
 
-    context "with end_of_month" do
-      it_behaves_like "a term type carrying no fields", "end_of_month", {month_offset: 1}
-    end
+    context "when the key is absent" do
+      subject(:validate_service) { described_class.new(result) }
 
-    context "with net_end_of_month" do
-      it_behaves_like "a term type carrying days", "net_end_of_month"
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
     end
+  end
 
-    context "with days_end_of_month" do
-      it_behaves_like "a term type carrying days", "days_end_of_month"
-    end
-
-    context "with day_of_month" do
-      context "when day_of_month is valid" do
-        [
-          {day_of_month: 15},
-          {day_of_month: 31, month_offset: 0},
-          {day_of_month: 1, month_offset: 12}
-        ].each do |fields|
-          context "with #{fields.inspect}" do
-            let(:payment_term) { {term_type: "day_of_month"}.merge(fields) }
+  describe "payment_term validation" do
+    shared_examples "a term type carrying days" do |term_type|
+      context "when days is valid" do
+        [0, 30, 400].each do |days|
+          context "with #{days}" do
+            let(:payment_term) { {term_type:, days:} }
 
             it "returns true" do
               expect(validate_service).to be_valid
@@ -152,52 +69,46 @@ RSpec.describe PaymentTerms::ValidateService do
         end
       end
 
-      context "when day_of_month is missing" do
-        let(:payment_term) { {term_type: "day_of_month"} }
+      context "when days is missing" do
+        let(:payment_term) { {term_type:} }
 
-        it "fails with invalid_day_of_month" do
+        it "fails with invalid_days" do
           expect(validate_service).not_to be_valid
-          expect(result.error.messages[:payment_term]).to eq(["invalid_day_of_month"])
+          expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
         end
       end
 
-      context "when day_of_month is out of the 1..31 range" do
-        [0, 32].each do |day|
-          context "with #{day}" do
-            let(:payment_term) { {term_type: "day_of_month", day_of_month: day} }
+      context "when days is negative" do
+        let(:payment_term) { {term_type:, days: -1} }
 
-            it "fails with invalid_day_of_month" do
-              expect(validate_service).not_to be_valid
-              expect(result.error.messages[:payment_term]).to eq(["invalid_day_of_month"])
-            end
-          end
-        end
-      end
-
-      context "when month_offset is out of the 0..12 range" do
-        [-1, 13].each do |offset|
-          context "with #{offset}" do
-            let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, month_offset: offset} }
-
-            it "fails with invalid_month_offset" do
-              expect(validate_service).not_to be_valid
-              expect(result.error.messages[:payment_term]).to eq(["invalid_month_offset"])
-            end
-          end
-        end
-      end
-
-      context "when month_offset is not an integer" do
-        let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, month_offset: "1"} }
-
-        it "fails with invalid_month_offset" do
+        it "fails with invalid_days" do
           expect(validate_service).not_to be_valid
-          expect(result.error.messages[:payment_term]).to eq(["invalid_month_offset"])
+          expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
         end
       end
 
-      context "when days is sent" do
-        let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, days: 30} }
+      context "when days is not an integer" do
+        let(:payment_term) { {term_type:, days: "30"} }
+
+        it "fails with invalid_days" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
+        end
+      end
+    end
+
+    shared_examples "a term type carrying no fields" do |term_type, unexpected_field|
+      context "when no other field is sent" do
+        let(:payment_term) { {term_type:} }
+
+        it "returns true" do
+          expect(validate_service).to be_valid
+          expect(result).to be_success
+        end
+      end
+
+      context "when #{unexpected_field.keys.first} is sent" do
+        let(:payment_term) { {term_type:}.merge(unexpected_field) }
 
         it "fails with unexpected_fields" do
           expect(validate_service).not_to be_valid
@@ -206,11 +117,149 @@ RSpec.describe PaymentTerms::ValidateService do
       end
     end
 
-    context "with string keys" do
-      let(:payment_term) { {"term_type" => "net", "days" => 30} }
+    describe "#valid?" do
+      context "when payment_term is not provided" do
+        let(:payment_term) { nil }
 
-      it "returns true" do
-        expect(validate_service).to be_valid
+        it "returns true" do
+          expect(validate_service).to be_valid
+        end
+      end
+
+      context "when payment_term is not a hash" do
+        let(:payment_term) { "net 30" }
+
+        it "fails with invalid_format" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_term]).to eq(["invalid_format"])
+        end
+      end
+
+      context "when term_type is missing" do
+        let(:payment_term) { {days: 20} }
+
+        it "fails with invalid_term_type" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_term]).to eq(["invalid_term_type"])
+        end
+      end
+
+      context "when term_type is unknown" do
+        let(:payment_term) { {term_type: "net_15_eom"} }
+
+        it "fails with invalid_term_type" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_term]).to eq(["invalid_term_type"])
+        end
+      end
+
+      context "with due_on_receipt" do
+        it_behaves_like "a term type carrying no fields", "due_on_receipt", {days: 0}
+      end
+
+      context "with net" do
+        it_behaves_like "a term type carrying days", "net"
+
+        context "when day_of_month is sent" do
+          let(:payment_term) { {term_type: "net", days: 30, day_of_month: 5} }
+
+          it "fails with unexpected_fields" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:payment_term]).to include("unexpected_fields")
+          end
+        end
+      end
+
+      context "with end_of_month" do
+        it_behaves_like "a term type carrying no fields", "end_of_month", {month_offset: 1}
+      end
+
+      context "with net_end_of_month" do
+        it_behaves_like "a term type carrying days", "net_end_of_month"
+      end
+
+      context "with days_end_of_month" do
+        it_behaves_like "a term type carrying days", "days_end_of_month"
+      end
+
+      context "with day_of_month" do
+        context "when day_of_month is valid" do
+          [
+            {day_of_month: 15},
+            {day_of_month: 31, month_offset: 0},
+            {day_of_month: 1, month_offset: 12}
+          ].each do |fields|
+            context "with #{fields.inspect}" do
+              let(:payment_term) { {term_type: "day_of_month"}.merge(fields) }
+
+              it "returns true" do
+                expect(validate_service).to be_valid
+                expect(result).to be_success
+              end
+            end
+          end
+        end
+
+        context "when day_of_month is missing" do
+          let(:payment_term) { {term_type: "day_of_month"} }
+
+          it "fails with invalid_day_of_month" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:payment_term]).to eq(["invalid_day_of_month"])
+          end
+        end
+
+        context "when day_of_month is out of the 1..31 range" do
+          [0, 32].each do |day|
+            context "with #{day}" do
+              let(:payment_term) { {term_type: "day_of_month", day_of_month: day} }
+
+              it "fails with invalid_day_of_month" do
+                expect(validate_service).not_to be_valid
+                expect(result.error.messages[:payment_term]).to eq(["invalid_day_of_month"])
+              end
+            end
+          end
+        end
+
+        context "when month_offset is out of the 0..12 range" do
+          [-1, 13].each do |offset|
+            context "with #{offset}" do
+              let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, month_offset: offset} }
+
+              it "fails with invalid_month_offset" do
+                expect(validate_service).not_to be_valid
+                expect(result.error.messages[:payment_term]).to eq(["invalid_month_offset"])
+              end
+            end
+          end
+        end
+
+        context "when month_offset is not an integer" do
+          let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, month_offset: "1"} }
+
+          it "fails with invalid_month_offset" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:payment_term]).to eq(["invalid_month_offset"])
+          end
+        end
+
+        context "when days is sent" do
+          let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, days: 30} }
+
+          it "fails with unexpected_fields" do
+            expect(validate_service).not_to be_valid
+            expect(result.error.messages[:payment_term]).to include("unexpected_fields")
+          end
+        end
+      end
+
+      context "with string keys" do
+        let(:payment_term) { {"term_type" => "net", "days" => 30} }
+
+        it "returns true" do
+          expect(validate_service).to be_valid
+        end
       end
     end
   end

--- a/spec/services/payment_terms/validate_service_spec.rb
+++ b/spec/services/payment_terms/validate_service_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentTerms::ValidateService do
+  subject(:validate_service) { described_class.new(result, payment_term:) }
+
+  let(:result) { BaseResult.new }
+
+  shared_examples "a term type carrying days" do |term_type|
+    context "when days is valid" do
+      [0, 30, 400].each do |days|
+        context "with #{days}" do
+          let(:payment_term) { {term_type:, days:} }
+
+          it "returns true" do
+            expect(validate_service).to be_valid
+            expect(result).to be_success
+          end
+        end
+      end
+    end
+
+    context "when days is missing" do
+      let(:payment_term) { {term_type:} }
+
+      it "fails with invalid_days" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
+      end
+    end
+
+    context "when days is negative" do
+      let(:payment_term) { {term_type:, days: -1} }
+
+      it "fails with invalid_days" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
+      end
+    end
+
+    context "when days is not an integer" do
+      let(:payment_term) { {term_type:, days: "30"} }
+
+      it "fails with invalid_days" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:payment_term]).to eq(["invalid_days"])
+      end
+    end
+  end
+
+  shared_examples "a term type carrying no fields" do |term_type, unexpected_field|
+    context "when no other field is sent" do
+      let(:payment_term) { {term_type:} }
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+        expect(result).to be_success
+      end
+    end
+
+    context "when #{unexpected_field.keys.first} is sent" do
+      let(:payment_term) { {term_type:}.merge(unexpected_field) }
+
+      it "fails with unexpected_fields" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:payment_term]).to include("unexpected_fields")
+      end
+    end
+  end
+
+  describe "#valid?" do
+    context "when payment_term is not provided" do
+      let(:payment_term) { nil }
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
+    end
+
+    context "when payment_term is not a hash" do
+      let(:payment_term) { "net 30" }
+
+      it "fails with invalid_format" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:payment_term]).to eq(["invalid_format"])
+      end
+    end
+
+    context "when term_type is missing" do
+      let(:payment_term) { {days: 20} }
+
+      it "fails with invalid_term_type" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:payment_term]).to eq(["invalid_term_type"])
+      end
+    end
+
+    context "when term_type is unknown" do
+      let(:payment_term) { {term_type: "net_15_eom"} }
+
+      it "fails with invalid_term_type" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:payment_term]).to eq(["invalid_term_type"])
+      end
+    end
+
+    context "with due_on_receipt" do
+      it_behaves_like "a term type carrying no fields", "due_on_receipt", {days: 0}
+    end
+
+    context "with net" do
+      it_behaves_like "a term type carrying days", "net"
+
+      context "when day_of_month is sent" do
+        let(:payment_term) { {term_type: "net", days: 30, day_of_month: 5} }
+
+        it "fails with unexpected_fields" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_term]).to include("unexpected_fields")
+        end
+      end
+    end
+
+    context "with end_of_month" do
+      it_behaves_like "a term type carrying no fields", "end_of_month", {month_offset: 1}
+    end
+
+    context "with net_end_of_month" do
+      it_behaves_like "a term type carrying days", "net_end_of_month"
+    end
+
+    context "with days_end_of_month" do
+      it_behaves_like "a term type carrying days", "days_end_of_month"
+    end
+
+    context "with day_of_month" do
+      context "when day_of_month is valid" do
+        [
+          {day_of_month: 15},
+          {day_of_month: 31, month_offset: 0},
+          {day_of_month: 1, month_offset: 12}
+        ].each do |fields|
+          context "with #{fields.inspect}" do
+            let(:payment_term) { {term_type: "day_of_month"}.merge(fields) }
+
+            it "returns true" do
+              expect(validate_service).to be_valid
+              expect(result).to be_success
+            end
+          end
+        end
+      end
+
+      context "when day_of_month is missing" do
+        let(:payment_term) { {term_type: "day_of_month"} }
+
+        it "fails with invalid_day_of_month" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_term]).to eq(["invalid_day_of_month"])
+        end
+      end
+
+      context "when day_of_month is out of the 1..31 range" do
+        [0, 32].each do |day|
+          context "with #{day}" do
+            let(:payment_term) { {term_type: "day_of_month", day_of_month: day} }
+
+            it "fails with invalid_day_of_month" do
+              expect(validate_service).not_to be_valid
+              expect(result.error.messages[:payment_term]).to eq(["invalid_day_of_month"])
+            end
+          end
+        end
+      end
+
+      context "when month_offset is out of the 0..12 range" do
+        [-1, 13].each do |offset|
+          context "with #{offset}" do
+            let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, month_offset: offset} }
+
+            it "fails with invalid_month_offset" do
+              expect(validate_service).not_to be_valid
+              expect(result.error.messages[:payment_term]).to eq(["invalid_month_offset"])
+            end
+          end
+        end
+      end
+
+      context "when month_offset is not an integer" do
+        let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, month_offset: "1"} }
+
+        it "fails with invalid_month_offset" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_term]).to eq(["invalid_month_offset"])
+        end
+      end
+
+      context "when days is sent" do
+        let(:payment_term) { {term_type: "day_of_month", day_of_month: 15, days: 30} }
+
+        it "fails with unexpected_fields" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_term]).to include("unexpected_fields")
+        end
+      end
+    end
+
+    context "with string keys" do
+      let(:payment_term) { {"term_type" => "net", "days" => 30} }
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
Structured payment terms can be configured at the customer or billing entity level. We need a single place to resolve the applicable term and validate each supported term shape before it is persisted.

## Description
These services are preparation for following PRs, where they will be used.

- Add PaymentTerms::ResolveService with the following precedence:
  `Customer.payment_term -> BillingEntity.payment_term -> due_on_receipt default`
- Return the resolved payment term and its source.
- Add PaymentTerms::ValidateService to validate:
  - Supported term types
  - Required and unexpected fields
  - Non-negative days
  - day_of_month between 1 and 31
  - month_offset between 0 and 12
- Support clearing an optional payment term with nil.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>