### PR TITLE
fix(auth): prevent cross-org account takeover via Okta SSO

### DIFF
--- a/app/models/integrations/okta_integration.rb
+++ b/app/models/integrations/okta_integration.rb
@@ -4,6 +4,7 @@ module Integrations
   class OktaIntegration < BaseIntegration
     validates :client_secret, :client_id, :domain, :organization_name, presence: true
     validate :domain_uniqueness
+    validate :host_format
 
     settings_accessors :client_id, :domain, :organization_name, :host
     secrets_accessors :client_secret
@@ -24,6 +25,14 @@ module Integrations
         .exists?
 
       errors.add(:domain, "domain_not_unique") if okta_integration
+    end
+
+    def host_format
+      configured_host = get_from_settings("host")
+      return if configured_host.blank?
+
+      url_segment = /\A[a-zA-Z0-9.-]+\z/
+      errors.add(:host, "host_invalid") unless configured_host.match?(url_segment)
     end
   end
 end

--- a/app/services/auth/entra_id/login_service.rb
+++ b/app/services/auth/entra_id/login_service.rb
@@ -23,7 +23,7 @@ module Auth
         find_or_create_user
         find_or_create_membership
 
-        unless result.user.active_organizations.pluck(:authentication_methods).flatten.uniq.include?(Organizations::AuthenticationMethods::ENTRA_ID)
+        unless entra_id_enabled_for_login?
           return result.single_validation_failure!(
             error_code: "login_method_not_authorized",
             field: Organizations::AuthenticationMethods::ENTRA_ID
@@ -40,6 +40,13 @@ module Auth
       private
 
       attr_reader :code, :state
+
+      def entra_id_enabled_for_login?
+        organization = result.entra_id_integration.organization
+
+        result.user.active_organizations.include?(organization) &&
+          organization.authentication_methods.include?(Organizations::AuthenticationMethods::ENTRA_ID)
+      end
 
       def generate_token
         result.token = Utils::AuthToken.encode(user: result.user, login_method: Organizations::AuthenticationMethods::ENTRA_ID)

--- a/app/services/auth/okta/accept_invite_service.rb
+++ b/app/services/auth/okta/accept_invite_service.rb
@@ -18,6 +18,9 @@ module Auth
         check_code
         check_okta_integration(result.email)
         check_invite(result.email)
+
+        raise ValidationError, "existing_user_must_authenticate" if existing_user_outside_organization?
+
         query_okta_access_token
         check_userinfo(result.email)
 
@@ -38,6 +41,13 @@ module Auth
       private
 
       attr_reader :invite_token, :code, :state
+
+      def existing_user_outside_organization?
+        user = User.find_by(email: result.email)
+        return false if user.nil?
+
+        !user.memberships.active.exists?(organization_id: result.invite.organization_id)
+      end
     end
   end
 end

--- a/app/services/auth/okta/base_service.rb
+++ b/app/services/auth/okta/base_service.rb
@@ -60,7 +60,7 @@ module Auth
         userinfo_headers = {"Authorization" => "Bearer #{result.okta_access_token}"}
         response = userinfo_client.get(headers: userinfo_headers)
 
-        raise ValidationError, "okta_userinfo_error" if response["email"] != email
+        raise ValidationError, "okta_userinfo_error" unless response["email"]&.casecmp?(email)
 
         result.userinfo = response
       end

--- a/app/services/auth/okta/login_service.rb
+++ b/app/services/auth/okta/login_service.rb
@@ -20,6 +20,10 @@ module Auth
         query_okta_access_token
         check_userinfo(result.email)
 
+        if existing_user_outside_organization?
+          return result.single_validation_failure!(error_code: "user_does_not_belong_to_organization")
+        end
+
         find_or_create_user
         find_or_create_membership
 
@@ -40,6 +44,13 @@ module Auth
       private
 
       attr_reader :code, :state
+
+      def existing_user_outside_organization?
+        user = User.find_by(email: result.email)
+        return false if user.nil?
+
+        !user.memberships.active.exists?(organization_id: result.okta_integration.organization_id)
+      end
 
       def generate_token
         result.token = Utils::AuthToken.encode(user: result.user, login_method: Organizations::AuthenticationMethods::OKTA)

--- a/app/services/auth/okta/login_service.rb
+++ b/app/services/auth/okta/login_service.rb
@@ -27,7 +27,7 @@ module Auth
         find_or_create_user
         find_or_create_membership
 
-        unless result.user.active_organizations.pluck(:authentication_methods).flatten.uniq.include?(Organizations::AuthenticationMethods::OKTA)
+        unless okta_enabled_for_login?
           return result.single_validation_failure!(
             error_code: "login_method_not_authorized",
             field: Organizations::AuthenticationMethods::OKTA
@@ -50,6 +50,13 @@ module Auth
         return false if user.nil?
 
         !user.memberships.active.exists?(organization_id: result.okta_integration.organization_id)
+      end
+
+      def okta_enabled_for_login?
+        organization = result.okta_integration.organization
+
+        result.user.active_organizations.include?(organization) &&
+          organization.authentication_methods.include?(Organizations::AuthenticationMethods::OKTA)
       end
 
       def generate_token

--- a/spec/models/integrations/okta_integration_spec.rb
+++ b/spec/models/integrations/okta_integration_spec.rb
@@ -46,5 +46,22 @@ RSpec.describe Integrations::OktaIntegration do
         expect(okta_integration.errors).to include(:domain)
       end
     end
+
+    context "when host contains unsafe URL characters" do
+      before { subject.host = "evil.com/path" }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors).to include(:host)
+      end
+    end
+
+    context "when host is a custom domain" do
+      before { subject.host = "login.acme.com" }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
   end
 end

--- a/spec/services/auth/entra_id/login_service_spec.rb
+++ b/spec/services/auth/entra_id/login_service_spec.rb
@@ -82,6 +82,27 @@ RSpec.describe Auth::EntraId::LoginService, cache: :memory do
       end
     end
 
+    context "when entra id is disabled on the integration's organization but enabled on another of the user's organizations" do
+      let(:user) { create(:user, email: "foo@bar.com") }
+
+      before do
+        create(:membership, user:, organization: entra_id_integration.organization)
+        entra_id_integration.organization.disable_entra_id_authentication!
+
+        other_organization = create(:organization)
+        other_organization.update!(premium_integrations: ["entra_id"])
+        other_organization.enable_entra_id_authentication!
+        create(:membership, user:, organization: other_organization)
+      end
+
+      it "returns error" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error.messages).to match(entra_id: ["login_method_not_authorized"])
+      end
+    end
+
     context "when domain is not configured with an integration" do
       let(:entra_id_integration) { nil }
 

