### PR TITLE
fix: secure weighted sum query

### DIFF
--- a/app/services/events/stores/postgres/weighted_sum_query.rb
+++ b/app/services/events/stores/postgres/weighted_sum_query.rb
@@ -140,18 +140,10 @@ module Events
 
         def grouped_initial_value_sql(initial_values)
           values = initial_values.map do |initial_value|
-            groups = store.grouped_by.map do |g|
-              if initial_value[:groups][g]
-                "'#{ActiveRecord::Base.sanitize_sql_for_conditions(initial_value[:groups][g])}'"
-              else
-                "NULL"
-              end
-            end
-
             [
-              groups,
+              quoted_group_values(initial_value),
               "timestamp without time zone :from_datetime",
-              initial_value[:value],
+              quoted_initial_value(initial_value),
               "timestamp without time zone :from_datetime"
             ].flatten.join(", ")
           end
@@ -166,16 +158,8 @@ module Events
 
         def grouped_end_of_period_value_sql(initial_values)
           values = initial_values.map do |initial_value|
-            groups = store.grouped_by.map do |g|
-              if initial_value[:groups][g]
-                "'#{ActiveRecord::Base.sanitize_sql_for_conditions(initial_value[:groups][g])}'"
-              else
-                "NULL"
-              end
-            end
-
             [
-              groups,
+              quoted_group_values(initial_value),
               "timestamp without time zone :to_datetime",
               0,
               "timestamp without time zone :to_datetime"
@@ -188,6 +172,17 @@ module Events
               VALUES #{values.map { "(#{it})" }.join(", ")}
             ) AS t(#{group_names}, timestamp, difference, created_at)
           SQL
+        end
+
+        def quoted_group_values(initial_value)
+          store.grouped_by.map do |group|
+            value = initial_value[:groups][group]
+            value ? ActiveRecord::Base.connection.quote(value.to_s) : "NULL"
+          end
+        end
+
+        def quoted_initial_value(initial_value)
+          "#{ActiveRecord::Base.connection.quote(initial_value[:value])}::numeric"
         end
 
         def grouped_period_ratio_sql

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -151,4 +151,41 @@ RSpec.describe Events::Stores::PostgresStore do
       end
     end
   end
+
+  describe "#grouped_weighted_sum" do
+    let(:group_value) { "europe' OR TRUE --" }
+    let(:billable_metric) { create(:weighted_sum_billable_metric) }
+    let(:organization) { billable_metric.organization }
+    let(:customer) { create(:customer, organization:) }
+    let(:started_at) { Time.zone.parse("2023-03-01") }
+    let(:subscription) { create(:subscription, customer:, started_at:) }
+    let(:event_store) do
+      described_class.new(
+        code: billable_metric.code,
+        subscription:,
+        boundaries: {
+          from_datetime: started_at,
+          to_datetime: started_at.end_of_month.end_of_day,
+          charges_duration: 31
+        },
+        filters: {grouped_by: ["region"]}
+      ).tap do |store|
+        store.aggregation_property = billable_metric.field_name
+        store.numeric_property = true
+      end
+    end
+
+    it "safely handles special characters in grouped values" do
+      create(
+        :event,
+        organization:,
+        external_subscription_id: subscription.external_id,
+        code: billable_metric.code,
+        timestamp: started_at + 1.day,
+        properties: {billable_metric.field_name => 2, "region" => group_value}
+      )
+
+      expect(event_store.grouped_weighted_sum.sole.groups).to eq("region" => group_value)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Grouped values were interpolated into PostgreSQL weighted-sum queries, allowing crafted event properties to alter the generated SQL.

## Description

- Quote grouped values and initial values using `ActiveRecord::Base.connection.quote(...)`
- Add regression coverage for SQL-shaped group values.
