### PR TITLE
feat(payment_terms): Dual-write to alias and jsonb

### DIFF
--- a/app/models/payment_term.rb
+++ b/app/models/payment_term.rb
@@ -24,6 +24,15 @@ class PaymentTerm
     )
   end
 
+  # Backward compatibility for the legacy net_payment_term_field
+  def self.from_net_payment_term(days)
+    if days.nil?
+      nil
+    else
+      new(term_type: "net", days:)
+    end
+  end
+
   def initialize(term_type:, days: nil, day_of_month: nil, month_offset: nil)
     @term_type = term_type.to_s
     @days = days&.to_i if carries?("days")

--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -26,6 +26,12 @@ module BillingEntities
         billing_entity.document_locale = billing_config[:document_locale] if billing_config[:document_locale]
         billing_entity.einvoicing = params[:einvoicing] if params[:einvoicing]
 
+        PaymentTerms::AssignService.call(record: billing_entity, params:)
+        # Mirror the net_payment_term column default so a new entity never carries a NULL payment_term.
+        if billing_entity.payment_term.nil?
+          billing_entity.payment_term = PaymentTerm.from_net_payment_term(billing_entity.net_payment_term)&.to_h
+        end
+
         handle_eu_tax_management if params[:eu_tax_management]
         handle_base64_logo
 

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -69,6 +69,8 @@ module BillingEntities
           )
         end
 
+        PaymentTerms::AssignService.call(record: billing_entity, params:)
+
         if params.key?(:tax_codes)
           BillingEntities::Taxes::ManageTaxesService.call!(billing_entity:, tax_codes: params[:tax_codes])
         end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -70,6 +70,8 @@ module Customers
         customer_type: args[:customer_type]
       )
 
+      PaymentTerms::AssignService.call(record: customer, params: args)
+
       if customer&.organization&.revenue_share_enabled?
         customer.account_type = args[:account_type] if args.key?(:account_type)
         customer.exclude_from_dunning_campaign = customer.partner_account?

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -96,6 +96,8 @@ module Customers
         Customers::UpdateInvoicePaymentDueDateService.call(customer:, net_payment_term: args[:net_payment_term])
       end
 
+      PaymentTerms::AssignService.call(record: customer, params: args)
+
       # NOTE: Some fields are not editable if customer is attached to subscriptions:
       #       external_id, account_type
       billing_entity_changed = false

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -78,6 +78,8 @@ module Customers
         customer.lastname = params[:lastname] if params.key?(:lastname)
         customer.customer_type = params[:customer_type] if params.key?(:customer_type)
 
+        PaymentTerms::AssignService.call(record: customer, params:)
+
         if customer.organization.revenue_share_enabled? && customer.editable?
           customer.account_type = params[:account_type] if params.key?(:account_type)
           customer.exclude_from_dunning_campaign = customer.partner_account?

--- a/app/services/payment_terms/assign_service.rb
+++ b/app/services/payment_terms/assign_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PaymentTerms
+  # Applies the alias equivalence matrix to a record's payment term columns.
+  # - payment_term sent (object or nil): it wins — the jsonb is assigned and
+  #   the integer alias is mirrored from it (nil clears both).
+  # - only net_payment_term sent: the integer is assigned and the jsonb is
+  #   derived from it as {term_type: "net", days: N} (nil clears both).
+  # Assigns without saving; the caller owns persistence.
+  class AssignService < BaseService
+    Result = BaseResult
+
+    def initialize(record:, params:)
+      @record = record
+      @params = params
+      super
+    end
+
+    def call
+      if params.key?(:payment_term)
+        term = params[:payment_term] && PaymentTerm.from_h(params[:payment_term])
+        record.payment_term = term&.to_h
+        record.net_payment_term = term&.net_payment_term_alias
+      elsif params.key?(:net_payment_term)
+        record.net_payment_term = params[:net_payment_term]
+        record.payment_term = PaymentTerm.from_net_payment_term(params[:net_payment_term])&.to_h
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :record, :params
+  end
+end

--- a/spec/models/payment_term_spec.rb
+++ b/spec/models/payment_term_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe PaymentTerm do
     end
   end
 
