### PR TITLE
[ING-560] fix(wallets): close the top-up gap in one charge

### DIFF
--- a/app/jobs/wallet_transactions/create_job.rb
+++ b/app/jobs/wallet_transactions/create_job.rb
@@ -5,6 +5,8 @@ module WalletTransactions
     queue_as "high_priority"
     unique :until_executed, on_conflict: :log
 
+    AUTOMATIC_SOURCES = %w[threshold interval].freeze
+
     # ActiveRecord::StaleObjectError is handled in WalletTransactions::CreateFromParamsService
 
     def perform(organization_id:, params:, unique_transaction: false)
@@ -21,12 +23,18 @@ module WalletTransactions
       unique_transaction = args[:unique_transaction]
 
       if unique_transaction
-        [
-          org_id,
-          params[:wallet_id],
-          params[:paid_credits],
-          params[:granted_credits]
-        ]
+        source = params[:source].to_s
+
+        if AUTOMATIC_SOURCES.include?(source)
+          [org_id, params[:wallet_id], source]
+        else
+          [
+            org_id,
+            params[:wallet_id],
+            params[:paid_credits],
+            params[:granted_credits]
+          ]
+        end
       else
         # Return a unique value for each job to effectively disable uniqueness
         # when unique_transaction is false

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -129,7 +129,7 @@ class RecurringTransactionRule < ApplicationRecord
     return paid_credits if paid_credits.zero? || threshold_credits.nil?
 
     gap = threshold_credits - ongoing_balance - granted_credits - pending_credits
-    return paid_credits if gap <= paid_credits
+    return paid_credits if gap < paid_credits
 
     apply_max_top_up_limits(credit_amount: paid_credits * ((gap / paid_credits).floor + 1))
   end

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -73,6 +73,14 @@ class RecurringTransactionRule < ApplicationRecord
     end
   end
 
+  def apply_max_top_up_limits(credit_amount:)
+    if ignore_paid_top_up_limits?
+      credit_amount
+    else
+      credit_amount.clamp(nil, wallet.paid_top_up_max_credits)
+    end
+  end
+
   def invoice_custom_section_params
     section_ids = applied_invoice_custom_sections.pluck(:invoice_custom_section_id)
     return if section_ids.none? && !skip_invoice_custom_sections
@@ -80,11 +88,13 @@ class RecurringTransactionRule < ApplicationRecord
     {skip_invoice_custom_sections:, invoice_custom_section_ids: section_ids}
   end
 
-  def compute_paid_credits(ongoing_balance:)
+  def compute_paid_credits(ongoing_balance:, pending_credits: 0)
     if target?
       return 0.0 if grants_target_top_up?
 
       compute_target_top_up_amount(ongoing_balance:)
+    elsif threshold?
+      compute_fixed_top_up_amount(ongoing_balance:, pending_credits:)
     else
       paid_credits
     end
@@ -113,6 +123,15 @@ class RecurringTransactionRule < ApplicationRecord
     if target_ongoing_balance < threshold_credits
       errors.add(:target_ongoing_balance, :must_be_greater_than_or_equal_threshold)
     end
+  end
+
+  def compute_fixed_top_up_amount(ongoing_balance:, pending_credits:)
+    return paid_credits if paid_credits.zero? || threshold_credits.nil?
+
+    gap = threshold_credits - ongoing_balance - granted_credits - pending_credits
+    return paid_credits if gap <= paid_credits
+
+    apply_max_top_up_limits(credit_amount: paid_credits * ((gap / paid_credits).floor + 1))
   end
 
   def compute_target_top_up_amount(ongoing_balance:)

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -20,7 +20,10 @@ module Wallets
       return result if wallet.credits_ongoing_balance > rule.threshold_credits
       return result if (pending_transactions_amount + wallet.credits_ongoing_balance) > rule.threshold_credits
 
