### PR TITLE
fix(charge_filters): cascade by filter code

### DIFF
--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -45,13 +45,13 @@ end
 # Table name: item_metadata
 # Database name: primary
 #
-#  id              :uuid             not null, primary key
-#  owner_type      :string           not null
-#  value           :jsonb            not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organization_id :uuid             not null
-#  owner_id        :uuid             not null
+#  id                                             :uuid             not null, primary key
+#  owner_type(Polymorphic owner type)             :string           not null
+#  value(item_metadata key-value pairs)           :jsonb            not null
+#  created_at                                     :datetime         not null
+#  updated_at                                     :datetime         not null
+#  organization_id(Reference to the organization) :uuid             not null
+#  owner_id(Polymorphic owner id)                 :uuid             not null
 #
 # Indexes
 #

--- a/app/models/metadata/item_metadata.rb
+++ b/app/models/metadata/item_metadata.rb
@@ -45,13 +45,13 @@ end
 # Table name: item_metadata
 # Database name: primary
 #
-#  id                                             :uuid             not null, primary key
-#  owner_type(Polymorphic owner type)             :string           not null
-#  value(item_metadata key-value pairs)           :jsonb            not null
-#  created_at                                     :datetime         not null
-#  updated_at                                     :datetime         not null
-#  organization_id(Reference to the organization) :uuid             not null
-#  owner_id(Polymorphic owner id)                 :uuid             not null
+#  id              :uuid             not null, primary key
+#  owner_type      :string           not null
+#  value           :jsonb            not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  owner_id        :uuid             not null
 #
 # Indexes
 #

--- a/app/services/charge_filters/cascade_dispatcher.rb
+++ b/app/services/charge_filters/cascade_dispatcher.rb
@@ -33,9 +33,9 @@ module ChargeFilters
       before_by_code.each_value { enqueue_destroy(charge, it) }
     end
 
-    # The legacy path, for the filters the backfill left without a code. Two of them can share
-    # a predicate once a metric change shortened them onto it, and this keeps one — the same
-    # loss the cascade service takes on the same filters. Delete it once none are left.
+    # The legacy path, for the filters the backfill left without a code. Two of them can share a
+    # predicate once a metric change shortened them onto it, and this keeps one: nothing here can
+    # tell them apart. Delete it once no filter is left without a code.
     def diff_by_predicate(charge, before, after)
       before_by_values = before.index_by { it[:values] }
 

--- a/app/services/charge_filters/cascade_dispatcher.rb
+++ b/app/services/charge_filters/cascade_dispatcher.rb
@@ -9,38 +9,63 @@ module ChargeFilters
     #   { values: {"key" => [...]}, properties: {...} | nil, invoice_display_name: "...",
     #     code: "..." | nil }
     # `values` and `properties` must be string-keyed.
+    #
+    # A plan edit never gives a filter a code it did not have, so a filter is either coded on
+    # both sides of the diff or on neither, and the split cannot cut one in half.
     def call(charge:, before:, after:)
-      before_by_values = before.index_by { |f| f[:values] }
+      coded_before, plain_before = before.partition { it[:code].present? }
+      coded_after, plain_after = after.partition { it[:code].present? }
+
+      diff_by_code(charge, coded_before, coded_after)
+      diff_by_predicate(charge, plain_before, plain_after)
+    end
+
+    def diff_by_code(charge, before, after)
+      before_by_code = before.index_by { it[:code] }
 
       after.each do |new_filter|
-        existing = before_by_values.delete(new_filter[:values])
+        previous = before_by_code.delete(new_filter[:code])
+        next if previous && unchanged?(previous, new_filter)
 
-        next if existing &&
-          existing[:properties] == new_filter[:properties] &&
-          existing[:invoice_display_name] == new_filter[:invoice_display_name]
-
-        ChargeFilters::CascadeJob.perform_later(
-          charge.id,
-          existing ? "update" : "create",
-          new_filter[:values],
-          existing&.dig(:properties),
-          new_filter[:properties],
-          new_filter[:invoice_display_name],
-          new_filter[:code]
-        )
+        enqueue_change(charge, previous ? "update" : "create", new_filter, previous&.dig(:properties))
       end
 
-      before_by_values.each_value do |old|
-        ChargeFilters::CascadeJob.perform_later(
-          charge.id,
-          "destroy",
-          old[:values],
-          old[:properties],
-          nil,
-          old[:invoice_display_name],
-          old[:code]
-        )
+      before_by_code.each_value { enqueue_destroy(charge, it) }
+    end
+
+    # The legacy path, for the filters the backfill left without a code. Two of them can share
+    # a predicate once a metric change shortened them onto it, and this keeps one — the same
+    # loss the cascade service takes on the same filters. Delete it once none are left.
+    def diff_by_predicate(charge, before, after)
+      before_by_values = before.index_by { it[:values] }
+
+      after.each do |new_filter|
+        previous = before_by_values.delete(new_filter[:values])
+        next if previous && unchanged?(previous, new_filter)
+
+        enqueue_change(charge, previous ? "update" : "create", new_filter, previous&.dig(:properties))
       end
+
+      before_by_values.each_value { enqueue_destroy(charge, it) }
+    end
+
+    def unchanged?(previous, new_filter)
+      previous[:properties] == new_filter[:properties] &&
+        previous[:invoice_display_name] == new_filter[:invoice_display_name]
+    end
+
+    def enqueue_change(charge, action, filter, old_properties)
+      ChargeFilters::CascadeJob.perform_later(
+        charge.id, action, filter[:values], old_properties,
+        filter[:properties], filter[:invoice_display_name], filter[:code]
+      )
+    end
+
+    def enqueue_destroy(charge, filter)
+      ChargeFilters::CascadeJob.perform_later(
+        charge.id, "destroy", filter[:values], filter[:properties],
+        nil, filter[:invoice_display_name], filter[:code]
+      )
     end
   end
 end

--- a/app/services/charge_filters/cascade_service.rb
+++ b/app/services/charge_filters/cascade_service.rb
@@ -8,6 +8,10 @@ module ChargeFilters
     # price with nobody the wiser, so it fails instead of guessing at the predicate.
     class MissingParentCode < StandardError; end
 
+    # Two filters on one predicate leave nothing to choose between them, and adopting the plan's
+    # code into one picked by row order would settle which of the two bills from then on.
+    class DuplicatePredicate < StandardError; end
+
     def initialize(charge:, action:, filter_values:, old_properties: nil, new_properties: nil, invoice_display_name: nil, parent_code: nil)
       @charge = charge
       @action = action
@@ -97,13 +101,18 @@ module ChargeFilters
         .pluck(:id)
       return {} if candidate_ids.empty?
 
-      ChargeFilter
+      matched = ChargeFilter
         .where(id: candidate_ids)
         .includes(values: :billable_metric_filter)
         .select { |filter| filter.to_h == filter_values }
-        # Two filters can share a predicate once a metric change shortened them onto it, and this
-        # keeps one. Only a create gets here, and only for filters without a code.
-        .index_by(&:charge_id)
+        .group_by(&:charge_id)
+
+      duplicated = matched.select { |_charge_id, filters| filters.many? }
+      if duplicated.any?
+        raise DuplicatePredicate, "charges #{duplicated.keys.join(", ")} hold #{filter_values} more than once"
+      end
+
+      matched.transform_values(&:first)
     end
 
     def child_filters_holding_parent_code(batch_child_ids)

--- a/app/services/charge_filters/cascade_service.rb
+++ b/app/services/charge_filters/cascade_service.rb
@@ -4,6 +4,10 @@ module ChargeFilters
   class CascadeService < BaseService
     Result = BaseResult
 
+    # An update with nothing to identify the filter by would leave the override on the old
+    # price with nobody the wiser, so it fails instead of guessing at the predicate.
+    class MissingParentCode < StandardError; end
+
     def initialize(charge:, action:, filter_values:, old_properties: nil, new_properties: nil, invoice_display_name: nil, parent_code: nil)
       @charge = charge
       @action = action
@@ -19,17 +23,19 @@ module ChargeFilters
     BATCH_SIZE = 1_000
 
     def call
+      raise MissingParentCode, "charge #{charge.id} filter #{filter_values} has no code" if action == "update" && parent_code.blank?
+
       # NOTE: The cascade runs one job per changed filter
       # Each job has a single target (filter_values), so the matching child filter
       # is resolved for a whole batch of children in one query rather than loading
       # every child's full filter set, which keeps each job lightweight.
       child_ids.each_slice(BATCH_SIZE) do |ids|
-        matches = matching_child_filters(ids)
+        child_filters = child_filters_by_charge(ids)
 
         Charge.where(id: ids).includes(:billable_metric).find_each do |child_charge|
           Charge.no_touching do
             Plan.no_touching do
-              child_filter = matches[child_charge.id]
+              child_filter = child_filters[child_charge.id]
 
               case action
               when "update" then update_child_filter(child_charge, child_filter)
@@ -55,11 +61,30 @@ module ChargeFilters
         .distinct.pluck(:id)
     end
 
+    # The code says which filter this is. The predicate is only a guess at it, and the
+    # legacy path until every filter has a code — so it is asked about the children the
+    # code could not reach, and about none once they all have one.
+    def child_filters_by_charge(batch_child_ids)
+      by_code = child_filters_holding_parent_code(batch_child_ids)
+
+      # Only a create still guesses, and it has to: anything already sitting on the predicate
+      # means there is nothing to add, and missing it would leave a duplicate. An update or a
+      # destroy acts on one filter, where acting on the wrong one is worse than not acting.
+      return by_code unless action == "create"
+
+      remaining = batch_child_ids.reject { by_code.key?(it) }
+      by_predicate = matching_child_filters(remaining)
+
+      by_code.merge(by_predicate)
+    end
+
     # Resolve the child filter matching filter_values for an entire batch of
     # children in two bounded queries: narrow candidates by a shared value via the
     # database, then confirm the exact match in Ruby. This avoids both loading each
     # child's full filter set (memory) and querying once per child (N+1).
     def matching_child_filters(batch_child_ids)
+      return {} if batch_child_ids.empty?
+
       _key, values = filter_values.first
       return {} if values.blank?
 
@@ -76,6 +101,16 @@ module ChargeFilters
         .where(id: candidate_ids)
         .includes(values: :billable_metric_filter)
         .select { |filter| filter.to_h == filter_values }
+        # Two filters can share a predicate once a metric change shortened them onto it, and this
+        # keeps one. Only a create gets here, and only for filters without a code.
+        .index_by(&:charge_id)
+    end
+
+    def child_filters_holding_parent_code(batch_child_ids)
+      return {} if parent_code.blank?
+
+      ChargeFilter
+        .where(charge_id: batch_child_ids, code: parent_code)
         .index_by(&:charge_id)
     end
 
@@ -97,7 +132,10 @@ module ChargeFilters
     end
 
     def create_child_filter(child_charge, existing_filter)
-      return if existing_filter
+      if existing_filter
+        adopt_parent_code(existing_filter)
+        return
+      end
 
       # NOTE: Resolve against the current state of the billable metric filters
       # to avoid any changes that may have occurred since the job was enqueued
@@ -123,6 +161,18 @@ module ChargeFilters
           )
         end
       end
