### PR TITLE
feat(invoices): backfill search_terms on existing invoices

### DIFF
--- a/app/jobs/database_migrations/backfill_invoices_search_terms_job.rb
+++ b/app/jobs/database_migrations/backfill_invoices_search_terms_job.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class BackfillInvoicesSearchTermsJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed, on_conflict: :log, lock_ttl: 30.minutes
+
+    # ApplicationJob sets retry: 0. The chain is self-terminating, so one failed batch
+    # would silently end the whole backfill.
+    sidekiq_options retry: 5
+
+    BATCH_SIZE = 5_000
+    MAX_PASSES = 2
+
+    def perform(cursor = nil, pass = 1)
+      ids = next_ids(cursor)
+      return finalize(pass) if ids.empty?
+
+      Invoice.where(id: ids)
+        .where("invoices.search_terms IS DISTINCT FROM (#{Invoice::SearchTerms::SQL})")
+        .update_all("search_terms = #{Invoice::SearchTerms::SQL}") # rubocop:disable Rails/SkipsModelValidations
+
+      return self.class.perform_later(ids.last, pass) if ids.size == BATCH_SIZE
+
+      finalize(pass)
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+
+    private
+
+    def next_ids(cursor)
+      scope = Invoice.order(:id).limit(BATCH_SIZE)
+      scope = scope.where("invoices.id > ?", cursor) if cursor
+
+      scope.ids
+    end
+
+    def finalize(pass)
+      unless Invoice.where(search_terms: nil).exists?
+        Rails.logger.info("Finished backfilling invoices.search_terms")
+        return
+      end
+
+      if pass < MAX_PASSES
+        self.class.perform_later(nil, pass + 1)
+      else
+        Rails.logger.error("invoices.search_terms backfill finished with rows still NULL")
+        Sentry.capture_message("invoices.search_terms backfill finished with rows still NULL", level: :error)
+      end
+    end
+  end
+end

--- a/lib/tasks/migrations/invoices_search_terms.rake
+++ b/lib/tasks/migrations/invoices_search_terms.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Usage:
+#   # Backfill everything:
+#   lago exec api bundle exec rails migrations:backfill_invoices_search_terms
+#
+#   # Resume a chain that died, from the last id it reported:
+#   lago exec api bundle exec rails migrations:backfill_invoices_search_terms START_AFTER=<invoice id>
+
+namespace :migrations do
+  desc "Enqueue the invoices.search_terms backfill on the low_priority queue"
+  task backfill_invoices_search_terms: :environment do
+    Rails.logger.level = Logger::Severity::ERROR
+
+    start_after = ENV["START_AFTER"].presence
+
+    if start_after && !Invoice.exists?(id: start_after)
+      abort "Unknown START_AFTER invoice id #{start_after}"
+    end
+
+    puts "##################################"
+    puts "Invoices search terms backfill"
+    puts "Starting #{start_after ? "after invoice #{start_after}" : "from the beginning"}"
+    puts "=" * 50
+
+    DatabaseMigrations::BackfillInvoicesSearchTermsJob.perform_later(start_after)
+
+    puts "Enqueued DatabaseMigrations::BackfillInvoicesSearchTermsJob"
+    puts "- Make sure a Sidekiq worker is draining the low_priority queue"
+    puts "- The job logs \"Finished backfilling invoices.search_terms\" when the walk is over,"
+    puts "  and reports to Sentry if any row is still missing its terms"
+  end
+end

