### PR TITLE
[ING-453] feat(connections): payment connection model helpers

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -379,6 +379,24 @@ class Customer < ApplicationRecord
     anrok_customer || avalara_customer
   end
 
+  def payment_connection(code = nil)
+    return payment_provider_customers.by_code(code).first if code.present?
+
+    payment_provider_customers.find_by(is_default: true)
+  end
+
+  def payment_connection_status
+    connection = payment_connection
+
+    if connection.nil?
+      PaymentProviderCustomers::BaseCustomer::CONNECTION_STATUSES[:not_connected]
+    elsif connection.manual?
+      PaymentProviderCustomers::BaseCustomer::CONNECTION_STATUSES[:manual]
+    else
+      PaymentProviderCustomers::BaseCustomer::CONNECTION_STATUSES[:connected]
+    end
+  end
+
   def address_changed?
     ADDRESS_FIELDS.any? { |field| send(:"#{field}_changed?") }
   end

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -52,19 +52,18 @@ module PaymentProviderCustomers
       get_from_settings("payment_method_id") || get_from_settings("provider_mandate_id")
     end
 
-    # A manual payment row is the reserved null-provider connection: a base-class row (no provider
-    # subclass) coded "manual".
+    # A manual payment row is the reserved null-provider connection (no payment provider) coded "manual".
     def manual?
-      instance_of?(BaseCustomer) && code == MANUAL_CODE
+      payment_provider_id.nil? && code == MANUAL_CODE
     end
 
     private
 
     # The "manual" code is reserved for the null-provider manual connection; a provider-backed
-    # connection (any subclass) cannot use it.
+    # connection cannot use it.
     def code_is_not_reserved
       return unless code == MANUAL_CODE
-      return if instance_of?(BaseCustomer)
+      return if manual?
 
       errors.add(:code, "value_is_reserved")
     end

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -11,6 +11,14 @@ module PaymentProviderCustomers
 
     self.table_name = "payment_provider_customers"
 
+    MANUAL_CODE = "manual"
+
+    CONNECTION_STATUSES = {
+      not_connected: "not_connected",
+      manual: "manual",
+      connected: "connected"
+    }.freeze
+
     belongs_to :customer
     belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
     belongs_to :organization
@@ -21,9 +29,11 @@ module PaymentProviderCustomers
 
     validates :customer_id, uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :type}
     validates :code, uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :customer_id}, allow_nil: true
+    validate :code_is_not_reserved
 
     settings_accessors :provider_mandate_id, :sync_with_provider
 
+    scope :by_code, ->(code) { where(code:) }
     scope :by_provider_id_from_organization, ->(organization_id, provider_id) do
       joins(:customer)
         .where(customers: {organization_id: organization_id})
@@ -40,6 +50,23 @@ module PaymentProviderCustomers
 
     def legacy_provider_method_id
       get_from_settings("payment_method_id") || get_from_settings("provider_mandate_id")
+    end
+
+    # A manual payment row is the reserved null-provider connection: a base-class row (no provider
+    # subclass) coded "manual".
+    def manual?
+      instance_of?(BaseCustomer) && code == MANUAL_CODE
+    end
+
+    private
+
+    # The "manual" code is reserved for the null-provider manual connection; a provider-backed
+    # connection (any subclass) cannot use it.
+    def code_is_not_reserved
+      return unless code == MANUAL_CODE
+      return if instance_of?(BaseCustomer)
+
+      errors.add(:code, "value_is_reserved")
     end
   end
 end

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -11,7 +11,7 @@ module PaymentProviderCustomers
 
     self.table_name = "payment_provider_customers"
 
