### PR TITLE
Multi currency billing enty flag drops phase 1

### DIFF
--- a/app/services/customers/update_currency_service.rb
+++ b/app/services/customers/update_currency_service.rb
@@ -17,28 +17,7 @@ module Customers
       return result if customer.currency == currency
 
       # Multi-currency: customer.currency becomes a default preference, not a constraint.
-      if customer.organization.feature_flag_enabled?(:multi_currency)
-        customer.update!(currency:) if customer_update || customer.currency.blank?
-        return result
-      end
-
-      if customer_update
-        # NOTE: direct update of the customer currency
-        unless customer.editable?
-          return result.single_validation_failure!(
-            field: :currency,
-            error_code: "currencies_does_not_match"
-          )
-        end
-      elsif customer.currency.present? || !customer.editable?
-        # NOTE: Assign currency from another resource
-        return result.single_validation_failure!(
-          field: :currency,
-          error_code: "currencies_does_not_match"
-        )
-      end
-
-      customer.update!(currency:)
+      customer.update!(currency:) if customer_update || customer.currency.blank?
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -96,11 +96,9 @@ module Customers
       end
 
       # NOTE: Some fields are not editable if customer is attached to subscriptions:
-      #       external_id,
-      #       account_type,
-      #       billing_entity_id (gated by editable? unless multi_entity_billing flag is enabled)
+      #       external_id, account_type
       billing_entity_changed = false
-      if args.key?(:billing_entity_code) && allow_billing_entity_update?
+      if args.key?(:billing_entity_code)
         customer.billing_entity = billing_entity
         billing_entity_changed = customer.billing_entity_id_changed?
       end
@@ -229,10 +227,6 @@ module Customers
       return true if metadata.count <= ::Metadata::CustomerMetadata::COUNT_PER_CUSTOMER
 
       false
-    end
-
-    def allow_billing_entity_update?
-      organization.feature_flag_enabled?(:multi_entity_billing) || customer.editable?
     end
 
     def assign_premium_attributes(customer, args)

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -47,7 +47,7 @@ module Customers
         original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
 
         billing_entity_changed = false
-        if new_customer || (params.key?(:billing_entity_code) && allow_billing_entity_update?(customer))
+        if new_customer || params.key?(:billing_entity_code)
           customer.billing_entity = billing_entity
           billing_entity_changed = !new_customer && customer.billing_entity_id_changed?
         end
@@ -189,10 +189,6 @@ module Customers
       input_types = integration_customers&.map { |c| c.to_h.deep_symbolize_keys }&.map { |c| c[:integration_type] }
 
       input_types.length == input_types.uniq.length
-    end
-
-    def allow_billing_entity_update?(customer)
-      organization.feature_flag_enabled?(:multi_entity_billing) || customer.editable?
     end
 
     def create_metadata(customer:, args:)

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -116,19 +116,15 @@ module Invoices
     end
 
     def resolve_billing_entity
-      if multi_entity_enabled? && billing_entity_id.present?
+      if billing_entity_id.present?
         @billing_entity = customer.organization.billing_entities.find_by(id: billing_entity_id)
         result.not_found_failure!(resource: "billing_entity") if @billing_entity.nil?
-      elsif multi_entity_enabled? && billing_entity_code.present?
+      elsif billing_entity_code.present?
         @billing_entity = customer.organization.billing_entities.find_by(code: billing_entity_code)
         result.not_found_failure!(resource: "billing_entity") if @billing_entity.nil?
       else
         @billing_entity = customer.billing_entity
       end
-    end
-
-    def multi_entity_enabled?
-      customer.organization.feature_flag_enabled?(:multi_entity_billing)
     end
 
     def create_one_off_fees(invoice)

--- a/app/services/invoices/preview/build_subscription_service.rb
+++ b/app/services/invoices/preview/build_subscription_service.rb
@@ -41,7 +41,6 @@ module Invoices
       end
 
       def effective_billing_entity
-        return nil unless organization.feature_flag_enabled?(:multi_entity_billing)
         return nil if billing_entity.nil? || billing_entity == customer.billing_entity
 
         billing_entity

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -43,11 +43,7 @@ module Invoices
     end
 
     def new_customer_billing_entity
-      if organization.feature_flag_enabled?(:multi_entity_billing)
-        organization.default_billing_entity
-      else
-        billing_entity
-      end
+      organization.default_billing_entity
     end
 
     def find_or_build_customer

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -62,15 +62,10 @@ module Invoices
     delegate :organization, to: :customer
 
     def billing_entity
-      @billing_entity ||= if multi_entity_billing_enabled?
-        first_subscription.billing_entity || customer.billing_entity
-      else
-        customer.billing_entity
-      end
+      @billing_entity ||= first_subscription.billing_entity || customer.billing_entity
     end
 
     def billing_entities_aligned?
-      return true unless multi_entity_billing_enabled?
       return true if subscriptions.size <= 1
 
       effective_entity_ids = subscriptions.map { |s| s.billing_entity_id || customer.billing_entity_id }.uniq
@@ -81,10 +76,6 @@ module Invoices
       end
 
       true
-    end
-
-    def multi_entity_billing_enabled?
-      organization.feature_flag_enabled?(:multi_entity_billing)
     end
 
     def fetch_context

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -101,13 +101,6 @@ module Invoices
         return false
       end
 
-      if customer.currency && customer.currency != subscription_currencies.first
-        unless organization.feature_flag_enabled?(:multi_currency)
-          result.single_validation_failure!(error_code: "customer_currency_does_not_match")
-          return false
-        end
-      end
-
       true
     end
 

--- a/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
+++ b/app/services/subscriptions/concerns/billing_entity_resolution_concern.rb
@@ -8,8 +8,6 @@ module Subscriptions
       private
 
       def resolve_billing_entity(organization:, params:)
