### PR TITLE
[ING-561] fix(wallets): skip idle threshold checks

### DIFF
--- a/app/services/wallets/balance/update_ongoing_service.rb
+++ b/app/services/wallets/balance/update_ongoing_service.rb
@@ -15,13 +15,15 @@ module Wallets
 
       def call
         wallet.update!(update_params)
+        state_changed = wallet.saved_change_to_ongoing_usage_balance_cents? ||
+          wallet.saved_change_to_ongoing_balance_cents?
 
         after_commit do
           if update_params[:depleted_ongoing_balance] == true
             SendWebhookJob.perform_later("wallet.depleted_ongoing_balance", wallet)
           end
 
-          ::Wallets::ThresholdTopUpService.call(wallet:)
+          ::Wallets::ThresholdTopUpService.call(wallet:, state_changed:)
           UsageMonitoring::ProcessWalletAlertsJob.perform_later(wallet)
         end
 

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -7,12 +7,14 @@ module Wallets
     BURST_TOP_UPS = 3
     BURST_WINDOW = 10.minutes
 
-    def initialize(wallet:)
+    def initialize(wallet:, state_changed: true)
       @wallet = wallet
+      @state_changed = state_changed
       super
     end
 
     def call
+      return result unless state_changed
       return result if rule.nil?
       return result if wallet.credits_ongoing_balance > rule.threshold_credits
       return result if (pending_transactions_amount + wallet.credits_ongoing_balance) > rule.threshold_credits
@@ -47,7 +49,7 @@ module Wallets
 
     private
 
-    attr_reader :wallet
+    attr_reader :wallet, :state_changed
 
     def rule
       @rule ||= wallet.recurring_transaction_rules.active.where(trigger: :threshold).first

--- a/spec/services/wallets/balance/update_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/update_ongoing_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Wallets::Balance::UpdateOngoingService do
 
       it "calls Wallets::ThresholdTopUpService" do
         subject
-        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:)
+        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:, state_changed: true)
       end
 
       it "enqueues a ProcessWalletAlertsJob" do
@@ -93,7 +93,26 @@ RSpec.describe Wallets::Balance::UpdateOngoingService do
 
       it "calls Wallets::ThresholdTopUpService" do
         subject
-        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:)
+        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:, state_changed: true)
+      end
+    end
+
+    context "when the update changes neither usage nor ongoing balance" do
+      let(:depleted_ongoing_balance) { false }
+
+      let(:update_params) do
+        {
+          ongoing_usage_balance_cents: wallet.ongoing_usage_balance_cents,
+          credits_ongoing_usage_balance: wallet.credits_ongoing_usage_balance,
+          ongoing_balance_cents: wallet.ongoing_balance_cents,
+          credits_ongoing_balance: wallet.credits_ongoing_balance
+        }
+      end
+
+      it "tells the threshold rule that nothing moved" do
+        subject
+
+        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:, state_changed: false)
       end
     end
 

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -255,6 +255,14 @@ RSpec.describe Wallets::ThresholdTopUpService do
       end
     end
 
+    context "when the ongoing balance write changed nothing" do
+      subject(:top_up_service) { described_class.new(wallet:, state_changed: false) }
+
+      it "does not call wallet transaction create job" do
+        expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+      end
+    end
+
     context "with pending transactions" do
       it "does not call wallet transaction create job" do
         create(:wallet_transaction, wallet:, amount: 1.0, credit_amount: 1.0, status: "pending")


### PR DESCRIPTION
## Context

A threshold top-up rule is evaluated from an `after_commit` hook on every ongoing balance write, and nothing checks whether anything actually changed since the last one. Organisations on a dedicated worker refresh every few seconds, so the rule runs its full evaluation, two count queries included, on the hottest wallet path even when the wallet is standing still.

A guard for exactly this shipped in April 2024 (`c74e86cca`) and was dropped a month later in `82fd1832a` during an extraction, with no mention in the commit message and nothing to replace it. Beyond the wasted work, it is also the cheapest bound on repeated top-ups, because it stops the rule reacting again to a state it has already reacted to without ever refusing a customer.

## Changes

- `Wallets::Balance::UpdateOngoingService` now tells `Wallets::ThresholdTopUpService` whether the write moved the usage balance or the ongoing balance, and the service returns immediately when it did not.
- Both columns are considered, so a change that does not come from usage, such as a manual outbound transaction or a settled top-up, still lets the rule fire. The sync timestamp is written on every call and is deliberately ignored.
- The flag defaults to true, so any other caller keeps today's behaviour.

Linear: [ING-561](https://linear.app/getlago/issue/ING-561)