### PR TITLE
[ING-556] feat(graphql): expose paymentMethods on the payment connection

### DIFF
--- a/app/graphql/resolvers/payment_provider_customers/payment_methods_resolver.rb
+++ b/app/graphql/resolvers/payment_provider_customers/payment_methods_resolver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module PaymentProviderCustomers
+    class PaymentMethodsResolver < Resolvers::BaseResolver
+      REQUIRED_PERMISSION = "payment_methods:view"
+
+      description "Query payment methods of a payment connection"
+
+      argument :limit, Integer, required: false
+      argument :page, Integer, required: false
+      argument :with_deleted, Boolean, required: false
+
+      type Types::PaymentMethods::Object.collection_type, null: false
+
+      def resolve(page: nil, limit: nil, with_deleted: nil)
+        result = PaymentMethodsQuery.call(
+          organization: object.organization,
+          filters: {
+            payment_provider_customer_id: object.id,
+            with_deleted:
+          },
+          pagination: {
+            page:,
+            limit:
+          }
+        )
+
+        result.payment_methods.includes(:payment_provider)
+      end
+    end
+  end
+end

--- a/app/graphql/types/payment_provider_customers/provider.rb
+++ b/app/graphql/types/payment_provider_customers/provider.rb
@@ -8,6 +8,7 @@ module Types
       field :code, String, null: true
       field :id, ID, null: false
       field :is_default, Boolean, null: false
+      field :payment_methods, resolver: Resolvers::PaymentProviderCustomers::PaymentMethodsResolver
       field :provider_customer_id, ID, null: true
       field :provider_payment_methods, [Types::PaymentProviderCustomers::ProviderPaymentMethodsEnum], null: true
       field :sync_with_provider, Boolean, null: true

--- a/app/queries/payment_methods_query.rb
+++ b/app/queries/payment_methods_query.rb
@@ -2,11 +2,12 @@
 
 class PaymentMethodsQuery < BaseQuery
   Result = BaseResult[:payment_methods]
-  Filters = BaseFilters[:external_customer_id, :with_deleted]
+  Filters = BaseFilters[:external_customer_id, :payment_provider_customer_id, :with_deleted]
 
   def call
     payment_methods = base_scope
     payment_methods = with_external_customer(payment_methods) if filters.external_customer_id.present?
+    payment_methods = with_payment_provider_customer(payment_methods) if filters.payment_provider_customer_id.present?
 
     payment_methods = apply_consistent_ordering(payment_methods)
     payment_methods = paginate(payment_methods)
@@ -22,6 +23,10 @@ class PaymentMethodsQuery < BaseQuery
     scope.joins(:customer)
       .where(customers: {external_id: filters.external_customer_id})
       .where("customers.deleted_at IS NULL")
+  end
+
+  def with_payment_provider_customer(scope)
+    scope.where(payment_provider_customer_id: filters.payment_provider_customer_id)
   end
 
   def base_scope

--- a/schema.graphql
+++ b/schema.graphql
@@ -11053,6 +11053,11 @@ type ProviderCustomer {
   code: String
   id: ID!
   isDefault: Boolean!
+
+  """
+  Query payment methods of a payment connection
+  """
+  paymentMethods(limit: Int, page: Int, withDeleted: Boolean): PaymentMethodCollection!
   providerCustomerId: ID
   providerPaymentMethods: [ProviderPaymentMethodsEnum!]
   syncWithProvider: Boolean

--- a/schema.json
+++ b/schema.json
@@ -56944,6 +56944,59 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentMethods",
+              "description": "Query payment methods of a payment connection",
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "withDeleted",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaymentMethodCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "providerCustomerId",
               "description": null,
               "args": [],

--- a/spec/graphql/resolvers/payment_provider_customers/payment_methods_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_provider_customers/payment_methods_resolver_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::PaymentProviderCustomers::PaymentMethodsResolver do
+  let(:required_permissions) { %w[customers:view payment_methods:view] }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:, payment_provider: "stripe") }
+  let(:connection) { create(:stripe_customer, customer:, organization:) }
+  let(:other_connection) { create(:gocardless_customer, customer:, organization:) }
+
+  let(:payment_method) { create(:payment_method, customer:, organization:, payment_provider_customer: connection) }
+  let(:other_payment_method) do
+    create(:payment_method, customer:, organization:, payment_provider_customer: other_connection, is_default: false)
+  end
+
+  let(:query) do
+    <<~GQL
+      query($id: ID!, $withDeleted: Boolean) {
+        customer(id: $id) {
+          id
+          providerCustomer {
+            id
+            paymentMethods(limit: 5, withDeleted: $withDeleted) {
+              collection { id }
+              metadata { currentPage totalCount }
+            }
+          }
+        }
+      }
+    GQL
+  end
+
+  before do
+    connection
+    other_connection
+    payment_method
+    other_payment_method
+  end
+
+  it "returns only the payment methods of the selected connection" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permissions,
+      query:,
+      variables: {id: customer.id}
+    )
+
+    payment_methods = result["data"]["customer"]["providerCustomer"]["paymentMethods"]
+
+    expect(payment_methods["collection"].map { |pm| pm["id"] }).to contain_exactly(payment_method.id)
+    expect(payment_methods["metadata"]["totalCount"]).to eq(1)
+  end
+
+  context "when withDeleted is true" do
+    let(:deleted_payment_method) do
+      create(:payment_method, customer:, organization:, payment_provider_customer: connection, deleted_at: Time.current)
+    end
+
+    before { deleted_payment_method }
+
+    it "includes the discarded payment methods of the connection" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permissions,
+        query:,
+        variables: {id: customer.id, withDeleted: true}
+      )
+
+      payment_methods = result["data"]["customer"]["providerCustomer"]["paymentMethods"]
+
+      expect(payment_methods["collection"].map { |pm| pm["id"] })
+        .to contain_exactly(payment_method.id, deleted_payment_method.id)
+    end
+  end
+end

