### PR TITLE
[ING-576] fix(wallets): back off after a declined top-up

### DIFF
--- a/app/services/wallets/balance/update_ongoing_service.rb
+++ b/app/services/wallets/balance/update_ongoing_service.rb
@@ -15,13 +15,15 @@ module Wallets
 
       def call
         wallet.update!(update_params)
+        state_changed = wallet.saved_change_to_ongoing_usage_balance_cents? ||
+          wallet.saved_change_to_ongoing_balance_cents?
 
         after_commit do
           if update_params[:depleted_ongoing_balance] == true
             SendWebhookJob.perform_later("wallet.depleted_ongoing_balance", wallet)
           end
 
-          ::Wallets::ThresholdTopUpService.call(wallet:)
+          ::Wallets::ThresholdTopUpService.call(wallet:, state_changed:)
           UsageMonitoring::ProcessWalletAlertsJob.perform_later(wallet)
         end
 

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -7,12 +7,14 @@ module Wallets
     BURST_TOP_UPS = 3
     BURST_WINDOW = 10.minutes
 
-    def initialize(wallet:)
+    def initialize(wallet:, state_changed: true)
       @wallet = wallet
+      @state_changed = state_changed
       super
     end
 
     def call
+      return result unless state_changed
       return result if rule.nil?
       return result if wallet.credits_ongoing_balance > rule.threshold_credits
       return result if (pending_transactions_amount + wallet.credits_ongoing_balance) > rule.threshold_credits
@@ -47,7 +49,7 @@ module Wallets
 
     private
 
-    attr_reader :wallet
+    attr_reader :wallet, :state_changed
 
     def rule
       @rule ||= wallet.recurring_transaction_rules.active.where(trigger: :threshold).first

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -6,6 +6,7 @@ module Wallets
 
     BURST_TOP_UPS = 3
     BURST_WINDOW = 10.minutes
+    DECLINE_BACKOFF = 1.hour
 
     def initialize(wallet:, state_changed: true)
       @wallet = wallet
@@ -19,6 +20,9 @@ module Wallets
       return result if wallet.credits_ongoing_balance > rule.threshold_credits
       return result if (pending_transactions_amount + wallet.credits_ongoing_balance) > rule.threshold_credits
 
+      paid_credits = rule.compute_paid_credits(ongoing_balance: wallet.credits_ongoing_balance)
+      return result if paid_credits.positive? && backing_off_after_decline?
+
       burst_top_ups = top_ups_since(BURST_WINDOW)
       if burst_top_ups >= BURST_TOP_UPS
         report("Automatic wallet top-up burst", count: burst_top_ups)
@@ -26,7 +30,7 @@ module Wallets
 
       params = {
         wallet_id: wallet.id,
-        paid_credits: rule.compute_paid_credits(ongoing_balance: wallet.credits_ongoing_balance).to_s,
+        paid_credits: paid_credits.to_s,
         granted_credits: rule.compute_granted_credits.to_s,
         source: :threshold,
         invoice_requires_successful_payment: rule.invoice_requires_successful_payment?,
@@ -39,7 +43,7 @@ module Wallets
       params[:invoice_custom_section] = rule.invoice_custom_section_params if rule.invoice_custom_section_params
 
       WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(
-        organization_id: wallet.organization.id,
+        organization_id: wallet.organization_id,
         params:,
         unique_transaction: true
       )
@@ -59,8 +63,25 @@ module Wallets
       @pending_transactions_amount ||= wallet.wallet_transactions.pending.sum(:amount)
     end
 
+    def backing_off_after_decline?
+      last_decline_at = automatic_top_ups.failed.maximum(:failed_at)
+
+      return false if last_decline_at.nil?
+      return false if last_decline_at < DECLINE_BACKOFF.ago
+
+      !paid_top_up_settled_since?(last_decline_at)
+    end
+
+    def paid_top_up_settled_since?(timestamp)
+      wallet.wallet_transactions.inbound.purchased.settled.where(settled_at: timestamp..).exists?
+    end
+
+    def automatic_top_ups
+      wallet.wallet_transactions.threshold.inbound.purchased
+    end
+
     def top_ups_since(window)
-      wallet.wallet_transactions.threshold.inbound.purchased.where(created_at: window.ago..).count
+      automatic_top_ups.where(created_at: window.ago..).count
     end
 
     def report(message, count:)

--- a/spec/services/wallets/balance/update_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/update_ongoing_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Wallets::Balance::UpdateOngoingService do
 
       it "calls Wallets::ThresholdTopUpService" do
         subject
-        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:)
+        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:, state_changed: true)
       end
 
       it "enqueues a ProcessWalletAlertsJob" do
@@ -93,7 +93,26 @@ RSpec.describe Wallets::Balance::UpdateOngoingService do
 
       it "calls Wallets::ThresholdTopUpService" do
         subject
-        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:)
+        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:, state_changed: true)
+      end
+    end
+
+    context "when the update changes neither usage nor ongoing balance" do
+      let(:depleted_ongoing_balance) { false }
+
+      let(:update_params) do
+        {
+          ongoing_usage_balance_cents: wallet.ongoing_usage_balance_cents,
+          credits_ongoing_usage_balance: wallet.credits_ongoing_usage_balance,
+          ongoing_balance_cents: wallet.ongoing_balance_cents,
+          credits_ongoing_balance: wallet.credits_ongoing_balance
+        }
+      end
+
+      it "tells the threshold rule that nothing moved" do
+        subject
+
+        expect(Wallets::ThresholdTopUpService).to have_received(:call).with(wallet:, state_changed: false)
       end
     end
 

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -347,6 +347,101 @@ RSpec.describe Wallets::ThresholdTopUpService do
       end
     end
 
