### PR TITLE
fix(minimum-commitment): fix minimum commitment calculation for subscriptions downgrade

### DIFF
--- a/app/services/commitments/calculate_prorated_coefficient_service.rb
+++ b/app/services/commitments/calculate_prorated_coefficient_service.rb
@@ -44,7 +44,7 @@ module Commitments
 
       days = Utils::Datetime.date_diff_with_timezone(
         all_invoice_subscriptions.first.from_datetime,
-        subscription.terminated? ? subscription.terminated_at : invoice_subscription.to_datetime,
+        ending_at,
         subscription.customer.applicable_timezone
       )
 
@@ -55,6 +55,17 @@ module Commitments
       )
 
       days / days_total.to_f
+    end
+
+    # NOTE: A subscription terminated shortly after its period closed is still billed for that
+    #       closed period, so `terminated_at` sits past its end. Counting up to `terminated_at`
+    #       would then charge more than the full commitment.
+    def ending_at
+      if subscription.terminated?
+        [subscription.terminated_at, dates_service.end_of_period].min
+      else
+        invoice_subscription.to_datetime
+      end
     end
   end
 end

--- a/app/services/commitments/calculate_prorated_coefficient_service.rb
+++ b/app/services/commitments/calculate_prorated_coefficient_service.rb
@@ -57,9 +57,8 @@ module Commitments
       days / days_total.to_f
     end
 
-    # NOTE: A subscription terminated shortly after its period closed is still billed for that
-    #       closed period, so `terminated_at` sits past its end. Counting up to `terminated_at`
-    #       would then charge more than the full commitment.
+    # NOTE: A subscription terminated as DOWNGRADE will have `terminated_at` after the end of the latest
+    # billing period. Counting up to `terminated_at` would then charge more than the full commitment.
     def ending_at
       if subscription.terminated?
         [subscription.terminated_at, dates_service.end_of_period].min

--- a/app/services/commitments/minimum/in_arrears/dates_service.rb
+++ b/app/services/commitments/minimum/in_arrears/dates_service.rb
@@ -4,11 +4,8 @@ module Commitments
   module Minimum
     module InArrears
       class DatesService < Commitments::DatesService
-        # NOTE: A downgraded subscription is billed for the period that just closed, not for the
-        #       current one. `Subscriptions::DatesService#terminated_pay_in_arrears?` already makes
-        #       that distinction when computing the invoice boundaries, and the commitment period
-        #       has to be derived from the same period, otherwise the two disagree and the
-        #       invoice_subscription of the billed period falls outside the commitment window.
+        # Downgraded subscriptions are billed AFTER the end of the billing period,
+        # so the dates are calculated for the previous billing period, not the current one.
         def current_usage
           subscription.terminated? && !subscription.downgraded?
         end

--- a/app/services/commitments/minimum/in_arrears/dates_service.rb
+++ b/app/services/commitments/minimum/in_arrears/dates_service.rb
@@ -4,9 +4,18 @@ module Commitments
   module Minimum
     module InArrears
       class DatesService < Commitments::DatesService
+        # NOTE: A downgraded subscription is billed for the period that just closed, not for the
+        #       current one. `Subscriptions::DatesService#terminated_pay_in_arrears?` already makes
+        #       that distinction when computing the invoice boundaries, and the commitment period
+        #       has to be derived from the same period, otherwise the two disagree and the
+        #       invoice_subscription of the billed period falls outside the commitment window.
         def current_usage
-          invoice_subscription.subscription.terminated?
+          subscription.terminated? && !subscription.downgraded?
         end
+
+        private
+
+        delegate :subscription, to: :invoice_subscription
       end
     end
   end

--- a/app/services/commitments/minimum/in_arrears/fetch_invoices_service.rb
+++ b/app/services/commitments/minimum/in_arrears/fetch_invoices_service.rb
@@ -10,7 +10,7 @@ module Commitments
           ds = Subscriptions::DatesService.new_instance(
             subscription,
             invoice_subscription.timestamp,
-            current_usage: subscription.terminated?
+            current_usage: subscription.terminated? && !subscription.downgraded?
           )
 
           return ds unless subscription.terminated?

