### PR TITLE
[LAGO-1326] feat(orders): add the execute REST endpoint

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -37,6 +37,24 @@ module Api
         render_order(order)
       end
 
+      def execute
+        order = current_organization.orders.find_by(id: params[:id])
+        return not_found_error(resource: "order") unless order
+
+        update_result = update_execution_mode(order)
+        return render_error_response(update_result) if update_result&.failure?
+
+        result = ::Orders::ExecuteService.call(order:)
+
+        if result.success?
+          render_order(result.order)
+        else
+          render_error_response(result)
+        end
+      rescue BaseLockService::FailedToAcquireLock
+        lock_acquisition_error(code: "lock_acquisition_failed")
+      end
+
       private
 
       def ensure_feature_flag!
@@ -56,6 +74,20 @@ module Api
           executed_at_from: params[:executed_at_from],
           executed_at_to: params[:executed_at_to]
         }
+      end
+
+      # execution_mode is normally chosen when the order form is signed. REST has no order update
+      # endpoint, so restating it here is the only way to set or change it. Skipping the update
+      # when the value is unchanged keeps a retry of a failed order from tripping not_editable.
+      def update_execution_mode(order)
+        execution_mode = execute_params[:execution_mode]
+        return if execution_mode.blank? || order.execution_mode == execution_mode
+
+        ::Orders::UpdateService.call(order:, params: {execution_mode:})
+      end
+
+      def execute_params
+        params.permit(order: [:execution_mode]).fetch(:order, {})
       end
 
       def render_order(order)

--- a/app/services/orders/one_off/execute_service.rb
+++ b/app/services/orders/one_off/execute_service.rb
@@ -19,10 +19,14 @@ module Orders
         ).invoice
       end
 
