### PR TITLE
fix(billing): avoid overlaping on anniversary charges periods

### DIFF
--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -60,22 +60,19 @@ module Subscriptions
           return from_date.end_of_quarter
         end
 
-        year = from_date.year
-        month = from_date.month + 3
-        day = subscription_at.day - 1
+        next_anniversary(from_date) - 1.day
+      end
 
-        if month > 12
-          month = (month % 12).zero? ? 12 : (month % 12)
-          year += 1
-        end
+      # `compute_to_date` is the day before this, so an anniversary always opens a period and never
+      # also closes the previous one.
+      def next_anniversary(from_date)
+        next_period_month = from_date.to_date >> 3
 
-        date = build_date(year, month, day)
-
-        # NOTE: if subscription anniversary day is higher than the current last day of the month,
-        #       subscription period, will end on the previous end of day
-        return date - 1.day if last_day_of_month?(date) && subscription_at.day > date.day
-
-        date
+        build_date(
+          next_period_month.year,
+          next_period_month.month,
+          anniversary_day_in(next_period_month.year, next_period_month.month)
+        )
       end
 
       def compute_next_end_of_period
@@ -108,14 +105,6 @@ module Subscriptions
         year = nil
         month = nil
 
-        # NOTE: if subscription anniversary day is higher than the current last day of the month,
-        #       anniversary day is on the current day
-        day = if subscription.anniversary? && last_day_of_month?(date) && (date.day < subscription_at.day)
-          date.day
-        else
-          subscription_at.day
-        end
-
         billing_months = [
           (subscription_at.month % 12).zero? ? 12 : (subscription_at.month % 12),
           ((subscription_at.month + 3) % 12).zero? ? 12 : ((subscription_at.month + 3) % 12),
@@ -125,38 +114,40 @@ module Subscriptions
 
         # This is the case when we terminate subscription on On February 10 but anniversary date is on
         # 5 of March. In that case we need to fetch billing period in previous year
-        if should_find_billing_date_in_previous_year?(date, billing_months, day)
+        if should_find_billing_date_in_previous_year?(date, billing_months)
           year = date.year - 1
           month = billing_months[3]
-          day = Time.days_in_month(month, year) if last_day_of_month?(subscription_at)
         # In case of termination that is in the middle of the year, previous period anniversary date has to be returned
-        elsif should_find_previous_billing_date?(date, billing_months, day)
+        elsif should_find_previous_billing_date?(date, billing_months)
           year = date.year
-          month = billing_months.reverse.find { |m| m < date.month }
-          day = Time.days_in_month(month, year) if last_day_of_month?(subscription_at)
+          month = billing_months.rfind { |m| m < date.month }
         else
           year = date.year
           month = date.month
         end
 
-        build_date(year, month, day)
+        build_date(year, month, anniversary_day_in(year, month))
       end
 
-      def should_find_billing_date_in_previous_year?(date, billing_months, day)
+      def anniversary_day_in(year, month)
+        [subscription_at.day, Time.days_in_month(month, year)].min
+      end
+
+      def should_find_billing_date_in_previous_year?(date, billing_months)
         return true if date.month < billing_months[0]
 
-        (date.month == billing_months[0]) && should_find_previous_billing_date?(date, billing_months, day)
+        (date.month == billing_months[0]) && should_find_previous_billing_date?(date, billing_months)
       end
 
-      def should_find_previous_billing_date?(date, billing_months, day)
-        return false if last_day_of_month?(date) && last_day_of_month?(subscription_at)
-
-        return true if date.day < day && terminated_pay_in_arrears?
-        return true if (date.day + 1) < day && last_day_of_month?(subscription_at)
-        return true if date.day < day && !last_day_of_month?(subscription_at)
+      def should_find_previous_billing_date?(date, billing_months)
+        # NOTE: checked first. A non-billing month always resolves to an earlier billing month, and
+        #       falling through to the same-month branch below would instead walk the period forward
+        #       one month at a time.
         return true if billing_months.exclude?(date.month)
 
-        false
+        anniversary_day = anniversary_day_in(date.year, date.month)
+
+        date.day < anniversary_day
       end
     end
   end

--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -117,10 +117,6 @@ module Subscriptions
         build_date(year, month, anniversary_day_in(year, month))
       end
 
-      def anniversary_day_in(year, month)
-        [subscription_at.day, Time.days_in_month(month, year)].min
-      end
-
       def should_find_billing_date_in_previous_year?(date, billing_months)
         return true if date.month < billing_months[0]
 

--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -75,24 +75,12 @@ module Subscriptions
         )
       end
 
