### PR TITLE
feat(graphql): Add flexible payment terms

### DIFF
--- a/app/graphql/mutations/billing_entities/create.rb
+++ b/app/graphql/mutations/billing_entities/create.rb
@@ -16,6 +16,10 @@ module Mutations
       type Types::BillingEntities::Object
 
       def resolve(**args)
+        if args[:payment_term]
+          args[:payment_term] = args[:payment_term].to_h
+        end
+
         result = ::BillingEntities::CreateService.call(
           organization: current_organization,
           params: args

--- a/app/graphql/mutations/billing_entities/update.rb
+++ b/app/graphql/mutations/billing_entities/update.rb
@@ -16,6 +16,10 @@ module Mutations
       type Types::BillingEntities::Object
 
       def resolve(**args)
+        if args[:payment_term]
+          args[:payment_term] = args[:payment_term].to_h
+        end
+
         billing_entity = current_organization.billing_entities.find_by(id: args[:id])
         result = ::BillingEntities::UpdateService.call(billing_entity:, params: args)
 

--- a/app/graphql/mutations/customers/create.rb
+++ b/app/graphql/mutations/customers/create.rb
@@ -16,6 +16,10 @@ module Mutations
       type Types::Customers::Object
 
       def resolve(**args)
+        if args[:payment_term]
+          args[:payment_term] = args[:payment_term].to_h
+        end
+
         result = ::Customers::CreateService.call(
           **args.merge(organization_id: current_organization.id)
         )

--- a/app/graphql/mutations/customers/update.rb
+++ b/app/graphql/mutations/customers/update.rb
@@ -16,6 +16,10 @@ module Mutations
       type Types::Customers::Object
 
       def resolve(**args)
+        if args[:payment_term]
+          args[:payment_term] = args[:payment_term].to_h
+        end
+
         customer = current_organization.customers.find_by(id: args[:id])
         result = ::Customers::UpdateService.call(customer:, args:)
 

--- a/app/graphql/mutations/subscriptions/create.rb
+++ b/app/graphql/mutations/subscriptions/create.rb
@@ -16,6 +16,10 @@ module Mutations
       type Types::Subscriptions::Object
 
       def resolve(entitlements: nil, **args)
+        if args[:payment_term]
+          args[:payment_term] = args[:payment_term].to_h
+        end
+
         customer = current_organization.customers.find_by(id: args[:customer_id])
         plan = current_organization.plans.find_by(id: args[:plan_id])
 

--- a/app/graphql/mutations/subscriptions/update.rb
+++ b/app/graphql/mutations/subscriptions/update.rb
@@ -16,6 +16,10 @@ module Mutations
       type Types::Subscriptions::Object
 
       def resolve(entitlements: nil, **args)
+        if args[:payment_term]
+          args[:payment_term] = args[:payment_term].to_h
+        end
+
         subscription = current_organization.subscriptions.find_by(id: args[:id])
         result = ::Subscriptions::UpdateService.call(subscription:, params: args)
 

--- a/app/graphql/types/billing_entities/create_input.rb
+++ b/app/graphql/types/billing_entities/create_input.rb
@@ -21,6 +21,7 @@ module Types
       argument :city, String, required: false
       argument :country, Types::CountryCodeEnum, required: false
       argument :net_payment_term, Integer, required: false
+      argument :payment_term, Types::PaymentTerms::Input, required: false
       argument :phone, String, required: false
       argument :state, String, required: false
       argument :zipcode, String, required: false

--- a/app/graphql/types/billing_entities/object.rb
+++ b/app/graphql/types/billing_entities/object.rb
@@ -26,6 +26,7 @@ module Types
       field :city, String
       field :country, Types::CountryCodeEnum
       field :net_payment_term, Integer
+      field :payment_term, Types::PaymentTerms::Object, null: true
       field :phone, String
       field :state, String
       field :zipcode, String
@@ -60,6 +61,12 @@ module Types
           subscription_invoice_issuing_date_anchor: object&.subscription_invoice_issuing_date_anchor,
           subscription_invoice_issuing_date_adjustment: object&.subscription_invoice_issuing_date_adjustment
         }
+      end
+
+      def payment_term
+        if object.payment_term.present?
+          PaymentTerm.from_h(object.payment_term)
+        end
       end
     end
   end

--- a/app/graphql/types/billing_entities/update_input.rb
+++ b/app/graphql/types/billing_entities/update_input.rb
@@ -23,6 +23,7 @@ module Types
       argument :city, String, required: false
       argument :country, Types::CountryCodeEnum, required: false
       argument :net_payment_term, Integer, required: false
+      argument :payment_term, Types::PaymentTerms::Input, required: false
       argument :phone, String, required: false
       argument :state, String, required: false
       argument :zipcode, String, required: false

--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -23,6 +23,7 @@ module Types
       argument :logo_url, String, required: false
       argument :name, String, required: false
       argument :net_payment_term, Integer, required: false
+      argument :payment_term, Types::PaymentTerms::Input, required: false
       argument :phone, String, required: false
       argument :state, String, required: false
       argument :tax_codes, [String], required: false

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -32,6 +32,7 @@ module Types
       field :net_payment_term, Integer, null: true
       field :payment_provider, Types::PaymentProviders::ProviderTypeEnum, null: true
       field :payment_provider_code, String, null: true
