### PR TITLE
feat(orders): Execute subscription amendments

### DIFF
--- a/app/graphql/types/orders/execution_record.rb
+++ b/app/graphql/types/orders/execution_record.rb
@@ -12,6 +12,7 @@ module Types
 
       field :applied_coupon_ids, [ID], null: false
       field :subscription_ids, [ID], null: false
+      field :terminated_subscription_ids, [ID], null: false
       field :wallet_ids, [ID], null: false
 
       def errors
@@ -26,6 +27,10 @@ module Types
 
       def subscription_ids
         object["subscription_ids"] || []
+      end
+
+      def terminated_subscription_ids
+        object["terminated_subscription_ids"] || []
       end
 
       def wallet_ids

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -22,6 +22,7 @@ class Order < ApplicationRecord
     "execution_mode" => nil,
     "invoice_id" => nil,
     "subscription_ids" => [],
+    "terminated_subscription_ids" => [],
     "applied_coupon_ids" => [],
     "wallet_ids" => [],
     "errors" => []

--- a/app/services/orders/execute_service.rb
+++ b/app/services/orders/execute_service.rb
@@ -2,7 +2,6 @@
 
 module Orders
   # Dispatches execution to the concrete service for the order's order_type.
-  # subscription_amendment is not supported yet.
   class ExecuteService < BaseService
     include OrderForms::Premium
 
@@ -22,6 +21,8 @@ module Orders
         Orders::OneOff::ExecuteService.call(order:)
       when Quote::ORDER_TYPES[:subscription_creation]
         Orders::SubscriptionCreation::ExecuteService.call(order:)
+      when Quote::ORDER_TYPES[:subscription_amendment]
+        Orders::SubscriptionAmendment::ExecuteService.call(order:)
       else
         result.single_validation_failure!(field: :order_type, error_code: "unsupported_order_type")
       end

--- a/app/services/orders/subscription_amendment/execute_service.rb
+++ b/app/services/orders/subscription_amendment/execute_service.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Orders
+  module SubscriptionAmendment
+    # An amendment restates one plan on a live subscription, so the payload it carries is a
+    # subscription_creation one and the whole mapping is inherited. Only the transition differs: the
+    # target is terminated and replaced, instead of a subscription being created.
+    class ExecuteService < Orders::SubscriptionCreation::ExecuteService
+      private
+
+      def create_records
+        validate_target_subscription!
+
+        super.merge(terminated_subscription_ids: [target_subscription.id])
+      end
+
+      def create_subscriptions
+        [amend_subscription]
+      end
+
+      # PlanUpgradeService is the existing composition of terminate then create on a single external
+      # id: it keeps subscription_at and billing_time so the billing anchor does not move, sets
+      # previous_subscription_id so the replacement's first fee is prorated from the amendment day,
+      # cancels a pending downgrade, and leaves ActivateService to terminate the target, credit its
+      # unconsumed pay-in-advance time and enqueue one combined invoice after commit.
+      def amend_subscription
+        subscription = ::Subscriptions::PlanUpgradeService.call!(
+          current_subscription: target_subscription,
+          plan: quoted_plan,
+          params: amendment_params
+        ).subscription
+
+        update_usage_thresholds!(subscription)
+
+        subscription
+      end
+
+      def amendment_params
+        payload = plan_item["payload"] || {}
+
+        {
+          # PlanUpgradeService strips this to a string, so the target's own name only survives when
+          # it is passed back.
+          name: payload["subscriptionName"].presence || target_subscription.name,
+          # The amendment restates the contract term. A quote carrying no ending date leaves the
+          # target's own in place.
+          ending_at: subscription_datetime(payload["endDate"], quote_version.end_date),
+          payment_method: payment_method_params(payload),
+          # Never .presence here, unlike the creation path: an empty override still has to mint a
+          # child plan. Were the replacement to share the target's plan id, ActivateService would
+          # take its standalone branch, leaving the target active and its external id duplicated.
+          plan_overrides: plan_overrides(plan_item, quoted_plan)
+        }.compact
+      end
+
+      # Thresholds ride on the subscription and PlanUpgradeService has no such parameter, so they
+      # reach the replacement the way Subscriptions::CreateService applies them to a new one.
+      def update_usage_thresholds!(subscription)
+        thresholds = usage_thresholds(plan_item)
+        return if thresholds.empty?
+
+        ::Subscriptions::UpdateUsageThresholdsService.call!(
+          subscription:,
+          usage_thresholds_params: thresholds,
+          partial: false
+        )
+      end
+
+      # Re-runs the approval gate: weeks pass between approval and execution and every state it
+      # covers can change in between. A failure here rolls the whole amendment back, leaving the
+      # order failed with the reason recorded and the signed order form untouched.
+      def validate_target_subscription!
+        if plan_items.count != 1
+          result.single_validation_failure!(field: :plans, error_code: "single_plan_expected").raise_if_error!
+        end
+
+        if target_subscription.nil? || target_subscription.customer_id != order.customer_id
+          result.not_found_failure!(resource: "subscription").raise_if_error!
+        end
+
+        unless target_subscription.active?
+          result
+            .single_validation_failure!(field: :subscription, error_code: "subscription_not_active")
+            .raise_if_error!
+        end
+
+        validate_amendment_direction!
+      end
+
+      # Mirrors Subscriptions::ActivateService#upgrade?, the price comparison that decides how both
+      # the terminated subscription and its replacement are prorated. A cheaper replacement takes
+      # the downgrade path, which bills the target for the whole current period and credits none of
+      # its unconsumed pay-in-advance time. Same check as the approval gate, see
+      # QuoteVersions::Validators::SubscriptionAmendment::BusinessValidator.
+      def validate_amendment_direction!
+        amount_cents = plan_item.dig("overrides", "amountCents") || quoted_plan.amount_cents
+        quoted = Plan.new(interval: quoted_plan.interval, amount_cents:)
+        return if quoted.yearly_amount_cents >= target_subscription.plan.yearly_amount_cents
+
+        result
+          .single_validation_failure!(field: :plan, error_code: "amendment_decreases_amount")
+          .raise_if_error!
+      end
+
+      def target_subscription
+        return @target_subscription if defined?(@target_subscription)
+
+        @target_subscription = order.quote.subscription
+      end
+
+      def plan_item
+        @plan_item ||= plan_items.first
+      end
+
+      def quoted_plan
+        @quoted_plan ||= find_plan!(plan_item["id"])
+      end
+    end
+  end
+end

--- a/app/services/orders/subscription_amendment/execute_service.rb
+++ b/app/services/orders/subscription_amendment/execute_service.rb
@@ -4,31 +4,34 @@ module Orders
   module SubscriptionAmendment
     # An amendment restates one plan on a live subscription, so the payload it carries is a
     # subscription_creation one and the whole mapping is inherited. Only the transition differs: the
-    # target is terminated and replaced, instead of a subscription being created.
+    # quoted plan replaces the one the target runs on, instead of a subscription being created.
     class ExecuteService < Orders::SubscriptionCreation::ExecuteService
       private
 
       def create_records
         validate_target_subscription!
 