+      # NOTE: the period is resolved from its own anniversary, not from `billing_date.month`, which is
+      #       not necessarily a billing month and would advance the period one month at a time.
       def compute_next_end_of_period
         return billing_date.end_of_quarter if calendar?
 
-        year = billing_date.year
-        month = billing_date.month
-        day = subscription_at.day
-
-        # NOTE: we need the last day of the period, and not the first of the next one
-        result_date = build_date(year, month, day) - 1.day
-        return result_date if result_date >= billing_date
-
-        month += 3
-        if month > 12
-          month = (month % 12).zero? ? 12 : (month % 12)
-          year += 1
-        end
-
-        build_date(year, month, day) - 1.day
+        compute_to_date(previous_anniversary_day(billing_date))
       end
 
       def compute_previous_beginning_of_period(date)

--- a/app/services/subscriptions/dates/semiannual_service.rb
+++ b/app/services/subscriptions/dates/semiannual_service.rb
@@ -153,24 +153,12 @@ module Subscriptions
         )
       end
 
+      # NOTE: the period is resolved from its own anniversary, not from `billing_date.month`, which is
+      #       not necessarily a billing month and would advance the period one month at a time.
       def compute_next_end_of_period
         return billing_date.end_of_half_year if calendar?
 
-        year = billing_date.year
-        month = billing_date.month
-        day = subscription_at.day
-
-        # NOTE: we need the last day of the period, and not the first of the next one
-        result_date = build_date(year, month, day) - 1.day
-        return result_date if result_date >= billing_date
-
-        month += 6
-        if month > 12
-          month = (month % 12).zero? ? 12 : (month % 12)
-          year += 1
-        end
-
-        build_date(year, month, day) - 1.day
+        compute_to_date(previous_anniversary_day(billing_date))
       end
 
       def compute_previous_beginning_of_period(date)

--- a/app/services/subscriptions/dates/semiannual_service.rb
+++ b/app/services/subscriptions/dates/semiannual_service.rb
@@ -138,22 +138,19 @@ module Subscriptions
           return from_date.end_of_half_year
         end
 
-        year = from_date.year
-        month = from_date.month + 6
-        day = subscription_at.day - 1
+        next_anniversary(from_date) - 1.day
+      end
 
-        if month > 12
-          month = (month % 12).zero? ? 12 : (month % 12)
-          year += 1
-        end
+      # `compute_to_date` is the day before this, so an anniversary always opens a period and never
+      # also closes the previous one.
+      def next_anniversary(from_date)
+        next_period_month = from_date.to_date >> 6
 
-        date = build_date(year, month, day)
-
-        # NOTE: if subscription anniversary day is higher than the current last day of the month,
-        #       subscription period, will end on the previous end of day
-        return date - 1.day if last_day_of_month?(date) && subscription_at.day > date.day
-
-        date
+        build_date(
+          next_period_month.year,
+          next_period_month.month,
+          anniversary_day_in(next_period_month.year, next_period_month.month)
+        )
       end
 
       def compute_next_end_of_period
@@ -186,14 +183,6 @@ module Subscriptions
         year = nil
         month = nil
 