+    end
+
+    # A filter already sitting on the predicate when the plan gains one is that filter's copy,
+    # and this is the only moment we can say so. Left unlinked it is unreachable for good: an
+    # update would raise and a destroy would pass it by, both for want of the code.
+    #
+    # A code of its own means the opposite — it was created on the override and is not a copy
+    # of anything, so it keeps it.
+    def adopt_parent_code(existing_filter)
+      return if parent_code.blank? || existing_filter.code.present?
+
+      existing_filter.update!(code: parent_code)
     end
 
     def resolved_filter_values

--- a/app/services/charge_filters/cascade_service.rb
+++ b/app/services/charge_filters/cascade_service.rb
@@ -27,6 +27,10 @@ module ChargeFilters
     BATCH_SIZE = 1_000
 
     def call
+      # Before the check below, so that a charge with nothing to cascade to stays quiet rather
+      # than reporting a filter whose missing code is costing nothing
+      return result if child_ids.empty?
+
       raise MissingParentCode, "charge #{charge.id} filter #{filter_values} has no code" if action == "update" && parent_code.blank?
 
       # NOTE: The cascade runs one job per changed filter

--- a/app/services/charge_filters/create_service.rb
+++ b/app/services/charge_filters/create_service.rb
@@ -34,6 +34,7 @@ module ChargeFilters
       trigger_filter_cascade(
         action: "create",
         filter_values: result.charge_filter.to_h,
+        code: result.charge_filter.code,
         new_properties: result.charge_filter.properties,
         invoice_display_name: result.charge_filter.invoice_display_name
       )

--- a/app/services/charge_filters/destroy_service.rb
+++ b/app/services/charge_filters/destroy_service.rb
@@ -27,7 +27,7 @@ module ChargeFilters
         result.charge_filter = charge_filter
       end
 
-      trigger_filter_cascade(action: "destroy", filter_values:)
+      trigger_filter_cascade(action: "destroy", filter_values:, code: charge_filter.code)
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/charge_filters/filter_cascadable.rb
+++ b/app/services/charge_filters/filter_cascadable.rb
@@ -6,7 +6,7 @@ module ChargeFilters
 
     private
 
-    def trigger_filter_cascade(action:, filter_values:, old_properties: nil, new_properties: nil, invoice_display_name: nil)
+    def trigger_filter_cascade(action:, filter_values:, code:, old_properties: nil, new_properties: nil, invoice_display_name: nil)
       return unless cascade_updates
       return unless charge.children.exists?
 
@@ -16,7 +16,8 @@ module ChargeFilters
         filter_values.deep_stringify_keys,
         old_properties&.deep_stringify_keys,
         new_properties&.deep_stringify_keys,
-        invoice_display_name
+        invoice_display_name,
+        code
       )
     end
   end

--- a/app/services/charge_filters/update_service.rb
+++ b/app/services/charge_filters/update_service.rb
@@ -30,6 +30,7 @@ module ChargeFilters
       trigger_filter_cascade(
         action: "update",
         filter_values: charge_filter.to_h,
+        code: charge_filter.code,
         old_properties:,
         new_properties: charge_filter.properties,
         invoice_display_name: charge_filter.invoice_display_name

--- a/lib/tasks/filters.rake
+++ b/lib/tasks/filters.rake
@@ -24,18 +24,22 @@ namespace :filters do
     end
   end
 
-  # The filters that make the cascade fail: a plan's own filter with no code, on a charge that has
-  # overrides to cascade to. Editing one enqueues an update the service cannot address, since the
-  # code is what identifies the copy on the override, so the job dies on MissingParentCode.
+  # A plan's own filters with no code, on charges that have overrides. Editing one enqueues an
+  # update the cascade cannot address — the code is what identifies the copy on the override — so
+  # the job dies on MissingParentCode.
   #
-  # Filters on the overrides themselves are not listed. Those cost nothing — the cascade simply
-  # does not reach them — whereas these stop a plan edit from propagating at all.
+  # This lists more than can fail today: `ChargeFilters::CascadeService#child_ids` only reaches an
+  # override whose plan carries an active or pending subscription, and the EXISTS below does not
+  # check that. Deliberately so — an override without one starts mattering the day it gains one.
+  #
+  # Filters on the overrides themselves are not listed: nothing dispatches a job for them, so a
+  # missing code there costs nothing.
   desc "Report the plan filters with no code to cascade with"
   task report_parent_codes: :environment do
     scope = ChargeFilter.unscope(:order)
       .where(code: nil, deleted_at: nil)
       .joins(charge: :plan)
-      .where(charges: {parent_id: nil, deleted_at: nil}, plans: {deleted_at: nil})
+      .where(charges: {parent_id: nil, deleted_at: nil}, plans: {parent_id: nil, deleted_at: nil})
       .where("EXISTS (SELECT 1 FROM charges children WHERE children.parent_id = charge_filters.charge_id AND children.deleted_at IS NULL)")
 
     puts "##################################"
@@ -45,7 +49,7 @@ namespace :filters do
     by_organization = scope.group(:organization_id).count
     if by_organization.any?
       puts "By organization:"
-      Organization.where(id: by_organization.keys).order(:name).find_each do |organization|
+      Organization.where(id: by_organization.keys).order(:name).each do |organization|
         puts "- #{organization.name}: #{by_organization[organization.id]} filters"
       end
 

--- a/lib/tasks/filters.rake
+++ b/lib/tasks/filters.rake
@@ -24,6 +24,39 @@ namespace :filters do
     end
   end
 
+  # The filters that make the cascade fail: a plan's own filter with no code, on a charge that has
+  # overrides to cascade to. Editing one enqueues an update the service cannot address, since the
+  # code is what identifies the copy on the override, so the job dies on MissingParentCode.
+  #
+  # Filters on the overrides themselves are not listed. Those cost nothing — the cascade simply
+  # does not reach them — whereas these stop a plan edit from propagating at all.
+  desc "Report the plan filters with no code to cascade with"
+  task report_parent_codes: :environment do
+    scope = ChargeFilter.unscope(:order)
+      .where(code: nil, deleted_at: nil)
+      .joins(charge: :plan)
+      .where(charges: {parent_id: nil, deleted_at: nil}, plans: {deleted_at: nil})
+      .where("EXISTS (SELECT 1 FROM charges children WHERE children.parent_id = charge_filters.charge_id AND children.deleted_at IS NULL)")
+
+    puts "##################################"
+    puts "Plan filters with no code, on charges that have overrides: #{scope.count}"
+    puts ""
+
+    by_organization = scope.group(:organization_id).count
+    if by_organization.any?
+      puts "By organization:"
+      Organization.where(id: by_organization.keys).order(:name).find_each do |organization|
+        puts "- #{organization.name}: #{by_organization[organization.id]} filters"
+      end
+
+      puts ""
+      puts "The charges to look at first:"
+      scope.group(:charge_id).order(Arel.sql("count(*) DESC")).limit(25).count.each do |charge_id, filters|
+        puts "- charge #{charge_id}: #{filters} filters"
+      end
+    end
+  end
+
   # Charge filters the backfill deliberately left alone. Two situations produce them, and neither
   # is a failure:
   #
@@ -38,7 +71,10 @@ namespace :filters do
   # Cleaning up the first kind and running upgrade:perform_required_jobs again converges.
   desc "Report the charge filters left without a code"
   task report_codes: :environment do
-    scope = ChargeFilter.where(code: nil, deleted_at: nil)
+    # `unscope(:order)`, because the model orders by `updated_at` by default and `order` adds to
+    # that rather than replacing it. Grouping by `charge_id` then leaves `updated_at` outside the
+    # GROUP BY, which Postgres rejects.
+    scope = ChargeFilter.unscope(:order).where(code: nil, deleted_at: nil)
 
     puts "##################################"
     puts "Charge filters without a code: #{scope.count}"

--- a/spec/scenarios/plans/cascade_filter_updates_spec.rb
+++ b/spec/scenarios/plans/cascade_filter_updates_spec.rb
@@ -138,21 +138,29 @@ RSpec.describe "Cascade filter updates", :premium do
 
     expect(child_charge.filters.count).to eq(2)
 
-    delete_plan_charge_filter(parent_plan, parent_charge.code, filter_eu.id)
-
-    # Destroy via API doesn't pass cascade_updates through the helper, so cascade manually to
-    # test the destroy path. The code is what the dispatcher would carry, and what the child's
-    # copy holds since the override deep-copied it.
-    ChargeFilters::CascadeService.call!(
-      charge: parent_charge,
-      action: "destroy",
-      filter_values: {"region" => ["eu"]},
-      parent_code: filter_eu.code
-    )
+    delete_plan_charge_filter(parent_plan, parent_charge.code, filter_eu.id, {cascade_updates: true})
 
     child_charge.reload
     expect(child_charge.filters.count).to eq(1)
     expect(child_charge.filters.first.invoice_display_name).to eq("US region")
+  end
+
+  # The copy is found by the code the override inherited. Without one there is nothing to identify
+  # it by, and whatever sits on the predicate may be a filter the customer negotiated, so it stays.
+  it "leaves a child copy with no code alone when the plan's filter is deleted" do
+    ctx = setup_plan_with_subscription
+    parent_plan = ctx[:parent_plan]
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+    filter_eu = parent_charge.filters.find_by(invoice_display_name: "EU region")
+
+    child_copy = child_charge.filters.find_by(invoice_display_name: "EU region")
+    child_copy.update!(code: nil)
+
+    delete_plan_charge_filter(parent_plan, parent_charge.code, filter_eu.id, {cascade_updates: true})
+
+    expect(child_copy.reload).not_to be_discarded
+    expect(child_charge.filters.reload.count).to eq(2)
   end
 
   it "does not overwrite a customer-customized filter" do

--- a/spec/scenarios/plans/cascade_filter_updates_spec.rb
+++ b/spec/scenarios/plans/cascade_filter_updates_spec.rb
@@ -72,6 +72,195 @@ RSpec.describe "Cascade filter updates", :premium do
     {parent_plan:, parent_charge:, child_charge:}
   end
 
+  # Broadening a filter's values does not edit it: CreateOrUpdateBatchService pairs the payload with
+  # the existing filters by their values, finds no match, and creates a new one while discarding the
+  # old. So the code changes too, and the diff sees the old one removed and a new one added — which
+  # is why a filter keeping its code always keeps its values, and `unchanged?` need not compare them.
+  it "replaces rather than edits a filter when a value is added to it" do
+    ctx = setup_plan_with_subscription
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    filter_us = parent_charge.filters.find_by(invoice_display_name: "US region")
+    old_id = filter_us.id
+    old_code = filter_us.code
+
+    update_plan(ctx[:parent_plan], {
+      name: "Enterprise", code: "enterprise", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false, cascade_updates: true,
+      charges: [
+        {
+          id: parent_charge.id,
+          billable_metric_id: billable_metric.id,
+          charge_model: "standard",
+          code: "storage_charge",
+          pay_in_advance: false,
+          properties: {amount: "0"},
+          filters: [
+            {invoice_display_name: "US region", properties: {amount: "10"}, values: {region: %w[us eu]}}
+          ]
+        }
+      ]
+    })
+
+    replacement = parent_charge.filters.reload.sole
+    expect(replacement.id).not_to eq(old_id)
+    expect(replacement.code).not_to eq(old_code)
+    expect(replacement.to_h).to eq({"region" => %w[us eu]})
+
+    # One filter on the override, not two: the destroy reached the old copy by its code and the
+    # create made the new one
+    child_filter = child_charge.filters.reload.sole
+    expect(child_filter.code).to eq(replacement.code)
+    expect(child_filter.to_h).to eq({"region" => %w[us eu]})
+  end
+
+  # The negotiated price is lost, because widening replaces the filter rather than editing it and
+  # the replacement is created with the plan's price. `filter_customized?` only guards the update
+  # path, and a widening never takes it.
+  #
+  # Pending rather than absent: this is a billing bug — the override starts charging the plan's
+  # price with nothing in the logs — and it predates the cascade being keyed by code, so it is not
+  # this change's to fix. The fix is letting the plan payload name a filter by its code, which makes
+  # widening an update. On the day that lands, this passes and RSpec says so.
+  it "keeps a price negotiated on the override when the plan widens a filter" do
+    pending "the plan payload cannot name a filter, so widening replaces it instead of editing it"
+
+    ctx = setup_plan_with_subscription
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+    subscription = organization.subscriptions.find_by(external_id: "sub_enterprise")
+
+    # The customer negotiates the US segment down from 10 to 2
+    child_us = child_charge.filters.find_by(invoice_display_name: "US region")
+    update_subscription_charge_filter(subscription, "storage_charge", child_us.id, {properties: {amount: "2"}})
+    expect(child_us.reload.properties).to eq({"amount" => "2"})
+
+    # The plan widens its US filter to cover EU as well, leaving its own price at 10
+    update_plan(ctx[:parent_plan], {
+      name: "Enterprise", code: "enterprise", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false, cascade_updates: true,
+      charges: [
+        {
+          id: parent_charge.id,
+          billable_metric_id: billable_metric.id,
+          charge_model: "standard",
+          code: "storage_charge",
+          pay_in_advance: false,
+          properties: {amount: "0"},
+          filters: [
+            {invoice_display_name: "US region", properties: {amount: "10"}, values: {region: %w[us eu]}}
+          ]
+        }
+      ]
+    })
+
+    expect(child_charge.filters.reload.sole.properties).to eq({"amount" => "2"})
+  end
+
+  # The override is created only after the plan has already widened the filter, so there is nothing
+  # on the child to reconcile — it deep-copies whatever the plan holds at that moment. Widening
+  # replaces the filter rather than editing it, so what gets copied is the replacement, and the two
+  # sides line up on its code.
+  context "when the plan widens a filter before any override exists" do
+    let(:bm_filter) do
+      create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us eu asia apac])
+    end
+
+    def plan_payload(values, charge_id: nil)
+      charge = {
+        billable_metric_id: billable_metric.id,
+        charge_model: "standard",
+        code: "storage_charge",
+        pay_in_advance: false,
+        properties: {amount: "0"},
+        filters: [{invoice_display_name: "Regions", properties: {amount: "10"}, values: {region: values}}]
+      }
+      charge[:id] = charge_id if charge_id
+
+      {
+        name: "Enterprise", code: "enterprise", interval: "monthly", amount_cents: 0,
+        amount_currency: "EUR", pay_in_advance: false, cascade_updates: true, charges: [charge]
+      }
+    end
+
+    it "gives the override's copy the same code as the plan's filter" do
+      # 1. a plan whose charge carries one filter on three values
+      create_plan(plan_payload(%w[us eu asia]))
+      plan = organization.plans.find_by(code: "enterprise")
+      charge = plan.charges.find_by(code: "storage_charge")
+      three_value_code = charge.filters.sole.code
+
+      # 2. the plan widens it to four. The filter is replaced rather than edited, so the code changes
+      update_plan(plan, plan_payload(%w[us eu asia apac], charge_id: charge.id))
+      plan_filter = charge.filters.reload.sole
+      expect(plan_filter.code).not_to eq(three_value_code)
+
+      # 3. only now is the charge overridden for a customer
+      create_subscription({
+        external_customer_id: customer.external_id,
+        external_id: "sub_enterprise",
+        plan_code: "enterprise"
+      })
+      subscription = organization.subscriptions.find_by(external_id: "sub_enterprise")
+      update_subscription_charge(subscription, "storage_charge", {properties: {amount: "0"}})
+      child_charge = subscription.reload.plan.charges.find_by(code: "storage_charge")
+
+      # 4. the copy carries the plan's current code, and the replaced filter was not copied with it
+      child_filter = child_charge.filters.sole
+      expect(child_filter.code).to eq(plan_filter.code)
+      expect(child_filter.to_h["region"]).to match_array(%w[us eu asia apac])
+    end
+  end
+
+  # A filter created straight on the override derives its code from its own values, and generate_code
+  # is deterministic, so the plan derives the very same one when it later prices that segment. The two
+  # line up by construction rather than by adoption: the create finds the copy by its code, so nothing
+  # is duplicated and the negotiated price stays.
+  it "lines up an override-only filter with the plan's when the plan later prices that segment" do
+    ctx = setup_plan_with_subscription
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+    subscription = organization.subscriptions.find_by(external_id: "sub_enterprise")
+
+    # The customer buys a segment the plan does not price, at a negotiated 3
+    create_subscription_charge_filter(subscription, "storage_charge", {
+      invoice_display_name: "Asia negotiated", properties: {amount: "3"}, values: {region: ["asia"]}
+    })
+
+    asia = {"region" => ["asia"]}
+    child_asia = child_charge.filters.reload.find { it.to_h == asia }
+    expect(parent_charge.filters.reload.map(&:to_h)).not_to include(asia)
+
+    # The plan now prices that same segment, at its own 20
+    update_plan(ctx[:parent_plan], {
+      name: "Enterprise", code: "enterprise", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false, cascade_updates: true,
+      charges: [
+        {
+          id: parent_charge.id,
+          billable_metric_id: billable_metric.id,
+          charge_model: "standard",
+          code: "storage_charge",
+          pay_in_advance: false,
+          properties: {amount: "0"},
+          filters: [
+            {invoice_display_name: "US region", properties: {amount: "10"}, values: {region: ["us"]}},
+            {invoice_display_name: "EU region", properties: {amount: "20"}, values: {region: ["eu"]}},
+            {invoice_display_name: "Asia", properties: {amount: "20"}, values: {region: ["asia"]}}
+          ]
+        }
+      ]
+    })
+
+    parent_asia = parent_charge.filters.reload.find { it.to_h == asia }
+    expect(parent_asia.code).to eq(child_asia.code)
+
+    # One filter on the override, still at the negotiated price
+    expect(child_charge.filters.reload.select { it.to_h == asia }).to eq([child_asia])
+    expect(child_asia.reload.properties).to eq({"amount" => "3"})
+  end
+
   it "cascades rapid-fire filter updates independently" do
     ctx = setup_plan_with_subscription
     parent_plan = ctx[:parent_plan]

