### PR TITLE
feat(quotes): bound signing and execution dates

### DIFF
--- a/app/services/order_forms/create_service.rb
+++ b/app/services/order_forms/create_service.rb
@@ -18,6 +18,10 @@ module OrderForms
       return result.single_validation_failure!(field: :quote_version, error_code: "not_approved") unless quote_version.approved?
       return result.single_validation_failure!(field: :expires_at, error_code: "invalid_date") unless valid_expires_at?
 
+      unless QuoteVersions::DealExpiration.covers?(quote_version, expires_at)
+        return result.single_validation_failure!(field: :expires_at, error_code: "after_deal_expiration")
+      end
+
       order_form = OrderForm.create!(
         organization: quote_version.organization,
         customer: quote_version.quote.customer,

--- a/app/services/order_forms/execution_settings_validation.rb
+++ b/app/services/order_forms/execution_settings_validation.rb
@@ -24,5 +24,14 @@ module OrderForms
 
       result.single_validation_failure!(field: :execute_at, error_code: "invalid_date")
     end
+
+    # The dates the deal is built on are only checked for futureness when it is approved, and the
+    # execution flow refuses them once past, so an execution scheduled after the earliest of them
+    # would fail instead of billing anything.
+    def validate_deal_expiration(execute_at:, quote_version:)
+      return if QuoteVersions::DealExpiration.covers?(quote_version, execute_at)
+
+      result.single_validation_failure!(field: :execute_at, error_code: "after_deal_expiration")
+    end
   end
 end

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -66,6 +66,9 @@ module OrderForms
       return if result.failure?
 
       validate_execute_at(execute_at:)
+      return if result.failure?
+
+      validate_deal_expiration(execute_at:, quote_version: order_form.quote_version)
     end
 
     def signed_document_attachment

--- a/app/services/orders/update_service.rb
+++ b/app/services/orders/update_service.rb
@@ -60,6 +60,9 @@ module Orders
       return if result.failure?
 
       validate_execute_at(execute_at: params[:execute_at])
+      return if result.failure?
+
+      validate_deal_expiration(execute_at: effective_execute_at, quote_version: order.quote_version)
     end
   end
 end

--- a/app/services/quote_versions/deal_expiration.rb
+++ b/app/services/quote_versions/deal_expiration.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module QuoteVersions
+  # A quote carries dates the execution flow re-validates and refuses in the past: the subscription
+  # ending date, a wallet expiration and a recurring rule expiration. Whichever comes first bounds
+  # the whole deal, so a signing window or an execution date landing after it produces a failed
+  # order rather than a subscription. one_off quotes carry none of them.
+  module DealExpiration
+    def self.earliest(quote_version)
+      items = billing_items(quote_version)
+
+      [
+        quote_version.end_date,
+        *plan_end_dates(items),
+        *wallet_expirations(items)
+      ].filter_map { Utils::Datetime.parse_iso8601(it)&.to_date }.min
+    end
+
+    # An unbounded deal, a blank value and a value no date can be read from all pass: only a date
+    # the deal no longer covers is refused, the boundary day included, since the execution flow
+    # requires the ending date to be strictly after the day it runs.
+    def self.covers?(quote_version, value)
+      expiration = earliest(quote_version)
+      return true if expiration.nil?
+
+      date = Utils::Datetime.parse_iso8601(value)&.to_date
+      return true if date.nil?
+
+      date < expiration
+    end
+
+    # The structural pass rejects a payload that is not an object, but nothing stops a caller from
+    # reading a version that never went through it.
+    def self.billing_items(quote_version)
+      items = quote_version.billing_items
+      items.is_a?(Hash) ? items : {}
+    end
+
+    def self.plan_end_dates(items)
+      Array(items["plans"]).map { it.dig("payload", "endDate") }
+    end
+
+    # Several recurring rules are legitimate on a draft, only an approved version is capped at one.
+    def self.wallet_expirations(items)
+      Array(items["walletCredits"]).flat_map do |item|
+        payload = item["payload"] || {}
+
+        [payload["expirationAt"], *Array(payload["recurringTransactionRules"]).map { it["expirationAt"] }]
+      end
+    end
+
+    private_class_method :billing_items, :plan_end_dates, :wallet_expirations
+  end
+end

--- a/spec/services/order_forms/create_service_spec.rb
+++ b/spec/services/order_forms/create_service_spec.rb
@@ -56,6 +56,65 @@ RSpec.describe OrderForms::CreateService do
       end
     end
 
+    context "when an expires_at outliving the deal is provided", :premium do
+      subject(:create_service) { described_class.new(quote_version:, expires_at:) }
+
+      let(:quote_version) do
+        create(:quote_version, :approved, quote:, organization:, end_date: 1.month.from_now.to_date)
+      end
+      let(:expires_at) { 2.months.from_now }
+
+      it "does not create an order form" do
+        expect { result }.not_to change(OrderForm, :count)
+      end
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages).to eq(expires_at: ["after_deal_expiration"])
+      end
+    end
+
+    context "when an expires_at falls on the day the deal ends", :premium do
+      subject(:create_service) { described_class.new(quote_version:, expires_at:) }
+
+      let(:end_date) { 1.month.from_now.to_date }
+      let(:quote_version) { create(:quote_version, :approved, quote:, organization:, end_date:) }
+      let(:expires_at) { end_date.to_time }
+
+      it "returns a validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages).to eq(expires_at: ["after_deal_expiration"])
+      end
+    end
+
+    context "when an expires_at inside the deal is provided", :premium do
+      subject(:create_service) { described_class.new(quote_version:, expires_at:) }
+
+      let(:quote_version) do
+        create(:quote_version, :approved, quote:, organization:, end_date: 2.months.from_now.to_date)
+      end
+      let(:expires_at) { 1.month.from_now }
+
+      it "creates an order form" do
+        expect(result).to be_success
+        expect(result.order_form.expires_at).to be_within(1.second).of(expires_at)
+      end
+    end
+
+    # A one_off deal carries no date the execution flow can outlive.
+    context "when the deal is one_off", :premium do
+      subject(:create_service) { described_class.new(quote_version:, expires_at:) }
+
+      let(:quote_version) do
+        create(:quote_version, :approved, :with_one_off_billing_items, quote:, organization:)
+      end
+      let(:expires_at) { 10.years.from_now }
+
+      it "creates an order form" do
+        expect(result).to be_success
+      end
+    end
+
     context "when the quote version is not approved", :premium do
       let(:quote_version) { create(:quote_version, quote:, organization:) }
 

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -322,6 +322,47 @@ RSpec.describe OrderForms::MarkAsSignedService do
           expect(result.error.messages[:execute_at]).to eq(["invalid_date"])
         end
       end