-        return unless organization.feature_flag_enabled?(:multi_entity_billing)
-
         if params[:billing_entity_id].present?
           organization.billing_entities.find(params[:billing_entity_id])
         elsif params[:billing_entity_code].present?

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -548,8 +548,6 @@ module Subscriptions
     end
 
     def group_by_billing_entity(subscription_groups)
-      return subscription_groups unless organization.feature_flag_enabled?(:multi_entity_billing)
-
       subscription_groups.flat_map do |subscriptions|
         subscriptions.group_by { |sub| sub.billing_entity_id || sub.customer.billing_entity_id }.values
       end

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -530,8 +530,6 @@ module Subscriptions
     end
 
     def group_by_currency(subscription_groups)
-      return subscription_groups unless organization.feature_flag_enabled?(:multi_currency)
-
       subscription_groups.flat_map do |subscriptions|
         subscriptions.group_by { |sub| sub.plan.amount_currency }.values
       end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -74,8 +74,7 @@ module Subscriptions
           subscription.payment_method_id = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
         end
 
-        if subscription.organization.feature_flag_enabled?(:multi_entity_billing) &&
-            (params.key?(:billing_entity_id) || params.key?(:billing_entity_code))
+        if params.key?(:billing_entity_id) || params.key?(:billing_entity_code)
           new_billing_entity = resolve_billing_entity(organization: subscription.organization, params:)
           subscription.billing_entity = new_billing_entity
         end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -69,11 +69,11 @@ module Wallets
       recurring_transaction_rule = nil
 
       ActiveRecord::Base.transaction do
-        if currency.present? && (!organization_flag_enabled?(:multi_currency) || customer.currency.blank?)
+        if currency.present? && customer.currency.blank?
           Customers::UpdateCurrencyService.call!(customer: customer, currency:)
         end
 
-        wallet.currency = organization_flag_enabled?(:multi_currency) ? (currency || wallet.customer.currency) : wallet.customer.currency
+        wallet.currency = currency || wallet.customer.currency
         wallet.save!
 
         validate_wallet_initial_amount! wallet

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -59,7 +59,7 @@ module Wallets
         attributes[:payment_method_id] = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
       end
 
-      if organization_flag_enabled?(:multi_entity_billing) && (params[:billing_entity_id].present? || params[:billing_entity_code].present?)
+      if params[:billing_entity_id].present? || params[:billing_entity_code].present?
         return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 
         attributes[:billing_entity_id] = billing_entity.id

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -24,7 +24,7 @@ module Wallets
       return result unless valid_limitations?
       return result unless valid_payment_method?
 
-      if organization_flag_enabled?(:multi_entity_billing) && billing_entity_param_sent?
+      if billing_entity_param_sent?
         if billing_entity_value_provided? && billing_entity.nil?
           return result.not_found_failure!(resource: "billing_entity")
         end

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -148,7 +148,6 @@ RSpec.describe Mutations::Invoices::Create do
     end
 
     before do
-      organization.enable_feature_flag!(:multi_entity_billing)
       create(:tax, :applied_to_billing_entity, billing_entity: other_billing_entity, organization:, rate: 20)
     end
 
@@ -192,39 +191,6 @@ RSpec.describe Mutations::Invoices::Create do
 
       expect(result["errors"].first["extensions"]["code"]).to eq("not_found")
       expect(result["errors"].first["extensions"]["details"]).to include("billingEntity" => ["not_found"])
-    end
-  end
-
-  context "when multi_entity_billing feature flag is disabled" do
-    let(:other_billing_entity) { create(:billing_entity, organization:) }
-    let(:mutation) do
-      <<-GQL
-        mutation($input: CreateInvoiceInput!) {
-          createInvoice(input: $input) {
-            id
-            billingEntity { id code }
-          }
-        }
-      GQL
-    end
-
-    it "ignores billingEntityId and falls back to the customer's billing entity" do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            currency:,
-            fees:,
-            billingEntityId: other_billing_entity.id
-          }
-        }
-      )
-
-      expect(result["data"]["createInvoice"]["billingEntity"]["id"]).to eq(customer.billing_entity.id)
     end
   end
 end

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -143,8 +143,6 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
     end
 
     context "when multi_entity_billing flag is enabled" do
-      before { organization.enable_feature_flag!(:multi_entity_billing) }
-
       it "binds the subscription to the resolved entity" do
         result = execute_graphql(
           current_user: membership.user,
@@ -186,29 +184,6 @@ RSpec.describe Mutations::Subscriptions::Create, :premium do
           "code" => "not_found",
           "details" => {"billingEntity" => ["not_found"]}
         )
-      end
-    end
-
-    context "when multi_entity_billing flag is disabled" do
-      it "ignores the billing entity binding" do
-        result = execute_graphql(
-          current_user: membership.user,
-          current_organization: organization,
-          permissions: required_permission,
-          query: mutation,
-          variables: {
-            input: {
-              customerId: customer.id,
-              planId: plan.id,
-              billingTime: "anniversary",
-              billingEntityId: billing_entity.id
-            }
-          }
-        )
-
-        external_id = result["data"]["createSubscription"]["externalId"]
-        subscription = Subscription.find_by(external_id:)
-        expect(subscription.billing_entity_id).to be_nil
       end
     end
   end

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -279,8 +279,6 @@ RSpec.describe Mutations::Subscriptions::Update, :premium do
 
     let(:input) { {id: subscription.id, billingEntityId: new_billing_entity.id} }
 
-    before { organization.update!(feature_flags: ["multi_entity_billing"]) }
-
     it "rebinds the subscription to the new billing entity" do
       result = subject
 

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -315,10 +315,6 @@ RSpec.describe Mutations::Wallets::Update, :premium do
   context "when updating billing_entity_id with multi_entity_billing enabled" do
     let(:billing_entity) { create(:billing_entity, organization:) }
 