-        # NOTE: if subscription anniversary day is higher than the current last day of the month,
-        #       anniversary day is on the current day
-        day = if subscription.anniversary? && last_day_of_month?(date) && (date.day < subscription_at.day)
-          date.day
-        else
-          subscription_at.day
-        end
-
         billing_months = [
           (subscription_at.month % 12).zero? ? 12 : (subscription_at.month % 12),
           ((subscription_at.month + 6) % 12).zero? ? 12 : ((subscription_at.month + 6) % 12)
@@ -201,38 +190,40 @@ module Subscriptions
 
         # This is the case when we terminate subscription on On February 10 but anniversary date is on
         # 5 of March. In that case we need to fetch billing period in previous year
-        if should_find_billing_date_in_previous_year?(date, billing_months, day)
+        if should_find_billing_date_in_previous_year?(date, billing_months)
           year = date.year - 1
           month = billing_months[1]
-          day = Time.days_in_month(month, year) if last_day_of_month?(subscription_at)
         # In case of termination that is in the middle of the year, previous period anniversary date has to be returned
-        elsif should_find_previous_billing_date?(date, billing_months, day)
+        elsif should_find_previous_billing_date?(date, billing_months)
           year = date.year
           month = billing_months.rfind { |m| m < date.month }
-          day = Time.days_in_month(month, year) if last_day_of_month?(subscription_at)
         else
           year = date.year
           month = date.month
         end
 
-        build_date(year, month, day)
+        build_date(year, month, anniversary_day_in(year, month))
       end
 
-      def should_find_billing_date_in_previous_year?(date, billing_months, day)
+      def anniversary_day_in(year, month)
+        [subscription_at.day, Time.days_in_month(month, year)].min
+      end
+
+      def should_find_billing_date_in_previous_year?(date, billing_months)
         return true if date.month < billing_months[0]
 
-        (date.month == billing_months[0]) && should_find_previous_billing_date?(date, billing_months, day)
+        (date.month == billing_months[0]) && should_find_previous_billing_date?(date, billing_months)
       end
 
-      def should_find_previous_billing_date?(date, billing_months, day)
-        return false if last_day_of_month?(date) && last_day_of_month?(subscription_at)
-
-        return true if date.day < day && terminated_pay_in_arrears?
-        return true if (date.day + 1) < day && last_day_of_month?(subscription_at)
-        return true if date.day < day && !last_day_of_month?(subscription_at)
+      def should_find_previous_billing_date?(date, billing_months)
+        # NOTE: checked first. A non-billing month always resolves to an earlier billing month, and
+        #       falling through to the same-month branch below would instead walk the period forward
+        #       one month at a time.
         return true if billing_months.exclude?(date.month)
 
-        false
+        anniversary_day = anniversary_day_in(date.year, date.month)
+
+        date.day < anniversary_day
       end
     end
   end

--- a/app/services/subscriptions/dates/semiannual_service.rb
+++ b/app/services/subscriptions/dates/semiannual_service.rb
@@ -193,10 +193,6 @@ module Subscriptions
         build_date(year, month, anniversary_day_in(year, month))
       end
 
-      def anniversary_day_in(year, month)
-        [subscription_at.day, Time.days_in_month(month, year)].min
-      end
-
       def should_find_billing_date_in_previous_year?(date, billing_months)
         return true if date.month < billing_months[0]
 

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -126,18 +126,12 @@ module Subscriptions
         compute_to_date(compute_fixed_charges_from_date)
       end
 
+      # NOTE: the period is resolved from its own anniversary rather than re-walked from the billing
+      #       date, so there is a single derivation of the anniversary day.
       def compute_next_end_of_period
         return billing_date.end_of_year if calendar?
 
-        year = billing_date.year
-        month = subscription_at.month
-        day = subscription_at.day
-
-        # NOTE: we need the last day of the period, and not the first of the next one
-        result_date = build_date(year, month, day) - 1.day
-        return result_date if result_date >= billing_date
-
-        build_date(year + 1, month, day) - 1.day
+        compute_to_date(previous_anniversary_day(billing_date))
       end
 
       def compute_previous_beginning_of_period(date)
@@ -179,10 +173,6 @@ module Subscriptions
         # NOTE: a Feb 29 subscription has its anniversary on Feb 28 in a common year, so the raw
         #       subscription day would leave Feb 28 trailing the previous period.
         date.day < anniversary_day_in(date.year, subscription_at.month)
-      end
-
-      def anniversary_day_in(year, month)
-        [subscription_at.day, Time.days_in_month(month, year)].min
       end
     end
   end

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -45,6 +45,16 @@ module Subscriptions
       end
 
       def compute_base_date
+        # NOTE: if subscription anniversary is on last day of month and current month days count
+        #       is less than month anniversary day count, we need to use the last day of the previous month
+        if subscription.anniversary? && last_day_of_month?(billing_date) && (billing_date.day < subscription_at.day)
+          if (billing_date - 1.year).end_of_month.day >= subscription_at.day
+            return (billing_date - 1.year).end_of_month.change(day: subscription_at.day)
+          end
+
+          return (billing_date - 1.year).end_of_month
+        end
+
         billing_date - 1.year
       end
 
@@ -147,11 +157,7 @@ module Subscriptions
       def compute_duration(from_date:)
         return Time.days_in_year(from_date.year) if calendar?
 
-        year = from_date.year
-        # NOTE: if after February we must check if next year is a leap year
-        year += 1 if from_date.month > 2
-
-        Time.days_in_year(year)
+        (compute_to_date(from_date).to_date + 1.day - from_date.to_date).to_i
       end
 
       def compute_charges_duration(from_date:)

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -67,7 +67,13 @@ module Subscriptions
         month = from_date.month
         day = subscription_at.day - 1
 
-        build_date(year, month, day)
+        date = build_date(year, month, day)
+
+        # NOTE: if subscription anniversary day is higher than the current last day of the month,
+        #       subscription period, will end on the previous end of day
+        return date - 1.day if last_day_of_month?(date) && subscription_at.day > date.day
+
+        date
       end
 
       def compute_charges_from_date
@@ -162,9 +168,15 @@ module Subscriptions
 
       def period_started_in_last_year?(date)
         return true if date.month < subscription_at.month
-        return true if (date.month == subscription_at.month) && (date.day < subscription_at.day)
+        return false unless date.month == subscription_at.month
 
-        false
+        # NOTE: a Feb 29 subscription has its anniversary on Feb 28 in a common year, so the raw
+        #       subscription day would leave Feb 28 trailing the previous period.
+        date.day < anniversary_day_in(date.year, subscription_at.month)
+      end
+
+      def anniversary_day_in(year, month)
+        [subscription_at.day, Time.days_in_month(month, year)].min
       end
     end
   end

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -148,10 +148,16 @@ module Subscriptions
         build_date(year, month, day)
       end
 
+      # NOTE: `from_date` is not necessarily the beginning of the period: on a subscription resulting
+      #       from an upgrade, it is clamped to `started_at` while the anniversary is inherited from the
+      #       previous subscription. The duration is the one of the whole period, so it is measured from
+      #       the anniversary opening the period holding `from_date`.
       def compute_duration(from_date:)
         return Time.days_in_year(from_date.year) if calendar?
 
-        (compute_to_date(from_date).to_date + 1.day - from_date.to_date).to_i
+        period_start = previous_anniversary_day(from_date.to_date)
+
+        (compute_to_date(period_start).to_date + 1.day - period_start).to_i
       end
 
       def compute_charges_duration(from_date:)

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -302,6 +302,12 @@ module Subscriptions
       date.day == date.end_of_month.day
     end
 
+    # NOTE: the anniversary day of a month that is shorter than the subscription day, clamped to that
+    #       month. Resolved from the subscription, so a short month never drags the following periods.
+    def anniversary_day_in(year, month)
+      [subscription_at.day, Time.days_in_month(month, year)].min
+    end
+
     def compute_base_date
       raise(NotImplementedError)
     end

--- a/spec/scenarios/current_usage/anniversary_period_boundaries_spec.rb
+++ b/spec/scenarios/current_usage/anniversary_period_boundaries_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Anniversary subscriptions whose day has to be clamped to a shorter month used to return charges
+# periods that overlapped, left a gap, or slid depending on when they were asked for. See
+# Subscriptions::DatesService for the fencepost model these periods follow.
+describe "Anniversary current usage period boundaries Scenarios" do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, timezone: "UTC") }
+  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+
+  def subscribe_on(date, interval:)
+    travel_to(date) do
+      plan = create(:plan, organization:, interval:, amount_cents: 0, pay_in_advance: false)
+      create(:standard_charge, plan:, billable_metric:, properties: {amount: "1"})
+
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time: "anniversary"
+        },
+        as: :model
+      )
+    end
+  end
+
+  def usage_on(date, subscription:)
+    travel_to(date) do
+      fetch_current_usage(customer:, subscription:)
+      json[:customer_usage]
+    end
+  end
+
+  def period_on(date, subscription:)
+    usage = usage_on(date, subscription:)
+    [Time.iso8601(usage[:from_datetime]), Time.iso8601(usage[:to_datetime])]
+  end
+
+  context "with a yearly subscription starting on a leap day" do
+    let(:subscription) { subscribe_on(DateTime.new(2024, 2, 29), interval: :yearly) }
+
+    # The anniversary clamps to 28 Feb in a common year, so the 27th closes the first period and the
+    # 28th opens the second. Both ends used to land on the 28th.
+    it "hands the clamped anniversary day to a single period" do
+      expect(period_on(DateTime.new(2025, 2, 20), subscription:))
+        .to eq([Time.utc(2024, 2, 29), Time.utc(2025, 2, 27, 23, 59, 59)])
+
+      expect(period_on(DateTime.new(2025, 3, 10), subscription:))
+        .to eq([Time.utc(2025, 2, 28), Time.utc(2026, 2, 27, 23, 59, 59)])
+    end
+
+    it "counts an event on the clamped anniversary day once" do
+      # Resolved before travelling: creating the subscription travels itself, and travel_to refuses
+      # to nest.
+      external_subscription_id = subscription.external_id
+
+      travel_to(DateTime.new(2025, 2, 28, 12)) do
+        create_event({code: billable_metric.code, external_subscription_id:})
+      end
+
+      opening_period = usage_on(DateTime.new(2025, 3, 10), subscription:)
+      closing_period = usage_on(DateTime.new(2025, 2, 20), subscription:)
+
+      expect(opening_period[:charges_usage].sum { |charge| charge[:events_count] }).to eq(1)
+      expect(closing_period[:charges_usage].sum { |charge| charge[:events_count] }).to eq(0)
+    end
+  end
+
+  context "with a quarterly subscription starting on a month end" do
+    let(:subscription) { subscribe_on(DateTime.new(2022, 1, 31), interval: :quarterly) }
+
+    # A month-end day used to be treated as an anniversary even in a month that is not a billing
+    # month, which moved the period forward one month at a time instead of one quarter.
+    it "holds the quarter instead of sliding monthly" do
+      expect(period_on(DateTime.new(2022, 5, 31), subscription:).first).to eq(Time.utc(2022, 4, 30))
+    end
+
+    # July's anniversary is the 31st, so the 30th still belongs to the April period.
+    it "keeps the day before an anniversary in the previous period" do
+      expect(period_on(DateTime.new(2022, 7, 30), subscription:).first).to eq(Time.utc(2022, 4, 30))
+    end
+
+    # The anniversary is re-derived from the subscription every period, so April being short does
+    # not drag the following periods onto the 30th.
+    it "does not let a clamped month drag the following periods" do
+      expect(period_on(DateTime.new(2022, 8, 15), subscription:).first).to eq(Time.utc(2022, 7, 31))
+    end
+
+    it "returns periods that meet without overlapping" do
+      closing = period_on(DateTime.new(2022, 4, 15), subscription:)
+      opening = period_on(DateTime.new(2022, 5, 15), subscription:)
+
+      expect(closing.last).to eq(Time.utc(2022, 4, 29, 23, 59, 59))
+      expect(opening.first).to eq(Time.utc(2022, 4, 30))
+    end
+  end
+
+  context "with a quarterly subscription starting on the 29th of a 31-day month" do
+    let(:subscription) { subscribe_on(DateTime.new(2022, 1, 29), interval: :quarterly) }
+
+    # February is shorter than the subscription day, and its length used to leak into the resolved
+    # anniversary of a different billing month, returning 28 Jan.
+    it "resolves the anniversary from the subscription day" do
+      expect(period_on(DateTime.new(2022, 2, 28), subscription:).first).to eq(Time.utc(2022, 1, 29))
+    end
+  end
+
+  context "with a semiannual subscription starting on a month end" do
+    let(:subscription) { subscribe_on(DateTime.new(2021, 1, 31), interval: :semiannual) }
+
+    # April is not a billing month for a January-anchored semiannual subscription, so 30 Apr belongs
+    # to the period opened in January rather than starting one of its own.
+    it "ignores month ends outside a billing month" do
+      expect(period_on(DateTime.new(2021, 4, 30), subscription:).first).to eq(Time.utc(2021, 1, 31))
+    end
+  end
+end

