### PR TITLE
fix(subscription): fix race on lifetime usage creation

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -123,16 +123,21 @@ class Subscription < ApplicationRecord
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
     self.activated_at ||= timestamp
-    self.lifetime_usage ||= previous_subscription&.lifetime_usage || find_or_create_lifetime_usage!
+    self.lifetime_usage ||= previous_subscription&.lifetime_usage || existing_or_new_lifetime_usage
     self.lifetime_usage.recalculate_invoiced_usage = true
     active!
   end
 
-  # Two concurrent requests activating the same subscription (e.g. a manual update racing
-  # a scheduled job) can both find `lifetime_usage` blank and both attempt to build one,
-  # tripping the `index_lifetime_usages_on_subscription_id` unique index. `create_or_find_by!`
-  # runs the insert in a savepoint and falls back to the row the other request created.
-  def find_or_create_lifetime_usage!
+  # A brand new subscription can't race anyone for its lifetime usage row (nothing else
+  # references it yet), so it's built unsaved and persisted together with the subscription,
+  # same as before. An already-persisted subscription can: two concurrent requests activating
+  # it (e.g. a manual update racing a scheduled job) can both find `lifetime_usage` blank and
+  # both attempt to create one, tripping the `index_lifetime_usages_on_subscription_id` unique
+  # index. `create_or_find_by!` runs that insert in a savepoint and falls back to the row the
+  # other request created.
+  def existing_or_new_lifetime_usage
+    return build_lifetime_usage(organization:) unless persisted?
+
     LifetimeUsage.create_with(organization:).create_or_find_by!(subscription: self)
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -120,10 +120,7 @@ class Subscription < ApplicationRecord
     billing_entity_id || customer&.billing_entity_id
   end
 
-  # Returns true when this call actually performed the activation, false when a concurrent
-  # request already did (see `resolve_lifetime_usage`). Callers that trigger billing side
-  # effects after activating (webhooks, invoicing jobs) must skip them on a `false` return,
-  # since the concurrent request that won the race already triggered them.
+  # Returns false when a concurrent request already activated this subscription.
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
     self.activated_at ||= timestamp
@@ -139,22 +136,14 @@ class Subscription < ApplicationRecord
     won_activation
   end
 
-  # Two concurrent requests activating the same persisted subscription (e.g. a manual
-  # update racing a scheduled job) can both find `lifetime_usage` blank and both attempt
-  # to create one, tripping the `index_lifetime_usages_on_subscription_id` unique index.
-  # `create_or_find_by!` runs that insert in a savepoint and falls back to the row the
-  # other request created - `previously_new_record?` then tells us which one we got.
   def resolve_lifetime_usage
     return [previous_subscription.lifetime_usage, true] if previous_subscription&.lifetime_usage
 
     usage = existing_or_new_lifetime_usage
-    won = !usage.persisted? || usage.previously_new_record?
-    [usage, won]
+    [usage, !usage.persisted? || usage.previously_new_record?]
   end
 
-  # A brand new subscription can't race anyone for its lifetime usage row (nothing else
-  # references it yet), so it's built unsaved and persisted together with the subscription,
-  # same as before. An already-persisted subscription can race a concurrent activation.
+  # `create_or_find_by!` recovers from the unique-index race between concurrent activations.
   def existing_or_new_lifetime_usage
     return build_lifetime_usage(organization:) unless persisted?
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -120,21 +120,41 @@ class Subscription < ApplicationRecord
     billing_entity_id || customer&.billing_entity_id
   end
 
+  # Returns true when this call actually performed the activation, false when a concurrent
+  # request already did (see `resolve_lifetime_usage`). Callers that trigger billing side
+  # effects after activating (webhooks, invoicing jobs) must skip them on a `false` return,
+  # since the concurrent request that won the race already triggered them.
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
     self.activated_at ||= timestamp
-    self.lifetime_usage ||= previous_subscription&.lifetime_usage || existing_or_new_lifetime_usage
-    self.lifetime_usage.recalculate_invoiced_usage = true
+
+    won_activation = true
+    if lifetime_usage.blank?
+      self.lifetime_usage, won_activation = resolve_lifetime_usage
+    end
+
+    lifetime_usage.recalculate_invoiced_usage = true
     active!
+
+    won_activation
+  end
+
+  # Two concurrent requests activating the same persisted subscription (e.g. a manual
+  # update racing a scheduled job) can both find `lifetime_usage` blank and both attempt
+  # to create one, tripping the `index_lifetime_usages_on_subscription_id` unique index.
+  # `create_or_find_by!` runs that insert in a savepoint and falls back to the row the
+  # other request created - `previously_new_record?` then tells us which one we got.
+  def resolve_lifetime_usage
+    return [previous_subscription.lifetime_usage, true] if previous_subscription&.lifetime_usage
+
+    usage = existing_or_new_lifetime_usage
+    won = !usage.persisted? || usage.previously_new_record?
+    [usage, won]
   end
 
   # A brand new subscription can't race anyone for its lifetime usage row (nothing else
   # references it yet), so it's built unsaved and persisted together with the subscription,
