### PR TITLE
feat(invoices): populate search_terms from the services

### DIFF
--- a/app/jobs/customers/refresh_invoices_search_terms_job.rb
+++ b/app/jobs/customers/refresh_invoices_search_terms_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Customers
+  class RefreshInvoicesSearchTermsJob < ApplicationJob
+    queue_as "default"
+    unique :until_executed
+
+    def perform(customer_id)
+      customer = Customer.with_discarded.find_by(id: customer_id)
+      return if customer.nil?
+
+      Customers::RefreshInvoicesSearchTermsService.call!(customer:)
+    end
+  end
+end

--- a/app/models/invoice/search_terms.rb
+++ b/app/models/invoice/search_terms.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Invoice
+  module SearchTerms
+    SQL = <<~SQL.squish.freeze
+      concat_ws(' ', invoices.number, invoices.purchase_order_number,
+        (SELECT concat_ws(' ', c.name, c.firstname, c.lastname, c.legal_name, c.external_id, c.email)
+         FROM customers c WHERE c.id = invoices.customer_id))
+    SQL
+  end
+end

--- a/app/services/customer_portal/customer_update_service.rb
+++ b/app/services/customer_portal/customer_update_service.rb
@@ -16,6 +16,7 @@ module CustomerPortal
 
       ActiveRecord::Base.transaction do
         original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
+        original_searchable_values = customer.slice(*Customer::SEARCHABLE_CUSTOMER_FIELDS)
 
         customer.customer_type = args[:customer_type] if args.key?(:customer_type)
         customer.name = args[:name] if args.key?(:name)
@@ -44,6 +45,10 @@ module CustomerPortal
 
         customer.save!
         customer.reload
+
+        if customer.slice(*Customer::SEARCHABLE_CUSTOMER_FIELDS) != original_searchable_values
+          Customers::RefreshInvoicesSearchTermsJob.perform_after_commit(customer.id)
+        end
 
         tax_codes = []
         # This service does not return a 'result' object but a string

--- a/app/services/customers/refresh_invoices_search_terms_service.rb
+++ b/app/services/customers/refresh_invoices_search_terms_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Customers
+  class RefreshInvoicesSearchTermsService < BaseService
+    Result = BaseResult[:customer]
+
+    BATCH_SIZE = 1_000
+
+    def initialize(customer:)
+      @customer = customer
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "customer") if customer.nil?
+
+      customer.invoices.in_batches(of: BATCH_SIZE) do |batch|
+        batch.update_all("search_terms = #{Invoice::SearchTerms::SQL}") # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      result.customer = customer
+      result
+    end
+
+    private
+
+    attr_reader :customer
+  end
+end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -32,6 +32,7 @@ module Customers
       old_payment_provider = customer.payment_provider
       old_provider_customer = customer.provider_customer
       original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
+      original_searchable_values = customer.slice(*Customer::SEARCHABLE_CUSTOMER_FIELDS)
       ActiveRecord::Base.transaction do
         billing_configuration = args[:billing_configuration]&.to_h || {}
         shipping_address = args[:shipping_address]&.to_h || {}
@@ -152,6 +153,10 @@ module Customers
         customer.save!
         customer.error_details.tax_error.delete_all if @address_changed
         customer.reload
+
+        if customer.slice(*Customer::SEARCHABLE_CUSTOMER_FIELDS) != original_searchable_values
+          Customers::RefreshInvoicesSearchTermsJob.perform_after_commit(customer.id)
+        end
 
         tax_attributes_changed = original_tax_values.any? { |key, value| args.key?(key) && args[key] != value }
 

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -20,6 +20,7 @@ module Customers
 
       customer = organization.customers.find_or_initialize_by(external_id: params[:external_id])
       new_customer = customer.new_record?
+      original_searchable_values = customer.slice(*Customer::SEARCHABLE_CUSTOMER_FIELDS)
       shipping_address = params[:shipping_address] ||= {}
 
       unless valid_metadata_count?(metadata: params[:metadata])
@@ -97,6 +98,10 @@ module Customers
 
         customer.save!
         customer.error_details.tax_error.delete_all if address_changed
+
+        if !new_customer && customer.slice(*Customer::SEARCHABLE_CUSTOMER_FIELDS) != original_searchable_values
+          Customers::RefreshInvoicesSearchTermsJob.perform_after_commit(customer.id)
+        end
 
         tax_attributes_changed = original_tax_values.any? { |key, value| params.key?(key) && params[key] != value }
 

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -43,6 +43,8 @@ module Invoices
         )
         result.invoice = invoice
 
+        Invoices::RefreshSearchTermsService.call!(invoice:)
+
         yield invoice if block_given?
       end
 