--- a/spec/scenarios/plans/cascade_filter_updates_spec.rb
+++ b/spec/scenarios/plans/cascade_filter_updates_spec.rb
@@ -140,12 +140,14 @@ RSpec.describe "Cascade filter updates", :premium do
 
     delete_plan_charge_filter(parent_plan, parent_charge.code, filter_eu.id)
 
-    # Destroy via API doesn't pass cascade_updates through the helper,
-    # so cascade manually to test the destroy path
+    # Destroy via API doesn't pass cascade_updates through the helper, so cascade manually to
+    # test the destroy path. The code is what the dispatcher would carry, and what the child's
+    # copy holds since the override deep-copied it.
     ChargeFilters::CascadeService.call!(
       charge: parent_charge,
       action: "destroy",
-      filter_values: {"region" => ["eu"]}
+      filter_values: {"region" => ["eu"]},
+      parent_code: filter_eu.code
     )
 
     child_charge.reload

--- a/spec/scenarios/plans/cascade_filters_over_metric_edits_spec.rb
+++ b/spec/scenarios/plans/cascade_filters_over_metric_edits_spec.rb
@@ -1,0 +1,705 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Walks a plan and its override through metric edits and plan edits, checking both sides
+# after every step. Each step lists the filters before and after, written out in full as
+# `{key: [values]} @price`, so the state is readable without running anything.
+#
+# Three things are pinned here:
+#   - filters left on a shared predicate by a metric edit are NOT deleted for the customer
+#   - a price negotiated on the override is NOT overwritten by a plan reprice. Note this holds
+#     for a reprice only: widening a filter's values replaces the filter rather than editing it,
+#     and the replacement is created with the plan's price, so the negotiated one is lost.
+#   - whatever the plan ends up with, the override follows
+#
+# Removing a metric value trims the value out of the charge filters referencing it rather
+# than destroying them, so predicates shorten and can collide. That is existing behaviour.
+RSpec.describe "Cascade filters over metric edits", :premium do
+  include ScenariosHelper
+
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:sum_billable_metric, organization:, code: "api_pages", field_name: "value") }
+
+  let(:models) { (1..10).map { "m#{it}" } }
+
+  let(:pages) { {"type" => %w[pages]} }
+  let(:m2) { {"type" => %w[pages], "model" => %w[m2]} }
+  let(:m3) { {"type" => %w[pages], "model" => %w[m3]} }
+  let(:m4) { {"type" => %w[pages], "model" => %w[m4]} }
+  let(:m5) { {"type" => %w[pages], "model" => %w[m5]} }
+
+  before do
+    create(:billable_metric_filter, billable_metric:, key: "type", values: %w[pages])
+    create(:billable_metric_filter, billable_metric:, key: "model", values: models)
+  end
+
+  def model_filter(model, amount)
+    {invoice_display_name: "Model #{model}", properties: {amount:}, values: {type: %w[pages], model: [model]}}
+  end
+
+  def pages_filter(amount)
+    {invoice_display_name: "Pages", properties: {amount:}, values: {type: %w[pages]}}
+  end
+
+  def plan_payload(filters, charge_id: nil, cascade: false)
+    charge = {
+      billable_metric_id: billable_metric.id,
+      charge_model: "standard",
+      code: "pages_charge",
+      pay_in_advance: false,
+      properties: {amount: "0.01"},
+      filters:
+    }
+    charge[:id] = charge_id if charge_id
+
+    payload = {
+      name: "API Plan", code: "api_plan", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false,
+      charges: [charge]
+    }
+    payload[:cascade_updates] = true if cascade
+    payload
+  end
+
+  def keep_metric_values(kept)
+    update_metric(billable_metric, {
+      filters: [{key: "type", values: %w[pages]}, {key: "model", values: kept}]
+    })
+  end
+
+  # Sorted so the comparisons do not depend on the order filters come back in
+  def predicates(charge)
+    charge.filters.reload.map(&:to_h).sort_by(&:to_s)
+  end
+
+  def prices_of(charge, predicate)
+    charge.filters.reload.select { it.to_h == predicate }.map { it.properties["amount"] }
+  end
+
+  # A plan whose charge carries four single-model filters and one on `type` alone, and a
+  # subscription whose charge is overridden, which deep-copies all five onto a child plan
+  def setup_plan_with_override
+    create_plan(plan_payload([
+      model_filter("m1", "1"),
+      model_filter("m2", "2"),
+      model_filter("m3", "3"),
+      model_filter("m5", "5"),
+      pages_filter("0.5")
+    ]))
+
+    parent_plan = organization.plans.find_by(code: "api_plan")
+    parent_charge = parent_plan.charges.find_by(code: "pages_charge")
+
+    create_subscription({
+      external_customer_id: customer.external_id,
+      external_id: "sub_api",
+      plan_code: "api_plan"
+    })
+
+    subscription = organization.subscriptions.find_by(external_id: "sub_api")
+    update_subscription_charge(subscription, "pages_charge", {properties: {amount: "0.01"}})
+
+    subscription.reload
+    {parent_plan:, parent_charge:, subscription:, child_charge: subscription.plan.charges.find_by(code: "pages_charge")}
+  end
+
+  # Three edits in a row: two metric edits that collapse filters onto a shared predicate,
+  # then one plan edit that adds, reprices, keeps and removes in the same request. Checks
+  # the parent and the override after each one.
+  it "keeps the override aligned with the plan across successive metric and plan edits" do
+    ctx = setup_plan_with_override
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    # STEP 0 — the override has just deep-copied the plan's filters, prices included.
+    # Parent and child both hold:
+    #
+    #   {type: [pages], model: [m1]}  @1
+    #   {type: [pages], model: [m2]}  @2
+    #   {type: [pages], model: [m3]}  @3
+    #   {type: [pages], model: [m5]}  @5
+    #   {type: [pages]}               @0.5
+    expect(predicates(parent_charge).size).to eq(5)
+    expect(predicates(child_charge)).to eq(predicates(parent_charge))
+
+    # STEP 1 — metric edit removing m1 and m2 in one go. Their filters lose the `model`
+    # key and land on `{type: [pages]}`, keeping their own price. Nothing is deleted, and
+    # no cascade runs: the metric edit walks charge_filter_values, which belong to no plan.
+    #
+    #   parent and child, before      ->  parent and child, after
+    #   {type: [pages], model: [m1]} @1   {type: [pages]}              @1
+    #   {type: [pages], model: [m2]} @2   {type: [pages]}              @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages], model: [m3]} @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @5
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    keep_metric_values(models - %w[m1 m2])
+
+    # note: only elements of {type: [pages]} are counted
+    expect(predicates(parent_charge).count(pages)).to eq(3)
+    expect(predicates(child_charge)).to eq(predicates(parent_charge))
+
+    # STEP 2 — metric edit removing m3 too, so a fourth filter joins the same predicate
+    #
+    #   parent and child, before      ->  parent and child, after
+    #   {type: [pages]}              @1   {type: [pages]}              @1
+    #   {type: [pages]}              @2   {type: [pages]}              @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages]}              @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @5
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    keep_metric_values(models - %w[m1 m2 m3])
+
+    expect(predicates(parent_charge).count(pages)).to eq(4)
+    expect(predicates(child_charge)).to eq(predicates(parent_charge))
+
+    # STEP 3 — one plan edit doing all four things at once: `m4` added, `m5` repriced
+    # 5 -> 50, `{type: [pages]}` left untouched at 0.5, and the four duplicates dropped.
+    # This is the only step that needs the cascade: the override follows if it propagates.
+    #
+    #   parent and child, before      ->  parent and child, after
+    #   {type: [pages]}              @1   (dropped)
+    #   {type: [pages]}              @2   (dropped)
+    #   {type: [pages]}              @3   (dropped)
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @50
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    #                                     {type: [pages], model: [m4]} @4   (added)
+    update_plan(ctx[:parent_plan], plan_payload(
+      [model_filter("m4", "4"), model_filter("m5", "50"), pages_filter("0.5")],
+      charge_id: parent_charge.id, cascade: true
+    ))
+
+    expect(predicates(parent_charge)).to eq([pages, m4, m5].sort_by(&:to_s))
+    expect(predicates(child_charge)).to eq(predicates(parent_charge))
+
+    expect(prices_of(parent_charge, m5)).to eq(%w[50])
+    expect(prices_of(child_charge, m5)).to eq(%w[50])
+    expect(prices_of(child_charge, pages)).to eq(%w[0.5])
+  end
+
+  # We do not pick prices for the customer. A price negotiated on the override survives a
+  # plan reprice, including when its filter sits on a predicate shared with others, where
+  # the cascade has to choose which row survives.
+  it "keeps a price negotiated on the override when the plan reprices" do
+    ctx = setup_plan_with_override
+    parent_charge = ctx[:parent_charge]
+    child_charge = ctx[:child_charge]
+
+    # STEP 0 — the customer negotiates `m5` down from 5 to 0.5 on their own plan.
+    # Only the child changes here.
+    #
+    #   parent, unchanged                 child, after the negotiation
+    #   {type: [pages], model: [m1]} @1   {type: [pages], model: [m1]} @1
+    #   {type: [pages], model: [m2]} @2   {type: [pages], model: [m2]} @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages], model: [m3]} @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @0.5   <- negotiated
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    child_charge.filters.reload.find { it.to_h == m5 }.update!(properties: {"amount" => "0.5"})
+
+    # STEP 1 — metric edit removing m1 and m2, so `{type: [pages]}` ends up shared by three
+    #
+    #   parent, after                     child, after
+    #   {type: [pages]}              @1   {type: [pages]}              @1
+    #   {type: [pages]}              @2   {type: [pages]}              @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages], model: [m3]} @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @0.5
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    keep_metric_values(models - %w[m1 m2])
+
+    # STEP 2 — the plan reprices everything it still knows about: m3 to 30, m5 to 50 and
+    # `{type: [pages]}` to 5. The negotiated 0.5 on the child must not move.
+    #
+    #   parent, after                     child, after
+    #   {type: [pages], model: [m3]} @30  {type: [pages], model: [m3]} @30
+    #   {type: [pages], model: [m5]} @50  {type: [pages], model: [m5]} @0.5   <- kept
+    #   {type: [pages]}              @5   {type: [pages]}              @5
+    update_plan(ctx[:parent_plan], plan_payload(
+      [model_filter("m3", "30"), model_filter("m5", "50"), pages_filter("5")],
+      charge_id: parent_charge.id, cascade: true
+    ))
+
+    expect(prices_of(parent_charge, m5)).to eq(%w[50])
+    expect(prices_of(child_charge, m5)).to eq(%w[0.5])
+  end
+
+  # Removing a single value collapses only the filter that referenced it. This is the
+  # counterpart to the collapse cases: it guards against an over-eager fix that would
+  # also delete or rewrite the filters carrying the values that are still allowed.
+  it "leaves the untouched filters alone when a single value is removed" do
+    ctx = setup_plan_with_override
+
+    # STEP 1 — metric edit removing m1 only. Its filter loses the `model` key and joins
+    # `{type: [pages]}`; m2, m3 and m5 keep theirs and are left exactly as they were.
+    #
+    #   parent and child, before      ->  parent and child, after
+    #   {type: [pages], model: [m1]} @1   {type: [pages]}              @1
+    #   {type: [pages], model: [m2]} @2   {type: [pages], model: [m2]} @2
+    #   {type: [pages], model: [m3]} @3   {type: [pages], model: [m3]} @3
+    #   {type: [pages], model: [m5]} @5   {type: [pages], model: [m5]} @5
+    #   {type: [pages]}            @0.5   {type: [pages]}              @0.5
+    keep_metric_values(models - %w[m1])
+
+    expect(predicates(ctx[:parent_charge])).to include(m2, m3, m5)
+    expect(predicates(ctx[:child_charge])).to eq(predicates(ctx[:parent_charge]))
+  end
+
+  # The cascade groups matching filters per child charge. With two charges on the same
+  # metric, a mistake there crosses filters between them.
+  it "cascades to the edited charge only, leaving the sibling charge untouched" do
+    create_plan({
+      name: "API Plan", code: "api_plan", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false,
+      charges: [
+        {billable_metric_id: billable_metric.id, charge_model: "standard", code: "pages_charge",
+         properties: {amount: "0.01"}, filters: [model_filter("m1", "1"), model_filter("m2", "2")]},
+        {billable_metric_id: billable_metric.id, charge_model: "standard", code: "tokens_charge",
+         properties: {amount: "0.02"}, filters: [model_filter("m1", "3"), model_filter("m2", "4")]}
+      ]
+    })
+
+    parent_plan = organization.plans.find_by(code: "api_plan")
+    pages = parent_plan.charges.find_by(code: "pages_charge")
+    tokens = parent_plan.charges.find_by(code: "tokens_charge")
+
+    create_subscription({external_customer_id: customer.external_id, external_id: "sub_api", plan_code: "api_plan"})
+    subscription = organization.subscriptions.find_by(external_id: "sub_api")
+    update_subscription_charge(subscription, "pages_charge", {properties: {amount: "0.01"}})
+    subscription.reload
+
+    child_pages = subscription.plan.charges.find_by(code: "pages_charge")
+    child_tokens = subscription.plan.charges.find_by(code: "tokens_charge")
+
+    # STEP 1 — the plan drops m2 from pages_charge only, with cascade on.
+    #
+    #   pages_charge   plan  before: {type: [pages], model: [m1]}  @1
+    #                              : {type: [pages], model: [m2]}  @2
+    #                        after:  {type: [pages], model: [m1]}  @1
+    #                  child before: {type: [pages], model: [m1]}  @1
+    #                              : {type: [pages], model: [m2]}  @2
+    #                        after:  {type: [pages], model: [m1]}  @1
+    #
+    #   tokens_charge  plan  before: {type: [pages], model: [m1]}  @3
+    #                              : {type: [pages], model: [m2]}  @4
+    #                        after:  {type: [pages], model: [m1]}  @3
+    #                              : {type: [pages], model: [m2]}  @4
+    #                  child before: {type: [pages], model: [m1]}  @3
+    #                              : {type: [pages], model: [m2]}  @4
+    #                        after:  {type: [pages], model: [m1]}  @3
+    #                              : {type: [pages], model: [m2]}  @4
+    update_plan(parent_plan, {
+      name: "API Plan", code: "api_plan", interval: "monthly", amount_cents: 0,
+      amount_currency: "EUR", pay_in_advance: false, cascade_updates: true,
+      charges: [
+        {id: pages.id, billable_metric_id: billable_metric.id, charge_model: "standard",
+         properties: {amount: "0.01"}, filters: [model_filter("m1", "1")]},
+        {id: tokens.id, billable_metric_id: billable_metric.id, charge_model: "standard",
+         properties: {amount: "0.02"}, filters: [model_filter("m1", "3"), model_filter("m2", "4")]}
+      ]
+    })
+
+    m1 = {"type" => %w[pages], "model" => %w[m1]}
+
+    expect(predicates(pages)).to eq([m1])
+    expect(predicates(child_pages)).to eq([m1])
+    expect(predicates(tokens)).to eq([m1, m2].sort_by(&:to_s))
+    expect(predicates(child_tokens)).to eq([m1, m2].sort_by(&:to_s))
+  end
+
+  # Two customers, each with their own override of the same plan. One plan edit has to
+  # reach both children: the cascade resolves matching filters per child charge, so a
+  # single-override test would never show the second one being skipped.
+  it "cascades to every override, not just the first" do
+    ctx = setup_plan_with_override
+    other = create(:customer, organization:)
+
+    create_subscription({external_customer_id: other.external_id, external_id: "sub_other", plan_code: "api_plan"})
+    second = organization.subscriptions.find_by(external_id: "sub_other")
+    update_subscription_charge(second, "pages_charge", {properties: {amount: "0.01"}})
+
+    # STEP 1 — the plan drops everything except m5, with cascade on.
+    #
+    #   before — plan, override A and override B each hold:
+    #     {type: [pages], model: [m1]}  @1
+    #     {type: [pages], model: [m2]}  @2
+    #     {type: [pages], model: [m3]}  @3
+    #     {type: [pages], model: [m5]}  @5
+    #     {type: [pages]}               @0.5
+    #
+    #   after — plan, override A and override B each hold:
+    #     {type: [pages], model: [m5]}  @5
+    update_plan(ctx[:parent_plan], plan_payload(
+      [model_filter("m5", "5")], charge_id: ctx[:parent_charge].id, cascade: true
+    ))
+
+    expect(predicates(ctx[:parent_charge])).to eq([m5])
+    expect(predicates(ctx[:child_charge])).to eq([m5])
+    expect(predicates(second.reload.plan.charges.find_by(code: "pages_charge"))).to eq([m5])
+  end
+
+  # `to_h` returns the sentinel itself, `to_h_with_all_values` expands it. The cascade
+  # matches on `to_h`, so a sentinel filter has to cascade like any other.
+  it "cascades a filter using the ALL_FILTER_VALUES sentinel" do
+    all_models = {"type" => %w[pages], "model" => [ChargeFilterValue::ALL_FILTER_VALUES]}
+    sentinel = {
+      invoice_display_name: "Any model", properties: {amount: "7"},
+      values: {type: %w[pages], model: [ChargeFilterValue::ALL_FILTER_VALUES]}
+    }
+
+    create_plan(plan_payload([sentinel, model_filter("m5", "5")]))
+    parent_plan = organization.plans.find_by(code: "api_plan")
+    parent_charge = parent_plan.charges.first
+
+    create_subscription({external_customer_id: customer.external_id, external_id: "sub_api", plan_code: "api_plan"})
+    subscription = organization.subscriptions.find_by(external_id: "sub_api")
+    update_subscription_charge(subscription, "pages_charge", {properties: {amount: "0.01"}})
+    child_charge = subscription.reload.plan.charges.first
+
+    expect(predicates(child_charge)).to include(all_models)
+
+    # STEP 1 — the plan drops the sentinel filter and keeps m5, with cascade on.
+    #
+    #   plan     before: {type: [pages], model: [__ALL_FILTER_VALUES__]}  @7
+    #                    {type: [pages], model: [m5]}                     @5
+    #            after:  {type: [pages], model: [m5]}                     @5
+    #   child    before: {type: [pages], model: [__ALL_FILTER_VALUES__]}  @7
+    #                    {type: [pages], model: [m5]}                     @5
+    #            after:  {type: [pages], model: [m5]}                     @5
+    update_plan(parent_plan, plan_payload(
+      [model_filter("m5", "5")], charge_id: parent_charge.id, cascade: true
+    ))
+
+    expect(predicates(parent_charge)).to eq([m5])
+    expect(predicates(child_charge)).to eq([m5])
+  end
+
+  # A full model x region matrix, so every metric edit collapses filters two at a time —
+  # once per region — instead of one at a time. Prices encode their origin: the first digit
+  # is the model, the second the region (1 = EU, 2 = US), so `21` is {model2, EU}. That
+  # makes it readable which row a collapsed predicate came from.
+  describe "a model x region matrix" do
+    let(:matrix_metric) { create(:sum_billable_metric, organization:, code: "api_calls", field_name: "value") }
+    let(:matrix_models) { (1..5).map { "model#{it}" } }
+
+    let(:eu) { {"region" => %w[EU]} }
+    let(:us) { {"region" => %w[US]} }
+
+    before do
+      create(:billable_metric_filter, billable_metric: matrix_metric, key: "region", values: %w[EU US])
+      create(:billable_metric_filter, billable_metric: matrix_metric, key: "model", values: matrix_models)
+    end
+
+    def combo(model, region)
+      {"region" => [region], "model" => [model]}
+    end
+
+    def combo_filter(model, region, amount)
+      {
+        invoice_display_name: "#{model} #{region}",
+        properties: {amount:},
+        values: {region: [region], model: [model]}
+      }
+    end
+
+    def region_filter(region, amount)
+      {invoice_display_name: "Any #{region}", properties: {amount:}, values: {region: [region]}}
+    end
+
+    def matrix_plan_payload(filters, charge_id: nil, cascade: false)
+      charge = {
+        billable_metric_id: matrix_metric.id,
+        charge_model: "standard",
+        code: "calls_charge",
+        pay_in_advance: false,
+        properties: {amount: "0.01"},
+        filters:
+      }
+      charge[:id] = charge_id if charge_id
+
+      payload = {
+        name: "Calls Plan", code: "calls_plan", interval: "monthly", amount_cents: 0,
+        amount_currency: "EUR", pay_in_advance: false,
+        charges: [charge]
+      }
+      payload[:cascade_updates] = true if cascade
+      payload
+    end
+
+    def keep_matrix_models(kept)
+      update_metric(matrix_metric, {
+        filters: [{key: "region", values: %w[EU US]}, {key: "model", values: kept}]
+      })
+    end
+
+    def tally(charge)
+      charge.filters.reload.map(&:to_h).tally
+    end
+
+    def filter_priced(charge, predicate, amount)
+      charge.filters.reload.find { it.to_h == predicate && it.properties["amount"] == amount }
+    end
+
+    # Every model x region combination priced individually, then overridden for a customer
+    def setup_matrix_with_override
+      create_plan(matrix_plan_payload(
+        matrix_models.each_with_index.flat_map do |model, index|
+          [combo_filter(model, "EU", "#{index + 1}1"), combo_filter(model, "US", "#{index + 1}2")]
+        end
+      ))
+
+      parent_plan = organization.plans.find_by(code: "calls_plan")
+      parent_charge = parent_plan.charges.find_by(code: "calls_charge")
+
+      create_subscription({
+        external_customer_id: customer.external_id,
+        external_id: "sub_calls",
+        plan_code: "calls_plan"
+      })
+
+      subscription = organization.subscriptions.find_by(external_id: "sub_calls")
+      update_subscription_charge(subscription, "calls_charge", {properties: {amount: "0.01"}})
+
+      subscription.reload
+      {parent_plan:, parent_charge:, subscription:,
+       child_charge: subscription.plan.charges.find_by(code: "calls_charge")}
+    end
+
+    # Three metric edits, each collapsing one model into both region predicates, then a
+    # single plan edit that drops, reprices and adds in one request.
+    it "carries the matrix through three metric edits and one plan edit" do
+      ctx = setup_matrix_with_override
+      parent_charge = ctx[:parent_charge]
+      child_charge = ctx[:child_charge]
+
+      # STEP 0 — ten filters, one per combination, deep-copied onto the override.
+      #
+      #   {region: [EU], model: [model1]} @11   {region: [US], model: [model1]} @12
+      #   {region: [EU], model: [model2]} @21   {region: [US], model: [model2]} @22
+      #   {region: [EU], model: [model3]} @31   {region: [US], model: [model3]} @32
+      #   {region: [EU], model: [model4]} @41   {region: [US], model: [model4]} @42
+      #   {region: [EU], model: [model5]} @51   {region: [US], model: [model5]} @52
+      expect(tally(parent_charge).values).to all(eq(1))
+      expect(tally(parent_charge).size).to eq(10)
+      expect(tally(child_charge)).to eq(tally(parent_charge))
+
+      # STEP 1 — metric edit dropping model1 and allowing model6. The two model1 filters
+      # lose the `model` key and land on the bare region predicates, keeping their prices.
+      # model6 becomes allowed but creates nothing on its own.
+      #
+      #   {region: [EU], model: [model1]} @11  ->  {region: [EU]} @11
+      #   {region: [US], model: [model1]} @12  ->  {region: [US]} @12
+      #   everything else unchanged
+      keep_matrix_models(matrix_models - %w[model1] + %w[model6])
+
+      expect(tally(parent_charge)[eu]).to eq(1)
+      expect(tally(parent_charge)[us]).to eq(1)
+      expect(tally(parent_charge).values.sum).to eq(10)
+      expect(tally(child_charge)).to eq(tally(parent_charge))
+
+      # STEP 2 — metric edit dropping model2, so a second filter joins each region
+      #
+      #   {region: [EU], model: [model2]} @21  ->  {region: [EU]} @21
+      #   {region: [US], model: [model2]} @22  ->  {region: [US]} @22
+      keep_matrix_models(%w[model3 model4 model5 model6])
+
+      expect(tally(parent_charge)[eu]).to eq(2)
+      expect(tally(parent_charge)[us]).to eq(2)
+      expect(tally(child_charge)).to eq(tally(parent_charge))
+
+      # STEP 3 — metric edit dropping model3, so a third joins each region
+      #
+      #   {region: [EU], model: [model3]} @31  ->  {region: [EU]} @31
+      #   {region: [US], model: [model3]} @32  ->  {region: [US]} @32
+      #
+      #   {region: [EU]} @11 @21 @31            {region: [US]} @12 @22 @32
+      #   {region: [EU], model: [model4]} @41   {region: [US], model: [model4]} @42
+      #   {region: [EU], model: [model5]} @51   {region: [US], model: [model5]} @52
+      keep_matrix_models(%w[model4 model5 model6])
+
+      expect(tally(parent_charge)[eu]).to eq(3)
+      expect(tally(parent_charge)[us]).to eq(3)
+      expect(tally(parent_charge).values.sum).to eq(10)
+      expect(tally(child_charge)).to eq(tally(parent_charge))
+
+      # STEP 4 — one plan edit stating the end state. A predicate can only be named once
+      # in a payload, so the three filters on each region collapse to the one kept here:
+      # EU stays at 11, US is repriced to 99, model4 and model5 are untouched, and model6
+      # is added for both regions. The cascade is what brings the override in line.
+      #
+      #   parent and child, before        ->  parent and child, after
+      #   {region: [EU]} @11 @21 @31          {region: [EU]} @11
+      #   {region: [US]} @12 @22 @32          {region: [US]} @99
+      #   {region: [EU], model: [model4]} @41 {region: [EU], model: [model4]} @41
+      #   {region: [US], model: [model4]} @42 {region: [US], model: [model4]} @42
+      #   {region: [EU], model: [model5]} @51 {region: [EU], model: [model5]} @51
+      #   {region: [US], model: [model5]} @52 {region: [US], model: [model5]} @52
+      #                                       {region: [EU], model: [model6]} @61  (added)
+      #                                       {region: [US], model: [model6]} @62  (added)
+      update_plan(ctx[:parent_plan], matrix_plan_payload([
+        region_filter("EU", "11"),
+        region_filter("US", "99"),
+        combo_filter("model4", "EU", "41"),
+        combo_filter("model4", "US", "42"),
+        combo_filter("model5", "EU", "51"),
+        combo_filter("model5", "US", "52"),
+        combo_filter("model6", "EU", "61"),
+        combo_filter("model6", "US", "62")
+      ], charge_id: parent_charge.id, cascade: true))
+
+      expected = {
+        eu => 1, us => 1,
+        combo("model4", "EU") => 1, combo("model4", "US") => 1,
+        combo("model5", "EU") => 1, combo("model5", "US") => 1,
+        combo("model6", "EU") => 1, combo("model6", "US") => 1
+      }
+
+      expect(tally(parent_charge)).to eq(expected)
+      expect(tally(child_charge)).to eq(expected)
+
+      expect(prices_of(parent_charge, us)).to eq(%w[99])
+      expect(prices_of(child_charge, us)).to eq(%w[99])
+      expect(prices_of(child_charge, eu)).to eq(%w[11])
+      expect(prices_of(child_charge, combo("model6", "EU"))).to eq(%w[61])
+      expect(prices_of(child_charge, combo("model6", "US"))).to eq(%w[62])
+    end
+
+    # The plan-level payload names a predicate once, so it cannot say "drop one of the
+    # three filters on {region: [EU]} and keep the other two". The filter endpoints address
+    # a filter by id and can. A cascade job only carries a predicate, so each of the three
+    # requests below is its own example: they fail independently, and a failure on the
+    # delete does not hide what the reprice or the create does.
+    #
+    # After the three metric edits both sides hold:
+    #
+    #   {region: [EU]} @11 @21 @31            {region: [US]} @12 @22 @32
+    #   {region: [EU], model: [model4]} @41   {region: [US], model: [model4]} @42
+    #   {region: [EU], model: [model5]} @51   {region: [US], model: [model5]} @52
+    def collapse_to_three_per_region
+      ctx = setup_matrix_with_override
+
+      keep_matrix_models(matrix_models - %w[model1] + %w[model6])
+      keep_matrix_models(%w[model3 model4 model5 model6])
+      keep_matrix_models(%w[model4 model5 model6])
+
+      expect(tally(ctx[:parent_charge])[eu]).to eq(3)
+      expect(tally(ctx[:parent_charge])[us]).to eq(3)
+      expect(tally(ctx[:child_charge])).to eq(tally(ctx[:parent_charge]))
+
+      ctx
+    end
+
+    # Deleting one filter of a collapsed group must leave the other two, on both sides. The job
+    # names {region: [EU]}, which all three answer to, so the code is the only thing that tells the
+    # cascade which copy the plan actually dropped.
+    it "deletes only the targeted filter of a collapsed group" do
+      ctx = collapse_to_three_per_region
+      parent_charge = ctx[:parent_charge]
+      child_charge = ctx[:child_charge]
+
+      # REQUEST 1 — delete the filter that used to be {model3, EU}, the one priced 31.
+      #
+      #   parent, before: {region: [EU]} @11 @21 @31
+      #          after:   {region: [EU]} @11 @21
+      #   child,  before: {region: [EU]} @11 @21 @31
+      #          after:   {region: [EU]} @11 @21
+      delete_plan_charge_filter(
+        ctx[:parent_plan], parent_charge.code, filter_priced(parent_charge, eu, "31").id,
+        {cascade_updates: true}
+      )
+
+      expect(tally(parent_charge)[eu]).to eq(2)
+      expect(prices_of(parent_charge, eu).sort).to eq(%w[11 21])
+
+      expect(tally(child_charge)[eu]).to eq(2)
+      expect(prices_of(child_charge, eu).sort).to eq(%w[11 21])
+
+      # The US side was not touched by this request
+      expect(tally(child_charge)[us]).to eq(3)
+    end
+
+    # Repricing one filter of a collapsed group must leave the other two at their own prices. Three
+    # filters answer to the predicate and only one of them was repriced, so pairing them by predicate
+    # would reprice whichever came back first.
+    it "reprices only the targeted filter of a collapsed group" do
+      ctx = collapse_to_three_per_region
+      parent_charge = ctx[:parent_charge]
+      child_charge = ctx[:child_charge]
+
+      # REQUEST 2 — reprice the filter that used to be {model2, US}, priced 22, to 99.
+      #
+      #   parent, before: {region: [US]} @12 @22 @32
+      #          after:   {region: [US]} @12 @99 @32
+      #   child,  before: {region: [US]} @12 @22 @32
+      #          after:   {region: [US]} @12 @99 @32
+      update_plan_charge_filter(
+        ctx[:parent_plan], parent_charge.code, filter_priced(parent_charge, us, "22").id,
+        {properties: {amount: "99"}, cascade_updates: true}
+      )
+
+      expect(tally(parent_charge)[us]).to eq(3)
+      expect(prices_of(parent_charge, us).sort).to eq(%w[12 32 99])
+
+      expect(tally(child_charge)[us]).to eq(3)
+      expect(prices_of(child_charge, us).sort).to eq(%w[12 32 99])
+
+      # The EU side was not touched by this request
+      expect(tally(child_charge)[eu]).to eq(3)
+    end
+
+    # model6 was allowed back by the first metric edit, so filters for it can be created.
+    # This one does not depend on the collapsed group being handled correctly.
+    it "creates filters for a value the metric allowed back" do
+      ctx = collapse_to_three_per_region
+      parent_charge = ctx[:parent_charge]
+      child_charge = ctx[:child_charge]
+
+      # REQUEST 3 and 4
+      #
+      #   parent and child, after: {region: [EU], model: [model6]} @61
+      #                            {region: [US], model: [model6]} @62
+      create_plan_charge_filter(ctx[:parent_plan], parent_charge.code,
+        combo_filter("model6", "EU", "61").merge(cascade_updates: true))
+      create_plan_charge_filter(ctx[:parent_plan], parent_charge.code,
+        combo_filter("model6", "US", "62").merge(cascade_updates: true))
+
+      expect(tally(parent_charge)[combo("model6", "EU")]).to eq(1)
+      expect(tally(parent_charge)[combo("model6", "US")]).to eq(1)
+
+      expect(tally(child_charge)[combo("model6", "EU")]).to eq(1)
+      expect(tally(child_charge)[combo("model6", "US")]).to eq(1)
+      expect(prices_of(child_charge, combo("model6", "EU"))).to eq(%w[61])
+      expect(prices_of(child_charge, combo("model6", "US"))).to eq(%w[62])
+
+      # Creating a filter must not disturb the collapsed groups
+      expect(tally(child_charge)[eu]).to eq(3)
+      expect(tally(child_charge)[us]).to eq(3)
+    end
+  end
+
+  # CascadeService targets children whose plan has an active or pending subscription
+  it "does not cascade to an override whose subscription is terminated" do
+    ctx = setup_plan_with_override
+    child_charge = ctx[:child_charge]
+
+    terminate_subscription(ctx[:subscription])
+
+    # STEP 1 — the plan drops everything except m5, with cascade on. The child plan is
+    # left alone because its subscription is no longer active or pending.
+    #
+    #   plan   before: {type: [pages], model: [m1]}  @1
+    #                  {type: [pages], model: [m2]}  @2
+    #                  {type: [pages], model: [m3]}  @3
+    #                  {type: [pages], model: [m5]}  @5
+    #                  {type: [pages]}               @0.5
+    #          after:  {type: [pages], model: [m5]}  @5
+    #   child  before: the same five filters
+    #          after:  the same five filters, untouched
+    before_predicates = predicates(child_charge)
+
+    update_plan(ctx[:parent_plan], plan_payload(
+      [model_filter("m5", "5")], charge_id: ctx[:parent_charge].id, cascade: true
+    ))
+
+    expect(predicates(ctx[:parent_charge])).to eq([m5])
+    expect(predicates(child_charge)).to eq(before_predicates)
+  end
+end