--- a/spec/scenarios/commitments/minimum/on_termination_spec.rb
+++ b/spec/scenarios/commitments/minimum/on_termination_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Minimum Commitment On Termination Scenario", transaction: false do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, timezone: "UTC", currency: "EUR") }
+
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      name: "Enterprise",
+      code: "enterprise",
+      amount_cents: 10_000,
+      amount_currency: "EUR",
+      interval: "monthly",
+      pay_in_advance: false
+    )
+  end
+
+  let(:pricier_plan) do
+    create(:plan, organization:, code: "pricier", amount_cents: 50_000, amount_currency: "EUR", interval: "monthly", pay_in_advance: false)
+  end
+
+  let(:cheaper_plan) do
+    create(:plan, organization:, code: "cheaper", amount_cents: 1_000, amount_currency: "EUR", interval: "monthly", pay_in_advance: false)
+  end
+
+  let(:subscription) { customer.subscriptions.order(created_at: :asc).first.reload }
+  let(:termination_invoice) { subscription.invoices.order(created_at: :asc).last }
+
+  before do
+    create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000)
+
+    # March 1st: subscribe to the monthly plan carrying the minimum commitment
+    travel_to(DateTime.new(2024, 3, 1)) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time: "calendar"
+        }
+      )
+    end
+
+    # April 1st and May 1st: the two periodic billing runs
+    [DateTime.new(2024, 4, 1), DateTime.new(2024, 5, 1)].each do |billing_time|
+      travel_to(billing_time) { perform_billing }
+    end
+  end
+
+  it "bills March and April with a minimum commitment true-up fee" do
+    expect(subscription.invoices.count).to eq(2)
+
+    subscription.invoices.order(created_at: :asc).each do |invoice|
+      expect(invoice.fees.commitment.count).to eq(1)
+      expect(invoice.total_amount_cents).to eq(1_000_000)
+    end
+  end
+
+  context "when the subscription is upgraded on June 1st at 10 AM" do
+    before { pricier_plan }
+
+    it "generates the termination invoice" do
+      travel_to(DateTime.new(2024, 6, 1, 10)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: pricier_plan.code,
+            billing_time: "calendar"
+          }
+        )
+      end
+
+      expect(subscription.reload).to be_terminated
+      expect(termination_invoice).to be_finalized
+
+      invoice_subscription = termination_invoice.invoice_subscriptions.sole
+      expect(invoice_subscription.from_datetime.iso8601).to eq("2024-06-01T00:00:00Z")
+      expect(invoice_subscription.to_datetime.iso8601).to eq("2024-06-01T10:00:00Z")
+      expect(termination_invoice.fees.commitment.count).to eq(1)
+    end
+  end
+
+  context "when the subscription is downgraded and the downgrade is applied on June 1st" do
+    before { cheaper_plan }
+
+    # The downgrade is requested mid-period and applied by the billing run on the
+    # first day of the next period, a few minutes after midnight.
+    it "generates the termination invoice" do
+      travel_to(DateTime.new(2024, 5, 15)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: cheaper_plan.code,
+            billing_time: "calendar"
+          }
+        )
+      end
+
+      expect(customer.subscriptions.reload.pluck(:status)).to match_array(%w[active pending])
+
+      travel_to(DateTime.new(2024, 6, 1, 0, 15, 49)) { perform_billing }
+
+      expect(subscription.reload).to be_terminated
+      expect(termination_invoice).to be_finalized
+
+      # The termination invoice covers the whole May period: on a downgrade the old
+      # plan is billed up to the end of its last full period.
+      invoice_subscription = termination_invoice.invoice_subscriptions.sole
+      expect(invoice_subscription.from_datetime.iso8601).to eq("2024-05-01T00:00:00Z")
+      expect(invoice_subscription.to_datetime.iso8601).to eq("2024-05-31T23:59:59Z")
+
+      # A full period was consumed, so the whole commitment is due, exactly like the
+      # March and April invoices above.
+      expect(termination_invoice.fees.subscription.sole.amount_cents).to eq(10_000)
+      expect(termination_invoice.fees.commitment.sole.amount_cents).to eq(990_000)
+      expect(termination_invoice.total_amount_cents).to eq(1_000_000)
+    end
+  end
+end

--- a/spec/services/commitments/calculate_prorated_coefficient_service_spec.rb
+++ b/spec/services/commitments/calculate_prorated_coefficient_service_spec.rb
@@ -63,5 +63,26 @@ RSpec.describe Commitments::CalculateProratedCoefficientService do
         expect(apply_service.proration_coefficient).to eq(1 / days_in_month.to_f)
       end
     end
+
+    context "when subscription is downgraded right after the period ended" do
+      let(:started_at) { DateTime.parse("2024-01-01T00:00:00") }
+      let(:from_datetime) { DateTime.parse("2024-07-01T00:00:00") }
+      let(:to_datetime) { DateTime.parse("2024-07-31T23:59:59") }
+      let(:charges_from_datetime) { from_datetime }
+      let(:charges_to_datetime) { to_datetime }
+      let(:terminated_at) { DateTime.parse("2024-08-01T00:15:49") }
+      let(:timestamp) { terminated_at }
+
+      let(:cheaper_plan) { create(:plan, organization:, amount_cents: plan.amount_cents / 2) }
+
+      before do
+        create(:subscription, :pending, customer:, plan: cheaper_plan, previous_subscription: subscription)
+        subscription.update!(status: :terminated, terminated_at:)
+      end
+
+      it "returns the coefficient of the whole period that was billed" do
+        expect(apply_service.proration_coefficient).to eq(1.0)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

When a subscription is terminated due to downgrade, it's termination date happens after the end of it's latest billing period. As result services that are calculating the dates for such subscription should take into account that if a subscription is terminated we should only get the dates as "current_usage" if subscription wasn't terminated due to downgrade

Note: similar logic already exists for `Subscriptions::DateService`

## Description

Updated `Commitments::DateServices` to take into account termination reasoning when passing "current_usage" to dates services