-  # same as before. An already-persisted subscription can: two concurrent requests activating
-  # it (e.g. a manual update racing a scheduled job) can both find `lifetime_usage` blank and
-  # both attempt to create one, tripping the `index_lifetime_usages_on_subscription_id` unique
-  # index. `create_or_find_by!` runs that insert in a savepoint and falls back to the row the
-  # other request created.
+  # same as before. An already-persisted subscription can race a concurrent activation.
   def existing_or_new_lifetime_usage
     return build_lifetime_usage(organization:) unless persisted?
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -123,9 +123,17 @@ class Subscription < ApplicationRecord
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
     self.activated_at ||= timestamp
-    self.lifetime_usage ||= previous_subscription&.lifetime_usage || build_lifetime_usage(organization:)
+    self.lifetime_usage ||= previous_subscription&.lifetime_usage || find_or_create_lifetime_usage!
     self.lifetime_usage.recalculate_invoiced_usage = true
     active!
+  end
+
+  # Two concurrent requests activating the same subscription (e.g. a manual update racing
+  # a scheduled job) can both find `lifetime_usage` blank and both attempt to build one,
+  # tripping the `index_lifetime_usages_on_subscription_id` unique index. `create_or_find_by!`
+  # runs the insert in a savepoint and falls back to the row the other request created.
+  def find_or_create_lifetime_usage!
+    LifetimeUsage.create_with(organization:).create_or_find_by!(subscription: self)
   end
 
   def mark_as_terminated!(timestamp = Time.current)

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -161,7 +161,9 @@ module Subscriptions
         )
       end
 
-      subscription.mark_as_active!(subscription.subscription_at)
+      # A concurrent request (e.g. the activation scheduler) may have already activated this
+      # subscription: don't repeat the billing side effects it already triggered.
+      return unless subscription.mark_as_active!(subscription.subscription_at)
 
       EmitFixedChargeEventsService.call!(
         subscriptions: [subscription],

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -161,8 +161,7 @@ module Subscriptions
         )
       end
 