--- a/spec/services/auth/okta/accept_invite_service_spec.rb
+++ b/spec/services/auth/okta/accept_invite_service_spec.rb
@@ -108,5 +108,22 @@ RSpec.describe Auth::Okta::AcceptInviteService, :premium, cache: :memory do
         expect(result.error.messages.values.flatten).to include("okta_userinfo_error")
       end
     end
+
+    context "when the invited email already belongs to an existing user" do
+      before { create(:user, email: "foo@bar.com") }
+
+      it "does not authenticate the user" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error.messages.values.flatten).to include("existing_user_must_authenticate")
+      end
+
+      it "does not accept the invite" do
+        service.call
+
+        expect(invite.reload).to be_pending
+      end
+    end
   end
 end

--- a/spec/services/auth/okta/login_service_spec.rb
+++ b/spec/services/auth/okta/login_service_spec.rb
@@ -82,6 +82,27 @@ RSpec.describe Auth::Okta::LoginService, cache: :memory do
       end
     end
 
+    context "when okta is disabled on the integration's organization but enabled on another of the user's organizations" do
+      let(:user) { create(:user, email: "foo@bar.com") }
+
+      before do
+        create(:membership, user:, organization: okta_integration.organization)
+        okta_integration.organization.disable_okta_authentication!
+
+        other_organization = create(:organization)
+        other_organization.update!(premium_integrations: ["okta"])
+        other_organization.enable_okta_authentication!
+        create(:membership, user:, organization: other_organization)
+      end
+
+      it "does not authenticate the user" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error.messages).to match(okta: ["login_method_not_authorized"])
+      end
+    end
+
     context "when domain is not configured with an integration" do
       let(:okta_integration) { nil }
 