-    MANUAL_CODE = "manual"
+    MANUAL_CODE = "lago_manual"
 
     CONNECTION_STATUSES = {
       not_connected: "not_connected",
@@ -52,14 +52,14 @@ module PaymentProviderCustomers
       get_from_settings("payment_method_id") || get_from_settings("provider_mandate_id")
     end
 
-    # A manual payment row is the reserved null-provider connection (no payment provider) coded "manual".
+    # A manual payment row is the reserved null-provider connection (no payment provider) coded "lago_manual".
     def manual?
       payment_provider_id.nil? && code == MANUAL_CODE
     end
 
     private
 
-    # The "manual" code is reserved for the null-provider manual connection; a provider-backed
+    # The "lago_manual" code is reserved for the null-provider manual connection; a provider-backed
     # connection cannot use it.
     def code_is_not_reserved
       return unless code == MANUAL_CODE

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1426,6 +1426,58 @@ RSpec.describe Customer do
     end
   end
 
+  describe "#payment_connection" do
+    let(:customer) { create(:customer) }
+    let!(:default_connection) { create(:stripe_customer, customer:, code: "stripe_eu", is_default: true) }
+    let!(:other_connection) { create(:gocardless_customer, customer:, code: "gc") }
+
+    it "returns the default connection when no code is given" do
+      expect(customer.payment_connection).to eq(default_connection)
+    end
+
+    it "returns the connection matching the given code" do
+      expect(customer.payment_connection("gc")).to eq(other_connection)
+    end
+
+    it "returns nil for an unknown code" do
+      expect(customer.payment_connection("unknown")).to be_nil
+    end
+  end
+
+  describe "#payment_connection_status" do
+    let(:customer) { create(:customer) }
+
+    context "when no connection is the default" do
+      it "returns not_connected" do
+        expect(customer.payment_connection_status).to eq("not_connected")
+      end
+    end
+
+    context "when the default is a provider connection" do
+      before { create(:stripe_customer, customer:, is_default: true) }
+
+      it "returns connected" do
+        expect(customer.payment_connection_status).to eq("connected")
+      end
+    end
+
+    context "when the default is the manual row" do
+      before do
+        PaymentProviderCustomers::BaseCustomer.create!(
+          customer:,
+          organization: customer.organization,
+          type: "PaymentProviderCustomers::BaseCustomer",
+          code: "manual",
+          is_default: true
+        )
+      end
+
+      it "returns manual" do
+        expect(customer.payment_connection_status).to eq("manual")
+      end
+    end
+  end
+
   describe "#address_changed?" do
     context "when a billing address field changes" do
       it "returns true" do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1467,7 +1467,7 @@ RSpec.describe Customer do
           customer:,
           organization: customer.organization,
           type: "PaymentProviderCustomers::BaseCustomer",
-          code: "manual",
+          code: "lago_manual",
           is_default: true
         )
       end

--- a/spec/models/payment_provider_customers/base_customer_spec.rb
+++ b/spec/models/payment_provider_customers/base_customer_spec.rb
@@ -11,6 +11,54 @@ RSpec.describe PaymentProviderCustomers::BaseCustomer do
     subject { create(:stripe_customer, code: "stripe_eu") }
 
     it { is_expected.to validate_uniqueness_of(:code).scoped_to(:customer_id).allow_nil }
+
+    describe "code_is_not_reserved" do
+      it "rejects a provider-backed connection using the reserved manual code" do
+        connection = create(:stripe_customer)
+        connection.code = "manual"
+
+        expect(connection).not_to be_valid
+        expect(connection.errors[:code]).to include("value_is_reserved")
+      end
+
+      it "allows a null-provider row to use the manual code" do
+        customer = create(:customer)
+        manual = described_class.new(
+          customer:,
+          organization: customer.organization,
+          type: "PaymentProviderCustomers::BaseCustomer",
+          code: "manual"
+        )
+
+        expect(manual).to be_valid
+      end
+    end
+  end
+
+  describe "scopes" do
+    describe ".by_code" do
+      it "returns connections matching the code" do
+        organization = create(:organization)
+        matching = create(:stripe_customer, customer: create(:customer, organization:), code: "stripe_eu")
+        create(:stripe_customer, customer: create(:customer, organization:), code: "other")
+
+        expect(described_class.by_code("stripe_eu")).to eq([matching])
+      end
+    end
+  end
+
+  describe "#manual?" do
+    it "is true for a null-provider row coded manual" do
+      expect(described_class.new(payment_provider_id: nil, code: "manual").manual?).to be(true)
+    end
+
+    it "is false for a provider-backed connection" do
+      expect(build(:stripe_customer).manual?).to be(false)
+    end
+
+    it "is false for a null-provider row with a different code" do
+      expect(described_class.new(payment_provider_id: nil, code: "other").manual?).to be(false)
+    end
   end
 
   describe "#legacy_provider_method_id" do