--- a/spec/jobs/database_migrations/backfill_invoices_search_terms_job_spec.rb
+++ b/spec/jobs/database_migrations/backfill_invoices_search_terms_job_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabaseMigrations::BackfillInvoicesSearchTermsJob do
+  subject(:perform_job) { described_class.perform_now }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:, name: "Acme Inc") }
+
+  let!(:invoice) { create(:invoice, organization:, customer:, number: "INV-001") }
+
+  before do
+    Invoice.where(id: invoice.id).update_all(search_terms: nil) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  it "fills the invoices missing their search terms" do
+    perform_job
+
+    expect(invoice.reload.search_terms).to include("INV-001", "Acme Inc")
+  end
+
+  it "does not enqueue another batch when the walk is over" do
+    expect { perform_job }.not_to have_enqueued_job(described_class)
+  end
+
+  context "when the batch is full" do
+    before do
+      stub_const("#{described_class}::BATCH_SIZE", 1)
+      create(:invoice, organization:, customer:, number: "INV-002")
+    end
+
+    it "chains to the next batch from the last id" do
+      expect { perform_job }.to have_enqueued_job(described_class)
+    end
+  end
+
+  context "when rows are still missing after a full pass" do
+    it "runs a second pass from the start" do
+      expect { described_class.perform_now(Invoice.order(:id).last.id, 1) }
+        .to have_enqueued_job(described_class).with(nil, 2)
+    end
+  end
+
+  context "when rows are still missing after the last pass" do
+    it "reports instead of looping" do
+      allow(Rails.logger).to receive(:error)
+
+      described_class.perform_now(Invoice.order(:id).last.id, described_class::MAX_PASSES)
+
+      expect(Rails.logger).to have_received(:error).with(/still NULL/)
+    end
+  end
+
+  context "when every invoice already has search terms" do
+    before { Invoices::RefreshSearchTermsService.call(invoice:) }
+
+    it "leaves them untouched" do
+      expect { perform_job }.not_to change { invoice.reload.search_terms }
+    end
+  end
+end

--- a/spec/lib/tasks/migrations/invoices_search_terms_rake_spec.rb
+++ b/spec/lib/tasks/migrations/invoices_search_terms_rake_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "migrations:backfill_invoices_search_terms" do # rubocop:disable RSpec/DescribeClass
+  let(:task) { Rake::Task["migrations:backfill_invoices_search_terms"] }
+  let(:job) { DatabaseMigrations::BackfillInvoicesSearchTermsJob }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:, name: "Acme Inc") }
+
+  before do
+    Rake.application.rake_require("tasks/migrations/invoices_search_terms")
+    Rake::Task.define_task(:environment)
+    task.reenable
+  end
+
+  it "enqueues the backfill from the beginning" do
+    expect { task.invoke }.to output(/from the beginning/).to_stdout
+
+    expect(job).to have_been_enqueued.with(nil)
+  end
+
+  it "fills the invoices missing their search terms" do
+    invoice = create(:invoice, organization:, customer:, number: "INV-001")
+    Invoice.where(id: invoice.id).update_all(search_terms: nil) # rubocop:disable Rails/SkipsModelValidations
+
+    expect { perform_enqueued_jobs { task.invoke } }.to output(/Enqueued/).to_stdout
+
+    expect(invoice.reload.search_terms).to include("INV-001", "Acme Inc")
+  end
+
+  context "when START_AFTER is set" do
+    let(:invoice) { create(:invoice, organization:, customer:) }
+
+    around do |example|
+      ENV["START_AFTER"] = invoice.id
+      example.run
+    ensure
+      ENV["START_AFTER"] = nil
+    end
+
+    it "enqueues the backfill from that invoice" do
+      expect { task.invoke }.to output(/after invoice #{invoice.id}/).to_stdout
+
+      expect(job).to have_been_enqueued.with(invoice.id)
+    end
+  end
+
+  context "when START_AFTER is unknown" do
+    around do |example|
+      ENV["START_AFTER"] = SecureRandom.uuid
+      example.run
+    ensure
+      ENV["START_AFTER"] = nil
+    end
+
+    it "aborts without enqueuing the backfill" do
+      expect { task.invoke }.to raise_error(SystemExit).and output(/Unknown START_AFTER/).to_stderr
+
+      expect(job).not_to have_been_enqueued
+    end
+  end
+end


### PR DESCRIPTION
3/4 of a stack improving invoice list search performance. Stacked on #6154.

Fills `search_terms` on invoices that existed before the write path shipped. A migration enqueues one self-chaining job that walks `invoices.id`; a short batch means the walk is over, so the last job checks for any remaining NULL and, if it finds some, runs one more full pass before giving up and reporting.

Two deliberate deviations:

- `sidekiq_options retry: 5`, overriding `ApplicationJob`'s `retry: 0`. The chain is self-terminating, so a single unretried failure would silently end the whole backfill. Five puts a permanently broken job in the morgue after ~11 minutes rather than the ~4.5 hours a higher count would cost.
- `on_conflict: :log`, because a duplicate enqueue otherwise raises `JobNotUnique` and aborts the migration, which would fail the deploy.

Next in the stack: the read switch behind a feature flag.