-      paid_credits = rule.compute_paid_credits(ongoing_balance: wallet.credits_ongoing_balance)
+      paid_credits = rule.compute_paid_credits(
+        ongoing_balance: wallet.credits_ongoing_balance,
+        pending_credits: pending_transactions_amount
+      )
       return result if paid_credits.positive? && backing_off_after_decline?
 
       burst_top_ups = top_ups_since(BURST_WINDOW)
@@ -60,7 +63,7 @@ module Wallets
     end
 
     def pending_transactions_amount
-      @pending_transactions_amount ||= wallet.wallet_transactions.pending.sum(:amount)
+      @pending_transactions_amount ||= wallet.wallet_transactions.pending.sum(:credit_amount)
     end
 
     def backing_off_after_decline?

--- a/spec/jobs/wallet_transactions/create_job_spec.rb
+++ b/spec/jobs/wallet_transactions/create_job_spec.rb
@@ -48,15 +48,26 @@ RSpec.describe WalletTransactions::CreateJob do
     end
 
     context "when unique_transaction is true" do
-      it "returns a stable lock key array" do
+      def lock_key_for(job_params)
         job = described_class.new
         allow(job).to receive(:arguments).and_return([{
           organization_id: organization_id,
-          params: params,
+          params: job_params,
           unique_transaction: true
         }])
+        job.lock_key_arguments
+      end
 