--- a/spec/models/payment_provider_customers/base_customer_spec.rb
+++ b/spec/models/payment_provider_customers/base_customer_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe PaymentProviderCustomers::BaseCustomer do
 
     describe "code_is_not_reserved" do
       it "rejects a provider-backed connection using the reserved manual code" do
-        connection = create(:stripe_customer)
+        customer = create(:customer)
+        provider = create(:stripe_provider, organization: customer.organization)
+        connection = create(:stripe_customer, customer:, organization: customer.organization, payment_provider: provider)
         connection.code = "manual"
 
         expect(connection).not_to be_valid
@@ -52,8 +54,8 @@ RSpec.describe PaymentProviderCustomers::BaseCustomer do
       expect(described_class.new(payment_provider_id: nil, code: "manual").manual?).to be(true)
     end
 
-    it "is false for a provider-backed connection" do
-      expect(build(:stripe_customer).manual?).to be(false)
+    it "is false for a provider-backed connection coded manual" do
+      expect(described_class.new(payment_provider_id: SecureRandom.uuid, code: "manual").manual?).to be(false)
     end
 
     it "is false for a null-provider row with a different code" do

--- a/spec/models/payment_provider_customers/base_customer_spec.rb
+++ b/spec/models/payment_provider_customers/base_customer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PaymentProviderCustomers::BaseCustomer do
         customer = create(:customer)
         provider = create(:stripe_provider, organization: customer.organization)
         connection = create(:stripe_customer, customer:, organization: customer.organization, payment_provider: provider)
-        connection.code = "manual"
+        connection.code = "lago_manual"
 
         expect(connection).not_to be_valid
         expect(connection.errors[:code]).to include("value_is_reserved")
@@ -29,7 +29,7 @@ RSpec.describe PaymentProviderCustomers::BaseCustomer do
           customer:,
           organization: customer.organization,
           type: "PaymentProviderCustomers::BaseCustomer",
-          code: "manual"
+          code: "lago_manual"
         )
 
         expect(manual).to be_valid
@@ -51,11 +51,11 @@ RSpec.describe PaymentProviderCustomers::BaseCustomer do
 
   describe "#manual?" do
     it "is true for a null-provider row coded manual" do
-      expect(described_class.new(payment_provider_id: nil, code: "manual").manual?).to be(true)
+      expect(described_class.new(payment_provider_id: nil, code: "lago_manual").manual?).to be(true)
     end
 
     it "is false for a provider-backed connection coded manual" do
-      expect(described_class.new(payment_provider_id: SecureRandom.uuid, code: "manual").manual?).to be(false)
+      expect(described_class.new(payment_provider_id: SecureRandom.uuid, code: "lago_manual").manual?).to be(false)
     end
 
     it "is false for a null-provider row with a different code" do


### PR DESCRIPTION
## Context

The multiple-connections work needs the payment provider customer model to understand connection codes and a reserved manual (null-provider) connection, plus customer-level helpers to resolve the active payment connection and report its status. The schema (code, is_default) and its indexes are already in place; this adds the model behaviour on top.

## Description

On PaymentProviderCustomers::BaseCustomer, add a by_code scope, a manual? predicate identifying the reserved base-class row coded "manual", and a validation rejecting the reserved manual code on any provider-backed connection. Expose MANUAL_CODE and CONNECTION_STATUSES constants.

On Customer, add payment_connection, which resolves a connection by code and otherwise falls back to the default connection, and payment_connection_status, returning not_connected, manual or connected based on the default connection.