+
+      context "when execute_at outlives the wallet the deal funds" do
+        let(:order_form) { create(:order_form, customer:, organization:, quote_version:) }
+        let(:quote_version) do
+          create(
+            :quote_version,
+            :approved,
+            quote:,
+            organization:,
+            end_date: 1.year.from_now.to_date,
+            billing_items: {
+              "walletCredits" => [{"payload" => {"expirationAt" => 1.month.from_now.iso8601}}]
+            }
+          )
+        end
+        let(:execution_mode) { "execute_in_lago" }
+        let(:execute_at) { 2.months.from_now.iso8601 }
+
+        it "returns a validation failure on execute_at" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:execute_at]).to eq(["after_deal_expiration"])
+        end
+      end
+
+      context "when execute_at falls inside the deal" do
+        let(:order_form) { create(:order_form, customer:, organization:, quote_version:) }
+        let(:quote_version) do
+          create(:quote_version, :approved, quote:, organization:, end_date: 1.year.from_now.to_date)
+        end
+        let(:execution_mode) { "execute_in_lago" }
+        let(:execute_at) { 1.month.from_now.iso8601 }
+
+        it "signs the order form" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.order.execute_at).to be_within(1.second).of(Time.zone.parse(execute_at))
+        end
+      end
     end
   end
 end

