### PR TITLE
fix(charges): Skip existing child charges in cascade

### DIFF
--- a/app/services/charges/create_children_service.rb
+++ b/app/services/charges/create_children_service.rb
@@ -18,6 +18,10 @@ module Charges
         # skip touching to avoid deadlocks
         Plan.no_touching do
           plan.children.where(id: child_ids).find_each do |child|
+            # NOTE: Cascade jobs are delivered at-least-once; a parent charge must
+            #       materialize at most once per child plan or usage is billed twice.
+            next if child.charges.exists?(parent_id: charge.id)
+
             create_params = if payload[:code].present?
               payload
             else

--- a/spec/services/charges/create_children_service_spec.rb
+++ b/spec/services/charges/create_children_service_spec.rb
@@ -89,5 +89,26 @@ RSpec.describe Charges::CreateChildrenService do
         )
       end
     end
+
+    context "when the child plan already has a charge for this parent" do
+      let(:payload) { {billable_metric_id: billable_metric.id, charge_model: "standard"} }
+
+      before do
+        create(:standard_charge, organization:, plan: child_plan, billable_metric:, parent_id: charge.id)
+      end
+
+      it "does not create a second copy" do
+        result = nil
+
+        expect { result = create_service.call }.not_to change(Charge, :count)
+        expect(result).to be_success
+      end
+
+      it "creates the charge again when the existing copy is discarded" do
+        child_plan.charges.find_by(parent_id: charge.id).discard!
+
+        expect { create_service.call }.to change(Charge, :count).by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Cascade jobs run at-least-once; a retry or concurrent plan update could materialize the same parent charge twice on a child plan, and every copy is billed. 

## Description

Skip a child plan when it already holds a non-deleted charge for the same parent charge, making the cascade idempotent. A discarded copy does not block re-creation.

Cleanup of existing duplicates and a unique index enforcing this at the database level are shipped separately in https://github.com/getlago/lago-api/pull/6129.