--- a/spec/scenarios/current_usage/anniversary_period_boundaries_spec.rb
+++ b/spec/scenarios/current_usage/anniversary_period_boundaries_spec.rb
@@ -117,4 +117,42 @@ describe "Anniversary current usage period boundaries Scenarios" do
       expect(period_on(DateTime.new(2021, 4, 30), subscription:).first).to eq(Time.utc(2021, 1, 31))
     end
   end
+
+  context "with a quarterly subscription starting on the end of a 30-day month" do
+    let(:subscription) { subscribe_on(DateTime.new(2021, 4, 30), interval: :quarterly) }
+
+    # May is not a billing month, but its own month end used to be taken for an anniversary, which
+    # moved the period start to 30 May.
+    it "ignores month ends outside a billing month" do
+      expect(period_on(DateTime.new(2021, 5, 31), subscription:).first).to eq(Time.utc(2021, 4, 30))
+    end
+
+    # July has 31 days, so the anniversary stays on the subscription day instead of following the
+    # month end.
+    it "keeps the anniversary on the subscription day in a longer month" do
+      expect(period_on(DateTime.new(2021, 8, 15), subscription:).first).to eq(Time.utc(2021, 7, 30))
+    end
+
+    it "returns periods that meet without overlapping" do
+      closing = period_on(DateTime.new(2021, 7, 29), subscription:)
+      opening = period_on(DateTime.new(2021, 7, 30), subscription:)
+
+      expect(closing.last).to eq(Time.utc(2021, 7, 29, 23, 59, 59))
+      expect(opening.first).to eq(Time.utc(2021, 7, 30))
+    end
+  end
+
+  context "with a semiannual subscription starting on the end of a 30-day month" do
+    let(:subscription) { subscribe_on(DateTime.new(2021, 4, 30), interval: :semiannual) }
+
+    # June is neither a billing month nor the anniversary, yet its month end used to open a period.
+    it "ignores month ends outside a billing month" do
+      expect(period_on(DateTime.new(2021, 6, 30), subscription:).first).to eq(Time.utc(2021, 4, 30))
+    end
+
+    # October has 31 days, so the anniversary stays on the subscription day.
+    it "keeps the anniversary on the subscription day in a longer month" do
+      expect(period_on(DateTime.new(2021, 11, 15), subscription:).first).to eq(Time.utc(2021, 10, 30))
+    end
+  end
 end