-        super.merge(terminated_subscription_ids: [target_subscription.id])
+        super.merge(terminated_subscription_ids:)
       end
 
       def create_subscriptions
         [amend_subscription]
       end
 
-      # PlanUpgradeService is the existing composition of terminate then create on a single external
-      # id: it keeps subscription_at and billing_time so the billing anchor does not move, sets
-      # previous_subscription_id so the replacement's first fee is prorated from the amendment day,
-      # cancels a pending downgrade, and leaves ActivateService to terminate the target, credit its
-      # unconsumed pay-in-advance time and enqueue one combined invoice after commit.
+      # Subscriptions::CreateService is the entry point the API and the UI already use for a plan
+      # change, so the amendment inherits Lago's own semantics in both directions: a raise rotates
+      # the subscription now, keeping the external id and the billing anchor, while a reduction keeps
+      # the target running and schedules the replacement for the next billing day.
       def amend_subscription
-        subscription = ::Subscriptions::PlanUpgradeService.call!(
-          current_subscription: target_subscription,
+        subscription = ::Subscriptions::CreateService.call!(
+          customer: order.customer,
           plan: quoted_plan,
           params: amendment_params
         ).subscription
+
+        # CreateService loaded its own instance of the target, so ours is stale.
+        target_subscription.reload
+        subscription = target_subscription.next_subscription if subscription.id == target_subscription.id
 
         update_usage_thresholds!(subscription)
 
@@ -39,22 +42,37 @@ module Orders
         payload = plan_item["payload"] || {}
 
         {
-          # PlanUpgradeService strips this to a string, so the target's own name only survives when
-          # it is passed back.
+          # Resolves the target through editable_subscriptions, so the plan change always dispatches
+          # on it instead of creating a second subscription.
+          subscription_id: target_subscription.id,
+          external_id: target_subscription.external_id,
+          # CreateService strips this to a string, so the target's own name only survives when it is
+          # passed back.
           name: payload["subscriptionName"].presence || target_subscription.name,
           # The amendment restates the contract term. A quote carrying no ending date leaves the
           # target's own in place.
           ending_at: subscription_datetime(payload["endDate"], quote_version.end_date),
-          payment_method: payment_method_params(payload),
-          # Never .presence here, unlike the creation path: an empty override still has to mint a
-          # child plan. Were the replacement to share the target's plan id, ActivateService would
-          # take its standalone branch, leaving the target active and its external id duplicated.
-          plan_overrides: plan_overrides(plan_item, quoted_plan)
+          payment_method: payment_method_params(payload)
         }.compact
       end
 
-      # Thresholds ride on the subscription and PlanUpgradeService has no such parameter, so they
-      # reach the replacement the way Subscriptions::CreateService applies them to a new one.
+      # The negotiated plan is built here rather than passed as plan_overrides because the plan
+      # change dispatches on plan ids before prices: a repricing of the same catalog plan would match
+      # on id and return the target untouched. An override plan always carries a fresh id, so the
+      # comparison reaches the negotiated amount whatever the quote restates.
+      def quoted_plan
+        @quoted_plan ||= ::Plans::OverrideService.call!(
+          plan: catalog_plan,
+          params: plan_overrides(plan_item, catalog_plan).with_indifferent_access
+        ).plan
+      end
+
+      def catalog_plan
+        @catalog_plan ||= find_plan!(plan_item["id"])
+      end
+
+      # Thresholds ride on the subscription, and CreateService would apply them to whatever the plan
+      # change returns, which for a reduction is the target rather than the replacement it scheduled.
       def update_usage_thresholds!(subscription)
         thresholds = usage_thresholds(plan_item)
         return if thresholds.empty?
@@ -64,6 +82,11 @@ module Orders
           usage_thresholds_params: thresholds,
           partial: false
         )
+      end
+
+      # Empty for a scheduled amendment: the target keeps running until the end of the period.
+      def terminated_subscription_ids
+        target_subscription.reload.terminated? ? [target_subscription.id] : []
       end
 
       # Re-runs the approval gate: weeks pass between approval and execution and every state it
@@ -78,27 +101,10 @@ module Orders
           result.not_found_failure!(resource: "subscription").raise_if_error!
         end
 
-        unless target_subscription.active?
-          result
-            .single_validation_failure!(field: :subscription, error_code: "subscription_not_active")
-            .raise_if_error!
-        end
-
-        validate_amendment_direction!
-      end
-
-      # Mirrors Subscriptions::ActivateService#upgrade?, the price comparison that decides how both
-      # the terminated subscription and its replacement are prorated. A cheaper replacement takes
-      # the downgrade path, which bills the target for the whole current period and credits none of
-      # its unconsumed pay-in-advance time. Same check as the approval gate, see
-      # QuoteVersions::Validators::SubscriptionAmendment::BusinessValidator.
-      def validate_amendment_direction!
-        amount_cents = plan_item.dig("overrides", "amountCents") || quoted_plan.amount_cents
-        quoted = Plan.new(interval: quoted_plan.interval, amount_cents:)
-        return if quoted.yearly_amount_cents >= target_subscription.plan.yearly_amount_cents
+        return if target_subscription.active?
 
         result
-          .single_validation_failure!(field: :plan, error_code: "amendment_decreases_amount")
+          .single_validation_failure!(field: :subscription, error_code: "subscription_not_active")
           .raise_if_error!
       end
 
@@ -110,10 +116,6 @@ module Orders
 
       def plan_item
         @plan_item ||= plan_items.first
-      end
-
-      def quoted_plan
-        @quoted_plan ||= find_plan!(plan_item["id"])
       end
     end
   end

--- a/app/services/quote_versions/validators.rb
+++ b/app/services/quote_versions/validators.rb
@@ -2,15 +2,14 @@
 
 module QuoteVersions
   module Validators
-    # NOTE: subscription_amendment has no validator yet, so it returns nil and the callers
-    # (ApproveService, UpdateService) let it through. Orders::ExecuteService refuses that order
-    # type anyway, until the amendment validator lands.
     def self.for(result, quote_version:, scope:)
       case quote_version.quote.order_type
       when Quote::ORDER_TYPES[:one_off]
         OneOffValidator.new(result, quote_version:, scope:)
       when Quote::ORDER_TYPES[:subscription_creation]
         SubscriptionCreationValidator.new(result, quote_version:, scope:)
+      when Quote::ORDER_TYPES[:subscription_amendment]
+        SubscriptionAmendmentValidator.new(result, quote_version:, scope:)
       end
     end
   end

--- a/app/services/quote_versions/validators/subscription_amendment/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_amendment/business_validator.rb
@@ -4,12 +4,12 @@ module QuoteVersions
   module Validators
     module SubscriptionAmendment
       # An amendment payload is a subscription_creation one with extra constraints, so currency,
-      # dates, plan overrides, coupons and wallet credits are all inherited. Only what is specific
-      # to restating one plan on a live subscription is added here.
+      # plan overrides, coupons and wallet credits are all inherited. Only what is specific to
+      # restating one plan on a live subscription is added here, and the inherited date validation
+      # is narrowed down to the ending date, the one an amendment carries over.
       class BusinessValidator < SubscriptionCreation::BusinessValidator
         def valid?
           validate_single_plan
