### PR TITLE
feat(invoices): add search_terms column and its gin index

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -827,6 +827,7 @@ end
 #  index_invoices_on_organization_id_and_customer_id               (customer_id,organization_id)
 #  index_invoices_on_organization_id_lower_purchase_order_number   (organization_id, lower((purchase_order_number)::text))
 #  index_invoices_on_organization_id_number_gin_trgm_ops           (organization_id,number) USING gin
+#  index_invoices_on_organization_id_search_terms_gin_trgm_ops     (organization_id,search_terms) USING gin
 #  index_invoices_on_payment_due_date                              (payment_due_date) WHERE ((status = 1) AND (payment_status <> 1) AND (payment_overdue = false) AND (payment_dispute_lost_at IS NULL))
 #  index_invoices_on_payment_method_id                             (payment_method_id)
 #  index_invoices_on_ready_to_be_refreshed                         (ready_to_be_refreshed) WHERE (ready_to_be_refreshed = true)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -789,6 +789,7 @@ end
 #  purchase_order_number                   :string
 #  ready_for_payment_processing            :boolean          default(TRUE), not null
 #  ready_to_be_refreshed                   :boolean          default(FALSE), not null
+#  search_terms                            :text
 #  self_billed                             :boolean          default(FALSE), not null
 #  skip_automatic_payment                  :boolean
 #  skip_charges                            :boolean          default(FALSE), not null

--- a/db/migrate/20260814095015_add_search_terms_to_invoices.rb
+++ b/db/migrate/20260814095015_add_search_terms_to_invoices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSearchTermsToInvoices < ActiveRecord::Migration[8.0]
+  def change
+    add_column :invoices, :search_terms, :text
+  end
+end

--- a/db/migrate/20260814095016_add_gin_index_for_invoice_search_terms.rb
+++ b/db/migrate/20260814095016_add_gin_index_for_invoice_search_terms.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddGinIndexForInvoiceSearchTerms < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :invoices, "organization_id, search_terms gin_trgm_ops", using: :gin, algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -634,6 +634,7 @@ DROP INDEX IF EXISTS public.index_invoices_on_voided_invoice_id;
 DROP INDEX IF EXISTS public.index_invoices_on_ready_to_be_refreshed;
 DROP INDEX IF EXISTS public.index_invoices_on_payment_method_id;
 DROP INDEX IF EXISTS public.index_invoices_on_payment_due_date;
+DROP INDEX IF EXISTS public.index_invoices_on_organization_id_search_terms_gin_trgm_ops;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_number_gin_trgm_ops;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_lower_purchase_order_number;
 DROP INDEX IF EXISTS public.index_invoices_on_organization_id_and_customer_id;
@@ -9578,6 +9579,13 @@ CREATE INDEX index_invoices_on_organization_id_number_gin_trgm_ops ON public.inv
 
 
 --
+-- Name: index_invoices_on_organization_id_search_terms_gin_trgm_ops; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_invoices_on_organization_id_search_terms_gin_trgm_ops ON public.invoices USING gin (organization_id, search_terms public.gin_trgm_ops);
+
+
+--
 -- Name: index_invoices_on_payment_due_date; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -14213,6 +14221,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260817175013'),
 ('20260817175012'),
 ('20260817120927'),
+('20260814095016'),
 ('20260814095015'),
 ('20260810135202'),
 ('20260805201143'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3649,6 +3649,7 @@ CREATE TABLE public.invoices (
     purchase_order_number character varying,
     payment_term jsonb,
     payment_term_source character varying,
+    search_terms text,
     CONSTRAINT check_organizations_on_net_payment_term CHECK ((net_payment_term >= 0))
 );
 
@@ -14212,6 +14213,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260817175013'),
 ('20260817175012'),
 ('20260817120927'),
+('20260814095015'),
 ('20260810135202'),
 ('20260805201143'),
 ('20260805110509'),
@@ -15314,4 +15316,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220530091046'),
 ('20220526101535'),
 ('20220525122759');
-


### PR DESCRIPTION
1/4 of a stack improving invoice list search performance. Stacked on `main`.

Adds a nullable `search_terms` text column and its GIN trigram index, as two migrations. Nothing reads or writes the column yet, NULL means "not backfilled".

Schema-only, and shipped ahead of the code that fills it. The index is built while the column is still empty, which makes it near-instant.

Next in the stack: write path, backfill, read switch behind a flag.