+      field :payment_term, Types::PaymentTerms::Object, null: true
       field :phone, String, null: true
       field :state, String, null: true
       field :tax_identification_number, String, null: true
@@ -205,6 +206,12 @@ module Types
 
       def has_overwritten_invoice_custom_sections_selection
         !object.skip_invoice_custom_sections && object.manual_selected_invoice_custom_sections.any?
+      end
+
+      def payment_term
+        if object.payment_term.present?
+          PaymentTerm.from_h(object.payment_term)
+        end
       end
     end
   end

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -45,6 +45,7 @@ module Types
       # Customer settings
       argument :invoice_grace_period, Integer, required: false, permissions: %w[customers:update]
       argument :net_payment_term, Integer, required: false, permissions: %w[customers:update]
+      argument :payment_term, Types::PaymentTerms::Input, required: false, permissions: %w[customers:update]
       argument :tax_codes, [String], required: false, permissions: %w[customers:update]
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -47,6 +47,7 @@ module Types
 
       field :expected_finalization_date, GraphQL::Types::ISO8601Date, null: false
       field :issuing_date, GraphQL::Types::ISO8601Date, null: false
+      field :payment_term, Types::PaymentTerms::Object, null: false, method: :snapshotted_payment_term
       field :payment_due_date, GraphQL::Types::ISO8601Date, null: false
       field :payment_overdue, Boolean, null: false
 

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -47,9 +47,9 @@ module Types
 
       field :expected_finalization_date, GraphQL::Types::ISO8601Date, null: false
       field :issuing_date, GraphQL::Types::ISO8601Date, null: false
-      field :payment_term, Types::PaymentTerms::Object, null: false, method: :snapshotted_payment_term
       field :payment_due_date, GraphQL::Types::ISO8601Date, null: false
       field :payment_overdue, Boolean, null: false
+      field :payment_term, Types::PaymentTerms::Object, null: false, method: :snapshotted_payment_term
 
       field :all_charges_have_fees, Boolean, null: false, method: :all_charges_have_fees?
       field :all_fixed_charges_have_fees, Boolean, null: false, method: :all_fixed_charges_have_fees?

--- a/app/graphql/types/payment_terms/input.rb
+++ b/app/graphql/types/payment_terms/input.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentTerms
+    class Input < BaseInputObject
+      graphql_name "PaymentTermInput"
+      description "Structured payment term input"
+
+      argument :day_of_month, Integer, required: false
+      argument :days, Integer, required: false
+      argument :month_offset, Integer, required: false
+      argument :term_type, Types::PaymentTerms::TermTypeEnum, required: true
+    end
+  end
+end

--- a/app/graphql/types/payment_terms/object.rb
+++ b/app/graphql/types/payment_terms/object.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentTerms
+    class Object < Types::BaseObject
+      graphql_name "PaymentTerm"
+      description "Structured payment term"
+
+      field :day_of_month, Integer, null: true
+      field :days, Integer, null: true
+      field :month_offset, Integer, null: true
+      field :term_type, Types::PaymentTerms::TermTypeEnum, null: false
+    end
+  end
+end

--- a/app/graphql/types/payment_terms/term_type_enum.rb
+++ b/app/graphql/types/payment_terms/term_type_enum.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentTerms
+    class TermTypeEnum < Types::BaseEnum
+      graphql_name "PaymentTermTypeEnum"
+      description "Payment term type"
+
+      ::PaymentTerm::FIELDS_BY_TERM_TYPE.each_key do |code|
+        value code
+      end
+    end
+  end
+end

--- a/app/graphql/types/subscriptions/create_subscription_input.rb
+++ b/app/graphql/types/subscriptions/create_subscription_input.rb
@@ -21,6 +21,7 @@ module Types
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
       argument :consolidate_invoice, Boolean, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
+      argument :payment_term, Types::PaymentTerms::Input, required: false
       argument :progressive_billing_disabled, Boolean, required: false
       argument :purchase_order_number, String, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -8,8 +8,8 @@ module Types
       field :billing_entity_id, ID, null: true
       field :customer, Types::Customers::Object, null: false
       field :external_id, String, null: false
-      field :payment_term, Types::PaymentTerms::Object, null: true
       field :id, ID, null: false
+      field :payment_term, Types::PaymentTerms::Object, null: true
       field :plan, Types::Plans::Object, null: false
 
       field :name, String, null: true

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -8,6 +8,7 @@ module Types
       field :billing_entity_id, ID, null: true
       field :customer, Types::Customers::Object, null: false
       field :external_id, String, null: false
+      field :payment_term, Types::PaymentTerms::Object, null: true
       field :id, ID, null: false
       field :plan, Types::Plans::Object, null: false
 

--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -14,6 +14,7 @@ module Types
       argument :invoice_custom_section, Types::InvoiceCustomSections::ReferenceInput, required: false
       argument :name, String, required: false
       argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
+      argument :payment_term, Types::PaymentTerms::Input, required: false
       argument :plan_overrides, Types::Subscriptions::PlanOverridesInput, required: false
       argument :progressive_billing_disabled, Boolean, required: false
       argument :purchase_order_number, String, required: false

