### PR TITLE
Fix(members): make members searchable

### DIFF
--- a/app/graphql/resolvers/invites_resolver.rb
+++ b/app/graphql/resolvers/invites_resolver.rb
@@ -10,15 +10,24 @@ module Resolvers
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
 
+    argument :search_term, String, required: false
+
+    argument :role_ids, [ID], required: false
+
     type Types::Invites::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil)
-      current_organization
-        .invites
-        .pending
-        .order(created_at: :desc)
-        .page(page)
-        .per(limit)
+    def resolve(search_term: nil, page: nil, limit: nil, **filters)
+      result = InvitesQuery.call(
+        organization: current_organization,
+        search_term:,
+        pagination: {
+          page:,
+          limit:
+        },
+        filters:
+      )
+
+      result.invites
     end
   end
 end

--- a/app/graphql/resolvers/memberships_resolver.rb
+++ b/app/graphql/resolvers/memberships_resolver.rb
@@ -10,15 +10,24 @@ module Resolvers
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
 
+    argument :search_term, String, required: false
+
+    argument :role_ids, [ID], required: false
+
     type Types::MembershipType.collection_type(metadata_type: Types::Memberships::Metadata), null: false
 
-    def resolve(page: nil, limit: nil)
-      current_organization
-        .memberships
-        .includes(:user)
-        .active
-        .page(page)
-        .per(limit)
+    def resolve(search_term: nil, page: nil, limit: nil, **filters)
+      result = MembershipsQuery.call(
+        organization: current_organization,
+        search_term:,
+        pagination: {
+          page:,
+          limit:
+        },
+        filters:
+      )
+
+      result.memberships.includes(:user)
     end
   end
 end

--- a/app/queries/invites_query.rb
+++ b/app/queries/invites_query.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class InvitesQuery < BaseQuery
+  Result = BaseResult[:invites]
+  Filters = BaseFilters[:role_ids]
+
+  def call
+    invites = base_scope
+
+    invites = with_role_ids(invites) if filters.role_ids.present?
+
+    invites = paginate(invites)
+    invites = apply_consistent_ordering(invites)
+
+    result.invites = invites
+    result
+  end
+
+  private
+
+  def base_scope
+    scope = organization.invites.pending
+
+    return scope if search_term.blank?
+
+    scope.where("invites.email ILIKE ?", "%#{Invite.sanitize_sql_like(search_term)}%")
+  end
+
+  # Invites store role codes in an array column rather than referencing roles, so the
+  # filtered ids are resolved to codes first. Codes are unique within an organization
+  # scope, predefined ones being reserved, so the resolution is unambiguous.
+  def with_role_ids(scope)
+    codes = Role.with_organization(organization.id).where(id: filters.role_ids).pluck(:code)
+
+    return scope.none if codes.empty?
+
+    scope.where("invites.roles && ARRAY[?]::varchar[]", codes)
+  end
+end

