### PR TITLE
Multi currency billing enty flag drops phase2

### DIFF
--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -14,10 +14,6 @@ payment_gated_subscriptions:
   description: "Enable payment-gated subscription activation rules"
   owners: ["@osmarluz", "@ancorcruz"]
 
-multi_entity_billing:
-  description: "Allow customers to have billing objects across multiple billing entities"
-  owners: ["@lovrocolic", "@feliperodrigues", "@mariohd"]
-
 order_forms:
   description: "Enable quotes, order forms and orders"
   owners: ["@murparreira", "@toommz", "@rinasergeeva"]

--- a/app/config/feature_flags.yaml
+++ b/app/config/feature_flags.yaml
@@ -10,10 +10,6 @@ wallet_traceability:
   description: "Enable wallet traceability on newly created wallets"
   owners: ["@groyoh", "@D1353L"]
 
-multi_currency:
-  description: "Allow customers to have billing objects in multiple currencies"
-  owners: ["@feliperodrigues", "@mariohd", "@lovrocolic"]
-
 payment_gated_subscriptions:
   description: "Enable payment-gated subscription activation rules"
   owners: ["@osmarluz", "@ancorcruz"]

--- a/schema.graphql
+++ b/schema.graphql
@@ -6340,7 +6340,6 @@ enum FeatureFlagEnum {
   lazy_charge_usage_cache
   meilisearch
   multi_connection
-  multi_currency
   multi_entity_billing
   order_forms
   payment_gated_subscriptions

--- a/schema.graphql
+++ b/schema.graphql
@@ -6340,7 +6340,6 @@ enum FeatureFlagEnum {
   lazy_charge_usage_cache
   meilisearch
   multi_connection
-  multi_entity_billing
   order_forms
   payment_gated_subscriptions
   postgres_enriched_events

--- a/schema.json
+++ b/schema.json
@@ -30827,12 +30827,6 @@
               "deprecationReason": null
             },
             {
-              "name": "multi_currency",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "payment_gated_subscriptions",
               "description": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -30833,12 +30833,6 @@
               "deprecationReason": null
             },
             {
-              "name": "multi_entity_billing",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "order_forms",
               "description": null,
               "isDeprecated": false,


### PR DESCRIPTION
## Context

Phase 2 of making `multi_currency` and `multi_entity_billing` generally available. Phase 1 is already merged in main: all gating has been removed from the code and the features behave as always-on, but the flag definitions were intentionally left in place. The frontend removal of the same flags ships as a single PR, so both are dropped together here. With no code referencing the flags anymore, their definitions can be removed and the schema regenerated.

## Description

Remove `multi_currency` and `multi_entity_billing` from `feature_flags.yaml`, and regenerate `schema.graphql` / `schema.json`, which drops both members from `FeatureFlagEnum`. Stale values left on organizations are cleared automatically by `FeatureFlag.sanitize!` at boot, so no migration is needed.

## Notes

This depends on the Phase 1 GA changes, which are already merged, so it can be merged on its own. No behavioral change: the features were already always-on after Phase 1; this only deletes the now-unused flag definitions.

## Tests

Feature-flag and representative wallet/service specs pass. No spec references either flag as a setup value.