-          validate_end_date_presence
           validate_target_subscription
 
           # Errors accumulate in a hash, so the inherited pass still reports everything at once.
@@ -26,14 +26,22 @@ module QuoteVersions
           add_error(field: :"billing_items.plans", error_code: "single_plan_expected")
         end
 
-        # subscription_creation deliberately allows an open-ended deal. An amendment restates the
-        # contract term instead, and its ending date is what the replacement subscription carries.
-        def validate_end_date_presence
-          return unless scope == :approve
-          return if quote_version.end_date.present?
-          return if plans.first&.dig("payload", "endDate").present?
+        # An amendment restates the term of a subscription that is already running: its start is the
+        # target's own anniversary date, which the plan change carries over, so a quoted start date
+        # is a commercial term only and is not validated here.
+        def validate_dates
+          validate_future_end_date(quote_version.end_date, :end_date)
+        end
 
-          add_error(field: :end_date, error_code: "value_is_mandatory")
+        # An absent ending date leaves the target's own in place, see the plan change services. The
+        # start date being out of the picture, there is no range left to compare: the ending date
+        # only has to be after the target's anniversary date, which its futureness already implies
+        # since the target must be running.
+        def validate_plan_dates(plan_item, index)
+          end_date = plan_item.dig("payload", "endDate")
+          return unless validate_plan_date(end_date, plan_field(index, "payload.endDate"))
+
+          validate_future_end_date(end_date, plan_field(index, "payload.endDate"))
         end
 
         # The quote pins its target at creation, where Quote requires it for this order type and

--- a/app/services/quote_versions/validators/subscription_amendment/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_amendment/business_validator.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    module SubscriptionAmendment
+      # An amendment payload is a subscription_creation one with extra constraints, so currency,
+      # dates, plan overrides, coupons and wallet credits are all inherited. Only what is specific
+      # to restating one plan on a live subscription is added here.
+      class BusinessValidator < SubscriptionCreation::BusinessValidator
+        def valid?
+          validate_single_plan
+          validate_end_date_presence
+          validate_target_subscription
+
+          # Errors accumulate in a hash, so the inherited pass still reports everything at once.
+          super
+        end
+
+        private
+
+        # Refused at both scopes so a draft never accumulates a second plan: the quote pins a single
+        # target subscription, and execution amends that one.
+        def validate_single_plan
+          return if plans.count <= 1
+
+          add_error(field: :"billing_items.plans", error_code: "single_plan_expected")
+        end
+
+        # subscription_creation deliberately allows an open-ended deal. An amendment restates the
+        # contract term instead, and its ending date is what the replacement subscription carries.
+        def validate_end_date_presence
+          return unless scope == :approve
+          return if quote_version.end_date.present?
+          return if plans.first&.dig("payload", "endDate").present?
+
+          add_error(field: :end_date, error_code: "value_is_mandatory")
+        end
+
+        # The quote pins its target at creation, where Quote requires it for this order type and
+        # Quotes::CreateService scopes it to the deal's organization and customer. Only the state
+        # that can change afterwards is checked here.
+        def validate_target_subscription
+          subscription = quote_version.quote.subscription
+          return add_error(field: :subscription_id, error_code: "value_is_mandatory") if subscription.nil?
+
+          unless subscription.active?
+            return add_error(field: :subscription_id, error_code: "subscription_not_active")
+          end
+
+          validate_amendment_direction(subscription)
+        end
+
+        # Lago tells an upgrade from a downgrade by comparing plan prices when the invoice is built,
+        # not from the caller's intent: Subscriptions::ActivateService#upgrade?,
+        # Subscription#upgraded?, Fees::SubscriptionService#should_compute_terminated_amount?. A
+        # cheaper replacement therefore takes the downgrade path, which bills the terminated
+        # subscription for the whole current period and credits none of its unused pay-in-advance
+        # time, over-billing the amended period. Refused until the billing engine can prorate an
+        # immediate downgrade.
+        def validate_amendment_direction(subscription)
+          plan_item = plans.first
+          plan = known_plans_by_id[plan_item&.dig("id")]
+          return if plan.nil?
+          return if quoted_yearly_amount_cents(plan_item, plan) >= subscription.plan.yearly_amount_cents
+
+          add_error(field: plan_field(0, "id"), error_code: "amendment_decreases_amount")
+        end
+
+        # Mirrors what ActivateService will compare: Plans::OverrideService prices the child plan
+        # from the negotiated amount and inherits the catalog interval.
+        def quoted_yearly_amount_cents(plan_item, plan)
+          amount_cents = plan_item.dig("overrides", "amountCents") || plan.amount_cents
+
+          Plan.new(interval: plan.interval, amount_cents:).yearly_amount_cents
+        end
+      end
+    end
+  end
+end

--- a/app/services/quote_versions/validators/subscription_amendment/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_amendment/business_validator.rb
@@ -39,39 +39,15 @@ module QuoteVersions
         # The quote pins its target at creation, where Quote requires it for this order type and
         # Quotes::CreateService scopes it to the deal's organization and customer. Only the state
         # that can change afterwards is checked here.
+        # A quoted plan cheaper than the one the target runs on is legitimate: execution routes the
+        # change through Subscriptions::CreateService, which schedules a reduction for the next
+        # billing day rather than applying it mid-period.
         def validate_target_subscription
           subscription = quote_version.quote.subscription
           return add_error(field: :subscription_id, error_code: "value_is_mandatory") if subscription.nil?
+          return if subscription.active?
 
-          unless subscription.active?
-            return add_error(field: :subscription_id, error_code: "subscription_not_active")
-          end
-
-          validate_amendment_direction(subscription)
-        end
-
-        # Lago tells an upgrade from a downgrade by comparing plan prices when the invoice is built,
-        # not from the caller's intent: Subscriptions::ActivateService#upgrade?,
-        # Subscription#upgraded?, Fees::SubscriptionService#should_compute_terminated_amount?. A
-        # cheaper replacement therefore takes the downgrade path, which bills the terminated
-        # subscription for the whole current period and credits none of its unused pay-in-advance
-        # time, over-billing the amended period. Refused until the billing engine can prorate an
-        # immediate downgrade.
-        def validate_amendment_direction(subscription)
-          plan_item = plans.first
-          plan = known_plans_by_id[plan_item&.dig("id")]
-          return if plan.nil?
-          return if quoted_yearly_amount_cents(plan_item, plan) >= subscription.plan.yearly_amount_cents
-
-          add_error(field: plan_field(0, "id"), error_code: "amendment_decreases_amount")
-        end
-
-        # Mirrors what ActivateService will compare: Plans::OverrideService prices the child plan
-        # from the negotiated amount and inherits the catalog interval.
-        def quoted_yearly_amount_cents(plan_item, plan)
-          amount_cents = plan_item.dig("overrides", "amountCents") || plan.amount_cents
-
-          Plan.new(interval: plan.interval, amount_cents:).yearly_amount_cents
+          add_error(field: :subscription_id, error_code: "subscription_not_active")
         end
       end
     end