--- a/spec/services/charge_filters/cascade_dispatcher_spec.rb
+++ b/spec/services/charge_filters/cascade_dispatcher_spec.rb
@@ -139,5 +139,87 @@ RSpec.describe ChargeFilters::CascadeDispatcher do
         )
       end
     end
+
+    # A metric change dropped the `tier` key, leaving two filters describing the same thing.
+    # Keyed by predicate one of them vanishes from the diff; keyed by code both survive.
+    context "when two filters share a predicate" do
+      let(:gold) { {values: us_values, properties: {"amount" => "10"}, invoice_display_name: "Gold", code: "us_gold_1a2b3c4d"} }
+      let(:silver) { {values: us_values, properties: {"amount" => "20"}, invoice_display_name: "Silver", code: "us_silver_5e6f7a8b"} }
+
+      context "when one of them is repriced" do
+        let(:before) { [gold, silver] }
+        let(:after) { [gold, silver.merge(properties: {"amount" => "25"})] }
+
+        it "enqueues a job for the repriced one only" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "update", us_values, {"amount" => "20"}, {"amount" => "25"}, "Silver", "us_silver_5e6f7a8b"
+          ).exactly(:once)
+        end
+
+        it "leaves the other one alone" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.to have_enqueued_job(ChargeFilters::CascadeJob).exactly(:once)
+        end
+      end
+
+      context "when one of them is removed" do
+        let(:before) { [gold, silver] }
+        let(:after) { [gold] }
+
+        it "enqueues a destroy for the one that went" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, "destroy", us_values, {"amount" => "20"}, nil, "Silver", "us_silver_5e6f7a8b"
+          ).exactly(:once)
+        end
+
+        it "does not touch the one that stayed" do
+          expect {
+            described_class.call(charge:, before:, after:)
+          }.not_to have_enqueued_job(ChargeFilters::CascadeJob).with(
+            charge.id, anything, anything, anything, anything, anything, "us_gold_1a2b3c4d"
+          )
+        end
+      end
+    end
+
+    # Codes are per charge, so a filter that is replaced rather than edited comes back with a
+    # new one, and the pair of jobs is what moves the override off the old predicate
+    context "when a coded filter is replaced by another" do
+      let(:before) { [{values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US", code: "us_1a2b3c4d"}] }
+      let(:after) { [{values: eu_values, properties: {"amount" => "10"}, invoice_display_name: "EU", code: "eu_9c8d7e6f"}] }
+
+      it "enqueues a destroy for the old code and a create for the new one" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "destroy", us_values, {"amount" => "10"}, nil, "US", "us_1a2b3c4d"
+        ).and have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "create", eu_values, nil, {"amount" => "10"}, "EU", "eu_9c8d7e6f"
+        )
+      end
+    end
+
+    context "when coded and codeless filters are mixed" do
+      let(:coded) { {values: us_values, properties: {"amount" => "10"}, invoice_display_name: "US", code: "us_1a2b3c4d"} }
+      let(:codeless) { {values: eu_values, properties: {"amount" => "20"}, invoice_display_name: "EU"} }
+
+      let(:before) { [coded, codeless] }
+      let(:after) { [coded.merge(properties: {"amount" => "15"}), codeless.merge(properties: {"amount" => "25"})] }
+
+      it "diffs each half on its own terms" do
+        expect {
+          described_class.call(charge:, before:, after:)
+        }.to have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "update", us_values, {"amount" => "10"}, {"amount" => "15"}, "US", "us_1a2b3c4d"
+        ).and have_enqueued_job(ChargeFilters::CascadeJob).with(
+          charge.id, "update", eu_values, {"amount" => "20"}, {"amount" => "25"}, "EU", nil
+        )
+      end
+    end
   end
 end

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -301,6 +301,21 @@ RSpec.describe ChargeFilters::CascadeService do
           expect(existing.reload.code).to eq("the-parents-code")
         end
 