-    before do
-      organization.update!(feature_flags: ["multi_entity_billing"])
-    end
-
     it "updates the wallet's billing entity" do
       result = execute_graphql(
         current_organization: organization,

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -146,7 +146,6 @@ RSpec.describe Api::V1::InvoicesController do
       let(:other_billing_entity) { create(:billing_entity, organization:) }
 
       before do
-        organization.enable_feature_flag!(:multi_entity_billing)
         create(:tax, :applied_to_billing_entity, billing_entity: other_billing_entity, organization:, rate: 20)
       end
 
@@ -200,25 +199,6 @@ RSpec.describe Api::V1::InvoicesController do
           expect(response).to have_http_status(:success)
           expect(json[:invoice][:billing_entity_code]).to eq(customer.billing_entity.code)
         end
-      end
-    end
-
-    context "when multi_entity_billing feature flag is disabled" do
-      let(:other_billing_entity) { create(:billing_entity, organization:) }
-      let(:create_params) do
-        {
-          external_customer_id: customer_external_id,
-          currency: "EUR",
-          billing_entity_code: other_billing_entity.code,
-          fees: [{add_on_code: add_on_first.code, unit_amount_cents: 1200, units: 2}]
-        }
-      end
-
-      it "ignores billing_entity_code and falls back to the customer's billing entity" do
-        subject
-
-        expect(response).to have_http_status(:success)
-        expect(json[:invoice][:billing_entity_code]).to eq(customer.billing_entity.code)
       end
     end
   end
@@ -1227,8 +1207,6 @@ RSpec.describe Api::V1::InvoicesController do
           }
         end
 
-        before { organization.enable_feature_flag!(:multi_entity_billing) }
-
         it "creates a preview invoice under the requested billing entity" do
           subject
 
@@ -1253,8 +1231,6 @@ RSpec.describe Api::V1::InvoicesController do
             billing_entity_code: billing_entity.code
           }
         end
-
-        before { organization.enable_feature_flag!(:multi_entity_billing) }
 
         it "stamps the invoice with the requested billing entity" do
           subject

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -331,8 +331,6 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
       end
 
       context "when multi_entity_billing flag is enabled" do
-        before { organization.enable_feature_flag!(:multi_entity_billing) }
-
         it "binds the subscription to the resolved billing entity" do
           subject
 
@@ -362,16 +360,6 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         end
       end
 
-      context "when multi_entity_billing flag is disabled" do
-        it "ignores the param and persists subscription with no explicit billing entity" do
-          subject
-
-          expect(response).to have_http_status(:ok)
-          subscription = Subscription.find_by(external_id: params[:external_id])
-          expect(subscription.billing_entity_id).to be_nil
-        end
-      end
-
       context "without billing_entity_code" do
         let(:params) do
           {
@@ -381,8 +369,6 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
             billing_time: "anniversary"
           }
         end
-
-        before { organization.enable_feature_flag!(:multi_entity_billing) }
 
         it "persists subscription with no explicit billing entity" do
           subject
@@ -1823,8 +1809,6 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
         let(:new_billing_entity) { create(:billing_entity, organization:) }
 
         context "with multi_entity_billing feature flag enabled" do
-          before { organization.update!(feature_flags: ["multi_entity_billing"]) }
-
           context "with billing_entity_code" do
             let(:update_params) { {billing_entity_code: new_billing_entity.code} }
 
@@ -1855,17 +1839,6 @@ RSpec.describe Api::V1::SubscriptionsController, :premium do
 
               expect(response).to be_not_found_error("billing_entity")
             end
-          end
-        end
-
-        context "with multi_entity_billing feature flag disabled" do
-          let(:update_params) { {billing_entity_code: new_billing_entity.code} }
-
-          it "silently ignores billing_entity_code and returns success" do
-            subject
-
-            expect(response).to have_http_status(:success)
-            expect(subscription.reload.billing_entity_id).to be_nil
           end
         end
       end

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -1164,8 +1164,6 @@ describe "Invoice Numbering Scenario", transaction: false do
     let(:subscription_under_first_external_id) { "sub-under-first" }
     let(:subscription_under_second_external_id) { "sub-under-second" }
 
-    before { organization.enable_feature_flag!(:multi_entity_billing) }
-
     it "numbers invoices gaplessly per (customer, billing_entity)" do
       # NOTE: Jul 19th: create two subscriptions for the same customer, one per billing entity
       travel_to(subscription_at) do

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -105,11 +105,10 @@ RSpec.describe AppliedCoupons::CreateService do
 
         before { customer.update!(currency: "EUR") }
 
-        it "fails" do
-          expect(create_result).not_to be_success
-          expect(create_result.error).to be_a(BaseService::ValidationFailure)
-          expect(create_result.error.messages.keys).to include(:currency)
-          expect(create_result.error.messages[:currency]).to include("currencies_does_not_match")
+        it "applies the coupon (currency is a default preference)" do
+          expect(create_result).to be_success
+          expect(create_result.applied_coupon.amount_currency).to eq("NOK")
+          expect(customer.reload.currency).to eq("EUR")
         end
       end
     end
@@ -224,11 +223,10 @@ RSpec.describe AppliedCoupons::CreateService do
 
       before { customer.update!(currency: "EUR") }
 
-      it "fails" do
-        expect(create_result).not_to be_success
-        expect(create_result.error).to be_a(BaseService::ValidationFailure)
-        expect(create_result.error.messages.keys).to include(:currency)
-        expect(create_result.error.messages[:currency]).to include("currencies_does_not_match")
+      it "applies the coupon (currency is a default preference)" do
+        expect(create_result).to be_success
+        expect(create_result.applied_coupon.amount_currency).to eq("NOK")
+        expect(customer.reload.currency).to eq("EUR")
       end
     end
 