--- a/app/services/quote_versions/validators/subscription_amendment_validator.rb
+++ b/app/services/quote_versions/validators/subscription_amendment_validator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  module Validators
+    # An amendment carries a subscription_creation payload, so its schema is reused as is. What an
+    # amendment constrains on top of it is business state, see SubscriptionAmendment::BusinessValidator.
+    class SubscriptionAmendmentValidator < BaseOrderTypeValidator
+      private
+
+      def structural_validator_class
+        SubscriptionCreation::StructuralValidator
+      end
+
+      def business_validator_class
+        SubscriptionAmendment::BusinessValidator
+      end
+    end
+  end
+end

--- a/app/services/quote_versions/validators/subscription_creation/business_validator.rb
+++ b/app/services/quote_versions/validators/subscription_creation/business_validator.rb
@@ -75,7 +75,6 @@ module QuoteVersions
 
             validate_plan_currency(plan, index)
             validate_minimum_commitment(plan, plan_item, index)
-            validate_plan_start_date_presence(plan_item, index)
             validate_plan_dates(plan_item, index)
             validate_plan_payment_method(plan_item, index)
             validate_charge_overrides(plan_item, plan, index)
@@ -295,6 +294,8 @@ module QuoteVersions
         # increasing. Both fallbacks are applied here so a plan overriding one side only is still
         # checked against the quote's other side.
         def validate_plan_dates(plan_item, index)
