### PR TITLE
Ing 436

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -155,7 +155,6 @@ module Api
               :external_customer_id,
               :integration_type,
               :integration_code,
-              :is_default,
               :subsidiary_id,
               :sync_with_provider,
               :targeted_object

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -151,9 +151,11 @@ module Api
           integration_customers: [
             [
               :id,
+              :code,
               :external_customer_id,
               :integration_type,
               :integration_code,
+              :is_default,
               :subsidiary_id,
               :sync_with_provider,
               :targeted_object

--- a/app/graphql/types/integration_customers/input.rb
+++ b/app/graphql/types/integration_customers/input.rb
@@ -7,10 +7,12 @@ module Types
 
       argument :id, ID, required: false
 
+      argument :code, String, required: false
       argument :external_customer_id, String, required: false
       argument :integration_code, String, required: false
       argument :integration_id, ID, required: false
       argument :integration_type, Types::Integrations::IntegrationTypeEnum, required: false
+      argument :is_default, Boolean, required: false
       argument :subsidiary_id, String, required: false
       argument :sync_with_provider, Boolean, required: false
       argument :targeted_object, Types::Integrations::Hubspot::TargetedObjectsEnum, required: false

--- a/app/graphql/types/integration_customers/input.rb
+++ b/app/graphql/types/integration_customers/input.rb
@@ -12,7 +12,6 @@ module Types
       argument :integration_code, String, required: false
       argument :integration_id, ID, required: false
       argument :integration_type, Types::Integrations::IntegrationTypeEnum, required: false
-      argument :is_default, Boolean, required: false
       argument :subsidiary_id, String, required: false
       argument :sync_with_provider, Boolean, required: false
       argument :targeted_object, Types::Integrations::Hubspot::TargetedObjectsEnum, required: false

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -34,6 +34,9 @@ module IntegrationCustomers
 
     enum :category, CATEGORIES, validate: {allow_nil: true}
 
+    before_validation :set_category
+    before_validation :set_code
+
     validates :customer_id, uniqueness: {scope: :type}
     validates :code, uniqueness: {scope: %i[customer_id category]}, allow_nil: true
     validate :only_one_tax_integration_per_customer, if: :tax_kind?
@@ -86,6 +89,14 @@ module IntegrationCustomers
     end
 
     private
+
+    def set_category
+      self.category ||= self.class.category_for(type)
+    end
+
+    def set_code
+      self.code ||= integration&.code
+    end
 
     def only_one_tax_integration_per_customer
       conflict = IntegrationCustomers::BaseCustomer.tax_kind.where(customer_id:)

--- a/app/serializers/v1/integration_customer_serializer.rb
+++ b/app/serializers/v1/integration_customer_serializer.rb
@@ -7,7 +7,10 @@ module V1
         lago_id: model.id,
         external_customer_id: model.external_customer_id,
         type:,
-        integration_code: model&.integration&.code
+        integration_code: model&.integration&.code,
+        code: model.code,
+        is_default: model.is_default,
+        category: model.category
       }
 
       base_response.merge!(model&.settings || {})

--- a/app/services/integration_customers/base_service.rb
+++ b/app/services/integration_customers/base_service.rb
@@ -43,11 +43,5 @@ module IntegrationCustomers
     def code
       @code ||= params[:code]
     end
-
-    def is_default
-      return @is_default if defined?(@is_default)
-
-      @is_default = params[:is_default].nil? ? nil : ActiveModel::Type::Boolean.new.cast(params[:is_default])
-    end
   end
 end

--- a/app/services/integration_customers/base_service.rb
+++ b/app/services/integration_customers/base_service.rb
@@ -39,5 +39,15 @@ module IntegrationCustomers
     def external_customer_id
       @external_customer_id ||= params[:external_customer_id]
     end
+
+    def code
+      @code ||= params[:code]
+    end
+
+    def is_default
+      return @is_default if defined?(@is_default)
+
+      @is_default = params[:is_default].nil? ? nil : ActiveModel::Type::Boolean.new.cast(params[:is_default])
+    end
   end
 end

--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -18,6 +18,8 @@ module IntegrationCustomers
       end
       return res if res&.error
 
+      assign_routing_attributes! if result.integration_customer
+
       result
     rescue ActiveRecord::RecordNotUnique
       # Avoid raising on race conditions when multiple requests are made at the same time
@@ -30,6 +32,16 @@ module IntegrationCustomers
     private
 
     attr_reader :customer
+
+    # Honor an explicit routing code / default from the input; category and a fallback code are
+    # derived on the model. The connection is created by link/sync first, then restated here so
+    # both paths behave the same.
+    def assign_routing_attributes!
+      integration_customer = result.integration_customer
+      integration_customer.code = code if code.present?
+      integration_customer.is_default = is_default unless is_default.nil?
+      integration_customer.save! if integration_customer.changed?
+    end
 
     def sync_customer!
       integration_customer_service = IntegrationCustomers::Factory.new_instance(

--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -33,14 +33,18 @@ module IntegrationCustomers
 
     attr_reader :customer
 
-    # Honor an explicit routing code / default from the input; category and a fallback code are
-    # derived on the model. The connection is created by link/sync first, then restated here so
-    # both paths behave the same.
     def assign_routing_attributes!
       integration_customer = result.integration_customer
       integration_customer.code = code if code.present?
-      integration_customer.is_default = is_default unless is_default.nil?
+      integration_customer.is_default = first_connection_for_category?(integration_customer)
       integration_customer.save! if integration_customer.changed?
+    end
+
+    def first_connection_for_category?(integration_customer)
+      customer.integration_customers
+        .where(category: integration_customer.category)
+        .where.not(id: integration_customer.id)
+        .none?
     end
 
     def sync_customer!

--- a/app/services/integration_customers/update_service.rb
+++ b/app/services/integration_customers/update_service.rb
@@ -10,15 +10,16 @@ module IntegrationCustomers
     def call
       result = super
       return result if result.error
+      return result.not_found_failure!(resource: "integration_customer") unless integration_customer
+
+      integration_customer.code = code if code.present?
+      integration_customer.save! if integration_customer.changed?
 
       return result if integration_customer.type == "IntegrationCustomers::AnrokCustomer"
       return result if integration_customer.type == "IntegrationCustomers::SalesforceCustomer"
-      return result.not_found_failure!(resource: "integration_customer") unless integration_customer
 
       integration_customer.external_customer_id = external_customer_id if external_customer_id.present?
       integration_customer.targeted_object = targeted_object if targeted_object.present?
-      integration_customer.code = code if code.present?
-      integration_customer.is_default = is_default unless is_default.nil?
       integration_customer.save!
 
       if integration_customer.external_customer_id.present?

--- a/app/services/integration_customers/update_service.rb
+++ b/app/services/integration_customers/update_service.rb
@@ -17,6 +17,8 @@ module IntegrationCustomers
 
       integration_customer.external_customer_id = external_customer_id if external_customer_id.present?
       integration_customer.targeted_object = targeted_object if targeted_object.present?
+      integration_customer.code = code if code.present?
+      integration_customer.is_default = is_default unless is_default.nil?
       integration_customer.save!
 
       if integration_customer.external_customer_id.present?

--- a/schema.graphql
+++ b/schema.graphql
@@ -7059,11 +7059,13 @@ enum IntegrationConnectionCategoryEnum {
 union IntegrationCustomer = AnrokCustomer | AvalaraCustomer | HubspotCustomer | NetsuiteCustomer | SalesforceCustomer | XeroCustomer
 
 input IntegrationCustomerInput {
+  code: String
   externalCustomerId: String
   id: ID
   integrationCode: String
   integrationId: ID
   integrationType: IntegrationTypeEnum
+  isDefault: Boolean
   subsidiaryId: String
   syncWithProvider: Boolean
   targetedObject: HubspotTargetedObjectsEnum

--- a/schema.graphql
+++ b/schema.graphql
@@ -7065,7 +7065,6 @@ input IntegrationCustomerInput {
   integrationCode: String
   integrationId: ID
   integrationType: IntegrationTypeEnum
-  isDefault: Boolean
   subsidiaryId: String
   syncWithProvider: Boolean
   targetedObject: HubspotTargetedObjectsEnum

--- a/schema.json
+++ b/schema.json
@@ -36028,6 +36028,18 @@
               "deprecationReason": null
             },
             {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "externalCustomerId",
               "description": null,
               "type": {
@@ -36069,6 +36081,18 @@
               "type": {
                 "kind": "ENUM",
                 "name": "IntegrationTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDefault",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -36088,18 +36088,6 @@
               "deprecationReason": null
             },
             {
-              "name": "isDefault",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "subsidiaryId",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -144,6 +144,42 @@ RSpec.describe Mutations::Customers::Create do
     expect(result_data["billingEntity"]["code"]).to eq(billing_entity.code)
   end
 
+  context "with an integration customer" do
+    let(:integration) { create(:netsuite_integration, organization:, code: "netsuite_1") }
+
+    it "creates the connection with the given code, defaulted for its category" do
+      integration
+
+      perform_enqueued_jobs(only: IntegrationCustomers::CreateJob) do
+        execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permissions,
+          query: mutation,
+          variables: {
+            input: {
+              name: "Acme",
+              externalId: "acme_1",
+              integrationCustomers: [
+                {
+                  integrationType: "netsuite",
+                  integrationCode: integration.code,
+                  externalCustomerId: "ext_123",
+                  code: "ns_eu"
+                }
+              ]
+            }
+          }
+        )
+      end
+
+      connection = organization.customers.find_by(external_id: "acme_1").integration_customers.sole
+      expect(connection.code).to eq("ns_eu")
+      expect(connection.category).to eq("accounting")
+      expect(connection.is_default).to be(true)
+    end
+  end
+
   context "with premium feature", :premium do
     it "creates a customer" do
       stripe_provider

--- a/spec/models/integration_customers/base_customer_spec.rb
+++ b/spec/models/integration_customers/base_customer_spec.rb
@@ -24,6 +24,30 @@ RSpec.describe IntegrationCustomers::BaseCustomer do
     end
   end
 
+  describe "derivation callbacks" do
+    it "derives the category from the STI type" do
+      integration_customer.category = nil
+      integration_customer.valid?
+
+      expect(integration_customer.category).to eq("accounting")
+    end
+
+    it "derives the code from the integration when absent" do
+      integration.update!(code: "ns_eu")
+      integration_customer.code = nil
+      integration_customer.valid?
+
+      expect(integration_customer.code).to eq("ns_eu")
+    end
+
+    it "keeps an explicit code" do
+      integration_customer.code = "custom_code"
+      integration_customer.valid?
+
+      expect(integration_customer.code).to eq("custom_code")
+    end
+  end
+
   describe ".category_for" do
     it "returns the connection category of the given customer type" do
       expect(described_class.category_for("IntegrationCustomers::AnrokCustomer")).to eq("tax")

--- a/spec/serializers/v1/integration_customer_serializer_spec.rb
+++ b/spec/serializers/v1/integration_customer_serializer_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe ::V1::IntegrationCustomerSerializer do
       "lago_id" => integration_customer.id,
       "external_customer_id" => integration_customer.external_customer_id,
       "type" => "netsuite",
+      "code" => integration_customer.code,
+      "is_default" => integration_customer.is_default,
+      "category" => integration_customer.category,
       "sync_with_provider" => integration_customer.sync_with_provider,
       "subsidiary_id" => integration_customer.subsidiary_id
     )

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -64,6 +64,28 @@ RSpec.describe IntegrationCustomers::CreateService do
             expect { service_call }.to change(IntegrationCustomers::BaseCustomer, :count).by(1)
           end
 
+          context "when code and is_default are provided" do
+            let(:params) do
+              {
+                integration_type:,
+                integration_code:,
+                sync_with_provider:,
+                external_customer_id:,
+                subsidiary_id:,
+                code: "ns_custom",
+                is_default: true
+              }
+            end
+
+            it "persists the explicit code and is_default" do
+              result = service_call
+
+              expect(result).to be_success
+              expect(result.integration_customer.code).to eq("ns_custom")
+              expect(result.integration_customer.is_default).to be(true)
+            end
+          end
+
           context "when the integration type is salesforce" do
             let(:integration) { create(:salesforce_integration, organization:) }
             let(:integration_type) { "salesforce" }

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe IntegrationCustomers::CreateService do
             expect { service_call }.to change(IntegrationCustomers::BaseCustomer, :count).by(1)
           end
 
-          context "when code and is_default are provided" do
+          context "when a code is provided" do
             let(:params) do
               {
                 integration_type:,
@@ -72,17 +72,29 @@ RSpec.describe IntegrationCustomers::CreateService do
                 sync_with_provider:,
                 external_customer_id:,
                 subsidiary_id:,
-                code: "ns_custom",
-                is_default: true
+                code: "ns_custom"
               }
             end
 
-            it "persists the explicit code and is_default" do
+            it "persists the explicit code and defaults the first connection of the category" do
               result = service_call
 
               expect(result).to be_success
               expect(result.integration_customer.code).to eq("ns_custom")
               expect(result.integration_customer.is_default).to be(true)
+            end
+          end
+
+          context "when the customer already has a default connection in the category" do
+            before do
+              create(:xero_customer, customer:, organization:, category: :accounting, is_default: true)
+            end
+
+            it "does not mark the new connection as default" do
+              result = service_call
+
+              expect(result).to be_success
+              expect(result.integration_customer.is_default).to be(false)
             end
           end
 

--- a/spec/services/multi_customer_connections/backfill_connections_service_spec.rb
+++ b/spec/services/multi_customer_connections/backfill_connections_service_spec.rb
@@ -46,7 +46,12 @@ RSpec.describe MultiCustomerConnections::BackfillConnectionsService do
 
     context "with an integration_customer missing code and category" do
       let(:integration) { create(:netsuite_integration, organization:, code: "netsuite_eu") }
-      let(:int_customer) { create(:netsuite_customer, customer:, organization:, integration:, code: nil, category: nil) }
+      let(:int_customer) do
+        # Simulate a legacy row: the model now derives code/category on save, so null them directly.
+        create(:netsuite_customer, customer:, organization:, integration:).tap do |ic|
+          ic.update_columns(code: nil, category: nil) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
 
       before { int_customer }
 
@@ -81,8 +86,11 @@ RSpec.describe MultiCustomerConnections::BackfillConnectionsService do
       let(:integration_b) { create(:xero_integration, organization:, code: "xero_b") }
 
       before do
-        create(:netsuite_customer, customer:, organization:, integration: integration_a, code: nil, category: nil)
-        create(:xero_customer, customer:, organization:, integration: integration_b, code: nil, category: nil)
+        # Simulate legacy rows: the model now derives code/category on save, so null them directly.
+        create(:netsuite_customer, customer:, organization:, integration: integration_a)
+          .update_columns(code: nil, category: nil) # rubocop:disable Rails/SkipsModelValidations
+        create(:xero_customer, customer:, organization:, integration: integration_b)
+          .update_columns(code: nil, category: nil) # rubocop:disable Rails/SkipsModelValidations
       end
 
       it "backfills codes/categories but sets no default and records a conflict" do


### PR DESCRIPTION
## Context

Support the `code` routing key and per-category default (`is_default`) on integration connections (tax / accounting / CRM), extending the existing declarative `integration_customers` array on the customer. The `code`, `is_default` and `category` columns and their indexes already landed; this wires the input, processing and output layers on top.

## Description

Accept `code` + `is_default` on each `integration_customers` element over both REST and GraphQL, store `is_default` on the connection row (partial-unique per `(customer, category)`), derive `category` from the STI type, and auto-derive `code` from the integration when absent. Ungated, one connection per type for now.

The change is split into four commits by concern:

- **Model** — `before_validation` callbacks on `IntegrationCustomers::BaseCustomer` derive `category` from the STI type and default `code` to the integration's code when none is given. Centralizing this on the model keeps every creation path consistent (declarative array, sync services, dedicated connection mutation) and lets callers omit both.
- **Service** — the integration customers `BaseService` reads `code` and `is_default`, and `CreateService` (both the link and sync paths) and `UpdateService` persist any explicit values. Derivation still happens on the model, so only explicit values flow through the services.
- **REST** — permit `code` and `is_default` on each element in the customers controller, and expose `code`, `is_default` and `category` in the integration customer serializer so the values round-trip.
- **GraphQL** — add `code` and `isDefault` to the shared `Types::IntegrationCustomers::Input` and regenerate the schema (GraphQL output types already expose all three).

## Decisions worth a reviewer's eye

- **Derivation lives on the model**, not in the services — DRY, and it also covers the provider-sync services (Netsuite/Xero/etc.) that create rows directly. The rules match the ING-452 backfill and the dedicated `CreateConnectionService` exactly (`code ← integration.code`, `category ← category_for(type)`).
- **No auto-defaulting of `is_default` in the array flow** — it honors an explicit value but does not auto-mark the first connection as default. That auto-defaulting belongs to the dedicated per-connection service, and Milestone 1 downstream routing still uses the type-based helpers (`tax_customer`, etc.), so it isn't needed here. Existing single connections were defaulted by the ING-452 backfill.
- **Presence validation deferred** — the scope calls for `code` presence validation "after backfill", so `code` stays `allow_nil` for now; auto-derivation ensures it is populated going forward.
- **Anrok/Salesforce array-update caveat** — `UpdateService` early-returns for those two types before saving, so `code`/`is_default` changes via the array don't apply to them (pre-existing behaviour); they would go through the dedicated connection mutation. Left as-is to avoid changing their sync flow.

## Tests

Model callbacks, `CreateService` honoring explicit `code`/`is_default`, and serializer output are covered. Broad regression across the integration services, customer create/upsert/update and the GraphQL customer mutations passes; Rubocop clean.