-        expect(job.lock_key_arguments).to eq([
+      it "keys an automatic top-up on the wallet and the source, ignoring the amount" do
+        expect(lock_key_for(params)).to eq([organization_id, wallet_id, "threshold"])
+      end
+
+      it "keys two automatic top-ups of different amounts the same" do
+        expect(lock_key_for(params)).to eq(lock_key_for(params.merge(paid_credits: "450.0")))
+      end
+
+      it "keys a manual top-up on the amounts" do
+        expect(lock_key_for(params.merge(source: :manual))).to eq([
           organization_id,
           wallet_id,
           "10.0",

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -311,6 +311,14 @@ RSpec.describe RecurringTransactionRule do
           expect(subject).to eq 450.0
         end
 
+        context "when the gap is exactly one top-up" do
+          let(:ongoing_balance) { -50.0 }
+
+          it "tops up past the threshold instead of landing on it" do
+            expect(subject).to eq 100.0
+          end
+        end
+
         context "when the gap divides exactly by the top-up amount" do
           let(:ongoing_balance) { -100.0 }
 

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -292,6 +292,132 @@ RSpec.describe RecurringTransactionRule do
       it "returns paid credits specified on rule" do
         expect(subject).to eq rule.paid_credits
       end
+
+      context "when the gap is larger than one top-up" do
+        let(:rule) do
+          create(
+            :recurring_transaction_rule,
+            wallet:,
+            method: :fixed,
+            trigger: :threshold,
+            threshold_credits: 10.0,
+            paid_credits: 50.0
+          )
+        end
+        let(:wallet) { create(:wallet, rate_amount: 1.0) }
+        let(:ongoing_balance) { -429.8 }
+
+        it "returns the whole gap rounded up to a multiple of paid credits" do
+          expect(subject).to eq 450.0
+        end
+
+        context "when the gap divides exactly by the top-up amount" do
+          let(:ongoing_balance) { -100.0 }
+
+          it "tops up past the threshold instead of landing on it" do
+            expect(subject).to eq 150.0
+          end
+        end
+
+        context "when a top-up is already in flight" do
+          subject { rule.compute_paid_credits(ongoing_balance:, pending_credits: 50.0) }
+
+          let(:rule) do
+            create(
+              :recurring_transaction_rule,
+              wallet:,
+              method: :fixed,
+              trigger: :threshold,
+              threshold_credits: 10.0,
+              paid_credits: 50.0,
+              granted_credits: 0.0
+            )
+          end
+
+          it "counts the pending credits towards the gap" do
+            expect(subject).to eq 400.0
+          end
+        end
+
+        context "when the rule also grants credits" do
+          let(:rule) do
+            create(
+              :recurring_transaction_rule,
+              wallet:,
+              method: :fixed,
+              trigger: :threshold,
+              threshold_credits: 10.0,
+              paid_credits: 50.0,
+              granted_credits: 50.0
+            )
+          end
+
+          it "counts the granted credits towards the gap" do
+            expect(subject).to eq 400.0
+          end
+        end
+
+        context "when the gap exceeds the wallet maximum top-up" do
+          let(:wallet) { create(:wallet, rate_amount: 1.0, paid_top_up_max_amount_cents: 100_00) }
+
+          it "returns the wallet maximum" do
+            expect(subject).to eq 100.0
+          end
+        end
+
+        context "when the rule ignores the top-up limits" do
+          let(:wallet) { create(:wallet, rate_amount: 1.0, paid_top_up_max_amount_cents: 100_00) }
+          let(:rule) do
+            create(
+              :recurring_transaction_rule,
+              wallet:,
+              method: :fixed,
+              trigger: :threshold,
+              threshold_credits: 10.0,
+              paid_credits: 50.0,
+              ignore_paid_top_up_limits: true
+            )
+          end
+
+          it "returns the whole gap" do
+            expect(subject).to eq 450.0
+          end
+        end
+
+        context "when the rule is triggered by an interval" do
+          let(:rule) do
+            create(
+              :recurring_transaction_rule,
+              wallet:,
+              method: :fixed,
+              trigger: :interval,
+              threshold_credits: 10.0,
+              paid_credits: 50.0
+            )
+          end
+
+          it "returns the configured amount, not the gap" do
+            expect(subject).to eq 50.0
+          end
+        end
+
+        context "when the rule pays nothing" do
+          let(:rule) do
+            create(
+              :recurring_transaction_rule,
+              wallet:,
+              method: :fixed,
+              trigger: :threshold,
+              threshold_credits: 10.0,
+              paid_credits: 0.0
+            )
+          end
+
+          it "returns zero" do
+            expect(subject).to eq 0.0
+          end
+        end
+      end
     end
 
     context "when method is target" do

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -271,6 +271,41 @@ RSpec.describe Wallets::ThresholdTopUpService do
       end
     end
 
+    context "when the wallet is several top-ups short" do
+      let(:wallet) do
+        create(
+          :wallet,
+          balance_cents: 5000,
+          ongoing_balance_cents: -42_980,
+          ongoing_usage_balance_cents: 47_980,
+          credits_balance: 50.0,
+          credits_ongoing_balance: -429.8,
+          credits_ongoing_usage_balance: 479.8,
+          rate_amount: 1.0
+        )
+      end
+
+      let(:recurring_transaction_rule) do
+        create(
+          :recurring_transaction_rule,
+          wallet:,
+          trigger: "threshold",
+          threshold_credits: "10.0",
+          paid_credits: "50.0",
+          granted_credits: "0.0"
+        )
+      end
+
+      it "closes the whole gap in a single top-up" do
+        expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+          .with(
+            organization_id: wallet.organization.id,
+            params: hash_including(paid_credits: "450.0", granted_credits: "0.0"),
+            unique_transaction: true
+          )
+      end
+    end
+
     context "when border has NOT been crossed" do
       let(:recurring_transaction_rule) do
         create(:recurring_transaction_rule, wallet:, trigger: "threshold", threshold_credits: "2.0")
@@ -294,6 +329,28 @@ RSpec.describe Wallets::ThresholdTopUpService do
         create(:wallet_transaction, wallet:, amount: 1.0, credit_amount: 1.0, status: "pending")
 
         expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+      end
+
+      context "when the wallet rate is not one" do
+        let(:wallet) do
+          create(
+            :wallet,
+            balance_cents: 1000,
+            ongoing_balance_cents: 550,
+            ongoing_usage_balance_cents: 450,
+            credits_balance: 10.0,
+            credits_ongoing_balance: 5.5,
+            credits_ongoing_usage_balance: 4.0,
+            rate_amount: 0.1,
+            paid_top_up_min_amount_cents: 205_50
+          )
+        end
+
+        it "counts the pending credits rather than the pending currency amount" do
+          create(:wallet_transaction, wallet:, amount: 0.1, credit_amount: 1.0, status: "pending")
+
+          expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

A threshold rule using the `fixed` method always tops up the configured amount, whatever the size of the shortfall. When a wallet falls further behind than one increment, the rule answers a shortfall that is still open on the next refresh, and does so again, and again: one card charge per increment until it catches up.

The repeated runs are not a loop and do not come from a stale value. `Wallets::ThresholdTopUpService` is only reachable from `Wallets::Balance::RefreshOngoingUsageService`, which reloads the wallet and recomputes its ongoing balance on the line before writing, so every evaluation reads a current number and each top-up is a correct answer to what is still missing. Only the size of each top-up can reduce the number of charges.

Sizing from the ongoing balance alone also ignored two things that already close part of the gap: the credits the same transaction grants for free, and a top-up still on its way. The pending amount was read from the transaction amount as well, a currency figure, and compared against a threshold expressed in credits; those agree only when the wallet rate is one.

## Changes

- A `fixed` rule on a threshold trigger now tops up enough to clear the shortfall in one go, rounded up to a whole number of increments so the configured amount stays the unit the customer chose. This is the shape `compute_target_top_up_amount` already uses.
- The gap accounts for the granted credits and for pending top-ups, and pending credits are read from the credit column so the comparison holds at any wallet rate.
- A gap that divides exactly takes one more increment, so the wallet lands above the threshold rather than exactly on it. Landing on it left the wallet still crossed and triggered another top-up immediately; the customer pays the same either way, but as one charge.
- The amount is capped by the wallet's own maximum paid top-up unless the rule ignores those limits. Charging the maximum once is deliberate: refusing would leave the wallet absorbing all of the customer's usage with no credits to cover it, and any remainder stays visible through the existing burst report.
- Rules triggered by an interval keep paying their configured amount, as the shortfall has no meaning there, and so do rules with nothing to pay.

- A shortfall of exactly one increment rounds the same way, so it clears the threshold instead of landing on it and firing again.
- `WalletTransactions::CreateJob` deduplicated on `[organization_id, wallet_id, paid_credits, granted_credits]`, which stopped collapsing repeat evaluations once the amount started tracking the shortfall. Automatic top-ups now lock on the wallet and the source instead, so a second evaluation collapses onto the queued job whatever it computed. Manual top-ups keep locking on the amounts, since two deliberate top-ups of different sizes are distinct requests.

Linear: [ING-560](https://linear.app/getlago/issue/ING-560)

## Before and after

Threshold 10 credits, top-up 50, no granted credits and no wallet maximum unless the row says otherwise.

| Scenario | Today on `main` | With this PR |
| -- | -- | -- |
| Balance dips just under the threshold | one charge of 50 | one charge of 50 |
| Balance is exactly one increment short, 40 short | one charge of 50, landing on the threshold, then another | one charge of 100 |
| Balance is 429.8 short | nine charges of 50 | one charge of 450 |
| Shortfall is an exact multiple, balance 90 short | three charges of 50, the second landing exactly on the threshold | one charge of 150 |
| Balance 429.8 short with a 50 top-up already in flight | one charge of 50, repeated | one charge of 400 next to the 50 in flight |
| Rule also grants 50, balance 429.8 short | 50 paid plus 50 granted, repeated | 400 paid plus 50 granted, once |
| Wallet maximum is 100, balance 429.8 short | one charge of 50, repeated | one charge of 100, remainder left open and reported as a burst |
| Wallet rate is 0.1 and 1 credit is pending | pending read as 0.1, so the rule fires anyway | pending read as 1 credit, so the rule holds |
| Rule is triggered by an interval | one charge of 50 | one charge of 50 |

Total charged is the same in every row; the difference is how many card charges it takes, except where the pending or granted credits were being double-counted.