--- a/spec/scenarios/subscriptions/billing_boundaries_spec.rb
+++ b/spec/scenarios/subscriptions/billing_boundaries_spec.rb
@@ -937,7 +937,9 @@ describe "Billing Boundaries Scenario" do
         invoice = subscription.invoices.order(created_at: :desc).first
         invoice_subscription = invoice.invoice_subscriptions.first
 
-        expect(invoice_subscription.from_datetime).to match_datetime("2024-02-29T00:00:00Z")
+        # Charges-only invoice: the subscription fee period is the semiannual one that is open,
+        # not the day it is billed on. February is not a billing month here.
+        expect(invoice_subscription.from_datetime).to match_datetime("2024-01-31T00:00:00Z")
         expect(invoice_subscription.charges_from_datetime).to match_datetime("2024-01-31T01:00:00Z")
         expect(invoice_subscription.charges_to_datetime).to match_datetime("2024-02-28T23:59:59Z")
         expect(invoice_subscription.fixed_charges_from_datetime).to eq(nil)
@@ -992,7 +994,9 @@ describe "Billing Boundaries Scenario" do
         invoice = subscription.invoices.order(created_at: :desc).first
         invoice_subscription = invoice.invoice_subscriptions.first
 
-        expect(invoice_subscription.from_datetime).to match_datetime("2024-02-29T00:00:00Z")
+        # Charges-only invoice: the subscription fee period is the semiannual one that is open,
+        # not the day it is billed on. February is not a billing month here.
+        expect(invoice_subscription.from_datetime).to match_datetime("2024-01-31T00:00:00Z")
         expect(invoice_subscription.charges_from_datetime).to eq(nil)
         expect(invoice_subscription.charges_to_datetime).to eq(nil)
         expect(invoice_subscription.fixed_charges_from_datetime).to match_datetime("2024-01-31T01:00:00Z")

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -151,7 +151,9 @@ RSpec.describe Subscriptions::Dates::QuarterlyService do
           let(:billing_at) { Time.zone.parse("27 Feb 2022") }
           let(:subscription_at) { Time.zone.parse("28 Feb 2021") }
 