--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -19,7 +19,7 @@ module BillingEntities
     def call
       return result.forbidden_failure! unless organization.can_create_billing_entity?
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term], net_payment_term: params[:net_payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, **params.slice(:payment_term, :net_payment_term)).valid?
         return result
       end
 

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -19,7 +19,7 @@ module BillingEntities
     def call
       return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term], net_payment_term: params[:net_payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, **params.slice(:payment_term, :net_payment_term)).valid?
         return result
       end
 

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -34,7 +34,7 @@ module Customers
         )
       end
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: args[:payment_term], net_payment_term: args[:net_payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, **args.slice(:payment_term, :net_payment_term)).valid?
         return result
       end
 

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -29,7 +29,7 @@ module Customers
         )
       end
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: args[:payment_term], net_payment_term: args[:net_payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, **args.slice(:payment_term, :net_payment_term)).valid?
         return result
       end
 

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -44,7 +44,7 @@ module Customers
         )
       end
 
-      unless PaymentTerms::ValidateService.new(result, payment_term: params[:payment_term], net_payment_term: params[:net_payment_term]).valid?
+      unless PaymentTerms::ValidateService.new(result, **params.slice(:payment_term, :net_payment_term)).valid?
         return result
       end
 

--- a/app/services/payment_terms/validate_service.rb
+++ b/app/services/payment_terms/validate_service.rb
@@ -8,6 +8,7 @@ module PaymentTerms
     def valid?
       valid_net_payment_term?
       valid_payment_term?
+      valid_alias_equivalence? unless errors?
 
       if errors?
         result.validation_failure!(errors:)
@@ -18,6 +19,17 @@ module PaymentTerms
     end
 
     private
+
+    def valid_alias_equivalence?
+      return true unless args.key?(:payment_term) && args[:net_payment_term].present?
+
+      alias_value = payment_term && PaymentTerm.from_h(payment_term).net_payment_term_alias
+      if alias_value != args[:net_payment_term]
+        add_error(field: :payment_term, error_code: "conflicting_net_payment_term")
+      else
+        true
+      end
+    end
 
     def valid_net_payment_term?
       value = args[:net_payment_term]

--- a/app/services/payment_terms/validate_service.rb
+++ b/app/services/payment_terms/validate_service.rb
@@ -21,9 +21,9 @@ module PaymentTerms
     private
 
     def valid_alias_equivalence?
-      return true unless args.key?(:payment_term) && args[:net_payment_term].present?
+      return true if payment_term.nil? || args[:net_payment_term].nil?
 
-      alias_value = payment_term && PaymentTerm.from_h(payment_term).net_payment_term_alias
+      alias_value = PaymentTerm.from_h(payment_term).net_payment_term_alias
       if alias_value != args[:net_payment_term]
         add_error(field: :payment_term, error_code: "conflicting_net_payment_term")
       else