+        # Which of the two adopts the code decides which one bills from then on, and row order is
+        # not a way to decide that. The pair has to be cleaned up first.
+        context "when the child holds the predicate twice" do
+          before do
+            other = create(:charge_filter, charge: child_charge, properties: {amount: "35"})
+            create(:charge_filter_value, charge_filter: other, billable_metric_filter: bm_filter, values: ["eu"])
+          end
+
+          it "raises rather than linking one at random" do
+            expect { service }.to raise_error(
+              described_class::DuplicatePredicate, /#{child_charge.id}/
+            )
+          end
+        end
+
         context "when it already has a code of its own" do
           let(:existing) do
             filter = create(:charge_filter, charge: child_charge, properties: {amount: "20"}, code: "its_own_code_1a2b3c4d")

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -12,8 +12,11 @@ RSpec.describe ChargeFilters::CascadeService do
   let(:child_plan) { create(:plan, organization:, parent: parent_plan) }
   let(:child_charge) { create(:standard_charge, plan: child_plan, billable_metric:, parent: parent_charge, properties: {amount: "0"}) }
 
+  # The override deep-copies the plan's filters, code included, so both sides hold the same one
+  let(:us_code) { "region_us_1a2b3c4d" }
+
   let(:child_filter) do
-    filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US region", properties: {amount: "10"})
+    filter = create(:charge_filter, charge: child_charge, invoice_display_name: "US region", properties: {amount: "10"}, code: us_code)
     create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
     filter
   end