-          before { subscription.mark_as_terminated!("25 Feb 2022") }
+          # The enclosing context already terminated the subscription, and mark_as_terminated! sets
+          # terminated_at with ||=, so it has to be assigned to move it earlier than billing_at.
+          before { subscription.update!(terminated_at: Time.zone.parse("25 Feb 2022")) }
 
           it "returns the previous quarter last day" do
             expect(result).to eq("2021-11-28 00:00:00 UTC")

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -151,7 +151,9 @@ RSpec.describe Subscriptions::Dates::SemiannualService do
           let(:billing_at) { Time.zone.parse("27 Feb 2022") }
           let(:subscription_at) { Time.zone.parse("28 Feb 2021") }
 
-          before { subscription.mark_as_terminated!("25 Feb 2022") }
+          # The enclosing context already terminated the subscription, and mark_as_terminated! sets
+          # terminated_at with ||=, so it has to be assigned to move it earlier than billing_at.
+          before { subscription.update!(terminated_at: Time.zone.parse("25 Feb 2022")) }
 
           it "returns the previous half year last day" do
             expect(result).to eq("2021-08-28 00:00:00 UTC")
@@ -165,8 +167,10 @@ RSpec.describe Subscriptions::Dates::SemiannualService do
         let(:billing_at) { Time.zone.parse("30 Apr 2021") }
         let(:subscription_at) { Time.zone.parse("31 Jan 2021") }
 