+      # Both add-on identifiers are sent because the billing services pick the one matching the
+      # source that triggered the execution: the code under api, the id otherwise. An execution
+      # replays the same snapshot whichever transport started it.
       def build_fees
         add_on_items.map do |item|
           {
             add_on_id: item["id"],
+            add_on_code: item.dig("payload", "code"),
             units: effective_value(item, "units"),
             unit_amount_cents: effective_value(item, "unitAmountCents"),
             invoice_display_name: effective_value(item, "invoiceDisplayName"),

--- a/app/services/orders/subscription_amendment/execute_service.rb
+++ b/app/services/orders/subscription_amendment/execute_service.rb
@@ -46,6 +46,8 @@ module Orders
           # on it instead of creating a second subscription.
           subscription_id: target_subscription.id,
           external_id: target_subscription.external_id,
+          # Mandatory under the api source, see Orders::SubscriptionCreation::ExecuteService.
+          external_customer_id: order.customer.external_id,
           # CreateService strips this to a string, so the target's own name only survives when it is
           # passed back.
           name: payload["subscriptionName"].presence || target_subscription.name,

--- a/app/services/orders/subscription_creation/execute_service.rb
+++ b/app/services/orders/subscription_creation/execute_service.rb
@@ -55,6 +55,9 @@ module Orders
           # id. NOTE: localId is optional on plan items, so an item carrying neither mints a new
           # external id on every attempt.
           external_id: payload["subscriptionExternalId"].presence || item["localId"].presence || SecureRandom.uuid,
+          # Mandatory under the api source, where the customer is normally identified by it rather
+          # than passed. Inert otherwise, but the customer here is always the order's own.
+          external_customer_id: order.customer.external_id,
           name: payload["subscriptionName"],
           billing_time: payload["billingTime"],
           subscription_at: subscription_datetime(payload["startDate"], quote_version.start_date),
@@ -261,6 +264,9 @@ module Orders
 
         {
           fee_types: applies_to["feeTypes"].presence,
+          # Wallets::CreateService reads the codes under the api source and the ids otherwise, so
+          # the limitation must be stated both ways for the execution to be transport independent.
+          billable_metric_codes: applies_to["billableMetricCodes"].presence,
           billable_metric_ids: billable_metric_ids!(applies_to["billableMetricCodes"])
         }.compact.presence
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,7 +162,9 @@ Rails.application.routes.draw do
         post :clone, on: :member
       end
 
-      resources :orders, only: %i[show index]
+      resources :orders, only: %i[show index] do
+        post :execute, on: :member
+      end
       resources :payments, only: %i[create index show]
       resources :plans, param: :code, code: /.*/ do
         resources :charges, only: %i[index show create update destroy], param: :code, code: /.*/, controller: "plans/charges" do

--- a/spec/requests/api/v1/orders_controller_spec.rb
+++ b/spec/requests/api/v1/orders_controller_spec.rb
@@ -99,4 +99,177 @@ RSpec.describe Api::V1::OrdersController do
       end
     end
   end
+
+  describe "POST /api/v1/orders/:id/execute" do
+    subject { post_with_token(organization, "/api/v1/orders/#{order.id}/execute", params) }
+
+    let(:params) { {} }
+    let(:customer) { create(:customer, organization:, currency: "EUR") }
+    let(:quote) { create(:quote, organization:, customer:, order_type: :one_off) }
+    let(:quote_version) do
+      create(:quote_version, :approved, :with_one_off_billing_items, quote:, organization:)
+    end
+    let(:order_form) { create(:order_form, :signed, organization:, customer:, quote_version:) }
+    let(:order) { create(:order, organization:, customer:, order_form:, execution_mode:) }
+    let(:execution_mode) { :order_only }
+
+    before { order }
+
+    include_examples "requires API permission", "order", "write"
+
+    it "executes the order", :premium do
+      subject
+
+      expect(response).to have_http_status(:ok)
+      expect(json[:order][:lago_id]).to eq(order.id)
+      expect(json[:order][:status]).to eq("executed")
+      expect(json[:order][:executed_at]).to be_present
+      expect(json[:order][:execution_record][:execution_mode]).to eq("order_only")
+    end
+
+    context "with the execute_in_lago mode", :premium do
+      let(:execution_mode) { :execute_in_lago }
+
+      it "bills the order and returns the invoice it created" do
+        expect { subject }.to change(Invoice, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:order][:status]).to eq("executed")
+        expect(json[:order][:execution_record][:invoice_id]).to eq(customer.invoices.sole.id)
+      end
+    end
+
+    context "when the order has already been executed", :premium do
+      let(:order) { create(:order, :executed_order_only, organization:, customer:, order_form:) }
+
+      it "returns the order untouched" do
+        executed_at = order.executed_at
+
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:order][:status]).to eq("executed")
+        expect(order.reload.executed_at).to eq(executed_at)
+      end
+    end
+
+    context "when a previous execution failed", :premium do
+      let(:order) { create(:order, :failed, organization:, customer:, order_form:, execution_mode: :order_only) }
+
+      it "executes the order again" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:order][:status]).to eq("executed")
+        expect(json[:order][:execution_record][:errors]).to eq([])
+      end
+    end
+
+    context "when the order carries no execution mode", :premium do
+      let(:execution_mode) { nil }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:execution_mode)
+      end
+
+      context "when an execution mode is provided" do
+        let(:params) { {order: {execution_mode: "order_only"}} }
+
+        it "executes the order with that mode" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          expect(json[:order][:status]).to eq("executed")
+          expect(order.reload.execution_mode).to eq("order_only")
+        end
+      end
+    end
+
+    context "when the provided execution mode is invalid", :premium do
+      let(:params) { {order: {execution_mode: "whenever"}} }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:execution_mode)
+      end
+    end
+
+    context "when the provided execution mode changes an executed order", :premium do
+      let(:order) { create(:order, :executed_order_only, organization:, customer:, order_form:) }
+      let(:params) { {order: {execution_mode: "execute_in_lago"}} }
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to include(:status)
+      end
+    end
+
+    context "when the execution fails", :premium do
+      let(:execution_mode) { :execute_in_lago }
+
+      let(:failed_result) do
+        Invoices::CreateOneOffService::Result.new.tap do |failed|
+          failed.single_validation_failure!(field: :currency, error_code: "currencies_does_not_match")
+        end
+      end
+
+      before { allow(Invoices::CreateOneOffService).to receive(:call!).and_raise(failed_result.error) }
+
+      it "surfaces the error and marks the order failed" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:error_details]).to eq({currency: ["currencies_does_not_match"]})
+        expect(order.reload.failed?).to eq(true)
+      end
+    end
+
+    context "when the execution lock cannot be acquired", :premium do
+      before { allow(Orders::ExecuteService).to receive(:call).and_raise(BaseLockService::FailedToAcquireLock) }
+
+      it "returns a lock acquisition error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json[:code]).to eq("lock_acquisition_failed")
+      end
+    end
+
+    context "when order does not exist", :premium do
+      subject { post_with_token(organization, "/api/v1/orders/#{SecureRandom.uuid}/execute") }
+
+      it "returns not found" do
+        subject
+
+        expect(response).to be_not_found_error("order")
+      end
+    end
+
+    context "without a premium license" do
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+
+    context "when the order_forms feature flag is disabled", :premium do
+      let(:organization) { create(:organization) }
+
+      it "returns forbidden" do
+        subject
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json[:code]).to eq("feature_unavailable")
+      end
+    end
+  end
 end