@@ -21,7 +24,7 @@ RSpec.describe ChargeFilters::CascadeService do
   before do
     create(:subscription, plan: child_plan, status: :active)
 
-    parent_filter = create(:charge_filter, charge: parent_charge, invoice_display_name: "US region", properties: {amount: "10"})
+    parent_filter = create(:charge_filter, charge: parent_charge, invoice_display_name: "US region", properties: {amount: "10"}, code: us_code)
     create(:charge_filter_value, charge_filter: parent_filter, billable_metric_filter: bm_filter, values: ["us"])
 
     child_filter
@@ -36,7 +39,8 @@ RSpec.describe ChargeFilters::CascadeService do
           filter_values: {"region" => ["us"]},
           old_properties: {"amount" => "10"},
           new_properties: {"amount" => "15"},
-          invoice_display_name: "US region updated"
+          invoice_display_name: "US region updated",
+          parent_code: us_code
         )
       end
 
@@ -56,7 +60,7 @@ RSpec.describe ChargeFilters::CascadeService do
         end
 
         let(:other_child_filter) do
-          create(:charge_filter, charge: other_child_charge, invoice_display_name: "US region", properties: {amount: "10"})
+          create(:charge_filter, charge: other_child_charge, invoice_display_name: "US region", properties: {amount: "10"}, code: us_code)
         end
 
         # A filter on a different value that must not be matched by the cascade