--- a/spec/services/customers/update_currency_service_spec.rb
+++ b/spec/services/customers/update_currency_service_spec.rb
@@ -40,53 +40,6 @@ RSpec.describe Customers::UpdateCurrencyService do
       end
     end
 
-    context "when customer already has a currency" do
-      let(:customer) { create(:customer, currency: "EUR") }
-
-      it "returns a failure" do
-        result = currency_service.call
-
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:currency]).to eq(["currencies_does_not_match"])
-      end
-
-      context "when in customer update" do
-        let(:customer_update) { true }
-
-        it "assigns the currency to the customer" do
-          result = currency_service.call
-
-          expect(result).to be_success
-          expect(customer.reload.currency).to eq(currency)
-        end
-
-        context "when customer is not editable" do
-          before { create(:subscription, customer:) }
-
-          it "returns a failure" do
-            result = currency_service.call
-
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages[:currency]).to eq(["currencies_does_not_match"])
-          end
-        end
-      end
-    end
-
-    context "when customer is not editable" do
-      before { create(:subscription, customer:) }
-
-      it "returns a failure" do
-        result = currency_service.call
-
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:currency]).to eq(["currencies_does_not_match"])
-      end
-    end
-
     context "when providing an invalid currency" do
       let(:currency) { "INVALID" }
 
@@ -99,9 +52,7 @@ RSpec.describe Customers::UpdateCurrencyService do
       end
     end
 
-    context "when multi_currency flag is enabled" do
-      before { customer.organization.enable_feature_flag!(:multi_currency) }
-
+    context "when the customer currency is a default preference" do
       context "when customer_update is false (billing object creation)" do
         let(:customer_update) { false }
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -135,20 +135,10 @@ RSpec.describe Customers::UpdateService do
           create(:subscription, customer:)
         end
 
-        it "does not update the billing entity" do
+        it "updates the billing entity" do
           result = customers_service.call
           expect(result).to be_success
-          expect(result.customer.billing_entity).to eq(billing_entity)
-        end
-
-        context "when multi_entity_billing feature flag is enabled" do
-          before { organization.enable_feature_flag!(:multi_entity_billing) }
-
-          it "updates the billing entity" do
-            result = customers_service.call
-            expect(result).to be_success
-            expect(result.customer.billing_entity).to eq(billing_entity_2)
-          end
+          expect(result.customer.billing_entity).to eq(billing_entity_2)
         end
       end
     end

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -324,13 +324,11 @@ RSpec.describe Customers::UpdateService do
           }
         end
 
-        it "fails" do
+        it "updates the currency" do
           result = customers_service.call
 
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to include(:currency)
-          expect(result.error.messages[:currency]).to include("currencies_does_not_match")
+          expect(result).to be_success
+          expect(result.customer.currency).to eq("CAD")
         end
       end
     end

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -842,11 +842,9 @@ RSpec.describe Customers::UpsertFromApiService do
         customer.update!(currency: subscription.plan.amount_currency)
       end
 
-      it "fails is we change the subscription" do
-        expect(result).to be_failure
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages.keys).to include(:currency)
-        expect(result.error.messages[:currency]).to include("currencies_does_not_match")
+      it "updates the customer currency (it is now a default preference)" do
+        expect(result).to be_success
+        expect(customer.reload.currency).to eq("CAD")
       end
     end
 

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -279,20 +279,10 @@ RSpec.describe Customers::UpsertFromApiService do
         create(:invoice, customer: customer)
       end
 
-      it "does not update the billing_entity of the customer" do
+      it "updates the billing_entity of the customer" do
         expect(result).to be_success
         expect(result.customer).to eq(customer)
-        expect(result.customer.billing_entity).to eq(billing_entity_2)
-      end
-
-      context "when multi_entity_billing feature flag is enabled" do
-        before { organization.enable_feature_flag!(:multi_entity_billing) }
-
-        it "updates the billing_entity of the customer" do
-          expect(result).to be_success
-          expect(result.customer).to eq(customer)
-          expect(result.customer.billing_entity).to eq(billing_entity)
-        end
+        expect(result.customer.billing_entity).to eq(billing_entity)
       end
     end
 

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -453,7 +453,6 @@ RSpec.describe Invoices::CreateOneOffService do
       let(:other_billing_entity) { create(:billing_entity, organization:) }
 
       before do
-        organization.enable_feature_flag!(:multi_entity_billing)
         create(:tax, :applied_to_billing_entity, billing_entity: other_billing_entity, organization:, rate: 20)
       end
 
@@ -510,18 +509,6 @@ RSpec.describe Invoices::CreateOneOffService do
           expect(result.error).to be_a(BaseService::NotFoundFailure)
           expect(result.error.message).to eq("billing_entity_not_found")
         end
-      end
-    end
-
-    context "when multi_entity_billing feature flag is disabled" do
-      let(:other_billing_entity) { create(:billing_entity, organization:) }
-      let(:args) { {customer:, timestamp: timestamp.to_i, fees:, currency:, billing_entity_id: other_billing_entity.id} }
-
-      it "ignores the billing_entity param and falls back to the customer's billing entity" do
-        result = described_class.call(**args)
-
-        expect(result).to be_success
-        expect(result.invoice.billing_entity).to eq(customer.billing_entity)
       end
     end
 

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -353,13 +353,11 @@ RSpec.describe Invoices::CreateOneOffService do
     context "when currency does not match" do
       let(:currency) { "NOK" }
 
-      it "fails" do
+      it "creates the invoice (currency is a default preference)" do
         result = described_class.call(**args)
 
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages.keys).to include(:currency)
-        expect(result.error.messages[:currency]).to include("currencies_does_not_match")
+        expect(result).to be_success
+        expect(result.invoice.currency).to eq("NOK")
       end
     end
 

