### PR TITLE
perf(invoices): cap the graphql invoice list count

### DIFF
--- a/app/graphql/mutations/invoices/finalize_all.rb
+++ b/app/graphql/mutations/invoices/finalize_all.rb
@@ -11,7 +11,7 @@ module Mutations
       graphql_name "FinalizeAllInvoices"
       description "Finalize all draft invoices"
 
-      type Types::Invoices::Object.collection_type
+      type Types::Invoices::Object.collection_type(metadata_type: Types::Invoices::CollectionMetadata)
 
       def resolve
         result = ::Invoices::FinalizeBatchService.new(organization: current_organization).call_async

--- a/app/graphql/mutations/invoices/retry_all.rb
+++ b/app/graphql/mutations/invoices/retry_all.rb
@@ -11,7 +11,7 @@ module Mutations
       graphql_name "RetryAllInvoices"
       description "Retry all failed invoices"
 
-      type Types::Invoices::Object.collection_type
+      type Types::Invoices::Object.collection_type(metadata_type: Types::Invoices::CollectionMetadata)
 
       def resolve
         result = ::Invoices::RetryBatchService.new(organization: current_organization).call_async

--- a/app/graphql/mutations/invoices/retry_all_payments.rb
+++ b/app/graphql/mutations/invoices/retry_all_payments.rb
@@ -11,7 +11,7 @@ module Mutations
       graphql_name "RetryAllInvoicePayments"
       description "Retry all invoice payments"
 
-      type Types::Invoices::Object.collection_type
+      type Types::Invoices::Object.collection_type(metadata_type: Types::Invoices::CollectionMetadata)
 
       def resolve
         result = ::Invoices::Payments::RetryBatchService.new(organization_id: current_organization.id).call_async

--- a/app/graphql/resolvers/customer_portal/invoices_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/invoices_resolver.rb
@@ -12,7 +12,7 @@ module Resolvers
       argument :search_term, String, required: false
       argument :status, [Types::Invoices::StatusTypeEnum], required: false
 