+          validate_plan_start_date_presence(plan_item, index)
+
           start_date = plan_item.dig("payload", "startDate")
           end_date = plan_item.dig("payload", "endDate")
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -10019,6 +10019,7 @@ type OrderExecutionRecord {
   executionMode: OrderExecutionModeEnum
   invoiceId: ID
   subscriptionIds: [ID!]!
+  terminatedSubscriptionIds: [ID!]!
   walletIds: [ID!]!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -47880,6 +47880,30 @@
               "deprecationReason": null
             },
             {
+              "name": "terminatedSubscriptionIds",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "walletIds",
               "description": null,
               "args": [],

--- a/spec/graphql/types/orders/execution_record_spec.rb
+++ b/spec/graphql/types/orders/execution_record_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Types::Orders::ExecutionRecord do
     expect(subject).to have_field(:invoice_id).of_type("ID")
     expect(subject).to have_field(:applied_coupon_ids).of_type("[ID!]!")
     expect(subject).to have_field(:subscription_ids).of_type("[ID!]!")
+    expect(subject).to have_field(:terminated_subscription_ids).of_type("[ID!]!")
     expect(subject).to have_field(:wallet_ids).of_type("[ID!]!")
   end
 end

--- a/spec/serializers/v1/order_serializer_spec.rb
+++ b/spec/serializers/v1/order_serializer_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe ::V1::OrderSerializer do
         "execution_mode" => "execute_in_lago",
         "invoice_id" => nil,
         "subscription_ids" => [],
+        "terminated_subscription_ids" => [],
         "applied_coupon_ids" => [],
         "wallet_ids" => [],
         "errors" => ["currencies_does_not_match"]

--- a/spec/services/orders/execute_service_spec.rb
+++ b/spec/services/orders/execute_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Orders::ExecuteService do
         end
       end
 
-      context "when the order type is not supported yet" do
+      context "when the order is a subscription_amendment" do
         let(:order_type) { :subscription_amendment }
         let(:quote) do
           create(
@@ -81,6 +81,18 @@ RSpec.describe Orders::ExecuteService do
             subscription: create(:subscription, organization:, customer:)
           )
         end
+
+        it "delegates to the subscription_amendment execute service" do
+          allow(Orders::SubscriptionAmendment::ExecuteService).to receive(:call).and_call_original
+
+          execute_service.call
+
+          expect(Orders::SubscriptionAmendment::ExecuteService).to have_received(:call).with(order:)
+        end
+      end
+
+      context "when the order type has no execute service" do
+        before { allow(order).to receive(:order_type).and_return("scheduled_amendment") }
 
         it "returns a validation failure" do
           result = execute_service.call

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -258,6 +258,76 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
         end
       end
 
+      # The target already paid for the running period, so terminating it mid-period has to credit
+      # the days the customer will now be billed for on the amended plan.
+      context "when the target subscription is paid in advance" do
+        let(:target_plan) do
+          create(:plan, organization:, amount_currency: "EUR", amount_cents: 50_000, pay_in_advance: true)
+        end
+        let(:target_subscription) do
+          create(
+            :subscription,
+            customer:,
+            organization:,
+            plan: target_plan,
+            name: "Original deal",
+            external_id: "sub_ext_42",
+            billing_time: :anniversary,
+            subscription_at: Time.current.beginning_of_month - 1.month,
+            started_at: Time.current.beginning_of_month - 1.month
+          )
+        end
+        let(:date_service) do
+          Subscriptions::DatesService.new_instance(
+            target_subscription,
+            Time.current.beginning_of_month,
+            current_usage: false
+          )
+        end
+        let(:invoice) do
+          create(
+            :invoice,
+            customer:,
+            currency: "EUR",
+            sub_total_excluding_taxes_amount_cents: 50_000,
+            fees_amount_cents: 50_000,
+            taxes_amount_cents: 10_000,
+            total_amount_cents: 60_000
+          )
+        end
+
+        before do
+          create(
+            :invoice_subscription,
+            invoice:,
+            subscription: target_subscription,
+            recurring: true,
+            from_datetime: date_service.from_datetime,
+            to_datetime: date_service.to_datetime,
+            charges_from_datetime: date_service.charges_from_datetime,
+            charges_to_datetime: date_service.charges_to_datetime
+          )
+          create(
+            :fee,
+            subscription: target_subscription,
+            invoice:,
+            amount_cents: 50_000,
+            taxes_amount_cents: 10_000,
+            taxes_rate: 20,
+            invoiceable_type: "Subscription",
+            invoiceable_id: target_subscription.id
+          )
+        end
+
+        it "credits the unconsumed days of the terminated subscription" do
+          expect { execute_service.call }.to change(CreditNote, :count).by(1)
+
+          credit_note = invoice.credit_notes.sole
+          expect(credit_note.credit_amount_cents).to be_positive
+          expect(credit_note.reason).to eq("order_cancellation")
+        end
+      end
+
       context "with a coupon and a wallet credit" do
         let(:coupon) { create(:coupon, organization:, amount_cents: 20_000, amount_currency: "EUR") }
         let(:billing_items) do

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
         order.reload
         expect(order.executed?).to eq(true)
         expect(order.execution_record["subscription_ids"]).to eq([])
-        expect(order.execution_record["terminated_subscription_ids"]).to be_nil
+        expect(order.execution_record["terminated_subscription_ids"]).to eq([])
       end
     end
   end

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -201,6 +201,33 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
         end
       end
 
+      # The replacement starts on the anniversary date of the one it amends, so the quoted start
+      # date is never read.
+      context "when the quote carries no start date" do
+        let(:quote_version) do
+          create(
+            :quote_version,
+            :approved,
+            quote:,
+            organization:,
+            currency: "EUR",
+            start_date: nil,
+            end_date: 1.year.from_now.to_date,
+            billing_items:
+          )
+        end
+
+        it "amends the subscription anyway" do
+          result = execute_service.call
+
+          expect(result).to be_success
+
+          replacement = customer.subscriptions.active.sole
+          expect(replacement.subscription_at.to_i).to eq(target_subscription.subscription_at.to_i)
+          expect(replacement.ending_at.to_date).to eq(quote_version.end_date)
+        end
+      end
+
       # The trial anchors on the oldest start of the external id, which the replacement inherits.
       context "when the amended plan carries a trial" do
         let(:plan) do

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -1,0 +1,426 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Orders::ExecuteService only dispatches here on a premium license, and plan overrides are
+# premium-gated downstream.
+RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
+  subject(:execute_service) { described_class.new(order:) }
+
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:customer) { create(:customer, organization:, billing_entity:, currency: "EUR") }
+
+  let(:target_plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 50_000) }
+  let(:target_subscription) do
+    create(
+      :subscription,
+      customer:,
+      organization:,
+      plan: target_plan,
+      name: "Original deal",
+      external_id: "sub_ext_42",
+      billing_time: :anniversary,
+      subscription_at: 7.months.ago,
+      started_at: 7.months.ago,
+      ending_at: 5.months.from_now
+    )
+  end
+
+  let(:plan) { create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000) }
+  let(:billable_metric) { create(:billable_metric, organization:, code: "api_calls") }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {"amount" => "50"}) }
+
+  let(:plan_item) do
+    {
+      "id" => plan.id,
+      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "type" => "plan",
+      "payload" => plan_payload,
+      "overrides" => plan_overrides
+    }.compact
+  end
+  let(:plan_payload) do
+    {
+      "code" => plan.code,
+      "subscriptionName" => "Amended deal",
+      "charges" => [
+        {
+          "id" => charge.id,
+          "billableMetric" => {"code" => billable_metric.code},
+          "chargeModel" => charge.charge_model
+        }
+      ]
+    }
+  end
+  let(:plan_overrides) do
+    {
+      "amountCents" => 80_000,
+      "charges" => [
+        {
+          "billableMetricCode" => billable_metric.code,
+          "chargeModel" => charge.charge_model,
+          "properties" => {"amount" => "30"}
+        }
+      ]
+    }
+  end
+
+  let(:billing_items) { {"plans" => [plan_item]} }
+  let(:quote) do
+    create(
+      :quote,
+      organization:,
+      customer:,
+      subscription: target_subscription,
+      order_type: :subscription_amendment
+    )
+  end
+  let(:quote_version) do
+    create(
+      :quote_version,
+      :approved,
+      quote:,
+      organization:,
+      currency: "EUR",
+      start_date: Date.current,
+      end_date: 1.year.from_now.to_date,
+      billing_items:
+    )
+  end
+  let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+  let(:order) { create(:order, organization:, customer:, order_form:, execution_mode:) }
+  let(:execution_mode) { :execute_in_lago }
+
+  # Records are resolved by id only outside api context, and CurrentContext leaks across spec
+  # files (no global reset), so pin it. The order is built up front so the target subscription
+  # never counts toward what an execution creates.
+  before do
+    CurrentContext.source = nil
+    charge
+    order
+  end
+
+  describe "#call" do
+    context "with execute_in_lago mode" do
+      it "terminates the target and replaces it on the amended plan" do
+        result = nil
+        expect { result = execute_service.call }.to change(Subscription, :count).by(1)
+
+        expect(result).to be_success
+        expect(target_subscription.reload).to be_terminated
+
+        replacement = customer.subscriptions.active.sole
+        expect(replacement.external_id).to eq("sub_ext_42")
+        expect(replacement.name).to eq("Amended deal")
+        expect(replacement.previous_subscription_id).to eq(target_subscription.id)
+        expect(replacement.ending_at.to_date).to eq(quote_version.end_date)
+
+        order.reload
+        expect(order.executed?).to eq(true)
+        expect(order.execution_record["execution_mode"]).to eq("execute_in_lago")
+        expect(order.execution_record["subscription_ids"]).to eq([replacement.id])
+        expect(order.execution_record["terminated_subscription_ids"]).to eq([target_subscription.id])
+        expect(order.execution_record["errors"]).to eq([])
+      end
+
+      # Without this the anniversary would move to the amendment date and every future invoice
+      # boundary would shift with it.
+      it "keeps the billing anchor of the terminated subscription" do
+        execute_service.call
+
+        replacement = customer.subscriptions.active.sole
+        expect(replacement.subscription_at.to_i).to eq(target_subscription.subscription_at.to_i)
+        expect(replacement.billing_time).to eq("anniversary")
+        expect(replacement.started_at).to be_within(5.seconds).of(Time.current)
+      end
+
+      # activate_for_upgrade bills the terminated subscription and its replacement together, after
+      # commit, so the amended period lands on one prorated invoice.
+      it "enqueues the rotation invoice for the terminated subscription" do
+        expect { execute_service.call }
+          .to have_enqueued_job(BillSubscriptionJob)
+          .with([target_subscription], anything, invoicing_reason: :upgrading)
+      end
+
+      it "bills the negotiated plan through an override plan" do
+        execute_service.call
+
+        overridden_plan = customer.subscriptions.active.sole.plan
+        expect(overridden_plan.parent_id).to eq(plan.id)
+        expect(overridden_plan.amount_cents).to eq(80_000)
+        expect(overridden_plan.charges.sole.properties["amount"]).to eq("30")
+      end
+
+      # A replacement sharing the target's plan id would make ActivateService take its standalone
+      # branch, leaving the target active.
+      context "without overrides" do
+        let(:plan_overrides) { nil }
+
+        it "still mints an override plan and still terminates the target" do
+          execute_service.call
+
+          expect(target_subscription.reload).to be_terminated
+
+          replacement = customer.subscriptions.active.sole
+          expect(replacement.plan.parent_id).to eq(plan.id)
+          expect(replacement.plan.amount_cents).to eq(100_000)
+        end
+      end
+
+      context "when the payload carries no subscription name" do
+        let(:plan_payload) { super().except("subscriptionName") }
+
+        it "keeps the name of the terminated subscription" do
+          execute_service.call
+
+          expect(customer.subscriptions.active.sole.name).to eq("Original deal")
+        end
+      end
+
+      context "when the quote carries no ending date" do
+        let(:plan_payload) { super().except("endDate") }
+        let(:quote_version) do
+          create(
+            :quote_version,
+            :approved,
+            quote:,
+            organization:,
+            currency: "EUR",
+            start_date: Date.current,
+            end_date: nil,
+            billing_items:
+          )
+        end
+
+        it "keeps the term of the terminated subscription" do
+          execute_service.call
+
+          replacement = customer.subscriptions.active.sole
+          expect(replacement.ending_at.to_i).to eq(target_subscription.ending_at.to_i)
+        end
+      end
+
+      # The trial anchors on the oldest start of the external id, which the replacement inherits.
+      context "when the amended plan carries a trial" do
+        let(:plan) do
+          create(:plan, organization:, amount_currency: "EUR", amount_cents: 100_000, trial_period: 14)
+        end
+
+        it "does not restart it" do
+          execute_service.call
+
+          replacement = customer.subscriptions.active.sole
+          expect(replacement.plan.trial_period).to eq(14)
+          expect(replacement.in_trial_period?).to eq(false)
+        end
+      end
+
+      context "with a pending downgrade on the target" do
+        let(:pending_downgrade) do
+          create(
+            :subscription,
+            :pending,
+            customer:,
+            organization:,
+            plan: create(:plan, organization:, amount_cents: 10_000),
+            external_id: target_subscription.external_id,
+            previous_subscription_id: target_subscription.id
+          )
+        end
+
+        before { pending_downgrade }
+
+        # Left alone it would activate later and silently undo the amendment.
+        it "cancels it" do
+          execute_service.call
+
+          expect(pending_downgrade.reload).to be_canceled
+        end
+      end
+
+      context "with usage thresholds" do
+        let(:organization) { create(:organization, premium_integrations: ["progressive_billing"]) }
+        let(:plan_overrides) do
+          super().merge(
+            "usageThresholds" => [
+              {"amountCents" => 100_000, "recurring" => false, "thresholdDisplayName" => "First"}
+            ]
+          )
+        end
+
+        it "creates them on the replacement, not on the overridden plan" do
+          execute_service.call
+
+          replacement = customer.subscriptions.active.sole
+          expect(replacement.usage_thresholds.pluck(:amount_cents)).to eq([100_000])
+          expect(replacement.plan.usage_thresholds).to be_empty
+        end
+      end
+
+      context "with a coupon and a wallet credit" do
+        let(:coupon) { create(:coupon, organization:, amount_cents: 20_000, amount_currency: "EUR") }
+        let(:billing_items) do
+          super().merge(
+            "coupons" => [
+              {
+                "id" => coupon.id,
+                "localId" => "ba54903c-7bd5-4d40-8d51-45a5157005ff",
+                "type" => "coupon",
+                "payload" => {"code" => coupon.code, "type" => "fixed_amount", "amountCents" => 20_000},
+                "overrides" => {"amountCents" => 15_000}
+              }
+            ],
+            "walletCredits" => [
+              {
+                "localId" => "e2a4a1a0-6f4d-4c1e-9c3f-2b1d0f8a7c11",
+                "type" => "wallet_credit",
+                "payload" => {
+                  "name" => "Amendment credits",
+                  "currency" => "EUR",
+                  "rateAmount" => "1",
+                  "paidCredits" => "0",
+                  "grantedCredits" => "50"
+                }
+              }
+            ]
+          )
+        end
+
+        it "applies them alongside the plan change" do
+          execute_service.call
+
+          applied_coupon = customer.applied_coupons.sole
+          expect(applied_coupon.amount_cents).to eq(15_000)
+
+          wallet = customer.wallets.sole
+          expect(wallet.name).to eq("Amendment credits")
+
+          order.reload
+          expect(order.execution_record["applied_coupon_ids"]).to eq([applied_coupon.id])
+          expect(order.execution_record["wallet_ids"]).to eq([wallet.id])
+        end
+
+        # The whole amendment is one transaction: a customer left with a terminated subscription and
+        # no replacement is a billing outage, not a retryable task.
+        context "when the coupon is discarded" do
+          before { coupon.discard! }
+
+          it "rolls the termination and the replacement back" do
+            result = nil
+            expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+            expect(result).not_to be_success
+            expect(target_subscription.reload).to be_active
+
+            order.reload
+            expect(order.failed?).to eq(true)
+            expect(order.execution_record["errors"]).to eq(["coupon_not_found"])
+            expect(order.execution_record["subscription_ids"]).to eq([])
+          end
+        end
+      end
+
+      context "when the target subscription was terminated since approval" do
+        before { target_subscription.mark_as_terminated! }
+
+        it "records the failure and marks the order failed" do
+          result = nil
+          expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+          expect(result).not_to be_success
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["subscription_not_active"])
+        end
+      end
+
+      context "when the quote carries a second plan" do
+        let(:billing_items) { {"plans" => [plan_item, plan_item]} }
+
+        it "records the failure and marks the order failed" do
+          result = nil
+          expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+          expect(result).not_to be_success
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["single_plan_expected"])
+        end
+      end
+
+      # The catalog can be repriced between approval and execution, flipping the direction the
+      # billing engine will infer.
+      context "when the amendment lowers the amount" do
+        let(:plan_overrides) { super().merge("amountCents" => 10_000) }
+
+        it "records the failure and marks the order failed" do
+          result = nil
+          expect { result = execute_service.call }.not_to change(Subscription, :count)
+
+          expect(result).not_to be_success
+          expect(target_subscription.reload).to be_active
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["amendment_decreases_amount"])
+        end
+      end
+
+      context "when the plan is gone" do
+        before { plan.discard! }
+
+        it "records the failure and marks the order failed" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["errors"]).to eq(["plan_not_found"])
+        end
+      end
+
+      context "when the plan upgrade fails" do
+        let(:failed_result) do
+          Subscriptions::PlanUpgradeService::Result.new.tap do |failed|
+            failed.single_validation_failure!(field: :ending_at, error_code: "invalid_date")
+          end
+        end
+
+        before do
+          allow(Subscriptions::PlanUpgradeService).to receive(:call!).and_raise(failed_result.error)
+        end
+
+        it "records the failure and leaves the target active" do
+          result = execute_service.call
+
+          expect(result).not_to be_success
+          expect(target_subscription.reload).to be_active
+
+          order.reload
+          expect(order.failed?).to eq(true)
+          expect(order.execution_record["executed_at"]).to be_nil
+          expect(order.execution_record["errors"]).to eq(["invalid_date"])
+        end
+      end
+    end
+
+    context "with order_only mode" do
+      let(:execution_mode) { :order_only }
+
+      it "marks the order executed without touching the subscription" do
+        expect { execute_service.call }.not_to change(Subscription, :count)
+
+        expect(target_subscription.reload).to be_active
+
+        order.reload
+        expect(order.executed?).to eq(true)
+        expect(order.execution_record["subscription_ids"]).to eq([])
+        expect(order.execution_record["terminated_subscription_ids"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -421,21 +421,44 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
         end
       end
 
-      # The catalog can be repriced between approval and execution, flipping the direction the
-      # billing engine will infer.
+      # Lago cannot prorate a mid-period reduction, so it keeps the target running and switches at
+      # the next billing day, exactly as the same plan change does through the API.
       context "when the amendment lowers the amount" do
         let(:plan_overrides) { super().merge("amountCents" => 10_000) }
 
-        it "records the failure and marks the order failed" do
+        it "schedules the replacement instead of terminating the target" do
           result = nil
-          expect { result = execute_service.call }.not_to change(Subscription, :count)
+          expect { result = execute_service.call }.to change(Subscription, :count).by(1)
 
-          expect(result).not_to be_success
+          expect(result).to be_success
           expect(target_subscription.reload).to be_active
 
+          replacement = target_subscription.next_subscription
+          expect(replacement).to be_pending
+          expect(replacement.external_id).to eq("sub_ext_42")
+          expect(replacement.plan.amount_cents).to eq(10_000)
+          expect(replacement.ending_at.to_date).to eq(quote_version.end_date)
+          expect(target_subscription.downgrade_plan_date).to be > Date.current
+
           order.reload
-          expect(order.failed?).to eq(true)
-          expect(order.execution_record["errors"]).to eq(["amendment_decreases_amount"])
+          expect(order.executed?).to eq(true)
+          expect(order.execution_record["subscription_ids"]).to eq([replacement.id])
+          expect(order.execution_record["terminated_subscription_ids"]).to eq([])
+        end
+
+        it "invoices nothing yet" do
+          expect { execute_service.call }.not_to have_enqueued_job(BillSubscriptionJob)
+        end
+      end
+
+      context "when the amendment keeps the same amount" do
+        let(:plan_overrides) { super().merge("amountCents" => target_plan.amount_cents) }
+
+        it "rotates the subscription right away" do
+          execute_service.call
+
+          expect(target_subscription.reload).to be_terminated
+          expect(customer.subscriptions.active.sole.plan.amount_cents).to eq(target_plan.amount_cents)
         end
       end
 
@@ -453,15 +476,15 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
         end
       end
 
-      context "when the plan upgrade fails" do
+      context "when the plan change fails" do
         let(:failed_result) do
-          Subscriptions::PlanUpgradeService::Result.new.tap do |failed|
+          Subscriptions::CreateService::Result.new.tap do |failed|
             failed.single_validation_failure!(field: :ending_at, error_code: "invalid_date")
           end
         end
 
         before do
-          allow(Subscriptions::PlanUpgradeService).to receive(:call!).and_raise(failed_result.error)
+          allow(Subscriptions::CreateService).to receive(:call!).and_raise(failed_result.error)
         end
 
         it "records the failure and leaves the target active" do

--- a/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
@@ -59,17 +59,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendment::BusinessValidat
       end
     end
 
+    # The replacement subscription then inherits the term of the one it amends.
     context "when the ending date is missing" do
-      let(:end_date) { nil }
-
-      it "refuses the amendment" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({end_date: ["value_is_mandatory"]})
-      end
-    end
-
-    context "when the ending date is missing at update scope" do
-      let(:scope) { :update }
       let(:end_date) { nil }
 
       it "is valid" do
@@ -80,6 +71,52 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendment::BusinessValidat
     context "when only the plan carries an ending date" do
       let(:end_date) { nil }
       let(:plan_payload) { super().merge("endDate" => 1.year.from_now.iso8601) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the ending date is in the past" do
+      let(:end_date) { 1.day.ago.to_date }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({end_date: ["invalid_date"]})
+      end
+    end
+
+    context "when the plan carries an ending date in the past" do
+      let(:end_date) { nil }
+      let(:plan_payload) { super().merge("endDate" => 1.day.ago.iso8601) }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.payload.endDate": ["invalid_date"]})
+      end
+    end
+
+    # The amendment starts on the target's own anniversary date, so the quoted start date is a
+    # commercial term the approval gate does not read.
+    context "when the quote carries no start date" do
+      let(:start_date) { nil }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the plan carries a start date that is not a date" do
+      let(:plan_payload) { super().merge("startDate" => "whenever") }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the ending date is before the start date" do
+      let(:start_date) { 2.years.from_now.to_date }
+      let(:end_date) { 1.year.from_now.to_date }
 
       it "is valid" do
         expect(validator).to be_valid

--- a/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::Validators::SubscriptionAmendment::BusinessValidator do
+  subject(:validator) { described_class.new(result, quote_version:, billing_items:, scope:) }
+
+  let(:result) { BaseService::Result.new }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
+  let(:subscription) { create(:subscription, customer:, organization:, plan: target_plan) }
+  let(:plan) { create(:plan, organization:, amount_cents: 20_000) }
+  let(:scope) { :approve }
+  let(:start_date) { Date.current }
+  let(:end_date) { 1.year.from_now.to_date }
+
+  let(:quote) do
+    create(:quote, organization:, customer:, subscription:, order_type: :subscription_amendment)
+  end
+  let(:quote_version) do
+    create(:quote_version, quote:, organization:, currency: "EUR", start_date:, end_date:, billing_items:)
+  end
+  let(:plan_payload) { {"code" => plan.code} }
+  let(:plan_overrides) { nil }
+  let(:plan_item) do
+    {
+      "id" => plan.id,
+      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "type" => "plan",
+      "payload" => plan_payload,
+      "overrides" => plan_overrides
+    }.compact
+  end
+  let(:billing_items) { {"plans" => [plan_item]} }
+
+  describe "#valid?" do
+    it "is valid and leaves the result untouched" do
+      expect(validator).to be_valid
+      expect(result).to be_success
+    end
+
+    context "when the quote carries a second plan" do
+      let(:billing_items) { {"plans" => [plan_item, plan_item]} }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans": ["single_plan_expected"]})
+      end
+    end
+
+    context "when the quote carries a second plan at update scope" do
+      let(:scope) { :update }
+      let(:billing_items) { {"plans" => [plan_item, plan_item]} }
+
+      it "refuses it too, so a draft never accumulates one" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans": ["single_plan_expected"]})
+      end
+    end
+
+    context "when the ending date is missing" do
+      let(:end_date) { nil }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({end_date: ["value_is_mandatory"]})
+      end
+    end
+
+    context "when the ending date is missing at update scope" do
+      let(:scope) { :update }
+      let(:end_date) { nil }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when only the plan carries an ending date" do
+      let(:end_date) { nil }
+      let(:plan_payload) { super().merge("endDate" => 1.year.from_now.iso8601) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the target subscription is terminated" do
+      let(:subscription) { create(:subscription, :terminated, customer:, organization:, plan: target_plan) }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({subscription_id: ["subscription_not_active"]})
+      end
+    end
+
+    context "when the target subscription is pending" do
+      let(:subscription) { create(:subscription, :pending, customer:, organization:, plan: target_plan) }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({subscription_id: ["subscription_not_active"]})
+      end
+    end
+
+    context "when the quote carries no target subscription" do
+      let(:quote) { build(:quote, organization:, customer:, order_type: :subscription_amendment) }
+      let(:quote_version) do
+        build(:quote_version, quote:, organization:, currency: "EUR", start_date:, end_date:, billing_items:)
+      end
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({subscription_id: ["value_is_mandatory"]})
+      end
+    end
+
+    context "when the amendment lowers the amount" do
+      let(:plan) { create(:plan, organization:, amount_cents: 5_000) }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["amendment_decreases_amount"]})
+      end
+    end
+
+    context "when the amendment keeps the same amount" do
+      let(:plan) { create(:plan, organization:, amount_cents: 10_000) }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when an override lowers the amount below the target plan" do
+      let(:plan_overrides) { {"amountCents" => 5_000} }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["amendment_decreases_amount"]})
+      end
+    end
+
+    context "when an override raises the amount above the target plan" do
+      let(:plan) { create(:plan, organization:, amount_cents: 5_000) }
+      let(:plan_overrides) { {"amountCents" => 20_000} }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the intervals differ" do
+      let(:target_plan) { create(:plan, organization:, interval: "yearly", amount_cents: 100_000) }
+      let(:plan) { create(:plan, organization:, interval: "monthly", amount_cents: 10_000) }
+
+      it "compares both on a yearly basis" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when a monthly amendment is cheaper than the target on a yearly basis" do
+      let(:target_plan) { create(:plan, organization:, interval: "yearly", amount_cents: 200_000) }
+      let(:plan) { create(:plan, organization:, interval: "monthly", amount_cents: 10_000) }
+
+      it "refuses the amendment" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["amendment_decreases_amount"]})
+      end
+    end
+
+    context "when the plan is unknown" do
+      let(:plan_item) { super().merge("id" => "11111111-2222-3333-4444-555555555555") }
+
+      it "reports the inherited error and skips the direction check" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["plan_not_found"]})
+      end
+    end
+
+    context "when the plan currency does not match the deal" do
+      let(:plan) { create(:plan, organization:, amount_cents: 20_000, amount_currency: "USD") }
+
+      it "still runs the inherited checks" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["currencies_does_not_match"]})
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_amendment/business_validator_spec.rb
@@ -116,17 +116,10 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendment::BusinessValidat
       end
     end
 