--- a/spec/services/invoices/preview/build_subscription_service_spec.rb
+++ b/spec/services/invoices/preview/build_subscription_service_spec.rb
@@ -120,18 +120,7 @@ RSpec.describe Invoices::Preview::BuildSubscriptionService do
         let(:other_billing_entity) { create(:billing_entity, organization: customer.organization) }
         let(:params) { {plan_code: plan.code} }
 
-        context "when multi_entity_billing flag is disabled" do
-          let(:billing_entity) { other_billing_entity }
-
-          it "does not assign an explicit billing entity on the subscription" do
-            expect(result).to be_success
-            expect(subscriptions.first.billing_entity_id).to be_nil
-          end
-        end
-
-        context "when multi_entity_billing flag is enabled" do
-          before { customer.organization.enable_feature_flag!(:multi_entity_billing) }
-
+        context "when the billing entity is resolved" do
           context "when the billing entity differs from the customer default" do
             let(:billing_entity) { other_billing_entity }
 

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -380,8 +380,6 @@ RSpec.describe Invoices::Preview::SubscriptionsService do
           let(:other_billing_entity) { create(:billing_entity, organization:) }
 
           context "when multi_entity_billing flag is enabled" do
-            before { organization.enable_feature_flag!(:multi_entity_billing) }
-
             context "when the billing entity differs from the customer default" do
               let(:billing_entity) { other_billing_entity }
 
@@ -398,15 +396,6 @@ RSpec.describe Invoices::Preview::SubscriptionsService do
                 expect(result).to be_success
                 expect(subject.first.billing_entity_id).to be_nil
               end
-            end
-          end
-
-          context "when multi_entity_billing flag is disabled" do
-            let(:billing_entity) { other_billing_entity }
-
-            it "leaves the built subscription's billing_entity_id nil" do
-              expect(result).to be_success
-              expect(subject.first.billing_entity_id).to be_nil
             end
           end
         end

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -187,18 +187,7 @@ RSpec.describe Invoices::PreviewContextService do
           }
         end
 
-        context "when multi_entity_billing flag is disabled" do
-          it "builds the customer with the passed billing entity" do
-            expect(subject)
-              .to be_present
-              .and be_new_record
-              .and have_attributes(billing_entity_id: billing_entity.id)
-          end
-        end
-
-        context "when multi_entity_billing flag is enabled" do
-          before { organization.enable_feature_flag!(:multi_entity_billing) }
-
+        context "with a brand-new customer" do
           it "builds the customer with the organization's default billing entity" do
             expect(subject)
               .to be_present

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -78,33 +78,7 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
       context "with multi-entity billing" do
         let(:other_billing_entity) { create(:billing_entity, organization:) }
 