--- a/app/services/invoices/refresh_search_terms_service.rb
+++ b/app/services/invoices/refresh_search_terms_service.rb
@@ -1,30 +1,22 @@
 # frozen_string_literal: true
 
 module Invoices
-  class FinalizeService < BaseService
+  class RefreshSearchTermsService < BaseService
     Result = BaseResult[:invoice]
 
     def initialize(invoice:)
       @invoice = invoice
+
       super
     end
 
     def call
       return result.not_found_failure!(resource: "invoice") if invoice.nil?
 
-      if invoice.finalized?
-        result.invoice = invoice
-        return result
-      end
-
-      invoice.finalized!
-
-      Invoices::RefreshSearchTermsService.call!(invoice:)
+      Invoice.where(id: invoice.id).update_all("search_terms = #{Invoice::SearchTerms::SQL}") # rubocop:disable Rails/SkipsModelValidations
 
       result.invoice = invoice
       result
-    rescue ActiveRecord::RecordInvalid => e
-      result.record_validation_failure!(record: e.record)
     end
 
     private

--- a/app/services/invoices/regenerate_from_voided_service.rb
+++ b/app/services/invoices/regenerate_from_voided_service.rb
@@ -274,6 +274,8 @@ module Invoices
           voided_invoice_id: voided_invoice.id,
           purchase_order_number: resolved_purchase_order_number
         )
+
+        Invoices::RefreshSearchTermsService.call!(invoice:)
       end
     end
 

--- a/spec/jobs/customers/refresh_invoices_search_terms_job_spec.rb
+++ b/spec/jobs/customers/refresh_invoices_search_terms_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Customers::RefreshInvoicesSearchTermsJob do
+  subject(:perform_job) { described_class.perform_now(customer_id) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:customer_id) { customer.id }
+
+  let(:refresh_service) { instance_double(Customers::RefreshInvoicesSearchTermsService) }
+
+  before do
+    allow(Customers::RefreshInvoicesSearchTermsService).to receive(:call!).and_return(BaseResult.new)
+  end
+
+  it "refreshes the invoices of the customer" do
+    perform_job
+
+    expect(Customers::RefreshInvoicesSearchTermsService).to have_received(:call!).with(customer:)
+  end
+
+  context "when the customer is discarded" do
+    before { customer.discard! }
+
+    it "still refreshes, since discarded customers keep their terms" do
+      perform_job
+
+      expect(Customers::RefreshInvoicesSearchTermsService).to have_received(:call!)
+    end
+  end
+
+  context "when the customer no longer exists" do
+    let(:customer_id) { SecureRandom.uuid }
+
+    it "does nothing" do
+      perform_job
+
+      expect(Customers::RefreshInvoicesSearchTermsService).not_to have_received(:call!)
+    end
+  end
+end

--- a/spec/services/customer_portal/customer_update_service_spec.rb
+++ b/spec/services/customer_portal/customer_update_service_spec.rb
@@ -64,6 +64,19 @@ RSpec.describe CustomerPortal::CustomerUpdateService do
     expect(updated_customer.shipping_country).to eq(shipping_address[:country].upcase)
   end
 
+  it "refreshes the invoices search terms when a searchable field changes" do
+    expect { result }
+      .to have_enqueued_job_after_commit(Customers::RefreshInvoicesSearchTermsJob).with(customer.id)
+  end
+
+  context "when no searchable field changes" do
+    let(:update_args) { {city: "Updated customer city"} }
+
+    it "does not refresh the invoices search terms" do
+      expect { result }.not_to have_enqueued_job(Customers::RefreshInvoicesSearchTermsJob)
+    end
+  end
+
   context "when partialy updating" do
     let(:update_args) do
       {

--- a/spec/services/customers/refresh_invoices_search_terms_service_spec.rb
+++ b/spec/services/customers/refresh_invoices_search_terms_service_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Customers::RefreshInvoicesSearchTermsService do
+  subject(:refresh_service) { described_class.new(customer:) }
+
+  describe "#call" do
+    context "when the customer is nil" do
+      let(:customer) { nil }
+
+      it "returns a not found failure" do
+        expect(refresh_service.call.error).to be_a(BaseService::NotFoundFailure)
+      end
+    end
+
+    context "with a customer" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:, name: "Acme Inc") }
+      let(:other_customer) { create(:customer, organization:, name: "Globex") }
+
+      let!(:invoice) { create(:invoice, organization:, customer:, number: "INV-001") }
+      let!(:other_invoice) { create(:invoice, organization:, customer: other_customer, number: "INV-002") }
+
+      before do
+        Invoice.where(id: [invoice.id, other_invoice.id]).update_all(search_terms: nil) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      it "refreshes every invoice of the customer" do
+        refresh_service.call
+
+        expect(invoice.reload.search_terms).to include("INV-001", "Acme Inc")
+      end
+
+      it "leaves other customers' invoices untouched" do
+        refresh_service.call
+
+        expect(other_invoice.reload.search_terms).to be_nil
+      end
+
+      it "returns the customer" do
+        expect(refresh_service.call.customer).to eq(customer)
+      end
+
+      context "with more invoices than one batch" do
+        before do
+          stub_const("#{described_class}::BATCH_SIZE", 1)
+          create(:invoice, organization:, customer:, number: "INV-003")
+        end
+
+        it "refreshes them all" do
+          refresh_service.call
+
+          expect(customer.invoices.pluck(:search_terms)).to all(include("Acme Inc"))
+        end
+      end
+
+      context "when the customer name changed" do
+        before do
+          refresh_service.call
+          customer.update!(name: "Acme Renamed")
+        end
+
+        it "rewrites the invoices with the new name" do
+          described_class.new(customer:).call
+
+          expect(invoice.reload.search_terms).to include("Acme Renamed")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -67,6 +67,19 @@ RSpec.describe Customers::UpdateService do
       expect(Utils::ActivityLog).to have_produced("customer.updated").after_commit.with(customer)
     end
 