+    # Execution schedules a reduction for the next billing day instead of applying it mid-period,
+    # so the direction of the amendment is not the approval gate's business.
     context "when the amendment lowers the amount" do
       let(:plan) { create(:plan, organization:, amount_cents: 5_000) }
-
-      it "refuses the amendment" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["amendment_decreases_amount"]})
-      end
-    end
-
-    context "when the amendment keeps the same amount" do
-      let(:plan) { create(:plan, organization:, amount_cents: 10_000) }
 
       it "is valid" do
         expect(validator).to be_valid
@@ -136,37 +129,8 @@ RSpec.describe QuoteVersions::Validators::SubscriptionAmendment::BusinessValidat
     context "when an override lowers the amount below the target plan" do
       let(:plan_overrides) { {"amountCents" => 5_000} }
 
-      it "refuses the amendment" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["amendment_decreases_amount"]})
-      end
-    end
-
-    context "when an override raises the amount above the target plan" do
-      let(:plan) { create(:plan, organization:, amount_cents: 5_000) }
-      let(:plan_overrides) { {"amountCents" => 20_000} }
-
       it "is valid" do
         expect(validator).to be_valid
-      end
-    end
-
-    context "when the intervals differ" do
-      let(:target_plan) { create(:plan, organization:, interval: "yearly", amount_cents: 100_000) }
-      let(:plan) { create(:plan, organization:, interval: "monthly", amount_cents: 10_000) }
-
-      it "compares both on a yearly basis" do
-        expect(validator).to be_valid
-      end
-    end
-
-    context "when a monthly amendment is cheaper than the target on a yearly basis" do
-      let(:target_plan) { create(:plan, organization:, interval: "yearly", amount_cents: 200_000) }
-      let(:plan) { create(:plan, organization:, interval: "monthly", amount_cents: 10_000) }
-
-      it "refuses the amendment" do
-        expect(validator).not_to be_valid
-        expect(result.error.messages).to eq({"billing_items.plans.0.id": ["amendment_decreases_amount"]})
       end
     end
 