-        context "when multi_entity_billing flag is disabled" do
-          let(:subscription) do
-            build(
-              :subscription,
-              customer:,
-              plan:,
-              billing_entity: other_billing_entity,
-              billing_time:,
-              subscription_at: timestamp,
-              started_at: timestamp,
-              created_at: timestamp
-            )
-          end
-
-          it "ignores the subscription's billing entity and uses the customer's entity" do
-            travel_to(timestamp) do
-              result = preview_service.call
-
-              expect(result).to be_success
-              expect(result.invoice.billing_entity).to eq(billing_entity)
-            end
-          end
-        end
-
-        context "when multi_entity_billing flag is enabled" do
-          before { organization.enable_feature_flag!(:multi_entity_billing) }
-
+        context "with a subscription-specific billing entity" do
           context "when the subscription has its own billing entity" do
             let(:subscription) do
               build(

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -62,26 +62,15 @@ RSpec.describe Invoices::PreviewService, cache: :memory do
         end
       end
 
-      context "when currencies do not match" do
+      context "when the customer currency differs from the subscription" do
         let(:customer) { build(:customer, organization:, billing_entity:, currency: "USD") }
 
-        it "returns an error" do
-          result = preview_service.call
+        it "allows the preview" do
+          travel_to(timestamp) do
+            result = preview_service.call
 
-          expect(result).not_to be_success
-          expect(result.error.messages[:base]).to include("customer_currency_does_not_match")
-        end
-
-        context "when multi_currency flag is enabled" do
-          before { organization.enable_feature_flag!(:multi_currency) }
-
-          it "allows the preview" do
-            travel_to(timestamp) do
-              result = preview_service.call
-
-              expect(result).to be_success
-              expect(result.invoice).to be_present
-            end
+            expect(result).to be_success
+            expect(result.invoice).to be_present
           end
         end
       end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -131,8 +131,6 @@ RSpec.describe Invoices::SubscriptionService do
     context "when a subscription is moved between billing entities mid-lifecycle" do
       let(:eu_entity) { create(:billing_entity, organization:) }
 
-      before { organization.update!(feature_flags: ["multi_entity_billing"]) }
-
       it "stamps the past invoice with the original entity, then the next billing cycle with the new one" do
         past_invoice = described_class.call(
           subscriptions:,

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1915,29 +1915,7 @@ RSpec.describe Subscriptions::CreateService do
     describe "billing entity binding" do
       let(:billing_entity) { create(:billing_entity, organization:) }
 
-      context "when multi_entity_billing flag is OFF" do
-        it "ignores billing_entity_code and persists nil" do
-          params[:billing_entity_code] = billing_entity.code
-
-          result = create_service.call
-
-          expect(result).to be_success
-          expect(result.subscription.billing_entity_id).to be_nil
-        end
-
-        it "ignores billing_entity_id and persists nil" do
-          params[:billing_entity_id] = billing_entity.id
-
-          result = create_service.call
-
-          expect(result).to be_success
-          expect(result.subscription.billing_entity_id).to be_nil
-        end
-      end
-
-      context "when multi_entity_billing flag is ON" do
-        before { organization.enable_feature_flag!(:multi_entity_billing) }
-
+      context "when binding a billing entity" do
         it "persists nil when no billing entity reference is provided" do
           result = create_service.call
 
@@ -2017,40 +1995,8 @@ RSpec.describe Subscriptions::CreateService do
 
       before { CurrentContext.source = "api" }
 
-      context "when multi_entity_billing flag is OFF" do
+      context "when downgrading" do
         before { subscription.mark_as_active! }
-
-        it "carries over current_subscription.billing_entity_id to the pending subscription" do
-          result = create_service.call
-
-          expect(result).to be_success
-          expect(result.subscription.next_subscription.billing_entity_id).to eq(current_entity.id)
-        end
-
-        it "carries over NULL when current_subscription is not bound to any entity" do
-          subscription.update!(billing_entity_id: nil)
-
-          result = create_service.call
-
-          expect(result).to be_success
-          expect(result.subscription.next_subscription.billing_entity_id).to be_nil
-        end
-
-        it "ignores billing_entity_code param and still carries over from current_subscription" do
-          params[:billing_entity_code] = target_entity.code
-
-          result = create_service.call
-
-          expect(result).to be_success
-          expect(result.subscription.next_subscription.billing_entity_id).to eq(current_entity.id)
-        end
-      end
-
-      context "when multi_entity_billing flag is ON" do
-        before do
-          subscription.mark_as_active!
-          organization.enable_feature_flag!(:multi_entity_billing)
-        end
 
         it "carries over current_subscription.billing_entity_id when no param is provided" do
           result = create_service.call
@@ -2131,7 +2077,6 @@ RSpec.describe Subscriptions::CreateService do
 
         before do
           subscription
-          organization.enable_feature_flag!(:multi_entity_billing)
         end
 
         it "re-binds the pending subscription when billing_entity_code is provided" do

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -1028,13 +1028,11 @@ RSpec.describe Subscriptions::CreateService do
       context "when new plan has different currency than the old plan" do
         let(:plan) { create(:plan, amount_cents: 200, organization:, amount_currency: "USD") }
 
-        it "fails" do
+        it "creates the subscription (currency is a default preference)" do
           result = create_service.call
 
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to include(:currency)
-          expect(result.error.messages[:currency]).to include("currencies_does_not_match")
+          expect(result).to be_success
+          expect(result.subscription).to be_present
         end
       end
 

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -899,7 +899,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
     end
 
     context "when grouping subscriptions by billing entity" do
-      let(:organization) { create(:organization, feature_flags: ["multi_entity_billing"]) }
+      let(:organization) { create(:organization) }
       let(:billing_entity) { create(:billing_entity, organization:) }
       let(:other_billing_entity) { create(:billing_entity, organization:) }
       let(:interval) { :monthly }
@@ -949,21 +949,6 @@ RSpec.describe Subscriptions::OrganizationBillingService do
             .with([subscription_default_entity], current_date)
           expect(BillNonInvoiceableFeesJob).to have_been_enqueued
             .with([subscription_other_entity], current_date)
-        end
-
-        context "without feature flag" do
-          let(:organization) { create(:organization) }
-
-          it "groups them into a single billing job" do
-            billing_service.call
-
-            expect(BillSubscriptionJob).to have_been_enqueued
-              .with(
-                contain_exactly(subscription_default_entity, subscription_other_entity),
-                current_date.to_i,
-                invoicing_reason: :subscription_periodic
-              )
-          end
         end
       end
 
@@ -1270,7 +1255,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
       end
 
       context "when combined with billing entity grouping" do
-        let(:organization) { create(:organization, feature_flags: ["multi_entity_billing"]) }
+        let(:organization) { create(:organization) }
         let(:other_billing_entity) { create(:billing_entity, organization:) }
 
         let(:default_entity_consolidated) do
@@ -1418,7 +1403,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
 
       context "when combined with payment method, currency and billing entity grouping" do
         let(:organization) do
-          create(:organization, feature_flags: %w[multi_entity_billing])
+          create(:organization)
         end
         let(:other_billing_entity) { create(:billing_entity, organization:) }
         let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
     end
 
     context "when grouping subscriptions by currency" do
-      let(:organization) { create(:organization, feature_flags: ["multi_currency"]) }
+      let(:organization) { create(:organization) }
       let(:interval) { :monthly }
       let(:billing_time) { :anniversary }
       let(:current_date) { subscription_at.next_month }
@@ -494,21 +494,6 @@ RSpec.describe Subscriptions::OrganizationBillingService do
           expect(BillNonInvoiceableFeesJob).to have_been_enqueued
             .with([eur_subscription], current_date)
         end
-
-        context "without feature flag" do
-          let(:organization) { create(:organization) }
-
-          it "groups them into a single billing job" do
-            billing_service.call
-
-            expect(BillSubscriptionJob).to have_been_enqueued
-              .with(
-                contain_exactly(usd_subscription, eur_subscription),
-                current_date.to_i,
-                invoicing_reason: :subscription_periodic
-              )
-          end
-        end
       end
 
       context "when subscriptions share the same currency" do
@@ -556,7 +541,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
       end
 
       context "when combined with payment method grouping" do
-        let(:organization) { create(:organization, feature_flags: %w[multi_currency]) }
+        let(:organization) { create(:organization) }
         let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }
         let(:eur_plan) { create(:plan, organization:, interval:, amount_currency: "EUR") }
 
@@ -1213,7 +1198,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
       end
 
       context "when combined with currency grouping" do
-        let(:organization) { create(:organization, feature_flags: ["multi_currency"]) }
+        let(:organization) { create(:organization) }
         let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }
         let(:eur_plan) { create(:plan, organization:, interval:, amount_currency: "EUR") }
 
@@ -1433,7 +1418,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
 
       context "when combined with payment method, currency and billing entity grouping" do
         let(:organization) do
-          create(:organization, feature_flags: %w[multi_currency multi_entity_billing])
+          create(:organization, feature_flags: %w[multi_entity_billing])
         end
         let(:other_billing_entity) { create(:billing_entity, organization:) }
         let(:usd_plan) { create(:plan, organization:, interval:, amount_currency: "USD") }

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -479,31 +479,7 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       let(:billing_entity) { create(:billing_entity, organization:) }
       let(:other_entity) { create(:billing_entity, organization:) }
 
