### PR TITLE
feat(multi-connection): add logic for grouping recurring invoices based on integration connec…

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -19,6 +19,7 @@ class Subscription < ApplicationRecord
   has_many :invoice_subscriptions
   has_many :invoices, through: :invoice_subscriptions
   has_many :integration_resources, as: :syncable
+  has_many :billing_object_connections, as: :owner, dependent: :destroy
   has_many :fees
   has_many :applied_rate_cards, class_name: "SubscriptionRateCard"
   has_many :daily_usages

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -4,6 +4,15 @@ module Subscriptions
   class OrganizationBillingService < BaseService
     Result = BaseResult
 
+    CONNECTION_ID_ATTRIBUTES = {
+      payment: :payment_provider_customer_id,
+      tax: :integration_customer_id,
+      accounting: :integration_customer_id,
+      crm: :integration_customer_id
+    }.freeze
+
+    CONNECTION_CATEGORIES = CONNECTION_ID_ATTRIBUTES.keys.freeze
+
     def initialize(organization:, billing_at: Time.current)
       @organization = organization
       @today = billing_at
@@ -29,6 +38,9 @@ module Subscriptions
         subscription_groups = group_by_payment_method(billing_subscriptions)
         subscription_groups = group_by_currency(subscription_groups)
         subscription_groups = group_by_billing_entity(subscription_groups)
+
+        subscription_groups = group_by_connections(subscription_groups) if multi_connection_enabled?
+
         subscription_groups = split_consolidation_opted_out(subscription_groups)
         subscription_groups = group_by_purchase_order_number(subscription_groups)
 
@@ -557,6 +569,58 @@ module Subscriptions
       subscription_groups.flat_map do |subscriptions|
         subscriptions.group_by(&:purchase_order_number).values
       end
+    end
+
+    def multi_connection_enabled?
+      organization.feature_flag_enabled?(:multi_connection)
+    end
+
+    def group_by_connections(subscription_groups)
+      subscription_groups.flat_map do |subscriptions|
+        next [subscriptions] if subscriptions.size <= 1
+
+        subscriptions.group_by { |sub| connection_key(sub) }.values
+      end
+    end
+
+    def connection_key(subscription)
+      CONNECTION_CATEGORIES.map { |category| effective_connection_id(subscription, category) }
+    end
+
+    def effective_connection_id(subscription, category)
+      override = subscription.billing_object_connections.find { |c| c.category == category.to_s }
+
+      return default_connection_id(subscription, category) unless override
+      return if override.skip?
+
+      override.public_send(CONNECTION_ID_ATTRIBUTES.fetch(category))
+    end
+
+    def default_connection_id(subscription, category)
+      key = [subscription.customer_id, category]
+
+      default_connection_ids.fetch(key) do
+        default_connection_ids[key] = resolve_default_connection_id(subscription.customer, category)
+      end
+    end
+
+    def default_connection_ids
+      @default_connection_ids ||= {}
+    end
+
+    def resolve_default_connection_id(customer, category)
+      connections = customer_connections(customer, category)
+
+      return connections.first.id if connections.one?
+
+      connections.find(&:is_default?)&.id
+    end
+
+    def customer_connections(customer, category)
+      return customer.payment_provider_customers.to_a if category == :payment
+
+      types = IntegrationCustomers::BaseCustomer::CATEGORY_BY_TYPE.select { |_type, c| c == category.to_s }.keys
+      customer.integration_customers.where(type: types).to_a
     end
 
     # NOTE: Returns array of subscription groups

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Subscription do
       expect(subject).to have_many(:invoice_subscriptions)
       expect(subject).to have_many(:invoices).through(:invoice_subscriptions)
       expect(subject).to have_many(:integration_resources)
+      expect(subject).to have_many(:billing_object_connections).dependent(:destroy)
       expect(subject).to have_many(:fees)
       expect(subject).to have_many(:daily_usages)
       expect(subject).to have_many(:usage_thresholds)

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -1279,6 +1279,7 @@ RSpec.describe Subscriptions::OrganizationBillingService do
         end
       end
     end