--- a/spec/services/orders/one_off/execute_service_spec.rb
+++ b/spec/services/orders/one_off/execute_service_spec.rb
@@ -132,6 +132,18 @@ RSpec.describe Orders::OneOff::ExecuteService do
         end
       end
 
+      context "when triggered under the api source" do
+        before { CurrentContext.source = "api" }
+
+        it "bills the same add-on" do
+          result = nil
+          expect { result = execute_service.call }.to change(Invoice, :count).by(1)
+
+          expect(result).to be_success
+          expect(customer.invoices.sole.fees.sole.add_on_id).to eq(add_on.id)
+        end
+      end
+
       context "when the invoice creation fails" do
         let(:failed_result) do
           Invoices::CreateOneOffService::Result.new.tap do |failed|

--- a/spec/services/orders/subscription_amendment/execute_service_spec.rb
+++ b/spec/services/orders/subscription_amendment/execute_service_spec.rb
@@ -154,6 +154,17 @@ RSpec.describe Orders::SubscriptionAmendment::ExecuteService, :premium do
 
       # A replacement sharing the target's plan id would make ActivateService take its standalone
       # branch, leaving the target active.
+      context "when triggered under the api source" do
+        before { CurrentContext.source = "api" }
+
+        it "amends the same subscription" do
+          expect { execute_service.call }.to change(Subscription, :count).by(1)
+
+          expect(target_subscription.reload).to be_terminated
+          expect(customer.subscriptions.active.sole.external_id).to eq("sub_ext_42")
+        end
+      end
+
       context "without overrides" do
         let(:plan_overrides) { nil }
 

--- a/spec/services/orders/subscription_creation/execute_service_spec.rb
+++ b/spec/services/orders/subscription_creation/execute_service_spec.rb
@@ -109,6 +109,20 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
         expect(overridden_plan.charges.sole.properties["amount"]).to eq("30")
       end
 
+      # The transports that trigger an execution set different sources, and the billing services
+      # resolve their input by code under api and by id otherwise. The snapshot must replay the
+      # same either way.
+      context "when triggered under the api source" do
+        before { CurrentContext.source = "api" }
+
+        it "creates the same subscription" do
+          expect { execute_service.call }.to change(Subscription, :count).by(1)
+
+          expect(customer.subscriptions.sole.external_id).to eq("sub_ext_42")
+          expect(order.reload.executed?).to eq(true)
+        end
+      end
+
       context "without overrides" do
         let(:plan_overrides) { nil }
 
@@ -521,6 +535,18 @@ RSpec.describe Orders::SubscriptionCreation::ExecuteService, :premium do
 
           order.reload
           expect(order.execution_record["wallet_ids"]).to eq([wallet.id])
+        end
+
+        context "when triggered under the api source" do
+          before { CurrentContext.source = "api" }
+
+          it "creates the same wallet and limitation" do
+            expect { execute_service.call }.to change(Wallet, :count).by(1)
+
+            wallet = customer.wallets.sole
+            expect(wallet.allowed_fee_types).to eq(["charge"])
+            expect(wallet.billable_metrics).to eq([billable_metric])
+          end
         end
 
         context "with a recurring rule" do


### PR DESCRIPTION
## Why

Order execution was reachable from the `executeOrder` mutation and the hourly clock job only, so an API-only integration could sign an order form and then had no way to execute the resulting order. Closes LAGO-1326 (its `order.executed` webhook half ships in #6134).

## What

`POST /api/v1/orders/:id/execute`, synchronous like the mutation so the response carries the final status and any execution error. `execution_mode` is optional in the body and only persisted when it differs from the stored value, so retrying a failed order does not trip `not_editable`. Re-executing stays idempotent, as `Orders::BaseExecuteService` already is.