--- a/app/queries/memberships_query.rb
+++ b/app/queries/memberships_query.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class MembershipsQuery < BaseQuery
+  Result = BaseResult[:memberships]
+  Filters = BaseFilters[:role_ids]
+
+  def call
+    memberships = base_scope
+
+    memberships = with_role_ids(memberships) if filters.role_ids.present?
+
+    memberships = paginate(memberships)
+    memberships = apply_consistent_ordering(memberships)
+
+    result.memberships = memberships
+    result
+  end
+
+  private
+
+  def base_scope
+    scope = organization.memberships.active
+
+    return scope if search_term.blank?
+
+    scope.where(user_id: matching_user_ids)
+  end
+
+  def matching_user_ids
+    User.where("users.email ILIKE ?", "%#{User.sanitize_sql_like(search_term)}%").select(:id)
+  end
+
+  def with_role_ids(scope)
+    scope.where(id: MembershipRole.joins(:role).where(organization:, role_id: filters.role_ids).select(:membership_id))
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -11938,7 +11938,7 @@ type Query {
   """
   Query memberships of an organization
   """
-  memberships(limit: Int, page: Int): MembershipCollection!
+  memberships(limit: Int, page: Int, roleIds: [ID!], searchTerm: String): MembershipCollection!
 
   """
   Query MRR of an organization

--- a/schema.graphql
+++ b/schema.graphql
@@ -11844,7 +11844,7 @@ type Query {
   """
   Query pending invites of an organization
   """
-  invites(limit: Int, page: Int): InviteCollection!
+  invites(limit: Int, page: Int, roleIds: [ID!], searchTerm: String): InviteCollection!
 
   """
   Query a single Invoice of an organization

--- a/schema.json
+++ b/schema.json
@@ -62915,6 +62915,38 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "roleIds",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -63552,6 +63552,38 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "roleIds",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {

--- a/spec/graphql/resolvers/invites_resolver_spec.rb
+++ b/spec/graphql/resolvers/invites_resolver_spec.rb
@@ -34,6 +34,77 @@ RSpec.describe Resolvers::InvitesResolver do
     expect(invites_response["metadata"]["totalCount"]).to eq(1)
   end
 
+  describe "filters" do
+    let(:admin_role) { create(:role, :admin) }
+    let(:finance_role) { create(:role, :finance) }
+
+    let(:query) do
+      <<~GQL
+        query($searchTerm: String, $roleIds: [ID!]) {
+          invites(limit: 5, searchTerm: $searchTerm, roleIds: $roleIds) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    let(:admin_invite) do
+      create(:invite, organization:, email: "jane.doe@example.com", roles: [admin_role.code])
+    end
+
+    let(:finance_invite) do
+      create(:invite, organization:, email: "john.doe@example.com", roles: [finance_role.code])
+    end
+
+    let(:result) do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables:
+      )
+    end
+
+    before do
+      admin_invite
+      finance_invite
+    end
+
+    context "with a search term" do
+      let(:variables) { {searchTerm: "jane"} }
+
+      it "returns the invites matching the email" do
+        invites_response = result["data"]["invites"]
+
+        expect(invites_response["collection"].map { it["id"] }).to eq([admin_invite.id])
+        expect(invites_response["metadata"]["totalCount"]).to eq(1)
+      end
+    end
+
+    context "with role ids" do
+      let(:variables) { {roleIds: [finance_role.id]} }
+
+      it "returns the invites holding one of the roles" do
+        invites_response = result["data"]["invites"]
+
+        expect(invites_response["collection"].map { it["id"] }).to eq([finance_invite.id])
+        expect(invites_response["metadata"]["totalCount"]).to eq(1)
+      end
+    end
+
+    context "with both a search term and role ids" do
+      let(:variables) { {searchTerm: "doe", roleIds: [admin_role.id]} }
+
+      it "returns the invites matching every filter" do
+        invites_response = result["data"]["invites"]
+
+        expect(invites_response["collection"].map { it["id"] }).to eq([admin_invite.id])
+        expect(invites_response["metadata"]["totalCount"]).to eq(1)
+      end
+    end
+  end
+
   context "without current organization" do
     it "returns an error" do
       result = execute_graphql(

--- a/spec/graphql/resolvers/memberships_resolver_spec.rb
+++ b/spec/graphql/resolvers/memberships_resolver_spec.rb
@@ -53,6 +53,81 @@ RSpec.describe Resolvers::MembershipsResolver do
     expect(result["data"]["memberships"]["metadata"]["adminCount"]).to eq(1)
   end
 
+  describe "filters" do
+    let(:admin_role) { create(:role, :admin) }
+    let(:finance_role) { create(:role, :finance) }
+
+    # The current user's own membership is pinned here: the default factory email is random
+    # and could otherwise match the search terms exercised below.
+    let(:membership) { create(:membership, roles: %i[manager], user: create(:user, email: "manager@lago.test")) }
+
+    let(:query) do
+      <<~GQL
+        query($searchTerm: String, $roleIds: [ID!]) {
+          memberships(limit: 5, searchTerm: $searchTerm, roleIds: $roleIds) {
+            collection { id }
+            metadata { totalCount }
+          }
+        }
+      GQL
+    end
+
+    let(:admin_membership) do
+      create(:membership, organization:, role: admin_role, user: create(:user, email: "jane.doe@example.com"))
+    end
+
+    let(:finance_membership) do
+      create(:membership, organization:, role: finance_role, user: create(:user, email: "john.doe@example.com"))
+    end
+
+    let(:result) do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables:
+      )
+    end
+
+    before do
+      admin_membership
+      finance_membership
+    end
+
+    context "with a search term" do
+      let(:variables) { {searchTerm: "jane"} }
+
+      it "returns the memberships matching the user email" do
+        memberships_response = result["data"]["memberships"]
+
+        expect(memberships_response["collection"].map { it["id"] }).to eq([admin_membership.id])
+        expect(memberships_response["metadata"]["totalCount"]).to eq(1)
+      end
+    end
+
+    context "with role ids" do
+      let(:variables) { {roleIds: [finance_role.id]} }
+
+      it "returns the memberships holding one of the roles" do
+        memberships_response = result["data"]["memberships"]
+
+        expect(memberships_response["collection"].map { it["id"] }).to eq([finance_membership.id])
+        expect(memberships_response["metadata"]["totalCount"]).to eq(1)
+      end
+    end
+
+    context "with both a search term and role ids" do
+      let(:variables) { {searchTerm: "doe", roleIds: [admin_role.id]} }
+
+      it "returns the memberships matching every filter" do
+        memberships_response = result["data"]["memberships"]
+
+        expect(memberships_response["collection"].map { it["id"] }).to eq([admin_membership.id])
+        expect(memberships_response["metadata"]["totalCount"]).to eq(1)
+      end
+    end
+  end
+
   describe "traversal attack attempt" do
     let!(:other_org) { create(:organization) }
 

--- a/spec/queries/invites_query_spec.rb
+++ b/spec/queries/invites_query_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InvitesQuery do
+  subject(:result) { described_class.call(organization:, search_term:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:pagination) { nil }
+  let(:search_term) { nil }
+  let(:filters) { {} }
+
+  context "when no filters applied" do
+    let!(:invites) do
+      [
+        create(:invite, organization:),
+        create(:invite, organization:, created_at: 2.days.ago),
+        create(:invite, organization:, created_at: 1.day.ago)
+      ]
+    end
+
+    before do
+      create(:invite)
+      create(:invite, organization:, status: :accepted)
+      create(:invite, organization:, status: :revoked)
+    end
+
+    it "returns pending invites of the organization ordered by created_at desc" do
+      expect(result).to be_success
+      expect(result.invites.pluck(:id)).to eq [invites.first.id, invites.third.id, invites.second.id]
+    end
+  end
+
+  context "when pagination options provided" do
+    let(:pagination) { {page: 2, limit: 1} }
+
+    let!(:invites) do
+      [
+        create(:invite, organization:),
+        create(:invite, organization:, created_at: 2.days.ago),
+        create(:invite, organization:, created_at: 1.day.ago)
+      ]
+    end
+
+    it "returns paginated invites" do
+      expect(result).to be_success
+      expect(result.invites).to contain_exactly invites.third
+      expect(result.invites.current_page).to eq 2
+      expect(result.invites.total_pages).to eq 3
+      expect(result.invites.total_count).to eq 3
+    end
+  end
+
+  context "when search term filter applied" do
+    let!(:matching_invite) { create(:invite, organization:, email: "jane.doe@example.com") }
+
+    before { create(:invite, organization:, email: "john@other.com") }
+
+    context "with term partially matching the email" do
+      let(:search_term) { "jane.d" }
+
+      it "returns the matching invites" do
+        expect(result).to be_success
+        expect(result.invites.pluck(:id)).to contain_exactly matching_invite.id
+      end
+    end
+
+    context "with term matching the email in a different case" do
+      let(:search_term) { "JANE.DOE@EXAMPLE.COM" }
+
+      it "returns the matching invites" do
+        expect(result).to be_success
+        expect(result.invites.pluck(:id)).to contain_exactly matching_invite.id
+      end
+    end
+
+    context "with a term containing SQL wildcards" do
+      let(:search_term) { "jane%example" }
+
+      it "treats the wildcards as literal characters" do
+        expect(result).to be_success
+        expect(result.invites).to be_empty
+      end
+    end
+
+    context "with term matching a non pending invite" do
+      let(:search_term) { "revoked" }
+
+      before { create(:invite, organization:, email: "revoked@example.com", status: :revoked) }
+
+      it "returns empty result" do
+        expect(result).to be_success
+        expect(result.invites).to be_empty
+      end
+    end
+
+    context "with term not matching any invite" do
+      let(:search_term) { "nonexistent" }
+
+      it "returns empty result" do
+        expect(result).to be_success
+        expect(result.invites).to be_empty
+      end
+    end
+  end
+
+  context "when role_ids filter applied" do
+    let(:admin_role) { create(:role, :admin) }
+    let(:finance_role) { create(:role, :finance) }
+    let(:custom_role) { create(:role, organization:) }
+
+    let!(:admin_invite) { create(:invite, organization:, roles: [admin_role.code]) }
+    let!(:custom_invite) { create(:invite, organization:, roles: [custom_role.code]) }
+
+    context "with a single role" do
+      let(:filters) { {role_ids: [admin_role.id]} }
+
+      it "returns invites holding that role" do
+        expect(result).to be_success
+        expect(result.invites.pluck(:id)).to contain_exactly admin_invite.id
+      end
+    end
+
+    context "with several roles" do
+      let(:filters) { {role_ids: [admin_role.id, custom_role.id]} }
+
+      it "returns invites holding any of the roles" do
+        expect(result).to be_success
+        expect(result.invites.pluck(:id)).to match_array [admin_invite.id, custom_invite.id]
+      end
+    end
+
+    context "when an invite holds several of the filtered roles" do
+      let(:filters) { {role_ids: [admin_role.id, finance_role.id]} }
+
+      let!(:multi_role_invite) { create(:invite, organization:, roles: [admin_role.code, finance_role.code]) }
+
+      it "returns the invite once" do
+        expect(result).to be_success
+        expect(result.invites.pluck(:id)).to match_array [admin_invite.id, multi_role_invite.id]
+      end
+    end
+
+    context "with a role of another organization" do
+      let(:other_role) { create(:role, organization: create(:organization)) }
+      let(:filters) { {role_ids: [other_role.id]} }
+
+      before { create(:invite, organization:, roles: [other_role.code]) }
+
+      it "returns no invite" do
+        expect(result).to be_success
+        expect(result.invites).to be_empty
+      end
+    end
+
+    context "with an unknown role id" do
+      let(:filters) { {role_ids: [SecureRandom.uuid]} }
+
+      it "returns no invite" do
+        expect(result).to be_success
+        expect(result.invites).to be_empty
+      end
+    end
+  end
+
+  context "when search term and role_ids filters are combined" do
+    let(:admin_role) { create(:role, :admin) }
+    let(:search_term) { "jane" }
+    let(:filters) { {role_ids: [admin_role.id]} }
+
+    let!(:matching_invite) { create(:invite, organization:, email: "jane.doe@example.com", roles: [admin_role.code]) }
+
+    before do
+      create(:invite, organization:, email: "john@example.com", roles: [admin_role.code])
+      create(:invite, organization:, email: "jane.roe@example.com", roles: [create(:role, organization:).code])
+    end
+
+    it "returns invites matching both filters" do
+      expect(result).to be_success
+      expect(result.invites.pluck(:id)).to contain_exactly matching_invite.id
+    end
+  end
+end

--- a/spec/queries/memberships_query_spec.rb
+++ b/spec/queries/memberships_query_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MembershipsQuery do
+  subject(:result) { described_class.call(organization:, search_term:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:pagination) { nil }
+  let(:search_term) { nil }
+  let(:filters) { {} }
+
+  context "when no filters applied" do
+    let!(:memberships) do
+      [
+        create(:membership, organization:),
+        create(:membership, organization:, created_at: 2.days.ago),
+        create(:membership, organization:, created_at: 1.day.ago)
+      ]
+    end
+
+    before do
+      create(:membership)
+      create(:membership, :revoked, organization:)
+    end
+
+    it "returns active memberships of the organization ordered by created_at desc" do
+      expect(result).to be_success
+      expect(result.memberships.pluck(:id)).to eq [memberships.first.id, memberships.third.id, memberships.second.id]
+    end
+  end
+
+  context "when pagination options provided" do
+    let(:pagination) { {page: 2, limit: 1} }
+
+    let!(:memberships) do
+      [
+        create(:membership, organization:),
+        create(:membership, organization:, created_at: 2.days.ago),
+        create(:membership, organization:, created_at: 1.day.ago)
+      ]
+    end
+
+    it "returns paginated memberships" do
+      expect(result).to be_success
+      expect(result.memberships).to contain_exactly memberships.third
+      expect(result.memberships.current_page).to eq 2
+      expect(result.memberships.total_pages).to eq 3
+      expect(result.memberships.total_count).to eq 3
+    end
+  end
+
+  context "when search term filter applied" do
+    let!(:matching_membership) do
+      create(:membership, organization:, user: create(:user, email: "jane.doe@example.com"))
+    end
+
+    before { create(:membership, organization:, user: create(:user, email: "john@other.com")) }
+
+    context "with term partially matching the user email" do
+      let(:search_term) { "jane.d" }
+
+      it "returns the matching memberships" do
+        expect(result).to be_success
+        expect(result.memberships.pluck(:id)).to contain_exactly matching_membership.id
+      end
+    end
+
+    context "with term matching the user email in a different case" do
+      let(:search_term) { "JANE.DOE@EXAMPLE.COM" }
+
+      it "returns the matching memberships" do
+        expect(result).to be_success
+        expect(result.memberships.pluck(:id)).to contain_exactly matching_membership.id
+      end
+    end
+
+    context "with a term containing SQL wildcards" do
+      let(:search_term) { "jane%example" }
+
+      it "treats the wildcards as literal characters" do
+        expect(result).to be_success
+        expect(result.memberships).to be_empty
+      end
+    end
+
+    context "with term not matching any membership" do
+      let(:search_term) { "nonexistent" }
+
+      it "returns empty result" do
+        expect(result).to be_success
+        expect(result.memberships).to be_empty
+      end
+    end
+
+    context "when the matching user belongs to another organization" do
+      let(:search_term) { "jane.doe@example.com" }
+
+      before { create(:membership, user: matching_membership.user) }
+
+      it "returns the membership of the current organization only" do
+        expect(result).to be_success
+        expect(result.memberships.pluck(:id)).to contain_exactly matching_membership.id
+      end
+    end
+  end
+
+  context "when role_ids filter applied" do
+    let(:admin_role) { create(:role, :admin) }
+    let(:finance_role) { create(:role, :finance) }
+    let(:custom_role) { create(:role, organization:) }
+
+    let!(:admin_membership) { create(:membership, organization:, role: admin_role) }
+    let!(:finance_membership) { create(:membership, organization:, role: finance_role) }
+    let!(:custom_membership) { create(:membership, organization:, role: custom_role) }
+
+    context "with a single role" do
+      let(:filters) { {role_ids: [admin_role.id]} }
+
+      it "returns memberships holding that role" do
+        expect(result).to be_success
+        expect(result.memberships.pluck(:id)).to contain_exactly admin_membership.id
+      end
+    end
+
+    context "with several roles" do
+      let(:filters) { {role_ids: [admin_role.id, custom_role.id]} }
+
+      it "returns memberships holding any of the roles" do
+        expect(result).to be_success
+        expect(result.memberships.pluck(:id)).to match_array [admin_membership.id, custom_membership.id]
+      end
+    end
+
+    context "when a membership holds several of the filtered roles" do
+      let(:filters) { {role_ids: [admin_role.id, finance_role.id]} }
+
+      before { create(:membership_role, membership: admin_membership, role: finance_role) }
+
+      it "returns the membership once" do
+        expect(result).to be_success
+        expect(result.memberships.pluck(:id)).to match_array [admin_membership.id, finance_membership.id]
+      end
+    end
+
+    context "when the role has been discarded" do
+      let(:filters) { {role_ids: [custom_role.id]} }
+
+      before { custom_role.discard! }
+
+      it "returns no membership" do
+        expect(result).to be_success
+        expect(result.memberships).to be_empty
+      end
+    end
+
+    context "with a role of another organization" do
+      let(:other_role) { create(:role, organization: create(:organization)) }
+      let(:filters) { {role_ids: [other_role.id]} }
+
+      before { create(:membership, organization: other_role.organization, role: other_role) }
+
+      it "returns no membership" do
+        expect(result).to be_success
+        expect(result.memberships).to be_empty
+      end
+    end
+  end
+
+  context "when search term and role_ids filters are combined" do
+    let(:admin_role) { create(:role, :admin) }
+    let(:search_term) { "jane" }
+    let(:filters) { {role_ids: [admin_role.id]} }
+
+    let!(:matching_membership) do
+      create(:membership, organization:, role: admin_role, user: create(:user, email: "jane.doe@example.com"))
+    end
+
+    before do
+      create(:membership, organization:, role: admin_role, user: create(:user, email: "john@example.com"))
+      create(:membership, organization:, user: create(:user, email: "jane.roe@example.com"))
+    end
+
+    it "returns memberships matching both filters" do
+      expect(result).to be_success
+      expect(result.memberships.pluck(:id)).to contain_exactly matching_membership.id
+    end
+  end
+end


### PR DESCRIPTION
## Context

Before we had all the list of members loaded at once for the billing entity. Now they are paginated, so the search should be on the BE

## Description

Added search and filter to membership_resolver
