### PR TITLE
[LAGO-1711] feat(quotes): record quote, order form and order activity logs

### DIFF
--- a/app/graphql/types/activity_logs/resource_object.rb
+++ b/app/graphql/types/activity_logs/resource_object.rb
@@ -22,7 +22,10 @@ module Types
         Types::ProductCategories::Object,
         Types::Products::Object,
         Types::ProductFilters::Object,
-        Types::RateCards::Object
+        Types::RateCards::Object,
+        Types::Quotes::Object,
+        Types::OrderForms::Object,
+        Types::Orders::Object
 
       def self.resolve_type(object, _context)
         case object.class.to_s
@@ -58,6 +61,12 @@ module Types
           Types::ProductFilters::Object
         when "RateCard"
           Types::RateCards::Object
+        when "Quote"
+          Types::Quotes::Object
+        when "OrderForm"
+          Types::OrderForms::Object
+        when "Order"
+          Types::Orders::Object
         else
           raise "Unexpected activity log resource type: #{object.inspect}"
         end

--- a/app/graphql/types/order_forms/object.rb
+++ b/app/graphql/types/order_forms/object.rb
@@ -19,6 +19,7 @@ module Types
 
       field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :customer, Types::Customers::Object, null: false
+      field :order, Types::Orders::Object, null: true
       field :organization, Types::Organizations::OrganizationType, null: false
       field :quote, Types::Quotes::Object, null: false
 
@@ -26,6 +27,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       dataload_association :customer
+      dataload_association :order
       dataload_association :organization
       dataload_association :quote
     end

--- a/app/graphql/types/order_forms/object.rb
+++ b/app/graphql/types/order_forms/object.rb
@@ -17,6 +17,7 @@ module Types
 
       field :signed_document_url, String, null: true
 
+      field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :customer, Types::Customers::Object, null: false
       field :organization, Types::Organizations::OrganizationType, null: false
       field :quote, Types::Quotes::Object, null: false

--- a/app/graphql/types/orders/object.rb
+++ b/app/graphql/types/orders/object.rb
@@ -17,6 +17,7 @@ module Types
       field :executed_at, GraphQL::Types::ISO8601DateTime, null: true
       field :execution_record, Types::Orders::ExecutionRecord, null: false
 
+      field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :customer, Types::Customers::Object, null: false
       field :order_form, Types::OrderForms::Object, null: false
       field :organization, Types::Organizations::OrganizationType, null: false

--- a/app/graphql/types/quote_versions/object.rb
+++ b/app/graphql/types/quote_versions/object.rb
@@ -13,6 +13,7 @@ module Types
       field :end_date, GraphQL::Types::ISO8601Date, null: true
       field :id, ID, null: false
       field :mention_variables, GraphQL::Types::JSON, null: false
+      field :order_form, Types::OrderForms::Object, null: true
       field :organization, Types::Organizations::OrganizationType, null: false
       field :quote, Types::Quotes::Object, null: false
       field :start_date, GraphQL::Types::ISO8601Date, null: true
@@ -21,9 +22,8 @@ module Types
       field :version, Integer, null: false
       field :void_reason, Types::QuoteVersions::VoidReasonEnum, null: true
       field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
-      # TODO: field :order_form, Types::OrderForms::Object, null: true
 
-      dataload_association :organization, :quote
+      dataload_association :organization, :quote, :order_form
 
       # The persisted snapshot is a raw, locale-independent dict (or computed live while the
       # version is editable). It is localized on every read with the customer's current

--- a/app/graphql/types/quotes/object.rb
+++ b/app/graphql/types/quotes/object.rb
@@ -5,6 +5,7 @@ module Types
     class Object < Types::BaseObject
       graphql_name "Quote"
 
+      field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :current_version, Types::QuoteVersions::Object, null: false
       field :customer, Types::Customers::Object, null: false

--- a/app/graphql/types/quotes/object.rb
+++ b/app/graphql/types/quotes/object.rb
@@ -12,6 +12,7 @@ module Types
       field :id, ID, null: false
       field :images, GraphQL::Types::JSON, null: false
       field :number, String, null: false
+      field :order_forms, [Types::OrderForms::Object], null: false
       field :order_type, Types::Quotes::OrderTypeEnum, null: false
       field :organization, Types::Organizations::OrganizationType, null: false
       field :owners, [Types::UserType], null: true
@@ -19,7 +20,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       field :versions, [Types::QuoteVersions::Object], null: false
 
-      dataload_association :customer, :organization, :subscription, :owners, :versions, :current_version
+      dataload_association :customer, :organization, :subscription, :owners, :versions, :current_version, :order_forms
 
       def images
         dataloader.with(Sources::ActiveRecordAssociation, :images_blobs).load(object).each_with_object({}) do |blob, urls|

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -40,7 +40,10 @@ module Clickhouse
       product_category: "ProductCategory",
       product: "Product",
       product_filter: "ProductFilter",