-      context "when multi_entity_billing flag is OFF" do
-        it "carries over the current subscription's billing_entity_id even without params" do
-          subscription.update!(billing_entity:)
-
-          expect(result).to be_success
-          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
-        end
-
-        it "ignores billing_entity_code in params but still carries over" do
-          subscription.update!(billing_entity:)
-          params[:billing_entity_code] = other_entity.code
-
-          expect(result).to be_success
-          expect(result.subscription.billing_entity_id).to eq(billing_entity.id)
-        end
-
-        it "persists nil when current subscription has no billing entity binding" do
-          expect(result).to be_success
-          expect(result.subscription.billing_entity_id).to be_nil
-        end
-      end
-
-      context "when multi_entity_billing flag is ON" do
-        before { organization.enable_feature_flag!(:multi_entity_billing) }
-
+      context "when binding a billing entity" do
         it "carries over the current subscription's billing_entity_id when no param is provided" do
           subscription.update!(billing_entity:)
 
@@ -559,8 +535,6 @@ RSpec.describe Subscriptions::PlanUpgradeService do
 
       context "when bill_subscriptions runs after the upgrade" do
         let(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true) }
-
-        before { organization.enable_feature_flag!(:multi_entity_billing) }
 
         it "carries the current subscription's entity into termination and new-period billing context" do
           subscription.update!(billing_entity:)

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -1447,8 +1447,6 @@ RSpec.describe Subscriptions::UpdateService do
       let(:new_billing_entity) { create(:billing_entity, organization:) }
 
       context "with multi_entity_billing feature flag enabled" do
-        before { organization.update!(feature_flags: ["multi_entity_billing"]) }
-
         context "with billing_entity_id" do
           let(:params) { {billing_entity_id: new_billing_entity.id} }
 
@@ -1609,37 +1607,6 @@ RSpec.describe Subscriptions::UpdateService do
               expect(result.error.resource).to eq("billing_entity")
               expect(subscription.reload.billing_entity_id).to eq(current_entity.id)
             end
-          end
-        end
-      end
-
-      context "with multi_entity_billing feature flag disabled" do
-        let(:params) { {billing_entity_id: new_billing_entity.id} }
-
-        it "silently ignores billing_entity_id" do
-          update_service.call
-
-          expect(subscription.reload.billing_entity_id).to be_nil
-        end
-
-        it "returns success" do
-          expect(update_service.call).to be_success
-        end
-
-        context "when the subscription already has a billing_entity attached" do
-          let(:current_entity) { create(:billing_entity, organization:) }
-          let(:subscription) { create(:subscription, customer:, plan:, organization:, billing_entity: current_entity) }
-
-          it "leaves billing_entity_id unchanged when an id is sent" do
-            update_service.call
-
-            expect(subscription.reload.billing_entity_id).to eq(current_entity.id)
-          end
-
-          it "leaves billing_entity_id unchanged when nil is sent" do
-            described_class.new(subscription:, params: {billing_entity_id: nil}).call
-
-            expect(subscription.reload.billing_entity_id).to eq(current_entity.id)
           end
         end
       end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -362,20 +362,6 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
-    context "when customer already has a different currency" do
-      let(:customer_currency) { "USD" }
-
-      it "returns a currency mismatch error" do
-        expect(service_result).not_to be_success
-        expect(service_result.error.messages[:currency]).to eq(["currencies_does_not_match"])
-      end
-
-      it "does not update the customer currency" do
-        service_result
-        expect(customer.reload.currency).to eq("USD")
-      end
-    end
-
     context "when customer already has the same currency" do
       let(:customer_currency) { "EUR" }
 
@@ -392,9 +378,7 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
-    context "when multi currency is enabled" do
-      before { organization.update!(feature_flags: ["multi_currency"]) }
-
+    context "when the wallet currency can differ from the customer currency" do
       context "when customer does not have a currency" do
         let(:customer_currency) { nil }
 

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -1070,10 +1070,6 @@ RSpec.describe Wallets::CreateService do
     context "when multi_entity_billing is enabled" do
       let!(:billing_entity) { create(:billing_entity, organization:, code: "be_code") }
 