+
     context "when grouping subscriptions by purchase order number" do
       let(:interval) { :monthly }
       let(:billing_time) { :anniversary }

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -995,6 +995,290 @@ RSpec.describe Subscriptions::OrganizationBillingService do
       end
     end
 
+    context "when grouping subscriptions by connections" do
+      let(:interval) { :monthly }
+      let(:billing_time) { :anniversary }
+      let(:current_date) { subscription_at.next_month }
+
+      let(:subscription1) do
+        create(
+          :subscription,
+          customer:,
+          plan:,
+          subscription_at:,
+          started_at: current_date - 10.days,
+          billing_time:,
+          created_at:
+        )
+      end
+      let(:subscription2) do
+        create(
+          :subscription,
+          customer:,
+          plan:,
+          subscription_at:,
+          started_at: current_date - 10.days,
+          billing_time:,
+          created_at:
+        )
+      end
+
+      before do
+        subscription.destroy
+        subscription1
+        subscription2
+      end
+
+      context "when the multi_connection feature flag is disabled" do
+        before do
+          create(
+            :billing_object_connection,
+            owner: subscription1,
+            organization:,
+            category: "accounting",
+            behavior: "specific",
+            integration_customer: create(:netsuite_customer, customer:)
+          )
+          create(
+            :billing_object_connection,
+            owner: subscription2,
+            organization:,
+            category: "accounting",
+            behavior: "specific",
+            integration_customer: create(:xero_customer, customer:)
+          )
+        end
+
+        it "ignores connections and groups the subscriptions together" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(
+              contain_exactly(subscription1, subscription2),
+              current_date.to_i,
+              invoicing_reason: :subscription_periodic
+            )
+        end
+      end
+
+      context "when the multi_connection feature flag is enabled" do
+        before { organization.enable_feature_flag!(:multi_connection) }
+
+        context "when subscriptions have different accounting connections" do
+          before do
+            create(
+              :billing_object_connection,
+              owner: subscription1,
+              organization:,
+              category: "accounting",
+              behavior: "specific",
+              integration_customer: create(:netsuite_customer, customer:)
+            )
+            create(
+              :billing_object_connection,
+              owner: subscription2,
+              organization:,
+              category: "accounting",
+              behavior: "specific",
+              integration_customer: create(:xero_customer, customer:)
+            )
+          end
+
+          it "produces separate billing jobs per accounting connection" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription1], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription2], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued.with([subscription1], current_date)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued.with([subscription2], current_date)
+          end
+        end
+
+        context "when subscriptions have different tax connections" do
+          let(:anrok_customer) { create(:anrok_customer, customer:) }
+          let(:avalara_customer) { build(:avalara_customer, customer:).tap { |ic| ic.save!(validate: false) } }
+
+          before do
+            create(
+              :billing_object_connection,
+              owner: subscription1,
+              organization:,
+              category: "tax",
+              behavior: "specific",
+              integration_customer: anrok_customer
+            )
+            create(
+              :billing_object_connection,
+              owner: subscription2,
+              organization:,
+              category: "tax",
+              behavior: "specific",
+              integration_customer: avalara_customer
+            )
+          end
+
+          it "produces separate billing jobs per tax connection" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription1], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription2], current_date.to_i, invoicing_reason: :subscription_periodic)
+          end
+        end
+
+        context "when subscriptions have different payment connections" do
+          before do
+            create(
+              :billing_object_connection,
+              owner: subscription1,
+              organization:,
+              category: "payment",
+              behavior: "specific",
+              payment_provider_customer: create(:stripe_customer, customer:)
+            )
+            create(
+              :billing_object_connection,
+              owner: subscription2,
+              organization:,
+              category: "payment",
+              behavior: "specific",
+              payment_provider_customer: create(:gocardless_customer, customer:)
+            )
+          end
+
+          it "produces separate billing jobs per payment connection" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription1], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription2], current_date.to_i, invoicing_reason: :subscription_periodic)
+          end
+        end
+
+        context "when a subscription skips a connection the other one inherits" do
+          before do
+            create(:anrok_customer, customer:)
+            create(
+              :billing_object_connection,
+              owner: subscription1,
+              organization:,
+              category: "tax",
+              behavior: "skip"
+            )
+          end
+
+          it "produces separate billing jobs" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription1], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription2], current_date.to_i, invoicing_reason: :subscription_periodic)
+          end
+        end
+
+        context "when a subscription pins the connection the other one inherits" do
+          let(:hubspot_customer) { create(:hubspot_customer, customer:) }
+
+          before do
+            create(
+              :billing_object_connection,
+              owner: subscription1,
+              organization:,
+              category: "crm",
+              behavior: "specific",
+              integration_customer: hubspot_customer
+            )
+          end
+
+          it "groups them into a single billing job" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with(
+                contain_exactly(subscription1, subscription2),
+                current_date.to_i,
+                invoicing_reason: :subscription_periodic
+              )
+          end
+        end
+
+        context "when the customer has several connections of the same category" do
+          let(:netsuite_customer) { create(:netsuite_customer, customer:, is_default: true) }
+
+          before do
+            netsuite_customer
+            create(:xero_customer, customer:)
+
+            create(
+              :billing_object_connection,
+              owner: subscription1,
+              organization:,
+              category: "accounting",
+              behavior: "specific",
+              integration_customer: netsuite_customer
+            )
+          end
+
+          it "resolves the inherited connection to the customer default" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with(
+                contain_exactly(subscription1, subscription2),
+                current_date.to_i,
+                invoicing_reason: :subscription_periodic
+              )
+          end
+        end
+
+        context "when a subscription pins a connection that is not the customer default" do
+          let(:netsuite_customer) { create(:netsuite_customer, customer:, is_default: true) }
+          let(:xero_customer) { create(:xero_customer, customer:) }
+
+          before do
+            netsuite_customer
+
+            create(
+              :billing_object_connection,
+              owner: subscription1,
+              organization:,
+              category: "accounting",
+              behavior: "specific",
+              integration_customer: xero_customer
+            )
+          end
+
+          it "produces separate billing jobs" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription1], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription2], current_date.to_i, invoicing_reason: :subscription_periodic)
+          end
+        end
+
+        context "when subscriptions have no connection override" do
+          before { create(:netsuite_customer, customer:) }
+
+          it "groups them into a single billing job" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with(
+                contain_exactly(subscription1, subscription2),
+                current_date.to_i,
+                invoicing_reason: :subscription_periodic
+              )
+          end
+        end
+      end
+    end
     context "when grouping subscriptions by purchase order number" do
       let(:interval) { :monthly }
       let(:billing_time) { :anniversary }


### PR DESCRIPTION
## Context

A customer can hold several connections per category (payment, tax, accounting, CRM), and an invoice can carry only one connection per category. Subscriptions routed to different connections therefore cannot share an invoice, so connection becomes an invoice-split dimension on top of billing entity, currency and payment method.

## Description

`Subscriptions::OrganizationBillingService` now splits each customer's subscription groups by their effective connections before invoices are generated. The effective connection of a subscription is resolved per category: an explicit `billing_object_connections` override pins a connection or skips the category entirely, and without a row the subscription falls back to the customer's default connection. Customers holding a single connection of a category resolve to it even when no default is flagged, so existing setups keep grouping exactly as before.

All four categories are resolved in one pass and compared as a single key, which partitions the groups identically to four sequential passes at a quarter of the work. The customer-level lookups are cached per customer and category, and the overrides are read through a new `billing_object_connections` association on Subscription.

The whole step is gated by the `multi_connection` feature flag: with the flag off, the billing pipeline is unchanged.