+  describe ".from_net_payment_term" do
+    it "builds a net term from the legacy alias" do
+      expect(described_class.from_net_payment_term(0)&.to_h)
+        .to eq("term_type" => "net", "days" => 0)
+      expect(described_class.from_net_payment_term(30)&.to_h)
+        .to eq("term_type" => "net", "days" => 30)
+    end
+
+    it "returns nil when the legacy alias is cleared" do
+      expect(described_class.from_net_payment_term(nil)).to be_nil
+    end
+  end
+
   describe "#to_h" do
     it "serializes only the fields carried by the term type" do
       expect(described_class.from_h(term_type: "due_on_receipt").to_h)

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe BillingEntities::CreateService do
         before { result }
       end
 
+      it "mirrors the default alias into the structured payment term when net_payment_term is not provided" do
+        expect(result).to be_success
+        expect(result.billing_entity.reload.net_payment_term).to eq(0)
+        expect(result.billing_entity.reload.payment_term).to eq("term_type" => "net", "days" => 0)
+      end
+
       it "does not set eu_tax_management when not provided" do
         expect(result).to be_success
         expect(result.billing_entity.eu_tax_management).to be false
@@ -177,6 +183,7 @@ RSpec.describe BillingEntities::CreateService do
           expect(result.billing_entity.legal_name).to eq("Legal Name")
           expect(result.billing_entity.legal_number).to eq("Legal Number")
           expect(result.billing_entity.net_payment_term).to eq(90)
+          expect(result.billing_entity.payment_term).to eq("term_type" => "net", "days" => 90)
           expect(result.billing_entity.state).to eq("State")
           expect(result.billing_entity.tax_identification_number).to eq("EU123456789")
           expect(result.billing_entity.vat_rate).to eq(1)

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -181,6 +181,7 @@ RSpec.describe BillingEntities::UpdateService do
         end
 
         before do
+          billing_entity.update!(net_payment_term: 30, payment_term: {"term_type" => "net", "days" => 30})
           allow(BillingEntities::UpdateInvoicePaymentDueDateService).to receive(:call).and_call_original
         end
 
@@ -192,6 +193,7 @@ RSpec.describe BillingEntities::UpdateService do
             expect(result).to be_success
 
             expect(result.billing_entity.net_payment_term).to eq(2)
+            expect(result.billing_entity.payment_term).to eq("term_type" => "net", "days" => 2)
             expect(BillingEntities::UpdateInvoicePaymentDueDateService).to have_received(:call).with(billing_entity:, net_payment_term: 2)
           end
         end

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe Customers::CreateService do
     expect(customer.shipping_country).to eq(shipping_address[:country])
   end
 
+  context "when net_payment_term is provided" do
+    before { create_args[:net_payment_term] = 30 }
+
+    it "writes the structured payment term alias" do
+      expect(result.customer.reload).to have_attributes(
+        net_payment_term: 30,
+        payment_term: {"term_type" => "net", "days" => 30}
+      )
+    end
+  end
+
+  context "when net_payment_term is not provided" do
+    it "leaves both the alias and the structured payment term unset" do
+      expect(result.customer.reload).to have_attributes(net_payment_term: nil, payment_term: nil)
+    end
+  end
+
   it "calls SendWebhookJob with customer.created" do
     result
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -509,6 +509,29 @@ RSpec.describe Customers::UpdateService do
     end
 
     context "when updating net payment term" do
+      before do
+        customer.update!(net_payment_term: 30, payment_term: {"term_type" => "net", "days" => 30})
+      end
+
+      it "writes the structured payment term alias" do
+        result = customers_service.call
+
+        expect(result.customer).to have_attributes(
+          net_payment_term: 8,
+          payment_term: {"term_type" => "net", "days" => 8}
+        )
+      end
+
+      context "when the net payment term is cleared" do
+        let(:update_args) { {id: customer.id, net_payment_term: nil} }
+
+        it "clears the structured payment term alias" do
+          result = customers_service.call
+
+          expect(result.customer).to have_attributes(net_payment_term: nil, payment_term: nil)
+        end
+      end
+
       it "updates the net payment term of all draft invoices" do
         create(:invoice, :draft, customer:, net_payment_term: 30)
         create(:invoice, customer:, net_payment_term: 30)

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -95,6 +95,50 @@ RSpec.describe Customers::UpsertFromApiService do
     )
   end
 