-        it "returns the current day" do
-          expect(result).to eq("2021-04-30 00:00:00 UTC")
+        # April is not a billing month here (January and July are), so 30 Apr belongs to the period
+        # opened in January. It used to open a period of its own, sliding the cycle monthly.
+        it "returns the anniversary of the period covering that day" do
+          expect(result).to eq("2021-01-31 00:00:00 UTC")
         end
       end
 

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -983,25 +983,25 @@ RSpec.describe Subscriptions::Dates::SemiannualService do
       let(:billing_at) { Time.zone.parse("07 May 2022") }
 
       it "returns the end of the billing month" do
-        expect(result).to eq("2022-11-01 23:59:59 UTC")
+        expect(result).to eq("2022-08-01 23:59:59 UTC")
       end
 
       context "with customer timezone" do
         let(:timezone) { "America/New_York" }
 
         it "takes customer timezone into account" do
-          expect(result).to eq("2022-11-01 03:59:59 UTC")
+          expect(result).to eq("2022-08-01 03:59:59 UTC")
         end
       end
 
       context "when end of billing month is in next year" do
         let(:billing_at) { Time.zone.parse("02 Nov 2021") }
 
-        it { expect(result).to eq("2022-05-01 23:59:59 UTC") }
+        it { expect(result).to eq("2022-02-01 23:59:59 UTC") }
       end
 
       context "when date is the end of the period" do
-        let(:billing_at) { Time.zone.parse("01 May 2022") }
+        let(:billing_at) { Time.zone.parse("01 Feb 2022") }
 
         it "returns the date" do
           expect(result).to eq(billing_at.utc.end_of_day.to_s)

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -115,6 +115,18 @@ RSpec.describe Subscriptions::Dates::YearlyService do
         end
       end
 
+      context "when subscription date on 29/02 of a leap year" do
+        let(:subscription_at) { Time.zone.parse("29 Feb 2020") }
+        let(:billing_at) { Time.zone.parse("28 Feb 2025") }
+
+        # The period being billed is the one that opened on the leap day. Resolving the base date from
+        # `billing_date - 1.year` alone lands on 28 Feb 2024, one day before that anniversary, and
+        # would walk the period back a further year.
+        it "returns the leap day of the previous period" do
+          expect(result).to eq("2024-02-29 00:00:00 UTC")
+        end
+      end
+
       context "when subscription is just terminated" do
         before { subscription.mark_as_terminated!("1 Feb 2022") }
 
@@ -226,6 +238,14 @@ RSpec.describe Subscriptions::Dates::YearlyService do
         # ends used to land on the 28th, putting that day in two periods.
         it "returns the day before the anniversary" do
           expect(result).to eq("2022-02-27 23:59:59 UTC")
+        end
+
+        context "when billing on the clamped anniversary of a common year" do
+          let(:billing_at) { Time.zone.parse("28 Feb 2025") }
+
+          it "closes the period that opened on the leap day" do
+            expect(result).to eq("2025-02-27 23:59:59 UTC")
+          end
         end
       end
 
@@ -1063,6 +1083,17 @@ RSpec.describe Subscriptions::Dates::YearlyService do
 
         it "returns the price of single day" do
           expect(result).to eq(plan.amount_cents.fdiv(366))
