### PR TITLE
Fix(subscriptions): started_at for subscription_at in the past

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -203,24 +203,21 @@ module Subscriptions
     end
 
     # NOTE: Backdating normally means "this subscription really started then, bill it from then".
-    #       But when a previous subscription on the same external_id was terminated after that date,
-    #       its terminating invoice already closed that window. Starting the new subscription at the
-    #       backdated date would re-open it and bill the same period a second time.
+    #       But a previous subscription on the same external_id may have already invoiced part of that
+    #       window when it terminated. Clamping to that boundary honours the backdate as far back as
+    #       is safe, instead of re-opening a period the terminating invoice already closed.
     def started_at_for(new_subscription)
-      return Time.current if invoiced_period_covers?(new_subscription.subscription_at)
-
-      new_subscription.subscription_at
+      [new_subscription.subscription_at, last_invoiced_termination_time].compact.max
     end
 
     # NOTE: A subscription terminated with `on_termination_invoice: skip` never billed its last
-    #       window, so there is nothing to double bill and the backdated period must stay billable.
-    def invoiced_period_covers?(date)
+    #       window, so it closes nothing and the backdated period must stay billable.
+    def last_invoiced_termination_time
       customer.subscriptions
         .terminated
         .where(external_id:)
         .where(on_termination_invoice: :generate)
-        .where("subscriptions.terminated_at > ?", date)
-        .exists?
+        .maximum(:terminated_at)
     end
 
     def upgrade_subscription

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -180,7 +180,7 @@ module Subscriptions
     end
 
     def handle_past_subscription(new_subscription)
