### PR TITLE
fix(charges): Enforce child charge uniqueness per plan

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -231,6 +231,7 @@ end
 #  index_charges_on_plan_id                                      (plan_id)
 #  index_charges_on_plan_id_and_billable_metric_id_and_prorated  (plan_id,billable_metric_id,prorated) WHERE (deleted_at IS NULL)
 #  index_charges_on_plan_id_and_code                             (plan_id,code) UNIQUE WHERE ((deleted_at IS NULL) AND (parent_id IS NULL))
+#  index_charges_on_plan_id_and_parent_id                        (plan_id,parent_id) UNIQUE WHERE ((parent_id IS NOT NULL) AND (deleted_at IS NULL))
 #  index_charges_pay_in_advance                                  (billable_metric_id) WHERE ((deleted_at IS NULL) AND (pay_in_advance = true))
 #
 # Foreign Keys

--- a/db/migrate/20260811193407_soft_delete_duplicate_child_charges.rb
+++ b/db/migrate/20260811193407_soft_delete_duplicate_child_charges.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+class SoftDeleteDuplicateChildCharges < ActiveRecord::Migration[8.0]
+  # NOTE: Child charges (parent_id set) are materialized on overridden plans by cascade
+  #       jobs; overlapping cascades could materialize the same parent charge several
+  #       times on a child plan. Each copy is billed, multiplying usage and invoices.
+  #
+  #       Only exact copies are safe to remove automatically: charges sharing
+  #       (plan_id, parent_id) AND identical in every billing attribute (scalar columns,
+  #       taxes, pricing unit, filters). For those, any copy is interchangeable — keep the
+  #       oldest, soft-delete the rest with their filters.
+  #
+  #       Copies that diverged (e.g. one was later customized for the subscription) are
+  #       left untouched: no rule can tell which one carries the intended pricing. They
+  #       must be resolved by a human; the next migration (unique index) fails with
+  #       instructions while any remain.
+  def up
+    safety_assured do
+      execute <<~SQL
+        WITH duplicate_groups AS (
+          SELECT plan_id, parent_id
+          FROM charges
+          WHERE parent_id IS NOT NULL AND deleted_at IS NULL
+          GROUP BY plan_id, parent_id
+          HAVING count(*) > 1
+        ),
+        signatures AS (
+          SELECT
+            c.id, c.plan_id, c.parent_id, c.created_at,
+            jsonb_build_object(
+              'billable_metric_id',    c.billable_metric_id,
+              'amount_currency',       c.amount_currency,
+              'charge_model',          c.charge_model,
+              'properties',            c.properties,
+              'pay_in_advance',        c.pay_in_advance,
+              'min_amount_cents',      c.min_amount_cents,
+              'invoiceable',           c.invoiceable,
+              'prorated',              c.prorated,
+              'invoice_display_name',  c.invoice_display_name,
+              'regroup_paid_fees',     c.regroup_paid_fees,
+              'accepts_target_wallet', c.accepts_target_wallet,
+              'tax_ids', (
+                SELECT coalesce(jsonb_agg(ct.tax_id ORDER BY ct.tax_id), '[]'::jsonb)
+                FROM charges_taxes ct
+                WHERE ct.charge_id = c.id
+              ),
+              'pricing_unit', (
+                SELECT jsonb_build_array(apu.pricing_unit_id, apu.conversion_rate)
+                FROM applied_pricing_units apu
+                WHERE apu.pricing_unitable_type = 'Charge'
+                  AND apu.pricing_unitable_id = c.id
+              ),
+              'filters', (
+                SELECT coalesce(jsonb_agg(fs.sig ORDER BY fs.sig::text), '[]'::jsonb)
+                FROM (
+                  SELECT jsonb_build_object(
+                    'properties',           cf.properties,
+                    'invoice_display_name', cf.invoice_display_name,
+                    'values', (
+                      SELECT coalesce(
+                        jsonb_agg(jsonb_build_array(bmf.key, to_jsonb(cfv.values)) ORDER BY bmf.key),
+                        '[]'::jsonb
+                      )
+                      FROM charge_filter_values cfv
+                      JOIN billable_metric_filters bmf ON bmf.id = cfv.billable_metric_filter_id
+                      WHERE cfv.charge_filter_id = cf.id
+                        AND cfv.deleted_at IS NULL
+                        AND bmf.deleted_at IS NULL
+                    )
+                  ) AS sig
+                  FROM charge_filters cf
+                  WHERE cf.charge_id = c.id AND cf.deleted_at IS NULL
+                ) fs
+              )
+            ) AS signature
+          FROM charges c
+          JOIN duplicate_groups dg ON dg.plan_id = c.plan_id AND dg.parent_id = c.parent_id
+          WHERE c.deleted_at IS NULL
+        ),
+        duplicates AS (
+          SELECT DISTINCT newer.id
+          FROM signatures newer
+          JOIN signatures older
+            ON older.plan_id = newer.plan_id
+            AND older.parent_id = newer.parent_id
+            AND older.signature = newer.signature
+            AND (older.created_at, older.id) < (newer.created_at, newer.id)
+        ),
+        deleted_charges AS (
+          UPDATE charges SET deleted_at = NOW()
+          WHERE id IN (SELECT id FROM duplicates)
+          RETURNING id
+        ),
+        deleted_filters AS (
+          UPDATE charge_filters SET deleted_at = NOW()
+          WHERE deleted_at IS NULL
+            AND charge_id IN (SELECT id FROM deleted_charges)
+          RETURNING id
+        )
+        UPDATE charge_filter_values SET deleted_at = NOW()
+        WHERE deleted_at IS NULL
+          AND charge_filter_id IN (SELECT id FROM deleted_filters)
+      SQL
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20260811193408_add_unique_index_on_charges_plan_id_and_parent_id.rb
+++ b/db/migrate/20260811193408_add_unique_index_on_charges_plan_id_and_parent_id.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnChargesPlanIdAndParentId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # NOTE: A parent charge must materialize at most once per child (overridden) plan.
+  #       Exact duplicate copies are soft-deleted by the previous migration; copies that
+  #       diverged in billing attributes cannot be resolved automatically — this migration
+  #       fails with the remaining ids so an operator can pick the copy carrying the
+  #       intended pricing and discard the others, then rerun db:migrate.
+  def up
+    remaining = select_rows(<<~SQL)
+      SELECT plan_id, parent_id, string_agg(id::text, ', ' ORDER BY created_at)
+      FROM charges
+      WHERE parent_id IS NOT NULL AND deleted_at IS NULL
+      GROUP BY plan_id, parent_id
+      HAVING count(*) > 1
+    SQL
+
+    if remaining.any?
+      details = remaining.map { |plan_id, parent_id, ids| "  plan #{plan_id}, parent charge #{parent_id}: charges #{ids}" }.join("\n")
+      raise StandardError, <<~MSG
+        Cannot add unique index on charges (plan_id, parent_id): #{remaining.size} child plan(s)
+        still hold several charges for the same parent charge, and the copies differ in billing
+        attributes, so no copy can be removed automatically.
+
+        #{details}
+
+        For each group, decide which charge carries the intended pricing, discard the others
+        (e.g. in a Rails console: Charges::DestroyService.call(charge: Charge.find("<id>"))),
+        then rerun the migrations.
+      MSG
+    end
+
+    add_index :charges,
+      [:plan_id, :parent_id],
+      unique: true,
+      where: "parent_id IS NOT NULL AND deleted_at IS NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+
+  def down
+    remove_index :charges, [:plan_id, :parent_id], if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -836,6 +836,7 @@ DROP INDEX IF EXISTS public.index_charges_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_charge_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_charge_id;
 DROP INDEX IF EXISTS public.index_charges_pay_in_advance;