@@ -81,7 +85,7 @@ RSpec.describe ChargeFilters::CascadeService do
 
       context "when child filter was customized" do
         let!(:child_filter) do
-          filter = create(:charge_filter, charge: child_charge, invoice_display_name: "Custom", properties: {amount: "99"})
+          filter = create(:charge_filter, charge: child_charge, invoice_display_name: "Custom", properties: {amount: "99"}, code: us_code)
           create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
           filter
         end
@@ -100,7 +104,8 @@ RSpec.describe ChargeFilters::CascadeService do
               filter_values: {"region" => ["us"]},
               old_properties: {"amount" => "10"},
               new_properties: {"amount" => "15", "pricing_group_keys" => ["agent_name"]},
-              invoice_display_name: "US region updated"
+              invoice_display_name: "US region updated",
+              parent_code: us_code
             )
           end
 
@@ -119,7 +124,8 @@ RSpec.describe ChargeFilters::CascadeService do
               filter_values: {"region" => ["us"]},
               old_properties: {"amount" => "10", "pricing_group_keys" => ["old_key"]},
               new_properties: {"amount" => "15"},
-              invoice_display_name: "US region updated"
+              invoice_display_name: "US region updated",
+              parent_code: us_code
             )
           end
 
@@ -128,7 +134,8 @@ RSpec.describe ChargeFilters::CascadeService do
               :charge_filter,
               charge: child_charge,
               invoice_display_name: "Custom",
-              properties: {"amount" => "99", "pricing_group_keys" => ["old_key"]}
+              properties: {"amount" => "99", "pricing_group_keys" => ["old_key"]},
+              code: us_code
             )
             create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["us"])
             filter
@@ -152,6 +159,69 @@ RSpec.describe ChargeFilters::CascadeService do
 
         it "succeeds without error" do
           expect(service).to be_success
+        end
+      end
+
+      # Deliberately loud. The job carries no identity, so the filters still missing a code
+      # surface as dead jobs naming the charge and the predicate, which is the list to fix.
+      context "when the plan's filter has no code" do
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "update",
+            filter_values: {"region" => ["us"]},
+            old_properties: {"amount" => "10"},
+            new_properties: {"amount" => "15"},
+            invoice_display_name: "US region updated"
+          )
+        end
+
+        it "raises rather than guessing at the predicate" do
+          expect { service }.to raise_error(
+            described_class::MissingParentCode, /#{parent_charge.id}.*region/
+          )
+        end
+
+        it "leaves the child filter on the old price" do
+          expect { service }.to raise_error(described_class::MissingParentCode)
+
+          expect(child_filter.reload.properties).to eq({"amount" => "10"})
+        end
+      end
+
+      # The predicate reaches whichever filter happens to sit on it; the code reaches the one
+      # the plan actually changed
+      context "when a filter holds the parent's code on another predicate" do
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "update",
+            filter_values: {"region" => ["us"]},
+            old_properties: {"amount" => "10"},
+            new_properties: {"amount" => "15"},
+            invoice_display_name: "US region updated",
+            parent_code: "the-parents-code"
+          )
+        end
+
+        let(:coded_filter) do
+          filter = create(:charge_filter, charge: child_charge, code: "the-parents-code", properties: {amount: "10"})
+          create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["eu"])
+          filter
+        end
+
+        before { coded_filter }
+
+        it "updates the filter holding the code" do
+          service
+
+          expect(coded_filter.reload.properties).to eq({"amount" => "15"})
+        end
+
+        it "leaves the one merely sharing the predicate alone" do
+          service
+
+          expect(child_filter.reload.properties).to eq({"amount" => "10"})
         end
       end
     end
@@ -200,13 +270,104 @@ RSpec.describe ChargeFilters::CascadeService do
       end
 
       context "when child already has the filter" do
-        before do
-          existing = create(:charge_filter, charge: child_charge, properties: {amount: "20"})
-          create(:charge_filter_value, charge_filter: existing, billable_metric_filter: bm_filter, values: ["eu"])
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "create",
+            filter_values: {"region" => ["eu"]},
+            new_properties: {"amount" => "20"},
+            invoice_display_name: "EU region",
+            parent_code: "the-parents-code"
+          )
         end
+
+        let(:existing) do
+          filter = create(:charge_filter, charge: child_charge, properties: {amount: "20"})
+          create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["eu"])
+          filter
+        end
+
+        before { existing }
 
         it "does not create a duplicate" do
           expect { service }.not_to change { child_charge.filters.reload.count }
+        end
+
+        # The filter got there before the plan had one. This is the only moment we can say the
+        # two are the same, and without it the cascade could never reach this one again.
+        it "links it to the plan's filter" do
+          service
+
+          expect(existing.reload.code).to eq("the-parents-code")
+        end
+
+        context "when it already has a code of its own" do
+          let(:existing) do
+            filter = create(:charge_filter, charge: child_charge, properties: {amount: "20"}, code: "its_own_code_1a2b3c4d")
+            create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["eu"])
+            filter
+          end
+
+          # Born on the override with an identity of its own, so it is nobody's copy
+          it "leaves the code alone" do
+            service
+
+            expect(existing.reload.code).to eq("its_own_code_1a2b3c4d")
+          end
+        end
+      end
+
+      # Two cascade jobs for the same filter both read the child's filters before either of
+      # them writes. The predicate lookup cannot pair them up once a billable metric change
+      # shortened one side, so without the code both go on to create.
+      context "when a copy already holds the parent's code" do
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "create",
+            filter_values: {"region" => ["eu"]},
+            new_properties: {"amount" => "20"},
+            invoice_display_name: "EU region",
+            parent_code: "the-parents-code"
+          )
+        end
+
+        # No values, so the predicate lookup passes it by and only the code identifies it
+        let(:copy) { create(:charge_filter, charge: child_charge, code: "the-parents-code", properties: {amount: "20"}) }
+
+        before { copy }
+
+        it "does not create a second copy" do
+          expect { service }.not_to change { child_charge.filters.reload.count }
+        end
+
+        it "leaves the copy untouched" do
+          expect { service }.not_to change { copy.reload.updated_at }
+        end
+      end
+
+      # The lookup ran before the other job committed, so the insert is the first thing to see
+      # the conflict. Left to fail on purpose: the retry finds the copy and passes, and a
+      # swallowed conflict would hide filters that still need cleaning up.
+      context "when another job commits the copy mid-flight" do
+        let(:racing) do
+          described_class.new(
+            charge: parent_charge,
+            action: "create",
+            filter_values: {"region" => ["eu"]},
+            new_properties: {"amount" => "20"},
+            invoice_display_name: "EU region",
+            parent_code: "the-parents-code"
+          )
+        end
+
+        before do
+          create(:charge_filter, charge: child_charge, code: "the-parents-code", properties: {amount: "20"})
+          allow(racing).to receive(:child_filters_holding_parent_code).and_return({})
+        end
+
+        it "lets the unique index reject it" do
+          expect { racing.call }.to raise_error(ActiveRecord::RecordNotUnique)
         end
       end
 
@@ -273,11 +434,67 @@ RSpec.describe ChargeFilters::CascadeService do
         )
       end
 
-      it "discards the matching child filter and its values" do
-        service
+      context "when the child holds the parent's code" do
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "destroy",
+            filter_values: {"region" => ["us"]},
+            parent_code: "the-parents-code"
+          )
+        end
 
-        expect(child_filter.reload).to be_discarded
-        expect(child_filter.values.kept).to be_empty
+        before { child_filter.update!(code: "the-parents-code") }
+
+        it "discards the matching child filter and its values" do
+          service
+
+          expect(child_filter.reload).to be_discarded
+          expect(child_filter.values.kept).to be_empty
+        end
+      end
+
+      # Nothing identifies which filter this is, and the one on the predicate may well belong
+      # to the customer rather than to the plan. Left alone rather than discarded on a guess.
+      context "when nothing holds the parent's code" do
+        it "leaves the filter sharing the predicate alone" do
+          service
+
+          expect(child_filter.reload).not_to be_discarded
+        end
+      end
+
+      # A billable metric change shortened the coded filter's predicate, so the two no longer
+      # describe the same thing and the predicate now points at the wrong one
+      context "when a filter holds the parent's code on another predicate" do
+        subject(:service) do
+          described_class.call(
+            charge: parent_charge,
+            action: "destroy",
+            filter_values: {"region" => ["us"]},
+            parent_code: "the-parents-code"
+          )
+        end
+
+        let(:coded_filter) do
+          filter = create(:charge_filter, charge: child_charge, code: "the-parents-code", properties: {amount: "10"})
+          create(:charge_filter_value, charge_filter: filter, billable_metric_filter: bm_filter, values: ["eu"])
+          filter
+        end
+
+        before { coded_filter }
+
+        it "discards the filter holding the code" do
+          service
+
+          expect(coded_filter.reload).to be_discarded
+        end
+
+        it "leaves the one merely sharing the predicate alone" do
+          service
+
+          expect(child_filter.reload).not_to be_discarded
+        end
       end
 
       context "when child has no matching filter" do
@@ -302,7 +519,8 @@ RSpec.describe ChargeFilters::CascadeService do
           filter_values: {"region" => ["us"]},
           old_properties: {"amount" => "10"},
           new_properties: {"amount" => "15"},
-          invoice_display_name: "US region"
+          invoice_display_name: "US region",
+          parent_code: us_code
         )
       end
 

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -329,6 +329,13 @@ RSpec.describe ChargeFilters::CascadeService do
 
             expect(existing.reload.code).to eq("its_own_code_1a2b3c4d")
           end