--- a/spec/queries/payment_methods_query_spec.rb
+++ b/spec/queries/payment_methods_query_spec.rb
@@ -106,4 +106,25 @@ RSpec.describe PaymentMethodsQuery do
       expect(returned_ids).to contain_exactly(payment_method_first.id, payment_method_second.id, payment_method_third.id)
     end
   end
+
+  context "when filtering by payment_provider_customer_id" do
+    let(:pm_customer) { create(:customer, organization:) }
+    let(:connection) { create(:stripe_customer, customer: pm_customer, organization:) }
+    let(:other_connection) { create(:gocardless_customer, customer: pm_customer, organization:) }
+    let(:filters) { {payment_provider_customer_id: connection.id} }
+    let(:matching) { create(:payment_method, organization:, customer: pm_customer, payment_provider_customer: connection) }
+    let(:other) do
+      create(:payment_method, organization:, customer: pm_customer, payment_provider_customer: other_connection, is_default: false)
+    end
+
+    before do
+      matching
+      other
+    end
+
+    it "returns only the payment methods of that connection" do
+      expect(result).to be_success
+      expect(returned_ids).to contain_exactly(matching.id)
+    end
+  end
 end


### PR DESCRIPTION
## Context

The customer-information view shows connections as a master-detail: selecting a payment connection should list the payment methods belonging to it. The data is there — `payment_methods.payment_provider_customer_id` is a real, indexed column and `PaymentMethod belongs_to :payment_provider_customer` — but it was not reachable over GraphQL. The `ProviderCustomer` type exposed no `paymentMethods`, and the root `paymentMethods` resolver only accepts an `externalCustomerId`. So the frontend could only render the customer-wide list, which surfaces payment methods from other connections, including deleted ones (e.g. old Stripe methods listed under a new Adyen connection as `Inactive`).

## Description

Expose a paginated `paymentMethods` field on the `ProviderCustomer` type so the list is read from the connection along with the rest of its data. This is modeled as a field on the connection rather than a filter argument on the customer-wide resolver: scoping happens before pagination, so each page contains only the selected connection's methods — correct by construction. Filtering the customer-wide list would paginate over the wrong set.

- `PaymentMethodsQuery` gains a `payment_provider_customer_id` filter.
- A new object-scoped resolver, `Resolvers::PaymentProviderCustomers::PaymentMethodsResolver`, resolves through that query from the connection, mirroring the root resolver's `limit` / `page` / `withDeleted` arguments and behaviour.
- The field is wired on `Types::PaymentProviderCustomers::Provider`, and the schema is regenerated.

It follows the existing nested-resolver precedent (`Resolvers::Customers::SubscriptionsResolver`) and reuses `PaymentMethodsQuery` so ordering, pagination and the `withDeleted` semantics stay identical to the existing `paymentMethods` resolver.

## Tests

- Query spec: the new `payment_provider_customer_id` filter returns only that connection's payment methods.
- GraphQL spec via `customer { providerCustomer { paymentMethods } }`: scoping to the selected connection, and `withDeleted: true` including discarded methods.

10 examples, 0 failures; Rubocop clean; existing payment-methods specs unaffected.

## Note

Frontend keeps the customer-wide list until this lands. Related backend gaps found while wiring this surface: ING-555 and the guard divergence fixed in #6088.