-      new_subscription.mark_as_active!(new_subscription.subscription_at)
+      new_subscription.mark_as_active!(started_at_for(new_subscription))
 
       EmitFixedChargeEventsService.call!(
         subscriptions: [new_subscription],
@@ -200,6 +200,27 @@ module Subscriptions
     def handle_future_subscription(new_subscription)
       new_subscription.pending!
       apply_activation_rules(new_subscription)
+    end
+
+    # NOTE: Backdating normally means "this subscription really started then, bill it from then".
+    #       But when a previous subscription on the same external_id was terminated after that date,
+    #       its terminating invoice already closed that window. Starting the new subscription at the
+    #       backdated date would re-open it and bill the same period a second time.
+    def started_at_for(new_subscription)
+      return Time.current if invoiced_period_covers?(new_subscription.subscription_at)
+
+      new_subscription.subscription_at
+    end
+
+    # NOTE: A subscription terminated with `on_termination_invoice: skip` never billed its last
+    #       window, so there is nothing to double bill and the backdated period must stay billable.
+    def invoiced_period_covers?(date)
+      customer.subscriptions
+        .terminated
+        .where(external_id:)
+        .where(on_termination_invoice: :generate)
+        .where("subscriptions.terminated_at > ?", date)
+        .exists?
     end
 
     def upgrade_subscription

--- a/spec/scenarios/subscriptions/terminate_recreate_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_recreate_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Subscription terminate and recreate on the same external_id", :premium do
+  let(:organization) do
+    create(:organization, webhook_url: nil, premium_integrations: ["lifetime_usage", "progressive_billing"])
+  end
+  let(:customer) { create(:customer, organization:, timezone: "UTC") }
+  let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: "item_count") }
+  let(:plan) { create(:plan, organization:, interval: :yearly, pay_in_advance: false, amount_cents: 365_00) }
+
+  let(:subscription_at) { DateTime.new(2025, 3, 15) }
+  let(:events_date) { DateTime.new(2025, 6, 1) }
+  let(:rotation_date) { DateTime.new(2026, 3, 13) }
+  let(:anniversary_date) { DateTime.new(2026, 3, 15) }
+
+  before { create(:standard_charge, billable_metric:, plan:, properties: {amount: "1"}) }
+
+  def terminated_subscription
+    customer.subscriptions.order(created_at: :asc).first
+  end
+
+  def recreated_subscription
+    customer.subscriptions.order(created_at: :asc).last
+  end
+
+  def subscription_params
+    {
+      external_customer_id: customer.external_id,
+      external_id: customer.external_id,
+      plan_code: plan.code,
+      billing_time: "anniversary",
+      subscription_at: subscription_at.iso8601
+    }
+  end
+
+  # 5 events * 10 item_count * 1 euro = 50 euro of usage in the first period
+  def add_events_to_subscription
+    travel_to(events_date) do
+      5.times do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: customer.external_id,
+            properties: {"item_count" => 10}
+          }
+        )
+      end
+    end
+  end
+
+  # Terminate and immediately recreate on the same external_id, replaying the original anchor.
+  # This is how customers hand-roll an upgrade when they need the anniversary date preserved.
+  def rotate_subscription
+    travel_to(rotation_date) do
+      terminate_subscription(terminated_subscription)
+      create_subscription(subscription_params)
+    end
+  end
+
+  def start_original_subscription
+    travel_to(subscription_at) { create_subscription(subscription_params) }
+    add_events_to_subscription
+  end
+
+  it "starts the recreated subscription at the termination, keeping the anniversary anchor" do
+    start_original_subscription
+    rotate_subscription
+
+    expect(recreated_subscription.id).not_to eq(terminated_subscription.id)
+    expect(recreated_subscription).to be_active
+    expect(recreated_subscription.subscription_at).to eq(subscription_at)
+    expect(recreated_subscription.started_at).to eq(terminated_subscription.reload.terminated_at)
+  end
+
+  it "does not bill the terminated period a second time" do
+    start_original_subscription
+
+    rotate_subscription
+
+    terminating_invoice = terminated_subscription.invoices.order(:created_at).last
+    expect(terminating_invoice.fees.charge.sum(:amount_cents)).to eq(50_00)
+
+    travel_to(anniversary_date) { perform_billing }
+
+    boundaries = recreated_subscription.invoice_subscriptions.order(:created_at).last
+    expect(boundaries.from_datetime).to eq(rotation_date)
+    expect(boundaries.charges_from_datetime).to eq(rotation_date)
+
+    anniversary_invoice = recreated_subscription.invoices.order(:created_at).last
+    expect(anniversary_invoice.fees.charge.sum(:amount_cents)).to eq(0)
+
+    # The 50 euro of usage is invoiced exactly once across the whole external_id lineage
+    all_charge_fees = customer.invoices.flat_map { |invoice| invoice.fees.charge }
+    expect(all_charge_fees.sum(&:amount_cents)).to eq(50_00)
+  end
+
+  it "carries the invoiced lifetime usage across the rotation without double counting it" do
+    start_original_subscription
+
+    travel_to(rotation_date) do
+      perform_usage_update
+
+      expect(terminated_subscription.lifetime_usage.reload.current_usage_amount_cents).to eq(50_00)
+    end
+
+    rotate_subscription
+
+    travel_to(rotation_date) { perform_usage_update }
+
+    lifetime_usage = recreated_subscription.lifetime_usage.reload
+
+    # A fresh record, but the amount is recomputed from every invoice sharing
+    # external_id + subscription_at, so the terminated subscription is included.
+    expect(lifetime_usage.id).not_to eq(terminated_subscription.lifetime_usage.id)
+    expect(lifetime_usage.invoiced_usage_amount_cents).to eq(50_00)
+    expect(lifetime_usage.current_usage_amount_cents).to eq(0)
+    expect(lifetime_usage.total_amount_cents).to eq(50_00)
+  end
+end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -899,6 +899,81 @@ RSpec.describe Subscriptions::CreateService do
           expect { create_service.call }.not_to have_enqueued_job(Invoices::CreatePayInAdvanceFixedChargesJob)
         end
       end