-      # A concurrent request (e.g. the activation scheduler) may have already activated this
-      # subscription: don't repeat the billing side effects it already triggered.
+      # Skip billing side effects if a concurrent request already activated the subscription.
       return unless subscription.mark_as_active!(subscription.subscription_at)
 
       EmitFixedChargeEventsService.call!(

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1064,11 +1064,7 @@ RSpec.describe Subscription do
     context "when a concurrent request already created the lifetime usage" do
       subject(:subscription) { create(:subscription, :pending) }
 
-      # Simulates the actual race: `subscription`'s association cache is memoized to nil
-      # (as it would be mid-request) before a *different* Ruby object inserts the row for
-      # the same row, via a separate `Subscription.find`. When `mark_as_active!` then tries
-      # to create its own, it hits the real `index_lifetime_usages_on_subscription_id`
-      # unique constraint instead of finding the row through its stale cache.
+      # Loads through a separate instance so `subscription`'s own cache stays stale, like the real race.
       let!(:concurrent_lifetime_usage) do
         subscription.lifetime_usage
         create(:lifetime_usage, subscription: described_class.find(subscription.id), organization: subscription.organization)
@@ -1089,10 +1085,6 @@ RSpec.describe Subscription do
     context "when the subscription is not persisted yet" do
       subject(:subscription) { build(:subscription, :pending) }
 
-      # A new subscription being created has nothing to race against yet, so it must not
-      # eagerly persist the lifetime usage before `active!` sets the subscription status -
-      # `create_or_find_by!` would autosave the new (still status-less) parent to get an FK,
-      # violating the `status` NOT NULL constraint.
       it "activates without prematurely saving the subscription" do
         expect { subscription.mark_as_active! }
           .to change(subscription, :status).from("pending").to("active")

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1073,6 +1073,22 @@ RSpec.describe Subscription do
         expect(subscription.lifetime_usage).to eq(concurrent_lifetime_usage)
       end
     end
+
+    context "when the subscription is not persisted yet" do
+      subject(:subscription) { build(:subscription, :pending) }
+
+      # A new subscription being created has nothing to race against yet, so it must not
+      # eagerly persist the lifetime usage before `active!` sets the subscription status -
+      # `create_or_find_by!` would autosave the new (still status-less) parent to get an FK,
+      # violating the `status` NOT NULL constraint.
+      it "activates without prematurely saving the subscription" do
+        expect { subscription.mark_as_active! }
+          .to change(subscription, :status).from("pending").to("active")
+
+        expect(subscription).to be_persisted
+        expect(subscription.lifetime_usage).to be_persisted
+      end
+    end
   end
 
   describe "#terminated_at?" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1017,12 +1017,15 @@ RSpec.describe Subscription do
 
     it "changes the status to active and sets started_at and activated_at" do
       freeze_time do
-        expect { subscription.mark_as_active! }
+        result = nil
+
+        expect { result = subscription.mark_as_active! }
           .to change(subscription, :status).from("pending").to("active")
 
         expect(subscription.started_at).to eq(Time.current)
         expect(subscription.activated_at).to eq(Time.current)
         expect(subscription.lifetime_usage).to be_present
+        expect(result).to eq(true)
       end
     end
 
@@ -1076,6 +1079,10 @@ RSpec.describe Subscription do
           .to change(subscription, :status).from("pending").to("active")
 
         expect(subscription.lifetime_usage).to eq(concurrent_lifetime_usage)
+      end
+
+      it "returns false so callers skip repeating the winner's billing side effects" do
+        expect(subscription.mark_as_active!).to eq(false)
       end
     end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1061,10 +1061,15 @@ RSpec.describe Subscription do
     context "when a concurrent request already created the lifetime usage" do
       subject(:subscription) { create(:subscription, :pending) }
 
-      # Simulates a concurrent request that already inserted the row: the real
-      # `index_lifetime_usages_on_subscription_id` unique constraint fires when
-      # `mark_as_active!` tries to create its own.
-      let!(:concurrent_lifetime_usage) { create(:lifetime_usage, subscription:, organization: subscription.organization) }
+      # Simulates the actual race: `subscription`'s association cache is memoized to nil
+      # (as it would be mid-request) before a *different* Ruby object inserts the row for
+      # the same row, via a separate `Subscription.find`. When `mark_as_active!` then tries
+      # to create its own, it hits the real `index_lifetime_usages_on_subscription_id`
+      # unique constraint instead of finding the row through its stale cache.
+      let!(:concurrent_lifetime_usage) do
+        subscription.lifetime_usage
+        create(:lifetime_usage, subscription: described_class.find(subscription.id), organization: subscription.organization)
+      end
 
       it "reuses the existing record instead of raising" do
         expect { subscription.mark_as_active! }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1057,6 +1057,22 @@ RSpec.describe Subscription do
         expect(lifetime_usage.reload.subscription).to eq(subscription)
       end
     end
+
+    context "when a concurrent request already created the lifetime usage" do
+      subject(:subscription) { create(:subscription, :pending) }
+
+      # Simulates a concurrent request that already inserted the row: the real
+      # `index_lifetime_usages_on_subscription_id` unique constraint fires when
+      # `mark_as_active!` tries to create its own.
+      let!(:concurrent_lifetime_usage) { create(:lifetime_usage, subscription:, organization: subscription.organization) }
+
+      it "reuses the existing record instead of raising" do
+        expect { subscription.mark_as_active! }
+          .to change(subscription, :status).from("pending").to("active")
+
+        expect(subscription.lifetime_usage).to eq(concurrent_lifetime_usage)
+      end
+    end
   end
 
   describe "#terminated_at?" do

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -448,10 +448,7 @@ RSpec.describe Subscriptions::UpdateService do
           context "when a concurrent request already activated the subscription" do
             let(:fixed_charge) { create(:fixed_charge, plan: subscription.plan) }
 
-            # Simulates a concurrent activation (e.g. the scheduler) winning the race on the
-            # `lifetime_usage` row before this request's transaction runs: `mark_as_active!`
-            # then returns false, and the billing side effects it already triggered must not
-            # run a second time here.
+            # Loads through a separate instance so `subscription`'s own cache stays stale, like the real race.
             before do
               fixed_charge
               subscription.lifetime_usage

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -444,6 +444,35 @@ RSpec.describe Subscriptions::UpdateService do
                 .to contain_exactly([fixed_charge.id, be_within(1.second).of(subscription.started_at)])
             end
           end
+
+          context "when a concurrent request already activated the subscription" do
+            let(:fixed_charge) { create(:fixed_charge, plan: subscription.plan) }
+
+            # Simulates a concurrent activation (e.g. the scheduler) winning the race on the
+            # `lifetime_usage` row before this request's transaction runs: `mark_as_active!`
+            # then returns false, and the billing side effects it already triggered must not
+            # run a second time here.
+            before do
+              fixed_charge
+              subscription.lifetime_usage
+              create(:lifetime_usage, subscription: Subscription.find(subscription.id), organization: subscription.organization)
+            end
+
+            it "does not enqueue a job to bill the subscription" do
+              expect { update_service.call }.not_to have_enqueued_job(BillSubscriptionJob)
+            end
+
+            it "does not create duplicate fixed charge events" do
+              expect { update_service.call }.not_to change(FixedChargeEvent, :count)
+            end
+
+            it "still activates the subscription" do
+              result = update_service.call
+
+              expect(result).to be_success
+              expect(result.subscription.status).to eq("active")
+            end
+          end
         end
 
         context "when subscription_at is set to future date" do


### PR DESCRIPTION
Two concurrent requests activating the same subscription (a manual update racing a scheduled job) could both find `lifetime_usage` blank and both try to build one, tripping the `index_lifetime_usages_on_subscription_id` unique constraint and raising `ActiveRecord::RecordNotUnique`. On the GraphQL mutation path this surfaced to the frontend as a 500 (Sentry FRONT-EU-EC).

`mark_as_active!` now creates the `LifetimeUsage` via `create_or_find_by!`, which retries the lookup on a unique violation instead of raising, so the loser of the race reuses the row the winner just inserted.