--- a/schema.graphql
+++ b/schema.graphql
@@ -1073,6 +1073,7 @@ type BillingEntity {
   name: String!
   netPaymentTerm: Int
   organization: Organization!
+  paymentTerm: PaymentTerm
   phone: String
   selectedInvoiceCustomSections: [InvoiceCustomSection!]
   state: String
@@ -3057,6 +3058,7 @@ input CreateBillingEntityInput {
   logo: String
   name: String!
   netPaymentTerm: Int
+  paymentTerm: PaymentTermInput
   phone: String
   state: String
   taxIdentificationNumber: String
@@ -3175,6 +3177,7 @@ input CreateCustomerInput {
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
   paymentProviderCustomers: [PaymentProviderCustomerInput!]
+  paymentTerm: PaymentTermInput
   phone: String
   providerCustomer: ProviderCustomerInput
   shippingAddress: CustomerAddressInput
@@ -3868,6 +3871,7 @@ input CreateSubscriptionInput {
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
   name: String
   paymentMethod: PaymentMethodReferenceInput
+  paymentTerm: PaymentTermInput
   planId: ID!
   planOverrides: PlanOverridesInput
   progressiveBillingDisabled: Boolean
@@ -4942,6 +4946,7 @@ type Customer {
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
   paymentProviderCustomers: [ProviderCustomer!]!
+  paymentTerm: PaymentTerm
   phone: String
   providerCustomer: ProviderCustomer @deprecated(reason: "Use paymentProviderCustomers instead")
   salesforceCustomer: SalesforceCustomer @deprecated(reason: "Use integrationCustomers instead")
@@ -7425,6 +7430,7 @@ type Invoice {
   paymentDueDate: ISO8601Date!
   paymentOverdue: Boolean!
   paymentStatus: InvoicePaymentStatusTypeEnum!
+  paymentTerm: PaymentTerm!
   payments: [Payment!]
   prepaidCreditAmountCents: BigInt!
   prepaidGrantedCreditAmountCents: BigInt
@@ -10742,6 +10748,38 @@ input PaymentRequestCreateInput {
   paymentMethod: PaymentMethodReferenceInput
 }
 
+"""
+Structured payment term
+"""
+type PaymentTerm {
+  dayOfMonth: Int
+  days: Int
+  monthOffset: Int
+  termType: PaymentTermTypeEnum!
+}
+
+"""
+Structured payment term input
+"""
+input PaymentTermInput {
+  dayOfMonth: Int
+  days: Int
+  monthOffset: Int
+  termType: PaymentTermTypeEnum!
+}
+
+"""
+Payment term type
+"""
+enum PaymentTermTypeEnum {
+  day_of_month
+  days_end_of_month
+  due_on_receipt
+  end_of_month
+  net
+  net_end_of_month
+}
+
 enum PaymentTypeEnum {
   manual
   provider
@@ -13569,6 +13607,7 @@ type Subscription {
   onTerminationInvoice: OnTerminationInvoiceEnum!
   paymentMethod: PaymentMethod
   paymentMethodType: PaymentMethodTypeEnum
+  paymentTerm: PaymentTerm
   periodEndDate: ISO8601Date
   plan: Plan!
   previousPlan: Plan
@@ -14764,6 +14803,7 @@ input UpdateBillingEntityInput {
   logo: String
   name: String
   netPaymentTerm: Int
+  paymentTerm: PaymentTermInput
   phone: String
   state: String
   taxIdentificationNumber: String
@@ -14903,6 +14943,7 @@ input UpdateCustomerInput {
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
   paymentProviderCustomers: [PaymentProviderCustomerInput!]
+  paymentTerm: PaymentTermInput
   phone: String
   providerCustomer: ProviderCustomerInput
   shippingAddress: CustomerAddressInput
@@ -15680,6 +15721,7 @@ input UpdateSubscriptionInput {
   invoiceCustomSection: InvoiceCustomSectionsReferenceInput
   name: String
   paymentMethod: PaymentMethodReferenceInput
+  paymentTerm: PaymentTermInput
   planOverrides: PlanOverridesInput
   progressiveBillingDisabled: Boolean
   purchaseOrderNumber: String

--- a/schema.json
+++ b/schema.json
@@ -5728,6 +5728,18 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentTerm",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PaymentTerm",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "phone",
               "description": null,
               "args": [],
@@ -12572,6 +12584,18 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentTerm",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentTermInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "phone",
               "description": null,
               "type": {
@@ -13504,6 +13528,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentTerm",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentTermInput",
                 "ofType": null
               },
               "defaultValue": null,
@@ -18584,6 +18620,18 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentTerm",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentTermInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "progressiveBillingDisabled",
               "description": null,
               "type": {
@@ -22790,6 +22838,18 @@
                     }
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentTerm",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PaymentTerm",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -38810,6 +38870,22 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentTerm",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaymentTerm",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "payments",
               "description": null,
               "args": [],
@@ -52127,6 +52203,179 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PaymentTerm",
+          "description": "Structured payment term",
+          "fields": [
+            {
+              "name": "dayOfMonth",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "days",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "monthOffset",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "termType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PaymentTermTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PaymentTermInput",
+          "description": "Structured payment term input",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "dayOfMonth",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "days",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "monthOffset",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "termType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PaymentTermTypeEnum",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "PaymentTermTypeEnum",
+          "description": "Payment term type",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "due_on_receipt",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "net",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "end_of_month",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "net_end_of_month",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "days_end_of_month",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "day_of_month",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -74115,6 +74364,18 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentTerm",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PaymentTerm",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "periodEndDate",
               "description": null,
               "args": [],
@@ -78033,6 +78294,18 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentTerm",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentTermInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "phone",
               "description": null,
               "type": {
@@ -79228,6 +79501,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentTerm",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentTermInput",
                 "ofType": null
               },
               "defaultValue": null,
@@ -84493,6 +84778,18 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "PaymentMethodReferenceInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentTerm",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentTermInput",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/billing_entities/create_spec.rb
+++ b/spec/graphql/mutations/billing_entities/create_spec.rb
@@ -175,4 +175,43 @@ RSpec.describe Mutations::BillingEntities::Create, :premium do
       expect(result_data["billingConfiguration"]["subscriptionInvoiceIssuingDateAdjustment"]).to eq("keep_anchor")
     end
   end
+
+  context "with payment_term" do
+    let(:organization) { create(:organization, premium_integrations: %w[multi_entities_enterprise]) }
+
+    let(:payment_term_mutation) do
+      <<~GQL
+        mutation($input: CreateBillingEntityInput!) {
+          createBillingEntity(input: $input) {
+            id
+            paymentTerm { termType days dayOfMonth monthOffset }
+          }
+        }
+      GQL
+    end
+
+    it "creates a billing entity with a payment term" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: payment_term_mutation,
+        variables: {
+          input: {
+            code: "entity-with-term",
+            name: "Entity with term",
+            paymentTerm: {termType: "day_of_month", dayOfMonth: 31, monthOffset: 0}
+          }
+        }
+      )
+
+      payment_term = result["data"]["createBillingEntity"]["paymentTerm"]
+      expect(payment_term["termType"]).to eq("day_of_month")
+      expect(payment_term["dayOfMonth"]).to eq(31)
+      expect(payment_term["monthOffset"]).to eq(0)
+
+      billing_entity = BillingEntity.find(result["data"]["createBillingEntity"]["id"])
+      expect(billing_entity.payment_term).to eq("term_type" => "day_of_month", "day_of_month" => 31, "month_offset" => 0)
+    end
+  end
 end

--- a/spec/graphql/mutations/billing_entities/update_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_spec.rb
@@ -231,6 +231,16 @@ RSpec.describe Mutations::BillingEntities::Update, :premium do
       expect(billing_entity.reload.payment_term).to be_nil
     end
 
+    it "clears both fields when null is sent alongside a legacy alias" do
+      billing_entity.update!(payment_term: {term_type: "net", days: 30}, net_payment_term: 30)
+
+      response = update_payment_term(nil, netPaymentTerm: 20)
+
+      expect(response["errors"]).to be_nil
+      expect(response.dig("data", "updateBillingEntity", "paymentTerm")).to be_nil
+      expect(billing_entity.reload).to have_attributes(payment_term: nil, net_payment_term: nil)
+    end
+
     it "rejects an invalid payment term" do
       result = update_payment_term({termType: "day_of_month", dayOfMonth: 32})
 

--- a/spec/graphql/mutations/billing_entities/update_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_spec.rb
@@ -190,4 +190,82 @@ RSpec.describe Mutations::BillingEntities::Update, :premium do
       )
     end
   end
+
+  context "with payment_term" do
+    let(:payment_term_mutation) do
+      <<~GQL
+        mutation($input: UpdateBillingEntityInput!) {
+          updateBillingEntity(input: $input) {
+            id
+            paymentTerm { termType days dayOfMonth monthOffset }
+          }
+        }
+      GQL
+    end
+
+    def update_payment_term(payment_term, **extra_input)
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: payment_term_mutation,
+        variables: {input: {id: billing_entity.id, paymentTerm: payment_term, **extra_input}}
+      )
+    end
+
+    it "sets the payment term" do
+      result = update_payment_term({termType: "end_of_month"})
+
+      payment_term = result["data"]["updateBillingEntity"]["paymentTerm"]
+      expect(payment_term["termType"]).to eq("end_of_month")
+      expect(payment_term["days"]).to be_nil
+      expect(billing_entity.reload.payment_term).to eq("term_type" => "end_of_month")
+    end
+
+    it "clears the payment term when null is sent" do
+      billing_entity.update!(payment_term: {term_type: "net", days: 30})
+
+      result = update_payment_term(nil)
+
+      expect(result["data"]["updateBillingEntity"]["paymentTerm"]).to be_nil
+      expect(billing_entity.reload.payment_term).to be_nil
+    end
+
+    it "rejects an invalid payment term" do
+      result = update_payment_term({termType: "day_of_month", dayOfMonth: 32})
+
+      expect_unprocessable_entity(result)
+      expect(billing_entity.reload.payment_term).to be_nil
+    end
+
+    it "rejects conflicting aliases without changing the record" do
+      billing_entity.update!(payment_term: {term_type: "net", days: 10}, net_payment_term: 10)
+
+      response = update_payment_term({termType: "net", days: 30}, netPaymentTerm: 60)
+
+      expect_unprocessable_entity(response)
+      expect(billing_entity.reload.payment_term).to eq("term_type" => "net", "days" => 10)
+      expect(billing_entity.net_payment_term).to eq(10)
+    end
+
+    it "accepts a null alias echoed back with a structured term" do
+      response = update_payment_term({termType: "end_of_month"}, netPaymentTerm: nil)
+
+      expect(response["errors"]).to be_nil
+      expect(response.dig("data", "updateBillingEntity", "paymentTerm", "termType")).to eq("end_of_month")
+      expect(billing_entity.reload.net_payment_term).to be_nil
+    end
+
+    it "keeps existing draft invoice terms and due dates unchanged" do
+      customer = create(:customer, organization:, billing_entity:)
+      draft = create(:invoice, :draft, customer:, organization:, billing_entity:, payment_term: {term_type: "net", days: 30}, net_payment_term: 30)
+      original_due_date = draft.payment_due_date
+
+      response = update_payment_term({termType: "end_of_month"})
+
+      expect(response["errors"]).to be_nil
+      expect(draft.reload.payment_due_date).to eq(original_due_date)
+      expect(draft.payment_term).to eq("term_type" => "net", "days" => 30)
+    end
+  end
 end

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -273,4 +273,40 @@ RSpec.describe Mutations::Customers::Create do
       expect(result["errors"]).to be_present
     end
   end
+
+  context "with payment_term" do
+    let(:payment_term_mutation) do
+      <<~GQL
+        mutation($input: CreateCustomerInput!) {
+          createCustomer(input: $input) {
+            id
+            paymentTerm { termType days dayOfMonth monthOffset }
+          }
+        }
+      GQL
+    end
+
+    it "creates a customer with a payment term" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permissions,
+        query: payment_term_mutation,
+        variables: {
+          input: {
+            name: "Payment term customer",
+            externalId: SecureRandom.uuid,
+            paymentTerm: {termType: "net_end_of_month", days: 15}
+          }
+        }
+      )
+
+      payment_term = result["data"]["createCustomer"]["paymentTerm"]
+      expect(payment_term["termType"]).to eq("net_end_of_month")
+      expect(payment_term["days"]).to eq(15)
+
+      customer = Customer.find(result["data"]["createCustomer"]["id"])
+      expect(customer.payment_term).to eq("term_type" => "net_end_of_month", "days" => 15)
+    end
+  end
 end

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -241,4 +241,82 @@ RSpec.describe Mutations::Customers::Update do
       expect(existing_connection.reload).to be_discarded
     end
   end
+
+  context "with payment_term" do
+    let(:payment_term_mutation) do
+      <<~GQL
+        mutation($input: UpdateCustomerInput!) {
+          updateCustomer(input: $input) {
+            id
+            paymentTerm { termType days dayOfMonth monthOffset }
+          }
+        }
+      GQL
+    end
+
+    def update_payment_term(payment_term, **extra_input)
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: payment_term_mutation,
+        variables: {input: {id: customer.id, externalId: customer.external_id, paymentTerm: payment_term, **extra_input}}
+      )
+    end
+
+    it "sets the payment term" do
+      result = update_payment_term({termType: "day_of_month", dayOfMonth: 15})
+
+      payment_term = result["data"]["updateCustomer"]["paymentTerm"]
+      expect(payment_term["termType"]).to eq("day_of_month")
+      expect(payment_term["dayOfMonth"]).to eq(15)
+      expect(payment_term["monthOffset"]).to eq(1)
+      expect(customer.reload.payment_term).to eq("term_type" => "day_of_month", "day_of_month" => 15, "month_offset" => 1)
+    end
+
+    it "clears the payment term when null is sent" do
+      customer.update!(payment_term: {term_type: "net", days: 30})
+
+      result = update_payment_term(nil)
+
+      expect(result["data"]["updateCustomer"]["paymentTerm"]).to be_nil
+      expect(customer.reload.payment_term).to be_nil
+    end
+
+    it "rejects an invalid payment term" do
+      result = update_payment_term({termType: "net", days: -1})
+
+      expect_unprocessable_entity(result)
+      expect(customer.reload.payment_term).to be_nil
+    end
+
+    it "rejects conflicting aliases without changing the record" do
+      customer.update!(payment_term: {term_type: "net", days: 10}, net_payment_term: 10)
+
+      response = update_payment_term({termType: "net", days: 30}, netPaymentTerm: 60)
+
+      expect_unprocessable_entity(response)
+      expect(customer.reload.payment_term).to eq("term_type" => "net", "days" => 10)
+      expect(customer.net_payment_term).to eq(10)
+    end
+
+    it "accepts a null alias echoed back with a structured term" do
+      response = update_payment_term({termType: "end_of_month"}, netPaymentTerm: nil)
+
+      expect(response["errors"]).to be_nil
+      expect(response.dig("data", "updateCustomer", "paymentTerm", "termType")).to eq("end_of_month")
+      expect(customer.reload.net_payment_term).to be_nil
+    end
+
+    it "keeps existing draft invoice terms and due dates unchanged" do
+      draft = create(:invoice, :draft, customer:, organization:, payment_term: {term_type: "net", days: 30}, net_payment_term: 30)
+      original_due_date = draft.payment_due_date
+
+      response = update_payment_term({termType: "end_of_month"})
+
+      expect(response["errors"]).to be_nil
+      expect(draft.reload.payment_due_date).to eq(original_due_date)
+      expect(draft.payment_term).to eq("term_type" => "net", "days" => 30)
+    end
+  end
 end

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -283,6 +283,16 @@ RSpec.describe Mutations::Customers::Update do
       expect(customer.reload.payment_term).to be_nil
     end
 
+    it "clears both fields when null is sent alongside a legacy alias" do
+      customer.update!(payment_term: {term_type: "net", days: 30}, net_payment_term: 30)
+
+      response = update_payment_term(nil, netPaymentTerm: 20)
+
+      expect(response["errors"]).to be_nil
+      expect(response.dig("data", "updateCustomer", "paymentTerm")).to be_nil
+      expect(customer.reload).to have_attributes(payment_term: nil, net_payment_term: nil)
+    end
+
     it "rejects an invalid payment term" do
       result = update_payment_term({termType: "net", days: -1})
 

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -251,4 +251,42 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
       )
     end
   end
+
+  context "with payment_term" do
+    let(:payment_term_mutation) do
+      <<~GQL
+        mutation($input: CreateSubscriptionInput!) {
+          createSubscription(input: $input) {
+            id
+            paymentTerm { termType days dayOfMonth monthOffset }
+          }
+        }
+      GQL
+    end
+
+    def write_payment_term(payment_term)
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: payment_term_mutation,
+        variables: {input: {customerId: customer.id, planId: plan.id, billingTime: "anniversary", subscriptionAt: (Time.current + 3.days).iso8601, paymentTerm: payment_term}}
+      )
+    end
+
+    it "persists and returns the normalized term" do
+      response = write_payment_term({termType: "day_of_month", dayOfMonth: 15})
+      data = response.dig("data", "createSubscription")
+
+      expect(response["errors"]).to be_nil
+      expect(data["paymentTerm"]).to eq("termType" => "day_of_month", "days" => nil, "dayOfMonth" => 15, "monthOffset" => 1)
+      expect(Subscription.find(data["id"]).payment_term).to eq("term_type" => "day_of_month", "day_of_month" => 15, "month_offset" => 1)
+    end
+
+    it "rejects a term missing required days" do
+      response = write_payment_term({termType: "net"})
+
+      expect_unprocessable_entity(response)
+    end
+  end
 end

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -302,4 +302,52 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
       end
     end
   end
+
+  context "with payment_term" do
+    let(:payment_term_mutation) do
+      <<~GQL
+        mutation($input: UpdateSubscriptionInput!) {
+          updateSubscription(input: $input) {
+            id
+            paymentTerm { termType days dayOfMonth monthOffset }
+          }
+        }
+      GQL
+    end
+
+    def write_payment_term(payment_term)
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: payment_term_mutation,
+        variables: {input: {id: subscription.id, paymentTerm: payment_term}}
+      )
+    end
+
+    it "persists and returns the normalized term" do
+      response = write_payment_term({termType: "day_of_month", dayOfMonth: 15})
+      data = response.dig("data", "updateSubscription")
+
+      expect(response["errors"]).to be_nil
+      expect(data["paymentTerm"]).to eq("termType" => "day_of_month", "days" => nil, "dayOfMonth" => 15, "monthOffset" => 1)
+      expect(Subscription.find(data["id"]).payment_term).to eq("term_type" => "day_of_month", "day_of_month" => 15, "month_offset" => 1)
+    end
+
+    it "rejects a term missing required days" do
+      response = write_payment_term({termType: "net"})
+
+      expect_unprocessable_entity(response)
+    end
+
+    it "clears the override when null is sent" do
+      subscription.update!(payment_term: {term_type: "net", days: 30})
+
+      response = write_payment_term(nil)
+
+      expect(response["errors"]).to be_nil
+      expect(response.dig("data", "updateSubscription", "paymentTerm")).to be_nil
+      expect(subscription.reload.payment_term).to be_nil
+    end
+  end
 end

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -476,4 +476,39 @@ RSpec.describe Resolvers::InvoiceResolver do
       expect(data.dig("fees", 0, "presentationBreakdowns")).to eq([])
     end
   end
+
+  context "with payment_term" do
+    let(:query) do
+      <<~GQL
+        query($id: ID!) {
+          invoice(id: $id) {
+            paymentTerm { termType days dayOfMonth monthOffset }
+          }
+        }
+      GQL
+    end
+
+    it "returns the frozen term rather than the current customer term" do
+      invoice.update!(payment_term: {term_type: "end_of_month"}, net_payment_term: nil)
+      customer.update!(payment_term: {term_type: "net", days: 60}, net_payment_term: 60)
+
+      response = execute_query(query:, variables: {id: invoice.id})
+
+      expect(response["errors"]).to be_nil
+      expect(response.dig("data", "invoice", "paymentTerm")).to eq(
+        "termType" => "end_of_month", "days" => nil, "dayOfMonth" => nil, "monthOffset" => nil
+      )
+    end
+
+    it "derives the term from the invoice alias for historical invoices" do
+      invoice.update!(payment_term: nil, net_payment_term: 30)
+
+      response = execute_query(query:, variables: {id: invoice.id})
+
+      expect(response["errors"]).to be_nil
+      expect(response.dig("data", "invoice", "paymentTerm")).to eq(
+        "termType" => "net", "days" => 30, "dayOfMonth" => nil, "monthOffset" => nil
+      )
+    end
+  end
 end

--- a/spec/graphql/types/billing_entities/object_spec.rb
+++ b/spec/graphql/types/billing_entities/object_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Types::BillingEntities::Object do
   it { is_expected.to have_field(:city).of_type("String") }
   it { is_expected.to have_field(:country).of_type("CountryCode") }
   it { is_expected.to have_field(:net_payment_term).of_type("Int") }
+  it { is_expected.to have_field(:payment_term).of_type("PaymentTerm") }
   it { is_expected.to have_field(:state).of_type("String") }
   it { is_expected.to have_field(:zipcode).of_type("String") }
 

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Types::Customers::Object do
     expect(subject).to have_field(:legal_number).of_type("String")
     expect(subject).to have_field(:logo_url).of_type("String")
     expect(subject).to have_field(:net_payment_term).of_type("Int")
+    expect(subject).to have_field(:payment_term).of_type("PaymentTerm")
     expect(subject).to have_field(:payment_provider).of_type("ProviderTypeEnum")
     expect(subject).to have_field(:payment_provider_code).of_type("String")
     expect(subject).to have_field(:phone).of_type("String")

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Invoices::Object do
   subject { described_class }
 
   it "has the expected fields with correct types" do
+    expect(subject).to have_field(:payment_term).of_type("PaymentTerm!")
     expect(subject).to have_field(:customer).of_type("Customer!")
     expect(subject).to have_field(:billing_entity).of_type("BillingEntity!")
 

--- a/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Subscriptions::CreateSubscriptionInput do
   subject { described_class }
 
   it do
+    expect(subject).to accept_argument(:payment_term).of_type("PaymentTermInput")
     expect(subject).to accept_argument(:ending_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:external_id).of_type("String")
     expect(subject).to accept_argument(:customer_id).of_type("ID!")

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Subscriptions::Object do
   subject { described_class }
 
   it do
+    expect(subject).to have_field(:payment_term).of_type("PaymentTerm")
     expect(subject).to have_field(:billing_entity_id).of_type("ID")
     expect(subject).to have_field(:customer).of_type("Customer!")
     expect(subject).to have_field(:external_id).of_type("String!")

--- a/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Subscriptions::UpdateSubscriptionInput do
   subject { described_class }
 
   it do
+    expect(subject).to accept_argument(:payment_term).of_type("PaymentTermInput")
     expect(subject).to accept_argument(:id).of_type("ID!")
     expect(subject).to accept_argument(:ending_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:name).of_type("String")

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -577,12 +577,14 @@ RSpec.describe Customers::UpdateService do
       context "with both fields sent" do
         let(:update_args) { {id: customer.id, net_payment_term: 45, payment_term: {term_type: "end_of_month"}} }
 
-        it "lets payment_term win" do
+        it "rejects conflicting aliases without changing the customer" do
           result = customers_service.call
 
-          expect(result.customer).to have_attributes(
-            payment_term: {"term_type" => "end_of_month"},
-            net_payment_term: nil
+          expect(result).to be_failure
+          expect(result.error.messages[:payment_term]).to eq(["conflicting_net_payment_term"])
+          expect(customer.reload).to have_attributes(
+            payment_term: {"term_type" => "net", "days" => 30},
+            net_payment_term: 30
           )
         end
       end

--- a/spec/services/payment_terms/validate_service_spec.rb
+++ b/spec/services/payment_terms/validate_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe PaymentTerms::ValidateService do
       [{payment_term: {term_type: "due_on_receipt"}, net_payment_term: 30}, false],
       [{payment_term: {term_type: "end_of_month"}, net_payment_term: 0}, false]
     ].each do |params, valid|
-      it "#{valid ? 'accepts' : 'rejects'} #{params.inspect}" do
+      it "#{valid ? "accepts" : "rejects"} #{params.inspect}" do
         validator = described_class.new(result, **params)
 
         expect(validator.valid?).to eq(valid)

--- a/spec/services/payment_terms/validate_service_spec.rb
+++ b/spec/services/payment_terms/validate_service_spec.rb
@@ -54,6 +54,31 @@ RSpec.describe PaymentTerms::ValidateService do
     end
   end
 
+  describe "alias equivalence" do
+    [
+      [{net_payment_term: 30}, true],
+      [{net_payment_term: nil}, true],
+      [{payment_term: {term_type: "net", days: 30}, net_payment_term: 30}, true],
+      [{payment_term: {term_type: "due_on_receipt"}, net_payment_term: 0}, true],
+      [{payment_term: {term_type: "end_of_month"}, net_payment_term: nil}, true],
+      [{payment_term: {term_type: "net", days: 30}, net_payment_term: nil}, true],
+      [{payment_term: nil, net_payment_term: nil}, true],
+      [{payment_term: nil, net_payment_term: 30}, false],
+      [{payment_term: {term_type: "net", days: 30}, net_payment_term: 60}, false],
+      [{payment_term: {term_type: "due_on_receipt"}, net_payment_term: 30}, false],
+      [{payment_term: {term_type: "end_of_month"}, net_payment_term: 0}, false]
+    ].each do |params, valid|
+      it "#{valid ? 'accepts' : 'rejects'} #{params.inspect}" do
+        validator = described_class.new(result, **params)
+
+        expect(validator.valid?).to eq(valid)
+        unless valid
+          expect(result.error.messages[:payment_term]).to eq(["conflicting_net_payment_term"])
+        end
+      end
+    end
+  end
+
   describe "payment_term validation" do
     shared_examples "a term type carrying days" do |term_type|
       context "when days is valid" do

--- a/spec/services/payment_terms/validate_service_spec.rb
+++ b/spec/services/payment_terms/validate_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe PaymentTerms::ValidateService do
       [{payment_term: {term_type: "end_of_month"}, net_payment_term: nil}, true],
       [{payment_term: {term_type: "net", days: 30}, net_payment_term: nil}, true],
       [{payment_term: nil, net_payment_term: nil}, true],
-      [{payment_term: nil, net_payment_term: 30}, false],
+      [{payment_term: nil, net_payment_term: 30}, true],
       [{payment_term: {term_type: "net", days: 30}, net_payment_term: 60}, false],
       [{payment_term: {term_type: "due_on_receipt"}, net_payment_term: 30}, false],
       [{payment_term: {term_type: "end_of_month"}, net_payment_term: 0}, false]


### PR DESCRIPTION
GraphQL clients can configure structured payment terms on customers, billing entities, and subscriptions, and read frozen payment terms on invoices. Historical invoices derive their term from their own legacy alias.

This PR builds on #6234, which contains the rebased dependency stack. It adds the six backend term types, normalizes mutation inputs through the shared assignment services, and preserves inheritance and draft invoice snapshots. Conflicting non-null `paymentTerm` / `netPaymentTerm` values are rejected. A null legacy alias echoed back with a structured term is accepted, and explicit `paymentTerm: null` still clears both fields even when a legacy integer accompanies it.

Validation on `f21da2dd1791d46e3561d511481a30c0da81b399`:
- [Lint and Zeitwerk](https://github.com/getlago/lago-api/actions/runs/34230984011): passed.
- [Migration checks](https://github.com/getlago/lago-api/actions/runs/34230984016): passed.
- [RSpec CI](https://github.com/getlago/lago-api/actions/runs/34230984018): passed. The dependency stack's regeneration and wallet column-coverage failures are fixed in #6195 and #6231 and propagated here.
- No tests were run locally for this CI-fix follow-up.

The dependency stack still has release gaps outside this GraphQL change: retries after live term changes, subscription overrides in preview/progressive/immediate invoice paths, issuing-entity resolution, wallet and one-off overrides, database constraints, frontend contract alignment, and API/SDK documentation.

Linear: https://linear.app/getlago/issue/BIL-530