--- a/spec/services/auth/okta/login_service_spec.rb
+++ b/spec/services/auth/okta/login_service_spec.rb
@@ -104,21 +104,47 @@ RSpec.describe Auth::Okta::LoginService, cache: :memory do
       end
     end
 
-    context "when user already exists" do
-      let(:user) { create(:user, email: "foo@bar.com") }
+    context "when the user exists but does not belong to the organization" do
+      before { create(:user, email: "foo@bar.com") }
 
-      before { user }
+      it "does not authenticate the user" do
+        result = service.call
 
-      it "does not create a new user" do
-        expect { service.call }.not_to change(User, :count)
+        expect(result).not_to be_success
+        expect(result.error.messages.values.flatten).to include("user_does_not_belong_to_organization")
+        expect(result.token).to be_nil
+      end
+
+      it "does not create a membership" do
+        expect { service.call }.not_to change(Membership, :count)
       end
     end
 
-    context "when membership already exists" do
+    context "when the user exists with a revoked membership in the organization" do
       let(:user) { create(:user, email: "foo@bar.com") }
-      let(:membership) { create(:membership, user:, organization: okta_integration.organization) }
 
-      before { membership }
+      before { create(:membership, :revoked, user:, organization: okta_integration.organization) }
+
+      it "does not authenticate the user" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error.messages.values.flatten).to include("user_does_not_belong_to_organization")
+      end
+    end
+
+    context "when the user already belongs to the organization" do
+      let(:user) { create(:user, email: "foo@bar.com") }
+
+      before { create(:membership, user:, organization: okta_integration.organization) }
+
+      it "authenticates without creating a new user" do
+        result = nil
+
+        expect { result = service.call }.not_to change(User, :count)
+        expect(result).to be_success
+        expect(result.token).to be_present
+      end
 
       it "does not create a new membership" do
         expect { service.call }.not_to change(Membership, :count)

--- a/spec/services/auth/okta/login_service_spec.rb
+++ b/spec/services/auth/okta/login_service_spec.rb
@@ -104,6 +104,17 @@ RSpec.describe Auth::Okta::LoginService, cache: :memory do
       end
     end
 
+    context "when okta userinfo email only differs in casing" do
+      let(:okta_userinfo_response) { {"email" => "FOO@BAR.COM"} }
+
+      it "authenticates the user" do
+        result = service.call
+
+        expect(result).to be_success
+        expect(result.token).to be_present
+      end
+    end
+
     context "when the user exists but does not belong to the organization" do
       before { create(:user, email: "foo@bar.com") }
 


### PR DESCRIPTION
Part of INT-203

## Context

Okta sign-in resolves the integration from the email domain, then exchanges the authorization code and fetches user identity from the host configured on that integration. The host is admin-configurable, and sign-in just-in-time (JIT) provisioned a membership for whatever email the host returned. An admin of any Okta-enabled organization could therefore point the host at a server they control and receive a session for an unrelated, existing user — a cross-organization account takeover.

Entra ID is unaffected: it fetches identity from a fixed Microsoft Graph endpoint rather than an admin-supplied host.

## Changes

- **Cross-org guard (the fix).** Reject Okta sign-in when the resolved email belongs to an existing user who is not an active member of the integration's organization. Brand-new users are still provisioned on the fly, and existing members keep signing in — so enabling Okta on an organization with existing members is unaffected. Adding an existing user to another organization now goes through an invite.
- **Case-insensitive userinfo email compare.** Okta does not guarantee the casing of the email it returns, so a user whose Okta email differed only in case from the address they typed was wrongly rejected. Aligns with Entra ID.
- **Host format validation (defense-in-depth).** The configured host is interpolated into the authorize/token/userinfo URLs, so restrict it to a bare host segment to prevent URL injection / SSRF. Only an explicitly configured host is validated; the derived `<organization_name>.okta.com` default and custom Okta domains such as `login.acme.com` remain valid.

If merged before #6146, existing users invited to Okta enabled organizations won't be able to accept the invite and join the organization. I'd still merge it as this fixes a security issue.
