### PR TITLE
fix: remove google auth from admin api

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -10,33 +10,15 @@ module Admin
     private
 
     def authenticate
-      auth_header = request.headers["Authorization"]
-
-      if auth_header&.start_with?("Bearer ")
-        begin
-          token = auth_header.split(" ").second
-          payload = Google::Auth::IDTokens.verify_oidc(
-            token,
-            aud: ENV["GOOGLE_AUTH_CLIENT_ID"]
-          )
-
-          CurrentContext.email = payload["email"]
-          return true
-        rescue Google::Auth::IDTokens::SignatureError
-          return unauthorized_error
-        end
-      end
-
-      # Fallback to X-Admin-API-Key header
       key_header = request.headers["X-Admin-API-Key"]
       expected_key = ENV["ADMIN_API_KEY"]
 
       if key_header.present? && expected_key.present? && ActiveSupport::SecurityUtils.secure_compare(key_header, expected_key)
         CurrentContext.email = nil
-        return true
+        true
+      else
+        unauthorized_error
       end
-
-      unauthorized_error
     end
 
     def set_context_source

--- a/spec/requests/admin/base_controller_spec.rb
+++ b/spec/requests/admin/base_controller_spec.rb
@@ -10,15 +10,50 @@ RSpec.describe Admin::BaseController, type: [:controller, :admin] do
   end
 
   describe "authenticate" do
-    it "validates the organization api key" do
-      request.headers["Authorization"] = "Bearer 123456"
+    context "with a valid admin api key" do
+      before { request.headers["X-Admin-API-Key"] = AdminHelper::ADMIN_API_KEY }
 
-      get :index
+      it "authenticates the request" do
+        get :index
 
-      expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:success)
+      end
     end
 
     context "without authentication header" do
+      it "returns an authentication error" do
+        get :index
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with an invalid admin api key" do
+      before { request.headers["X-Admin-API-Key"] = "wrong" }
+
+      it "returns an authentication error" do
+        get :index
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a bearer token" do
+      before { request.headers["Authorization"] = "Bearer 123456" }
+
+      it "returns an authentication error" do
+        get :index
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when ADMIN_API_KEY is not configured" do
+      before do
+        allow(ENV).to receive(:[]).with("ADMIN_API_KEY").and_return(nil)
+        request.headers["X-Admin-API-Key"] = ""
+      end
+
       it "returns an authentication error" do
         get :index
 

--- a/spec/requests/admin/invoices_controller_spec.rb
+++ b/spec/requests/admin/invoices_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Admin::InvoicesController, type: [:request, :admin] do
 
   describe "POST /admin/invoices/:id/regenerate" do
     it "regenerates the invoice PDF" do
-      admin_post("/admin/invoices/#{invoice.id}/regenerate")
+      admin_post("/admin/invoices/#{invoice.id}/regenerate", {}, admin_headers)
 
       expect(Invoices::GeneratePdfService).to have_received(:call)
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/memberships_controller_spec.rb
+++ b/spec/requests/admin/memberships_controller_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Admin::MembershipsController, type: [:request, :admin] do
     it "creates a membership" do
       admin_post(
         "/admin/memberships",
-        create_params
+        create_params,
+        admin_headers
       )
 
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
     it "updates an organization" do
       admin_put(
         "/admin/organizations/#{organization.id}",
-        update_params
+        update_params,
+        admin_headers
       )
 
       expect(response).to have_http_status(:success)
@@ -40,17 +41,12 @@ RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
       }
     end
 
-    before do
-      create(:role, :admin)
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("ADMIN_API_KEY").and_return("super-secret")
-    end
+    before { create(:role, :admin) }
 
     context "with a valid admin key" do
       it "creates an organization and returns 201" do
-        headers = {"X-Admin-API-Key" => "super-secret"}
         expect do
-          admin_post_without_bearer("/admin/organizations", create_params, headers)
+          admin_post("/admin/organizations", create_params, admin_headers)
         end.to change(Organization, :count).by(1)
 
         expect(response).to have_http_status(:created)
@@ -62,8 +58,14 @@ RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
 
     context "with an invalid admin key" do
       it "returns unauthorized" do
-        headers = {"X-Admin-API-Key" => "wrong"}
-        admin_post_without_bearer("/admin/organizations", create_params, headers)
+        admin_post("/admin/organizations", create_params, admin_headers("wrong"))
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "without an admin key" do
+      it "returns unauthorized" do
+        admin_post("/admin/organizations", create_params)
         expect(response).to have_http_status(:unauthorized)
       end
     end

--- a/spec/support/admin_helper.rb
+++ b/spec/support/admin_helper.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.configure do |config|
-  config.before(:each, type: :admin) do
-    allow(Google::Auth::IDTokens)
-      .to receive(:verify_oidc)
-      .and_return({email: "test@getlago.com"})
-  end
-end
-
 module AdminHelper
+  ADMIN_API_KEY = "admin-api-key"
+
   def admin_put(path, params = {}, headers = {})
     apply_headers(headers)
     put(path, params: params.to_json, headers:)
@@ -19,10 +13,8 @@ module AdminHelper
     post(path, params: params.to_json, headers:)
   end
 
-  def admin_post_without_bearer(path, params = {}, headers = {})
-    apply_headers(headers)
-    headers.delete("Authorization")
-    post(path, params: params.to_json, headers:)
+  def admin_headers(api_key = ADMIN_API_KEY)
+    {"X-Admin-API-Key" => api_key}
   end
 
   def json
@@ -36,6 +28,12 @@ module AdminHelper
   def apply_headers(headers)
     headers["Content-Type"] = "application/json"
     headers["Accept"] = "application/json"
-    headers["Authorization"] = "Bearer 123456"
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:each, type: :admin) do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("ADMIN_API_KEY").and_return(AdminHelper::ADMIN_API_KEY)
   end
 end


### PR DESCRIPTION
## Context

Google auth is not used anymore in admin API.

## Description

Drop Google auth from the admin API, leaving `X-Admin-API-Key` as the only accepted auth method.