-      before do
-        organization.update!(feature_flags: ["multi_entity_billing"])
-      end
-
       context "when billing_entity_code is provided" do
         let(:params) do
           {
@@ -1242,32 +1238,6 @@ RSpec.describe Wallets::CreateService do
           wallet = service_result.wallet
           expect(wallet.billing_entity_id).to eq(billing_entity.id)
         end
-      end
-    end
-
-    context "when multi_entity_billing is not enabled" do
-      let(:billing_entity) { create(:billing_entity, organization:, code: "be_code") }
-
-      let(:params) do
-        {
-          name: "New Wallet",
-          customer:,
-          organization_id: organization.id,
-          currency: "EUR",
-          rate_amount: "1.00",
-          paid_credits: "0.00",
-          granted_credits: "0.00",
-          billing_entity_code: "be_code"
-        }
-      end
-
-      before { billing_entity }
-
-      it "does not assign the billing entity even if code is provided" do
-        expect(service_result).to be_success
-
-        wallet = service_result.wallet
-        expect(wallet.billing_entity_id).to be_nil
       end
     end
 

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -984,10 +984,6 @@ RSpec.describe Wallets::UpdateService do
     context "when multi_entity_billing is enabled" do
       let!(:billing_entity) { create(:billing_entity, organization:, code: "be_code") }
 
-      before do
-        organization.update!(feature_flags: ["multi_entity_billing"])
-      end
-
       context "when billing_entity_code is provided" do
         let(:params) do
           {
@@ -1197,22 +1193,6 @@ RSpec.describe Wallets::UpdateService do
             expect(wallet.reload.billing_entity_id).to eq(current_entity.id)
           end
         end
-      end
-    end
-
-    context "when multi_entity_billing is not enabled" do
-      let(:params) do
-        {
-          id: wallet&.id,
-          billing_entity_code: "be_code"
-        }
-      end
-
-      before { create(:billing_entity, organization:, code: "be_code") }
-
-      it "does not assign the billing entity even if code is provided" do
-        expect(result).to be_success
-        expect(result.wallet.billing_entity_id).to be_nil
       end
     end
   end

--- a/spec/support/shared_examples/wallet_actions.rb
+++ b/spec/support/shared_examples/wallet_actions.rb
@@ -719,23 +719,6 @@ RSpec.shared_examples "a wallet create endpoint" do
       end
     end
   end
-
-  context "when multi_entity_billing is not enabled" do
-    context "when billing_entity_code is provided" do
-      let(:billing_entity) { create(:billing_entity, organization:, code: "be_wallet") }
-
-      before { create_params[:billing_entity_code] = billing_entity.code }
-
-      it "does not assign a billing entity" do
-        subject
-
-        expect(response).to have_http_status(:success)
-
-        wallet = Wallet.find(json[:wallet][:lago_id])
-        expect(wallet.billing_entity_id).to be_nil
-      end
-    end
-  end
 end
 
 RSpec.shared_examples "a wallet create endpoint with billing_entity_id" do
@@ -771,23 +754,6 @@ RSpec.shared_examples "a wallet create endpoint with billing_entity_id" do
         subject
 
         expect(response).to have_http_status(:not_found)
-      end
-    end
-  end
-
-  context "when multi_entity_billing is not enabled" do
-    context "when billing_entity_id is provided" do
-      let(:billing_entity) { create(:billing_entity, organization:) }
-
-      before { create_params[:billing_entity_id] = billing_entity.id }
-
-      it "does not assign a billing entity" do
-        subject
-
-        expect(response).to have_http_status(:success)
-
-        wallet = Wallet.find(json[:wallet][:lago_id])
-        expect(wallet.billing_entity_id).to be_nil
       end
     end
   end
@@ -1283,17 +1249,6 @@ RSpec.shared_examples "a wallet update endpoint" do
           expect(response).to be_not_found_error("billing_entity")
           expect(wallet.reload.billing_entity_id).to eq(initial_billing_entity.id)
         end
-      end
-    end
-
-    context "when multi_entity_billing is not enabled" do
-      let(:update_params) { {billing_entity_code: target_billing_entity.code} }
-
-      it "ignores billing_entity_code and leaves the wallet untouched" do
-        subject
-
-        expect(response).to have_http_status(:success)
-        expect(wallet.reload.billing_entity_id).to eq(initial_billing_entity.id)
       end
     end
   end

--- a/spec/support/shared_examples/wallet_actions.rb
+++ b/spec/support/shared_examples/wallet_actions.rb
@@ -683,8 +683,6 @@ RSpec.shared_examples "a wallet create endpoint" do
   end
 
   context "when multi_entity_billing is enabled" do
-    before { organization.update!(feature_flags: ["multi_entity_billing"]) }
-
     context "when billing_entity_code is provided" do
       let(:billing_entity) { create(:billing_entity, organization:, code: "be_wallet") }
 
@@ -751,8 +749,6 @@ RSpec.shared_examples "a wallet create endpoint with billing_entity_id" do
   end
 
   context "when multi_entity_billing is enabled" do
-    before { organization.update!(feature_flags: ["multi_entity_billing"]) }
-
     context "when billing_entity_id is provided" do
       let(:billing_entity) { create(:billing_entity, organization:) }
 
@@ -1266,8 +1262,6 @@ RSpec.shared_examples "a wallet update endpoint" do
     let(:wallet) { create(:wallet, customer:, billing_entity: initial_billing_entity) }
 
     context "when multi_entity_billing is enabled" do
-      before { organization.update!(feature_flags: ["multi_entity_billing"]) }
-
       context "when billing_entity_code matches an entity" do
         let(:update_params) { {billing_entity_code: target_billing_entity.code} }
 


### PR DESCRIPTION
## Context

This makes the `multi_currency` and `multi_entity_billing` features generally available. Both had been gated behind per-organization feature flags; the frontend removal of the same gating ships as a single PR, so both flags are handled together here on the backend. This is phase 1 only: the gating is removed but the flags stay defined in `feature_flags.yaml`, so the change is safe to merge once the flags are enabled everywhere in production. Dropping the flags from the config and schema, and sanitizing the organization arrays, is a separate follow-up.

## Description

Remove the `multi_currency` and `multi_entity_billing` gating so the features behave as always-on: billing objects may use multiple currencies, and billing entities may be assigned across the API and GraphQL regardless of any flag. Update the specs that previously toggled the flags — enabled paths become unconditional and the obsolete flag-off contexts (which asserted behavior that no longer exists) are removed, including the wallet endpoint shared examples.

## Rollout order

This must not be merged before the flags are enabled for all organizations in production. Because current production still checks the flags, enabling them first turns the features on through the existing path; merging this PR then removes the checks with no behavioral change. Suggested step before merge:

```ruby
Organization.find_each do |org|
  org.update!(feature_flags: org.feature_flags | %w[multi_currency multi_entity_billing])
end
```

New organizations default to no flags, so run this close to merge (or re-run just before) to avoid a window where a newly created org has the feature off. After merge the code no longer checks the flags, so the gap disappears.

## Follow-up (separate branch)

The two `chore: drop the feature flag` commits — removing both flags from `feature_flags.yaml` and the GraphQL schema, plus `FeatureFlag.sanitize!` — live on a separate branch and land after this one.

## Tests

Affected model, request, GraphQL and service specs pass locally.