+  context "when net_payment_term is provided" do
+    let(:customer) do
+      create(
+        :customer,
+        organization:,
+        external_id:,
+        net_payment_term: 30,
+        payment_term: {"term_type" => "net", "days" => 30}
+      )
+    end
+
+    before do
+      customer
+      create_args[:net_payment_term] = 45
+    end
+
+    it "writes the structured payment term alias" do
+      expect(result.customer).to have_attributes(
+        net_payment_term: 45,
+        payment_term: {"term_type" => "net", "days" => 45}
+      )
+    end
+  end
+
+  context "when net_payment_term is cleared" do
+    let(:customer) do
+      create(
+        :customer,
+        organization:,
+        external_id:,
+        net_payment_term: 30,
+        payment_term: {"term_type" => "net", "days" => 30}
+      )
+    end
+
+    let(:create_args) { {external_id:, net_payment_term: nil} }
+
+    before { customer }
+
+    it "clears the structured payment term alias" do
+      expect(result.customer).to have_attributes(net_payment_term: nil, payment_term: nil)
+    end
+  end
+
   it "calls SendWebhookJob with customer.created" do
     customer = result.customer
 

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -249,6 +249,10 @@ RSpec.describe Organizations::UpdateService do
 
         before do
           draft_invoice
+          organization.default_billing_entity.update!(
+            net_payment_term: 30,
+            payment_term: {"term_type" => "net", "days" => 30}
+          )
           allow(BillingEntities::UpdateInvoicePaymentDueDateService).to receive(:call).and_call_original
         end
 
@@ -260,6 +264,7 @@ RSpec.describe Organizations::UpdateService do
             expect(result).to be_success
 
             expect(result.organization.net_payment_term).to eq(2)
+            expect(result.organization.default_billing_entity.payment_term).to eq("term_type" => "net", "days" => 2)
             expect(BillingEntities::UpdateInvoicePaymentDueDateService).to have_received(:call).with(billing_entity: organization.default_billing_entity, net_payment_term: 2)
           end
         end