--- a/spec/services/orders/update_service_spec.rb
+++ b/spec/services/orders/update_service_spec.rb
@@ -141,6 +141,51 @@ RSpec.describe Orders::UpdateService do
         end
       end
 
+      context "when execute_at outlives the deal" do
+        let(:quote) { create(:quote, organization:, customer:) }
+        let(:quote_version) do
+          create(:quote_version, :approved, quote:, organization:, end_date: 1.month.from_now.to_date)
+        end
+        let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+        let(:order) { create(:order, organization:, customer:, order_form:) }
+        let(:params) { {execution_mode: "execute_in_lago", execute_at: 2.months.from_now.iso8601} }
+
+        it "returns a validation failure on execute_at" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:execute_at]).to eq(["after_deal_expiration"])
+        end
+      end
+
+      # The stored date is what execution will use, so it is bounded even when the update leaves it
+      # alone.
+      context "when the stored execute_at outlives the deal" do
+        let(:quote) { create(:quote, organization:, customer:) }
+        let(:quote_version) do
+          create(:quote_version, :approved, quote:, organization:, end_date: 1.month.from_now.to_date)
+        end
+        let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+        let(:order) do
+          create(
+            :order,
+            organization:,
+            customer:,
+            order_form:,
+            execution_mode: "execute_in_lago",
+            execute_at: 2.months.from_now
+          )
+        end
+        let(:params) { {execution_mode: "order_only"} }
+
+        it "returns a validation failure on execute_at" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:execute_at]).to eq(["after_deal_expiration"])
+        end
+      end
+
       context "when clearing execute_at while keeping an execution_mode" do
         let(:order) { create(:order, organization:, customer:, execution_mode: "execute_in_lago", execute_at: 1.month.from_now) }
         let(:params) { {execute_at: nil} }