--- a/spec/services/quote_versions/validators/subscription_amendment_validator_spec.rb
+++ b/spec/services/quote_versions/validators/subscription_amendment_validator_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::Validators::SubscriptionAmendmentValidator do
+  subject(:validator) { described_class.new(result, quote_version:, scope:) }
+
+  let(:result) { BaseService::Result.new }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:target_plan) { create(:plan, organization:, amount_cents: 10_000) }
+  let(:subscription) { create(:subscription, customer:, organization:, plan: target_plan) }
+  let(:plan) { create(:plan, organization:, amount_cents: 20_000) }
+  let(:scope) { :approve }
+
+  let(:quote) do
+    create(:quote, organization:, customer:, subscription:, order_type: :subscription_amendment)
+  end
+  let(:quote_version) do
+    create(
+      :quote_version,
+      quote:,
+      organization:,
+      currency: "EUR",
+      start_date: Date.current,
+      end_date: 1.year.from_now.to_date,
+      billing_items:
+    )
+  end
+  let(:plan_item) do
+    {
+      "id" => plan.id,
+      "localId" => "3d08b2df-4e4c-4d58-b415-a525c1663735",
+      "type" => "plan",
+      "payload" => {"code" => plan.code}
+    }
+  end
+  let(:billing_items) { {"plans" => [plan_item]} }
+
+  describe "#valid?" do
+    context "with a complete valid quote version" do
+      it "is valid and leaves the result untouched" do
+        expect(validator).to be_valid
+        expect(result).to be_success
+      end
+    end
+
+    context "with both structural and business errors" do
+      let(:plan_item) { super().merge("overrides" => {"taxCodes" => ["vat_20"]}) }
+      let(:subscription) { create(:subscription, :terminated, customer:, organization:, plan: target_plan) }
+
+      it "returns the structural errors first" do
+        expect(validator).not_to be_valid
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages).to eq({"billing_items.plans.0.overrides.taxCodes": ["unsupported_key"]})
+      end
+    end
+
+    context "with a valid structure and an inactive target subscription" do
+      let(:subscription) { create(:subscription, :terminated, customer:, organization:, plan: target_plan) }
+
+      it "reports the business error" do
+        expect(validator).not_to be_valid
+        expect(result.error.messages).to eq({subscription_id: ["subscription_not_active"]})
+      end
+    end
+
+    context "when billing_items is nil at update scope" do
+      let(:scope) { :update }
+      let(:billing_items) { nil }
+
+      it "is valid" do
+        expect(validator).to be_valid
+        expect(result).to be_success
+      end
+    end
+  end
+end