+        end
+      end
+
+      context "when subscription date on 29/02 of a leap year" do
+        let(:subscription_at) { Time.zone.parse("29 Feb 2020") }
+        let(:billing_at) { Time.zone.parse("28 Feb 2025") }
+
+        # The period runs from 29 Feb 2024 to 27 Feb 2025, which is 365 days and not the 366 days of
+        # the leap year it starts in.
+        it "returns the price of single day of the computed period" do
+          expect(result).to eq(plan.amount_cents.fdiv(365))
         end
       end
     end

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -222,8 +222,10 @@ RSpec.describe Subscriptions::Dates::YearlyService do
         let(:subscription_at) { Time.zone.parse("29 Feb 2020") }
         let(:billing_at) { Time.zone.parse("01 Mar 2022") }
 
-        it "returns the previous month last day" do
-          expect(result).to eq("2022-02-28 23:59:59 UTC")
+        # The anniversary clamps to 28 Feb in a common year, so the period ends on the 27th. Both
+        # ends used to land on the 28th, putting that day in two periods.
+        it "returns the day before the anniversary" do
+          expect(result).to eq("2022-02-27 23:59:59 UTC")
         end
       end
 

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -1096,6 +1096,29 @@ RSpec.describe Subscriptions::Dates::YearlyService do
           expect(result).to eq(plan.amount_cents.fdiv(365))
         end
       end
+
+      # NOTE: a subscription created by an upgrade inherits the anniversary of the one it replaces, so it
+      #       starts in the middle of its first period. The termination and trial fees pass the boundary
+      #       start, which is clamped to `started_at`, and must still be prorated on the whole period.
+      context "when subscription started in the middle of a period" do
+        let(:result) { date_service.single_day_price(optional_from_date: started_at.to_date) }
+
+        let(:subscription_at) { Time.zone.parse("01 Jan 2024") }
+        let(:started_at) { Time.zone.parse("10 Oct 2024") }
+        let(:billing_at) { Time.zone.parse("01 Nov 2024") }
+
+        it "returns the price of single day of the whole period" do
+          expect(result).to eq(plan.amount_cents.fdiv(366))
+        end
+
+        context "when the anniversary is not the first day of the year" do
+          let(:subscription_at) { Time.zone.parse("15 Mar 2024") }
+
+          it "returns the price of single day of the whole period" do
+            expect(result).to eq(plan.amount_cents.fdiv(365))
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context

Charges periods for anniversary subscriptions did not tile: consecutive periods could overlap or leave a gap, and the period returned could slide depending on when it was asked for. Bounds are inclusive, so an overlapping day is billed twice and a gap day never billed. It happens when the subscription day has to be clamped to a shorter month — yearly on 29 Feb, quarterly and semiannual dated 29 or later. Calendar, weekly and monthly are unaffected. One production subscription is affected, on a non-production account.

The common cause is resolving a period from the billing date rather than from the anniversary that opens it. A yearly leap-day subscription resolved its base date a plain year back, landing one day before the clamped anniversary and walking the period back a further year, so two consecutive billing dates produced identical boundaries and the year in between was dropped as a duplicate invoice. Quarterly and semiannual anchored the next end of period on the billing month, which is not necessarily a billing month, so the period advanced a month at a time — that value prices prorated termination credit notes.

## Description

The anniversary day is now derived from the subscription and clamped to the target month, a non-billing month resolves back to an earlier billing month, and period ends are the day before the next anniversary, so periods tile by construction. The next end of period and the period duration are both read off those boundaries rather than recomputed from the billing date.

Resolving the period covering a date is now one strict comparison against the anniversary on or before it, for billing as much as for current usage. The one-day tolerance it used to have for month-end subscriptions was held in place by a spec whose two nested `mark_as_terminated!` calls made the inner one a no-op, so the tolerance stood in for a termination branch that was never reached; that spec now assigns `terminated_at` directly. The semiannual `next_end_of_period` expectations asserted the month-by-month walk and are corrected to the real period ends. A new scenario over the current usage endpoint fails five of its eight examples on `main`.

## Behavior change to be aware of

Affected boundaries move by a day. Quarterly and semiannual boundaries on actual billing days are unchanged, so those invoices need nothing. A yearly 29 Feb subscription previously closed its period on 28 Feb and the next period now opens on that day, so the transition invoice covers that day twice; with a single affected subscription there is nothing to backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