-      rate_card: "RateCard"
+      rate_card: "RateCard",
+      quote: "Quote",
+      order_form: "OrderForm",
+      order: "Order"
     }.freeze
 
     ACTIVITY_TYPES = {
@@ -106,7 +109,19 @@ module Clickhouse
       product_filter_deleted: "product_filter.deleted",
       rate_card_created: "rate_card.created",
       rate_card_updated: "rate_card.updated",
-      rate_card_deleted: "rate_card.deleted"
+      rate_card_deleted: "rate_card.deleted",
+      quote_created: "quote.created",
+      quote_updated: "quote.updated",
+      quote_approved: "quote.approved",
+      quote_voided: "quote.voided",
+      quote_version_created: "quote.version_created",
+      order_form_created: "order_form.created",
+      order_form_signed: "order_form.signed",
+      order_form_file_uploaded: "order_form.file_uploaded",
+      order_form_expired: "order_form.expired",
+      order_form_voided: "order_form.voided",
+      order_created: "order.created",
+      order_executed: "order.executed"
     }
 
     before_save :ensure_activity_id

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -36,6 +36,11 @@ class Order < ApplicationRecord
   has_one :quote_version, through: :order_form
   has_one :quote, through: :quote_version
 
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
+
   enum :status, STATUSES,
     default: :created,
     validate: true

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -27,6 +27,11 @@ class OrderForm < ApplicationRecord
   has_one :quote, through: :quote_version
   has_one :order
 
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
+
   has_one_attached :signed_document
 
   enum :status, STATUSES,

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -27,6 +27,11 @@ class Quote < ApplicationRecord
   has_one :current_version, -> { order(sequential_id: :desc) }, class_name: "QuoteVersion"
   has_many :order_forms, through: :versions
 
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
+
   has_many_attached :images
 
   enum :order_type, ORDER_TYPES,

--- a/app/models/quote_version.rb
+++ b/app/models/quote_version.rb
@@ -51,6 +51,8 @@ class QuoteVersion < ApplicationRecord
     lock_key: ->(quote_version) { quote_version.quote_id }
   )
 
+  delegate :customer, to: :quote
+
   def version = sequential_id
 end
 

--- a/app/services/order_forms/create_service.rb
+++ b/app/services/order_forms/create_service.rb
@@ -27,6 +27,7 @@ module OrderForms
       )
 
       SendWebhookJob.perform_after_commit("order_form.created", order_form)
+      Utils::ActivityLog.produce_after_commit(order_form, "order_form.created")
 
       result.order_form = order_form
       result

--- a/app/services/order_forms/expire_service.rb
+++ b/app/services/order_forms/expire_service.rb
@@ -31,6 +31,7 @@ module OrderForms
           order_form.update!(status: :expired, voided_at: Time.current, void_reason: :expired)
 
           SendWebhookJob.perform_after_commit("order_form.expired", order_form)
+          Utils::ActivityLog.produce_after_commit(order_form, "order_form.expired")
 
           QuoteVersions::VoidService.call!(quote_version: order_form.quote_version, reason: :cascade_of_expired)
 

--- a/app/services/order_forms/mark_as_signed_service.rb
+++ b/app/services/order_forms/mark_as_signed_service.rb
@@ -39,6 +39,8 @@ module OrderForms
           order_form.save!
 
           SendWebhookJob.perform_after_commit("order_form.signed", order_form)
+          Utils::ActivityLog.produce_after_commit(order_form, "order_form.signed")
+          Utils::ActivityLog.produce_after_commit(order_form, "order_form.file_uploaded") if attachment
 
           order = Order.create!(
             organization: order_form.organization,
@@ -49,6 +51,7 @@ module OrderForms
           )
 
           SendWebhookJob.perform_after_commit("order.created", order)
+          Utils::ActivityLog.produce_after_commit(order, "order.created")
 
           result.order = order
           result.order_form = order_form

--- a/app/services/order_forms/void_service.rb
+++ b/app/services/order_forms/void_service.rb
@@ -28,6 +28,7 @@ module OrderForms
           )
 
           SendWebhookJob.perform_after_commit("order_form.voided", order_form)
+          Utils::ActivityLog.produce_after_commit(order_form, "order_form.voided")
 
           QuoteVersions::VoidService.call!(quote_version: order_form.quote_version, reason: :cascade_of_voided)
 

--- a/app/services/orders/base_execute_service.rb
+++ b/app/services/orders/base_execute_service.rb
@@ -65,6 +65,7 @@ module Orders
       )
 
       SendWebhookJob.perform_after_commit("order.executed", order)
+      Utils::ActivityLog.produce_after_commit(order, "order.executed")
     end
 
     # The transaction has already rolled back, so this trace is the only durable outcome of the

--- a/app/services/quote_versions/approve_service.rb
+++ b/app/services/quote_versions/approve_service.rb
@@ -33,6 +33,7 @@ module QuoteVersions
           )
 
           SendWebhookJob.perform_after_commit("quote.approved", quote_version)
+          Utils::ActivityLog.produce_after_commit(quote_version, "quote.approved")
 
           result.order_form = OrderForms::CreateService.call!(quote_version:, expires_at:).order_form
           result.quote_version = quote_version

--- a/app/services/quote_versions/clone_service.rb
+++ b/app/services/quote_versions/clone_service.rb
@@ -33,6 +33,8 @@ module QuoteVersions
 
           void_active_version!
           result.quote_version = create_next_version(quote_version:)
+
+          Utils::ActivityLog.produce_after_commit(result.quote_version, "quote.version_created")
         end
       end
 

--- a/app/services/quote_versions/update_service.rb
+++ b/app/services/quote_versions/update_service.rb
@@ -8,6 +8,10 @@ module QuoteVersions
 
     Result = BaseResult[:quote_version]
 
+    # The middleware is used rather than an inline produce because the diff is what makes this
+    # entry useful, and object_changes is only computed when produce wraps the call.
+    activity_loggable(action: "quote.updated", record: -> { quote_version })
+
     def initialize(quote_version:, params:)
       @quote_version = quote_version
       @params = params