+    it "refreshes the invoices search terms when a searchable field changes" do
+      expect { customers_service.call }
+        .to have_enqueued_job_after_commit(Customers::RefreshInvoicesSearchTermsJob).with(customer.id)
+    end
+
+    context "when no searchable field changes" do
+      let(:update_args) { {id: customer.id, net_payment_term: 8} }
+
+      it "does not refresh the invoices search terms" do
+        expect { customers_service.call }.not_to have_enqueued_job(Customers::RefreshInvoicesSearchTermsJob)
+      end
+    end
+
     context "when Meilisearch is enabled" do
       before do
         customer

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -107,6 +107,10 @@ RSpec.describe Customers::UpsertFromApiService do
     expect(Utils::ActivityLog).to have_produced("customer.created").after_commit.with(result.customer)
   end
 
+  it "does not refresh the invoices search terms" do
+    expect { result }.not_to have_enqueued_job(Customers::RefreshInvoicesSearchTermsJob)
+  end
+
   context "when organization has multiple billing entities" do
     let(:billing_entity_2) { create(:billing_entity, organization:) }
 
@@ -626,6 +630,19 @@ RSpec.describe Customers::UpsertFromApiService do
       result = described_class.call(organization:, params: create_args)
 
       expect(Utils::ActivityLog).to have_produced("customer.updated").after_commit.with(result.customer)
+    end
+
+    it "refreshes the invoices search terms when a searchable field changes" do
+      expect { result }
+        .to have_enqueued_job_after_commit(Customers::RefreshInvoicesSearchTermsJob).with(customer.id)
+    end
+
+    context "when no searchable field changes" do
+      let(:create_args) { {external_id:, city: "Paris"} }
+
+      it "does not refresh the invoices search terms" do
+        expect { result }.not_to have_enqueued_job(Customers::RefreshInvoicesSearchTermsJob)
+      end
     end
 
     context "with provider customer" do

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe Invoices::CreateGeneratingService do
   let(:recurring) { false }
 
   describe "call" do
+    it "populates the search terms" do
+      result = create_service.call
+
+      expect(result.invoice.reload.search_terms).to include(result.invoice.number, customer.name)
+    end
+
     it "creates an invoice" do
       result = create_service.call
 

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe Invoices::FinalizeService do
         expect(result.invoice.finalized_at).to be_within(1.second).of(Time.current)
       end
 
+      it "refreshes the search terms with the generated number" do
+        result = service.call
+
+        expect(result.invoice.reload.search_terms).to include(result.invoice.number)
+      end
+
       context "when the subscription has a different purchase order number" do
         let(:invoice) do
           create(:invoice, :draft, customer:, organization:, purchase_order_number: "PO-ORIGINAL")