+    describe "declined top-ups" do
+      let(:failed_top_up) do
+        create(:wallet_transaction, :failed, wallet:, source: :threshold, failed_at: 10.minutes.ago)
+      end
+
+      before { failed_top_up }
+
+      it "does not call wallet transaction create job while the failure is recent" do
+        expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+      end
+
+      context "when the failure is older than the back-off window" do
+        let(:failed_top_up) do
+          create(
+            :wallet_transaction,
+            :failed,
+            wallet:,
+            source: :threshold,
+            failed_at: described_class::DECLINE_BACKOFF.ago - 1.minute
+          )
+        end
+
+        it "calls wallet transaction create job" do
+          expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
+
+      context "when a top-up settled after the failure" do
+        before { create(:wallet_transaction, wallet:, source: :threshold, created_at: 1.minute.ago) }
+
+        it "calls wallet transaction create job" do
+          expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
+
+      context "when only granted credits arrived after the failure" do
+        before do
+          create(
+            :wallet_transaction,
+            wallet:,
+            source: :threshold,
+            transaction_status: :granted,
+            settled_at: 1.minute.ago
+          )
+        end
+
+        it "does not call wallet transaction create job" do
+          expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
+
+      context "when a top-up created before the failure settled after it" do
+        before do
+          create(
+            :wallet_transaction,
+            wallet:,
+            source: :manual,
+            created_at: 2.hours.ago,
+            settled_at: 1.minute.ago
+          )
+        end
+
+        it "calls wallet transaction create job" do
+          expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
+
+      context "when the rule only grants credits" do
+        let(:recurring_transaction_rule) do
+          create(
+            :recurring_transaction_rule,
+            wallet:,
+            trigger: "threshold",
+            threshold_credits: "6.0",
+            paid_credits: "0.0",
+            granted_credits: "3.0"
+          )
+        end
+
+        it "calls wallet transaction create job" do
+          expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
+
+      context "when the failed transaction was not an automatic top-up" do
+        let(:failed_top_up) do
+          create(:wallet_transaction, :failed, wallet:, source: :manual, failed_at: 10.minutes.ago)
+        end
+
+        it "calls wallet transaction create job" do
+          expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
+    end
+
     # Reporting only. Refusing a top-up would leave the wallet short, and the allocator
     # routes all of a customer's usage into a threshold wallet on the assumption that its
     # rule always refills it.

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -255,6 +255,14 @@ RSpec.describe Wallets::ThresholdTopUpService do
       end
     end
 
+    context "when the ongoing balance write changed nothing" do
+      subject(:top_up_service) { described_class.new(wallet:, state_changed: false) }
+
+      it "does not call wallet transaction create job" do
+        expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+      end
+    end
+
     context "with pending transactions" do
       it "does not call wallet transaction create job" do
         create(:wallet_transaction, wallet:, amount: 1.0, credit_amount: 1.0, status: "pending")


### PR DESCRIPTION
> Stacked on #6175 (ING-561), which is its base branch. Review that one first; this diff shows only the back-off.

## Context

When an automatic threshold top-up is declined, the credits are never granted, so the balance stays below the threshold and the rule fires again on the next ongoing balance refresh. Neither existing guard holds: the balance is still low, and the failed transaction leaves `scope :pending` as soon as `mark_as_failed!` runs. The result is an attempt every few seconds, then one per refresh, for as long as the customer keeps sending usage, and a wallet can keep that up for days.

No money moves, since every attempt is declined, but each one is a real authorisation against a card that is already failing, which is a good way to get it blocked by the issuer, and each one leaves an open credit invoice behind.

## Changes

- After a declined automatic top-up, the rule stops firing for an hour. The back-off is keyed on the outcome of the last automatic attempt rather than on the balance, which is what lets it bound a case the balance guards cannot see.
- It clears as soon as a paid top-up settles, since that is the one signal proving a payment can go through. A change of payment method is deliberately not treated as recovery: `PaymentMethods::DetermineService` resolves a threshold top-up through the rule, then the wallet, then the customer default, so reading the customer default here would unblock rules pinned to another method while leaving repointed ones stuck.
- Only rules that charge are paused. A rule that just grants credits, or a target rule that grants its top-up, cannot be declined, so pausing it would withhold credits for no protection.
- A declined manual top-up does not pause the rule, since only automatic attempts are retried without anyone asking, and free granted credits do not count as recovery.
- Nothing new is reported on the paused path: wallets on a dedicated worker refresh every few seconds, so a report per evaluation would flood, and the existing burst report already fires during the rapid phase that precedes the back-off.

Linear: [ING-576](https://linear.app/getlago/issue/ING-576)

## Before and after

Every row assumes the wallet is below its threshold and the customer keeps sending usage, so the rule is evaluated on each refresh.

| Scenario | Today on `main` | With this PR |
| -- | -- | -- |
| The card declines | a fresh attempt on every refresh, until the usage stops | one attempt, then nothing for an hour |
| An hour has passed since the decline | a fresh attempt on every refresh | one attempt, and the cycle repeats if it declines again |
| A paid top-up settles after the decline | a fresh attempt on every refresh | the pause lifts at once |
| The rule only grants credits, so nothing can decline | a fresh attempt on every refresh | keeps firing, never paused |
| Only free granted credits arrive | a fresh attempt on every refresh | the pause holds, since nothing proves the card works |
| A manual top-up is the one that declined | a fresh attempt on every refresh | the rule keeps firing, as before |

No money moves in any of these rows, since the attempts are declined. What changes is how many authorisations the card takes and how many open credit invoices are left behind.