+
+      context "when a terminated subscription on the same external_id covered that period" do
+        let(:terminated_at) { 2.days.ago }
+        let(:on_termination_invoice) { :generate }
+
+        let(:previous_subscription) do
+          create(
+            :subscription,
+            :terminated,
+            customer:,
+            plan:,
+            organization:,
+            external_id:,
+            started_at: 1.month.ago,
+            terminated_at:,
+            on_termination_invoice:
+          )
+        end
+
+        before { previous_subscription }
+
+        it "starts now so the already invoiced period is not billed twice" do
+          result = create_service.call
+
+          expect(result).to be_success
+
+          subscription = result.subscription
+          expect(subscription).to be_active
+          expect(subscription.started_at).to be_within(2.seconds).of(Time.current)
+          expect(subscription.subscription_at.to_s).to eq(subscription_at.to_s)
+        end
+
+        context "when the previous subscription skipped its termination invoice" do
+          let(:on_termination_invoice) { :skip }
+
+          it "starts at subscription_at since that period was never invoiced" do
+            result = create_service.call
+
+            expect(result).to be_success
+            expect(result.subscription.started_at.to_s).to eq(subscription_at.to_s)
+          end
+        end
+
+        context "when the previous subscription was terminated before subscription_at" do
+          let(:terminated_at) { subscription_at - 1.day }
+
+          it "starts at subscription_at since the periods do not overlap" do
+            result = create_service.call
+
+            expect(result).to be_success
+            expect(result.subscription.started_at.to_s).to eq(subscription_at.to_s)
+          end
+        end
+
+        context "when the previous subscription has a different external_id" do
+          let(:previous_subscription) do
+            create(
+              :subscription,
+              :terminated,
+              customer:,
+              plan:,
+              organization:,
+              started_at: 1.month.ago,
+              terminated_at:
+            )
+          end
+
+          it "starts at subscription_at" do
+            result = create_service.call
+
+            expect(result).to be_success
+            expect(result.subscription.started_at.to_s).to eq(subscription_at.to_s)
+          end
+        end
+      end
     end
 
     context "when subscription_at is earlier today" do

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -920,15 +920,39 @@ RSpec.describe Subscriptions::CreateService do
 
         before { previous_subscription }
 
-        it "starts now so the already invoiced period is not billed twice" do
+        it "starts at the termination so the already invoiced period is not billed twice" do
           result = create_service.call
 
           expect(result).to be_success
 
           subscription = result.subscription
           expect(subscription).to be_active
-          expect(subscription.started_at).to be_within(2.seconds).of(Time.current)
+          expect(subscription.started_at).to eq(previous_subscription.reload.terminated_at)
           expect(subscription.subscription_at.to_s).to eq(subscription_at.to_s)
+        end
+
+        context "when several terminated subscriptions share the external_id" do
+          let(:latest_terminated_at) { 1.day.ago }
+
+          before do
+            create(
+              :subscription,
+              :terminated,
+              customer:,
+              plan:,
+              organization:,
+              external_id:,
+              started_at: terminated_at,
+              terminated_at: latest_terminated_at
+            )
+          end
+
+          it "starts at the most recent invoiced termination" do
+            result = create_service.call
+
+            expect(result).to be_success
+            expect(result.subscription.started_at).to be_within(1.second).of(latest_terminated_at)
+          end
         end
 
         context "when the previous subscription skipped its termination invoice" do


### PR DESCRIPTION
## Context

We have a case where an organization handles subscriptions upgrades-downgrades manually. 
So they terminate a subscription and then create a new one with the same external_id;
depending on their internal logic, they send the same subscription_at as the previous subscirption, or subscription_at is now

however, there is already an invoice from the previous subscription for the existing billing period, so even though the subscription has subscription_at in the past, the past usage should not be shared (started_at) should be now - this can happen if sub_1 is terminated but not yet billed, sub_2 is already created and billing job picks it up

Also, having this change prevents us from double billing, if an organization already had an invoice for this customer and this external_id, having repeated started_at will result in double billing

## Description

Added a condition that checks if there is another terminated subscription with the same external_id with matching dates, if there is - started_at is previous subscription's terminated_at