--- a/app/services/quote_versions/void_service.rb
+++ b/app/services/quote_versions/void_service.rb
@@ -32,6 +32,7 @@ module QuoteVersions
           )
 
           SendWebhookJob.perform_after_commit("quote.voided", quote_version)
+          Utils::ActivityLog.produce_after_commit(quote_version, "quote.voided")
 
           result.quote_version = quote_version
         end

--- a/app/services/quotes/create_service.rb
+++ b/app/services/quotes/create_service.rb
@@ -36,6 +36,9 @@ module Quotes
         add_owners!(quote:)
 
         SendWebhookJob.perform_after_commit("quote.created", quote_version)
+        # The webhook needs the version for its payload; the activity log records the quote, whose
+        # number, order type and owners are what a reader looks for on a creation entry.
+        Utils::ActivityLog.produce_after_commit(quote, "quote.created")
 
         result.quote = quote
       end

--- a/app/services/quotes/update_service.rb
+++ b/app/services/quotes/update_service.rb
@@ -8,6 +8,14 @@ module Quotes
 
     Result = BaseResult[:quote]
 
+    # The middleware is used rather than an inline produce because the diff is what makes this
+    # entry useful, and object_changes is only computed when produce wraps the call.
+    activity_loggable(
+      action: "quote.updated",
+      record: -> { quote },
+      condition: -> { params.has_key?(:owners) }
+    )
+
     def initialize(quote:, params:)
       @quote = quote
       @params = params

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -15,6 +15,10 @@ module Utils
       customer: %i[taxes integration_customers applicable_invoice_custom_sections],
       invoice: %i[customer integration_customers billing_periods subscriptions fees credits metadata applied_taxes error_details applied_invoice_custom_sections],
       plan: %i[charges usage_thresholds taxes minimum_commitment],
+      quote: %i[owners],
+      # content is an unbounded rich-text document and produce serializes the record three times
+      # per log, so only the billing state is auditable here.
+      quote_version: %i[billing_items],
       subscription: %i[plan],
       wallet: %i[recurring_transaction_rules]
     }.freeze
@@ -176,6 +180,10 @@ module Utils
         object.coupon
       when "WalletTransaction"
         object.wallet