-      type Types::Invoices::Object.collection_type, null: false
+      type Types::Invoices::Object.collection_type(metadata_type: Types::Invoices::CollectionMetadata), null: false
 
       def resolve(status: nil, page: nil, limit: nil, search_term: nil)
         result = InvoicesQuery.call(

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -18,7 +18,7 @@ module Resolvers
       argument :search_term, String, required: false
       argument :status, [Types::Invoices::StatusTypeEnum], required: false
 
-      type Types::Invoices::Object.collection_type, null: false
+      type Types::Invoices::Object.collection_type(metadata_type: Types::Invoices::CollectionMetadata), null: false
 
       def resolve(customer_id: nil, status: nil, page: nil, limit: nil, search_term: nil, currency: nil, billing_entity_ids: nil)
         result = InvoicesQuery.call(

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -32,7 +32,7 @@ module Resolvers
     argument :status, [Types::Invoices::StatusTypeEnum], required: false
     argument :subscription_id, ID, required: false
 
-    type Types::Invoices::Object.collection_type, null: false
+    type Types::Invoices::Object.collection_type(metadata_type: Types::Invoices::CollectionMetadata), null: false
 
     def resolve( # rubocop:disable Metrics/ParameterLists
       amount_from: nil,
@@ -89,6 +89,7 @@ module Resolvers
       return result_error(result) unless result.success?
 
       invoices = result.invoices
+      invoices = invoices.without_count.extend(BaseQuery::CappedTotalCount) if capped_count?(invoices)
 
       ActiveRecord::Associations::Preloader.new(
         records: invoices.to_a,
@@ -103,6 +104,15 @@ module Resolvers
       ).call
 
       Invoice.preload_offset_amounts(invoices)
+    end
+
+    private
+
+    # Meilisearch returns a paginated array, which has no `without_count`. An organization
+    # can have both feature flags enabled, so the flag alone is not enough to tell them apart.
+    def capped_count?(invoices)
+      invoices.respond_to?(:without_count) &&
+        current_organization.feature_flag_enabled?(:invoice_search_terms)
     end
   end
 end

--- a/app/graphql/types/invoices/collection_metadata.rb
+++ b/app/graphql/types/invoices/collection_metadata.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  module Invoices
+    class CollectionMetadata < GraphqlPagination::CollectionMetadataType
+      graphql_name "InvoiceCollectionMetadata"
+      description "Pagination metadata for a collection of invoices"
+
+      field :has_next_page, Boolean, null: false,
+        description: "True when another page follows, even when `totalCount` is capped"
+      field :total_count_capped, Boolean, null: false,
+        description: "True when `totalCount` hit the counting limit and is a lower bound, not the exact total"
+
+      def has_next_page
+        return object.has_next_page? if object.respond_to?(:has_next_page?)
+
+        object.current_page < object.total_pages
+      end
+
+      def total_count_capped
+        object.respond_to?(:capped_total_count?) && object.capped_total_count?
+      end
+    end
+  end
+end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -9,17 +9,15 @@ class BaseQuery < BaseService
   Pagination = Struct.new(:page, :limit, keyword_init: true)
   Filters = BaseFilters
 
-  # Highest number of records the pagination will count. Beyond it, the total is
-  # reported as MAX_COUNTED_RECORDS and callers must treat it as "at least that many".
-  MAX_COUNTED_RECORDS = 10_000
-
   # Restores a capped `total_count` on a `without_count` relation, so that pagination
   # metadata keeps working without counting every matching row.
   module CappedTotalCount
+    # Highest number of records the pagination will report. Beyond it, the total is
+    # MAX_COUNTED_RECORDS and callers must treat it as "at least that many".
+    MAX_COUNTED_RECORDS = 10_000
+
     def total_count(*)
-      @capped_total_count ||= except(:offset, :limit, :order, :includes, :preload, :eager_load)
-        .limit(MAX_COUNTED_RECORDS)
-        .count
+      [counted_records, MAX_COUNTED_RECORDS].min
     end
 
     def total_pages
@@ -27,7 +25,7 @@ class BaseQuery < BaseService
     end
 
     def capped_total_count?
-      total_count == MAX_COUNTED_RECORDS
+      counted_records > MAX_COUNTED_RECORDS
     end
 
     # Exact even beyond the cap: `without_count` fetches one extra record to know
@@ -35,6 +33,16 @@ class BaseQuery < BaseService
     # `last_page?` is false for an out of range page, hence the two conditions.
     def has_next_page?
       !out_of_range? && !last_page?
+    end
+
+    private
+
+    # Counts one past the cap, so that a result set landing exactly on it is reported
+    # as an exact total rather than as a lower bound.
+    def counted_records
+      @counted_records ||= except(:offset, :limit, :order, :includes, :preload, :eager_load)
+        .limit(MAX_COUNTED_RECORDS + 1)
+        .count
     end
   end
 

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -9,6 +9,35 @@ class BaseQuery < BaseService
   Pagination = Struct.new(:page, :limit, keyword_init: true)
   Filters = BaseFilters
 
+  # Highest number of records the pagination will count. Beyond it, the total is
+  # reported as MAX_COUNTED_RECORDS and callers must treat it as "at least that many".
+  MAX_COUNTED_RECORDS = 10_000
+
+  # Restores a capped `total_count` on a `without_count` relation, so that pagination
+  # metadata keeps working without counting every matching row.
+  module CappedTotalCount
+    def total_count(*)
+      @capped_total_count ||= except(:offset, :limit, :order, :includes, :preload, :eager_load)
+        .limit(MAX_COUNTED_RECORDS)
+        .count
+    end
+
+    def total_pages
+      (total_count.to_f / limit_value).ceil
+    end
+
+    def capped_total_count?
+      total_count == MAX_COUNTED_RECORDS
+    end
+
+    # Exact even beyond the cap: `without_count` fetches one extra record to know
+    # whether a next page exists, so navigation is not bounded by the capped total.
+    # `last_page?` is false for an out of range page, hence the two conditions.
+    def has_next_page?
+      !out_of_range? && !last_page?
+    end
+  end
+
   def initialize(organization:, pagination: DEFAULT_PAGINATION_PARAMS, filters: {}, search_term: nil, order: nil)
     @organization = organization
     @pagination_params = pagination

--- a/schema.graphql
+++ b/schema.graphql
@@ -7313,7 +7313,42 @@ type InvoiceCollection {
   """
   Pagination Metadata for navigating the Pagination
   """
-  metadata: CollectionMetadata!
+  metadata: InvoiceCollectionMetadata!
+}
+
+"""
+Pagination metadata for a collection of invoices
+"""
+type InvoiceCollectionMetadata {
+  """
+  Current Page of loaded data
+  """
+  currentPage: Int!
+
+  """
+  True when another page follows, even when `totalCount` is capped
+  """
+  hasNextPage: Boolean!
+
+  """
+  The number of items per page
+  """
+  limitValue: Int!
+
+  """
+  The total number of items to be paginated
+  """
+  totalCount: Int!
+
+  """
+  True when `totalCount` hit the counting limit and is a lower bound, not the exact total
+  """
+  totalCountCapped: Boolean!
+
+  """
+  The total number of pages in the pagination
+  """
+  totalPages: Int!
 }
 
 type InvoiceCustomSection {

--- a/schema.json
+++ b/schema.json
@@ -38346,7 +38346,114 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "CollectionMetadata",
+                  "name": "InvoiceCollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InvoiceCollectionMetadata",
+          "description": "Pagination metadata for a collection of invoices",
+          "fields": [
+            {
+              "name": "currentPage",
+              "description": "Current Page of loaded data",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasNextPage",
+              "description": "True when another page follows, even when `totalCount` is capped",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "limitValue",
+              "description": "The number of items per page",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The total number of items to be paginated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCountCapped",
+              "description": "True when `totalCount` hit the counting limit and is a lower bound, not the exact total",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalPages",
+              "description": "The total number of pages in the pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 }
               },

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -834,4 +834,101 @@ RSpec.describe Resolvers::InvoicesResolver do
       expect(result["data"]["invoices"]["collection"].count).to eq(2)
     end
   end
+
+  describe "total count" do
+    let(:page) { 1 }
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(page: #{page}, limit: 1) {
+            collection { id }
+            metadata { currentPage totalCount totalPages totalCountCapped hasNextPage }
+          }
+        }
+      GQL
+    end
+
+    let(:metadata) do
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )["data"]["invoices"]["metadata"]
+    end
+
+    it "returns the exact total" do
+      expect(metadata).to eq(
+        "currentPage" => 1,
+        "totalCount" => 2,
+        "totalPages" => 2,
+        "totalCountCapped" => false,
+        "hasNextPage" => true
+      )
+    end
+
+    context "when the organization reads from search terms" do
+      before do
+        stub_const("BaseQuery::MAX_COUNTED_RECORDS", 1)
+        organization.enable_feature_flag!(:invoice_search_terms)
+      end
+
+      it "caps the total and keeps advertising the next page" do
+        expect(metadata).to eq(
+          "currentPage" => 1,
+          "totalCount" => 1,
+          "totalPages" => 1,
+          "totalCountCapped" => true,
+          "hasNextPage" => true
+        )
+      end
+
+      context "when on the last page" do
+        let(:page) { 2 }
+
+        it "reports no next page" do
+          expect(metadata).to include("totalCountCapped" => true, "hasNextPage" => false)
+        end
+      end
+
+      context "when past the last page" do
+        let(:page) { 3 }
+
+        it "reports no next page" do
+          expect(metadata).to include("hasNextPage" => false)
+        end
+      end
+
+      context "when the search is delegated to Meilisearch" do
+        let(:query) do
+          <<~GQL
+            query {
+              invoices(page: 1, limit: 1, searchTerm: "Acme") {
+                collection { id }
+                metadata { totalCount totalCountCapped hasNextPage }
+              }
+            }
+          GQL
+        end
+
+        before do
+          organization.enable_feature_flag!(:meilisearch)
+          stub_const(
+            "ENV",
+            ENV.to_h.merge("LAGO_MEILISEARCH_URL" => "http://meilisearch:7700", "LAGO_MEILISEARCH_SEARCH_ENABLED" => "true")
+          )
+          allow(Invoice).to receive(:search)
+            .and_return(Kaminari.paginate_array([invoice_first], total_count: 42).page(1).per(1))
+        end
+
+        it "leaves the Meilisearch total untouched" do
+          expect(metadata).to eq(
+            "totalCount" => 42,
+            "totalCountCapped" => false,
+            "hasNextPage" => true
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -869,7 +869,7 @@ RSpec.describe Resolvers::InvoicesResolver do
 
     context "when the organization reads from search terms" do
       before do
-        stub_const("BaseQuery::MAX_COUNTED_RECORDS", 1)
+        stub_const("BaseQuery::CappedTotalCount::MAX_COUNTED_RECORDS", 1)
         organization.enable_feature_flag!(:invoice_search_terms)
       end
 
@@ -888,6 +888,20 @@ RSpec.describe Resolvers::InvoicesResolver do
 
         it "reports no next page" do
           expect(metadata).to include("totalCountCapped" => true, "hasNextPage" => false)
+        end
+      end
+
+      context "when the results land exactly on the limit" do
+        before { stub_const("BaseQuery::CappedTotalCount::MAX_COUNTED_RECORDS", 2) }
+
+        it "reports the total as exact" do
+          expect(metadata).to eq(
+            "currentPage" => 1,
+            "totalCount" => 2,
+            "totalPages" => 2,
+            "totalCountCapped" => false,
+            "hasNextPage" => true
+          )
         end
       end
 

--- a/spec/graphql/types/invoices/collection_metadata_spec.rb
+++ b/spec/graphql/types/invoices/collection_metadata_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Invoices::CollectionMetadata do
+  subject { described_class }
+
+  it do
+    expect(subject.graphql_name).to eq("InvoiceCollectionMetadata")
+    expect(subject).to have_field(:current_page).of_type("Int!")
+    expect(subject).to have_field(:has_next_page).of_type("Boolean!")
+    expect(subject).to have_field(:limit_value).of_type("Int!")
+    expect(subject).to have_field(:total_count).of_type("Int!")
+    expect(subject).to have_field(:total_count_capped).of_type("Boolean!")
+    expect(subject).to have_field(:total_pages).of_type("Int!")
+  end
+end

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -463,7 +463,7 @@ RSpec.describe Api::V1::InvoicesController do
 
     context "when the organization reads from search terms" do
       before do
-        stub_const("BaseQuery::MAX_COUNTED_RECORDS", 1)
+        stub_const("BaseQuery::CappedTotalCount::MAX_COUNTED_RECORDS", 1)
         organization.enable_feature_flag!(:invoice_search_terms)
         create(:invoice, customer:, organization:)
         create(:invoice, customer:, organization:)

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -461,6 +461,23 @@ RSpec.describe Api::V1::InvoicesController do
       end
     end
 
+    context "when the organization reads from search terms" do
+      before do
+        stub_const("BaseQuery::MAX_COUNTED_RECORDS", 1)
+        organization.enable_feature_flag!(:invoice_search_terms)
+        create(:invoice, customer:, organization:)
+        create(:invoice, customer:, organization:)
+      end
+
+      it "still returns the exact total count" do
+        get_with_token(organization, "/api/v1/invoices", page: 1, per_page: 1)
+
+        expect(response).to have_http_status(:success)
+        expect(json[:meta][:total_count]).to eq(2)
+        expect(json[:meta]).not_to have_key(:total_count_capped)
+      end
+    end
+
     context "with unknown params" do
       before do
         allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)


### PR DESCRIPTION
With the rows query fast, the pagination `COUNT` is what is left: ~16s on a 12M-invoice organization, because counting every match means finding every match, and a lossy trigram index has to visit the heap to verify each one.

The GraphQL invoice list now uses Kaminari `without_count` plus a count capped at 10,000, behind the existing per-organization `invoice_search_terms` flag. On 12M invoices, a term matching every row goes from 123s to 21ms.

The collection metadata gains two fields: `totalCountCapped`, for the frontend to render "10,000+" rather than a flat "10,000", and `hasNextPage`, which stays exact because `without_count` fetches one extra row, so paging continues past the cap. A result set landing exactly on the cap is reported as exact, since the count goes one past it.

REST keeps the exact count: integrations page it to completion, and it is already cached for 30 minutes per organization and filter set there.

Frontend PR: https://github.com/getlago/lago-front/pull/4148