--- a/spec/services/quote_versions/deal_expiration_spec.rb
+++ b/spec/services/quote_versions/deal_expiration_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteVersions::DealExpiration do
+  let(:organization) { create(:organization) }
+  let(:quote) { create(:quote, organization:) }
+  let(:end_date) { Date.new(2026, 6, 1) }
+  let(:billing_items) { {} }
+  let(:quote_version) { build(:quote_version, quote:, organization:, end_date:, billing_items:) }
+
+  describe ".earliest" do
+    it "returns the ending date of the deal" do
+      expect(described_class.earliest(quote_version)).to eq(Date.new(2026, 6, 1))
+    end
+
+    context "when the deal carries no dates" do
+      let(:end_date) { nil }
+
+      it "returns nil" do
+        expect(described_class.earliest(quote_version)).to be_nil
+      end
+    end
+
+    context "when a plan ends before the deal" do
+      let(:billing_items) do
+        {"plans" => [{"payload" => {"endDate" => "2026-03-15T00:00:00Z"}}]}
+      end
+
+      it "returns the plan ending date" do
+        expect(described_class.earliest(quote_version)).to eq(Date.new(2026, 3, 15))
+      end
+    end
+
+    context "when a plan ends after the deal" do
+      let(:billing_items) do
+        {"plans" => [{"payload" => {"endDate" => "2027-03-15T00:00:00Z"}}]}
+      end
+
+      it "returns the deal ending date" do
+        expect(described_class.earliest(quote_version)).to eq(Date.new(2026, 6, 1))
+      end
+    end
+
+    context "when a wallet expires before the deal" do
+      let(:billing_items) do
+        {"walletCredits" => [{"payload" => {"expirationAt" => "2026-02-01T00:00:00Z"}}]}
+      end
+
+      it "returns the wallet expiration" do
+        expect(described_class.earliest(quote_version)).to eq(Date.new(2026, 2, 1))
+      end
+    end
+
+    context "when a recurring rule expires before everything else" do
+      let(:billing_items) do
+        {
+          "walletCredits" => [
+            {
+              "payload" => {
+                "expirationAt" => "2026-02-01T00:00:00Z",
+                "recurringTransactionRules" => [
+                  {"expirationAt" => "2026-05-01T00:00:00Z"},
+                  {"expirationAt" => "2026-01-10T00:00:00Z"}
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      it "returns the earliest rule expiration" do
+        expect(described_class.earliest(quote_version)).to eq(Date.new(2026, 1, 10))
+      end
+    end
+
+    # The only dates a one_off deal carries are fee service periods, legitimately in the past.
+    context "when the deal is one_off" do
+      let(:end_date) { nil }
+      let(:quote_version) do
+        build(:quote_version, :with_one_off_billing_items, quote:, organization:, end_date:)
+      end
+
+      it "returns nil" do
+        expect(described_class.earliest(quote_version)).to be_nil
+      end
+    end
+
+    context "when the billing items are nil" do
+      let(:end_date) { nil }
+      let(:billing_items) { nil }
+
+      it "returns nil" do
+        expect(described_class.earliest(quote_version)).to be_nil
+      end
+    end
+
+    context "when the billing items are not an object" do
+      let(:end_date) { nil }
+      let(:billing_items) { ["plans"] }
+
+      it "returns nil" do
+        expect(described_class.earliest(quote_version)).to be_nil
+      end
+    end
+
+    context "when a quoted date is not a date" do
+      let(:end_date) { nil }
+      let(:billing_items) do
+        {"plans" => [{"payload" => {"endDate" => "whenever"}}]}
+      end
+
+      it "ignores it" do
+        expect(described_class.earliest(quote_version)).to be_nil
+      end
+    end
+
+    context "when a plan carries no payload" do
+      let(:billing_items) { {"plans" => [{"id" => "plan-id"}]} }
+
+      it "returns the deal ending date" do
+        expect(described_class.earliest(quote_version)).to eq(Date.new(2026, 6, 1))
+      end
+    end
+  end
+
+  describe ".covers?" do
+    it "covers a date before the expiration" do
+      expect(described_class.covers?(quote_version, "2026-05-31T23:00:00Z")).to eq(true)
+    end
+
+    # The execution flow requires the ending date to be strictly after the day it runs.
+    it "does not cover the expiration day itself" do
+      expect(described_class.covers?(quote_version, "2026-06-01T00:00:00Z")).to eq(false)
+    end
+
+    it "does not cover a date after the expiration" do
+      expect(described_class.covers?(quote_version, "2026-06-02T00:00:00Z")).to eq(false)
+    end
+
+    it "covers a blank value" do
+      expect(described_class.covers?(quote_version, nil)).to eq(true)
+    end
+
+    it "covers a value no date can be read from" do
+      expect(described_class.covers?(quote_version, "whenever")).to eq(true)
+    end
+
+    it "covers a datetime object" do
+      expect(described_class.covers?(quote_version, Time.zone.parse("2026-05-01T00:00:00Z"))).to eq(true)
+    end
+
+    context "when the deal carries no dates" do
+      let(:end_date) { nil }
+
+      it "covers any date" do
+        expect(described_class.covers?(quote_version, "2099-01-01T00:00:00Z")).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Three quote dates are refused in the past by the execution flow: the subscription ending date (`end_date`, `plans[].payload.endDate`), a wallet `expirationAt` and a recurring rule `expirationAt`. They are only checked for futureness at approve, and nothing ties them to the dates that decide *when* execution happens, so a deal can be signed or scheduled past its own term and only blows up at execution as a failed order.

## Description

Adds `QuoteVersions::DealExpiration`, which folds those fields into the earliest date the deal must still be running, and bounds both write points against it:

- `expires_at` at approve (`OrderForms::CreateService`)
- `execute_at` at signing and on update, via the shared `ExecutionSettingsValidation` concern

Both fail with `after_deal_expiration`. The comparison is by date and strictly earlier, matching `valid_ending_at?`, which already fails on a same-day landing. `one_off` quotes carry none of these fields, so the check is a no-op for them.

Two known limits: an order with no `execute_at` is executed manually at any time, so the execution-time failure stays the backstop; and a short-lived wallet now constrains the signing window too.