--- a/spec/services/payment_terms/assign_service_spec.rb
+++ b/spec/services/payment_terms/assign_service_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentTerms::AssignService do
+  subject(:result) { described_class.call(record:, params:) }
+
+  let(:existing_term) { {"term_type" => "net", "days" => 30} }
+  let(:record) { create(:customer, net_payment_term: 30, payment_term: existing_term) }
+
+  describe "alias equivalence matrix" do
+    context "when payment_term is not sent" do
+      context "with net_payment_term N" do
+        let(:params) { {net_payment_term: 45} }
+
+        it "assigns the equivalent net term on both columns, without saving the record" do
+          expect(result).to be_success
+
+          expect(record.net_payment_term).to eq(45)
+          expect(record.payment_term).to eq("term_type" => "net", "days" => 45)
+          expect(record.reload.payment_term).to eq(existing_term)
+        end
+      end
+
+      context "with net_payment_term null" do
+        let(:params) { {net_payment_term: nil} }
+
+        it "clears both columns" do
+          result
+
+          expect(record.net_payment_term).to be_nil
+          expect(record.payment_term).to be_nil
+        end
+      end
+
+      context "with net_payment_term absent" do
+        let(:params) { {name: "Updated name"} }
+
+        it "makes no change" do
+          result
+
+          expect(record.net_payment_term).to eq(30)
+          expect(record.payment_term).to eq(existing_term)
+        end
+      end
+    end
+
+    context "when payment_term is sent" do
+      context "with net_payment_term absent, payment_term object" do
+        let(:params) { {payment_term: {term_type: "end_of_month"}} }
+
+        it "assigns the term and mirrors a null alias for a non-net type" do
+          result
+
+          expect(record.payment_term).to eq("term_type" => "end_of_month")
+          expect(record.net_payment_term).to be_nil
+        end
+      end
+
+      context "with net_payment_term absent, payment_term null" do
+        let(:params) { {payment_term: nil} }
+
+        it "clears both columns" do
+          result
+
+          expect(record.payment_term).to be_nil
+          expect(record.net_payment_term).to be_nil
+        end
+      end
+
+      context "with net_payment_term N, payment_term equivalent object" do
+        let(:params) { {net_payment_term: 45, payment_term: {term_type: "net", days: 45}} }
+
+        it "assigns the term and mirrors the alias" do
+          result
+
+          expect(record.payment_term).to eq("term_type" => "net", "days" => 45)
+          expect(record.net_payment_term).to eq(45)
+        end
+      end
+
+      context "with net_payment_term N, payment_term different object" do
+        let(:params) { {net_payment_term: 45, payment_term: {term_type: "end_of_month"}} }
+
+        it "lets payment_term win, ignoring the sent alias" do
+          result
+
+          expect(record.payment_term).to eq("term_type" => "end_of_month")
+          expect(record.net_payment_term).to be_nil
+        end
+      end
+
+      context "with net_payment_term null, payment_term object (echo-back)" do
+        let(:params) { {net_payment_term: nil, payment_term: {term_type: "net", days: 45}} }
+
+        it "lets payment_term win and mirrors its alias" do
+          result
+
+          expect(record.payment_term).to eq("term_type" => "net", "days" => 45)
+          expect(record.net_payment_term).to eq(45)
+        end
+      end
+
+      context "with net_payment_term null, payment_term null" do
+        let(:params) { {net_payment_term: nil, payment_term: nil} }
+
+        it "clears both columns" do
+          result
+
+          expect(record.payment_term).to be_nil
+          expect(record.net_payment_term).to be_nil
+        end
+      end
+
+      context "with net_payment_term N, payment_term null" do
+        let(:params) { {net_payment_term: 45, payment_term: nil} }
+
+        it "lets payment_term win and clears both columns" do
+          result
+
+          expect(record.payment_term).to be_nil
+          expect(record.net_payment_term).to be_nil
+        end
+      end
+
+      context "with a due_on_receipt term" do
+        let(:params) { {payment_term: {term_type: "due_on_receipt"}} }
+
+        it "mirrors a zero alias" do
+          result
+
+          expect(record.payment_term).to eq("term_type" => "due_on_receipt")
+          expect(record.net_payment_term).to eq(0)
+        end
+      end
+    end
+  end
+
+  context "when net_payment_term is zero" do
+    let(:params) { {net_payment_term: 0} }
+
+    it "assigns a net term of zero rather than due_on_receipt" do
+      result
+
+      expect(record.payment_term).to eq("term_type" => "net", "days" => 0)
+      expect(record.net_payment_term).to eq(0)
+    end
+  end
+
+  context "when the record is a billing entity" do
+    let(:record) { create(:billing_entity, net_payment_term: 30) }
+    let(:params) { {payment_term: {term_type: "day_of_month", day_of_month: 15}} }
+
+    it "assigns the term with its defaults and a null alias" do
+      result
+
+      expect(record.payment_term).to eq("term_type" => "day_of_month", "day_of_month" => 15, "month_offset" => 1)
+      expect(record.net_payment_term).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Context

Payment terms are moving from a single integer (net_payment_term, days) to a structured payment_term jsonb that can express more term types (net N days, due on receipt, day of month, etc.). Both columns already exist on customers and billing entities. This step starts writing them together so they never disagree.

## Description

Adds `PaymentTerms::AssignService`, the single writer for both payment term columns. Every create/update path for customers and billing entities now goes through it instead of assigning `net_payment_term` inline.

The service applies the equivalence rules between the two fields:
  - payment_term sent (object or null): it wins. The jsonb is assigned, and the integer alias is mirrored from it
  (`{net, N}` → N, `due_on_receipt` → 0, other types → null). null clears both.
  - Only net_payment_term sent: the integer is assigned and the jsonb is derived as `{term_type: "net", days: N}`. null clears both.

The service only does assignment; callers still own validation and persistence. The payment_term branch is not reachable from the public API yet. API params for it ship in a later PR - so behavior for existing callers is unchanged: sending net_payment_term works exactly as before, it just also fills the jsonb.

Also adds PaymentTerm.from_net_payment_term to build a net term from a legacy integer.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>