--- a/spec/services/quote_versions/validators_spec.rb
+++ b/spec/services/quote_versions/validators_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe QuoteVersions::Validators do
     context "when the quote is subscription_amendment" do
       let(:order_type) { :subscription_amendment }
 
-      it "returns no validator" do
-        expect(validator).to be_nil
+      it "returns a subscription_amendment validator" do
+        expect(validator).to be_a(QuoteVersions::Validators::SubscriptionAmendmentValidator)
       end
     end
   end


### PR DESCRIPTION
Step 3 of the CPQ execution engine: `subscription_amendment` under `execute_in_lago`.

An amendment restates one plan on a live subscription. Execution routes it through `Subscriptions::CreateService`, the entry point the API and the UI already use for a plan change, so it inherits Lago's own semantics in both directions: a raise or a repricing rotates the subscription now, keeping the `external_id` and the billing anchor, while a reduction keeps the target running and schedules the replacement for the next billing day (`Subscription#downgrade_plan_date`). The negotiated plan is built up front with `Plans::OverrideService` so the dispatch, which compares plan ids before prices, still rotates a repricing of the same catalog plan.

Both the approval gate and the executor inherit from their `subscription_creation` counterparts, since an amendment payload is a creation payload with extra constraints: a single plan, a mandatory ending date, and an active target subscription.