--- a/spec/services/invoices/refresh_search_terms_service_spec.rb
+++ b/spec/services/invoices/refresh_search_terms_service_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::RefreshSearchTermsService do
+  subject(:refresh_service) { described_class.new(invoice:) }
+
+  let(:organization) { create(:organization) }
+
+  let(:customer) do
+    create(
+      :customer,
+      organization:,
+      name: "Acme Inc",
+      firstname: "Rick",
+      lastname: "Sanchez",
+      legal_name: "Acme Incorporated",
+      external_id: "cust-1",
+      email: "rick@acme.test"
+    )
+  end
+
+  let(:invoice) do
+    create(:invoice, organization:, customer:, number: "INV-001", purchase_order_number: "PO-42")
+  end
+
+  def search_terms
+    invoice.reload.search_terms
+  end
+
+  describe "#call" do
+    it "concatenates the invoice and customer fields" do
+      refresh_service.call
+
+      expect(search_terms).to eq("INV-001 PO-42 Acme Inc Rick Sanchez Acme Incorporated cust-1 rick@acme.test")
+    end
+
+    it "returns the invoice" do
+      expect(refresh_service.call.invoice).to eq(invoice)
+    end
+
+    context "when a field is nil" do
+      let(:invoice) do
+        create(:invoice, organization:, customer:, number: "INV-001", purchase_order_number: nil)
+      end
+
+      it "skips it without leaving a double separator" do
+        refresh_service.call
+
+        expect(search_terms).to eq("INV-001 Acme Inc Rick Sanchez Acme Incorporated cust-1 rick@acme.test")
+      end
+    end
+
+    context "when a field is an empty string" do
+      before { customer.update!(firstname: "") }
+
+      it "keeps the separator, as concat_ws does" do
+        refresh_service.call
+
+        expect(search_terms).to eq("INV-001 PO-42 Acme Inc  Sanchez Acme Incorporated cust-1 rick@acme.test")
+      end
+    end
+
+    context "when the invoice has no customer" do
+      before { invoice.update_column(:customer_id, nil) } # rubocop:disable Rails/SkipsModelValidations
+
+      it "writes the invoice fields only" do
+        refresh_service.call
+
+        expect(search_terms).to eq("INV-001 PO-42")
+      end
+    end
+
+    context "when the customer is discarded" do
+      before { customer.discard! }
+
+      it "keeps the customer fields" do
+        refresh_service.call
+
+        expect(search_terms).to include("Acme Inc")
+      end
+    end
+
+    context "when called twice" do
+      before { refresh_service.call }
+
+      it "is idempotent" do
+        expect { described_class.new(invoice:).call }.not_to change { search_terms }
+      end
+    end
+
+    context "when the invoice is nil" do
+      let(:invoice) { nil }
+
+      it "returns a not found failure" do
+        expect(refresh_service.call.error).to be_a(BaseService::NotFoundFailure)
+      end
+    end
+  end
+end

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -76,6 +76,13 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
         it "inherits the value from the voided invoice" do
           expect(regenerate_result.invoice.purchase_order_number).to eq("PO-ORIGINAL")
         end
+
+        it "writes the inherited value to the search terms" do
+          invoice = regenerate_result.invoice.reload
+
+          expect(invoice.search_terms).to include("PO-ORIGINAL")
+          expect(invoice.search_terms).to include(invoice.number)
+        end
       end
 
       context "when a purchase_order_number is provided" do
@@ -86,6 +93,14 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
 
           expect(result.invoice.purchase_order_number).to eq("PO-EDITED")
         end
+
+        it "writes the provided value to the search terms" do
+          result = Invoices::RegenerateFromVoidedService.call!(
+            voided_invoice:, fees_params:, purchase_order_number: "  PO-EDITED  "
+          )
+
+          expect(result.invoice.reload.search_terms).to include("PO-EDITED")
+        end
       end
 
       context "when a blank purchase_order_number is provided" do
@@ -95,6 +110,36 @@ describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, 
           )
 
           expect(result.invoice.purchase_order_number).to be_nil
+        end
+
+        it "keeps the voided invoice value out of the search terms" do
+          result = Invoices::RegenerateFromVoidedService.call!(
+            voided_invoice:, fees_params:, purchase_order_number: "   "
+          )
+
+          expect(result.invoice.reload.search_terms).not_to include("PO-ORIGINAL")
+        end
+      end
+
+      context "when the regenerated invoice is closed instead of finalized" do
+        let(:fees_params) do
+          [
+            {
+              id: original_fee.id,
+              subscription_id: subscription.id,
+              units: 10,
+              unit_amount_cents: 0
+            }
+          ]
+        end
+
+        before { customer.update!(finalize_zero_amount_invoice: :skip) }
+
+        it "writes the purchase order number to the search terms" do
+          invoice = regenerate_result.invoice.reload
+
+          expect(invoice).to be_closed
+          expect(invoice.search_terms).to include("PO-ORIGINAL")
         end
       end
     end


### PR DESCRIPTION
2/4 of a stack improving invoice list search performance. Stacked on #6152.

Fills `search_terms` from the services that write the underlying data, rather than from model callbacks:

- `Invoices::RefreshSearchTermsService` at invoice creation, finalization and regeneration
- `Customers::RefreshInvoicesSearchTermsJob` from the three services that persist customer names or emails

From here every new or updated invoice is correct; existing rows stay NULL until the backfill.

Next in the stack: backfill, read switch behind a flag.