+
+          # Nor is the plan's filter created beside it. The code does not reach this filter but the
+          # predicate does, and that is what keeps a create from duplicating. Narrowing the predicate
+          # lookup to codeless filters would hide this one and land a second filter on the predicate.
+          it "does not create a second filter on the same predicate" do
+            expect { service }.not_to change { child_charge.filters.reload.count }
+          end
         end
       end
 

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -368,9 +368,9 @@ RSpec.describe ChargeFilters::CascadeService do
         end
       end
 
-      # The lookup ran before the other job committed, so the insert is the first thing to see
-      # the conflict. Left to fail on purpose: the retry finds the copy and passes, and a
-      # swallowed conflict would hide filters that still need cleaning up.
+      # The lookup ran before the other job committed, so the insert is the first thing to see the
+      # conflict. Left to fail on purpose: swallowing it would hide filters that still need
+      # cleaning up. needs manual retry
       context "when another job commits the copy mid-flight" do
         let(:racing) do
           described_class.new(

--- a/spec/services/charge_filters/cascade_service_spec.rb
+++ b/spec/services/charge_filters/cascade_service_spec.rb
@@ -548,6 +548,20 @@ RSpec.describe ChargeFilters::CascadeService do
 
         expect(child_filter.reload.properties).to eq({"amount" => "10"})
       end
+
+      # A missing code costs nothing when there is nobody to cascade to, so it is not reported
+      it "does not report a missing code either" do
+        expect {
+          described_class.call(
+            charge: parent_charge,
+            action: "update",
+            filter_values: {"region" => ["us"]},
+            old_properties: {"amount" => "10"},
+            new_properties: {"amount" => "15"},
+            invoice_display_name: "US region"
+          )
+        }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/services/charge_filters/create_service_spec.rb
+++ b/spec/services/charge_filters/create_service_spec.rb
@@ -108,6 +108,89 @@ RSpec.describe ChargeFilters::CreateService do
       end
     end
 
+    context "with cascade_updates" do
+      subject(:service) { described_class.call(charge:, params:, cascade_updates: true) }
+
+      let(:child_plan) { create(:plan, organization: charge.organization, parent: charge.plan) }
+      let(:child_charge) do
+        create(:standard_charge, plan: child_plan, organization: charge.organization, billable_metric: charge.billable_metric, parent: charge)
+      end
+
+      let(:params) do
+        {
+          invoice_display_name: "Domestic Visa",
+          properties: {amount: "50"},
+          values: {card_location_filter.key => ["domestic"]}
+        }
+      end
+
+      before do
+        create(:subscription, plan: child_plan, status: :active)
+        child_charge
+      end
+
+      # The children are matched on this code, so the filter created here has to hand over
+      # the one it was just given rather than let the cascade fall back to the predicate
+      it "triggers filter-level cascade carrying the new filter's code" do
+        result = service
+
+        expect(result.charge_filter.code).to be_present
+        expect(ChargeFilters::CascadeJob).to have_been_enqueued.with(
+          charge.id,
+          "create",
+          hash_including("card_location"),
+          nil,
+          hash_including("amount"),
+          "Domestic Visa",
+          result.charge_filter.code
+        )
+      end
+    end
+
+    context "without cascade_updates when charge has children" do
+      let(:child_plan) { create(:plan, organization: charge.organization, parent: charge.plan) }
+      let(:child_charge) do
+        create(:standard_charge, plan: child_plan, organization: charge.organization, billable_metric: charge.billable_metric, parent: charge)
+      end
+
+      let(:params) do
+        {
+          invoice_display_name: "Domestic Visa",
+          properties: {amount: "50"},
+          values: {card_location_filter.key => ["domestic"]}
+        }
+      end
+
+      before do
+        create(:subscription, plan: child_plan, status: :active)
+        child_charge
+      end
+
+      it "does not trigger cascade update" do
+        service
+
+        expect(ChargeFilters::CascadeJob).not_to have_been_enqueued
+      end
+    end
+
+    # Nothing to cascade to, so the job would find no children and do nothing
+    context "with cascade_updates when charge has no children" do
+      subject(:service) { described_class.call(charge:, params:, cascade_updates: true) }
+
+      let(:params) do
+        {
+          invoice_display_name: "Domestic Visa",
+          properties: {amount: "50"},
+          values: {card_location_filter.key => ["domestic"]}
+        }
+      end
+
+      it "creates the filter without enqueuing a cascade job" do
+        expect { service }.to change(ChargeFilter, :count).by(1)
+        expect(ChargeFilters::CascadeJob).not_to have_been_enqueued
+      end
+    end
+
     context "with graduated charge model" do
       let(:charge) { create(:graduated_charge) }
       let(:params) do

--- a/spec/services/charge_filters/destroy_service_spec.rb
+++ b/spec/services/charge_filters/destroy_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ChargeFilters::DestroyService do
   subject(:service) { described_class.call(charge_filter:) }
 
   let(:charge) { create(:standard_charge) }
-  let(:charge_filter) { create(:charge_filter, charge:) }
+  let(:charge_filter) { create(:charge_filter, charge:, code: "card_location_domestic_9f2a1c7b") }
 
   let(:card_location_filter) do
     create(
@@ -73,7 +73,8 @@ RSpec.describe ChargeFilters::DestroyService do
           hash_including("card_location"),
           nil,
           nil,
-          nil
+          nil,
+          "card_location_domestic_9f2a1c7b"
         )
       end
     end
@@ -92,7 +93,7 @@ RSpec.describe ChargeFilters::DestroyService do
       it "does not trigger cascade update" do
         service
 
-        expect(Charges::UpdateChildrenJob).not_to have_been_enqueued
+        expect(ChargeFilters::CascadeJob).not_to have_been_enqueued
       end
     end
   end

--- a/spec/services/charge_filters/update_service_spec.rb
+++ b/spec/services/charge_filters/update_service_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe ChargeFilters::UpdateService do
   subject(:service) { described_class.call(charge_filter:, params:) }
 
   let(:charge) { create(:standard_charge) }
-  let(:charge_filter) { create(:charge_filter, charge:, invoice_display_name: "Original Name", properties: {"amount" => "10"}) }
+  let(:charge_filter) do
+    create(:charge_filter, charge:, invoice_display_name: "Original Name", properties: {"amount" => "10"}, code: "card_location_domestic_9f2a1c7b")
+  end
   let(:params) { {} }
 
   let(:card_location_filter) do
@@ -108,7 +110,8 @@ RSpec.describe ChargeFilters::UpdateService do
           hash_including("card_location"),
           hash_including("amount"),
           hash_including("amount"),
-          anything
+          anything,
+          "card_location_domestic_9f2a1c7b"
         )
       end
     end
@@ -127,7 +130,7 @@ RSpec.describe ChargeFilters::UpdateService do
       it "does not trigger cascade update" do
         service
 
-        expect(Charges::UpdateChildrenJob).not_to have_been_enqueued
+        expect(ChargeFilters::CascadeJob).not_to have_been_enqueued
       end
     end
   end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -129,9 +129,9 @@ module ScenariosHelper
     end
   end
 
-  def delete_plan_charge_filter(plan, charge_code, filter_id, **kwargs)
+  def delete_plan_charge_filter(plan, charge_code, filter_id, params = {}, **kwargs)
     api_call(**kwargs) do
-      delete_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge_code}/filters/#{filter_id}")
+      delete_with_token(organization, "/api/v1/plans/#{plan.code}/charges/#{charge_code}/filters/#{filter_id}", {filter: params})
     end
   end
 


### PR DESCRIPTION
## Context

Charge filters were given a code to serve as their identity, precisely because their values move:
removing a value from a billable metric trims it out of every filter using it, so two filters that
were distinct collapse onto the same values and stop being distinguishable.

The cascade never used it. It still addressed the copies on overridden plans by their values, which
is the thing the code was introduced to replace, so the ambiguity remained: whichever filter
happened to sit on the predicate was the one repriced or discarded. And resolving a whole batch
through `index_by` silently kept one of the two, so deleting a filter on the plan left the duplicate
on the override behind.

## Description

The code now travels on every cascade job. `FilterCascadable` was dropping it, which meant the
single-filter REST and GraphQL surface ran entirely on the predicate no matter what the filters held.

Children are resolved by code, and the predicate is asked only about the ones the code could not
reach — so it is asked about none once every filter has one, and the legacy path is observably dead
before anyone deletes it.

### One rule per action

- **create** takes the widest match. Anything already on the predicate means there is nothing to add,
  and missing it would leave a duplicate. A filter that got there before the plan had one adopts the
  plan's code: this is the only moment the two can be said to be the same, and left unlinked it
  would be unreachable for good. A code of its own means the opposite — born on the override, nobody's
  copy — so it keeps it. Two filters on the predicate raise `DuplicatePredicate` instead: adopting
  into one picked by row order would settle which of the two bills from then on.
- **update** raises `MissingParentCode` rather than guess. Guessing wrong reprices a filter the
  customer negotiated, and doing nothing quietly leaves the override on the old price, which is the
  one failure nothing else in the system would surface. It stays quiet when the charge has no
  override with an active subscription, since a missing code costs nothing where there is nothing to
  cascade to.
- **destroy** does nothing without the code. Discarding the wrong filter takes billing config away
  from a customer irreversibly, whereas a filter left behind is already listed by the report below.

A filter created straight on an override needs none of this: `generate_code` is deterministic on the
values, so the plan derives the very same code when it later prices that segment and the two pair up
by construction rather than by adoption.

### What changes for filters still without a code

Two new exceptions, both raised inside the job after the user's request has already succeeded, and
`ApplicationJob` does not retry — so one occurrence is one dead job naming what to fix, not twenty.

- `MissingParentCode` — the plan's filter has no code, so a reprice no longer reaches the override.
  `rake filters:report_parent_codes` lists them ahead of time.
- `DuplicatePredicate` — an override holds two filters on the predicate. A plan gaining a filter
  fails for every override in that batch, not just the affected one. Cleaning the duplicate and
  retrying the job recovers it; the retry is idempotent, since copies already made are found by
  their code and skipped.

Both shrink as the codeless filters are cleaned up and the backfill is re-run, which is what
`upgrade:perform_required_jobs` does — a charge cleaned by hand goes back to having filters without
a code and the walk selects it again.

## Known issue, surfaced while reviewing this

> [!WARNING]
> **A price negotiated on an override is lost when the plan widens a filter's values.** Widening
> replaces the filter rather than editing it — `CreateOrUpdateBatchService` pairs the payload against
> the existing filters by their values, finds no match, and creates a new one while discarding the
> old. The replacement is created with the plan's price, so `filter_customized?` never gets to guard
> it and the override silently starts charging the plan's rate.
>
> ```
> child, negotiated   {region: [us]}       @2
> plan widens to      {region: [us, eu]}   @10
> child, after        {region: [us, eu]}   @10    ← the negotiated 2 is gone
> ```
>
> **This is not introduced here.** Verified against `main`, same failure: a changed predicate was a
> removal plus an addition there too. It is not fixed here either — it needs the plan payload to be
> able to name a filter by its `lago_id`, which the API already returns and which charges in the same
> payload already accept. Then widening becomes an update.
>
> It is pinned as a **pending spec** rather than left to a ticket, so it fails loudly the day someone
> fixes it, and lives where whoever edits the file will see it.

### Rake tasks

- `filters:report_parent_codes` — new. The plan's own filters with no code, on charges that have
  overrides, grouped by organization and by charge.
- `filters:report_codes` — every filter with no code, and the charges holding the most of them.