+      when "QuoteVersion"
+        # The quote lifecycle events are named quote.*: anchor them on the quote so a single
+        # resource carries the whole timeline, while activity_object keeps the version payload.
+        object.quote
       else
         object
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -72,7 +72,8 @@ type ActivityLogCollection {
 """
 Activity log resource
 """
-union ActivityLogResourceObject = BillableMetric | BillingEntity | Coupon | CreditNote | Customer | FeatureObject | Invoice | PaymentReceipt | PaymentRequest | Plan | Product | ProductCategory | ProductFilter | RateCard | Subscription | Wallet
+union ActivityLogResourceObject = BillableMetric | BillingEntity | Coupon | CreditNote | Customer | FeatureObject | Invoice | Order | OrderForm | PaymentReceipt | PaymentRequest | Plan | Product | ProductCategory | ProductFilter | Quote | RateCard | Subscription | Wallet
+
 """
 Activity Logs source enums
 """
@@ -370,6 +371,31 @@ enum ActivityTypeEnum {
   product.updated
   """
   product_updated
+
+  """
+  quote.approved
+  """
+  quote_approved
+
+  """
+  quote.created
+  """
+  quote_created
+
+  """
+  quote.updated
+  """
+  quote_updated
+
+  """
+  quote.version_created
+  """
+  quote_version_created
+
+  """
+  quote.voided
+  """
+  quote_voided
 
   """
   rate_card.created
@@ -12668,6 +12694,11 @@ enum ResourceTypeEnum {
   ProductFilter
   """
   product_filter
+
+  """
+  Quote
+  """
+  quote
 
   """
   RateCard

--- a/schema.graphql
+++ b/schema.graphql
@@ -73,7 +73,6 @@ type ActivityLogCollection {
 Activity log resource
 """
 union ActivityLogResourceObject = BillableMetric | BillingEntity | Coupon | CreditNote | Customer | FeatureObject | Invoice | PaymentReceipt | PaymentRequest | Plan | Product | ProductCategory | ProductFilter | RateCard | Subscription | Wallet
-
 """
 Activity Logs source enums
 """
@@ -256,6 +255,41 @@ enum ActivityTypeEnum {
   invoice.voided
   """
   invoice_voided
+
+  """
+  order.created
+  """
+  order_created
+
+  """
+  order.executed
+  """
+  order_executed
+
+  """
+  order_form.created
+  """
+  order_form_created
+
+  """
+  order_form.expired
+  """
+  order_form_expired
+
+  """
+  order_form.file_uploaded
+  """
+  order_form_file_uploaded
+
+  """
+  order_form.signed
+  """
+  order_form_signed
+
+  """
+  order_form.voided
+  """
+  order_form_voided
 
   """
   payment_receipt.created
@@ -10001,6 +10035,7 @@ enum OnTerminationInvoiceEnum {
 }
 
 type Order {
+  activityLogs: [ActivityLog!]
   billingSnapshot: JSON!
   createdAt: ISO8601DateTime!
   currency: CurrencyEnum
@@ -10055,6 +10090,7 @@ type OrderExecutionRecord {
 }
 
 type OrderForm {
+  activityLogs: [ActivityLog!]
   billingSnapshot: JSON!
   createdAt: ISO8601DateTime!
   customer: Customer!
@@ -12134,6 +12170,7 @@ type Query {
 }
 
 type Quote {
+  activityLogs: [ActivityLog!]
   createdAt: ISO8601DateTime!
   currentVersion: QuoteVersion!
   customer: Customer!
@@ -12591,6 +12628,16 @@ enum ResourceTypeEnum {
   Invoice
   """
   invoice
+
+  """
+  Order
+  """
+  order
+
+  """
+  OrderForm
+  """
+  order_form
 
   """
   PaymentReceipt

--- a/schema.graphql
+++ b/schema.graphql
@@ -10123,6 +10123,7 @@ type OrderForm {
   expiresAt: ISO8601DateTime
   id: ID!
   number: String!
+  order: Order
   organization: Organization!
   quote: Quote!
   signedAt: ISO8601DateTime
@@ -12203,6 +12204,7 @@ type Quote {
   id: ID!
   images: JSON!
   number: String!
+  orderForms: [OrderForm!]!
   orderType: OrderTypeEnum!
   organization: Organization!
   owners: [User!]
@@ -12235,6 +12237,7 @@ type QuoteVersion {
   endDate: ISO8601Date
   id: ID!
   mentionVariables: JSON!
+  orderForm: OrderForm
   organization: Organization!
   quote: Quote!
   startDate: ISO8601Date

--- a/schema.json
+++ b/schema.json
@@ -476,6 +476,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "Quote",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "RateCard",
               "ofType": null
             },
@@ -903,6 +908,78 @@
             {
               "name": "rate_card_deleted",
               "description": "rate_card.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quote_created",
+              "description": "quote.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quote_updated",
+              "description": "quote.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quote_approved",
+              "description": "quote.approved",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quote_voided",
+              "description": "quote.voided",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quote_version_created",
+              "description": "quote.version_created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_form_created",
+              "description": "order_form.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_form_signed",
+              "description": "order_form.signed",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_form_file_uploaded",
+              "description": "order_form.file_uploaded",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_form_expired",
+              "description": "order_form.expired",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_form_voided",
+              "description": "order_form.voided",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_created",
+              "description": "order.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_executed",
+              "description": "order.executed",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -68810,6 +68887,24 @@
             {
               "name": "rate_card",
               "description": "RateCard",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quote",
+              "description": "Quote",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_form",
+              "description": "OrderForm",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": "Order",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/schema.json
+++ b/schema.json
@@ -48286,6 +48286,18 @@
               "deprecationReason": null
             },
             {
+              "name": "order",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "organization",
               "description": null,
               "args": [],
@@ -66185,6 +66197,30 @@
               "deprecationReason": null
             },
             {
+              "name": "orderForms",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "OrderForm",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "orderType",
               "description": null,
               "args": [],
@@ -66454,6 +66490,18 @@
                   "name": "JSON",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderForm",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "OrderForm",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/schema.json
+++ b/schema.json
@@ -436,6 +436,16 @@
             },
             {
               "kind": "OBJECT",
+              "name": "Order",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "OrderForm",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "PaymentReceipt",
               "ofType": null
             },
@@ -47568,6 +47578,26 @@
           "description": null,
           "fields": [
             {
+              "name": "activityLogs",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivityLog",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "billingSnapshot",
               "description": null,
               "args": [],
@@ -48066,6 +48096,26 @@
           "name": "OrderForm",
           "description": null,
           "fields": [
+            {
+              "name": "activityLogs",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivityLog",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "billingSnapshot",
               "description": null,
@@ -65941,6 +65991,26 @@
           "name": "Quote",
           "description": null,
           "fields": [
+            {
+              "name": "activityLogs",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivityLog",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "createdAt",
               "description": null,

--- a/spec/graphql/resolvers/quote_resolver_spec.rb
+++ b/spec/graphql/resolvers/quote_resolver_spec.rb
@@ -93,6 +93,74 @@ RSpec.describe Resolvers::QuoteResolver do
     end
   end
 
+  context "when the quote has an order form and an order" do
+    let(:quote) { create(:quote, organization:, customer:) }
+    let(:quote_version) { create(:quote_version, :approved, organization:, quote:) }
+    let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+    let(:order) { create(:order, organization:, customer:, order_form:) }
+
+    let(:query) do
+      <<~GQL
+        query($quoteId: ID!) {
+          quote(id: $quoteId) {
+            id
+            orderForms { id order { id } }
+            versions { id orderForm { id } }
+          }
+        }
+      GQL
+    end
+
+    before { order }
+
+    it "exposes the order form and the order it produced" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {quoteId: quote.id}
+      )
+
+      response = result.dig("data", "quote")
+
+      expect(response["orderForms"]).to eq([{"id" => order_form.id, "order" => {"id" => order.id}}])
+      expect(response["versions"]).to eq([{"id" => quote_version.id, "orderForm" => {"id" => order_form.id}}])
+    end
+  end
+
+  context "when a version has no order form" do
+    let(:quote) { create(:quote, :with_version, organization:, customer:) }
+
+    let(:query) do
+      <<~GQL
+        query($quoteId: ID!) {
+          quote(id: $quoteId) {
+            orderForms { id }
+            versions { orderForm { id } }
+          }
+        }
+      GQL
+    end
+
+    before { quote }
+
+    it "returns an empty list and a null order form" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {quoteId: quote.id}
+      )
+
+      response = result.dig("data", "quote")
+
+      expect(response["orderForms"]).to eq([])
+      expect(response["versions"]).to eq([{"orderForm" => nil}])
+    end
+  end
+
   context "when the quote has images" do
     let(:quote) { create(:quote, organization:, customer:) }
     let(:query) do
@@ -161,7 +229,8 @@ RSpec.describe Resolvers::QuoteResolver do
             organization { id }
             subscription { id }
             owners { id }
-            versions { id quote { id } organization { id } }
+            orderForms { id order { id } }
+            versions { id quote { id } organization { id } orderForm { id } }
             currentVersion { id quote { id } organization { id } }
           }
         }
@@ -172,7 +241,16 @@ RSpec.describe Resolvers::QuoteResolver do
       quote
       QuoteOwner.create!(organization:, quote:, user: membership.user)
       QuoteOwner.create!(organization:, quote:, user: other_user)
-      create(:quote_version, :voided, organization:, quote:)
+
+      # Two voided versions, each carrying an order form, so that `orderForm` and `order` are
+      # resolved for several parents and an unbatched association would surface as an N+1.
+      first_voided = create(:quote_version, :voided, organization:, quote:)
+      second_voided = create(:quote_version, :voided, organization:, quote:)
+      create(:order, organization:, customer:,
+        order_form: create(:order_form, :signed, organization:, customer:, quote_version: first_voided))
+      create(:order, organization:, customer:,
+        order_form: create(:order_form, :signed, organization:, customer:, quote_version: second_voided))
+
       create(:quote_version, organization:, quote:)
     end
 

--- a/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe Types::ActivityLogs::ActivityTypeEnum do
         rate_card_updated
         rate_card_deleted
         email_sent
+        quote_created
+        quote_updated
+        quote_approved
+        quote_voided
+        quote_version_created
+        order_form_created
+        order_form_signed
+        order_form_file_uploaded
+        order_form_expired
+        order_form_voided
+        order_created
+        order_executed
       ]
     )
   end

--- a/spec/graphql/types/activity_logs/resource_object_spec.rb
+++ b/spec/graphql/types/activity_logs/resource_object_spec.rb
@@ -26,7 +26,10 @@ RSpec.describe Types::ActivityLogs::ResourceObject do
       Types::ProductCategories::Object,
       Types::Products::Object,
       Types::ProductFilters::Object,
-      Types::RateCards::Object
+      Types::RateCards::Object,
+      Types::Quotes::Object,
+      Types::OrderForms::Object,
+      Types::Orders::Object
     )
   end
 
@@ -46,6 +49,9 @@ RSpec.describe Types::ActivityLogs::ResourceObject do
     let(:product) { create(:product) }
     let(:product_filter) { create(:product_filter) }
     let(:rate_card) { create(:rate_card) }
+    let(:quote) { create(:quote) }
+    let(:order_form) { create(:order_form) }
+    let(:order) { create(:order) }
 
     it "returns Types::BillableMetrics::Object for BillableMetric objects" do
       expect(subject.resolve_type(billable_metric, {})).to eq(Types::BillableMetrics::Object)
@@ -109,6 +115,18 @@ RSpec.describe Types::ActivityLogs::ResourceObject do
 
     it "returns Types::RateCards::Object for RateCard objects" do
       expect(subject.resolve_type(rate_card, {})).to eq(Types::RateCards::Object)
+    end
+
+    it "returns Types::Quotes::Object for Quote objects" do
+      expect(subject.resolve_type(quote, {})).to eq(Types::Quotes::Object)
+    end
+
+    it "returns Types::OrderForms::Object for OrderForm objects" do
+      expect(subject.resolve_type(order_form, {})).to eq(Types::OrderForms::Object)
+    end
+
+    it "returns Types::Orders::Object for Order objects" do
+      expect(subject.resolve_type(order, {})).to eq(Types::Orders::Object)
     end
   end
 end

--- a/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe Types::ActivityLogs::ResourceTypeEnum do
         product
         product_filter
         rate_card
+        quote
+        order_form
+        order
       ]
     )
   end

--- a/spec/graphql/types/order_forms/object_spec.rb
+++ b/spec/graphql/types/order_forms/object_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Types::OrderForms::Object do
     expect(subject).to have_field(:signed_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:voided_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:signed_document_url).of_type("String")
+    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:customer).of_type("Customer!")
     expect(subject).to have_field(:organization).of_type("Organization!")
     expect(subject).to have_field(:quote).of_type("Quote!")

--- a/spec/graphql/types/order_forms/object_spec.rb
+++ b/spec/graphql/types/order_forms/object_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Types::OrderForms::Object do
     expect(subject).to have_field(:signed_document_url).of_type("String")
     expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:customer).of_type("Customer!")
+    expect(subject).to have_field(:order).of_type("Order")
     expect(subject).to have_field(:organization).of_type("Organization!")
     expect(subject).to have_field(:quote).of_type("Quote!")
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")

--- a/spec/graphql/types/orders/object_spec.rb
+++ b/spec/graphql/types/orders/object_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Types::Orders::Object do
     expect(subject).to have_field(:executed_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:execution_record).of_type("OrderExecutionRecord!")
 
+    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:customer).of_type("Customer!")
     expect(subject).to have_field(:order_form).of_type("OrderForm!")
     expect(subject).to have_field(:organization).of_type("Organization!")

--- a/spec/graphql/types/quote_versions/object_spec.rb
+++ b/spec/graphql/types/quote_versions/object_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Types::QuoteVersions::Object do
     expect(subject).to have_field(:billing_items).of_type("JSON")
     expect(subject).to have_field(:content).of_type("String")
     expect(subject).to have_field(:mention_variables).of_type("JSON!")
+    expect(subject).to have_field(:order_form).of_type("OrderForm")
     expect(subject).to have_field(:status).of_type("StatusEnum!")
     expect(subject).to have_field(:version).of_type("Int!")
     expect(subject).to have_field(:void_reason).of_type("VoidReasonEnum")

--- a/spec/graphql/types/quotes/object_spec.rb
+++ b/spec/graphql/types/quotes/object_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Types::Quotes::Object do
     expect(subject).to have_field(:versions).of_type("[QuoteVersion!]!")
     expect(subject).to have_field(:number).of_type("String!")
     expect(subject).to have_field(:images).of_type("JSON!")
+    expect(subject).to have_field(:order_forms).of_type("[OrderForm!]!")
     expect(subject).to have_field(:order_type).of_type("OrderTypeEnum!")
     expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")

--- a/spec/graphql/types/quotes/object_spec.rb
+++ b/spec/graphql/types/quotes/object_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Types::Quotes::Object do
     expect(subject).to have_field(:number).of_type("String!")
     expect(subject).to have_field(:images).of_type("JSON!")
     expect(subject).to have_field(:order_type).of_type("OrderTypeEnum!")
+    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
   end

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe OrderForm do
     end
   end
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   describe "Scopes" do
     describe ".expirable" do
       let(:organization) { create(:organization) }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe Order do
     end
   end
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   describe "Scopes" do
     describe ".executable" do
       let(:organization) { create(:organization) }

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe Quote do
     end
   end
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   describe "validations" do
     describe "subscription_id" do
       it "requires subscription_id when order_type is subscription_amendment" do

--- a/spec/models/quote_version_spec.rb
+++ b/spec/models/quote_version_spec.rb
@@ -89,4 +89,13 @@ RSpec.describe QuoteVersion do
       expect(quote_version.version).to eq(42)
     end
   end
+
+  describe "#customer" do
+    it "delegates to the quote" do
+      quote = create(:quote)
+      quote_version = create(:quote_version, quote:, organization: quote.organization)
+
+      expect(quote_version.customer).to eq(quote.customer)
+    end
+  end
 end

--- a/spec/services/order_forms/create_service_spec.rb
+++ b/spec/services/order_forms/create_service_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe OrderForms::CreateService do
           .to have_enqueued_job_after_commit(SendWebhookJob)
           .with("order_form.created", OrderForm)
       end
+
+      it "produces an order_form.created activity log" do
+        result = create_service.call
+
+        expect(Utils::ActivityLog).to have_produced("order_form.created").after_commit.with(result.order_form)
+      end
     end
 
     context "when an expires_at in the future is provided", :premium do

--- a/spec/services/order_forms/expire_service_spec.rb
+++ b/spec/services/order_forms/expire_service_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe OrderForms::ExpireService do
             ApplicationRecord.transaction { service.call }
           end.not_to have_enqueued_job(SendWebhookJob)
         end
+
+        it "does not produce an activity log" do
+          service.call
+
+          expect(Utils::ActivityLog).not_to have_produced("order_form.expired")
+        end
       end
 
       context "when order_form is already voided" do
@@ -136,6 +142,18 @@ RSpec.describe OrderForms::ExpireService do
           expect { service.call }
             .to have_enqueued_job_after_commit(SendWebhookJob)
             .with("quote.voided", quote_version)
+        end
+
+        it "produces an order_form.expired activity log" do
+          service.call
+
+          expect(Utils::ActivityLog).to have_produced("order_form.expired").after_commit.with(order_form)
+        end
+
+        it "produces a cascaded quote.voided activity log" do
+          service.call
+
+          expect(Utils::ActivityLog).to have_produced("quote.voided").after_commit.with(quote_version)
         end
       end
     end

--- a/spec/services/order_forms/mark_as_signed_service_spec.rb
+++ b/spec/services/order_forms/mark_as_signed_service_spec.rb
@@ -138,6 +138,24 @@ RSpec.describe OrderForms::MarkAsSignedService do
             .to have_enqueued_job_after_commit(SendWebhookJob)
             .with("order.created", Order)
         end
+
+        it "produces an order_form.signed activity log" do
+          service.call
+
+          expect(Utils::ActivityLog).to have_produced("order_form.signed").after_commit.with(order_form)
+        end
+
+        it "produces an order.created activity log" do
+          result = service.call
+
+          expect(Utils::ActivityLog).to have_produced("order.created").after_commit.with(result.order)
+        end
+
+        it "does not produce an order_form.file_uploaded activity log" do
+          service.call
+
+          expect(Utils::ActivityLog).not_to have_produced("order_form.file_uploaded")
+        end
       end
 
       context "when a signed_document is provided" do
@@ -152,6 +170,12 @@ RSpec.describe OrderForms::MarkAsSignedService do
           expect(result.order_form).to be_signed
           expect(result.order_form.signed_document).to be_attached
           expect(result.order_form.signed_document.blob.content_type).to eq("application/pdf")
+        end
+
+        it "produces an order_form.file_uploaded activity log" do
+          service.call
+
+          expect(Utils::ActivityLog).to have_produced("order_form.file_uploaded").after_commit.with(order_form)
         end
       end
 

--- a/spec/services/order_forms/void_service_spec.rb
+++ b/spec/services/order_forms/void_service_spec.rb
@@ -96,6 +96,18 @@ RSpec.describe OrderForms::VoidService do
             .to have_enqueued_job_after_commit(SendWebhookJob)
             .with("quote.voided", quote_version)
         end
+
+        it "produces an order_form.voided activity log" do
+          service.call
+
+          expect(Utils::ActivityLog).to have_produced("order_form.voided").after_commit.with(order_form)
+        end
+
+        it "produces a cascaded quote.voided activity log" do
+          service.call
+
+          expect(Utils::ActivityLog).to have_produced("quote.voided").after_commit.with(quote_version)
+        end
       end
     end
   end

--- a/spec/services/orders/one_off/execute_service_spec.rb
+++ b/spec/services/orders/one_off/execute_service_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe Orders::OneOff::ExecuteService do
           .with("order.executed", order)
       end
 
+      it "produces an order.executed activity log" do
+        execute_service.call
+
+        expect(Utils::ActivityLog).to have_produced("order.executed").after_commit.with(order)
+      end
+
       it "bills the payload values" do
         execute_service.call
 
@@ -259,6 +265,12 @@ RSpec.describe Orders::OneOff::ExecuteService do
         expect do
           ApplicationRecord.transaction { execute_service.call }
         end.not_to have_enqueued_job(SendWebhookJob)
+      end
+
+      it "does not produce an activity log" do
+        execute_service.call
+
+        expect(Utils::ActivityLog).not_to have_produced("order.executed")
       end
     end
 

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -541,6 +541,12 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
         expect(order.execution_record["subscription_ids"]).to eq([])
         expect(order.execution_record["terminated_subscription_ids"]).to eq([])
       end
+
+      it "produces an order.executed activity log" do
+        execute_service.call
+
+        expect(Utils::ActivityLog).to have_produced("order.executed").after_commit.with(order)
+      end
     end
   end
 end

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -608,6 +608,12 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
         expect(order.execution_record["subscription_ids"]).to eq([])
         expect(order.execution_record["errors"]).to eq([])
       end
+
+      it "produces an order.executed activity log" do
+        execute_service.call
+
+        expect(Utils::ActivityLog).to have_produced("order.executed").after_commit.with(order)
+      end
     end
 
     context "when the order is already executed" do

--- a/spec/services/quote_versions/approve_service_spec.rb
+++ b/spec/services/quote_versions/approve_service_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe QuoteVersions::ApproveService do
           .with("order_form.created", OrderForm)
       end
 
+      it "produces a quote.approved activity log" do
+        approve_service.call
+
+        expect(Utils::ActivityLog).to have_produced("quote.approved").after_commit.with(quote_version)
+      end
+
+      it "produces an order_form.created activity log" do
+        result = approve_service.call
+
+        expect(Utils::ActivityLog).to have_produced("order_form.created").after_commit.with(result.order_form)
+      end
+
       it "persists the raw computed mention variables snapshot" do
         expect(result).to be_success
         expect(result.quote_version.reload.mention_variables).to include(

--- a/spec/services/quote_versions/clone_service_spec.rb
+++ b/spec/services/quote_versions/clone_service_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe QuoteVersions::CloneService do
           expect(quote_version.void_reason).to eq("manual")
           expect(quote_version.voided_at).not_to eq(nil)
         end
+
+        it "produces a quote.version_created activity log for the clone" do
+          expect(Utils::ActivityLog)
+            .to have_produced("quote.version_created").after_commit.with(result.quote_version)
+        end
       end
 
       context "when the source version is draft" do
@@ -70,6 +75,12 @@ RSpec.describe QuoteVersions::CloneService do
           expect { clone_service.call }
             .to have_enqueued_job_after_commit(SendWebhookJob)
             .with("quote.voided", quote_version)
+        end
+
+        it "produces a quote.voided activity log for the superseded source" do
+          clone_service.call
+
+          expect(Utils::ActivityLog).to have_produced("quote.voided").after_commit.with(quote_version)
         end
       end
     end

--- a/spec/services/quote_versions/update_service_spec.rb
+++ b/spec/services/quote_versions/update_service_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe QuoteVersions::UpdateService do
         expect(result.quote_version.start_date).to eq(start_date)
         expect(result.quote_version.end_date).to eq(end_date)
       end
+
+      # Called through the class so the request goes through the activity log middleware, which an
+      # instance #call bypasses.
+      it "produces a quote.updated activity log" do
+        described_class.call(quote_version:, params: update_params)
+
+        expect(Utils::ActivityLog).to have_produced("quote.updated").after_commit.with(quote_version)
+      end
     end
 
     context "when the quote is one_off", :premium do

--- a/spec/services/quote_versions/void_service_spec.rb
+++ b/spec/services/quote_versions/void_service_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe QuoteVersions::VoidService do
           .to have_enqueued_job_after_commit(SendWebhookJob)
           .with("quote.voided", quote_version)
       end
+
+      it "produces a quote.voided activity log" do
+        void_service.call
+
+        expect(Utils::ActivityLog).to have_produced("quote.voided").after_commit.with(quote_version)
+      end
     end
 
     context "when the version is superseded by a clone", :premium do
@@ -39,6 +45,12 @@ RSpec.describe QuoteVersions::VoidService do
           .with("quote.voided", quote_version)
 
         expect(quote_version.reload.void_reason).to eq("superseded")
+      end
+
+      it "produces a quote.voided activity log for the superseded version" do
+        void_service.call
+
+        expect(Utils::ActivityLog).to have_produced("quote.voided").after_commit.with(quote_version)
       end
     end
 

--- a/spec/services/quotes/create_service_spec.rb
+++ b/spec/services/quotes/create_service_spec.rb
@@ -60,6 +60,16 @@ RSpec.describe Quotes::CreateService do
           .to have_enqueued_job_after_commit(SendWebhookJob)
           .with("quote.created", QuoteVersion)
       end
+
+      it "produces a quote.created activity log for the quote" do
+        expect(Utils::ActivityLog).to have_produced("quote.created").after_commit.with(result.quote)
+      end
+
+      it "does not produce a quote.version_created activity log for the initial version" do
+        result
+
+        expect(Utils::ActivityLog).not_to have_produced("quote.version_created")
+      end
     end
 
     context "when the customer has no currency", :premium do

--- a/spec/services/quotes/update_service_spec.rb
+++ b/spec/services/quotes/update_service_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe Quotes::UpdateService do
       expect(result.quote.owner_ids).to eq([owner.id])
     end
 
+    # Called through the class so the request goes through the activity log middleware, which an
+    # instance #call bypasses.
+    it "produces a quote.updated activity log", :premium do
+      described_class.call(quote:, params: update_params)
+
+      expect(Utils::ActivityLog).to have_produced("quote.updated").after_commit.with(quote)
+    end
+
+    context "when owners are not part of the params", :premium do
+      let(:update_params) { {} }
+
+      it "does not produce an activity log" do
+        described_class.call(quote:, params: update_params)
+
+        expect(Utils::ActivityLog).not_to have_produced("quote.updated")
+      end
+    end
+
     context "when owners include invalid user ids", :premium do
       let(:update_params) { {owners: ["invalid_user_id"]} }
 

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -140,6 +140,36 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
         end
       end
 
+      context "when the object is a quote version" do
+        let(:quote) { create(:quote, organization:) }
+        let(:quote_version) { create(:quote_version, quote:, organization:) }
+
+        it "uses quote as resource" do
+          activity_log.produce(quote_version, "quote.approved", activity_id: "activity-id") { BaseService::Result.new }
+
+          expect(karafka_producer).to have_received(:produce_async).with(
+            topic: "activity_logs",
+            key: "#{organization.id}--activity-id",
+            payload: {
+              activity_source: "api",
+              api_key_id: api_key.id,
+              user_id: nil,
+              activity_type: "quote.approved",
+              activity_id: "activity-id",
+              logged_at: Time.current.iso8601[...-1],
+              created_at: Time.current.iso8601[...-1],
+              resource_id: quote.id,
+              resource_type: "Quote",
+              organization_id: organization.id,
+              activity_object: V1::QuoteVersionSerializer.new(quote_version, includes: %i[billing_items]).serialize,
+              activity_object_changes: {},
+              external_customer_id: quote.customer.external_id,
+              external_subscription_id: nil
+            }.to_json
+          )
+        end
+      end
+
       context "when the object is a payment receipt" do
         let(:payment_receipt) { create(:payment_receipt, organization:) }
 
@@ -431,6 +461,22 @@ RSpec.describe Utils::ActivityLog, :capture_kafka_messages do
 
       it "returns the default includes for the object" do
         expect(method_call).to eq(serialized_includes)
+      end
+    end
+
+    context "when object is a quote" do
+      let(:object) { create(:quote, organization:) }
+
+      it "includes the owners" do
+        expect(method_call).to eq(%i[owners])
+      end
+    end
+
+    context "when object is a quote version" do
+      let(:object) { create(:quote_version, organization:) }
+
+      it "includes the billing items but not the content" do
+        expect(method_call).to eq(%i[billing_items])
       end
     end
 


### PR DESCRIPTION
## Context

Quotes, order forms and orders record no activity logs, so a quote's lifecycle is invisible in the audit trail while every other billing resource is covered. This adds the set from LAGO-1711 (LAGO-1712 → LAGO-1722).

Stacked on #6134, so each log sits on the line below its webhook counterpart.

## Description

Twelve activity types. `order_form.created` is the 12th, on top of the spec's 11, settling the same coherence question #6134 settled for webhooks.

| activity_type | Emitted from | Object |
|---|---|---|
| `quote.created` | `Quotes::CreateService` | quote |
| `quote.updated` | `Quotes::UpdateService` (owners) | quote |
| `quote.updated` | `QuoteVersions::UpdateService` (billing items, content, dates) | version |
| `quote.approved` | `QuoteVersions::ApproveService` | version |
| `quote.voided` | `QuoteVersions::VoidService` | version |
| `quote.version_created` | `QuoteVersions::CloneService` | version |
| `order_form.created` | `OrderForms::CreateService` | order_form |
| `order_form.signed` | `OrderForms::MarkAsSignedService` | order_form |
| `order_form.file_uploaded` | `OrderForms::MarkAsSignedService`, when a document is attached | order_form |
| `order_form.expired` | `OrderForms::ExpireService` | order_form |
| `order_form.voided` | `OrderForms::VoidService` | order_form |
| `order.created` | `OrderForms::MarkAsSignedService` | order |
| `order.executed` | `Orders::BaseExecuteService` | order |

Quote, order form and order also gain an `activityLogs` field and join the `ActivityLogResourceObject` union, which is required rather than cosmetic: `resolve_type` raises on an unknown class, so the activity-logs screen would break on the first quote log without it.