+DROP INDEX IF EXISTS public.index_charges_on_plan_id_and_parent_id;
 DROP INDEX IF EXISTS public.index_charges_on_plan_id_and_code;
 DROP INDEX IF EXISTS public.index_charges_on_plan_id_and_billable_metric_id_and_prorated;
 DROP INDEX IF EXISTS public.index_charges_on_plan_id;
@@ -8130,6 +8131,13 @@ CREATE UNIQUE INDEX index_charges_on_plan_id_and_code ON public.charges USING bt
 
 
 --
+-- Name: index_charges_on_plan_id_and_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_charges_on_plan_id_and_parent_id ON public.charges USING btree (plan_id, parent_id) WHERE ((parent_id IS NOT NULL) AND (deleted_at IS NULL));
+
+
+--
 -- Name: index_charges_pay_in_advance; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -14172,6 +14180,8 @@ ALTER TABLE ONLY public.membership_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260811193408'),
+('20260811193407'),
 ('20260805201143'),
 ('20260805110509'),
 ('20260805110508'),


### PR DESCRIPTION
## Context

At-least-once cascade jobs could materialize the same parent charge several times on a child plan; each copy is billed. 

## Description

- First migration soft-deletes every copy but the oldest (with its filters)
- Second migration enforces uniqueness with a partial index on (plan_id, parent_id).
- Intentional duplicates keep distinct parent ids and are unaffected.